### PR TITLE
fix(app): filter screen-share artifacts from participant names

### DIFF
--- a/app/MeetingTranscriber/Sources/ParticipantReader.swift
+++ b/app/MeetingTranscriber/Sources/ParticipantReader.swift
@@ -126,6 +126,22 @@ struct ParticipantReader {
 
             let lower = text.lowercased()
 
+            // Skip overly long strings — real names rarely exceed 60 chars
+            if text.count > 60 { continue }
+
+            // Skip strings with navigation arrows (screen-shared UI breadcrumbs)
+            if text.contains("→") || text.contains("›") { continue }
+
+            // Skip strings ending with ":" — UI labels, not names
+            if text.hasSuffix(":") || text.hasSuffix("::") { continue }
+
+            // Skip strings containing URL-like patterns
+            if lower.contains("://") || lower.contains(".com") || lower.contains(".ai")
+                || lower.contains(".io") || lower.contains(".org") || lower.contains(".net") { continue }
+
+            // Skip strings with path separators (UI navigation, file paths)
+            if text.contains("/") && text.filter({ $0 == "/" }).count >= 2 { continue }
+
             // Skip timestamps like "10:30"
             if text.contains(":") && text.contains(where: \.isNumber) { continue }
 

--- a/app/MeetingTranscriber/Tests/ParticipantReaderTests.swift
+++ b/app/MeetingTranscriber/Tests/ParticipantReaderTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import MeetingTranscriber
+
+final class ParticipantReaderTests: XCTestCase {
+
+    // MARK: - Basic Filtering
+
+    func testFilterValidNames() {
+        let input = ["Alice Smith", "Bob Jones", "Carol Lee"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice Smith", "Bob Jones", "Carol Lee"])
+    }
+
+    func testFilterRemovesEmptyAndShort() {
+        let input = ["", " ", "A", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesDuplicates() {
+        let input = ["Alice", "Alice", "Bob"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice", "Bob"])
+    }
+
+    func testFilterRemovesYouSuffix() {
+        let input = ["Alice Smith (you)"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice Smith"])
+    }
+
+    // MARK: - UI Label Filtering
+
+    func testFilterRemovesKnownUILabels() {
+        let input = ["Mute", "participants", "Alice", "Share"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesTimestamps() {
+        let input = ["10:30", "Alice", "2:45"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    // MARK: - Screen Share Artifact Filtering
+
+    func testFilterRemovesNavigationBreadcrumbs() {
+        let input = [
+            "Go to App → Settings → Connectors/Integrations → Connection:",
+            "Alice Smith",
+        ]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice Smith"])
+    }
+
+    func testFilterRemovesArrowSeparators() {
+        let input = ["Home → Settings → Profile", "Bob"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Bob"])
+    }
+
+    func testFilterRemovesChevronSeparators() {
+        let input = ["Home › Settings › Profile", "Carol"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Carol"])
+    }
+
+    func testFilterRemovesColonSuffix() {
+        let input = ["Integration-Page::", "Connection:", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesURLLikeStrings() {
+        let input = ["example.ai", "example.com", "example.io", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesHTTPUrls() {
+        let input = ["https://example.com", "http://localhost", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesLongStrings() {
+        let longText = String(repeating: "a", count: 61)
+        let input = [longText, "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterRemovesPathLikeStrings() {
+        let input = ["Connectors/Integrations/Settings", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice"])
+    }
+
+    func testFilterKeepsNameWithSingleSlash() {
+        // Some corporate names might have a single slash
+        let input = ["Team A/B", "Alice"]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Team A/B", "Alice"])
+    }
+
+    // MARK: - Realistic Screen Share Scenario
+
+    func testFilterRealisticScreenShareArtifacts() {
+        let input = [
+            "Alice Smith",
+            "Bob Jones",
+            "Go to App → Settings → Connectors/Integrations → Connection:",
+            "Integration-Page::",
+            "https://id.example.com/manage-profile",
+        ]
+        let result = ParticipantReader.filterParticipantNames(input)
+        XCTAssertEqual(result, ["Alice Smith", "Bob Jones"])
+    }
+}


### PR DESCRIPTION
## Summary
- When someone screen-shares in a Teams meeting, the shared content's accessibility elements leak into the participant roster reader (Strategy 2: AXList/AXTable containers)
- This caused speaker labels like `Geh in Claude.ai → Settings → Connectors/Integrations → Atlassian-Verbindung:` to appear in transcripts
- Adds heuristic filters to `ParticipantReader.filterParticipantNames`: max length (60 chars), no navigation arrows (→/›), no trailing colons, no URL patterns, no multi-slash paths
- Adds 16 unit tests for the filter logic including screen-share artifact scenarios

## Test plan
- [x] All 16 `ParticipantReaderTests` pass
- [ ] Verify in a real meeting with screen sharing that participant names are clean