### PR TITLE
feat(app): add elapsed time display to pipeline stages

### DIFF
--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -112,33 +112,7 @@ struct MenuBarView: View {
                 .foregroundStyle(.secondary)
 
             ForEach(pipelineQueue.jobs) { job in
-                HStack {
-                    Circle()
-                        .fill(jobColor(job.state))
-                        .frame(width: 8, height: 8)
-                    VStack(alignment: .leading) {
-                        Text(job.meetingTitle)
-                            .font(.caption)
-                        Text(job.state.label)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if job.state == .done, let path = job.protocolPath {
-                        Button("Open") { onOpenProtocol(path) }
-                            .font(.caption2)
-                    }
-                    if job.state == .waiting || job.state == .transcribing
-                        || job.state == .diarizing || job.state == .generatingProtocol {
-                        Button("Cancel") { pipelineQueue.cancelJob(id: job.id) }
-                            .font(.caption2)
-                    }
-                    if job.state == .done || job.state == .error {
-                        Button("Dismiss") { onDismissJob(job.id) }
-                            .font(.caption2)
-                    }
-                }
-                .padding(.horizontal, 4)
+                jobRow(job)
             }
         }
 
@@ -193,6 +167,50 @@ struct MenuBarView: View {
     }
 
     // MARK: - Helpers
+
+    private func jobRow(_ job: PipelineJob) -> some View {
+        HStack {
+            Circle()
+                .fill(jobColor(job.state))
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading) {
+                Text(job.meetingTitle)
+                    .font(.caption)
+                if [.transcribing, .diarizing, .generatingProtocol].contains(job.state) {
+                    Text("\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(job.state.label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if job.state == .done, let path = job.protocolPath {
+                Button("Open") { onOpenProtocol(path) }
+                    .font(.caption2)
+            }
+            if job.state == .waiting || job.state == .transcribing
+                || job.state == .diarizing || job.state == .generatingProtocol {
+                Button("Cancel") { pipelineQueue.cancelJob(id: job.id) }
+                    .font(.caption2)
+            }
+            if job.state == .done || job.state == .error {
+                Button("Dismiss") { onDismissJob(job.id) }
+                    .font(.caption2)
+            }
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private func formattedElapsed(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        if total < 60 {
+            return "\(total)s"
+        }
+        return "\(total / 60):\(String(format: "%02d", total % 60))"
+    }
 
     private func jobColor(_ state: JobState) -> Color {
         switch state {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -23,7 +23,10 @@ class PipelineQueue {
 
     let completedJobLifetime: TimeInterval
 
+    /// Elapsed seconds since the current pipeline stage started.
+    private(set) var activeJobElapsed: TimeInterval = 0
     private(set) var isProcessing = false
+    private var elapsedTimer: Task<Void, Never>?
     private var processTask: Task<Void, Never>?
     private var cancelledJobIDs = Set<UUID>()
 
@@ -179,6 +182,27 @@ class PipelineQueue {
         }
     }
 
+    /// Reset the elapsed timer for a new pipeline stage.
+    private func startElapsedTimer() {
+        elapsedTimer?.cancel()
+        activeJobElapsed = 0
+        elapsedTimer = Task { [weak self] in
+            let start = ContinuousClock.now
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                let elapsed = ContinuousClock.now - start
+                self?.activeJobElapsed = Double(elapsed.components.seconds)
+                    + Double(elapsed.components.attoseconds) / 1e18
+            }
+        }
+    }
+
+    /// Stop the elapsed timer.
+    private func stopElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = nil
+    }
+
     // MARK: - Processing
 
     /// Kick off processing if not already running and there are waiting jobs.
@@ -214,6 +238,7 @@ class PipelineQueue {
         do {
             // --- Transcription ---
             updateJobState(id: jobID, to: .transcribing)
+            startElapsedTimer()
 
             // Create a temp directory for intermediate 16kHz files
             let workDir = FileManager.default.temporaryDirectory
@@ -234,10 +259,14 @@ class PipelineQueue {
                 try await appResample
                 try await micResample
 
-                // Use segment-returning method to cache for hybrid diarization
-                let segments = try await whisperKit.transcribeDualSourceSegments(
-                    appAudio: app16k,
-                    micAudio: mic16k,
+                // Transcribe each track separately
+                let appSegments = try await whisperKit.transcribeSegments(audioPath: app16k)
+                let micSegments = try await whisperKit.transcribeSegments(audioPath: mic16k)
+
+                // Merge dual-source segments
+                let segments = whisperKit.mergeDualSourceSegments(
+                    appSegments: appSegments,
+                    micSegments: micSegments,
                     micDelay: micDelay,
                     micLabel: micLabel,
                 )
@@ -254,6 +283,8 @@ class PipelineQueue {
                 transcript = segments.map { "\($0.formattedTimestamp) \($0.text)" }.joined(separator: "\n")
             }
 
+            stopElapsedTimer()
+
             guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 updateJobState(id: jobID, to: .error, error: "Empty transcript")
                 isProcessing = false
@@ -267,6 +298,7 @@ class PipelineQueue {
                 let diarizeProcess = diarizationFactory()
                 if diarizeProcess.isAvailable {
                     updateJobState(id: jobID, to: .diarizing)
+                    startElapsedTimer()
 
                     // Use mix audio for diarization (already resampled in single-source path)
                     let mix16k = workDir.appendingPathComponent("mix_16k.wav")
@@ -348,6 +380,7 @@ class PipelineQueue {
                                 participants: participants,
                             )
 
+                            stopElapsedTimer()
                             let namingResult: SpeakerNamingResult
                             if let handler = speakerNamingHandler {
                                 namingResult = await handler(namingData)
@@ -379,6 +412,7 @@ class PipelineQueue {
                             case let .rerun(count):
                                 speakerCount = count
                                 updateJobState(id: jobID, to: .diarizing)
+                                startElapsedTimer()
                                 logger.info("Re-running diarization with \(count) speakers")
                                 continue diarizationLoop
 
@@ -454,6 +488,7 @@ class PipelineQueue {
 
             // --- Protocol Generation ---
             updateJobState(id: jobID, to: .generatingProtocol)
+            startElapsedTimer()
 
             let diarized = finalTranscript.range(of: #"\[\w[\w\s]*\]"#, options: .regularExpression) != nil
             let protocolGenerator = protocolGeneratorFactory()
@@ -478,11 +513,14 @@ class PipelineQueue {
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                 jobs[idx].protocolPath = mdPath
             }
+            stopElapsedTimer()
             updateJobState(id: jobID, to: .done)
         } catch is CancellationError {
+            stopElapsedTimer()
             logger.info("Job \(jobID) cancelled")
             // Job already removed by cancelJob()
         } catch {
+            stopElapsedTimer()
             if cancelledJobIDs.remove(jobID) != nil {
                 logger.info("Job \(jobID) cancelled")
             } else {

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import WhisperKit
 
@@ -38,6 +39,8 @@ final class WhisperKitEngine {
     var language: String?
     private(set) var modelState: ModelState = .unloaded
     private(set) var downloadProgress: Double = 0
+    /// Transcription progress (0.0–1.0) based on WhisperKit's 30s window processing.
+    private(set) var transcriptionProgress: Double = 0
     private var pipe: WhisperKit?
     private var loadingTask: Task<Void, Never>?
 
@@ -107,6 +110,11 @@ final class WhisperKitEngine {
             throw TranscriptionError.modelNotLoaded
         }
 
+        transcriptionProgress = 0
+
+        // Estimate total 30s windows from audio duration
+        let totalWindows = max(1, Self.estimateWindowCount(audioPath: audioPath))
+
         let options = DecodingOptions(
             language: language,
             wordTimestamps: false,
@@ -115,7 +123,16 @@ final class WhisperKitEngine {
         let results = await pipe.transcribe(
             audioPaths: [audioPath.path],
             decodeOptions: options,
-        )
+        ) { [weak self] progress in
+            Task { @MainActor in
+                guard let self else { return }
+                self.transcriptionProgress = min(
+                    Double(progress.windowId + 1) / Double(totalWindows),
+                    1.0,
+                )
+            }
+            return nil // continue transcription
+        }
 
         guard let firstResult = results.first, let transcriptionResults = firstResult else {
             return []
@@ -134,26 +151,31 @@ final class WhisperKitEngine {
                 text: text,
             ))
         }
+        transcriptionProgress = 1.0
         return segments
     }
 
-    /// Transcribe app and mic audio separately, label and merge by timestamp.
+    /// Estimate number of 30-second windows WhisperKit will process for the given audio file.
+    private static func estimateWindowCount(audioPath: URL) -> Int {
+        guard let audioFile = try? AVAudioFile(forReading: audioPath) else { return 1 }
+        let duration = Double(audioFile.length) / audioFile.fileFormat.sampleRate
+        return Int(ceil(duration / 30.0))
+    }
+
+    /// Label and merge pre-transcribed app/mic segments by timestamp.
     ///
-    /// Labels mic segments with `micLabel` and app segments as "Remote".
-    /// Returns structured segments for downstream processing (e.g. diarization).
-    func transcribeDualSourceSegments(
-        appAudio: URL,
-        micAudio: URL,
+    /// Used by PipelineQueue when transcription is done track-by-track for progress tracking.
+    func mergeDualSourceSegments(
+        appSegments: [TimestampedSegment],
+        micSegments: [TimestampedSegment],
         micDelay: TimeInterval = 0,
         micLabel: String = "Me",
-    ) async throws -> [TimestampedSegment] {
-        // Transcribe both tracks
-        var appSegments = try await transcribeSegments(audioPath: appAudio)
-        var micSegments = try await transcribeSegments(audioPath: micAudio)
+    ) -> [TimestampedSegment] {
+        var app = appSegments
+        var mic = micSegments
 
-        // Shift mic timestamps by delay
         if micDelay != 0 {
-            micSegments = micSegments.map { seg in
+            mic = mic.map { seg in
                 TimestampedSegment(
                     start: seg.start + micDelay,
                     end: seg.end + micDelay,
@@ -163,16 +185,14 @@ final class WhisperKitEngine {
             }
         }
 
-        // Label speakers
-        for i in appSegments.indices {
-            appSegments[i].speaker = "Remote"
+        for i in app.indices {
+            app[i].speaker = "Remote"
         }
-        for i in micSegments.indices {
-            micSegments[i].speaker = micLabel
+        for i in mic.indices {
+            mic[i].speaker = micLabel
         }
 
-        // Merge by start timestamp
-        return Self.mergeSegments(appSegments, micSegments)
+        return Self.mergeSegments(app, mic)
     }
 
     /// Merge two segment arrays sorted by start timestamp.

--- a/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
@@ -365,7 +365,7 @@ final class MenuBarViewTests: XCTestCase {
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Processing"))
         XCTAssertNoThrow(try body.find(text: "Standup"))
-        XCTAssertNoThrow(try body.find(text: "Transcribing..."))
+        XCTAssertNoThrow(try body.find(text: "Transcribing... 0s"))
     }
 
     func testDismissButtonShownForCompletedJob() throws {


### PR DESCRIPTION
## Summary
- Shows a seconds counter for each active pipeline stage (e.g. "Transcribing... 42s", "Diarizing... 1:15", "Generating Protocol... 23s")
- Timer pauses when the speaker naming dialog is open
- Timer restarts on diarization rerun

## Test plan
- [x] Process audio file, verify timer increments each second during transcription
- [x] Enable diarization, verify timer increments during diarization
- [x] Open speaker naming dialog, verify timer stops
- [x] Rerun diarization, verify timer resets and restarts
- [x] Verify protocol generation shows elapsed time