### PR TITLE
refactor(app): extract AppState ViewModel + BadgeKind.compute pure function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@ VERSION                    # App version (read by build scripts)
 app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
   Package.swift            # SPM manifest (ViewInspector test dep)
   Sources/
-    MeetingTranscriberApp.swift  # @main, menu bar scene
+    MeetingTranscriberApp.swift  # @main, UI shell (scenes, NSOpenPanel, NSWorkspace)
+    AppState.swift         # @Observable @MainActor ViewModel (business state, badge logic, pipeline wiring)
     MenuBarView.swift      # Menu bar dropdown UI
-    MenuBarIcon.swift      # Animated waveform menu bar icon (reflects pipeline state)
+    MenuBarIcon.swift      # Animated waveform menu bar icon + BadgeKind.compute() pure function
     SettingsView.swift     # Settings window
     SpeakerNamingView.swift # Speaker naming dialog + AccessibleTextField
     AppPickerView.swift    # App picker for manual recording

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -1,0 +1,283 @@
+import Foundation
+import Observation
+
+// MARK: - AppNotifying
+
+/// Notification abstraction that keeps AppKit out of AppState.
+///
+/// Real implementation: `NotificationManager` (AppKit, used in menu bar app).
+/// Test implementation: `RecordingNotifier` (records calls, no side effects).
+protocol AppNotifying {
+    func notify(title: String, body: String)
+}
+
+// MARK: - AppState
+
+/// Observable ViewModel that owns all business state and derived UI properties.
+///
+/// Extracted from `MeetingTranscriberApp` so that:
+/// - Badge/watching logic is testable without instantiating the `@main` App struct.
+/// - `BadgeKind.compute(...)` can be called directly in tests.
+@Observable
+@MainActor
+final class AppState {
+    // MARK: - Dependencies
+
+    let settings: AppSettings
+    let whisperKit: WhisperKitEngine
+    private let notifier: any AppNotifying
+
+    // MARK: - State
+
+    var watchLoop: WatchLoop?
+    var pipelineQueue: PipelineQueue
+    var updateChecker: UpdateChecker
+
+    // MARK: - Init
+
+    init(
+        settings: AppSettings = AppSettings(),
+        whisperKit: WhisperKitEngine? = nil,
+        notifier: any AppNotifying = SilentNotifier(),
+        updateChecker: UpdateChecker? = nil,
+    ) {
+        self.settings = settings
+        self.whisperKit = whisperKit ?? WhisperKitEngine()
+        self.notifier = notifier
+        self.updateChecker = updateChecker ?? UpdateChecker()
+        self.pipelineQueue = PipelineQueue()
+    }
+
+    // MARK: - Derived properties
+
+    var isWatching: Bool {
+        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
+    }
+
+    var currentBadge: BadgeKind {
+        BadgeKind.compute(
+            watchLoopActive: watchLoop?.isActive == true,
+            watchLoopState: watchLoop?.state ?? .idle,
+            transcriberState: watchLoop?.transcriberState ?? .idle,
+            activeJobState: pipelineQueue.activeJobs.first?.state,
+            updateAvailable: updateChecker.availableUpdate != nil,
+        )
+    }
+
+    var currentStateLabel: String {
+        if let loop = watchLoop, loop.isActive {
+            return loop.transcriberState.label
+        }
+        return "Idle"
+    }
+
+    private static let isoFormatter = ISO8601DateFormatter()
+
+    var currentStatus: TranscriberStatus? {
+        guard let loop = watchLoop, loop.isActive else { return nil }
+
+        let meeting: MeetingInfo? = if let manual = loop.manualRecordingInfo {
+            MeetingInfo(
+                app: manual.appName,
+                title: manual.title,
+                pid: Int(manual.pid),
+            )
+        } else {
+            loop.currentMeeting.map { meeting in
+                MeetingInfo(
+                    app: meeting.pattern.appName,
+                    title: meeting.windowTitle,
+                    pid: Int(meeting.windowPID),
+                )
+            }
+        }
+
+        return TranscriberStatus(
+            version: 1,
+            timestamp: Self.isoFormatter.string(from: Date()),
+            state: loop.transcriberState,
+            detail: loop.detail,
+            meeting: meeting,
+            protocolPath: nil,
+            error: loop.lastError,
+            audioPath: nil,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+        )
+    }
+
+    // MARK: - Start / Stop
+
+    func toggleWatching() {
+        if let loop = watchLoop, loop.isManualRecording { return }
+        if let loop = watchLoop, loop.isActive {
+            loop.stop()
+            watchLoop = nil
+        } else {
+            // swiftlint:disable:next closure_body_length
+            Task { @MainActor in
+                _ = await Permissions.ensureMicrophoneAccess()
+
+                whisperKit.language = settings.whisperLanguageOrNil
+                pipelineQueue = makePipelineQueue()
+
+                let detector: MeetingDetecting = PowerAssertionDetector()
+
+                let loop = WatchLoop(
+                    detector: detector,
+                    pipelineQueue: pipelineQueue,
+                    pollInterval: settings.pollInterval,
+                    endGracePeriod: settings.endGrace,
+                    noMic: settings.noMic,
+                    micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+                )
+
+                loop.onStateChange = { [weak loop, notifier] _, newState in
+                    switch newState {
+                    case .recording:
+                        if let meeting = loop?.currentMeeting {
+                            notifier.notify(
+                                title: "Meeting Detected",
+                                body: "Recording: \(meeting.windowTitle)",
+                            )
+                        }
+
+                    case .error:
+                        if let err = loop?.lastError {
+                            notifier.notify(title: "Error", body: err)
+                        }
+
+                    default:
+                        break
+                    }
+                }
+
+                configurePipelineCallbacks()
+
+                watchLoop = loop
+                loop.start()
+            }
+        }
+    }
+
+    func startManualRecording(pid: pid_t, appName: String, title: String) {
+        // Stop auto-watch if active
+        if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
+            loop.stop()
+            watchLoop = nil
+        }
+
+        Task { @MainActor in
+            _ = await Permissions.ensureMicrophoneAccess()
+
+            ensurePipelineQueue()
+
+            let loop = WatchLoop(
+                recorderFactory: { DualSourceRecorder() },
+                pipelineQueue: pipelineQueue,
+                pollInterval: settings.pollInterval,
+                noMic: settings.noMic,
+                micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+            )
+            watchLoop = loop
+
+            do {
+                try loop.startManualRecording(pid: pid, appName: appName, title: title)
+                notifier.notify(
+                    title: "Manual Recording",
+                    body: "Recording: \(title)",
+                )
+            } catch {
+                notifier.notify(title: "Error", body: error.localizedDescription)
+                watchLoop = nil
+            }
+        }
+    }
+
+    func stopManualRecording() {
+        watchLoop?.stopManualRecording()
+        watchLoop = nil
+    }
+
+    func enqueueFiles(_ urls: [URL]) {
+        ensurePipelineQueue()
+
+        for url in urls {
+            let title = url.deletingPathExtension().lastPathComponent
+            let job = PipelineJob(
+                meetingTitle: title,
+                appName: "File",
+                mixPath: url,
+                appPath: nil,
+                micPath: nil,
+                micDelay: 0,
+            )
+            pipelineQueue.enqueue(job)
+        }
+    }
+
+    // MARK: - Pipeline
+
+    func ensurePipelineQueue() {
+        guard pipelineQueue.whisperKit == nil else { return }
+        whisperKit.language = settings.whisperLanguageOrNil
+        pipelineQueue = makePipelineQueue()
+        configurePipelineCallbacks()
+    }
+
+    func makePipelineQueue() -> PipelineQueue {
+        let queue = PipelineQueue(
+            whisperKit: whisperKit,
+            diarizationFactory: { FluidDiarizer() },
+            protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
+            outputDir: settings.effectiveOutputDir,
+            diarizeEnabled: settings.diarize,
+            numSpeakers: settings.numSpeakers,
+            micLabel: settings.micName,
+        )
+        queue.loadSnapshot()
+        queue.recoverOrphanedRecordings()
+        return queue
+    }
+
+    func makeProtocolGenerator() -> ProtocolGenerating {
+        switch settings.protocolProvider {
+        #if !APPSTORE
+            case .claudeCLI:
+                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin)
+        #endif
+
+        case .openAICompatible:
+            OpenAIProtocolGenerator(
+                endpoint: URL(string: settings.openAIEndpoint)
+                    // swiftlint:disable:next force_unwrapping
+                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
+                model: settings.openAIModel,
+                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
+            )
+        }
+    }
+
+    func configurePipelineCallbacks() {
+        pipelineQueue.onJobStateChange = { [notifier] job, _, newState in
+            switch newState {
+            case .done:
+                notifier.notify(title: "Protocol Ready", body: job.meetingTitle)
+
+            case .error:
+                if let err = job.error {
+                    notifier.notify(title: "Error", body: err)
+                }
+
+            default:
+                break
+            }
+        }
+    }
+}
+
+// MARK: - SilentNotifier
+
+/// No-op notifier for CLI targets and tests that don't need notifications.
+struct SilentNotifier: AppNotifying {
+    func notify(title _: String, body _: String) {}
+}

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -9,24 +9,15 @@ extension Notification.Name {
 
 @main
 struct MeetingTranscriberApp: App {
-    @State private var settings = AppSettings()
-    @State private var watchLoop: WatchLoop?
-    @State private var pipelineQueue = PipelineQueue()
+    @State private var appState = AppState(notifier: NotificationManager.shared)
     @State private var iconAnimationFrame = 0
-    @State private var updateChecker = UpdateChecker()
     @Environment(\.openWindow)
     private var openWindow
-    private let notifications = NotificationManager.shared
-    private let whisperKit = WhisperKitEngine()
     private let iconTimer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
-
-    private var isWatching: Bool {
-        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
-    }
 
     init() {
         AppPaths.migrateIfNeeded()
-        notifications.setUp()
+        NotificationManager.shared.setUp()
         DualSourceRecorder.cleanupTempFiles()
         // Auto-watch: schedule on main run loop after app finishes launching
         if CommandLine.arguments.contains("--auto-watch")
@@ -40,15 +31,14 @@ struct MeetingTranscriberApp: App {
     var body: some Scene {
         MenuBarExtra {
             MenuBarView(
-                status: currentStatus,
-                isWatching: isWatching,
-                pipelineQueue: pipelineQueue,
-                updateChecker: updateChecker,
-                onStartStop: toggleWatching,
+                status: appState.currentStatus,
+                isWatching: appState.isWatching,
+                pipelineQueue: appState.pipelineQueue,
+                updateChecker: appState.updateChecker,
+                onStartStop: appState.toggleWatching,
                 onRecordApp: { bringWindowToFront(id: "record-app") },
-                onStopManualRecording: watchLoop?.isManualRecording == true ? {
-                    watchLoop?.stopManualRecording()
-                    watchLoop = nil
+                onStopManualRecording: appState.watchLoop?.isManualRecording == true ? {
+                    appState.stopManualRecording()
                 } : nil,
                 onOpenLastProtocol: openLastProtocol,
                 onOpenProtocol: { url in NSWorkspace.shared.open(url) },
@@ -60,15 +50,15 @@ struct MeetingTranscriberApp: App {
                     bringWindowToFront(id: "speaker-naming")
                 },
                 onProcessFiles: processAudioFiles,
-                onDismissJob: { id in pipelineQueue.removeJob(id: id) },
+                onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
                 onQuit: quit,
             )
         } label: {
             Label {
-                Text(currentStateLabel)
+                Text(appState.currentStateLabel)
             } icon: {
                 Image(nsImage: MenuBarIcon.image(
-                    badge: currentBadge,
+                    badge: appState.currentBadge,
                     animationFrame: iconAnimationFrame,
                 ))
             }
@@ -78,27 +68,27 @@ struct MeetingTranscriberApp: App {
                 iconAnimationFrame = (iconAnimationFrame + 1) % MenuBarIcon.frameCount
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
-                if !isWatching {
-                    toggleWatching()
+                if !appState.isWatching {
+                    appState.toggleWatching()
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
                 bringWindowToFront(id: "speaker-naming")
             }
             .task {
-                whisperKit.modelVariant = settings.whisperKitModel
-                whisperKit.language = settings.whisperLanguageOrNil
-                await whisperKit.loadModel()
+                appState.whisperKit.modelVariant = appState.settings.whisperKitModel
+                appState.whisperKit.language = appState.settings.whisperLanguageOrNil
+                await appState.whisperKit.loadModel()
             }
             .task {
-                updateChecker.startPeriodicChecks(settings: settings)
+                appState.updateChecker.startPeriodicChecks(settings: appState.settings)
             }
         }
 
         Window("Name Speakers", id: "speaker-naming") {
-            if let data = pipelineQueue.pendingSpeakerNaming {
+            if let data = appState.pipelineQueue.pendingSpeakerNaming {
                 SpeakerNamingView(data: data) { result in
-                    pipelineQueue.completeSpeakerNaming(result: result)
+                    appState.pipelineQueue.completeSpeakerNaming(result: result)
                     closeWindow(id: "speaker-naming")
                 }
             } else {
@@ -110,9 +100,9 @@ struct MeetingTranscriberApp: App {
 
         Window("Settings", id: "settings") {
             SettingsView(
-                settings: settings,
-                whisperKitEngine: whisperKit,
-                updateChecker: updateChecker,
+                settings: appState.settings,
+                whisperKitEngine: appState.whisperKit,
+                updateChecker: appState.updateChecker,
             )
         }
         .windowResizability(.contentSize)
@@ -120,7 +110,7 @@ struct MeetingTranscriberApp: App {
         Window("Record App", id: "record-app") {
             AppPickerView(
                 onStartRecording: { pid, appName, title in
-                    startManualRecording(pid: pid, appName: appName, title: title)
+                    appState.startManualRecording(pid: pid, appName: appName, title: title)
                     closeWindow(id: "record-app")
                 },
                 onCancel: { closeWindow(id: "record-app") },
@@ -129,225 +119,7 @@ struct MeetingTranscriberApp: App {
         .windowResizability(.contentSize)
     }
 
-    // MARK: - Status
-
-    private static let isoFormatter = ISO8601DateFormatter()
-
-    private var currentStatus: TranscriberStatus? {
-        guard let loop = watchLoop, loop.isActive else { return nil }
-
-        let meeting: MeetingInfo? = if let manual = loop.manualRecordingInfo {
-            MeetingInfo(
-                app: manual.appName,
-                title: manual.title,
-                pid: Int(manual.pid),
-            )
-        } else {
-            loop.currentMeeting.map { meeting in
-                MeetingInfo(
-                    app: meeting.pattern.appName,
-                    title: meeting.windowTitle,
-                    pid: Int(meeting.windowPID),
-                )
-            }
-        }
-
-        return TranscriberStatus(
-            version: 1,
-            timestamp: Self.isoFormatter.string(from: Date()),
-            state: loop.transcriberState,
-            detail: loop.detail,
-            meeting: meeting,
-            protocolPath: nil,
-            error: loop.lastError,
-            audioPath: nil,
-            pid: Int(ProcessInfo.processInfo.processIdentifier),
-        )
-    }
-
-    private var currentStateLabel: String {
-        if let loop = watchLoop, loop.isActive {
-            return loop.transcriberState.label
-        }
-        return "Idle"
-    }
-
-    private var currentBadge: BadgeKind {
-        // Manual / auto recording via WatchLoop
-        if let loop = watchLoop, loop.isActive {
-            if loop.state == .recording { return .recording }
-            switch loop.transcriberState {
-            case .waitingForSpeakerCount, .waitingForSpeakerNames: return .userAction
-            case .protocolReady: return .done
-            case .error: return .error
-            case .transcribing, .recordingDone: return .transcribing
-            case .generatingProtocol: return .processing
-            default: break
-            }
-        }
-        // Pipeline queue (file processing or post-recording pipeline)
-        if let activeJob = pipelineQueue.activeJobs.first {
-            switch activeJob.state {
-            case .transcribing: return .transcribing
-            case .diarizing: return .diarizing
-            default: return .processing
-            }
-        }
-        if updateChecker.availableUpdate != nil { return .updateAvailable }
-        return .inactive
-    }
-
-    // MARK: - Start / Stop
-
-    private func startManualRecording(pid: pid_t, appName: String, title: String) {
-        // Stop auto-watch if active
-        if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
-            loop.stop()
-            watchLoop = nil
-        }
-
-        Task {
-            _ = await Permissions.ensureMicrophoneAccess()
-
-            ensurePipelineQueue()
-
-            let loop = WatchLoop(
-                recorderFactory: { DualSourceRecorder() },
-                pipelineQueue: pipelineQueue,
-                pollInterval: settings.pollInterval,
-                noMic: settings.noMic,
-                micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-            )
-            watchLoop = loop
-
-            do {
-                try loop.startManualRecording(pid: pid, appName: appName, title: title)
-                notifications.notify(
-                    title: "Manual Recording",
-                    body: "Recording: \(title)",
-                )
-            } catch {
-                notifications.notify(title: "Error", body: error.localizedDescription)
-                watchLoop = nil
-            }
-        }
-    }
-
-    private func toggleWatching() {
-        if let loop = watchLoop, loop.isManualRecording { return }
-        if let loop = watchLoop, loop.isActive {
-            loop.stop()
-            watchLoop = nil
-        } else {
-            // swiftlint:disable:next closure_body_length
-            Task {
-                _ = await Permissions.ensureMicrophoneAccess()
-
-                // swiftlint:disable:next closure_body_length
-                await MainActor.run {
-                    whisperKit.language = settings.whisperLanguageOrNil
-                    pipelineQueue = makePipelineQueue()
-
-                    let detector: MeetingDetecting = PowerAssertionDetector()
-
-                    let loop = WatchLoop(
-                        detector: detector,
-                        pipelineQueue: pipelineQueue,
-                        pollInterval: settings.pollInterval,
-                        endGracePeriod: settings.endGrace,
-                        noMic: settings.noMic,
-                        micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                    )
-
-                    loop.onStateChange = { [weak loop, notifications] _, newState in
-                        switch newState {
-                        case .recording:
-                            if let meeting = loop?.currentMeeting {
-                                notifications.notify(
-                                    title: "Meeting Detected",
-                                    body: "Recording: \(meeting.windowTitle)",
-                                )
-                            }
-
-                        case .error:
-                            if let err = loop?.lastError {
-                                notifications.notify(title: "Error", body: err)
-                            }
-
-                        default:
-                            break
-                        }
-                    }
-
-                    configurePipelineCallbacks()
-
-                    watchLoop = loop
-                    loop.start()
-                }
-            }
-        }
-    }
-
-    // MARK: - Pipeline
-
-    private func ensurePipelineQueue() {
-        guard pipelineQueue.whisperKit == nil else { return }
-        whisperKit.language = settings.whisperLanguageOrNil
-        pipelineQueue = makePipelineQueue()
-        configurePipelineCallbacks()
-    }
-
-    private func makeProtocolGenerator() -> ProtocolGenerating {
-        switch settings.protocolProvider {
-        #if !APPSTORE
-            case .claudeCLI:
-                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin)
-        #endif
-
-        case .openAICompatible:
-            OpenAIProtocolGenerator(
-                endpoint: URL(string: settings.openAIEndpoint)
-                    // swiftlint:disable:next force_unwrapping
-                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
-                model: settings.openAIModel,
-                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
-            )
-        }
-    }
-
-    private func makePipelineQueue() -> PipelineQueue {
-        let queue = PipelineQueue(
-            whisperKit: whisperKit,
-            diarizationFactory: { FluidDiarizer() },
-            protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
-            outputDir: settings.effectiveOutputDir,
-            diarizeEnabled: settings.diarize,
-            numSpeakers: settings.numSpeakers,
-            micLabel: settings.micName,
-        )
-        queue.loadSnapshot()
-        queue.recoverOrphanedRecordings()
-        return queue
-    }
-
-    private func configurePipelineCallbacks() {
-        pipelineQueue.onJobStateChange = { [notifications] job, _, newState in
-            switch newState {
-            case .done:
-                notifications.notify(title: "Protocol Ready", body: job.meetingTitle)
-
-            case .error:
-                if let err = job.error {
-                    notifications.notify(title: "Error", body: err)
-                }
-
-            default:
-                break
-            }
-        }
-    }
-
-    // MARK: - Actions
+    // MARK: - UI Actions
 
     private func processAudioFiles() {
         let panel = NSOpenPanel()
@@ -364,26 +136,11 @@ struct MeetingTranscriberApp: App {
         panel.canChooseDirectories = false
 
         guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
-
-        // Ensure queue has processing dependencies
-        ensurePipelineQueue()
-
-        for url in panel.urls {
-            let title = url.deletingPathExtension().lastPathComponent
-            let job = PipelineJob(
-                meetingTitle: title,
-                appName: "File",
-                mixPath: url,
-                appPath: nil,
-                micPath: nil,
-                micDelay: 0,
-            )
-            pipelineQueue.enqueue(job)
-        }
+        appState.enqueueFiles(panel.urls)
     }
 
     private func openLastProtocol() {
-        if let job = pipelineQueue.completedJobs.last,
+        if let job = appState.pipelineQueue.completedJobs.last,
            let path = job.protocolPath {
             NSWorkspace.shared.open(path)
         }
@@ -407,7 +164,7 @@ struct MeetingTranscriberApp: App {
     }
 
     private func openProtocolsFolder() {
-        let protocols = settings.effectiveOutputDir
+        let protocols = appState.settings.effectiveOutputDir
         let accessing = protocols.startAccessingSecurityScopedResource()
         defer { if accessing { protocols.stopAccessingSecurityScopedResource() } }
         try? FileManager.default.createDirectory(at: protocols, withIntermediateDirectories: true)
@@ -415,7 +172,7 @@ struct MeetingTranscriberApp: App {
     }
 
     private func quit() {
-        watchLoop?.stop()
+        appState.watchLoop?.stop()
         NSApplication.shared.terminate(nil)
     }
 }

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -240,3 +240,39 @@ enum MenuBarIcon {
         }
     }
 }
+
+// MARK: - Badge State Logic (pure function, testable without UI)
+
+extension BadgeKind {
+    /// Computes the current badge from plain value inputs.
+    ///
+    /// This is a pure function with no object dependencies — tests can call it
+    /// directly with any combination of inputs without driving WatchLoop into states.
+    static func compute(
+        watchLoopActive: Bool,
+        watchLoopState: WatchLoop.State,
+        transcriberState: TranscriberState,
+        activeJobState: JobState?,
+        updateAvailable: Bool,
+    ) -> BadgeKind {
+        if watchLoopActive {
+            if watchLoopState == .recording { return .recording }
+            switch transcriberState {
+            case .waitingForSpeakerCount, .waitingForSpeakerNames: return .userAction
+            case .protocolReady: return .done
+            case .error: return .error
+            case .transcribing, .recordingDone: return .transcribing
+            case .generatingProtocol: return .processing
+            default: break
+            }
+        }
+        switch activeJobState {
+        case .transcribing: return .transcribing
+        case .diarizing: return .diarizing
+        case .some: return .processing
+        case .none: break
+        }
+        if updateAvailable { return .updateAvailable }
+        return .inactive
+    }
+}

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import UserNotifications
 
 /// Sends macOS notifications for meeting state transitions.
-final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
+final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, AppNotifying {
     static let shared = NotificationManager()
 
     private(set) var isSetUp = false

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -1,63 +1,190 @@
 @testable import MeetingTranscriber
 import XCTest
 
-// MARK: - Test Helpers
-
-final class RecordingNotifier: AppNotifying {
-    private(set) var calls: [(title: String, body: String)] = []
-
-    func notify(title: String, body: String) {
-        calls.append((title: title, body: body))
-    }
-}
-
-// MARK: - AppState Integration Tests
-
 @MainActor
 final class AppStateTests: XCTestCase {
-    func testAppStateIsWatchingFalseWhenNoWatchLoop() {
-        let state = AppState()
-        XCTAssertFalse(state.isWatching)
+    // MARK: - Helpers
+
+    /// Yields repeatedly until `condition()` is true or the timeout elapses.
+    /// Needed for tests that await toggleWatching()/startManualRecording() which
+    /// internally spawn a Task containing AVCaptureDevice.requestAccess — a real
+    /// async suspension point that requires more than one yield to resolve.
+    private func waitFor(
+        _ condition: @autoclosure () -> Bool,
+        timeout: Duration = .milliseconds(500),
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            await Task.yield()
+        }
     }
 
-    func testAppStateCurrentStateLabelIdleByDefault() {
-        let state = AppState()
-        XCTAssertEqual(state.currentStateLabel, "Idle")
+    private func makeState() -> (AppState, RecordingNotifier) {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        return (state, notifier)
     }
 
-    func testAppStateCurrentBadgeInactiveByDefault() {
-        let state = AppState()
-        XCTAssertEqual(state.currentBadge, .inactive)
+    /// AppState whose pipelineQueue writes to a temp dir (no real filesystem side effects).
+    private func makeIsolatedState(logDir: URL) -> (AppState, RecordingNotifier) {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.pipelineQueue = PipelineQueue(logDir: logDir)
+        return (state, notifier)
     }
 
-    func testAppStateCurrentStatusNilWhenNoWatchLoop() {
-        let state = AppState()
-        XCTAssertNil(state.currentStatus)
-    }
-
-    func testAppStateCurrentBadgeReflectsEnqueuedJob() throws {
-        let state = AppState()
-        let tmpDir = FileManager.default.temporaryDirectory
-        let audioURL = tmpDir.appendingPathComponent("test_badge_\(UUID()).wav")
-        try Data().write(to: audioURL)
-        defer { try? FileManager.default.removeItem(at: audioURL) }
-
-        let job = PipelineJob(
-            meetingTitle: "Test Meeting",
+    private func makeJob(title: String = "Sprint Review") -> PipelineJob {
+        PipelineJob(
+            meetingTitle: title,
             appName: "TestApp",
-            mixPath: audioURL,
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
             appPath: nil,
             micPath: nil,
             micDelay: 0,
         )
-        state.pipelineQueue.enqueue(job)
-
-        // waiting jobs are not active — badge stays inactive until processing starts
-        XCTAssertFalse(state.pipelineQueue.jobs.isEmpty)
     }
 
-    func testAppStateCurrentBadgeUpdateAvailableWithNoActivity() throws {
-        let state = AppState()
+    // MARK: - Default State
+
+    func testIsWatchingFalseWhenNoWatchLoop() {
+        let (state, _) = makeState()
+        XCTAssertFalse(state.isWatching)
+    }
+
+    func testCurrentStateLabelIdleByDefault() {
+        let (state, _) = makeState()
+        XCTAssertEqual(state.currentStateLabel, "Idle")
+    }
+
+    func testCurrentBadgeInactiveByDefault() {
+        let (state, _) = makeState()
+        XCTAssertEqual(state.currentBadge, .inactive)
+    }
+
+    func testCurrentStatusNilWhenNoWatchLoop() {
+        let (state, _) = makeState()
+        XCTAssertNil(state.currentStatus)
+    }
+
+    // MARK: - isWatching
+
+    func testIsWatchingTrueWhenLoopActiveNotManual() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertTrue(state.isWatching)
+    }
+
+    func testIsWatchingFalseWhenLoopNotStarted() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        // loop not started → isActive == false
+        XCTAssertFalse(state.isWatching)
+    }
+
+    func testIsWatchingFalseWhenManualRecording() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+        XCTAssertFalse(state.isWatching)
+    }
+
+    // MARK: - currentStateLabel
+
+    func testCurrentStateLabelWatchingWhenLoopActive() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertEqual(state.currentStateLabel, "Watching for Meetings...")
+    }
+
+    func testCurrentStateLabelRecordingWhenManualRecording() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+        XCTAssertEqual(state.currentStateLabel, "Recording")
+    }
+
+    func testCurrentStateLabelIdleWhenLoopStopped() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        loop.stop()
+        state.watchLoop = nil
+        XCTAssertEqual(state.currentStateLabel, "Idle")
+    }
+
+    // MARK: - currentStatus
+
+    func testCurrentStatusNilWhenLoopNotStarted() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        XCTAssertNil(state.currentStatus)
+    }
+
+    func testCurrentStatusNotNilWhenLoopActive() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertNotNil(state.currentStatus)
+    }
+
+    func testCurrentStatusStateMatchesLoopTranscriberState() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertEqual(state.currentStatus?.state, .watching)
+    }
+
+    func testCurrentStatusDetailMatchesLoopDetail() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertEqual(state.currentStatus?.detail, "Polling for meetings...")
+    }
+
+    func testCurrentStatusMeetingNilWhenNoActiveMeeting() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        loop.start()
+        defer { loop.stop() }
+        XCTAssertNil(state.currentStatus?.meeting)
+    }
+
+    func testCurrentStatusMeetingFromManualRecordingInfo() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+        defer { loop.stop() }
+        let status = try XCTUnwrap(state.currentStatus)
+        XCTAssertEqual(status.meeting?.app, "Chrome")
+        XCTAssertEqual(status.meeting?.title, "Standup")
+        XCTAssertEqual(status.meeting?.pid, 42)
+    }
+
+    // MARK: - currentBadge integration
+
+    func testCurrentBadgeUpdateAvailableWithNoActivity() throws {
+        let (state, _) = makeState()
         let url = try XCTUnwrap(URL(string: "https://example.com"))
         state.updateChecker.availableUpdate = ReleaseInfo(
             tagName: "v9.9.9",
@@ -68,4 +195,301 @@ final class AppStateTests: XCTestCase {
         )
         XCTAssertEqual(state.currentBadge, .updateAvailable)
     }
+
+    func testCurrentBadgeRecordingWhenLoopRecording() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+        XCTAssertEqual(state.currentBadge, .recording)
+    }
+
+    // MARK: - toggleWatching: stop path
+
+    func testToggleWatchingStopsActiveLoop() {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        loop.start()
+        state.watchLoop = loop
+        XCTAssertTrue(state.isWatching)
+
+        state.toggleWatching()
+
+        XCTAssertNil(state.watchLoop)
+        XCTAssertFalse(state.isWatching)
+    }
+
+    func testToggleWatchingWhileManualRecordingIsNoOp() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+
+        state.toggleWatching() // must be a no-op
+
+        XCTAssertNotNil(state.watchLoop)
+        XCTAssertEqual(state.watchLoop?.isManualRecording, true)
+    }
+
+    // MARK: - toggleWatching: start path (async)
+
+    // toggleWatching() spawns a Task { @MainActor }. We yield once to let it run.
+    // In CI, Permissions.ensureMicrophoneAccess() returns false immediately (no bundle),
+    // but toggleWatching() ignores the return value so WatchLoop is always created.
+
+    func testToggleWatchingCreatesWatchLoop() async {
+        let (state, _) = makeState()
+        addTeardownBlock { state.watchLoop?.stop() }
+
+        state.toggleWatching()
+        await waitFor(state.watchLoop != nil)
+
+        XCTAssertNotNil(state.watchLoop)
+    }
+
+    func testToggleWatchingMakesLoopActive() async {
+        let (state, _) = makeState()
+        addTeardownBlock { state.watchLoop?.stop() }
+
+        state.toggleWatching()
+        await waitFor(state.watchLoop?.isActive == true)
+
+        XCTAssertEqual(state.watchLoop?.isActive, true)
+    }
+
+    // MARK: - stopManualRecording
+
+    func testStopManualRecordingClearsWatchLoop() throws {
+        let (state, _) = makeState()
+        let (loop, _) = makeTestWatchLoop()
+        state.watchLoop = loop
+        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+
+        state.stopManualRecording()
+
+        XCTAssertNil(state.watchLoop)
+    }
+
+    func testStopManualRecordingWhenNoLoopIsNoOp() {
+        let (state, _) = makeState()
+        state.stopManualRecording() // must not crash
+        XCTAssertNil(state.watchLoop)
+    }
+
+    // MARK: - enqueueFiles
+
+    func testEnqueueFilesSingleURL() {
+        let (state, _) = makeState()
+        let url = URL(fileURLWithPath: "/tmp/sprint-review.wav")
+
+        state.enqueueFiles([url])
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+    }
+
+    func testEnqueueFilesMultipleURLs() {
+        let (state, _) = makeState()
+        let urls = (1 ... 3).map { URL(fileURLWithPath: "/tmp/meeting-\($0).wav") }
+
+        state.enqueueFiles(urls)
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 3)
+    }
+
+    func testEnqueueFilesTitleFromLastPathComponent() {
+        let (state, _) = makeState()
+        let url = URL(fileURLWithPath: "/tmp/sprint-review.wav")
+
+        state.enqueueFiles([url])
+
+        XCTAssertEqual(state.pipelineQueue.jobs[0].meetingTitle, "sprint-review")
+    }
+
+    func testEnqueueFilesAppNameIsFile() {
+        let (state, _) = makeState()
+        state.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
+        XCTAssertEqual(state.pipelineQueue.jobs[0].appName, "File")
+    }
+
+    func testEnqueueFilesEmptyArrayIsNoOp() {
+        let (state, _) = makeState()
+        state.enqueueFiles([])
+        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+    }
+
+    func testEnqueueFilesCreatesJobsWithNilAudioPaths() {
+        let (state, _) = makeState()
+        state.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
+        XCTAssertNil(state.pipelineQueue.jobs[0].appPath)
+        XCTAssertNil(state.pipelineQueue.jobs[0].micPath)
+    }
+
+    // MARK: - ensurePipelineQueue
+
+    func testEnsurePipelineQueueReplacesBareQueue() {
+        let (state, _) = makeState()
+        XCTAssertNil(state.pipelineQueue.whisperKit, "Precondition: fresh queue has no whisperKit")
+
+        state.ensurePipelineQueue()
+
+        XCTAssertNotNil(state.pipelineQueue.whisperKit)
+    }
+
+    func testEnsurePipelineQueueIdempotent() {
+        let (state, _) = makeState()
+        state.ensurePipelineQueue()
+        let firstID = ObjectIdentifier(state.pipelineQueue)
+
+        state.ensurePipelineQueue()
+
+        XCTAssertEqual(ObjectIdentifier(state.pipelineQueue), firstID)
+    }
+
+    // MARK: - makePipelineQueue
+
+    func testMakePipelineQueueHasWhisperKit() {
+        let (state, _) = makeState()
+        XCTAssertNotNil(state.makePipelineQueue().whisperKit)
+    }
+
+    func testMakePipelineQueueHasDiarizationFactory() {
+        let (state, _) = makeState()
+        XCTAssertNotNil(state.makePipelineQueue().diarizationFactory)
+    }
+
+    func testMakePipelineQueueHasProtocolGeneratorFactory() {
+        let (state, _) = makeState()
+        XCTAssertNotNil(state.makePipelineQueue().protocolGeneratorFactory)
+    }
+
+    func testMakePipelineQueueSetsOutputDir() {
+        let (state, _) = makeState()
+        XCTAssertNotNil(state.makePipelineQueue().outputDir)
+    }
+
+    // MARK: - makeProtocolGenerator
+
+    func testMakeProtocolGeneratorOpenAI() {
+        let settings = AppSettings()
+        settings.protocolProvider = .openAICompatible
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.makeProtocolGenerator() is OpenAIProtocolGenerator)
+    }
+
+    #if !APPSTORE
+        func testMakeProtocolGeneratorClaudeCLI() {
+            let settings = AppSettings()
+            settings.protocolProvider = .claudeCLI
+            let state = AppState(settings: settings)
+            XCTAssertTrue(state.makeProtocolGenerator() is ClaudeCLIProtocolGenerator)
+        }
+    #endif
+
+    // MARK: - configurePipelineCallbacks
+
+    func testConfigurePipelineCallbacksDoneFiresNotification() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let (state, notifier) = makeIsolatedState(logDir: tmpDir)
+        state.configurePipelineCallbacks()
+
+        let job = makeJob(title: "Sprint Review")
+        state.pipelineQueue.onJobStateChange?(job, .transcribing, .done)
+
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertEqual(notifier.calls[0].title, "Protocol Ready")
+        XCTAssertEqual(notifier.calls[0].body, "Sprint Review")
+    }
+
+    func testConfigurePipelineCallbacksErrorFiresNotification() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let (state, notifier) = makeIsolatedState(logDir: tmpDir)
+        state.configurePipelineCallbacks()
+
+        var job = makeJob()
+        job = PipelineJob(
+            meetingTitle: job.meetingTitle,
+            appName: job.appName,
+            mixPath: job.mixPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        // Simulate a job with an error string
+        let errorJob = jobWithError(job, message: "Transcription failed")
+        state.pipelineQueue.onJobStateChange?(errorJob, .transcribing, .error)
+
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertEqual(notifier.calls[0].title, "Error")
+        XCTAssertEqual(notifier.calls[0].body, "Transcription failed")
+    }
+
+    func testConfigurePipelineCallbacksTranscribingNoNotification() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let (state, notifier) = makeIsolatedState(logDir: tmpDir)
+        state.configurePipelineCallbacks()
+
+        state.pipelineQueue.onJobStateChange?(makeJob(), .waiting, .transcribing)
+
+        XCTAssertTrue(notifier.calls.isEmpty)
+    }
+
+    // MARK: - startManualRecording (async, environment-sensitive)
+
+    // DualSourceRecorder.start() requires real audio hardware — will throw in CI.
+    // AppState catches the error and fires notify("Error", ...) / sets watchLoop = nil.
+    // Both paths fire exactly one notification, so we assert on that.
+
+    func testStartManualRecordingSendsNotification() async {
+        let (state, notifier) = makeState()
+        addTeardownBlock { state.watchLoop?.stop() }
+
+        state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        // Success → "Manual Recording" / hardware unavailable → "Error"
+        await waitFor(!notifier.calls.isEmpty)
+
+        XCTAssertTrue(
+            notifier.calls.contains { $0.title == "Manual Recording" || $0.title == "Error" },
+            "Expected a notification but got none. calls: \(notifier.calls)",
+        )
+    }
+
+    func testStartManualRecordingStopsExistingAutoWatchLoop() async {
+        let (state, _) = makeState()
+        let (existingLoop, _) = makeTestWatchLoop()
+        existingLoop.start()
+        state.watchLoop = existingLoop
+        XCTAssertTrue(existingLoop.isActive)
+
+        state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        await waitFor(!existingLoop.isActive)
+
+        XCTAssertFalse(existingLoop.isActive, "Existing auto-watch loop should be stopped")
+    }
+}
+
+// MARK: - Private helpers
+
+/// Returns a copy of `job` with the error field set via updateJobState simulation.
+/// Since PipelineJob is a struct and error is set by PipelineQueue internally,
+/// we construct a new job and set the error via the queue's updateJobState.
+@MainActor
+private func jobWithError(_ job: PipelineJob, message: String) -> PipelineJob {
+    // PipelineJob.error is var but directly settable since it's internal
+    var copy = job
+    copy.error = message
+    return copy
 }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -1,0 +1,71 @@
+@testable import MeetingTranscriber
+import XCTest
+
+// MARK: - Test Helpers
+
+final class RecordingNotifier: AppNotifying {
+    private(set) var calls: [(title: String, body: String)] = []
+
+    func notify(title: String, body: String) {
+        calls.append((title: title, body: body))
+    }
+}
+
+// MARK: - AppState Integration Tests
+
+@MainActor
+final class AppStateTests: XCTestCase {
+    func testAppStateIsWatchingFalseWhenNoWatchLoop() {
+        let state = AppState()
+        XCTAssertFalse(state.isWatching)
+    }
+
+    func testAppStateCurrentStateLabelIdleByDefault() {
+        let state = AppState()
+        XCTAssertEqual(state.currentStateLabel, "Idle")
+    }
+
+    func testAppStateCurrentBadgeInactiveByDefault() {
+        let state = AppState()
+        XCTAssertEqual(state.currentBadge, .inactive)
+    }
+
+    func testAppStateCurrentStatusNilWhenNoWatchLoop() {
+        let state = AppState()
+        XCTAssertNil(state.currentStatus)
+    }
+
+    func testAppStateCurrentBadgeReflectsEnqueuedJob() throws {
+        let state = AppState()
+        let tmpDir = FileManager.default.temporaryDirectory
+        let audioURL = tmpDir.appendingPathComponent("test_badge_\(UUID()).wav")
+        try Data().write(to: audioURL)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let job = PipelineJob(
+            meetingTitle: "Test Meeting",
+            appName: "TestApp",
+            mixPath: audioURL,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        state.pipelineQueue.enqueue(job)
+
+        // waiting jobs are not active — badge stays inactive until processing starts
+        XCTAssertFalse(state.pipelineQueue.jobs.isEmpty)
+    }
+
+    func testAppStateCurrentBadgeUpdateAvailableWithNoActivity() throws {
+        let state = AppState()
+        let url = try XCTUnwrap(URL(string: "https://example.com"))
+        state.updateChecker.availableUpdate = ReleaseInfo(
+            tagName: "v9.9.9",
+            name: "Test Release",
+            prerelease: false,
+            htmlURL: url,
+            dmgURL: nil,
+        )
+        XCTAssertEqual(state.currentBadge, .updateAvailable)
+    }
+}

--- a/app/MeetingTranscriber/Tests/BadgeKindComputeTests.swift
+++ b/app/MeetingTranscriber/Tests/BadgeKindComputeTests.swift
@@ -1,0 +1,164 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class BadgeKindComputeTests: XCTestCase {
+    // MARK: WatchLoop active
+
+    func testBadgeRecordingWhenWatchLoopStateIsRecording() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .recording,
+            transcriberState: .recording,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .recording)
+    }
+
+    func testBadgeTranscribingForTranscribingState() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .transcribing,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .transcribing)
+    }
+
+    func testBadgeTranscribingForRecordingDoneState() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .recordingDone,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .transcribing)
+    }
+
+    func testBadgeUserActionForWaitingForSpeakerCount() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .waitingForSpeakerCount,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .userAction)
+    }
+
+    func testBadgeUserActionForWaitingForSpeakerNames() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .waitingForSpeakerNames,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .userAction)
+    }
+
+    func testBadgeDoneForProtocolReadyState() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .protocolReady,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .done)
+    }
+
+    func testBadgeErrorForErrorState() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .error,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .error)
+    }
+
+    func testBadgeProcessingForGeneratingProtocol() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .watching,
+            transcriberState: .generatingProtocol,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .processing)
+    }
+
+    // MARK: WatchLoop inactive, active job
+
+    func testBadgeTranscribingForActiveTranscribingJob() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: .transcribing,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .transcribing)
+    }
+
+    func testBadgeDiarizingForActiveDiarizingJob() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: .diarizing,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .diarizing)
+    }
+
+    func testBadgeProcessingForActiveGeneratingProtocolJob() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: .generatingProtocol,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .processing)
+    }
+
+    func testWatchLoopTakesPriorityOverActiveJob() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .recording,
+            transcriberState: .recording,
+            activeJobState: .transcribing,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .recording)
+    }
+
+    // MARK: No watchloop, no jobs
+
+    func testBadgeUpdateAvailableWhenNoWatchLoopNoJobs() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: true,
+        )
+        XCTAssertEqual(badge, .updateAvailable)
+    }
+
+    func testBadgeInactiveWhenNothingActive() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+        )
+        XCTAssertEqual(badge, .inactive)
+    }
+}

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -1,6 +1,43 @@
 import Foundation
 @testable import MeetingTranscriber
 
+// MARK: - WatchLoop / AppState Helpers
+
+/// Returns a MeetingDetector with no patterns — never matches any window.
+func makeSilentDetector() -> MeetingDetector {
+    MeetingDetector(patterns: [])
+}
+
+/// Creates a WatchLoop backed by a MockRecorder and a silent detector.
+/// Assign the returned loop to `appState.watchLoop` in tests that need
+/// an active loop without calling toggleWatching() (which requires Permissions).
+@MainActor
+func makeTestWatchLoop(
+    pipelineQueue: PipelineQueue? = nil,
+) -> (WatchLoop, MockRecorder) {
+    let recorder = MockRecorder()
+    recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+    let loop = WatchLoop(
+        detector: makeSilentDetector(),
+        recorderFactory: { recorder },
+        pipelineQueue: pipelineQueue,
+        pollInterval: 0.05,
+        endGracePeriod: 0.1,
+    )
+    return (loop, recorder)
+}
+
+// MARK: - AppNotifying spy
+
+/// Records all notify() calls for assertions.
+final class RecordingNotifier: AppNotifying {
+    private(set) var calls: [(title: String, body: String)] = []
+
+    func notify(title: String, body: String) {
+        calls.append((title: title, body: body))
+    }
+}
+
 // MARK: - Shared Mock Classes
 
 /// Mock recorder that returns a pre-prepared fixture WAV as the recording result.

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -28,7 +28,8 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 
 | File | Role |
 |------|------|
-| `MeetingTranscriberApp.swift` | `@main` entry point, scene management, WatchLoop lifecycle |
+| `MeetingTranscriberApp.swift` | `@main` UI shell — SwiftUI scenes, windows, NSOpenPanel, NSWorkspace |
+| `AppState.swift` | `@Observable @MainActor` ViewModel — business state, badge logic, pipeline wiring |
 | `MenuBarView.swift` | Menu bar dropdown (state, actions, meeting info) |
 | `SettingsView.swift` | Settings window (apps, recording, transcription, diarization) |
 | `SpeakerNamingView.swift` | Speaker naming dialog after diarization |
@@ -225,10 +226,11 @@ When dual-source recording (app + mic) is available:
 AppSettings (UserDefaults)
   → WatchLoop (@Observable: state, detail, currentMeeting, lastError)
   → PipelineQueue (@Observable: jobs, isProcessing, pendingSpeakerNaming)
-    → MeetingTranscriberApp (computed: currentStatus, currentStateLabel, currentStateIcon)
-      → MenuBarView (receives status + callbacks + pipeline queue)
-      → SettingsView (receives @Bindable settings)
-      → SpeakerNamingView (receives pendingSpeakerNaming data)
+    → AppState (computed: currentBadge via BadgeKind.compute(), currentStatus, currentStateLabel)
+      → MeetingTranscriberApp (reads appState.*, passes to views)
+        → MenuBarView (receives status + callbacks + pipeline queue)
+        → SettingsView (receives @Bindable settings)
+        → SpeakerNamingView (receives pendingSpeakerNaming data)
 ```
 
 ### File Locations
@@ -254,6 +256,8 @@ AppSettings (UserDefaults)
 | ProtocolGenerating | `protocolGenerator` protocol in PipelineQueue |
 | RecordingProvider | `recorderFactory` closure in WatchLoop |
 | ProtocolGenerator | `claudeBin` parameter |
+| AppNotifying | `notifier` parameter in `AppState.init` (`SilentNotifier` default, `RecordingNotifier` in tests) |
+| BadgeKind.compute | Pure static function — call directly with any input combination, no WatchLoop needed |
 
 ---
 

--- a/docs/plans/appstate-tests.md
+++ b/docs/plans/appstate-tests.md
@@ -1,0 +1,412 @@
+# AppState Test Expansion Plan
+
+## Overview
+
+`AppStateTests.swift` currently covers only the nil/default state of four properties (6 tests). This plan expands coverage to all public methods and derived properties — 39 new tests across two files.
+
+**All new tests go in `AppStateTests.swift`. All new mock/helper types go in `TestHelpers.swift`. No new files are created.**
+
+---
+
+## 1. Test Infrastructure to Add to TestHelpers.swift
+
+### 1.1 makeSilentDetector()
+
+```swift
+/// Returns a PowerAssertionDetector that never detects a meeting.
+func makeSilentDetector() -> PowerAssertionDetector {
+    let d = PowerAssertionDetector()
+    d.assertionProvider = { [:] }
+    return d
+}
+```
+
+### 1.2 makeTestWatchLoop()
+
+Assigns `WatchLoop` directly into `state.watchLoop` to exercise derived properties without calling `toggleWatching()` (which calls `Permissions.ensureMicrophoneAccess()`).
+
+```swift
+@MainActor
+func makeTestWatchLoop(
+    pipelineQueue: PipelineQueue? = nil,
+) -> (WatchLoop, MockRecorder) {
+    let recorder = MockRecorder()
+    let loop = WatchLoop(
+        detector: makeSilentDetector(),
+        recorderFactory: { recorder },
+        pipelineQueue: pipelineQueue,
+        pollInterval: 0.05,
+        endGracePeriod: 0.1,
+    )
+    return (loop, recorder)
+}
+```
+
+### 1.3 makeState() helper in AppStateTests
+
+Add a private factory to `AppStateTests` for consistent setup:
+
+```swift
+private func makeState() -> (AppState, RecordingNotifier) {
+    let notifier = RecordingNotifier()
+    let state = AppState(notifier: notifier)
+    return (state, notifier)
+}
+```
+
+`RecordingNotifier` is already defined in `AppStateTests.swift` — move it to `TestHelpers.swift` so it can be reused across test files.
+
+### 1.4 makeIsolatedState() — for pipeline callback tests
+
+Pipeline tests write snapshot files to disk. Use a temp logDir to keep tests filesystem-isolated:
+
+```swift
+private func makeIsolatedState(logDir: URL) -> (AppState, RecordingNotifier) {
+    let notifier = RecordingNotifier()
+    let state = AppState(notifier: notifier)
+    state.pipelineQueue = PipelineQueue(logDir: logDir)
+    return (state, notifier)
+}
+```
+
+Follow the same `setUp`/`tearDown` temp-directory pattern as `PipelineQueueTests.swift`.
+
+---
+
+## 2. Derived Properties with Active WatchLoop
+
+These tests assign a `WatchLoop` directly to `state.watchLoop` — no `toggleWatching()` needed.
+
+### 2.1 isWatching (3 tests)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testIsWatchingTrueWhenLoopActiveNotManual` | `loop.start()` | `true` |
+| `testIsWatchingFalseWhenLoopNotActive` | no start | `false` |
+| `testIsWatchingFalseWhenManualRecording` | `try loop.startManualRecording(pid:...)` | `false` |
+
+### 2.2 currentStateLabel (3 tests)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testCurrentStateLabelWatchingWhenLoopActive` | `loop.start()` | `"Watching for Meetings..."` |
+| `testCurrentStateLabelRecordingWhenManualRecording` | `try loop.startManualRecording(...)` | `"Recording"` |
+| `testCurrentStateLabelIdleWhenLoopStopped` | `loop.start()` then `loop.stop()` | `"Idle"` |
+
+### 2.3 currentStatus (6 tests)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testCurrentStatusNilWhenLoopInactive` | no start | `nil` |
+| `testCurrentStatusNotNilWhenLoopActive` | `loop.start()` | `!= nil` |
+| `testCurrentStatusStateMatchesLoopTranscriberState` | `loop.start()` | `.state == .watching` |
+| `testCurrentStatusDetailMatchesLoopDetail` | `loop.start()` | `.detail == "Polling for meetings..."` |
+| `testCurrentStatusMeetingNilWhenNoActiveMeeting` | `loop.start()` | `.meeting == nil` |
+| `testCurrentStatusMeetingFromManualRecordingInfo` | `try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")` | `.meeting?.app == "Chrome"`, `.meeting?.title == "Standup"`, `.meeting?.pid == 42` |
+
+Example for the manual recording status test:
+```swift
+func testCurrentStatusMeetingFromManualRecordingInfo() throws {
+    let (state, _) = makeState()
+    let (loop, _) = makeTestWatchLoop()
+    state.watchLoop = loop
+    try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+    defer { loop.stop() }
+    let status = try XCTUnwrap(state.currentStatus)
+    XCTAssertEqual(status.meeting?.app, "Chrome")
+    XCTAssertEqual(status.meeting?.title, "Standup")
+    XCTAssertEqual(status.meeting?.pid, 42)
+}
+```
+
+---
+
+## 3. toggleWatching()
+
+### 3.1 Permissions problem
+
+`toggleWatching()` calls `Permissions.ensureMicrophoneAccess()` and hard-codes `PowerAssertionDetector()`. There is no detector injection point. **Strategy:**
+
+- **Stop path:** assign a `WatchLoop` directly, call `toggleWatching()` — no permissions needed.
+- **Start path:** call `toggleWatching()`, drain main actor with `await Task.yield()`, observe side effects.
+
+### 3.2 Stop path (2 tests, synchronous)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testToggleWatchingStopsActiveLoop` | assign active loop, call `toggleWatching()` | `state.watchLoop == nil` |
+| `testToggleWatchingWhileManualRecordingIsNoOp` | assign manual-recording loop, call `toggleWatching()` | `state.watchLoop != nil` (unchanged) |
+
+```swift
+func testToggleWatchingStopsActiveLoop() {
+    let (state, _) = makeState()
+    let (loop, _) = makeTestWatchLoop()
+    loop.start()
+    state.watchLoop = loop
+    XCTAssertTrue(state.isWatching)
+
+    state.toggleWatching()
+
+    XCTAssertNil(state.watchLoop)
+}
+```
+
+### 3.3 Start path (2 tests, async)
+
+In CI, `Permissions.ensureMicrophoneAccess()` returns `false` immediately (no app bundle). `toggleWatching()` ignores the return value, so `WatchLoop` is created regardless.
+
+| Test | Expected |
+|---|---|
+| `testToggleWatchingCreatesWatchLoop` | `state.watchLoop != nil` after yield |
+| `testToggleWatchingMakesLoopActive` | `state.watchLoop?.isActive == true` after yield |
+
+```swift
+func testToggleWatchingCreatesWatchLoop() async {
+    let (state, _) = makeState()
+    addTeardownBlock { state.watchLoop?.stop() }
+
+    state.toggleWatching()
+    await Task.yield()
+
+    XCTAssertNotNil(state.watchLoop)
+}
+```
+
+If a single `Task.yield()` proves insufficient on CI, use a bounded retry with `ContinuousClock` (max 500ms) — but only escalate if the single-yield test is actually flaky.
+
+---
+
+## 4. startManualRecording() (3 tests, async)
+
+`startManualRecording()` also spawns `Task { @MainActor }`. `DualSourceRecorder.start()` requires `CATapDescription` and real audio hardware — it will throw in CI. The catch block fires `notifier.notify(title: "Error", ...)` and sets `watchLoop = nil`. Test both paths defensively.
+
+| Test | Expected |
+|---|---|
+| `testStartManualRecordingCreatesOrCleansUpWatchLoop` | either `watchLoop != nil` (success) or `watchLoop == nil` + error notification (failure) |
+| `testStartManualRecordingSendsNotification` | notifier called with either `"Manual Recording"` or `"Error"` |
+| `testStartManualRecordingStopsExistingAutoWatchLoop` | old active loop is stopped |
+
+```swift
+func testStartManualRecordingSendsNotification() async {
+    let (state, notifier) = makeState()
+    state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+    await Task.yield()
+    // Either success or error — both fire a notification
+    XCTAssertTrue(
+        notifier.calls.contains { $0.title == "Manual Recording" || $0.title == "Error" },
+        "Expected at least one notification, got: \(notifier.calls)",
+    )
+}
+```
+
+---
+
+## 5. stopManualRecording() (2 tests, synchronous)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testStopManualRecordingClearsWatchLoop` | assign manual-recording loop | `state.watchLoop == nil` |
+| `testStopManualRecordingWhenNoLoopIsNoOp` | no watchLoop | no crash, `state.watchLoop == nil` |
+
+```swift
+func testStopManualRecordingClearsWatchLoop() throws {
+    let (state, _) = makeState()
+    let (loop, _) = makeTestWatchLoop()
+    state.watchLoop = loop
+    try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+
+    state.stopManualRecording()
+
+    XCTAssertNil(state.watchLoop)
+}
+```
+
+---
+
+## 6. enqueueFiles() (6 tests, synchronous)
+
+Fully synchronous, no permissions, no audio hardware — the most reliable tests in this plan.
+
+| Test | Input | Expected |
+|---|---|---|
+| `testEnqueueFilesSingleURL` | one URL | `jobs.count == 1` |
+| `testEnqueueFilesMultipleURLs` | three URLs | `jobs.count == 3` |
+| `testEnqueueFilesTitleFromLastPathComponent` | `/tmp/sprint-review.wav` | `jobs[0].meetingTitle == "sprint-review"` |
+| `testEnqueueFilesAppNameIsFile` | any URL | `jobs[0].appName == "File"` |
+| `testEnqueueFilesEmptyArrayIsNoOp` | `[]` | `jobs.isEmpty` |
+| `testEnqueueFilesCreatesJobsWithNilPaths` | one URL | `jobs[0].appPath == nil`, `jobs[0].micPath == nil` |
+
+```swift
+func testEnqueueFilesSingleURL() {
+    let (state, _) = makeState()
+    let url = URL(fileURLWithPath: "/tmp/sprint-review.wav")
+
+    state.enqueueFiles([url])
+
+    XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+    XCTAssertEqual(state.pipelineQueue.jobs[0].meetingTitle, "sprint-review")
+    XCTAssertEqual(state.pipelineQueue.jobs[0].appName, "File")
+}
+```
+
+---
+
+## 7. ensurePipelineQueue() (2 tests, synchronous)
+
+The bare `PipelineQueue()` from `AppState.init` has `whisperKit == nil`. The first call to `ensurePipelineQueue()` always replaces it.
+
+| Test | Expected |
+|---|---|
+| `testEnsurePipelineQueueReplacesBareQueue` | `pipelineQueue.whisperKit != nil` |
+| `testEnsurePipelineQueueIdempotent` | second call returns same queue identity |
+
+```swift
+func testEnsurePipelineQueueReplacesBareQueue() {
+    let (state, _) = makeState()
+    XCTAssertNil(state.pipelineQueue.whisperKit)
+    state.ensurePipelineQueue()
+    XCTAssertNotNil(state.pipelineQueue.whisperKit)
+}
+
+func testEnsurePipelineQueueIdempotent() {
+    let (state, _) = makeState()
+    state.ensurePipelineQueue()
+    let first = ObjectIdentifier(state.pipelineQueue)
+    state.ensurePipelineQueue()
+    XCTAssertEqual(ObjectIdentifier(state.pipelineQueue), first)
+}
+```
+
+---
+
+## 8. makePipelineQueue() (4 tests, synchronous)
+
+`makePipelineQueue()` is `internal`, callable via `@testable`. It calls `loadSnapshot()` and `recoverOrphanedRecordings()` — both are harmless if the recordings directory doesn't exist.
+
+| Test | Expected |
+|---|---|
+| `testMakePipelineQueueHasWhisperKit` | `queue.whisperKit != nil` |
+| `testMakePipelineQueueHasDiarizationFactory` | `queue.diarizationFactory != nil` |
+| `testMakePipelineQueueHasProtocolGeneratorFactory` | `queue.protocolGeneratorFactory != nil` |
+| `testMakePipelineQueueSetsOutputDir` | `queue.outputDir != nil` |
+
+---
+
+## 9. makeProtocolGenerator() (2 tests, synchronous)
+
+| Test | Setup | Expected |
+|---|---|---|
+| `testMakeProtocolGeneratorOpenAI` | `settings.protocolProvider = .openAICompatible` | `gen is OpenAIProtocolGenerator` |
+| `testMakeProtocolGeneratorClaudeCLI` (`#if !APPSTORE`) | `settings.protocolProvider = .claudeCLI` | `gen is ClaudeCLIProtocolGenerator` |
+
+```swift
+func testMakeProtocolGeneratorOpenAI() {
+    let settings = AppSettings()
+    settings.protocolProvider = .openAICompatible
+    let state = AppState(settings: settings)
+    XCTAssertTrue(state.makeProtocolGenerator() is OpenAIProtocolGenerator)
+}
+
+#if !APPSTORE
+func testMakeProtocolGeneratorClaudeCLI() {
+    let settings = AppSettings()
+    settings.protocolProvider = .claudeCLI
+    let state = AppState(settings: settings)
+    XCTAssertTrue(state.makeProtocolGenerator() is ClaudeCLIProtocolGenerator)
+}
+#endif
+```
+
+---
+
+## 10. configurePipelineCallbacks() (3 tests, synchronous)
+
+Call `configurePipelineCallbacks()` to wire the closure, then trigger state transitions directly via `pipelineQueue.onJobStateChange?(job, oldState, newState)` — no real processing needed.
+
+Use `makeIsolatedState(logDir:)` (section 1.4) to avoid writing queue snapshots to the real filesystem.
+
+| Test | Transition | Expected notification |
+|---|---|---|
+| `testConfigurePipelineCallbacksDoneFiresNotification` | `→ .done` | `("Protocol Ready", jobTitle)` |
+| `testConfigurePipelineCallbacksErrorFiresNotification` | `→ .error` with error string | `("Error", errorString)` |
+| `testConfigurePipelineCallbacksTranscribingNoNotification` | `→ .transcribing` | no notification |
+
+```swift
+func testConfigurePipelineCallbacksDoneFiresNotification() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let (state, notifier) = makeIsolatedState(logDir: tmpDir)
+    state.configurePipelineCallbacks()
+
+    let job = PipelineJob(
+        meetingTitle: "Sprint Review",
+        appName: "TestApp",
+        mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+        appPath: nil, micPath: nil, micDelay: 0,
+    )
+    // Trigger the callback directly
+    state.pipelineQueue.onJobStateChange?(job, .transcribing, .done)
+
+    XCTAssertEqual(notifier.calls.count, 1)
+    XCTAssertEqual(notifier.calls[0].title, "Protocol Ready")
+    XCTAssertEqual(notifier.calls[0].body, "Sprint Review")
+}
+```
+
+---
+
+## 11. Async Test Pattern
+
+All async tests must be `@MainActor` (the class already is). Use `await Task.yield()` to let spawned tasks run. Always clean up active loops with `addTeardownBlock { state.watchLoop?.stop() }`.
+
+```swift
+// Standard async test pattern
+func testSomeAsyncBehavior() async {
+    let (state, _) = makeState()
+    addTeardownBlock { state.watchLoop?.stop() }
+
+    state.someMethodThatSpawnsATask()
+    await Task.yield()
+
+    XCTAssertNotNil(state.something)
+}
+```
+
+Never use `XCTestExpectation` or `sleep` — Swift concurrency primitives only.
+
+---
+
+## 12. Implementation Order
+
+Build confidence incrementally:
+
+1. **TestHelpers.swift**: add `makeSilentDetector()`, `makeTestWatchLoop()`, move `RecordingNotifier` there
+2. **enqueueFiles** (section 6) — synchronous, zero dependencies, fastest feedback
+3. **configurePipelineCallbacks** (section 10) — synchronous, validates notification wiring
+4. **isWatching / currentStateLabel / currentStatus** (sections 2.1–2.3) — needs `makeTestWatchLoop`
+5. **toggleWatching stop-path** (section 3.2) — synchronous, needs active loop
+6. **ensurePipelineQueue / makePipelineQueue / makeProtocolGenerator** (sections 7–9)
+7. **toggleWatching start-path** (section 3.3) — async, environment-sensitive
+8. **startManualRecording / stopManualRecording** (sections 4–5) — leave for last
+
+---
+
+## 13. Summary
+
+| Group | New tests |
+|---|---|
+| isWatching | 3 |
+| currentStateLabel | 3 |
+| currentStatus | 6 |
+| toggleWatching (stop) | 2 |
+| toggleWatching (start, async) | 2 |
+| startManualRecording | 3 |
+| stopManualRecording | 2 |
+| enqueueFiles | 6 |
+| ensurePipelineQueue | 2 |
+| makePipelineQueue | 4 |
+| makeProtocolGenerator | 2 (+1 conditional) |
+| configurePipelineCallbacks | 3 |
+| **Total** | **39** |

--- a/docs/plans/swift-architecture.md
+++ b/docs/plans/swift-architecture.md
@@ -70,11 +70,23 @@ Audio Capture Detail:
 ### 3.1 MeetingTranscriberApp
 
 **File:** `Sources/MeetingTranscriberApp.swift`
-**Responsibility:** Application entry point. Owns the SwiftUI scene graph: a `MenuBarExtra` for the dropdown UI, a `Window` for speaker naming, and a `Window` for settings. Wires together `WatchLoop`, `PipelineQueue`, `WhisperKitEngine`, and `AppSettings`. Handles auto-watch on launch (via `--auto-watch` CLI flag or `autoWatch` UserDefaults key).
+**Responsibility:** Thin UI shell. Owns the SwiftUI scene graph: a `MenuBarExtra` for the dropdown UI, a `Window` for speaker naming, and a `Window` for settings. All business logic is delegated to `AppState`. Handles `NSOpenPanel`, `NSWorkspace`, `NSApp` — AppKit operations that must stay in the UI layer. Handles auto-watch on launch (via `--auto-watch` CLI flag or `autoWatch` UserDefaults key).
 
 **Key types:** `MeetingTranscriberApp` (struct, conforms to `App`)
-**Dependencies:** `WatchLoop`, `PipelineQueue`, `WhisperKitEngine`, `AppSettings`, `NotificationManager`, `MenuBarView`, `SettingsView`, `SpeakerNamingView`
-**Concurrency:** The app struct itself is on `@MainActor` implicitly (SwiftUI `App`). WhisperKit model loading is kicked off in a `.task` modifier on the menu bar label. Watch loop toggling uses `Task { }` for async permission checks before constructing the loop on `MainActor.run`.
+**Dependencies:** `AppState`, `MenuBarView`, `SettingsView`, `SpeakerNamingView`, `NotificationManager`
+**Concurrency:** Implicitly `@MainActor` (SwiftUI `App`). WhisperKit model loading in a `.task` modifier, update checker start in a `.task` modifier.
+
+### 3.1.1 AppState
+
+**File:** `Sources/AppState.swift`
+**Responsibility:** `@Observable @MainActor` ViewModel owning all business state: `watchLoop`, `pipelineQueue`, `updateChecker`, `settings`, `whisperKit`. Provides derived computed properties (`currentBadge`, `isWatching`, `currentStatus`, `currentStateLabel`) and all business logic methods (`toggleWatching`, `startManualRecording`, `enqueueFiles`, `makePipelineQueue`, etc.). Has no AppKit/SwiftUI imports — importable by future CLI targets.
+
+**`BadgeKind.compute(...)`** (extension on `BadgeKind` in `MenuBarIcon.swift`): Pure static function that maps plain value inputs (watchLoopActive, watchLoopState, transcriberState, activeJobState, updateAvailable) to a `BadgeKind`. `AppState.currentBadge` calls it. Tests call it directly without driving WatchLoop into states.
+
+**`AppNotifying` protocol:** Abstracts notification delivery to keep AppKit out of AppState.
+- `NotificationManager` — real implementation (AppKit, menu bar app)
+- `SilentNotifier` — no-op struct (default, CLI targets)
+- `RecordingNotifier` — test stub (records calls for assertions)
 
 ### 3.2 WatchLoop
 
@@ -502,9 +514,9 @@ final class WatchLoopTests: XCTestCase { ... }
 
 ```
 MeetingTranscriberApp
-  └─ .task { whisperKit.loadModel() }         // Model preloading
-  └─ toggleWatching()
-       └─ Task { ... MainActor.run { loop.start() } }
+  └─ .task { appState.whisperKit.loadModel() }  // Model preloading
+  └─ AppState.toggleWatching()
+       └─ Task { @MainActor ... loop.start() }
             └─ WatchLoop.watchTask              // Polling loop
                  └─ polls detector every N seconds
                  └─ handleMeeting() → recorder.start/stop
@@ -561,7 +573,7 @@ await withCheckedContinuation { continuation in
 
 ### Test Count and Framework
 
-341 Swift tests using XCTest + ViewInspector. Run with `cd app/MeetingTranscriber && swift test`.
+Swift tests using XCTest + ViewInspector. Run with `cd app/MeetingTranscriber && swift test`.
 
 ### Mock/Protocol DI Pattern
 
@@ -572,6 +584,7 @@ Three protocols enable mock injection in tests:
 | `RecordingProvider` | `DualSourceRecorder` | `MockRecorder` — returns pre-prepared fixture WAV paths |
 | `DiarizationProvider` | `FluidDiarizer` | `MockDiarization` — returns pre-set segments and embeddings |
 | `ProtocolGenerating` | `DefaultProtocolGenerator` | `MockProtocolGen` — captures transcript/title/diarized for assertions |
+| `AppNotifying` | `NotificationManager` | `RecordingNotifier` — records calls; `SilentNotifier` — no-op |
 
 Defined in `Tests/TestHelpers.swift`.
 
@@ -605,6 +618,8 @@ Defined in `Tests/TestHelpers.swift`.
 | `SettingsViewTests.swift` | Settings UI (ViewInspector) |
 | `SpeakerNamingViewTests.swift` | Speaker naming dialog, accessibility text fields |
 | `AppSettingsTests.swift` | UserDefaults persistence, value clamping |
+| `AppStateTests.swift` | AppState isWatching, currentBadge, currentStatus integration (`@MainActor`) |
+| `BadgeKindComputeTests.swift` | All branches of `BadgeKind.compute(...)` pure function |
 | `NotificationContentTests.swift` | Notification content for state transitions |
 | `NotificationManagerTests.swift` | Setup, permission handling |
 | `TranscriberStatusTests.swift` | Status model codability |


### PR DESCRIPTION
## Summary

- Extracts all business state and badge logic out of the untestable `@main` App struct into `AppState` (`@Observable @MainActor class`) and `BadgeKind.compute(...)` (pure static function)
- `MeetingTranscriberApp` shrinks from ~420 to ~150 lines (UI shell only: SwiftUI scenes, NSOpenPanel, NSWorkspace)
- `AppNotifying` protocol keeps AppKit out of `AppState` — enables future CLI reuse
- Expands `AppStateTests` from 6 to 40 tests covering the full public API

## Changes

**`AppState.swift`** (new) — ViewModel owning `watchLoop`, `pipelineQueue`, `updateChecker`, `settings`, `whisperKit` + all business logic methods

**`MenuBarIcon.swift`** — adds `BadgeKind.compute(watchLoopActive:watchLoopState:transcriberState:activeJobState:updateAvailable:)` — pure function, testable without driving WatchLoop into states

**`MeetingTranscriberApp.swift`** — slimmed to UI shell

**`NotificationManager.swift`** — conforms to `AppNotifying`

**`AppStateTests.swift`** — 40 tests: isWatching, currentStateLabel, currentStatus, currentBadge, toggleWatching, startManualRecording, stopManualRecording, enqueueFiles, ensurePipelineQueue, makePipelineQueue, makeProtocolGenerator, configurePipelineCallbacks

**`BadgeKindComputeTests.swift`** (new) — 13 tests covering all branches of the pure compute function

**`TestHelpers.swift`** — adds `makeSilentDetector()`, `makeTestWatchLoop()`, `RecordingNotifier`

**Docs** — `architecture-macos.md`, `swift-architecture.md`, `CLAUDE.md` updated

## Test plan

- [x] `swift test` — all 36 suites pass
- [x] `./scripts/lint.sh` — 0 violations
- [x] App läuft: `./scripts/run_app.sh` — badge animiert, watching/recording funktioniert