### PR TITLE
docs(docs): add branch protection rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - **Stage explicitly:** `git add <file1> <file2>` — never `git add -A` or `git add .`
 - **Verify first:** run tests before committing
 - **Commit body:** document the WHY for non-trivial changes (architecture decisions, rejected alternatives)
+- **Never push to main directly.** Always create a branch, open a PR, and merge via `gh pr merge --rebase --delete-branch`. Only exception: version bumps in `VERSION` file.
+- **Rebase merge only.** Squash and merge commits are disabled by repo policy.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- Document that all changes go through branches + PRs (no direct push to main)
- Only exception: version bumps in VERSION file
- Document rebase merge as the only allowed merge strategy