### PR TITLE
fix(app): update Accessibility permission description

### DIFF
--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -324,7 +324,7 @@ struct SettingsView: View {
                 )
                 PermissionRow(
                     label: "Accessibility",
-                    detail: "Optional — enables mute detection",
+                    detail: "Optional — enables mute detection and meeting naming",
                     granted: accessibilityOK,
                     optional: true,
                     help: "System Settings → Privacy & Security → Accessibility → enable Meeting Transcriber",


### PR DESCRIPTION
## Summary
- Update Accessibility permission detail text to mention meeting naming in addition to mute detection
- The Accessibility API is also used to read meeting participant names for proper meeting naming

## Test plan
- [x] Verify Settings → Permissions shows updated description