### PR TITLE
feat(app): add custom protocol output directory

### DIFF
--- a/app/MeetingTranscriber/Entitlements/AppStore.entitlements
+++ b/app/MeetingTranscriber/Entitlements/AppStore.entitlements
@@ -8,7 +8,9 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
     <true/>
 </dict>
 </plist>

--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -23,8 +23,19 @@ enum AppPaths {
     /// Recordings directory.
     static let recordingsDir = dataDir.appendingPathComponent("recordings")
 
-    /// Protocols output directory.
+    /// Protocols output directory (legacy, inside Application Support).
     static let protocolsDir = dataDir.appendingPathComponent("protocols")
+
+    /// Default protocols output in Downloads: `~/Downloads/MeetingTranscriber/`
+    /// In sandbox, `FileManager.urls(for: .downloadsDirectory)` resolves to the container-granted path.
+    static let downloadsProtocolsDir: URL = {
+        guard let downloads = FileManager.default
+            .urls(for: .downloadsDirectory, in: .userDomainMask).first
+        else {
+            return protocolsDir
+        }
+        return downloads.appendingPathComponent("MeetingTranscriber")
+    }()
 
     /// Speaker voice profiles DB.
     static let speakersDB = dataDir.appendingPathComponent("speakers.json")

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -142,6 +142,57 @@ final class AppSettings {
         }
     }
 
+    // MARK: - Output Directory
+
+    /// Security-scoped bookmark for a user-chosen output directory.
+    var customOutputDirBookmark: Data? {
+        get { defaults.data(forKey: "customOutputDirBookmark") }
+        set { defaults.set(newValue, forKey: "customOutputDirBookmark") }
+    }
+
+    /// Resolved URL from the security-scoped bookmark. Calls `startAccessingSecurityScopedResource()`.
+    var customOutputDir: URL? {
+        guard let data = customOutputDirBookmark else { return nil }
+        var isStale = false
+        guard let url = try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale,
+        ) else { return nil }
+        if isStale {
+            // Re-create bookmark from resolved URL
+            if let newData = try? url.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil,
+            ) {
+                customOutputDirBookmark = newData
+            }
+        }
+        return url
+    }
+
+    /// Store a user-selected directory as a security-scoped bookmark.
+    func setCustomOutputDir(_ url: URL) {
+        guard let data = try? url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil,
+        ) else { return }
+        customOutputDirBookmark = data
+    }
+
+    /// Clear the custom output directory, reverting to the default.
+    func clearCustomOutputDir() {
+        customOutputDirBookmark = nil
+    }
+
+    /// The effective output directory: custom choice or ~/Downloads/MeetingTranscriber/.
+    var effectiveOutputDir: URL {
+        customOutputDir ?? AppPaths.downloadsProtocolsDir
+    }
+
     // MARK: - Updates
 
     var checkForUpdates: Bool = defaults.object(forKey: "checkForUpdates") as? Bool ?? true {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -317,7 +317,7 @@ struct MeetingTranscriberApp: App {
             whisperKit: whisperKit,
             diarizationFactory: { FluidDiarizer() },
             protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
-            outputDir: WatchLoop.defaultOutputDir,
+            outputDir: settings.effectiveOutputDir,
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
@@ -404,7 +404,9 @@ struct MeetingTranscriberApp: App {
     }
 
     private func openProtocolsFolder() {
-        let protocols = WatchLoop.defaultOutputDir
+        let protocols = settings.effectiveOutputDir
+        let accessing = protocols.startAccessingSecurityScopedResource()
+        defer { if accessing { protocols.stopAccessingSecurityScopedResource() } }
         try? FileManager.default.createDirectory(at: protocols, withIntermediateDirectories: true)
         NSWorkspace.shared.open(protocols)
     }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -448,7 +448,8 @@ class PipelineQueue {
             }
 
             // Save transcript
-            let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: title, dir: outputDir)
+            let protocolsDir = outputDir.appendingPathComponent("protocols")
+            let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: title, dir: protocolsDir)
             logger.info("Transcript saved: \(txtPath.lastPathComponent)")
 
             // --- Protocol Generation ---
@@ -463,8 +464,15 @@ class PipelineQueue {
             )
 
             let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + finalTranscript
-            let mdPath = try ProtocolGenerator.saveProtocol(fullMD, title: title, dir: outputDir)
+            let mdPath = try ProtocolGenerator.saveProtocol(fullMD, title: title, dir: protocolsDir)
             logger.info("Protocol saved: \(mdPath.lastPathComponent)")
+
+            // Move audio files to recordings subdirectory
+            let recordingsDir = outputDir.appendingPathComponent("recordings")
+            Self.copyAudioToOutput(
+                mixPath: mixPath, appPath: appPath, micPath: micPath,
+                title: title, outputDir: recordingsDir,
+            )
 
             // Update job with protocol path and mark done
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
@@ -530,6 +538,37 @@ class PipelineQueue {
             triggerProcessing()
         } catch {
             logger.error("Failed to load pipeline snapshot: \(error)")
+        }
+    }
+
+    // MARK: - Audio File Copy
+
+    /// Copy recording audio files to the protocol output directory.
+    private static func copyAudioToOutput(
+        mixPath: URL, appPath: URL?, micPath: URL?,
+        title: String, outputDir: URL,
+    ) {
+        let accessing = outputDir.startAccessingSecurityScopedResource()
+        defer { if accessing { outputDir.stopAccessingSecurityScopedResource() } }
+
+        let fm = FileManager.default
+        try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        let slug = ProtocolGenerator.filename(title: title, ext: "").dropLast() // remove trailing "."
+        let audioPaths: [(URL, String)] = [
+            (mixPath, "\(slug)_mix.wav"),
+            appPath.map { ($0, "\(slug)_app.wav") },
+            micPath.map { ($0, "\(slug)_mic.wav") },
+        ].compactMap(\.self)
+
+        for (src, name) in audioPaths {
+            let dst = outputDir.appendingPathComponent(name)
+            do {
+                if fm.fileExists(atPath: dst.path) { try fm.removeItem(at: dst) }
+                try fm.moveItem(at: src, to: dst)
+                logger.info("Audio moved: \(name)")
+            } catch {
+                logger.warning("Failed to move audio \(name): \(error.localizedDescription)")
+            }
         }
     }
 

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -91,6 +91,8 @@ enum ProtocolGenerator {
     ///
     /// - Returns: URL of the saved file
     static func saveTranscript(_ text: String, title: String, dir: URL) throws -> URL {
+        let accessing = dir.startAccessingSecurityScopedResource()
+        defer { if accessing { dir.stopAccessingSecurityScopedResource() } }
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent(filename(title: title, ext: "txt"))
         try text.write(to: url, atomically: true, encoding: .utf8)
@@ -102,6 +104,8 @@ enum ProtocolGenerator {
     ///
     /// - Returns: URL of the saved file
     static func saveProtocol(_ markdown: String, title: String, dir: URL) throws -> URL {
+        let accessing = dir.startAccessingSecurityScopedResource()
+        defer { if accessing { dir.stopAccessingSecurityScopedResource() } }
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent(filename(title: title, ext: "md"))
         try markdown.write(to: url, atomically: true, encoding: .utf8)

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -263,6 +263,28 @@ struct SettingsView: View {
                     }
                 }
 
+                HStack {
+                    Text("Output Folder")
+                    Spacer()
+                    Text(outputDirDisplay)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                HStack {
+                    Button("Choose\u{2026}") {
+                        chooseOutputFolder()
+                    }
+
+                    Button("Reset") {
+                        settings.clearCustomOutputDir()
+                    }
+                    .disabled(settings.customOutputDirBookmark == nil)
+
+                    Spacer()
+                }
+
                 // swiftlint:disable:next closure_body_length
                 HStack {
                     Button("Edit Prompt") {
@@ -535,6 +557,27 @@ struct SettingsView: View {
         } else {
             try? FileManager.default.copyItem(at: source, to: dest)
         }
+    }
+
+    private var outputDirDisplay: String {
+        let url = settings.effectiveOutputDir
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let path = url.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    private func chooseOutputFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose a folder for protocol output"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        settings.setCustomOutputDir(url)
     }
 
     private func refreshAudioDevices() {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -75,7 +75,7 @@ class WatchLoop {
     }
 
     nonisolated static var defaultOutputDir: URL {
-        AppPaths.protocolsDir
+        AppPaths.downloadsProtocolsDir
     }
 
     nonisolated static func defaultDetector() -> MeetingDetecting {

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -122,7 +122,7 @@ final class WatchLoopTests: XCTestCase {
 
     func testDefaultOutputDir() {
         let dir = WatchLoop.defaultOutputDir
-        XCTAssertTrue(dir.path.contains("Library/Application Support/MeetingTranscriber/protocols"))
+        XCTAssertTrue(dir.path.contains("Downloads/MeetingTranscriber"))
     }
 
     // MARK: - Meeting End Detection


### PR DESCRIPTION
## Summary
- Add configurable output directory in Settings (defaults to `~/Downloads/MeetingTranscriber`)
- Organize output into `protocols/` (`.md`, `.txt`) and `recordings/` (`.wav`) subdirectories
- Move audio files to output directory after processing
- Fix App Store entitlements to apply without notarization

## Structure
```
~/Downloads/MeetingTranscriber/
├── protocols/
│   ├── 20260317_2130_meeting.md
│   └── 20260317_2130_meeting.txt
└── recordings/
    ├── 20260317_2130_meeting_mix.wav
    ├── 20260317_2130_meeting_app.wav
    └── 20260317_2130_meeting_mic.wav
```

## Test plan
- [x] Verify default output directory is `~/Downloads/MeetingTranscriber`
- [ ] Change output directory in Settings, verify files go to new location
- [x] Process audio file, verify `.md`/`.txt` in `protocols/` and `.wav` in `recordings/`
- [x] Verify "Open Protocols Folder" opens the root output directory
- [x] App Store build: verify sandbox entitlements work with file picker