### PR TITLE
fix(app): mark recording as processed when job fails

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -21,7 +21,7 @@ struct MeetingTranscriberApp: App {
     private let iconTimer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
 
     private var isWatching: Bool {
-        watchLoop?.isActive == true
+        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
     }
 
     init() {

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -176,15 +176,7 @@ struct MenuBarView: View {
             VStack(alignment: .leading) {
                 Text(job.meetingTitle)
                     .font(.caption)
-                if [.transcribing, .diarizing, .generatingProtocol].contains(job.state) {
-                    Text("\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(job.state.label)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
+                jobStateLabel(job)
             }
             Spacer()
             if job.state == .done, let path = job.protocolPath {
@@ -202,6 +194,22 @@ struct MenuBarView: View {
             }
         }
         .padding(.horizontal, 4)
+    }
+
+    private func jobStateLabel(_ job: PipelineJob) -> some View {
+        Group {
+            if [.transcribing, .diarizing, .generatingProtocol].contains(job.state) {
+                Text("\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))")
+                    .foregroundStyle(.secondary)
+            } else if job.state == .error, let msg = job.error {
+                Text(msg)
+                    .foregroundStyle(.red)
+            } else {
+                Text(job.state.label)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption2)
     }
 
     private func formattedElapsed(_ seconds: TimeInterval) -> String {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -173,8 +173,10 @@ class PipelineQueue {
         writeSnapshot()
         onJobStateChange?(jobs[index], oldState, newState)
 
-        if newState == .done {
+        if newState == .done || newState == .error {
             markProcessed(mixPath: jobs[index].mixPath)
+        }
+        if newState == .done {
             Task { [weak self] in
                 try? await Task.sleep(for: .seconds(self?.completedJobLifetime ?? 60))
                 self?.removeJob(id: id)

--- a/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
@@ -494,7 +494,7 @@ final class MenuBarViewTests: XCTestCase {
         )
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Dismiss"))
-        XCTAssertNoThrow(try body.find(text: "Error"))
+        XCTAssertNoThrow(try body.find(text: "Failed"))
     }
 
     // MARK: - Record App button

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -328,6 +328,30 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(freshQueue.jobs.count, 0)
     }
 
+    func testErrorJobIsMarkedProcessedSoRecoverySkipsIt() throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260318_214744_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+
+        // Enqueue and fail the job (simulates "Empty transcript" scenario)
+        let job = PipelineJob(
+            meetingTitle: "Brave Browser",
+            appName: "Brave Browser",
+            mixPath: mixFile,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        queue.enqueue(job)
+        queue.updateJobState(id: job.id, to: .error, error: "Empty transcript")
+
+        // A fresh queue (simulates pressing Start Watching) must not recover the failed recording
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        XCTAssertTrue(freshQueue.jobs.isEmpty, "Failed recording should not be re-queued")
+    }
+
     func testMarkProcessedPersists() throws {
         let mixPath = tmpDir.appendingPathComponent("test_mix.wav")
 


### PR DESCRIPTION
## Problem
Failed jobs did not call `markProcessed`, so their recording files remained untracked on disk. When pressing "Start Watching" afterwards, `recoverOrphanedRecordings` picked them up and re-queued them — causing e.g. a "Empty transcript" error to be retried endlessly.

## Fix
`updateJobState` now calls `markProcessed` for both `.done` and `.error` terminal states.

## Test
Added `testErrorJobIsMarkedProcessedSoRecoverySkipsIt` which simulates the exact scenario: enqueue → fail → new queue instance must not recover the file.