### PR TITLE
fix(ci): use ncipollo/release-action for complete release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,23 @@ jobs:
           path: .build/release/MeetingTranscriber-${{ steps.version.outputs.version }}.dmg
           retention-days: 3
 
+      - name: Find previous stable release
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: prev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          files: .build/release/MeetingTranscriber-${{ steps.version.outputs.version }}.dmg
+          artifacts: .build/release/MeetingTranscriber-${{ steps.version.outputs.version }}.dmg
+          generateReleaseNotes: true
+          generateReleaseNotesPreviousTag: ${{ steps.prev.outputs.tag }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
           body: |
             ## MeetingTranscriber ${{ steps.version.outputs.version }}
 
@@ -122,9 +134,6 @@ jobs:
             ```
             ${{ steps.sha.outputs.sha256 }}
             ```
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: Update Homebrew tap with new version and SHA256
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Replace `softprops/action-gh-release@v2` with `ncipollo/release-action@v1`
- New step finds last stable release via `gh release list --exclude-pre-releases`
- Passes it as `generateReleaseNotesPreviousTag` so final releases always include all changes since last stable — not just the delta from the last pre-release (RC)

## Context
With `softprops`, `generate_release_notes: true` compared `v0.3.0` against `v0.3.0-rc1` instead of `v0.2.0`, resulting in incomplete release notes for the final release.

## Test plan
- [ ] Tag `v0.3.1-rc1` → release notes should span from `v0.3.0`
- [ ] Tag `v0.3.1` → release notes should also span from `v0.3.0` (not from rc1)