### PR TITLE
docs: fix setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ Single-source: Audio → 16kHz mono WAV → WhisperKit → FluidAudio diarizatio
 # Build audiotap Swift binary (app audio capture):
 ./scripts/build_audiotap.sh
 
-# Swift menu bar app
-cd app/MeetingTranscriber && swift build -c release
+# Run menu bar app (builds automatically):
+./scripts/run_app.sh
 ```
 
 ## Key Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 git clone https://github.com/pasrom/meeting-transcriber
 cd meeting-transcriber
 ./scripts/build_audiotap.sh
-cd app/MeetingTranscriber && swift build
+./scripts/run_app.sh
 ```
 
 Run the tests to verify everything works:

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ brew install --cask meeting-transcriber
 
 ```bash
 git clone https://github.com/pasrom/meeting-transcriber
-cd Transcriber
+cd meeting-transcriber
 ./scripts/build_audiotap.sh
-cd app/MeetingTranscriber && swift build -c release
-cd ../..
 ./scripts/run_app.sh
 ```
 


### PR DESCRIPTION
## Summary
- Fix `cd Transcriber` → `cd meeting-transcriber` in README (matches actual clone dir)
- Remove redundant `swift build -c release` step — `run_app.sh` already builds
- Update CLAUDE.md and CONTRIBUTING.md accordingly