### PR TITLE
fix(app): fix menu bar icon staying inactive during file processing

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -69,11 +69,12 @@ struct MeetingTranscriberApp: App {
             } icon: {
                 Image(nsImage: MenuBarIcon.image(
                     badge: currentBadge,
-                    animationFrame: currentBadge.isAnimated ? iconAnimationFrame : 0,
+                    animationFrame: iconAnimationFrame,
                 ))
             }
             .onReceive(iconTimer) { _ in
-                guard currentBadge.isAnimated else { return }
+                // Always tick so currentBadge is re-read every 0.4s.
+                // Non-animated badges ignore animationFrame (cached frame 0).
                 iconAnimationFrame = (iconAnimationFrame + 1) % MenuBarIcon.frameCount
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
@@ -172,22 +173,24 @@ struct MeetingTranscriberApp: App {
     }
 
     private var currentBadge: BadgeKind {
+        // Manual / auto recording via WatchLoop
         if let loop = watchLoop, loop.isActive {
             if loop.state == .recording { return .recording }
-            if let activeJob = pipelineQueue.activeJobs.first {
-                switch activeJob.state {
-                case .transcribing: return .transcribing
-                case .diarizing: return .diarizing
-                default: return .processing
-                }
-            }
             switch loop.transcriberState {
             case .waitingForSpeakerCount, .waitingForSpeakerNames: return .userAction
             case .protocolReady: return .done
             case .error: return .error
             case .transcribing, .recordingDone: return .transcribing
             case .generatingProtocol: return .processing
-            default: return .inactive
+            default: break
+            }
+        }
+        // Pipeline queue (file processing or post-recording pipeline)
+        if let activeJob = pipelineQueue.activeJobs.first {
+            switch activeJob.state {
+            case .transcribing: return .transcribing
+            case .diarizing: return .diarizing
+            default: return .processing
             }
         }
         if updateChecker.availableUpdate != nil { return .updateAvailable }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -76,6 +76,27 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(queue.activeJobs[0].meetingTitle, "Active")
     }
 
+    func testActiveJobsIncludesDiarizingAndGeneratingProtocol() {
+        var j1 = makeJob(title: "Diarizing")
+        j1.state = .diarizing
+        var j2 = makeJob(title: "Protocol")
+        j2.state = .generatingProtocol
+        queue.enqueue(j1)
+        queue.enqueue(j2)
+        XCTAssertEqual(queue.activeJobs.count, 2)
+    }
+
+    func testActiveJobsExcludesTerminalStates() {
+        var done = makeJob(title: "Done")
+        done.state = .done
+        var err = makeJob(title: "Error")
+        err.state = .error
+        queue.enqueue(done)
+        queue.enqueue(err)
+        queue.enqueue(makeJob(title: "Waiting"))
+        XCTAssertTrue(queue.activeJobs.isEmpty)
+    }
+
     func testPendingJobs() {
         queue.enqueue(makeJob(title: "Waiting 1"))
         queue.enqueue(makeJob(title: "Waiting 2"))


### PR DESCRIPTION
## Problem
The menu bar icon stayed `.inactive` in two cases:
1. **File processing** — no `watchLoop` exists, so `currentBadge` never checked the pipeline queue
2. **State transitions** — the timer guard (`guard currentBadge.isAnimated`) stopped ticking, so the icon could get stuck when transitioning from inactive to an active state

## Fix
- `currentBadge` now checks `pipelineQueue.activeJobs` independently of `watchLoop`
- Timer always ticks every 0.4s — non-animated badges return cached frame 0, so there's no visual cost

## Test plan
- [ ] Open file via "Process Audio/Video Files..." → icon animates during transcribing/diarizing/protocol
- [ ] Start manual recording via "Record App..." → icon shows recording animation immediately
- [ ] Icon transitions correctly between all states without getting stuck