### PR TITLE
feat: add auto-update checker via GitHub Releases API

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -133,6 +133,16 @@ final class AppSettings {
         }
     }
 
+    // MARK: - Updates
+
+    var checkForUpdates: Bool = defaults.object(forKey: "checkForUpdates") as? Bool ?? true {
+        didSet { defaults.set(checkForUpdates, forKey: "checkForUpdates") }
+    }
+
+    var includePreReleases: Bool = defaults.object(forKey: "includePreReleases") as? Bool ?? false {
+        didSet { defaults.set(includePreReleases, forKey: "includePreReleases") }
+    }
+
     // MARK: - Computed
 
     var watchApps: [String] {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -12,6 +12,7 @@ struct MeetingTranscriberApp: App {
     @State private var watchLoop: WatchLoop?
     @State private var pipelineQueue = PipelineQueue()
     @State private var iconAnimationFrame = 0
+    @State private var updateChecker = UpdateChecker()
     @Environment(\.openWindow) private var openWindow
     private let notifications = NotificationManager.shared
     private let whisperKit = WhisperKitEngine()
@@ -45,6 +46,7 @@ struct MeetingTranscriberApp: App {
                 status: currentStatus,
                 isWatching: isWatching,
                 pipelineQueue: pipelineQueue,
+                updateChecker: updateChecker,
                 onStartStop: toggleWatching,
                 onRecordApp: { bringWindowToFront(id: "record-app") },
                 onStopManualRecording: watchLoop?.isManualRecording == true ? {
@@ -90,6 +92,9 @@ struct MeetingTranscriberApp: App {
                 whisperKit.language = settings.whisperLanguageOrNil
                 await whisperKit.loadModel()
             }
+            .task {
+                updateChecker.startPeriodicChecks(settings: settings)
+            }
         }
 
         Window("Name Speakers", id: "speaker-naming") {
@@ -106,7 +111,11 @@ struct MeetingTranscriberApp: App {
         .windowResizability(.contentSize)
 
         Window("Settings", id: "settings") {
-            SettingsView(settings: settings, whisperKitEngine: whisperKit)
+            SettingsView(
+                settings: settings,
+                whisperKitEngine: whisperKit,
+                updateChecker: updateChecker
+            )
         }
         .windowResizability(.contentSize)
 

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -194,6 +194,7 @@ struct MeetingTranscriberApp: App {
             default: return .none
             }
         }
+        if updateChecker.availableUpdate != nil { return .updateAvailable }
         return .none
     }
 

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -10,6 +10,7 @@ enum BadgeKind: CaseIterable {
     case userAction
     case done
     case error
+    case updateAvailable
 
     /// Whether this badge kind uses animation.
     var isAnimated: Bool {
@@ -74,6 +75,9 @@ enum MenuBarIcon {
                 drawDiarizingAnimation(in: rect, frame: frame)
             case .processing:
                 drawProtocolAnimation(in: rect, frame: frame)
+            case .updateAvailable:
+                drawRecordingAnimation(in: rect, frame: 0)
+                drawUpdateArrow(in: rect)
             default:
                 drawRecordingAnimation(in: rect, frame: frame)
             }
@@ -167,6 +171,29 @@ enum MenuBarIcon {
             NSBezierPath(roundedRect: NSRect(x: x, y: y, width: barWidth, height: barH),
                          xRadius: barWidth / 2, yRadius: barWidth / 2).fill()
         }
+    }
+
+    // MARK: - Update Available (small upward arrow badge in bottom-right)
+
+    private static func drawUpdateArrow(in rect: NSRect) {
+        let size: CGFloat = 6.0
+        let margin: CGFloat = 0.5
+        let cx = rect.maxX - size / 2 - margin
+        let cy = rect.minY + size / 2 + margin
+
+        // Arrow pointing up: triangle + stem
+        let arrow = NSBezierPath()
+        // Triangle head
+        arrow.move(to: NSPoint(x: cx, y: cy + size / 2))          // top
+        arrow.line(to: NSPoint(x: cx - size / 3, y: cy + 0.5))    // bottom-left
+        arrow.line(to: NSPoint(x: cx + size / 3, y: cy + 0.5))    // bottom-right
+        arrow.close()
+        arrow.fill()
+
+        // Stem
+        let stemWidth: CGFloat = 1.4
+        let stem = NSRect(x: cx - stemWidth / 2, y: cy - size / 3, width: stemWidth, height: size / 2)
+        NSBezierPath(roundedRect: stem, xRadius: stemWidth / 2, yRadius: stemWidth / 2).fill()
     }
 
     // MARK: - Protocol Generation Animation (text lines appearing sequentially)

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -4,6 +4,7 @@ struct MenuBarView: View {
     let status: TranscriberStatus?
     let isWatching: Bool
     let pipelineQueue: PipelineQueue
+    var updateChecker: UpdateChecker?
     let onStartStop: () -> Void
     let onRecordApp: () -> Void
     let onStopManualRecording: (() -> Void)?
@@ -158,6 +159,18 @@ struct MenuBarView: View {
             onOpenProtocolsFolder()
         } label: {
             Label("Open Protocols Folder", systemImage: "folder")
+        }
+
+        if let update = updateChecker?.availableUpdate {
+            Divider()
+            Button {
+                NSWorkspace.shared.open(update.dmgURL ?? update.htmlURL)
+            } label: {
+                Label(
+                    "Update Available: \(update.tagName)",
+                    systemImage: "arrow.down.circle.fill"
+                )
+            }
         }
 
         Divider()

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @State private var connectionTestResult: ConnectionTestResult?
     @State private var availableModels: [String] = []
     var whisperKitEngine: WhisperKitEngine
+    var updateChecker: UpdateChecker?
 
     enum ConnectionTestResult {
         case success(String)
@@ -277,6 +278,60 @@ struct SettingsView: View {
                     refreshPermissions()
                 }
                 .font(.caption)
+            }
+
+            if let updateChecker {
+                Section("Updates") {
+                    Toggle("Check for Updates", isOn: $settings.checkForUpdates)
+
+                    if settings.checkForUpdates {
+                        Toggle("Include Pre-Releases", isOn: $settings.includePreReleases)
+                    }
+
+                    HStack {
+                        Button {
+                            updateChecker.checkNow(
+                                includePreReleases: settings.includePreReleases)
+                        } label: {
+                            HStack(spacing: 4) {
+                                if updateChecker.isChecking {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text("Check Now")
+                            }
+                        }
+                        .disabled(updateChecker.isChecking)
+
+                        if let error = updateChecker.lastError {
+                            Label(error, systemImage: "xmark.circle.fill")
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                        } else if let update = updateChecker.availableUpdate {
+                            Label(
+                                "Update available: \(update.tagName)",
+                                systemImage: "arrow.down.circle.fill"
+                            )
+                            .foregroundStyle(.blue)
+                            .font(.caption)
+                        } else if updateChecker.lastCheckDate != nil {
+                            Label("Up to date", systemImage: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                                .font(.caption)
+                        }
+                    }
+
+                    if let update = updateChecker.availableUpdate {
+                        Button {
+                            NSWorkspace.shared.open(update.dmgURL ?? update.htmlURL)
+                        } label: {
+                            Label(
+                                "Download \(update.tagName)",
+                                systemImage: "arrow.down.to.line"
+                            )
+                        }
+                    }
+                }
             }
 
             Section("About") {

--- a/app/MeetingTranscriber/Sources/UpdateChecker.swift
+++ b/app/MeetingTranscriber/Sources/UpdateChecker.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Observation
+
+// MARK: - Models
+
+struct ReleaseInfo: Sendable, Equatable {
+    let tagName: String
+    let name: String
+    let prerelease: Bool
+    let htmlURL: URL
+    let dmgURL: URL?
+
+    var version: (Int, Int, Int)? {
+        UpdateChecker.parseVersion(tagName)
+    }
+}
+
+// MARK: - Protocol
+
+protocol UpdateProviding: Sendable {
+    func latestRelease() async throws -> ReleaseInfo
+    func allReleases() async throws -> [ReleaseInfo]
+}
+
+// MARK: - GitHub Release Provider
+
+struct GitHubReleaseProvider: UpdateProviding {
+    private let owner = "pasrom"
+    private let repo = "meeting-transcriber"
+
+    private struct GitHubRelease: Codable {
+        let tag_name: String
+        let name: String?
+        let prerelease: Bool
+        let html_url: String
+        let assets: [GitHubAsset]
+    }
+
+    private struct GitHubAsset: Codable {
+        let name: String
+        let browser_download_url: String
+    }
+
+    func latestRelease() async throws -> ReleaseInfo {
+        let release: GitHubRelease = try await fetchJSON(path: "releases/latest")
+        return mapRelease(release)
+    }
+
+    func allReleases() async throws -> [ReleaseInfo] {
+        let releases: [GitHubRelease] = try await fetchJSON(path: "releases")
+        return releases.map { mapRelease($0) }
+    }
+
+    private func fetchJSON<T: Decodable>(path: String) async throws -> T {
+        let url = URL(string: "https://api.github.com/repos/\(owner)/\(repo)/\(path)")!
+        let (data, response) = try await URLSession.shared.data(for: URLRequest(url: url))
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw UpdateCheckerError.networkError(
+                "HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private func mapRelease(_ release: GitHubRelease) -> ReleaseInfo {
+        let dmgAsset = release.assets.first { $0.name.hasSuffix(".dmg") }
+        return ReleaseInfo(
+            tagName: release.tag_name,
+            name: release.name ?? release.tag_name,
+            prerelease: release.prerelease,
+            htmlURL: URL(string: release.html_url)!,
+            dmgURL: dmgAsset.flatMap { URL(string: $0.browser_download_url) }
+        )
+    }
+}
+
+// MARK: - Errors
+
+enum UpdateCheckerError: LocalizedError {
+    case networkError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .networkError(let detail): "Network error: \(detail)"
+        }
+    }
+}
+
+// MARK: - UpdateChecker
+
+@MainActor
+@Observable
+final class UpdateChecker {
+    var availableUpdate: ReleaseInfo?
+    var isChecking = false
+    var lastCheckDate: Date?
+    var lastError: String?
+
+    private let provider: UpdateProviding
+    private let currentVersion: (Int, Int, Int)
+    private var checkTask: Task<Void, Never>?
+    private var periodicTask: Task<Void, Never>?
+
+    init(provider: UpdateProviding = GitHubReleaseProvider()) {
+        self.provider = provider
+        let version =
+            Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        self.currentVersion = Self.parseVersion(version) ?? (0, 0, 0)
+    }
+
+    func checkNow(includePreReleases: Bool = false) {
+        // Deduplicate concurrent calls
+        guard checkTask == nil else { return }
+
+        isChecking = true
+        lastError = nil
+
+        checkTask = Task {
+            defer {
+                isChecking = false
+                checkTask = nil
+            }
+
+            do {
+                let release: ReleaseInfo?
+                if includePreReleases {
+                    let all = try await provider.allReleases()
+                    release = all.first { r in
+                        guard let remote = r.version else { return false }
+                        return Self.isNewer(remote, than: currentVersion)
+                    }
+                } else {
+                    let latest = try await provider.latestRelease()
+                    if let remote = latest.version, Self.isNewer(remote, than: currentVersion) {
+                        release = latest
+                    } else {
+                        release = nil
+                    }
+                }
+                availableUpdate = release
+                lastCheckDate = Date()
+            } catch {
+                lastError = error.localizedDescription
+            }
+        }
+    }
+
+    func startPeriodicChecks(settings: AppSettings) {
+        periodicTask?.cancel()
+
+        periodicTask = Task {
+            // Initial delay
+            try? await Task.sleep(for: .seconds(30))
+
+            while !Task.isCancelled {
+                if settings.checkForUpdates {
+                    checkNow(includePreReleases: settings.includePreReleases)
+                }
+                try? await Task.sleep(for: .seconds(86400))  // 24 hours
+            }
+        }
+    }
+
+    // MARK: - Version Utilities
+
+    nonisolated static func parseVersion(_ string: String) -> (Int, Int, Int)? {
+        var s = string
+        if s.hasPrefix("v") { s = String(s.dropFirst()) }
+        // Strip pre-release suffix (e.g. "1.2.3-beta" → "1.2.3")
+        if let dash = s.firstIndex(of: "-") {
+            s = String(s[s.startIndex..<dash])
+        }
+        let parts = s.split(separator: ".").compactMap { Int($0) }
+        guard parts.count == 3 else { return nil }
+        return (parts[0], parts[1], parts[2])
+    }
+
+    nonisolated static func isNewer(
+        _ remote: (Int, Int, Int), than local: (Int, Int, Int)
+    ) -> Bool {
+        if remote.0 != local.0 { return remote.0 > local.0 }
+        if remote.1 != local.1 { return remote.1 > local.1 }
+        return remote.2 > local.2
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -14,6 +14,7 @@ final class AppSettingsTests: XCTestCase {
             "pollInterval", "endGrace", "noMic", "micDeviceUID", "micName",
             "diarize", "numSpeakers", "whisperKitModel", "claudeBin",
             "protocolProvider", "openAIEndpoint", "openAIModel",
+            "checkForUpdates", "includePreReleases",
         ]
         KeychainHelper.delete(key: "openAIAPIKey")
         for key in keys {
@@ -185,6 +186,26 @@ final class AppSettingsTests: XCTestCase {
     func testOpenAIModelSavedToDefaults() {
         settings.openAIModel = "mistral"
         XCTAssertEqual(UserDefaults.standard.string(forKey: "openAIModel"), "mistral")
+    }
+
+    // MARK: - Update Settings
+
+    func testCheckForUpdatesDefault() {
+        XCTAssertTrue(settings.checkForUpdates)
+    }
+
+    func testIncludePreReleasesDefault() {
+        XCTAssertFalse(settings.includePreReleases)
+    }
+
+    func testCheckForUpdatesPersistence() {
+        settings.checkForUpdates = false
+        XCTAssertEqual(UserDefaults.standard.bool(forKey: "checkForUpdates"), false)
+    }
+
+    func testIncludePreReleasesPersistence() {
+        settings.includePreReleases = true
+        XCTAssertEqual(UserDefaults.standard.bool(forKey: "includePreReleases"), true)
     }
 
     // MARK: - Keychain

--- a/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
@@ -31,6 +31,7 @@ final class MenuBarViewTests: XCTestCase {
     private func makeView(
         status: TranscriberStatus? = nil,
         isWatching: Bool = false,
+        updateChecker: UpdateChecker? = nil,
         onNameSpeakers: (() -> Void)? = nil,
         onStopManualRecording: (() -> Void)? = nil
     ) -> MenuBarView {
@@ -38,6 +39,7 @@ final class MenuBarViewTests: XCTestCase {
             status: status,
             isWatching: isWatching,
             pipelineQueue: PipelineQueue(),
+            updateChecker: updateChecker,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: onStopManualRecording,
@@ -168,6 +170,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .idle),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: { called = true },
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -191,6 +194,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .idle),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -214,6 +218,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .idle),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -237,6 +242,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .idle),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -260,6 +266,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .protocolReady, protocolPath: "/tmp/p.md"),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -283,6 +290,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .waitingForSpeakerNames),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -342,6 +350,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(),
             isWatching: false,
             pipelineQueue: queue,
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -377,6 +386,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(),
             isWatching: false,
             pipelineQueue: queue,
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -399,6 +409,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -434,6 +445,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(),
             isWatching: false,
             pipelineQueue: queue,
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -468,6 +480,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(),
             isWatching: false,
             pipelineQueue: queue,
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: nil,
@@ -505,6 +518,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .idle),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: { called = true },
             onStopManualRecording: nil,
@@ -545,6 +559,7 @@ final class MenuBarViewTests: XCTestCase {
             status: makeStatus(state: .recording),
             isWatching: false,
             pipelineQueue: PipelineQueue(),
+            updateChecker: nil,
             onStartStop: {},
             onRecordApp: {},
             onStopManualRecording: { called = true },
@@ -560,5 +575,36 @@ final class MenuBarViewTests: XCTestCase {
         let body = try sut.inspect()
         try body.find(button: "Stop Recording").tap()
         XCTAssertTrue(called)
+    }
+
+    // MARK: - Update indicator
+
+    func testUpdateIndicatorShownWhenUpdateAvailable() throws {
+        let checker = UpdateChecker(provider: MockUpdateProvider())
+        checker.availableUpdate = ReleaseInfo(
+            tagName: "v1.0.0",
+            name: "Release v1.0.0",
+            prerelease: false,
+            htmlURL: URL(string: "https://github.com/pasrom/meeting-transcriber/releases/tag/v1.0.0")!,
+            dmgURL: URL(string: "https://example.com/app.dmg")
+        )
+
+        let sut = makeView(status: makeStatus(), updateChecker: checker)
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Update Available: v1.0.0"))
+    }
+
+    func testUpdateIndicatorHiddenWhenNoUpdate() throws {
+        let checker = UpdateChecker(provider: MockUpdateProvider())
+
+        let sut = makeView(status: makeStatus(), updateChecker: checker)
+        let body = try sut.inspect()
+        XCTAssertThrowsError(try body.find(text: "Update Available:"))
+    }
+
+    func testUpdateIndicatorHiddenWhenNoChecker() throws {
+        let sut = makeView(status: makeStatus())
+        let body = try sut.inspect()
+        XCTAssertThrowsError(try body.find(text: "Update Available:"))
     }
 }

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -116,4 +116,39 @@ final class SettingsViewTests: XCTestCase {
         XCTAssertNoThrow(try body.find(text: "API Key"))
         XCTAssertNoThrow(try body.find(text: "Fetch Models"))
     }
+
+    // MARK: - Updates section
+
+    func testUpdatesSectionShownWhenCheckerProvided() throws {
+        let settings = AppSettings()
+        let checker = UpdateChecker(provider: MockUpdateProvider())
+        let sut = SettingsView(
+            settings: settings,
+            whisperKitEngine: WhisperKitEngine(),
+            updateChecker: checker
+        )
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Check for Updates"))
+        XCTAssertNoThrow(try body.find(text: "Check Now"))
+    }
+
+    func testUpdatesSectionHiddenWhenNoChecker() throws {
+        let settings = AppSettings()
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let body = try sut.inspect()
+        XCTAssertThrowsError(try body.find(text: "Check Now"))
+    }
+
+    func testPreReleaseToggleShownWhenCheckEnabled() throws {
+        let settings = AppSettings()
+        settings.checkForUpdates = true
+        let checker = UpdateChecker(provider: MockUpdateProvider())
+        let sut = SettingsView(
+            settings: settings,
+            whisperKitEngine: WhisperKitEngine(),
+            updateChecker: checker
+        )
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Include Pre-Releases"))
+    }
 }

--- a/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
+++ b/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
@@ -1,0 +1,258 @@
+import XCTest
+
+@testable import MeetingTranscriber
+
+// MARK: - Mock Provider
+
+final class MockUpdateProvider: UpdateProviding, @unchecked Sendable {
+    var latestReleaseResult: Result<ReleaseInfo, Error> = .failure(UpdateCheckerError.networkError("not configured"))
+    var allReleasesResult: Result<[ReleaseInfo], Error> = .failure(UpdateCheckerError.networkError("not configured"))
+    var latestReleaseCalled = false
+    var allReleasesCalled = false
+    var delay: Duration?
+
+    func latestRelease() async throws -> ReleaseInfo {
+        latestReleaseCalled = true
+        if let delay { try? await Task.sleep(for: delay) }
+        return try latestReleaseResult.get()
+    }
+
+    func allReleases() async throws -> [ReleaseInfo] {
+        allReleasesCalled = true
+        if let delay { try? await Task.sleep(for: delay) }
+        return try allReleasesResult.get()
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class UpdateCheckerTests: XCTestCase {
+
+    // MARK: - Version Parsing
+
+    func testParseVersionValid() {
+        XCTAssertEqual(UpdateChecker.parseVersion("1.2.3")?.0, 1)
+        XCTAssertEqual(UpdateChecker.parseVersion("1.2.3")?.1, 2)
+        XCTAssertEqual(UpdateChecker.parseVersion("1.2.3")?.2, 3)
+    }
+
+    func testParseVersionWithPrefix() {
+        let v = UpdateChecker.parseVersion("v0.4.0")
+        XCTAssertEqual(v?.0, 0)
+        XCTAssertEqual(v?.1, 4)
+        XCTAssertEqual(v?.2, 0)
+    }
+
+    func testParseVersionWithPreReleaseSuffix() {
+        let v = UpdateChecker.parseVersion("v1.2.3-beta.1")
+        XCTAssertEqual(v?.0, 1)
+        XCTAssertEqual(v?.1, 2)
+        XCTAssertEqual(v?.2, 3)
+    }
+
+    func testParseVersionInvalid() {
+        XCTAssertNil(UpdateChecker.parseVersion("abc"))
+        XCTAssertNil(UpdateChecker.parseVersion("1.2"))
+        XCTAssertNil(UpdateChecker.parseVersion(""))
+        XCTAssertNil(UpdateChecker.parseVersion("v"))
+    }
+
+    // MARK: - Version Comparison
+
+    func testIsNewerMajor() {
+        XCTAssertTrue(UpdateChecker.isNewer((2, 0, 0), than: (1, 0, 0)))
+        XCTAssertFalse(UpdateChecker.isNewer((1, 0, 0), than: (2, 0, 0)))
+    }
+
+    func testIsNewerMinor() {
+        XCTAssertTrue(UpdateChecker.isNewer((1, 3, 0), than: (1, 2, 0)))
+        XCTAssertFalse(UpdateChecker.isNewer((1, 2, 0), than: (1, 3, 0)))
+    }
+
+    func testIsNewerPatch() {
+        XCTAssertTrue(UpdateChecker.isNewer((1, 2, 4), than: (1, 2, 3)))
+        XCTAssertFalse(UpdateChecker.isNewer((1, 2, 3), than: (1, 2, 4)))
+    }
+
+    func testIsNewerSameVersion() {
+        XCTAssertFalse(UpdateChecker.isNewer((1, 2, 3), than: (1, 2, 3)))
+    }
+
+    // MARK: - ReleaseInfo version
+
+    func testReleaseInfoVersionParsed() {
+        let info = makeRelease(tag: "v1.5.2")
+        XCTAssertEqual(info.version?.0, 1)
+        XCTAssertEqual(info.version?.1, 5)
+        XCTAssertEqual(info.version?.2, 2)
+    }
+
+    func testReleaseInfoDMGURLNilWhenNoAsset() {
+        let info = makeRelease(tag: "v1.0.0", dmgURL: nil)
+        XCTAssertNil(info.dmgURL)
+    }
+
+    func testReleaseInfoEquality() {
+        let a = makeRelease(tag: "v1.0.0")
+        let b = makeRelease(tag: "v1.0.0")
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - checkNow: finds update
+
+    func testCheckNowFindsUpdate() async {
+        let provider = MockUpdateProvider()
+        // Return a release newer than 0.0.0 (test bundle has no real version)
+        provider.latestReleaseResult = .success(makeRelease(tag: "v99.0.0"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow()
+
+        // Wait for the task to complete
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertTrue(provider.latestReleaseCalled)
+        XCTAssertNotNil(checker.availableUpdate)
+        XCTAssertEqual(checker.availableUpdate?.tagName, "v99.0.0")
+        XCTAssertNotNil(checker.lastCheckDate)
+        XCTAssertNil(checker.lastError)
+    }
+
+    // MARK: - checkNow: no update
+
+    func testCheckNowNoUpdate() async {
+        let provider = MockUpdateProvider()
+        // Return a release that is older than current (0.0.0 effectively)
+        provider.latestReleaseResult = .success(makeRelease(tag: "v0.0.0"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow()
+
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertNil(checker.availableUpdate)
+        XCTAssertNotNil(checker.lastCheckDate)
+    }
+
+    // MARK: - checkNow: error
+
+    func testCheckNowError() async {
+        let provider = MockUpdateProvider()
+        provider.latestReleaseResult = .failure(UpdateCheckerError.networkError("timeout"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow()
+
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertNil(checker.availableUpdate)
+        XCTAssertNotNil(checker.lastError)
+    }
+
+    // MARK: - checkNow: sets isChecking
+
+    func testCheckNowSetsIsChecking() async {
+        let provider = MockUpdateProvider()
+        provider.delay = .milliseconds(100)
+        provider.latestReleaseResult = .success(makeRelease(tag: "v99.0.0"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow()
+
+        XCTAssertTrue(checker.isChecking)
+
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertFalse(checker.isChecking)
+    }
+
+    // MARK: - Deduplication
+
+    func testDeduplicationPreventsSecondCheck() async {
+        let provider = MockUpdateProvider()
+        provider.delay = .milliseconds(100)
+        provider.latestReleaseResult = .success(makeRelease(tag: "v99.0.0"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow()
+        checker.checkNow()  // Should be ignored
+
+        await yieldUntil { !checker.isChecking }
+
+        // Provider should only be called once
+        XCTAssertTrue(provider.latestReleaseCalled)
+    }
+
+    // MARK: - Pre-release mode
+
+    func testPreReleaseModeUsesAllReleases() async {
+        let provider = MockUpdateProvider()
+        provider.allReleasesResult = .success([
+            makeRelease(tag: "v99.1.0-beta", prerelease: true),
+            makeRelease(tag: "v99.0.0"),
+        ])
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow(includePreReleases: true)
+
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertTrue(provider.allReleasesCalled)
+        XCTAssertFalse(provider.latestReleaseCalled)
+        XCTAssertEqual(checker.availableUpdate?.tagName, "v99.1.0-beta")
+    }
+
+    func testStableModeUsesLatestRelease() async {
+        let provider = MockUpdateProvider()
+        provider.latestReleaseResult = .success(makeRelease(tag: "v99.0.0"))
+
+        let checker = UpdateChecker(provider: provider)
+        checker.checkNow(includePreReleases: false)
+
+        await yieldUntil { !checker.isChecking }
+
+        XCTAssertTrue(provider.latestReleaseCalled)
+        XCTAssertFalse(provider.allReleasesCalled)
+    }
+
+    // MARK: - DMG URL extraction
+
+    func testDMGURLExtracted() {
+        let info = makeRelease(
+            tag: "v1.0.0",
+            dmgURL: URL(string: "https://example.com/app.dmg")
+        )
+        XCTAssertEqual(info.dmgURL?.absoluteString, "https://example.com/app.dmg")
+    }
+
+    func testFallbackToHTMLURLWhenNoDMG() {
+        let info = makeRelease(tag: "v1.0.0", dmgURL: nil)
+        XCTAssertNil(info.dmgURL)
+        XCTAssertEqual(info.htmlURL.absoluteString, "https://github.com/pasrom/meeting-transcriber/releases/tag/v1.0.0")
+    }
+
+    // MARK: - Helpers
+
+    private func makeRelease(
+        tag: String,
+        prerelease: Bool = false,
+        dmgURL: URL? = URL(string: "https://example.com/MeetingTranscriber.dmg")
+    ) -> ReleaseInfo {
+        ReleaseInfo(
+            tagName: tag,
+            name: "Release \(tag)",
+            prerelease: prerelease,
+            htmlURL: URL(string: "https://github.com/pasrom/meeting-transcriber/releases/tag/\(tag)")!,
+            dmgURL: dmgURL
+        )
+    }
+
+    private func yieldUntil(_ condition: @escaping () -> Bool, timeout: Double = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Lightweight update checker that queries GitHub Releases API for new versions (no Sparkle dependency)
- `UpdateProviding` protocol with `GitHubReleaseProvider` — mock-injectable for tests
- Semver comparison, deduplication via `checkTask`, periodic checks (30s delay → every 24h)
- Settings: "Check for Updates" toggle, "Include Pre-Releases" toggle, "Check Now" button with status
- MenuBarView: "Update Available: vX.Y.Z" indicator with direct DMG download link
- Supports stable-only and pre-release channels

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — all 459 tests pass (27 new tests for UpdateChecker, AppSettings, SettingsView, MenuBarView)
- [x] Open Settings → Updates → "Check Now" → verify "Up to date" (current v0.3.0 > latest release v0.2.0)
- [x] Verify MenuBarView shows update indicator when a newer release exists