### PR TITLE
refactor(app): use sandbox-compatible paths in AppPaths

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -31,4 +31,40 @@ enum AppPaths {
 
     /// Custom protocol prompt file.
     static let customPromptFile = dataDir.appendingPathComponent("protocol_prompt.md")
+
+    /// Legacy IPC directory (`~/.meeting-transcriber/`) used before sandbox migration.
+    private static let legacyIpcDir = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".meeting-transcriber")
+
+    private static let logger = Logger(subsystem: logSubsystem, category: "AppPaths")
+
+    /// Migrate IPC files from `~/.meeting-transcriber/` to `dataDir/ipc/`.
+    /// Safe to call multiple times — copyItem fails gracefully if destination exists.
+    static func migrateIfNeeded() {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: legacyIpcDir.path) else { return }
+
+        let filesToMigrate = [
+            "processed_recordings.json",
+            "pipeline_queue.json",
+            "pipeline_log.jsonl",
+        ]
+
+        try? fm.createDirectory(at: ipcDir, withIntermediateDirectories: true)
+
+        for name in filesToMigrate {
+            let src = legacyIpcDir.appendingPathComponent(name)
+            let dst = ipcDir.appendingPathComponent(name)
+            do {
+                try fm.copyItem(at: src, to: dst)
+                logger.info("Migrated \(name) from legacy IPC directory")
+            } catch CocoaError.fileWriteFileExists {
+                // Already migrated — expected on subsequent launches
+            } catch CocoaError.fileReadNoSuchFile {
+                // Source doesn't exist — skip
+            } catch {
+                logger.error("Failed to migrate \(name): \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -6,13 +6,19 @@ enum AppPaths {
     /// Logger subsystem for all os.log loggers.
     static let logSubsystem = "com.meetingtranscriber"
 
-    private static let home = FileManager.default.homeDirectoryForCurrentUser
-
-    /// IPC directory: `~/.meeting-transcriber/`
-    static let ipcDir = home.appendingPathComponent(".meeting-transcriber")
-
     /// App data directory: `~/Library/Application Support/MeetingTranscriber/`
-    static let dataDir = home.appendingPathComponent("Library/Application Support/MeetingTranscriber")
+    /// In sandbox, this automatically resolves to the container path.
+    static let dataDir: URL = {
+        guard let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else {
+            fatalError("Application Support directory unavailable")
+        }
+        return appSupport.appendingPathComponent("MeetingTranscriber")
+    }()
+
+    /// IPC directory: under `dataDir` for sandbox compatibility.
+    static let ipcDir = dataDir.appendingPathComponent("ipc")
 
     /// Recordings directory.
     static let recordingsDir = dataDir.appendingPathComponent("recordings")

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -25,6 +25,7 @@ struct MeetingTranscriberApp: App {
     }
 
     init() {
+        AppPaths.migrateIfNeeded()
         notifications.setUp()
         DualSourceRecorder.cleanupTempFiles()
         // Auto-watch: schedule on main run loop after app finishes launching

--- a/app/MeetingTranscriber/Tests/AppPathsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPathsTests.swift
@@ -1,0 +1,40 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class AppPathsTests: XCTestCase {
+    // MARK: - dataDir
+
+    func testDataDirUsesApplicationSupport() {
+        XCTAssertTrue(
+            AppPaths.dataDir.path.contains("Application Support/MeetingTranscriber"),
+            "dataDir should be under Application Support",
+        )
+    }
+
+    // MARK: - ipcDir
+
+    func testIpcDirIsUnderDataDir() {
+        XCTAssertTrue(
+            AppPaths.ipcDir.path.hasPrefix(AppPaths.dataDir.path),
+            "ipcDir should be a subdirectory of dataDir",
+        )
+    }
+
+    // MARK: - Derived paths under dataDir
+
+    func testRecordingsDirIsUnderDataDir() {
+        XCTAssertTrue(AppPaths.recordingsDir.path.hasPrefix(AppPaths.dataDir.path))
+    }
+
+    func testProtocolsDirIsUnderDataDir() {
+        XCTAssertTrue(AppPaths.protocolsDir.path.hasPrefix(AppPaths.dataDir.path))
+    }
+
+    func testSpeakersDBIsUnderDataDir() {
+        XCTAssertTrue(AppPaths.speakersDB.path.hasPrefix(AppPaths.dataDir.path))
+    }
+
+    func testCustomPromptFileIsUnderDataDir() {
+        XCTAssertTrue(AppPaths.customPromptFile.path.hasPrefix(AppPaths.dataDir.path))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `homeDirectoryForCurrentUser`-based paths with `FileManager.urls(for:in:)` API
- `dataDir` now uses `applicationSupportDirectory` which automatically resolves to the sandbox container path
- Move `ipcDir` under `dataDir/ipc` instead of `~/.meeting-transcriber/` (no longer needs a separate dotdir in $HOME)
- Remove private `home` property

## Test plan
- [x] `swift build` compiles
- [x] `swift test` — all 491 tests pass
- [x] `./scripts/lint.sh` — 0 violations
- [x] Manual: verify paths resolve correctly outside sandbox (same as before)