### PR TITLE
feat(app): add configurable protocol prompt via file

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -22,4 +22,7 @@ enum AppPaths {
 
     /// Speaker voice profiles DB.
     static let speakersDB = dataDir.appendingPathComponent("speakers.json")
+
+    /// Custom protocol prompt file.
+    static let customPromptFile = dataDir.appendingPathComponent("protocol_prompt.md")
 }

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -18,7 +18,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     }
 
     func generate(transcript: String, title: String, diarized: Bool) async throws -> String {
-        var systemPrompt = ProtocolGenerator.protocolPrompt
+        var systemPrompt = ProtocolGenerator.loadPrompt()
         if diarized {
             systemPrompt += ProtocolGenerator.diarizationNote
         }

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -83,6 +83,20 @@ struct ProtocolGenerator {
 
         """
 
+    /// Load the protocol prompt, preferring a custom file over the built-in default.
+    ///
+    /// Reads `AppPaths.customPromptFile` if it exists and is non-empty,
+    /// otherwise falls back to the hardcoded `protocolPrompt`.
+    static func loadPrompt() -> String {
+        let url = AppPaths.customPromptFile
+        if let custom = try? String(contentsOf: url, encoding: .utf8),
+           !custom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            logger.info("Using custom protocol prompt from \(url.path)")
+            return custom
+        }
+        return protocolPrompt
+    }
+
     /// Generate a meeting protocol from a transcript using the Claude CLI.
     ///
     /// - Parameters:
@@ -97,7 +111,7 @@ struct ProtocolGenerator {
         diarized: Bool = false,
         claudeBin: String = "claude"
     ) async throws -> String {
-        var prompt = protocolPrompt
+        var prompt = loadPrompt()
         if diarized {
             prompt += diarizationNote
         }

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -1,6 +1,7 @@
 import ApplicationServices
 import AVFoundation
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Bindable var settings: AppSettings
@@ -13,6 +14,8 @@ struct SettingsView: View {
     @State private var testingConnection = false
     @State private var connectionTestResult: ConnectionTestResult?
     @State private var availableModels: [String] = []
+    @State private var showResetPromptConfirmation = false
+    @State private var hasCustomPrompt = FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path)
     var whisperKitEngine: WhisperKitEngine
     var updateChecker: UpdateChecker?
 
@@ -245,6 +248,45 @@ struct SettingsView: View {
                         }
                     }
                 }
+
+                HStack {
+                    Button("Edit Prompt") {
+                        openCustomPrompt()
+                        refreshCustomPromptState()
+                    }
+
+                    Button("Import Prompt") {
+                        importCustomPrompt()
+                        refreshCustomPromptState()
+                    }
+
+                    Button("Reset to Default") {
+                        showResetPromptConfirmation = true
+                    }
+                    .disabled(!hasCustomPrompt)
+                    .confirmationDialog(
+                        "Reset protocol prompt to the built-in default?",
+                        isPresented: $showResetPromptConfirmation,
+                        titleVisibility: .visible
+                    ) {
+                        Button("Reset", role: .destructive) {
+                            try? FileManager.default.removeItem(at: AppPaths.customPromptFile)
+                            refreshCustomPromptState()
+                        }
+                    }
+
+                    Spacer()
+
+                    if hasCustomPrompt {
+                        Label("Custom prompt active", systemImage: "doc.text.fill")
+                            .foregroundStyle(.blue)
+                            .font(.caption)
+                    } else {
+                        Label("Using default prompt", systemImage: "doc.text")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
+                }
             }
 
             Section("Permissions") {
@@ -418,6 +460,42 @@ struct SettingsView: View {
             options.insert(settings.openAIModel, at: 0)
         }
         return options
+    }
+
+    private func refreshCustomPromptState() {
+        hasCustomPrompt = FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path)
+    }
+
+    private func ensurePromptDirectory() {
+        try? FileManager.default.createDirectory(
+            at: AppPaths.customPromptFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+    }
+
+    private func openCustomPrompt() {
+        let url = AppPaths.customPromptFile
+        if !FileManager.default.fileExists(atPath: url.path) {
+            ensurePromptDirectory()
+            try? ProtocolGenerator.protocolPrompt.write(to: url, atomically: true, encoding: .utf8)
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func importCustomPrompt() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.plainText, .init(filenameExtension: "md")].compactMap { $0 }
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = "Select a prompt file to import"
+        guard panel.runModal() == .OK, let source = panel.url else { return }
+        ensurePromptDirectory()
+        let dest = AppPaths.customPromptFile
+        if FileManager.default.fileExists(atPath: dest.path) {
+            _ = try? FileManager.default.replaceItemAt(dest, withItemAt: source)
+        } else {
+            try? FileManager.default.copyItem(at: source, to: dest)
+        }
     }
 
     private func refreshAudioDevices() {

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -186,6 +186,65 @@ final class ProtocolGeneratorTests: XCTestCase {
         )
     }
 
+    // MARK: - Custom Prompt Loading
+
+    /// Run a test block with a temporary custom prompt file, restoring the original state afterwards.
+    private func withCustomPromptFile(_ body: (URL) throws -> Void) throws {
+        let url = AppPaths.customPromptFile
+        let fm = FileManager.default
+        let backup = fm.fileExists(atPath: url.path)
+            ? try? String(contentsOf: url, encoding: .utf8)
+            : nil
+        defer {
+            if let backup {
+                try? backup.write(to: url, atomically: true, encoding: .utf8)
+            } else {
+                try? fm.removeItem(at: url)
+            }
+        }
+        try body(url)
+    }
+
+    func testLoadPromptReturnsDefaultWhenNoFile() throws {
+        try withCustomPromptFile { url in
+            try? FileManager.default.removeItem(at: url)
+
+            let prompt = ProtocolGenerator.loadPrompt()
+            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
+        }
+    }
+
+    func testLoadPromptReadsCustomFile() throws {
+        try withCustomPromptFile { url in
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let custom = "Custom prompt for testing"
+            try custom.write(to: url, atomically: true, encoding: .utf8)
+
+            let prompt = ProtocolGenerator.loadPrompt()
+            XCTAssertEqual(prompt, custom)
+        }
+    }
+
+    func testLoadPromptIgnoresEmptyFile() throws {
+        try withCustomPromptFile { url in
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try "".write(to: url, atomically: true, encoding: .utf8)
+
+            let prompt = ProtocolGenerator.loadPrompt()
+            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
+        }
+    }
+
+    func testLoadPromptIgnoresWhitespaceOnlyFile() throws {
+        try withCustomPromptFile { url in
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try "   \n  \n  ".write(to: url, atomically: true, encoding: .utf8)
+
+            let prompt = ProtocolGenerator.loadPrompt()
+            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
+        }
+    }
+
     func testGenerateEnvStripDoesNotRemoveOtherVars() throws {
         // Verify that removing CLAUDECODE doesn't affect other env vars
         let testKey = "MEETING_TRANSCRIBER_TEST_VAR_\(UUID().uuidString)"


### PR DESCRIPTION
## Summary
- Users can now customize the protocol generation prompt via a file at `~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`
- Built-in default prompt is used as fallback when no custom file exists or file is empty
- Settings UI provides Edit Prompt (opens in editor), Import Prompt (file picker), and Reset to Default buttons

## Changes
- **AppPaths**: `customPromptFile` path constant
- **ProtocolGenerator**: `loadPrompt()` reads custom file with fallback to built-in default; used by both Claude CLI and OpenAI-compatible generators
- **SettingsView**: Three action buttons + status indicator (custom/default)
- **Tests**: 4 new tests for `loadPrompt()` with `withCustomPromptFile` helper

## Test plan
- [x] `swift test` — 468 tests pass
- [x] Open Settings → verify Edit/Import/Reset buttons visible
- [x] Edit Prompt → file opens in editor, status shows "Custom prompt active"
- [x] Reset to Default → confirmation dialog, status reverts to "Using default prompt"
- [x] Import Prompt → file picker, selected file becomes custom prompt
- [x] Delete file manually → verify fallback to default