### PR TITLE
ci: add release note categorization and release flags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feat
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "🧹 Maintenance"
+      labels:
+        - chore
+        - refactor
+        - dependencies
+    - title: "📖 Documentation"
+      labels:
+        - documentation
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
             ${{ steps.sha.outputs.sha256 }}
             ```
           generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: Update Homebrew tap with new version and SHA256
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` to categorize auto-generated release notes by PR labels (Features, Bug Fixes, Maintenance, Documentation)
- Set `draft: false` explicitly on GitHub Release creation
- Auto-detect pre-releases from tag name: `v0.3.0-rc1` → prerelease, `v0.3.0` → stable

## Test plan
- [ ] Push a `v*-rc1` tag → verify GitHub Release is marked as pre-release
- [ ] Push a `v*` tag → verify GitHub Release is marked as stable
- [ ] Add labels to PRs → verify release notes are categorized