### PR TITLE
build(app): remove unnecessary entitlements

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -116,10 +116,6 @@ if [ "$NOTARIZE" = true ]; then
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>


### PR DESCRIPTION
## Summary
- Remove `com.apple.security.cs.disable-library-validation` and `com.apple.security.cs.allow-jit` from build entitlements
- Both are forbidden in the Mac App Store
- Verified: app launches and runs correctly without them
- Verified: Apple notarization accepted the build (submission `1b972268`)

## Test plan
- [x] Build with `--no-notarize`, app starts and runs
- [x] `codesign --verify --deep --strict` passes
- [x] Apple notarization accepted