### PR TITLE
feat: add OpenAI-compatible API provider for protocol generation

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -2,6 +2,18 @@ import SwiftUI
 
 private let defaults = UserDefaults.standard
 
+enum ProtocolProvider: String, CaseIterable {
+    case claudeCLI = "claudeCLI"
+    case openAICompatible = "openAICompatible"
+
+    var label: String {
+        switch self {
+        case .claudeCLI: "Claude CLI"
+        case .openAICompatible: "OpenAI-Compatible API"
+        }
+    }
+}
+
 @Observable
 final class AppSettings {
     // MARK: - Apps to Watch
@@ -86,8 +98,39 @@ final class AppSettings {
 
     // MARK: - Protocol Generation
 
+    var protocolProvider: ProtocolProvider = {
+        if let raw = defaults.string(forKey: "protocolProvider"),
+           let provider = ProtocolProvider(rawValue: raw) {
+            return provider
+        }
+        return .claudeCLI
+    }() {
+        didSet { defaults.set(protocolProvider.rawValue, forKey: "protocolProvider") }
+    }
+
     var claudeBin: String = defaults.object(forKey: "claudeBin") as? String ?? "claude" {
         didSet { defaults.set(claudeBin, forKey: "claudeBin") }
+    }
+
+    var openAIEndpoint: String = defaults.object(forKey: "openAIEndpoint") as? String
+        ?? "http://localhost:11434/v1/chat/completions"
+    {
+        didSet { defaults.set(openAIEndpoint, forKey: "openAIEndpoint") }
+    }
+
+    var openAIModel: String = defaults.object(forKey: "openAIModel") as? String ?? "llama3.1" {
+        didSet { defaults.set(openAIModel, forKey: "openAIModel") }
+    }
+
+    var openAIAPIKey: String {
+        get { KeychainHelper.read(key: "openAIAPIKey") ?? "" }
+        set {
+            if newValue.isEmpty {
+                KeychainHelper.delete(key: "openAIAPIKey")
+            } else {
+                KeychainHelper.save(key: "openAIAPIKey", value: newValue)
+            }
+        }
     }
 
     // MARK: - Computed

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -292,7 +292,7 @@ struct MeetingTranscriberApp: App {
         let queue = PipelineQueue(
             whisperKit: whisperKit,
             diarizationFactory: { FluidDiarizer() },
-            protocolGenerator: makeProtocolGenerator(),
+            protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
             outputDir: WatchLoop.defaultOutputDir,
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -278,12 +278,11 @@ struct MeetingTranscriberApp: App {
         let queue = PipelineQueue(
             whisperKit: whisperKit,
             diarizationFactory: { FluidDiarizer() },
-            protocolGenerator: DefaultProtocolGenerator(),
+            protocolGenerator: ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin),
             outputDir: WatchLoop.defaultOutputDir,
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,
-            micLabel: settings.micName,
-            claudeBin: settings.claudeBin
+            micLabel: settings.micName
         )
         queue.loadSnapshot()
         queue.recoverOrphanedRecordings()

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -274,11 +274,25 @@ struct MeetingTranscriberApp: App {
         configurePipelineCallbacks()
     }
 
+    private func makeProtocolGenerator() -> ProtocolGenerating {
+        switch settings.protocolProvider {
+        case .claudeCLI:
+            ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin)
+        case .openAICompatible:
+            OpenAIProtocolGenerator(
+                endpoint: URL(string: settings.openAIEndpoint)
+                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
+                model: settings.openAIModel,
+                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey
+            )
+        }
+    }
+
     private func makePipelineQueue() -> PipelineQueue {
         let queue = PipelineQueue(
             whisperKit: whisperKit,
             diarizationFactory: { FluidDiarizer() },
-            protocolGenerator: ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin),
+            protocolGenerator: makeProtocolGenerator(),
             outputDir: WatchLoop.defaultOutputDir,
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -1,0 +1,154 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "OpenAIProtocolGenerator")
+
+/// Generates meeting protocols via an OpenAI-compatible HTTP API (e.g. Ollama, LM Studio, llama.cpp).
+struct OpenAIProtocolGenerator: ProtocolGenerating {
+    let endpoint: URL
+    let model: String
+    let apiKey: String?
+    let timeoutSeconds: TimeInterval
+
+    init(endpoint: URL, model: String, apiKey: String? = nil, timeoutSeconds: TimeInterval = 600) {
+        self.endpoint = endpoint
+        self.model = model
+        self.apiKey = apiKey
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    func generate(transcript: String, title: String, diarized: Bool) async throws -> String {
+        var systemPrompt = ProtocolGenerator.protocolPrompt
+        if diarized {
+            systemPrompt += ProtocolGenerator.diarizationNote
+        }
+
+        let messages: [[String: Any]] = [
+            ["role": "system", "content": systemPrompt],
+            ["role": "user", "content": transcript],
+        ]
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": messages,
+            "stream": true,
+        ]
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = bodyData
+        request.timeoutInterval = timeoutSeconds
+
+        logger.info("Generating protocol via OpenAI-compatible API (\(model))...")
+
+        let (bytes, response): (URLSession.AsyncBytes, URLResponse)
+        do {
+            (bytes, response) = try await URLSession.shared.bytes(for: request)
+        } catch {
+            throw ProtocolError.connectionFailed(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProtocolError.connectionFailed("Invalid response")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            // Try to read error body
+            var errorBody = ""
+            for try await line in bytes.lines {
+                errorBody += line
+                if errorBody.count > 500 { break }
+            }
+            throw ProtocolError.httpError(httpResponse.statusCode, errorBody)
+        }
+
+        var parts: [String] = []
+        for try await line in bytes.lines {
+            if let content = parseSSELine(line) {
+                parts.append(content)
+            }
+        }
+
+        let result = parts.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !result.isEmpty else {
+            throw ProtocolError.emptyProtocol
+        }
+
+        return result
+    }
+
+    /// Parse a single SSE line and extract the content delta.
+    /// Returns `nil` for non-content lines (e.g. `data: [DONE]`, empty lines, comments).
+    static func parseSSELine(_ line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+        guard trimmed.hasPrefix("data: ") else { return nil }
+        let payload = String(trimmed.dropFirst(6))
+
+        if payload == "[DONE]" { return nil }
+
+        guard let data = payload.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = obj["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let delta = first["delta"] as? [String: Any],
+              let content = delta["content"] as? String
+        else { return nil }
+
+        return content
+    }
+
+    /// Test connection to the API by querying available models.
+    /// Returns model names on success.
+    static func testConnection(endpoint: String, model: String, apiKey: String?) async -> Result<[String], Error> {
+        // Derive models endpoint from chat completions endpoint
+        guard let chatURL = URL(string: endpoint) else {
+            return .failure(ProtocolError.connectionFailed("Invalid endpoint URL"))
+        }
+
+        // Navigate from .../v1/chat/completions to .../v1/models
+        let baseURL = chatURL.deletingLastPathComponent().deletingLastPathComponent()
+        let modelsURL = baseURL.appendingPathComponent("models")
+
+        var request = URLRequest(url: modelsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 10
+        if let apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode)
+            else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                return .failure(ProtocolError.httpError(code, "Failed to fetch models"))
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let modelList = json["data"] as? [[String: Any]]
+            else {
+                return .success([])
+            }
+
+            let names = modelList.compactMap { $0["id"] as? String }.sorted()
+            return .success(names)
+        } catch {
+            return .failure(ProtocolError.connectionFailed(error.localizedDescription))
+        }
+    }
+}
+
+// Private instance helper that delegates to the static method
+private extension OpenAIProtocolGenerator {
+    func parseSSELine(_ line: String) -> String? {
+        Self.parseSSELine(line)
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -12,7 +12,7 @@ class PipelineQueue {
     // Dependencies for processing
     let whisperKit: WhisperKitEngine?
     let diarizationFactory: (() -> DiarizationProvider)?
-    let protocolGenerator: ProtocolGenerating?
+    let protocolGeneratorFactory: (() -> ProtocolGenerating)?
     let outputDir: URL?
     let diarizeEnabled: Bool
     let numSpeakers: Int
@@ -76,7 +76,7 @@ class PipelineQueue {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.whisperKit = nil
         self.diarizationFactory = nil
-        self.protocolGenerator = nil
+        self.protocolGeneratorFactory = nil
         self.outputDir = nil
         self.diarizeEnabled = false
         self.numSpeakers = 0
@@ -90,7 +90,7 @@ class PipelineQueue {
         logDir: URL? = nil,
         whisperKit: WhisperKitEngine,
         diarizationFactory: @escaping () -> DiarizationProvider,
-        protocolGenerator: ProtocolGenerating,
+        protocolGeneratorFactory: @escaping () -> ProtocolGenerating,
         outputDir: URL,
         diarizeEnabled: Bool = false,
         numSpeakers: Int = 0,
@@ -101,7 +101,7 @@ class PipelineQueue {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.whisperKit = whisperKit
         self.diarizationFactory = diarizationFactory
-        self.protocolGenerator = protocolGenerator
+        self.protocolGeneratorFactory = protocolGeneratorFactory
         self.outputDir = outputDir
         self.diarizeEnabled = diarizeEnabled
         self.numSpeakers = numSpeakers
@@ -198,7 +198,7 @@ class PipelineQueue {
             isProcessing = false
             return
         }
-        guard let whisperKit, let protocolGenerator, let outputDir else {
+        guard let whisperKit, let protocolGeneratorFactory, let outputDir else {
             logger.warning("Processing dependencies not configured — skipping")
             isProcessing = false
             return
@@ -453,6 +453,7 @@ class PipelineQueue {
             updateJobState(id: jobID, to: .generatingProtocol)
 
             let diarized = finalTranscript.range(of: #"\[\w[\w\s]*\]"#, options: .regularExpression) != nil
+            let protocolGenerator = protocolGeneratorFactory()
             let protocolMD = try await protocolGenerator.generate(
                 transcript: finalTranscript,
                 title: title,

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -17,7 +17,6 @@ class PipelineQueue {
     let diarizeEnabled: Bool
     let numSpeakers: Int
     let micLabel: String
-    let claudeBin: String
     let speakerMatcherFactory: () -> SpeakerMatcher
 
     let completedJobLifetime: TimeInterval
@@ -82,7 +81,6 @@ class PipelineQueue {
         self.diarizeEnabled = false
         self.numSpeakers = 0
         self.micLabel = "Me"
-        self.claudeBin = "claude"
         self.speakerMatcherFactory = { SpeakerMatcher() }
         self.completedJobLifetime = completedJobLifetime
     }
@@ -97,7 +95,6 @@ class PipelineQueue {
         diarizeEnabled: Bool = false,
         numSpeakers: Int = 0,
         micLabel: String = "Me",
-        claudeBin: String = "claude",
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = { SpeakerMatcher() },
         completedJobLifetime: TimeInterval = 60
     ) {
@@ -109,7 +106,6 @@ class PipelineQueue {
         self.diarizeEnabled = diarizeEnabled
         self.numSpeakers = numSpeakers
         self.micLabel = micLabel
-        self.claudeBin = claudeBin
         self.speakerMatcherFactory = speakerMatcherFactory
         self.completedJobLifetime = completedJobLifetime
     }
@@ -460,8 +456,7 @@ class PipelineQueue {
             let protocolMD = try await protocolGenerator.generate(
                 transcript: finalTranscript,
                 title: title,
-                diarized: diarized,
-                claudeBin: claudeBin
+                diarized: diarized
             )
 
             let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + finalTranscript

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -5,12 +5,14 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Protoco
 
 /// Abstraction for protocol generation, enabling mock injection in tests.
 protocol ProtocolGenerating {
-    func generate(transcript: String, title: String, diarized: Bool, claudeBin: String) async throws -> String
+    func generate(transcript: String, title: String, diarized: Bool) async throws -> String
 }
 
-/// Default implementation that delegates to `ProtocolGenerator.generate(...)`.
-struct DefaultProtocolGenerator: ProtocolGenerating {
-    func generate(transcript: String, title: String, diarized: Bool, claudeBin: String) async throws -> String {
+/// Claude CLI implementation that delegates to `ProtocolGenerator.generate(...)`.
+struct ClaudeCLIProtocolGenerator: ProtocolGenerating {
+    let claudeBin: String
+
+    func generate(transcript: String, title: String, diarized: Bool) async throws -> String {
         try await ProtocolGenerator.generate(transcript: transcript, title: title, diarized: diarized, claudeBin: claudeBin)
     }
 }

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -344,6 +344,8 @@ enum ProtocolError: LocalizedError {
     case cliFailed(Int, String)
     case emptyProtocol
     case timeout
+    case httpError(Int, String)
+    case connectionFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -351,6 +353,8 @@ enum ProtocolError: LocalizedError {
         case .cliFailed(let code, let stderr): "Claude CLI exited with code \(code)\(stderr.isEmpty ? "" : ": \(stderr)")"
         case .emptyProtocol: "Protocol is empty. Tip: Test manually: echo Hello | claude --print"
         case .timeout: "Claude CLI took too long (>10 min)"
+        case .httpError(let code, let body): "HTTP \(code)\(body.isEmpty ? "" : ": \(body)")"
+        case .connectionFailed(let reason): "Connection failed: \(reason)"
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @State private var accessibilityOK = false
     @State private var testingConnection = false
     @State private var connectionTestResult: ConnectionTestResult?
+    @State private var availableModels: [String] = []
     var whisperKitEngine: WhisperKitEngine
 
     enum ConnectionTestResult {
@@ -178,43 +179,51 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
 
                 case .openAICompatible:
-                    HStack {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text("Endpoint")
-                        Spacer()
-                        TextField("http://localhost:11434/v1/chat/completions", text: $settings.openAIEndpoint)
-                            .frame(width: 280)
-                            .multilineTextAlignment(.trailing)
+                        TextField("", text: $settings.openAIEndpoint)
+                            .textFieldStyle(.roundedBorder)
                     }
 
-                    HStack {
-                        Text("Model")
-                        Spacer()
-                        TextField("llama3.1", text: $settings.openAIModel)
-                            .frame(width: 160)
-                            .multilineTextAlignment(.trailing)
+                    if !availableModels.isEmpty {
+                        Picker("Model", selection: $settings.openAIModel) {
+                            ForEach(modelPickerOptions, id: \.self) { model in
+                                Text(model).tag(model)
+                            }
+                        }
+                    } else {
+                        HStack {
+                            Text("Model")
+                            Spacer()
+                            TextField("", text: $settings.openAIModel)
+                                .frame(width: 200)
+                                .multilineTextAlignment(.trailing)
+                        }
                     }
 
                     HStack {
                         Text("API Key")
                         Spacer()
-                        SecureField("Optional", text: $settings.openAIAPIKey)
-                            .frame(width: 160)
-                            .multilineTextAlignment(.trailing)
+                        SecureField("", text: $settings.openAIAPIKey)
+                            .frame(width: 200)
                     }
                     Text("Leave empty if your local server doesn't require authentication")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
                     HStack {
-                        Button("Test Connection") {
+                        Button {
                             testConnection()
+                        } label: {
+                            HStack(spacing: 4) {
+                                if testingConnection {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(availableModels.isEmpty ? "Fetch Models" : "Refresh Models")
+                            }
                         }
                         .disabled(testingConnection)
-
-                        if testingConnection {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
 
                         if let result = connectionTestResult {
                             switch result {
@@ -227,6 +236,11 @@ struct SettingsView: View {
                                     .foregroundStyle(.red)
                                     .font(.caption)
                             }
+                        }
+                    }
+                    .onAppear {
+                        if availableModels.isEmpty {
+                            testConnection()
                         }
                     }
                 }
@@ -278,7 +292,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 480)
+        .frame(width: 520)
         .onAppear {
             claudeBinaries = ProtocolGenerator.availableClaudeBinaries()
             refreshPermissions()
@@ -320,15 +334,30 @@ struct SettingsView: View {
             testingConnection = false
             switch result {
             case .success(let models):
-                if models.isEmpty {
-                    connectionTestResult = .success("Connected")
-                } else {
+                availableModels = models
+                if !models.isEmpty {
+                    // Auto-select first model if current selection is not available
+                    if !models.contains(settings.openAIModel) {
+                        settings.openAIModel = models[0]
+                    }
                     connectionTestResult = .success("Connected (\(models.count) models)")
+                } else {
+                    connectionTestResult = .success("Connected")
                 }
             case .failure(let error):
+                availableModels = []
                 connectionTestResult = .failure(error.localizedDescription)
             }
         }
+    }
+
+    /// Options for the model picker: fetched models + current setting if not in list.
+    private var modelPickerOptions: [String] {
+        var options = availableModels
+        if !settings.openAIModel.isEmpty && !options.contains(settings.openAIModel) {
+            options.insert(settings.openAIModel, at: 0)
+        }
+        return options
     }
 
     private func refreshAudioDevices() {

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -10,7 +10,14 @@ struct SettingsView: View {
     @State private var micPermission: AVAuthorizationStatus = .notDetermined
     @State private var screenRecordingOK = false
     @State private var accessibilityOK = false
+    @State private var testingConnection = false
+    @State private var connectionTestResult: ConnectionTestResult?
     var whisperKitEngine: WhisperKitEngine
+
+    enum ConnectionTestResult {
+        case success(String)
+        case failure(String)
+    }
 
     private let whisperKitModels: [(variant: String, label: String)] = [
         ("openai_whisper-large-v3-v20240930_turbo", "Large V3 Turbo (recommended)"),
@@ -153,14 +160,76 @@ struct SettingsView: View {
             }
 
             Section("Protocol Generation") {
-                Picker("Claude CLI", selection: $settings.claudeBin) {
-                    ForEach(claudeBinaries, id: \.self) { bin in
-                        Text(bin).tag(bin)
+                Picker("Provider", selection: $settings.protocolProvider) {
+                    ForEach(ProtocolProvider.allCases, id: \.self) { provider in
+                        Text(provider.label).tag(provider)
                     }
                 }
-                Text("Binary used for protocol generation")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+
+                switch settings.protocolProvider {
+                case .claudeCLI:
+                    Picker("Claude CLI", selection: $settings.claudeBin) {
+                        ForEach(claudeBinaries, id: \.self) { bin in
+                            Text(bin).tag(bin)
+                        }
+                    }
+                    Text("Binary used for protocol generation")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                case .openAICompatible:
+                    HStack {
+                        Text("Endpoint")
+                        Spacer()
+                        TextField("http://localhost:11434/v1/chat/completions", text: $settings.openAIEndpoint)
+                            .frame(width: 280)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    HStack {
+                        Text("Model")
+                        Spacer()
+                        TextField("llama3.1", text: $settings.openAIModel)
+                            .frame(width: 160)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    HStack {
+                        Text("API Key")
+                        Spacer()
+                        SecureField("Optional", text: $settings.openAIAPIKey)
+                            .frame(width: 160)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    Text("Leave empty if your local server doesn't require authentication")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        Button("Test Connection") {
+                            testConnection()
+                        }
+                        .disabled(testingConnection)
+
+                        if testingConnection {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+
+                        if let result = connectionTestResult {
+                            switch result {
+                            case .success(let msg):
+                                Label(msg, systemImage: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                    .font(.caption)
+                            case .failure(let msg):
+                                Label(msg, systemImage: "xmark.circle.fill")
+                                    .foregroundStyle(.red)
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                }
             }
 
             Section("Permissions") {
@@ -209,7 +278,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 420)
+        .frame(width: 480)
         .onAppear {
             claudeBinaries = ProtocolGenerator.availableClaudeBinaries()
             refreshPermissions()
@@ -236,6 +305,30 @@ struct SettingsView: View {
         micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
         screenRecordingOK = Permissions.checkScreenRecording()
         accessibilityOK = AXIsProcessTrusted()
+    }
+
+    private func testConnection() {
+        testingConnection = true
+        connectionTestResult = nil
+        Task {
+            let apiKey = settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey
+            let result = await OpenAIProtocolGenerator.testConnection(
+                endpoint: settings.openAIEndpoint,
+                model: settings.openAIModel,
+                apiKey: apiKey
+            )
+            testingConnection = false
+            switch result {
+            case .success(let models):
+                if models.isEmpty {
+                    connectionTestResult = .success("Connected")
+                } else {
+                    connectionTestResult = .success("Connected (\(models.count) models)")
+                }
+            case .failure(let error):
+                connectionTestResult = .failure(error.localizedDescription)
+            }
+        }
     }
 
     private func refreshAudioDevices() {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -13,7 +13,9 @@ final class AppSettingsTests: XCTestCase {
             "watchTeams", "watchZoom", "watchWebex",
             "pollInterval", "endGrace", "noMic", "micDeviceUID", "micName",
             "diarize", "numSpeakers", "whisperKitModel", "claudeBin",
+            "protocolProvider", "openAIEndpoint", "openAIModel",
         ]
+        KeychainHelper.delete(key: "openAIAPIKey")
         for key in keys {
             UserDefaults.standard.removeObject(forKey: key)
         }
@@ -133,6 +135,56 @@ final class AppSettingsTests: XCTestCase {
     func testMicNameSavedToDefaults() {
         settings.micName = "Roman"
         XCTAssertEqual(UserDefaults.standard.string(forKey: "micName"), "Roman")
+    }
+
+    // MARK: - Protocol Provider
+
+    func testProtocolProviderDefault() {
+        XCTAssertEqual(settings.protocolProvider, .claudeCLI)
+    }
+
+    func testProtocolProviderPersistence() {
+        settings.protocolProvider = .openAICompatible
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "protocolProvider"),
+            "openAICompatible"
+        )
+        // Verify a fresh instance reads it back
+        let fresh = AppSettings()
+        XCTAssertEqual(fresh.protocolProvider, .openAICompatible)
+    }
+
+    func testOpenAIEndpointDefault() {
+        XCTAssertEqual(settings.openAIEndpoint, "http://localhost:11434/v1/chat/completions")
+    }
+
+    func testOpenAIModelDefault() {
+        XCTAssertEqual(settings.openAIModel, "llama3.1")
+    }
+
+    func testOpenAIAPIKeyViaKeychainHelper() {
+        XCTAssertEqual(settings.openAIAPIKey, "")
+
+        settings.openAIAPIKey = "sk-test-key"
+        XCTAssertEqual(KeychainHelper.read(key: "openAIAPIKey"), "sk-test-key")
+        XCTAssertEqual(settings.openAIAPIKey, "sk-test-key")
+
+        settings.openAIAPIKey = ""
+        XCTAssertNil(KeychainHelper.read(key: "openAIAPIKey"))
+        XCTAssertEqual(settings.openAIAPIKey, "")
+    }
+
+    func testOpenAIEndpointSavedToDefaults() {
+        settings.openAIEndpoint = "http://localhost:8080/v1/chat/completions"
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "openAIEndpoint"),
+            "http://localhost:8080/v1/chat/completions"
+        )
+    }
+
+    func testOpenAIModelSavedToDefaults() {
+        settings.openAIModel = "mistral"
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "openAIModel"), "mistral")
     }
 
     // MARK: - Keychain

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import MeetingTranscriber
+
+final class OpenAIProtocolGeneratorTests: XCTestCase {
+
+    // MARK: - SSE Line Parsing
+
+    func testParseSSELineExtractsContent() {
+        let line = #"data: {"choices":[{"delta":{"content":"Hello"}}]}"#
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "Hello")
+    }
+
+    func testParseSSELineDoneReturnsNil() {
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine("data: [DONE]"))
+    }
+
+    func testParseSSELineEmptyDelta() {
+        let line = #"data: {"choices":[{"delta":{}}]}"#
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine(line))
+    }
+
+    func testParseSSELineInvalidJSON() {
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine("data: not json"))
+    }
+
+    func testParseSSELineEmptyLine() {
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine(""))
+    }
+
+    func testParseSSELineComment() {
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine(": keepalive"))
+    }
+
+    func testParseSSELineNoDataPrefix() {
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine("event: message"))
+    }
+
+    func testParseSSELineMultipleChoices() {
+        // Should extract from first choice
+        let line = #"data: {"choices":[{"delta":{"content":"A"}},{"delta":{"content":"B"}}]}"#
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "A")
+    }
+
+    func testParseSSELineRoleDelta() {
+        // Role-only delta (first chunk) has no content
+        let line = #"data: {"choices":[{"delta":{"role":"assistant"}}]}"#
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine(line))
+    }
+
+    func testParseSSELineEmptyContent() {
+        let line = #"data: {"choices":[{"delta":{"content":""}}]}"#
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "")
+    }
+
+    // MARK: - Prompt Construction
+
+    func testPromptContainsSystemInstructions() {
+        // Verify the protocol prompt includes key structural elements
+        let prompt = ProtocolGenerator.protocolPrompt
+        XCTAssertTrue(prompt.contains("meeting minute taker"))
+        XCTAssertTrue(prompt.contains("German"))
+        XCTAssertTrue(prompt.contains("Markdown"))
+    }
+
+    func testPromptIncludesDiarizationNote() {
+        let note = ProtocolGenerator.diarizationNote
+        XCTAssertTrue(note.contains("speaker labels"))
+        XCTAssertTrue(note.contains("SPEAKER_00"))
+    }
+
+    // MARK: - Initializer
+
+    func testDefaultTimeout() {
+        let gen = OpenAIProtocolGenerator(
+            endpoint: URL(string: "http://localhost:11434/v1/chat/completions")!,
+            model: "test"
+        )
+        XCTAssertEqual(gen.timeoutSeconds, 600)
+    }
+
+    func testCustomTimeout() {
+        let gen = OpenAIProtocolGenerator(
+            endpoint: URL(string: "http://localhost:11434/v1/chat/completions")!,
+            model: "test",
+            timeoutSeconds: 120
+        )
+        XCTAssertEqual(gen.timeoutSeconds, 120)
+    }
+
+    func testAPIKeyOptional() {
+        let gen = OpenAIProtocolGenerator(
+            endpoint: URL(string: "http://localhost:11434/v1/chat/completions")!,
+            model: "test"
+        )
+        XCTAssertNil(gen.apiKey)
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -341,7 +341,7 @@ final class PipelineQueueTests: XCTestCase {
             logDir: tmpDir,
             whisperKit: WhisperKitEngine(),
             diarizationFactory: { MockDiarization() },
-            protocolGenerator: MockProtocolGen(),
+            protocolGeneratorFactory: { MockProtocolGen() },
             outputDir: tmpDir,
             diarizeEnabled: false,
             micLabel: "Me"

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -114,6 +114,6 @@ final class SettingsViewTests: XCTestCase {
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Endpoint"))
         XCTAssertNoThrow(try body.find(text: "API Key"))
-        XCTAssertNoThrow(try body.find(text: "Test Connection"))
+        XCTAssertNoThrow(try body.find(text: "Fetch Models"))
     }
 }

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -89,4 +89,31 @@ final class SettingsViewTests: XCTestCase {
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Model"))
     }
+
+    // MARK: - Protocol Provider
+
+    func testProviderPickerExists() throws {
+        let settings = AppSettings()
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Provider"))
+    }
+
+    func testClaudeCLIProviderShowsBinaryPicker() throws {
+        let settings = AppSettings()
+        settings.protocolProvider = .claudeCLI
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Claude CLI"))
+    }
+
+    func testOpenAIProviderShowsEndpointField() throws {
+        let settings = AppSettings()
+        settings.protocolProvider = .openAICompatible
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Endpoint"))
+        XCTAssertNoThrow(try body.find(text: "API Key"))
+        XCTAssertNoThrow(try body.find(text: "Test Connection"))
+    }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -62,7 +62,7 @@ class MockProtocolGen: ProtocolGenerating {
     var capturedTitle: String?
     var capturedDiarized: Bool?
 
-    func generate(transcript: String, title: String, diarized: Bool, claudeBin: String) async throws -> String {
+    func generate(transcript: String, title: String, diarized: Bool) async throws -> String {
         generateCalled = true
         capturedTranscript = transcript
         capturedTitle = title

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -80,7 +80,7 @@ final class WatchLoopE2ETests: XCTestCase {
             logDir: tmpDir,
             whisperKit: whisperKit ?? WhisperKitEngine(),
             diarizationFactory: { diarization },
-            protocolGenerator: protocolGen,
+            protocolGeneratorFactory: { protocolGen },
             outputDir: tmpDir,
             diarizeEnabled: diarizeEnabled,
             micLabel: micLabel
@@ -415,7 +415,7 @@ final class WatchLoopE2ETests: XCTestCase {
             logDir: tmpDir,
             whisperKit: engine,
             diarizationFactory: { FluidDiarizer() },
-            protocolGenerator: mockProtocol,
+            protocolGeneratorFactory: { mockProtocol },
             outputDir: tmpDir,
             diarizeEnabled: true,
             micLabel: "Roman",


### PR DESCRIPTION
## Summary
- Refactors `ProtocolGenerating` protocol to remove `claudeBin` parameter — provider config is now encapsulated in each implementation
- Adds `ProtocolProvider` enum (`claudeCLI`, `openAICompatible`) with new AppSettings properties (endpoint, model, API key via KeychainHelper)
- New `OpenAIProtocolGenerator` with SSE streaming via `URLSession.bytes` — supports Ollama, LM Studio, llama.cpp, and any OpenAI-compatible server
- Settings UI with provider picker, auto-fetched model list from `/v1/models`, and connection test button
- Claude CLI remains the default — no behavior change for existing users

## Test plan
- [x] 411 tests pass (25 new tests added)
- [x] Manual: Settings → Provider picker → switch between Claude CLI and OpenAI-Compatible
- [x] Manual: OpenAI-Compatible → models auto-fetched on appear (requires running Ollama/LM Studio)
- [x] Manual: "Fetch Models" button → model picker populates
- [x] Manual: Switch back to Claude CLI → binary picker visible
- [x] Manual: Full pipeline with local LLM (Ollama + llama3.1)