### PR TITLE
fix(app): use actual sample rate for mix instead of hardcoded 48kHz

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -110,7 +110,7 @@ class DualSourceRecorder: RecordingProvider {
     }
 
     /// Stop recording and produce a mixed WAV.
-    func stop() throws -> RecordingResult { // swiftlint:disable:this function_body_length cyclomatic_complexity
+    func stop() throws -> RecordingResult { // swiftlint:disable:this function_body_length
         guard isRecording else {
             throw RecorderError.notRecording
         }
@@ -188,11 +188,6 @@ class DualSourceRecorder: RecordingProvider {
             try AudioMixer.saveWAV(samples: appSamples, sampleRate: actualRate, url: appFile)
             appPath = appFile
             logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate) Hz)")
-
-            // Resample to recordRate if needed
-            if actualRate != recordRate {
-                appSamples = AudioMixer.resample(appSamples, from: actualRate, to: recordRate)
-            }
         } else if FileManager.default.fileExists(atPath: tempURL.path) {
             // Clean up empty temp file left by failed app audio capture
             try? FileManager.default.removeItem(at: tempURL)
@@ -216,14 +211,11 @@ class DualSourceRecorder: RecordingProvider {
             micSamples = try AudioMixer.loadAudioFileAsFloat32(url: expectedMicPath)
             micPath = expectedMicPath
             logger.info("Mic audio loaded: \(expectedMicPath.lastPathComponent) (\(micFileRate) Hz)")
-
-            if micFileRate != recordRate {
-                micSamples = AudioMixer.resample(micSamples, from: micFileRate, to: recordRate)
-                logger.info("Mic resampled: \(micFileRate) → \(self.recordRate) Hz")
-            }
         }
 
         // ── Mix via AudioMixer ──
+        // Use the actual capture rate for mixing — the pipeline resamples to 16kHz later.
+        let mixRate = actualRate > 0 ? actualRate : recordRate
         let mixPath = recDir.appendingPathComponent("\(ts)_mix.wav")
 
         if let app = appPath, let mic = micPath {
@@ -235,12 +227,12 @@ class DualSourceRecorder: RecordingProvider {
                 micDelay: micDelay,
                 muteTimeline: muteTimeline,
                 recordingStart: recordingStart,
-                sampleRate: recordRate,
+                sampleRate: mixRate,
             )
         } else if !appSamples.isEmpty {
-            try AudioMixer.saveWAV(samples: appSamples, sampleRate: recordRate, url: mixPath)
+            try AudioMixer.saveWAV(samples: appSamples, sampleRate: mixRate, url: mixPath)
         } else if !micSamples.isEmpty {
-            try AudioMixer.saveWAV(samples: micSamples, sampleRate: recordRate, url: mixPath)
+            try AudioMixer.saveWAV(samples: micSamples, sampleRate: mixRate, url: mixPath)
         } else {
             throw RecorderError.noAudioData
         }

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -150,36 +150,7 @@ public class AppAudioCapture {
             )
         }
         aggregateID = newAggregateID
-
-        // Query actual sample rate of the aggregate device
-        var actualRate: Float64 = 0
-        var rateAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyNominalSampleRate,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
-        )
-        var rateSize = UInt32(MemoryLayout<Float64>.size)
-        AudioObjectGetPropertyData(aggregateID, &rateAddress, 0, nil, &rateSize, &actualRate)
-        let queriedRate = Int(actualRate)
-        logger.info("Created aggregate device: \(self.aggregateID) (actual rate: \(queriedRate) Hz)")
-
-        // If the aggregate device rate differs from requested, force it
-        if queriedRate != sampleRate && actualRate > 0 {
-            var desiredRate = Float64(sampleRate)
-            let setStatus = AudioObjectSetPropertyData(
-                aggregateID, &rateAddress, 0, nil,
-                UInt32(MemoryLayout<Float64>.size), &desiredRate,
-            )
-            if setStatus == noErr {
-                // Re-query to confirm
-                AudioObjectGetPropertyData(aggregateID, &rateAddress, 0, nil, &rateSize, &actualRate)
-                actualSampleRate = Int(actualRate)
-                logger.info("App audio: forced rate to \(self.sampleRate) Hz (actual: \(self.actualSampleRate) Hz)")
-            } else {
-                actualSampleRate = queriedRate
-                logger.warning("App audio: could not set rate to \(self.sampleRate) Hz, using \(queriedRate) Hz (status: \(setStatus))")
-            }
-        }
+        logger.info("Created aggregate device: \(self.aggregateID)")
 
         // Set up IOProc to read audio data and write to file descriptor
         let fd = outputFileDescriptor
@@ -196,7 +167,7 @@ public class AppAudioCapture {
                 self.appFirstFrameTime = mach_absolute_time()
                 let frames = Int(abl.mBuffers.mDataByteSize) / MemoryLayout<Float>.size
                 logger.info(
-                    "Audio format: \(queriedRate) Hz actual, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
+                    "Audio format: \(self.actualSampleRate) Hz, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
                 )
             }
 
@@ -232,7 +203,18 @@ public class AppAudioCapture {
         }
 
         isRunning = true
-        logger.info("Audio capture started (CATapDescription, PID \(self.pid))")
+
+        // Query actual sample rate after device start
+        var rateAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var rateSize = UInt32(MemoryLayout<Float64>.size)
+        var actualRate: Float64 = 0
+        AudioObjectGetPropertyData(aggregateID, &rateAddress, 0, nil, &rateSize, &actualRate)
+        actualSampleRate = Int(actualRate)
+        logger.info("Audio capture started (PID \(self.pid), rate: \(self.actualSampleRate) Hz)")
     }
 
     private func installOutputDeviceChangeListener() {


### PR DESCRIPTION
The output device rate can differ from 48kHz (e.g. 24kHz when meeting-simulator plays 16kHz fixtures via AVAudioPlayer). The mix was always saved at 48kHz regardless of the actual capture rate, causing 2x playback speed ("Mickey Mouse" audio).

Fix: use actualSampleRate from AudioCaptureSession for the mix WAV header. Remove unnecessary in-memory resampling of app/mic samples in DualSourceRecorder.stop() — the pipeline resamples to 16kHz later. Also simplify AppAudioCapture rate handling: query rate after device start, accept whatever CoreAudio reports.