### PR TITLE
feat: use PowerAssertionDetector for meeting detection

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingDetecting.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetecting.swift
@@ -1,0 +1,44 @@
+import CoreGraphics
+import Foundation
+
+/// Represents a detected active meeting.
+struct DetectedMeeting {
+    let pattern: AppMeetingPattern
+    let windowTitle: String
+    let ownerName: String
+    let windowPID: pid_t
+    let detectedAt: Date
+
+    init(
+        pattern: AppMeetingPattern,
+        windowTitle: String,
+        ownerName: String,
+        windowPID: pid_t,
+        detectedAt: Date = Date(),
+    ) {
+        self.pattern = pattern
+        self.windowTitle = windowTitle
+        self.ownerName = ownerName
+        self.windowPID = windowPID
+        self.detectedAt = detectedAt
+    }
+}
+
+/// Protocol for meeting detection strategies.
+protocol MeetingDetecting {
+    /// Single poll: check for active meetings. Returns a meeting after confirmation threshold.
+    func checkOnce() -> DetectedMeeting?
+
+    /// Check if a previously detected meeting is still active.
+    func isMeetingActive(_ meeting: DetectedMeeting) -> Bool
+
+    /// Reset confirmation counters and start cooldown for the given app.
+    func reset(appName: String?)
+}
+
+extension MeetingDetecting {
+    // swiftlint:disable:next unused_declaration
+    func reset() {
+        reset(appName: nil)
+    }
+}

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -1,8 +1,8 @@
-import ApplicationServices
 import CoreGraphics
 import Foundation
 import os.log
 
+// swiftlint:disable:next unused_declaration
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "MeetingDetector")
 
 /// Polls window list to detect active meeting windows.
@@ -24,10 +24,6 @@ class MeetingDetector: MeetingDetecting {
     /// Closure that provides the window list. Defaults to CGWindowListCopyWindowInfo.
     /// Override in tests to inject mock window data.
     var windowListProvider: () -> [[String: Any]] = MeetingDetector.systemWindowList
-
-    /// Closure to verify a Teams window is a real meeting (not a pop-out chat).
-    /// Searches the AXWebArea DOM for the hangup button. Override in tests.
-    var meetingVerifier: ((_ pid: pid_t) -> Bool) = MeetingDetector.verifyTeamsMeeting
 
     init(patterns: [AppMeetingPattern], confirmationCount: Int = 2) {
         self.patterns = patterns
@@ -82,12 +78,6 @@ class MeetingDetector: MeetingDetecting {
             if hits >= confirmationCount, let match = firstMatch[appName],
                let pattern = patterns.first(where: { $0.appName == appName }) {
                 let pid = match.window["kCGWindowOwnerPID"] as? Int32 ?? 0
-
-                // Verify Teams windows are actual meetings (not pop-out chats)
-                if appName == "Microsoft Teams" && !meetingVerifier(pid) {
-                    consecutiveHits[appName] = 0
-                    continue
-                }
 
                 return DetectedMeeting(
                     pattern: pattern,
@@ -160,54 +150,6 @@ class MeetingDetector: MeetingDetecting {
             }
         }
 
-        return nil
-    }
-
-    // MARK: - Meeting Verification
-
-    /// DOM identifiers that indicate an active Teams call/meeting.
-    /// These are stable Electron DOM IDs used by Teams' web content.
-    private static let meetingDOMIdentifiers: Set<String> = [
-        "hangup-button",
-        "microphone-button",
-        "video-button",
-    ]
-
-    /// Verify that a Teams window is an active meeting by searching the AXWebArea
-    /// DOM for call-control buttons (hangup, microphone, video).
-    ///
-    /// Teams is an Electron app — standard AXButton roles on window chrome don't
-    /// expose meeting controls. The web content inside AXWebArea does expose them
-    /// via `AXDOMIdentifier`.
-    static func verifyTeamsMeeting(pid: pid_t) -> Bool {
-        guard AXIsProcessTrusted() else { return true } // can't verify, assume meeting
-        let app = AXUIElementCreateApplication(pid)
-        let found = findMeetingControl(app) != nil
-        if !found {
-            logger.info("Teams AX verification: no call controls found for PID \(pid) — skipping as chat")
-        }
-        return found
-    }
-
-    /// Search AX tree for an element with a meeting-related AXDOMIdentifier.
-    private static func findMeetingControl(_ element: AXUIElement, depth: Int = 0) -> AXUIElement? {
-        if depth > 30 { return nil }
-
-        // Check AXDOMIdentifier (set on Electron/WebView elements)
-        if let domId = AXHelper.getAttribute(element, attribute: "AXDOMIdentifier") as? String {
-            if meetingDOMIdentifiers.contains(domId) {
-                return element
-            }
-        }
-
-        guard let children = AXHelper.getAttribute(element, attribute: kAXChildrenAttribute) as? [AXUIElement] else {
-            return nil
-        }
-        for child in children {
-            if let found = findMeetingControl(child, depth: depth + 1) {
-                return found
-            }
-        }
         return nil
     }
 

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -5,35 +5,12 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "MeetingDetector")
 
-/// Represents a detected active meeting.
-struct DetectedMeeting {
-    let pattern: AppMeetingPattern
-    let windowTitle: String
-    let ownerName: String
-    let windowPID: pid_t
-    let detectedAt: Date
-
-    init(
-        pattern: AppMeetingPattern,
-        windowTitle: String,
-        ownerName: String,
-        windowPID: pid_t,
-        detectedAt: Date = Date(),
-    ) {
-        self.pattern = pattern
-        self.windowTitle = windowTitle
-        self.ownerName = ownerName
-        self.windowPID = windowPID
-        self.detectedAt = detectedAt
-    }
-}
-
 /// Polls window list to detect active meeting windows.
 ///
 /// Uses CGWindowListCopyWindowInfo to read on-screen windows.
 /// Requires Screen Recording permission.
 @Observable
-class MeetingDetector {
+class MeetingDetector: MeetingDetecting {
     private let patterns: [AppMeetingPattern]
     private let confirmationCount: Int
     private var consecutiveHits: [String: Int] = [:]

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -99,4 +99,9 @@ extension AppMeetingPattern {
         }
         return dict
     }()
+
+    /// Lookup pattern by app name (case-insensitive).
+    static func forAppName(_ name: String) -> AppMeetingPattern? {
+        byName[name.lowercased()]
+    }
 }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -255,8 +255,14 @@ struct MeetingTranscriberApp: App {
                     whisperKit.language = settings.whisperLanguageOrNil
                     pipelineQueue = makePipelineQueue()
 
+                    #if APPSTORE
+                        let detector: MeetingDetecting = PowerAssertionDetector()
+                    #else
+                        let detector: MeetingDetecting = MeetingDetector(patterns: patterns)
+                    #endif
+
                     let loop = WatchLoop(
-                        detector: MeetingDetector(patterns: patterns),
+                        detector: detector,
                         pipelineQueue: pipelineQueue,
                         pollInterval: settings.pollInterval,
                         endGracePeriod: settings.endGrace,

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -239,31 +239,13 @@ struct MeetingTranscriberApp: App {
             // swiftlint:disable:next closure_body_length
             Task {
                 _ = await Permissions.ensureMicrophoneAccess()
-                #if !APPSTORE
-                    _ = Permissions.ensureAccessibilityAccess()
-                #endif
 
-                #if !APPSTORE
-                    var patterns: [AppMeetingPattern] = []
-                    if settings.watchTeams { patterns.append(.teams) }
-                    if settings.watchZoom { patterns.append(.zoom) }
-                    if settings.watchWebex { patterns.append(.webex) }
-                    if patterns.isEmpty { patterns = AppMeetingPattern.all }
-                    // Always include simulator for debug/testing
-                    if !patterns.contains(where: { $0.appName == "MeetingSimulator" }) {
-                        patterns.append(.simulator)
-                    }
-                #endif
-
+                // swiftlint:disable:next closure_body_length
                 await MainActor.run {
                     whisperKit.language = settings.whisperLanguageOrNil
                     pipelineQueue = makePipelineQueue()
 
-                    #if APPSTORE
-                        let detector: MeetingDetecting = PowerAssertionDetector()
-                    #else
-                        let detector: MeetingDetecting = MeetingDetector(patterns: patterns)
-                    #endif
+                    let detector: MeetingDetecting = PowerAssertionDetector()
 
                     let loop = WatchLoop(
                         detector: detector,

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -239,17 +239,21 @@ struct MeetingTranscriberApp: App {
             // swiftlint:disable:next closure_body_length
             Task {
                 _ = await Permissions.ensureMicrophoneAccess()
-                _ = Permissions.ensureAccessibilityAccess()
+                #if !APPSTORE
+                    _ = Permissions.ensureAccessibilityAccess()
+                #endif
 
-                var patterns: [AppMeetingPattern] = []
-                if settings.watchTeams { patterns.append(.teams) }
-                if settings.watchZoom { patterns.append(.zoom) }
-                if settings.watchWebex { patterns.append(.webex) }
-                if patterns.isEmpty { patterns = AppMeetingPattern.all }
-                // Always include simulator for debug/testing
-                if !patterns.contains(where: { $0.appName == "MeetingSimulator" }) {
-                    patterns.append(.simulator)
-                }
+                #if !APPSTORE
+                    var patterns: [AppMeetingPattern] = []
+                    if settings.watchTeams { patterns.append(.teams) }
+                    if settings.watchZoom { patterns.append(.zoom) }
+                    if settings.watchWebex { patterns.append(.webex) }
+                    if patterns.isEmpty { patterns = AppMeetingPattern.all }
+                    // Always include simulator for debug/testing
+                    if !patterns.contains(where: { $0.appName == "MeetingSimulator" }) {
+                        patterns.append(.simulator)
+                    }
+                #endif
 
                 await MainActor.run {
                     whisperKit.language = settings.whisperLanguageOrNil

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -4,17 +4,19 @@ import CoreGraphics
 import Foundation
 
 enum Permissions {
-    /// Check if Screen Recording permission is granted.
-    static func checkScreenRecording() -> Bool {
-        guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
-            return false
+    #if !APPSTORE
+        /// Check if Screen Recording permission is granted.
+        static func checkScreenRecording() -> Bool {
+            guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
+                return false
+            }
+            let ownPID = ProcessInfo.processInfo.processIdentifier
+            return windowList.contains { info in
+                guard let pid = info[kCGWindowOwnerPID as String] as? Int32, pid != ownPID else { return false }
+                return info[kCGWindowName as String] is String
+            }
         }
-        let ownPID = ProcessInfo.processInfo.processIdentifier
-        return windowList.contains { info in
-            guard let pid = info[kCGWindowOwnerPID as String] as? Int32, pid != ownPID else { return false }
-            return info[kCGWindowName as String] is String
-        }
-    }
+    #endif
 
     static func ensureMicrophoneAccess() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -4,19 +4,17 @@ import CoreGraphics
 import Foundation
 
 enum Permissions {
-    #if !APPSTORE
-        /// Check if Screen Recording permission is granted.
-        static func checkScreenRecording() -> Bool {
-            guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
-                return false
-            }
-            let ownPID = ProcessInfo.processInfo.processIdentifier
-            return windowList.contains { info in
-                guard let pid = info[kCGWindowOwnerPID as String] as? Int32, pid != ownPID else { return false }
-                return info[kCGWindowName as String] is String
-            }
+    /// Check if Screen Recording permission is granted.
+    static func checkScreenRecording() -> Bool {
+        guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
+            return false
         }
-    #endif
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        return windowList.contains { info in
+            guard let pid = info[kCGWindowOwnerPID as String] as? Int32, pid != ownPID else { return false }
+            return info[kCGWindowName as String] is String
+        }
+    }
 
     static func ensureMicrophoneAccess() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
@@ -28,6 +26,7 @@ enum Permissions {
     }
 
     private static var hasPromptedAccessibility = false
+    // swiftlint:disable:next unused_declaration
     static func ensureAccessibilityAccess() -> Bool {
         if AXIsProcessTrusted() { return true }
         guard !hasPromptedAccessibility else { return false }

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -1,4 +1,3 @@
-import CoreGraphics
 import Foundation
 import IOKit.pwr_mgt
 import os.log
@@ -50,10 +49,7 @@ class PowerAssertionDetector: MeetingDetecting {
 
     /// Closure that provides the window list for title lookup. Defaults to CGWindowListCopyWindowInfo.
     /// Override in tests to inject mock data.
-    var windowListProvider: () -> [[String: Any]] = PowerAssertionDetector.systemWindowList
-
-    /// Last detected meeting, kept for isMeetingActive checks.
-    private var lastDetectedAppName: String?
+    var windowListProvider: () -> [[String: Any]] = MeetingDetector.systemWindowList
 
     init(
         patterns: [AssertionPattern] = PowerAssertionDetector.defaultPatterns,
@@ -101,7 +97,6 @@ class PowerAssertionDetector: MeetingDetecting {
                     ownerNames: [match.processName],
                     meetingPatterns: [],
                 )
-                lastDetectedAppName = appName
                 let title = lookupWindowTitle(appName: appName) ?? match.assertName
                 return DetectedMeeting(
                     pattern: meetingPattern,
@@ -164,16 +159,6 @@ class PowerAssertionDetector: MeetingDetecting {
             return title
         }
         return nil
-    }
-
-    /// Default window list provider using CGWindowListCopyWindowInfo.
-    static func systemWindowList() -> [[String: Any]] {
-        guard let windowList = CGWindowListCopyWindowInfo(
-            [.optionAll, .excludeDesktopElements], kCGNullWindowID,
-        ) as? [[String: Any]] else {
-            return []
-        }
-        return windowList
     }
 
     // MARK: - Private

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -24,17 +24,17 @@ class PowerAssertionDetector: MeetingDetecting {
         AssertionPattern(
             appName: "Microsoft Teams",
             processNames: ["MSTeams", "Microsoft Teams", "Microsoft Teams WebView", "Microsoft Teams (work or school)"],
-            keywords: ["call in progress"]
+            keywords: ["call in progress"],
         ),
         AssertionPattern(
             appName: "Zoom",
             processNames: ["zoom.us", "CptHost"],
-            keywords: ["zoom"]
+            keywords: ["zoom"],
         ),
         AssertionPattern(
             appName: "Webex",
             processNames: ["Webex", "Cisco Webex Meetings", "Meeting Center"],
-            keywords: ["webex"]
+            keywords: ["webex"],
         ),
     ]
 
@@ -99,7 +99,7 @@ class PowerAssertionDetector: MeetingDetecting {
                 let meetingPattern = AppMeetingPattern.forAppName(appName) ?? AppMeetingPattern(
                     appName: appName,
                     ownerNames: [match.processName],
-                    meetingPatterns: []
+                    meetingPatterns: [],
                 )
                 lastDetectedAppName = appName
                 let title = lookupWindowTitle(appName: appName) ?? match.assertName
@@ -107,7 +107,7 @@ class PowerAssertionDetector: MeetingDetecting {
                     pattern: meetingPattern,
                     windowTitle: title,
                     ownerName: match.processName,
-                    windowPID: match.pid
+                    windowPID: match.pid,
                 )
             }
         }
@@ -169,7 +169,7 @@ class PowerAssertionDetector: MeetingDetecting {
     /// Default window list provider using CGWindowListCopyWindowInfo.
     static func systemWindowList() -> [[String: Any]] {
         guard let windowList = CGWindowListCopyWindowInfo(
-            [.optionAll, .excludeDesktopElements], kCGNullWindowID
+            [.optionAll, .excludeDesktopElements], kCGNullWindowID,
         ) as? [[String: Any]] else {
             return []
         }

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -22,17 +22,17 @@ class PowerAssertionDetector: MeetingDetecting {
     static let defaultPatterns: [AssertionPattern] = [
         AssertionPattern(
             appName: "Microsoft Teams",
-            processNames: ["Microsoft Teams", "Microsoft Teams (work or school)"],
+            processNames: ["MSTeams", "Microsoft Teams", "Microsoft Teams WebView", "Microsoft Teams (work or school)"],
             keywords: ["call in progress"]
         ),
         AssertionPattern(
             appName: "Zoom",
-            processNames: ["zoom.us"],
+            processNames: ["zoom.us", "CptHost"],
             keywords: ["zoom"]
         ),
         AssertionPattern(
             appName: "Webex",
-            processNames: ["Webex", "Cisco Webex Meetings"],
+            processNames: ["Webex", "Cisco Webex Meetings", "Meeting Center"],
             keywords: ["webex"]
         ),
     ]
@@ -148,21 +148,36 @@ class PowerAssertionDetector: MeetingDetecting {
     }
 
     /// Default assertion provider using IOPMCopyAssertionsByProcess.
+    ///
+    /// The API returns a CFDictionary keyed by PID (CFNumber), not String.
+    /// We extract keys/values manually via CFDictionaryGetKeysAndValues.
     static func systemAssertions() -> [Int32: [[String: Any]]] {
         var assertionsByProcess: Unmanaged<CFDictionary>?
         let status = IOPMCopyAssertionsByProcess(&assertionsByProcess)
-        guard status == kIOReturnSuccess,
-              let dict = assertionsByProcess?.takeRetainedValue() as? [String: [[String: Any]]] else {
+        guard status == kIOReturnSuccess, let raw = assertionsByProcess else {
             return [:]
         }
 
-        // Convert to PID-keyed dict by looking up PID in each assertion
+        let cfDict = raw.takeRetainedValue()
+        let count = CFDictionaryGetCount(cfDict)
+        guard count > 0 else { return [:] }
+
+        let keys = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: count)
+        let values = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: count)
+        defer {
+            keys.deallocate()
+            values.deallocate()
+        }
+        CFDictionaryGetKeysAndValues(cfDict, keys, values)
+
         var result: [Int32: [[String: Any]]] = [:]
-        for (_, assertions) in dict {
-            for assertion in assertions {
-                if let pid = assertion["AssertPID"] as? Int32 {
-                    result[pid, default: []].append(assertion)
-                }
+        for i in 0 ..< count {
+            guard let valPtr = values[i] else { continue }
+            let keyObj = Unmanaged<AnyObject>.fromOpaque(keys[i]!).takeUnretainedValue()
+            let pid = (keyObj as? NSNumber)?.int32Value ?? 0
+            let valObj = Unmanaged<AnyObject>.fromOpaque(valPtr).takeUnretainedValue()
+            if let assertions = valObj as? [[String: Any]] {
+                result[pid] = assertions
             }
         }
         return result

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -35,6 +35,11 @@ class PowerAssertionDetector: MeetingDetecting {
             processNames: ["Webex", "Cisco Webex Meetings", "Meeting Center"],
             keywords: ["webex"],
         ),
+        AssertionPattern(
+            appName: AppMeetingPattern.simulator.appName,
+            processNames: ["meeting-simulator"],
+            keywords: ["simulator meeting"],
+        ),
     ]
 
     private let patterns: [AssertionPattern]

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -1,0 +1,170 @@
+import Foundation
+import IOKit.pwr_mgt
+import os.log
+
+// swiftlint:disable:next unused_declaration
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PowerAssertionDetector")
+
+/// Detects active meetings via IOKit power assertions.
+///
+/// Meeting apps (Teams, Zoom, Webex) create `PreventUserIdleDisplaySleep`
+/// assertions during calls. This detector reads those assertions via
+/// `IOPMCopyAssertionsByProcess()` — sandbox-safe, no entitlement needed.
+@Observable
+class PowerAssertionDetector: MeetingDetecting {
+    /// Known meeting apps and their assertion keywords.
+    struct AssertionPattern {
+        let appName: String
+        let processNames: [String]
+        let keywords: [String]
+    }
+
+    static let defaultPatterns: [AssertionPattern] = [
+        AssertionPattern(
+            appName: "Microsoft Teams",
+            processNames: ["Microsoft Teams", "Microsoft Teams (work or school)"],
+            keywords: ["call in progress"]
+        ),
+        AssertionPattern(
+            appName: "Zoom",
+            processNames: ["zoom.us"],
+            keywords: ["zoom"]
+        ),
+        AssertionPattern(
+            appName: "Webex",
+            processNames: ["Webex", "Cisco Webex Meetings"],
+            keywords: ["webex"]
+        ),
+    ]
+
+    private let patterns: [AssertionPattern]
+    private let confirmationCount: Int
+    private var consecutiveHits: [String: Int] = [:]
+    private var cooldownUntil: [String: Date] = [:]
+    private let cooldownDuration: TimeInterval = 5
+
+    /// Closure that provides assertion data. Defaults to IOPMCopyAssertionsByProcess.
+    /// Override in tests to inject mock data.
+    var assertionProvider: () -> [Int32: [[String: Any]]] = PowerAssertionDetector.systemAssertions
+
+    /// Last detected meeting, kept for isMeetingActive checks.
+    private var lastDetectedAppName: String?
+
+    init(
+        patterns: [AssertionPattern] = PowerAssertionDetector.defaultPatterns,
+        confirmationCount: Int = 2,
+    ) {
+        self.patterns = patterns
+        self.confirmationCount = confirmationCount
+    }
+
+    func checkOnce() -> DetectedMeeting? {
+        let assertions = assertionProvider()
+        var hitsThisRound: Set<String> = []
+        var firstMatch: [String: (pid: Int32, processName: String, assertName: String)] = [:]
+
+        for (pid, pidAssertions) in assertions {
+            for assertion in pidAssertions {
+                guard let processName = assertion["Process Name"] as? String,
+                      let assertName = assertion["AssertName"] as? String else {
+                    continue
+                }
+
+                for pattern in patterns {
+                    // Skip apps in cooldown
+                    if let until = cooldownUntil[pattern.appName], Date() < until {
+                        continue
+                    }
+
+                    // Only count each pattern once per poll
+                    guard !hitsThisRound.contains(pattern.appName) else { continue }
+
+                    if matchAssertion(processName: processName, assertName: assertName, pattern: pattern) {
+                        hitsThisRound.insert(pattern.appName)
+                        firstMatch[pattern.appName] = (pid, processName, assertName)
+                        consecutiveHits[pattern.appName, default: 0] += 1
+                    }
+                }
+            }
+        }
+
+        // Check confirmation threshold
+        for (appName, hits) in consecutiveHits {
+            if hits >= confirmationCount, let match = firstMatch[appName] {
+                let meetingPattern = AppMeetingPattern.forAppName(appName) ?? AppMeetingPattern(
+                    appName: appName,
+                    ownerNames: [match.processName],
+                    meetingPatterns: []
+                )
+                lastDetectedAppName = appName
+                return DetectedMeeting(
+                    pattern: meetingPattern,
+                    windowTitle: match.assertName,
+                    ownerName: match.processName,
+                    windowPID: match.pid
+                )
+            }
+        }
+
+        // Reset counters for apps with no hit this round
+        for appName in consecutiveHits.keys where !hitsThisRound.contains(appName) {
+            consecutiveHits[appName] = 0
+        }
+
+        return nil
+    }
+
+    func isMeetingActive(_ meeting: DetectedMeeting) -> Bool {
+        let assertions = assertionProvider()
+        for (_, pidAssertions) in assertions {
+            for assertion in pidAssertions {
+                guard let processName = assertion["Process Name"] as? String,
+                      let assertName = assertion["AssertName"] as? String else {
+                    continue
+                }
+                for pattern in patterns where pattern.appName == meeting.pattern.appName {
+                    if matchAssertion(processName: processName, assertName: assertName, pattern: pattern) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    func reset(appName: String? = nil) {
+        consecutiveHits.removeAll()
+        if let appName {
+            cooldownUntil[appName] = Date().addingTimeInterval(cooldownDuration)
+        }
+    }
+
+    // MARK: - Private
+
+    private func matchAssertion(processName: String, assertName: String, pattern: AssertionPattern) -> Bool {
+        guard pattern.processNames.contains(processName) else { return false }
+        let lowerAssert = assertName.lowercased()
+        return pattern.keywords.contains { lowerAssert.contains($0.lowercased()) }
+    }
+
+    /// Default assertion provider using IOPMCopyAssertionsByProcess.
+    static func systemAssertions() -> [Int32: [[String: Any]]] {
+        var assertionsByProcess: Unmanaged<CFDictionary>?
+        let status = IOPMCopyAssertionsByProcess(&assertionsByProcess)
+        guard status == kIOReturnSuccess,
+              let dict = assertionsByProcess?.takeRetainedValue() as? [String: [[String: Any]]] else {
+            return [:]
+        }
+
+        // Convert to PID-keyed dict by looking up PID in each assertion
+        var result: [Int32: [[String: Any]]] = [:]
+        for (_, assertions) in dict {
+            for assertion in assertions {
+                if let pid = assertion["AssertPID"] as? Int32 {
+                    result[pid, default: []].append(assertion)
+                }
+            }
+        }
+        return result
+    }
+}

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import IOKit.pwr_mgt
 import os.log
@@ -46,6 +47,10 @@ class PowerAssertionDetector: MeetingDetecting {
     /// Closure that provides assertion data. Defaults to IOPMCopyAssertionsByProcess.
     /// Override in tests to inject mock data.
     var assertionProvider: () -> [Int32: [[String: Any]]] = PowerAssertionDetector.systemAssertions
+
+    /// Closure that provides the window list for title lookup. Defaults to CGWindowListCopyWindowInfo.
+    /// Override in tests to inject mock data.
+    var windowListProvider: () -> [[String: Any]] = PowerAssertionDetector.systemWindowList
 
     /// Last detected meeting, kept for isMeetingActive checks.
     private var lastDetectedAppName: String?
@@ -97,9 +102,10 @@ class PowerAssertionDetector: MeetingDetecting {
                     meetingPatterns: []
                 )
                 lastDetectedAppName = appName
+                let title = lookupWindowTitle(appName: appName) ?? match.assertName
                 return DetectedMeeting(
                     pattern: meetingPattern,
-                    windowTitle: match.assertName,
+                    windowTitle: title,
                     ownerName: match.processName,
                     windowPID: match.pid
                 )
@@ -139,6 +145,37 @@ class PowerAssertionDetector: MeetingDetecting {
         }
     }
 
+    // MARK: - Window Title Lookup
+
+    /// Look up the actual window title for a detected meeting app via CGWindowListCopyWindowInfo.
+    /// Returns the first non-empty, non-idle window title matching the app's owner names.
+    private func lookupWindowTitle(appName: String) -> String? {
+        guard let meetingPattern = AppMeetingPattern.forAppName(appName) else { return nil }
+        let windows = windowListProvider()
+
+        for window in windows {
+            guard let owner = window["kCGWindowOwnerName"] as? String,
+                  meetingPattern.ownerNames.contains(owner),
+                  let title = window["kCGWindowName"] as? String,
+                  !title.isEmpty,
+                  title != appName else {
+                continue
+            }
+            return title
+        }
+        return nil
+    }
+
+    /// Default window list provider using CGWindowListCopyWindowInfo.
+    static func systemWindowList() -> [[String: Any]] {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionAll, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return []
+        }
+        return windowList
+    }
+
     // MARK: - Private
 
     private func matchAssertion(processName: String, assertName: String, pattern: AssertionPattern) -> Bool {
@@ -173,8 +210,9 @@ class PowerAssertionDetector: MeetingDetecting {
         var result: [Int32: [[String: Any]]] = [:]
         for i in 0 ..< count {
             guard let valPtr = values[i] else { continue }
-            let keyObj = Unmanaged<AnyObject>.fromOpaque(keys[i]!).takeUnretainedValue()
-            let pid = (keyObj as? NSNumber)?.int32Value ?? 0
+            guard let keyPtr = keys[i] else { continue }
+            let keyObj = Unmanaged<AnyObject>.fromOpaque(keyPtr).takeUnretainedValue()
+            let pid = keyObj as? Int32 ?? 0
             let valObj = Unmanaged<AnyObject>.fromOpaque(valPtr).takeUnretainedValue()
             if let assertions = valObj as? [[String: Any]] {
                 result[pid] = assertions

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -305,13 +305,15 @@ struct SettingsView: View {
             }
 
             Section("Permissions") {
-                PermissionRow(
-                    label: "Screen Recording",
-                    detail: "Required for meeting detection (window titles)",
-                    granted: screenRecordingOK,
-                    help: "System Settings → Privacy & Security → Screen Recording → enable Meeting Transcriber",
-                    settingsURL: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-                )
+                #if !APPSTORE
+                    PermissionRow(
+                        label: "Screen Recording",
+                        detail: "Required for meeting detection (window titles)",
+                        granted: screenRecordingOK,
+                        help: "System Settings → Privacy & Security → Screen Recording → enable Meeting Transcriber",
+                        settingsURL: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+                    )
+                #endif
                 PermissionRow(
                     label: "Microphone",
                     detail: micPermission == .authorized ? "Granted"
@@ -446,7 +448,9 @@ struct SettingsView: View {
 
     private func refreshPermissions() {
         micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
-        screenRecordingOK = Permissions.checkScreenRecording()
+        #if !APPSTORE
+            screenRecordingOK = Permissions.checkScreenRecording()
+        #endif
         accessibilityOK = AXIsProcessTrusted()
     }
 

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -305,15 +305,13 @@ struct SettingsView: View {
             }
 
             Section("Permissions") {
-                #if !APPSTORE
-                    PermissionRow(
-                        label: "Screen Recording",
-                        detail: "Required for meeting detection (window titles)",
-                        granted: screenRecordingOK,
-                        help: "System Settings → Privacy & Security → Screen Recording → enable Meeting Transcriber",
-                        settingsURL: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-                    )
-                #endif
+                PermissionRow(
+                    label: "Screen Recording",
+                    detail: Self.screenRecordingDetail,
+                    granted: screenRecordingOK,
+                    help: "System Settings → Privacy & Security → Screen Recording → enable Meeting Transcriber",
+                    settingsURL: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+                )
                 PermissionRow(
                     label: "Microphone",
                     detail: micPermission == .authorized ? "Granted"
@@ -430,6 +428,12 @@ struct SettingsView: View {
         }
     }
 
+    #if APPSTORE
+        private static let screenRecordingDetail = "Required for app audio capture"
+    #else
+        private static let screenRecordingDetail = "Required for meeting detection and app audio capture"
+    #endif
+
     private static let versionString: String = {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
@@ -448,9 +452,7 @@ struct SettingsView: View {
 
     private func refreshPermissions() {
         micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
-        #if !APPSTORE
-            screenRecordingOK = Permissions.checkScreenRecording()
-        #endif
+        screenRecordingOK = Permissions.checkScreenRecording()
         accessibilityOK = AXIsProcessTrusted()
     }
 

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -437,7 +437,12 @@ struct SettingsView: View {
     private static let versionString: String = {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
-        return "\(version) (\(commit))"
+        #if APPSTORE
+            let variant = "App Store"
+        #else
+            let variant = "Homebrew"
+        #endif
+        return "\(version) (\(commit)) · \(variant)"
     }()
 
     private static let buildDate: String = {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -55,7 +55,7 @@ class WatchLoop {
     var onStateChange: ((State, State) -> Void)?
 
     init(
-        detector: MeetingDetecting = MeetingDetector(patterns: AppMeetingPattern.all),
+        detector: MeetingDetecting = WatchLoop.defaultDetector(),
         recorderFactory: @MainActor @escaping () -> RecordingProvider = { DualSourceRecorder() },
         pipelineQueue: PipelineQueue? = nil,
         pollInterval: TimeInterval = 3.0,
@@ -76,6 +76,14 @@ class WatchLoop {
 
     nonisolated static var defaultOutputDir: URL {
         AppPaths.protocolsDir
+    }
+
+    nonisolated static func defaultDetector() -> MeetingDetecting {
+        #if APPSTORE
+            PowerAssertionDetector()
+        #else
+            MeetingDetector(patterns: AppMeetingPattern.all)
+        #endif
     }
 
     var isActive: Bool {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -79,11 +79,7 @@ class WatchLoop {
     }
 
     nonisolated static func defaultDetector() -> MeetingDetecting {
-        #if APPSTORE
-            PowerAssertionDetector()
-        #else
-            MeetingDetector(patterns: AppMeetingPattern.all)
-        #endif
+        PowerAssertionDetector()
     }
 
     var isActive: Bool {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -38,7 +38,7 @@ class WatchLoop {
     }
 
     // Dependencies
-    let detector: MeetingDetector
+    let detector: MeetingDetecting
     let recorderFactory: @MainActor () -> RecordingProvider
     var pipelineQueue: PipelineQueue?
 
@@ -55,7 +55,7 @@ class WatchLoop {
     var onStateChange: ((State, State) -> Void)?
 
     init(
-        detector: MeetingDetector = MeetingDetector(patterns: AppMeetingPattern.all),
+        detector: MeetingDetecting = MeetingDetector(patterns: AppMeetingPattern.all),
         recorderFactory: @MainActor @escaping () -> RecordingProvider = { DualSourceRecorder() },
         pipelineQueue: PipelineQueue? = nil,
         pollInterval: TimeInterval = 3.0,

--- a/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
@@ -19,14 +19,11 @@ private func makeWindow(
     ]
 }
 
-/// Create a MeetingDetector with AX meeting verification bypassed (for unit tests).
 private func makeDetector(
     patterns: [AppMeetingPattern],
     confirmationCount: Int = 1,
 ) -> MeetingDetector {
-    let detector = MeetingDetector(patterns: patterns, confirmationCount: confirmationCount)
-    detector.meetingVerifier = { _ in true }
-    return detector
+    MeetingDetector(patterns: patterns, confirmationCount: confirmationCount)
 }
 
 // MARK: - Pattern Tests

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -1,0 +1,300 @@
+@testable import MeetingTranscriber
+import XCTest
+
+// MARK: - Test Helpers
+
+private func makeAssertionDict(
+    pid: Int32,
+    processName: String,
+    assertName: String,
+    assertType: String = "PreventUserIdleDisplaySleep",
+) -> [Int32: [[String: Any]]] {
+    [
+        pid: [
+            [
+                "Process Name": processName,
+                "AssertName": assertName,
+                "AssertType": assertType,
+                "AssertPID": pid,
+                "AssertLevel": 255,
+            ],
+        ],
+    ]
+}
+
+private func makeDetector(confirmationCount: Int = 1) -> PowerAssertionDetector {
+    PowerAssertionDetector(confirmationCount: confirmationCount)
+}
+
+// MARK: - Detection Tests
+
+final class PowerAssertionDetectorTests: XCTestCase {
+    func testNoAssertionsReturnsNil() {
+        let detector = makeDetector()
+        detector.assertionProvider = { [:] }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testDetectsTeamsCall() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1234,
+                processName: "Microsoft Teams",
+                assertName: "Microsoft Teams Call in progress"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Microsoft Teams")
+        XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
+        XCTAssertEqual(result?.ownerName, "Microsoft Teams")
+        XCTAssertEqual(result?.windowPID, 1234)
+    }
+
+    func testDetectsTeamsWorkOrSchool() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 5678,
+                processName: "Microsoft Teams (work or school)",
+                assertName: "Microsoft Teams Call in progress"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Microsoft Teams")
+    }
+
+    func testDetectsZoomCall() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 2345,
+                processName: "zoom.us",
+                assertName: "Zoom Video Communication"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Zoom")
+    }
+
+    func testDetectsWebexCall() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 3456,
+                processName: "Webex",
+                assertName: "Webex Meeting Active"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Webex")
+    }
+
+    func testDetectsCiscoWebexCall() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 3457,
+                processName: "Cisco Webex Meetings",
+                assertName: "Webex active call"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Webex")
+    }
+
+    // MARK: - Ignore Non-Meeting Assertions
+
+    func testIgnoresSafariAssertion() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 9999,
+                processName: "Safari",
+                assertName: "Playing video"
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresSpotifyAssertion() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 8888,
+                processName: "Spotify",
+                assertName: "Spotify is playing"
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresUnknownProcess() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 7777,
+                processName: "SomeRandomApp",
+                assertName: "call in progress"
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresTeamsWithoutKeyword() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1234,
+                processName: "Microsoft Teams",
+                assertName: "Downloading update"
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    // MARK: - Confirmation Threshold
+
+    func testConfirmationThreshold() {
+        let detector = makeDetector(confirmationCount: 3)
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+        detector.assertionProvider = { assertions }
+
+        XCTAssertNil(detector.checkOnce()) // count=1
+        XCTAssertNil(detector.checkOnce()) // count=2
+        XCTAssertNotNil(detector.checkOnce()) // count=3
+    }
+
+    func testCounterResetsWhenAssertionDisappears() {
+        let detector = makeDetector(confirmationCount: 3)
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+
+        detector.assertionProvider = { assertions }
+        XCTAssertNil(detector.checkOnce()) // count=1
+
+        // Assertion disappears
+        detector.assertionProvider = { [:] }
+        XCTAssertNil(detector.checkOnce()) // resets
+
+        // Needs full count again
+        detector.assertionProvider = { assertions }
+        XCTAssertNil(detector.checkOnce()) // count=1
+        XCTAssertNil(detector.checkOnce()) // count=2
+        XCTAssertNotNil(detector.checkOnce()) // count=3
+    }
+
+    // MARK: - Cooldown
+
+    func testCooldownPreventsRedetection() {
+        let detector = makeDetector()
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+        detector.assertionProvider = { assertions }
+
+        XCTAssertNotNil(detector.checkOnce())
+        detector.reset(appName: "Microsoft Teams")
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testCooldownDoesNotAffectOtherApps() {
+        let detector = makeDetector()
+
+        // Detect Teams
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1234,
+                processName: "Microsoft Teams",
+                assertName: "Microsoft Teams Call in progress"
+            )
+        }
+        XCTAssertNotNil(detector.checkOnce())
+        detector.reset(appName: "Microsoft Teams")
+
+        // Zoom should still work
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 2345,
+                processName: "zoom.us",
+                assertName: "Zoom Video Communication"
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Zoom")
+    }
+
+    // MARK: - isMeetingActive
+
+    func testIsMeetingActiveTrue() {
+        let detector = makeDetector()
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+        detector.assertionProvider = { assertions }
+        let meeting = detector.checkOnce()!
+
+        XCTAssertTrue(detector.isMeetingActive(meeting))
+    }
+
+    func testIsMeetingActiveFalse() {
+        let detector = makeDetector()
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+        detector.assertionProvider = { assertions }
+        let meeting = detector.checkOnce()!
+
+        detector.assertionProvider = { [:] }
+        XCTAssertFalse(detector.isMeetingActive(meeting))
+    }
+
+    // MARK: - Keyword Case Insensitivity
+
+    func testKeywordMatchIsCaseInsensitive() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1234,
+                processName: "Microsoft Teams",
+                assertName: "MICROSOFT TEAMS CALL IN PROGRESS"
+            )
+        }
+        XCTAssertNotNil(detector.checkOnce())
+    }
+
+    // MARK: - Reset Without App Name
+
+    func testResetWithoutAppNameNoCooldown() {
+        let detector = makeDetector()
+        let assertions = makeAssertionDict(
+            pid: 1234,
+            processName: "Microsoft Teams",
+            assertName: "Microsoft Teams Call in progress"
+        )
+        detector.assertionProvider = { assertions }
+
+        XCTAssertNotNil(detector.checkOnce())
+        detector.reset()
+        XCTAssertNotNil(detector.checkOnce())
+    }
+}

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -23,7 +23,9 @@ private func makeAssertionDict(
 }
 
 private func makeDetector(confirmationCount: Int = 1) -> PowerAssertionDetector {
-    PowerAssertionDetector(confirmationCount: confirmationCount)
+    let detector = PowerAssertionDetector(confirmationCount: confirmationCount)
+    detector.windowListProvider = { [] } // no real windows in unit tests
+    return detector
 }
 
 // MARK: - Detection Tests
@@ -41,7 +43,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 1438,
                 processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress"
+                assertName: "Microsoft Teams Call in progress",
             )
         }
         let result = detector.checkOnce()
@@ -58,7 +60,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 1234,
                 processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress"
+                assertName: "Microsoft Teams Call in progress",
             )
         }
         XCTAssertNotNil(detector.checkOnce())
@@ -70,7 +72,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 5678,
                 processName: "Microsoft Teams (work or school)",
-                assertName: "Microsoft Teams Call in progress"
+                assertName: "Microsoft Teams Call in progress",
             )
         }
         let result = detector.checkOnce()
@@ -85,7 +87,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 4211,
                 processName: "Microsoft Teams WebView",
-                assertName: "Video Wake Lock"
+                assertName: "Video Wake Lock",
             )
         }
         XCTAssertNil(detector.checkOnce())
@@ -97,7 +99,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 2345,
                 processName: "zoom.us",
-                assertName: "Zoom Video Communication"
+                assertName: "Zoom Video Communication",
             )
         }
         let result = detector.checkOnce()
@@ -111,7 +113,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 3456,
                 processName: "Webex",
-                assertName: "Webex Meeting Active"
+                assertName: "Webex Meeting Active",
             )
         }
         let result = detector.checkOnce()
@@ -125,7 +127,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 3457,
                 processName: "Cisco Webex Meetings",
-                assertName: "Webex active call"
+                assertName: "Webex active call",
             )
         }
         let result = detector.checkOnce()
@@ -141,7 +143,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 9999,
                 processName: "Safari",
-                assertName: "Playing video"
+                assertName: "Playing video",
             )
         }
         XCTAssertNil(detector.checkOnce())
@@ -153,7 +155,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 8888,
                 processName: "Spotify",
-                assertName: "Spotify is playing"
+                assertName: "Spotify is playing",
             )
         }
         XCTAssertNil(detector.checkOnce())
@@ -165,7 +167,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 7777,
                 processName: "SomeRandomApp",
-                assertName: "call in progress"
+                assertName: "call in progress",
             )
         }
         XCTAssertNil(detector.checkOnce())
@@ -177,7 +179,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 1234,
                 processName: "MSTeams",
-                assertName: "Downloading update"
+                assertName: "Downloading update",
             )
         }
         XCTAssertNil(detector.checkOnce())
@@ -190,7 +192,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
         detector.assertionProvider = { assertions }
 
@@ -204,7 +206,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
 
         detector.assertionProvider = { assertions }
@@ -228,7 +230,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
         detector.assertionProvider = { assertions }
 
@@ -245,7 +247,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 1234,
                 processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress"
+                assertName: "Microsoft Teams Call in progress",
             )
         }
         XCTAssertNotNil(detector.checkOnce())
@@ -256,7 +258,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 2345,
                 processName: "zoom.us",
-                assertName: "Zoom Video Communication"
+                assertName: "Zoom Video Communication",
             )
         }
         let result = detector.checkOnce()
@@ -266,28 +268,28 @@ final class PowerAssertionDetectorTests: XCTestCase {
 
     // MARK: - isMeetingActive
 
-    func testIsMeetingActiveTrue() {
+    func testIsMeetingActiveTrue() throws {
         let detector = makeDetector()
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
         detector.assertionProvider = { assertions }
-        let meeting = detector.checkOnce()!
+        let meeting = try XCTUnwrap(detector.checkOnce())
 
         XCTAssertTrue(detector.isMeetingActive(meeting))
     }
 
-    func testIsMeetingActiveFalse() {
+    func testIsMeetingActiveFalse() throws {
         let detector = makeDetector()
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
         detector.assertionProvider = { assertions }
-        let meeting = detector.checkOnce()!
+        let meeting = try XCTUnwrap(detector.checkOnce())
 
         detector.assertionProvider = { [:] }
         XCTAssertFalse(detector.isMeetingActive(meeting))
@@ -301,10 +303,86 @@ final class PowerAssertionDetectorTests: XCTestCase {
             makeAssertionDict(
                 pid: 1234,
                 processName: "MSTeams",
-                assertName: "MICROSOFT TEAMS CALL IN PROGRESS"
+                assertName: "MICROSOFT TEAMS CALL IN PROGRESS",
             )
         }
         XCTAssertNotNil(detector.checkOnce())
+    }
+
+    // MARK: - Reset Without App Name
+
+    // MARK: - Window Title Lookup
+
+    func testWindowTitleUsedWhenFound() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1438,
+                processName: "MSTeams",
+                assertName: "Microsoft Teams Call in progress",
+            )
+        }
+        detector.windowListProvider = {
+            [[
+                "kCGWindowOwnerName": "Microsoft Teams",
+                "kCGWindowName": "Sprint Review | Microsoft Teams",
+                "kCGWindowOwnerPID": Int32(1438),
+            ]]
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.windowTitle, "Sprint Review | Microsoft Teams")
+    }
+
+    func testAssertionNameUsedWhenNoWindowFound() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1438,
+                processName: "MSTeams",
+                assertName: "Microsoft Teams Call in progress",
+            )
+        }
+        // No matching windows
+        detector.windowListProvider = { [] }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
+    }
+
+    func testWindowTitleSkipsEmptyAndAppNameOnly() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1438,
+                processName: "MSTeams",
+                assertName: "Microsoft Teams Call in progress",
+            )
+        }
+        detector.windowListProvider = {
+            [
+                // Empty title — should be skipped
+                [
+                    "kCGWindowOwnerName": "Microsoft Teams",
+                    "kCGWindowName": "",
+                    "kCGWindowOwnerPID": Int32(1438),
+                ],
+                // Title equals app name — should be skipped
+                [
+                    "kCGWindowOwnerName": "Microsoft Teams",
+                    "kCGWindowName": "Microsoft Teams",
+                    "kCGWindowOwnerPID": Int32(1438),
+                ],
+                // Real meeting title
+                [
+                    "kCGWindowOwnerName": "Microsoft Teams",
+                    "kCGWindowName": "Daily Standup | Microsoft Teams",
+                    "kCGWindowOwnerPID": Int32(1438),
+                ],
+            ]
+        }
+        let result = detector.checkOnce()
+        XCTAssertEqual(result?.windowTitle, "Daily Standup | Microsoft Teams")
     }
 
     // MARK: - Reset Without App Name
@@ -314,7 +392,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let assertions = makeAssertionDict(
             pid: 1234,
             processName: "Microsoft Teams",
-            assertName: "Microsoft Teams Call in progress"
+            assertName: "Microsoft Teams Call in progress",
         )
         detector.assertionProvider = { assertions }
 

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -35,12 +35,12 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNil(detector.checkOnce())
     }
 
-    func testDetectsTeamsCall() {
+    func testDetectsMSTeamsCall() {
         let detector = makeDetector()
         detector.assertionProvider = {
             makeAssertionDict(
-                pid: 1234,
-                processName: "Microsoft Teams",
+                pid: 1438,
+                processName: "MSTeams",
                 assertName: "Microsoft Teams Call in progress"
             )
         }
@@ -48,8 +48,20 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.pattern.appName, "Microsoft Teams")
         XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
-        XCTAssertEqual(result?.ownerName, "Microsoft Teams")
-        XCTAssertEqual(result?.windowPID, 1234)
+        XCTAssertEqual(result?.ownerName, "MSTeams")
+        XCTAssertEqual(result?.windowPID, 1438)
+    }
+
+    func testDetectsTeamsLegacyProcessName() {
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 1234,
+                processName: "MSTeams",
+                assertName: "Microsoft Teams Call in progress"
+            )
+        }
+        XCTAssertNotNil(detector.checkOnce())
     }
 
     func testDetectsTeamsWorkOrSchool() {
@@ -64,6 +76,19 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let result = detector.checkOnce()
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.pattern.appName, "Microsoft Teams")
+    }
+
+    func testIgnoresTeamsVideoWakeLock() {
+        // "Video Wake Lock" persists even without a call — must NOT trigger detection
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 4211,
+                processName: "Microsoft Teams WebView",
+                assertName: "Video Wake Lock"
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
     }
 
     func testDetectsZoomCall() {
@@ -151,7 +176,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         detector.assertionProvider = {
             makeAssertionDict(
                 pid: 1234,
-                processName: "Microsoft Teams",
+                processName: "MSTeams",
                 assertName: "Downloading update"
             )
         }
@@ -219,7 +244,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         detector.assertionProvider = {
             makeAssertionDict(
                 pid: 1234,
-                processName: "Microsoft Teams",
+                processName: "MSTeams",
                 assertName: "Microsoft Teams Call in progress"
             )
         }
@@ -275,7 +300,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         detector.assertionProvider = {
             makeAssertionDict(
                 pid: 1234,
-                processName: "Microsoft Teams",
+                processName: "MSTeams",
                 assertName: "MICROSOFT TEAMS CALL IN PROGRESS"
             )
         }

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -309,8 +309,6 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNotNil(detector.checkOnce())
     }
 
-    // MARK: - Reset Without App Name
-
     // MARK: - Window Title Lookup
 
     func testWindowTitleUsedWhenFound() {

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -309,7 +309,6 @@ final class WatchLoopE2ETests: XCTestCase {
 
     func testCooldownPreventsRedetectionAfterHandling() {
         let detector = MeetingDetector(patterns: AppMeetingPattern.all, confirmationCount: 1)
-        detector.meetingVerifier = { _ in true }
 
         let teamsWindow: [String: Any] = [
             "kCGWindowOwnerName": "Microsoft Teams" as CFString,

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -91,9 +91,9 @@ final class WatchLoopE2ETests: XCTestCase {
         recorder: MockRecorder,
         pipelineQueue: PipelineQueue,
     ) -> WatchLoop {
-        let detector = MeetingDetector(patterns: AppMeetingPattern.all)
-        // Meeting ends immediately (no windows)
-        detector.windowListProvider = { [] }
+        let detector = PowerAssertionDetector()
+        // Meeting ends immediately (no assertions)
+        detector.assertionProvider = { [:] }
 
         return WatchLoop(
             detector: detector,
@@ -308,19 +308,16 @@ final class WatchLoopE2ETests: XCTestCase {
     // MARK: - 5. Cooldown Prevents Re-detection After Handling
 
     func testCooldownPreventsRedetectionAfterHandling() {
-        let detector = MeetingDetector(patterns: AppMeetingPattern.all, confirmationCount: 1)
+        let detector = PowerAssertionDetector(confirmationCount: 1)
+        detector.windowListProvider = { [] }
 
-        let teamsWindow: [String: Any] = [
-            "kCGWindowOwnerName": "Microsoft Teams" as CFString,
-            "kCGWindowName": "Standup | Microsoft Teams" as CFString,
-            "kCGWindowOwnerPID": 1234 as CFNumber,
-            "kCGWindowNumber": 1 as CFNumber,
-            "kCGWindowBounds": [
-                "X": 0, "Y": 0, "Width": 800, "Height": 600,
-            ] as CFDictionary,
+        let teamsAssertions: [Int32: [[String: Any]]] = [
+            1234: [[
+                "Process Name": "MSTeams",
+                "AssertName": "Microsoft Teams Call in progress",
+            ]],
         ]
-
-        detector.windowListProvider = { [teamsWindow] }
+        detector.assertionProvider = { teamsAssertions }
 
         // First detection succeeds
         let firstDetection = detector.checkOnce()

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -4,8 +4,10 @@ import XCTest
 @MainActor
 final class WatchLoopTests: XCTestCase {
     private func makeLoop(pipelineQueue: PipelineQueue? = nil) -> WatchLoop {
-        WatchLoop(
-            detector: MeetingDetector(patterns: AppMeetingPattern.all),
+        let detector = PowerAssertionDetector()
+        detector.assertionProvider = { [:] }
+        return WatchLoop(
+            detector: detector,
             pipelineQueue: pipelineQueue,
         )
     }
@@ -126,13 +128,9 @@ final class WatchLoopTests: XCTestCase {
     // MARK: - Meeting End Detection
 
     func testWaitForMeetingEndGracePeriod() async throws {
-        let detector = MeetingDetector(patterns: AppMeetingPattern.all)
-        // Mock: meeting disappears immediately
-        var callCount = 0
-        detector.windowListProvider = {
-            callCount += 1
-            return [] // no windows = meeting gone
-        }
+        let detector = PowerAssertionDetector()
+        // Mock: meeting gone (no assertions)
+        detector.assertionProvider = { [:] }
 
         let loop = WatchLoop(
             detector: detector,
@@ -180,18 +178,10 @@ final class WatchLoopTests: XCTestCase {
     // MARK: - Meeting End Detection (Max Duration)
 
     func testWaitForMeetingEndMaxDuration() async throws {
-        let detector = MeetingDetector(patterns: AppMeetingPattern.all)
-        // Mock: meeting stays active forever
-        detector.windowListProvider = {
-            [[
-                "kCGWindowOwnerName": "Microsoft Teams" as CFString,
-                "kCGWindowName": "Test | Microsoft Teams" as CFString,
-                "kCGWindowOwnerPID": 1234 as CFNumber,
-                "kCGWindowNumber": 1 as CFNumber,
-                "kCGWindowBounds": [
-                    "X": 0, "Y": 0, "Width": 800, "Height": 600,
-                ] as CFDictionary,
-            ] as [String: Any]]
+        let detector = PowerAssertionDetector()
+        // Mock: meeting stays active forever (assertion always present)
+        detector.assertionProvider = {
+            [1234: [["Process Name": "MSTeams", "AssertName": "Microsoft Teams Call in progress"]]]
         }
 
         let loop = WatchLoop(

--- a/tools/meeting-simulator/Sources/main.swift
+++ b/tools/meeting-simulator/Sources/main.swift
@@ -1,6 +1,7 @@
 import AppKit
 import AVFoundation
 import Foundation
+import IOKit.pwr_mgt
 
 // --- Configuration ---
 let fixturePath = CommandLine.arguments.count > 1
@@ -91,6 +92,20 @@ window.contentView = contentView
 window.makeKeyAndOrderFront(nil)
 app.activate(ignoringOtherApps: true)
 
+// --- Create power assertion (triggers PowerAssertionDetector) ---
+var assertionID: IOPMAssertionID = 0
+let assertionResult = IOPMAssertionCreateWithName(
+    "PreventUserIdleDisplaySleep" as CFString,
+    IOPMAssertionLevel(kIOPMAssertionLevelOn),
+    "Simulator Meeting Call in progress" as CFString,
+    &assertionID,
+)
+if assertionResult == kIOReturnSuccess {
+    print("Power assertion created (ID: \(assertionID))")
+} else {
+    print("WARNING: Could not create power assertion (status: \(assertionResult))")
+}
+
 print("Window: \"\(windowTitle)\"")
 print("PID: \(ProcessInfo.processInfo.processIdentifier)")
 print("Audio: \(fixturePath)")
@@ -105,6 +120,10 @@ guard FileManager.default.fileExists(atPath: fixturePath) else {
 
 // --- App delegate to handle window close + audio end ---
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, AVAudioPlayerDelegate {
+    func applicationWillTerminate(_: Notification) {
+        IOPMAssertionRelease(assertionID)
+    }
+
     func windowWillClose(_: Notification) {
         print("Window closed — exiting.")
         NSApplication.shared.terminate(nil)


### PR DESCRIPTION
## Summary
- Extract `MeetingDetecting` protocol from `MeetingDetector` for testability and build variant flexibility
- Add `PowerAssertionDetector` that detects meetings via IOKit power assertions + window title lookup — works in sandbox without Screen Recording
- Use `PowerAssertionDetector` as default detector for both Homebrew and App Store variants
- Remove Teams AX verification from `MeetingDetector` (redundant with power assertion approach)
- Add power assertion to `MeetingSimulator` for end-to-end testing
- Show build variant (Homebrew/App Store) in Settings version string
- Migrate WatchLoop tests to use `PowerAssertionDetector`

## Test plan
- [x] `swift build` passes (Homebrew variant)
- [x] `swift build -Xswiftc -DAPPSTORE` passes (App Store variant)
- [x] 520 tests pass (23 new PowerAssertionDetector tests)
- [x] Lint clean (no serious violations)