### PR TITLE
fix(app): exclude manual recording from isWatching state

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -21,7 +21,7 @@ struct MeetingTranscriberApp: App {
     private let iconTimer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
 
     private var isWatching: Bool {
-        watchLoop?.isActive == true
+        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
     }
 
     init() {


### PR DESCRIPTION
## Problem
During manual recording ("Record App..."), the "Start Watching" button incorrectly showed "Stop Watching" because `isWatching` only checked `watchLoop?.isActive`. Clicking it did nothing (guarded in `toggleWatching`), but the label was misleading.

## Fix
`isWatching` now also requires `isManualRecording == false`.

## Test plan
- [x] Start manual recording → "Start Watching" stays as "Start Watching"
- [x] Start auto-watch → "Start Watching" changes to "Stop Watching"