### PR TITLE
fix(build): use PlistBuddy for version injection

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -80,8 +80,8 @@ echo ""
 echo "Step 3: Assembling app bundle..."
 
 # Info.plist with version
-sed "s|<string>0.1.0</string>|<string>${VERSION}</string>|g" \
-    "$SPM_DIR/Sources/Info.plist" > "$CONTENTS/Info.plist"
+cp "$SPM_DIR/Sources/Info.plist" "$CONTENTS/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$CONTENTS/Info.plist"
 
 # App icon
 ICONSET_SRC="$SPM_DIR/Sources/Assets.xcassets/AppIcon.appiconset"

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -27,6 +27,10 @@ mkdir -p "$APP_MACOS"
 sed 's/com\.meetingtranscriber\.app/com.meetingtranscriber.dev/' \
     "$INFO_PLIST" > "$APP_BUNDLE/Contents/Info.plist"
 
+# Inject version from VERSION file
+APP_VERSION=$(cat "$TRANSCRIBER_ROOT/VERSION" | tr -d '[:space:]')
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $APP_VERSION" "$APP_BUNDLE/Contents/Info.plist"
+
 # Inject git commit hash into Info.plist
 GIT_HASH=$(git -C "$TRANSCRIBER_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 /usr/libexec/PlistBuddy -c "Add :GitCommitHash string $GIT_HASH" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || \


### PR DESCRIPTION
## Summary
- Replace fragile `sed` substitution (matching hardcoded `0.1.0`) with `PlistBuddy` in `build_release.sh`
- Add version injection from `VERSION` file to `run_app.sh` (dev builds showed `0.1.0` instead of current version)

## Test plan
- [ ] `./scripts/run_app.sh` — verify Settings → About shows correct version from `VERSION` file
- [ ] `./scripts/build_release.sh --no-notarize` — verify release build has correct version