### PR TITLE
fix(build): use tag name as DMG version for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,24 @@ jobs:
           TEAM_ID: ${{ secrets.TEAM_ID }}
           APP_PASSWORD: ${{ secrets.APP_PASSWORD }}
         run: |
+          # Use tag name as version (v0.3.0-rc1 → 0.3.0-rc1), fall back to VERSION file
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            BUILD_VERSION="--version=${GITHUB_REF_NAME#v}"
+          fi
           if [ -n "$DEVELOPER_ID" ]; then
-            ./scripts/build_release.sh
+            ./scripts/build_release.sh ${BUILD_VERSION:-}
           else
-            ./scripts/build_release.sh --no-notarize
+            ./scripts/build_release.sh --no-notarize ${BUILD_VERSION:-}
           fi
 
       - name: Get version
         id: version
         run: |
-          VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(cat VERSION | tr -d '[:space:]')
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compute DMG SHA256

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -30,14 +30,20 @@ MACOS_DIR="$CONTENTS/MacOS"
 RESOURCES="$CONTENTS/Resources"
 
 NOTARIZE=true
+OVERRIDE_VERSION=""
 for arg in "$@"; do
     case "$arg" in
         --no-notarize) NOTARIZE=false ;;
+        --version=*) OVERRIDE_VERSION="${arg#--version=}" ;;
     esac
 done
 
-# Read version from VERSION file
-VERSION=$(cat "$PROJECT_ROOT/VERSION" | tr -d '[:space:]')
+# Read version: prefer --version flag, then VERSION file
+if [ -n "$OVERRIDE_VERSION" ]; then
+    VERSION="$OVERRIDE_VERSION"
+else
+    VERSION=$(cat "$PROJECT_ROOT/VERSION" | tr -d '[:space:]')
+fi
 echo "Building MeetingTranscriber v${VERSION}"
 echo "  Notarize:    $NOTARIZE"
 echo "======================================="


### PR DESCRIPTION
## Summary
- Add `--version` flag to `build_release.sh` to override VERSION file
- Release workflow passes tag name (e.g. `v0.3.0-rc1` → `0.3.0-rc1`) so DMG filename and Info.plist include pre-release suffix

## Test plan
- [ ] `./scripts/build_release.sh --no-notarize --version=0.3.0-rc1` → DMG named `MeetingTranscriber-0.3.0-rc1.dmg`
- [ ] `./scripts/build_release.sh --no-notarize` → still uses VERSION file