### PR TITLE
refactor(app): normalize all recorded audio to 16kHz at capture time

### DIFF
--- a/app/MeetingTranscriber/Sources/AudioConstants.swift
+++ b/app/MeetingTranscriber/Sources/AudioConstants.swift
@@ -1,0 +1,8 @@
+/// Shared audio pipeline constants.
+///
+/// Note: `tools/audiotap/Sources/Helpers.swift` defines a matching
+/// `speechSampleRate` constant for use within the AudioTapLib package.
+enum AudioConstants {
+    /// Target sample rate for speech recognition (WhisperKit).
+    static let targetSampleRate = 16000
+}

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -16,7 +16,7 @@ enum AudioMixer {
         micAudioPath: URL,
         outputPath: URL,
         micDelay: TimeInterval = 0,
-        sampleRate: Int = 48000,
+        sampleRate: Int = AudioConstants.targetSampleRate,
     ) throws {
         var appSamples = try loadAudioFileAsFloat32(url: appAudioPath)
         var micSamples = try loadAudioFileAsFloat32(url: micAudioPath)
@@ -255,7 +255,7 @@ enum AudioMixer {
             AVLinearPCMBitDepthKey: 32,
             AVLinearPCMIsNonInterleaved: false,
             AVNumberOfChannelsKey: 1,
-            AVSampleRateKey: 16000,
+            AVSampleRateKey: AudioConstants.targetSampleRate,
         ]
         let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
         reader.add(output)
@@ -269,7 +269,7 @@ enum AudioMixer {
         // Pre-allocate based on asset duration to avoid repeated array reallocations
         var samples = [Float]()
         let duration = try await asset.load(.duration)
-        let estimatedSamples = Int(CMTimeGetSeconds(duration) * 16000)
+        let estimatedSamples = Int(CMTimeGetSeconds(duration) * Double(AudioConstants.targetSampleRate))
         if estimatedSamples > 0 {
             samples.reserveCapacity(estimatedSamples)
         }
@@ -296,12 +296,21 @@ enum AudioMixer {
             )
         }
 
-        logger.info("AVAsset audio extracted: \(samples.count) samples at 16kHz")
-        return (samples, 16000)
+        logger.info("AVAsset audio extracted: \(samples.count) samples at \(AudioConstants.targetSampleRate)Hz")
+        return (samples, AudioConstants.targetSampleRate)
     }
 
     /// Load an audio or video file, resample to a target rate, and save to a new WAV file.
-    static func resampleFile(from source: URL, to destination: URL, targetRate: Int = 16000) async throws {
+    ///
+    /// Fast path: if the source is already at `targetRate` (readable by AVAudioFile), copies
+    /// the file directly instead of decoding and re-encoding.
+    static func resampleFile(from source: URL, to destination: URL, targetRate: Int = AudioConstants.targetSampleRate) async throws {
+        // Probe rate without loading all samples — O(1) for WAV/MP3/M4A
+        if let audioFile = try? AVAudioFile(forReading: source),
+           Int(audioFile.processingFormat.sampleRate) == targetRate {
+            try FileManager.default.copyItem(at: source, to: destination)
+            return
+        }
         let (samples, sourceRate) = try await loadAudioAsFloat32(url: source)
         let resampled = resample(samples, from: sourceRate, to: targetRate)
         try saveWAV(samples: resampled, sampleRate: targetRate, url: destination)

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -38,6 +38,7 @@ class DualSourceRecorder: RecordingProvider {
     private var startTimestamp: String?
 
     private let recordRate = 48000
+    private let targetRate = AudioConstants.targetSampleRate
     private let appChannels = 2
 
     /// Recordings directory.
@@ -166,11 +167,12 @@ class DualSourceRecorder: RecordingProvider {
                 appSamples = floats
             }
 
-            // Save app track
+            // Resample to 16kHz and save app track
+            let appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: targetRate)
             let appFile = recDir.appendingPathComponent("\(ts)_app.wav")
-            try AudioMixer.saveWAV(samples: appSamples, sampleRate: actualRate, url: appFile)
+            try AudioMixer.saveWAV(samples: appSamples16k, sampleRate: targetRate, url: appFile)
             appPath = appFile
-            logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate) Hz)")
+            logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate)→\(self.targetRate) Hz)")
         } else if FileManager.default.fileExists(atPath: tempURL.path) {
             // Clean up empty temp file left by failed app audio capture
             try? FileManager.default.removeItem(at: tempURL)
@@ -197,8 +199,8 @@ class DualSourceRecorder: RecordingProvider {
         }
 
         // ── Mix via AudioMixer ──
-        // Use the actual capture rate for mixing — the pipeline resamples to 16kHz later.
-        let mixRate = actualRate > 0 ? actualRate : recordRate
+        // Both app and mic are already at 16kHz at this point.
+        let mixRate = targetRate
         let mixPath = recDir.appendingPathComponent("\(ts)_mix.wav")
 
         if let app = appPath, let mic = micPath {

--- a/app/MeetingTranscriber/Sources/FFmpegHelper.swift
+++ b/app/MeetingTranscriber/Sources/FFmpegHelper.swift
@@ -73,7 +73,7 @@ enum FFmpegHelper {
             "-i", url.path,
             "-vn", // no video
             "-ac", "1", // mono
-            "-ar", "16000", // 16kHz
+            "-ar", "\(AudioConstants.targetSampleRate)", // speech recognition rate
             "-f", "wav", // WAV output
             tempURL.path,
             "-y", // overwrite
@@ -134,6 +134,6 @@ enum FFmpegHelper {
         // Load the temp WAV file
         let samples = try AudioMixer.loadAudioFileAsFloat32(url: tempURL)
         logger.info("ffmpeg extracted \(samples.count) samples at 16kHz from \(url.lastPathComponent)")
-        return (samples, 16000)
+        return (samples, AudioConstants.targetSampleRate)
     }
 }

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -1,6 +1,10 @@
 import CoreAudio
 import Foundation
 
+/// Target sample rate for speech recognition (WhisperKit).
+/// Must match `AudioConstants.targetSampleRate` in the app target.
+public let speechSampleRate: Double = 16000
+
 /// Convert mach_absolute_time() ticks to seconds.
 func machTicksToSeconds(_ ticks: UInt64) -> Double {
     var info = mach_timebase_info_data_t()

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -85,9 +85,10 @@ public class MicCaptureHandler {
         )! // swiftlint:disable:this force_unwrapping
         logger.info("Mic tap format: \(tapFormat.sampleRate) Hz, \(tapFormat.channelCount)ch")
 
-        // Create WAV file on first start; keep its sample rate for the entire recording
+        // Create WAV file on first start; always at 16kHz (WhisperKit target rate).
+        // The AVAudioConverter below handles resampling from any hardware rate.
         if outputFile == nil {
-            fileSampleRate = tapFormat.sampleRate
+            fileSampleRate = speechSampleRate
             let wavSettings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatLinearPCM,
                 AVSampleRateKey: fileSampleRate,


### PR DESCRIPTION
## Summary

- App and mic audio are now resampled to 16kHz when saved, instead of preserving the native device sample rate
- `AudioConstants.targetSampleRate` (app target) and `speechSampleRate` (audiotap package) replace all hardcoded `16000` literals
- `resampleFile()` fast-paths with a file copy when the source is already at 16kHz (pipeline calls become no-ops)

## Problem

Mickey Mouse / pitch artifacts occurred when the system output device ran at a rate other than 48kHz (e.g. 44100Hz on some Macs/AirPods setups), or when the app and mic tracks had mismatched sample rates that were silently mixed at the wrong ratio.

## Test plan

- [x] All 559 unit tests pass (`swift test`)
- [x] All 29 E2E tests pass (`swift test --filter E2E`)
- [x] Build and smoke-test the app (`./scripts/run_app.sh`)
- [x] Record a meeting and verify no pitch artifacts in the transcription