### PR TITLE
feat: add NVIDIA Parakeet TDT v3 as alternative ASR engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     NotificationManager.swift # macOS notifications
     KeychainHelper.swift   # Keychain CRUD (legacy/test-only, token now file-based)
     TranscriberStatus.swift # Status + MeetingInfo models
-    WhisperKitEngine.swift # Native WhisperKit transcription (CoreML/ANE)
+    TranscribingEngine.swift # TranscribingEngine protocol + mergeDualSourceSegments default impl
+    WhisperKitEngine.swift # WhisperKit transcription engine (CoreML/ANE, 99+ languages)
+    ParakeetEngine.swift   # NVIDIA Parakeet TDT v3 engine via FluidAudio (CoreML/ANE, 25 EU languages)
     FluidDiarizer.swift    # CoreML-based speaker diarization via FluidAudio (on-device)
     SpeakerMatcher.swift   # Speaker embedding DB + cosine similarity matching
     DiarizationProcess.swift  # DiarizationProvider protocol + result types
@@ -87,8 +89,8 @@ speakers.json              # Saved voice profiles (gitignored, created at runtim
 ## Pipeline
 
 ```
-Dual-source: AudioTapLib (CATapDescription + AVAudioEngine) → separate 16kHz audio → WhisperKit per track → FluidAudio diarization per track (CoreML/ANE) → merge speakers → Claude CLI / OpenAI-compatible API → Markdown protocol
-Single-source: Audio/Video → 16kHz mono (AVAudioFile → AVAsset → ffmpeg fallback) → WhisperKit → FluidAudio diarization → Claude CLI / OpenAI-compatible API → Markdown protocol
+Dual-source: AudioTapLib (CATapDescription + AVAudioEngine) → separate 16kHz audio → [WhisperKit | Parakeet] per track → FluidAudio diarization per track (CoreML/ANE) → merge speakers → Claude CLI / OpenAI-compatible API → Markdown protocol
+Single-source: Audio/Video → 16kHz mono (AVAudioFile → AVAsset → ffmpeg fallback) → [WhisperKit | Parakeet] → FluidAudio diarization → Claude CLI / OpenAI-compatible API → Markdown protocol
 ```
 
 ## Setup
@@ -156,13 +158,19 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 ## Architecture Notes
 
+**Transcription engines:**
+- `TranscribingEngine` protocol abstracts ASR backends. Two implementations: `WhisperKitEngine` (99+ languages, ~1 GB model) and `ParakeetEngine` (25 EU languages, ~50 MB model, ~10× faster).
+- `AppSettings.transcriptionEngine` enum (`.whisperKit` / `.parakeet`) selects the engine. Settings UI shows engine picker; WhisperKit-specific options (model, language) hidden when Parakeet is selected.
+- Parakeet does NOT support explicit language selection — it auto-detects from audio. Only WhisperKit has a language parameter.
+- `AppState.activeTranscriptionEngine` returns the selected engine, used by `PipelineQueue`.
+
 **Concurrency:**
 - `WatchLoop` is `@MainActor`. Tests for this class must also be `@MainActor`.
-- `WhisperKitEngine.loadModel()` deduplicates concurrent calls via `loadingTask` — second caller awaits the first's task. Safe to call from multiple places.
+- `WhisperKitEngine.loadModel()` and `ParakeetEngine.loadModel()` both deduplicate concurrent calls via `loadingTask` — second caller awaits the first's task. Safe to call from multiple places.
 - `ProtocolGenerator` uses async process I/O: `terminationHandler` + `withCheckedContinuation` instead of `process.waitUntilExit()`. stdout/stderr are read in detached `Task`s.
 
 **View architecture:**
-- `SettingsView` receives `WhisperKitEngine` as a stored property (not `@State`). Constructor: `SettingsView(settings:whisperKitEngine:)`.
+- `SettingsView` receives `WhisperKitEngine` and `ParakeetEngine` as stored properties (not `@State`). Constructor: `SettingsView(settings:whisperKitEngine:parakeetEngine:)`.
 
 **Audio loading:**
 - `AudioMixer.loadAudioAsFloat32()` uses a 3-tier fallback: `AVAudioFile` → `AVAsset` → `FFmpegHelper` (ffmpeg CLI).
@@ -213,7 +221,7 @@ Two build variants controlled by compile-time flag `APPSTORE` (`-Xswiftc -DAPPST
 | **OpenAI API** | Yes | Yes (only option) |
 | **Entitlements** | Mic only | Sandbox + mic + network + file picker |
 | **Build** | `./scripts/build_release.sh` | `./scripts/build_release.sh --appstore` |
-| **Tests** | 497 | 483 (14 CLI tests excluded) |
+| **Tests** | 597 | ~583 (14 CLI tests excluded) |
 
 - CLI-specific code lives in `ClaudeCLIProtocolGenerator.swift` (entire file `#if !APPSTORE`)
 - `ProtocolProvider` enum uses `CaseIterable` — `.claudeCLI` case excluded at compile time, picker adapts automatically

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -2,6 +2,18 @@ import SwiftUI
 
 private let defaults = UserDefaults.standard
 
+enum TranscriptionEngineSetting: String, CaseIterable {
+    case whisperKit
+    case parakeet
+
+    var label: String {
+        switch self {
+        case .whisperKit: "WhisperKit (Whisper)"
+        case .parakeet: "Parakeet TDT v3 (NVIDIA)"
+        }
+    }
+}
+
 enum ProtocolProvider: String, CaseIterable {
     #if !APPSTORE
         case claudeCLI
@@ -72,6 +84,16 @@ final class AppSettings {
     }
 
     // MARK: - Transcription
+
+    var transcriptionEngine: TranscriptionEngineSetting = {
+        if let raw = defaults.string(forKey: "transcriptionEngine"),
+           let engine = TranscriptionEngineSetting(rawValue: raw) {
+            return engine
+        }
+        return .whisperKit
+    }() {
+        didSet { defaults.set(transcriptionEngine.rawValue, forKey: "transcriptionEngine") }
+    }
 
     var whisperKitModel: String = defaults.object(forKey: "whisperKitModel") as? String
         ?? "openai_whisper-large-v3-v20240930_turbo" {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -25,6 +25,7 @@ final class AppState {
 
     let settings: AppSettings
     let whisperKit: WhisperKitEngine
+    let parakeetEngine: ParakeetEngine
     private let notifier: any AppNotifying
 
     // MARK: - State
@@ -38,14 +39,21 @@ final class AppState {
     init(
         settings: AppSettings = AppSettings(),
         whisperKit: WhisperKitEngine? = nil,
+        parakeetEngine: ParakeetEngine? = nil,
         notifier: any AppNotifying = SilentNotifier(),
         updateChecker: UpdateChecker? = nil,
     ) {
         self.settings = settings
         self.whisperKit = whisperKit ?? WhisperKitEngine()
+        self.parakeetEngine = parakeetEngine ?? ParakeetEngine()
         self.notifier = notifier
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
+    }
+
+    /// The active transcription engine based on the current settings.
+    var activeTranscriptionEngine: any TranscribingEngine {
+        settings.transcriptionEngine == .parakeet ? parakeetEngine : whisperKit
     }
 
     // MARK: - Derived properties
@@ -218,7 +226,7 @@ final class AppState {
     // MARK: - Pipeline
 
     func ensurePipelineQueue() {
-        guard pipelineQueue.whisperKit == nil else { return }
+        guard pipelineQueue.engine == nil else { return }
         whisperKit.language = settings.whisperLanguageOrNil
         pipelineQueue = makePipelineQueue()
         configurePipelineCallbacks()
@@ -226,7 +234,7 @@ final class AppState {
 
     func makePipelineQueue() -> PipelineQueue {
         let queue = PipelineQueue(
-            whisperKit: whisperKit,
+            engine: activeTranscriptionEngine,
             diarizationFactory: { FluidDiarizer() },
             protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
             outputDir: settings.effectiveOutputDir,

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -125,7 +125,9 @@ final class AppState {
             Task { @MainActor in
                 _ = await Permissions.ensureMicrophoneAccess()
 
-                whisperKit.language = settings.whisperLanguageOrNil
+                if settings.transcriptionEngine == .whisperKit {
+                    whisperKit.language = settings.whisperLanguageOrNil
+                }
                 pipelineQueue = makePipelineQueue()
 
                 let detector: MeetingDetecting = PowerAssertionDetector()
@@ -227,7 +229,9 @@ final class AppState {
 
     func ensurePipelineQueue() {
         guard pipelineQueue.engine == nil else { return }
-        whisperKit.language = settings.whisperLanguageOrNil
+        if settings.transcriptionEngine == .whisperKit {
+            whisperKit.language = settings.whisperLanguageOrNil
+        }
         pipelineQueue = makePipelineQueue()
         configurePipelineCallbacks()
     }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -53,7 +53,7 @@ struct MeetingTranscriberApp: App {
                 onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
                 onQuit: quit,
             )
-        } label: {
+        } label: { // swiftlint:disable:this closure_body_length
             Label {
                 Text(appState.currentStateLabel)
             } icon: {
@@ -76,9 +76,15 @@ struct MeetingTranscriberApp: App {
                 bringWindowToFront(id: "speaker-naming")
             }
             .task {
-                appState.whisperKit.modelVariant = appState.settings.whisperKitModel
-                appState.whisperKit.language = appState.settings.whisperLanguageOrNil
-                await appState.whisperKit.loadModel()
+                switch appState.settings.transcriptionEngine {
+                case .whisperKit:
+                    appState.whisperKit.modelVariant = appState.settings.whisperKitModel
+                    appState.whisperKit.language = appState.settings.whisperLanguageOrNil
+                    await appState.whisperKit.loadModel()
+
+                case .parakeet:
+                    await appState.parakeetEngine.loadModel()
+                }
             }
             .task {
                 appState.updateChecker.startPeriodicChecks(settings: appState.settings)
@@ -102,6 +108,7 @@ struct MeetingTranscriberApp: App {
             SettingsView(
                 settings: appState.settings,
                 whisperKitEngine: appState.whisperKit,
+                parakeetEngine: appState.parakeetEngine,
                 updateChecker: appState.updateChecker,
             )
         }

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -1,0 +1,114 @@
+import FluidAudio
+import Foundation
+import WhisperKit
+
+/// Transcription engine backed by NVIDIA Parakeet TDT v3 via FluidAudio CoreML.
+///
+/// Supports 25 European languages with ~10× faster transcription than Whisper Large v3
+/// and lower hallucination risk. Model download is ~50 MB (CoreML, same infrastructure
+/// as the FluidAudio diarization models).
+@MainActor
+@Observable
+final class ParakeetEngine: TranscribingEngine {
+    private(set) var modelState: ModelState = .unloaded
+    private(set) var downloadProgress: Double = 0
+    private(set) var transcriptionProgress: Double = 0
+
+    private var asrManager: AsrManager?
+    private var loadingTask: Task<Void, Never>?
+
+    func loadModel() async {
+        if let existing = loadingTask {
+            await existing.value
+            return
+        }
+
+        let task = Task {
+            modelState = .downloading
+            downloadProgress = 0
+            do {
+                let models = try await AsrModels.downloadAndLoad { [weak self] progress in
+                    Task { @MainActor in
+                        self?.downloadProgress = progress.fractionCompleted
+                    }
+                }
+                modelState = .loading
+                downloadProgress = 1.0
+                let manager = AsrManager(config: .default)
+                try await manager.initialize(models: models)
+                asrManager = manager
+                modelState = .loaded
+            } catch {
+                NSLog("Parakeet model load failed: \(error)")
+                modelState = .unloaded
+                downloadProgress = 0
+            }
+            loadingTask = nil
+        }
+        loadingTask = task
+        await task.value
+    }
+
+    private func ensureModel() async throws {
+        if asrManager != nil { return }
+        NSLog("Parakeet: model not loaded, loading…")
+        await loadModel()
+        guard asrManager != nil else {
+            NSLog("Parakeet: model load FAILED, state=\(modelState)")
+            throw TranscriptionError.modelNotLoaded
+        }
+        NSLog("Parakeet: model loaded successfully")
+    }
+
+    func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment] {
+        try await ensureModel()
+        guard let manager = asrManager else {
+            throw TranscriptionError.modelNotLoaded
+        }
+
+        transcriptionProgress = 0
+        let result = try await manager.transcribe(audioPath, source: .system)
+        transcriptionProgress = 1.0
+
+        guard let timings = result.tokenTimings, !timings.isEmpty else {
+            // No per-token timestamps: emit single segment spanning full duration
+            return result.text.isEmpty ? [] : [
+                TimestampedSegment(start: 0, end: result.duration, text: result.text.trimmingCharacters(in: .whitespaces)),
+            ]
+        }
+
+        return Self.groupTokensIntoSegments(timings)
+    }
+
+    /// Group token-level timings into sentence-level `TimestampedSegment`s.
+    ///
+    /// Ends a segment at sentence-terminating punctuation (`. ! ?`) or
+    /// after 20 tokens to keep segment lengths reasonable.
+    private static func groupTokensIntoSegments(_ timings: [TokenTiming]) -> [TimestampedSegment] {
+        var segments: [TimestampedSegment] = []
+        var group: [TokenTiming] = []
+
+        for timing in timings {
+            let token = timing.token
+            guard !token.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty else { continue }
+            group.append(timing)
+
+            let endsWithPunct = token.hasSuffix(".") || token.hasSuffix("!") || token.hasSuffix("?")
+            if endsWithPunct || group.count >= 20 {
+                if let seg = makeSegment(from: group) { segments.append(seg) }
+                group = []
+            }
+        }
+        if let seg = makeSegment(from: group) { segments.append(seg) }
+
+        return segments
+    }
+
+    private static func makeSegment(from timings: [TokenTiming]) -> TimestampedSegment? {
+        guard !timings.isEmpty else { return nil }
+        let text = timings.map(\.token).joined().trimmingCharacters(in: CharacterSet.whitespaces)
+        guard !text.isEmpty else { return nil }
+        // swiftlint:disable:next force_unwrapping
+        return TimestampedSegment(start: timings.first!.startTime, end: timings.last!.endTime, text: text)
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -12,7 +12,7 @@ class PipelineQueue {
     private let logDir: URL
 
     // Dependencies for processing
-    let whisperKit: WhisperKitEngine?
+    let engine: (any TranscribingEngine)?
     let diarizationFactory: (() -> DiarizationProvider)?
     let protocolGeneratorFactory: (() -> ProtocolGenerating)?
     let outputDir: URL?
@@ -79,7 +79,7 @@ class PipelineQueue {
     /// Simple init for skeleton tests and basic queue usage.
     init(logDir: URL? = nil, completedJobLifetime: TimeInterval = 60) {
         self.logDir = logDir ?? AppPaths.ipcDir
-        self.whisperKit = nil
+        self.engine = nil
         self.diarizationFactory = nil
         self.protocolGeneratorFactory = nil
         self.outputDir = nil
@@ -92,7 +92,7 @@ class PipelineQueue {
 
     /// Full init with all processing dependencies.
     init(
-        whisperKit: WhisperKitEngine,
+        engine: any TranscribingEngine,
         diarizationFactory: @escaping () -> DiarizationProvider,
         protocolGeneratorFactory: @escaping () -> ProtocolGenerating,
         outputDir: URL,
@@ -104,7 +104,7 @@ class PipelineQueue {
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
-        self.whisperKit = whisperKit
+        self.engine = engine
         self.diarizationFactory = diarizationFactory
         self.protocolGeneratorFactory = protocolGeneratorFactory
         self.outputDir = outputDir
@@ -224,7 +224,7 @@ class PipelineQueue {
             isProcessing = false
             return
         }
-        guard let whisperKit, let protocolGeneratorFactory, let outputDir else {
+        guard let engine, let protocolGeneratorFactory, let outputDir else {
             logger.warning("Processing dependencies not configured — skipping")
             isProcessing = false
             return
@@ -262,11 +262,11 @@ class PipelineQueue {
                 try await micResample
 
                 // Transcribe each track separately
-                let appSegments = try await whisperKit.transcribeSegments(audioPath: app16k)
-                let micSegments = try await whisperKit.transcribeSegments(audioPath: mic16k)
+                let appSegments = try await engine.transcribeSegments(audioPath: app16k)
+                let micSegments = try await engine.transcribeSegments(audioPath: mic16k)
 
                 // Merge dual-source segments
-                let segments = whisperKit.mergeDualSourceSegments(
+                let segments = engine.mergeDualSourceSegments(
                     appSegments: appSegments,
                     micSegments: micSegments,
                     micDelay: micDelay,
@@ -280,7 +280,7 @@ class PipelineQueue {
                 try await AudioMixer.resampleFile(from: mixPath, to: mix16k)
 
                 // Use transcribeSegments to cache results for diarization
-                let segments = try await whisperKit.transcribeSegments(audioPath: mix16k)
+                let segments = try await engine.transcribeSegments(audioPath: mix16k)
                 cachedSegments = segments
                 transcript = segments.map { "\($0.formattedTimestamp) \($0.text)" }.joined(separator: "\n")
             }
@@ -462,9 +462,7 @@ class PipelineQueue {
                             let segments: [TimestampedSegment] = if let cached = cachedSegments {
                                 cached
                             } else {
-                                try await whisperKit.transcribeSegments(
-                                    audioPath: mix16k,
-                                )
+                                try await engine.transcribeSegments(audioPath: mix16k)
                             }
                             let labeled = DiarizationProcess.assignSpeakers(
                                 transcript: segments,

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import ApplicationServices
 import AVFoundation
 import SwiftUI
@@ -20,6 +21,7 @@ struct SettingsView: View {
     @State private var showResetPromptConfirmation = false
     @State private var hasCustomPrompt = FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path)
     var whisperKitEngine: WhisperKitEngine
+    var parakeetEngine: ParakeetEngine
     var updateChecker: UpdateChecker?
 
     enum ConnectionTestResult {
@@ -108,56 +110,29 @@ struct SettingsView: View {
                 }
             }
 
-            // swiftlint:disable:next closure_body_length
             Section("Transcription") {
-                Picker("Model", selection: $settings.whisperKitModel) {
-                    ForEach(whisperKitModels, id: \.variant) { model in
-                        Text(model.label).tag(model.variant)
+                Picker("Engine", selection: $settings.transcriptionEngine) {
+                    ForEach(TranscriptionEngineSetting.allCases, id: \.self) { engine in
+                        Text(engine.label).tag(engine)
                     }
                 }
 
-                Picker("Language", selection: $settings.whisperLanguage) {
-                    ForEach(whisperLanguages, id: \.code) { lang in
-                        Text(lang.label).tag(lang.code)
+                if settings.transcriptionEngine == .whisperKit {
+                    Picker("Model", selection: $settings.whisperKitModel) {
+                        ForEach(whisperKitModels, id: \.variant) { model in
+                            Text(model.label).tag(model.variant)
+                        }
+                    }
+
+                    Picker("Language", selection: $settings.whisperLanguage) {
+                        ForEach(whisperLanguages, id: \.code) { lang in
+                            Text(lang.label).tag(lang.code)
+                        }
                     }
                 }
 
-                // Model status
-                switch whisperKitEngine.modelState {
-                case .downloading:
-                    ProgressView(value: whisperKitEngine.downloadProgress)
-                        .progressViewStyle(.linear)
-                    Text("Downloading model... \(Int(whisperKitEngine.downloadProgress * 100))%")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                case .loading:
-                    HStack {
-                        ProgressView().controlSize(.small)
-                        Text("Loading model...")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                case .loaded:
-                    Label("Model ready", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                        .font(.caption)
-
-                case .unloaded, .unloading:
-                    Button("Load Model") {
-                        whisperKitEngine.modelVariant = settings.whisperKitModel
-                        Task { await whisperKitEngine.loadModel() }
-                    }
-
-                case .prewarming, .prewarmed, .downloaded:
-                    HStack {
-                        ProgressView().controlSize(.small)
-                        Text("Preparing model...")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                // Model status for active engine
+                engineStatusView
 
                 Toggle("Speaker Diarization", isOn: $settings.diarize)
 
@@ -447,6 +422,53 @@ struct SettingsView: View {
                 claudeBinaries = ClaudeCLIProtocolGenerator.availableClaudeBinaries()
             #endif
             refreshPermissions()
+        }
+    }
+
+    /// Active engine for status display.
+    private var activeEngine: any TranscribingEngine {
+        settings.transcriptionEngine == .parakeet ? parakeetEngine : whisperKitEngine
+    }
+
+    @ViewBuilder
+    private var engineStatusView: some View { // swiftlint:disable:this attributes
+        let engine = activeEngine
+        switch engine.modelState {
+        case .downloading:
+            ProgressView(value: engine.downloadProgress)
+                .progressViewStyle(.linear)
+            Text("Downloading model... \(Int(engine.downloadProgress * 100))%")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+        case .loading:
+            HStack {
+                ProgressView().controlSize(.small)
+                Text("Loading model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .loaded:
+            Label("Model ready", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .font(.caption)
+
+        case .unloaded, .unloading:
+            Button("Load Model") {
+                if settings.transcriptionEngine == .whisperKit {
+                    whisperKitEngine.modelVariant = settings.whisperKitModel
+                }
+                Task { await engine.loadModel() }
+            }
+
+        case .prewarming, .prewarmed, .downloaded:
+            HStack {
+                ProgressView().controlSize(.small)
+                Text("Preparing model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/app/MeetingTranscriber/Sources/TranscribingEngine.swift
+++ b/app/MeetingTranscriber/Sources/TranscribingEngine.swift
@@ -1,0 +1,48 @@
+import Foundation
+import WhisperKit
+
+/// Common interface for transcription engine implementations (WhisperKit, Parakeet, …).
+@MainActor
+protocol TranscribingEngine: AnyObject {
+    var modelState: ModelState { get }
+    var downloadProgress: Double { get }
+    var transcriptionProgress: Double { get } // swiftlint:disable:this unused_declaration
+
+    func loadModel() async
+    func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment]
+}
+
+extension TranscribingEngine {
+    /// Label and merge pre-transcribed app/mic segments by timestamp.
+    func mergeDualSourceSegments(
+        appSegments: [TimestampedSegment],
+        micSegments: [TimestampedSegment],
+        micDelay: TimeInterval = 0,
+        micLabel: String = "Me",
+    ) -> [TimestampedSegment] {
+        var app = appSegments
+        var mic = micSegments
+
+        if micDelay != 0 {
+            mic = mic.map { seg in
+                TimestampedSegment(
+                    start: seg.start + micDelay,
+                    end: seg.end + micDelay,
+                    text: seg.text,
+                    speaker: seg.speaker,
+                )
+            }
+        }
+
+        for i in app.indices {
+            app[i].speaker = "Remote"
+        }
+        for i in mic.indices {
+            mic[i].speaker = micLabel
+        }
+
+        var result = app + mic
+        result.sort { $0.start < $1.start }
+        return result
+    }
+}

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -34,7 +34,7 @@ extension TimestampedSegment {
 
 @MainActor
 @Observable
-final class WhisperKitEngine {
+final class WhisperKitEngine: TranscribingEngine {
     var modelVariant = "openai_whisper-large-v3-v20240930_turbo"
     var language: String?
     private(set) var modelState: ModelState = .unloaded
@@ -160,46 +160,6 @@ final class WhisperKitEngine {
         guard let audioFile = try? AVAudioFile(forReading: audioPath) else { return 1 }
         let duration = Double(audioFile.length) / audioFile.fileFormat.sampleRate
         return Int(ceil(duration / 30.0))
-    }
-
-    /// Label and merge pre-transcribed app/mic segments by timestamp.
-    ///
-    /// Used by PipelineQueue when transcription is done track-by-track for progress tracking.
-    func mergeDualSourceSegments(
-        appSegments: [TimestampedSegment],
-        micSegments: [TimestampedSegment],
-        micDelay: TimeInterval = 0,
-        micLabel: String = "Me",
-    ) -> [TimestampedSegment] {
-        var app = appSegments
-        var mic = micSegments
-
-        if micDelay != 0 {
-            mic = mic.map { seg in
-                TimestampedSegment(
-                    start: seg.start + micDelay,
-                    end: seg.end + micDelay,
-                    text: seg.text,
-                    speaker: seg.speaker,
-                )
-            }
-        }
-
-        for i in app.indices {
-            app[i].speaker = "Remote"
-        }
-        for i in mic.indices {
-            mic[i].speaker = micLabel
-        }
-
-        return Self.mergeSegments(app, mic)
-    }
-
-    /// Merge two segment arrays sorted by start timestamp.
-    static func mergeSegments(_ a: [TimestampedSegment], _ b: [TimestampedSegment]) -> [TimestampedSegment] {
-        var result = a + b
-        result.sort { $0.start < $1.start }
-        return result
     }
 
     /// Remove Whisper special tokens like <|startoftranscript|>, <|en|>, <|0.00|>, etc.

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -330,11 +330,11 @@ final class AppStateTests: XCTestCase {
 
     func testEnsurePipelineQueueReplacesBareQueue() {
         let (state, _) = makeState()
-        XCTAssertNil(state.pipelineQueue.whisperKit, "Precondition: fresh queue has no whisperKit")
+        XCTAssertNil(state.pipelineQueue.engine, "Precondition: fresh queue has no engine")
 
         state.ensurePipelineQueue()
 
-        XCTAssertNotNil(state.pipelineQueue.whisperKit)
+        XCTAssertNotNil(state.pipelineQueue.engine)
     }
 
     func testEnsurePipelineQueueIdempotent() {
@@ -349,9 +349,9 @@ final class AppStateTests: XCTestCase {
 
     // MARK: - makePipelineQueue
 
-    func testMakePipelineQueueHasWhisperKit() {
+    func testMakePipelineQueueHasEngine() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().whisperKit)
+        XCTAssertNotNil(state.makePipelineQueue().engine)
     }
 
     func testMakePipelineQueueHasDiarizationFactory() {

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -479,6 +479,50 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertFalse(existingLoop.isActive, "Existing auto-watch loop should be stopped")
     }
+
+    // MARK: - Engine Switching
+
+    func testActiveTranscriptionEngineDefaultsToWhisperKit() {
+        let settings = AppSettings()
+        settings.transcriptionEngine = .whisperKit
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+    }
+
+    func testActiveTranscriptionEngineReturnsParakeetWhenSet() {
+        let settings = AppSettings()
+        settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+    }
+
+    func testActiveTranscriptionEngineSwitchesBack() {
+        let settings = AppSettings()
+        settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+
+        settings.transcriptionEngine = .whisperKit
+        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+    }
+
+    func testMakePipelineQueueUsesActiveEngine() {
+        let (state, _) = makeState()
+        XCTAssertNotNil(state.makePipelineQueue().engine, "WhisperKit engine should be set")
+
+        state.settings.transcriptionEngine = .parakeet
+        XCTAssertNotNil(state.makePipelineQueue().engine, "Parakeet engine should be set")
+    }
+
+    func testEnsurePipelineQueueWithParakeet() {
+        let settings = AppSettings()
+        settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+
+        state.ensurePipelineQueue()
+
+        XCTAssertNotNil(state.pipelineQueue.engine)
+    }
 }
 
 // MARK: - Private helpers

--- a/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
@@ -1,0 +1,198 @@
+import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class ParakeetE2ETests: XCTestCase {
+    // MARK: - Model loading
+
+    func testParakeetModelLoadsSuccessfully() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+    }
+
+    // MARK: - Transcription with fixture
+
+    func testTranscribeSegmentsWithFixture() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        // Resample 48kHz fixture to 16kHz for Parakeet
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        let segments = try await engine.transcribeSegments(audioPath: resampled16k)
+
+        XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
+
+        // Verify timestamps are non-negative and ordered
+        for segment in segments {
+            XCTAssertGreaterThanOrEqual(segment.start, 0, "Start should be non-negative")
+            XCTAssertGreaterThanOrEqual(segment.end, segment.start, "End should be >= start")
+        }
+
+        // Verify text is non-empty per segment
+        for segment in segments {
+            XCTAssertFalse(segment.text.isEmpty, "Segment text should not be empty")
+        }
+    }
+
+    func testTranscribeSegmentsProducesGermanContent() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        // Resample 48kHz fixture to 16kHz for Parakeet
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        let segments = try await engine.transcribeSegments(audioPath: resampled16k)
+        XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
+
+        let fullText = segments.map(\.text).joined(separator: " ")
+        assertTranscriptContent(fullText)
+    }
+
+    func testTranscribeSegmentsGroupsIntoSentences() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        // Resample 48kHz fixture to 16kHz for Parakeet
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        let segments = try await engine.transcribeSegments(audioPath: resampled16k)
+
+        // The fixture has two speakers with multiple sentences — expect more than one segment
+        XCTAssertGreaterThan(
+            segments.count, 1,
+            "Should produce multiple segments, not just one giant segment (got \(segments.count))",
+        )
+    }
+
+    // MARK: - Progress tracking
+
+    func testDownloadProgressReachesOne() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+        XCTAssertEqual(engine.downloadProgress, 1.0, "Download progress should be 1.0 after model load")
+    }
+
+    func testTranscriptionProgressReachesOne() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        // Resample 48kHz fixture to 16kHz for Parakeet
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        _ = try await engine.transcribeSegments(audioPath: resampled16k)
+        XCTAssertEqual(
+            engine.transcriptionProgress, 1.0,
+            "Transcription progress should be 1.0 after transcribeSegments completes",
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Keywords expected in the fixture's German transcript.
+    private let expectedKeywords = [
+        "willkommen", "Projekt", "Status", "Entwicklung", "Zeitplan",
+    ]
+
+    private func assertTranscriptContent(_ transcript: String) {
+        let lower = transcript.lowercased()
+        var matched = 0
+        for keyword in expectedKeywords where lower.contains(keyword.lowercased()) {
+            matched += 1
+        }
+        // At least 3 of 5 keywords should appear
+        XCTAssertGreaterThanOrEqual(
+            matched, 3,
+            "Expected at least 3 of \(expectedKeywords) in transcript, found \(matched). Transcript:\n\(transcript)",
+        )
+    }
+
+    private func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests/
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent(name)
+    }
+
+    /// Resample the 48kHz fixture to a 16kHz temp WAV file for Parakeet.
+    private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("parakeet_e2e_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")
+
+        let samples = try AudioMixer.loadAudioFileAsFloat32(url: fixture)
+        XCTAssertFalse(samples.isEmpty, "Should load samples from fixture")
+
+        let file = try AVAudioFile(forReading: fixture)
+        let sourceSampleRate = Int(file.processingFormat.sampleRate)
+        let targetRate = 16000
+
+        let resampled: [Float]
+        if sourceSampleRate != targetRate {
+            resampled = AudioMixer.resample(samples, from: sourceSampleRate, to: targetRate)
+            XCTAssertFalse(resampled.isEmpty, "Resampled audio should not be empty")
+        } else {
+            resampled = samples
+        }
+
+        try AudioMixer.saveWAV(samples: resampled, sampleRate: targetRate, url: resampled16k)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resampled16k.path))
+
+        return resampled16k
+    }
+}

--- a/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
@@ -1,0 +1,159 @@
+@testable import MeetingTranscriber
+import WhisperKit
+import XCTest
+
+@MainActor
+final class ParakeetEngineTests: XCTestCase {
+    // MARK: - Initial State
+
+    func testModelStateStartsUnloaded() {
+        let engine = ParakeetEngine()
+        XCTAssertEqual(engine.modelState, .unloaded)
+    }
+
+    func testDownloadProgressStartsAtZero() {
+        let engine = ParakeetEngine()
+        XCTAssertEqual(engine.downloadProgress, 0, accuracy: 0.001)
+    }
+
+    func testTranscriptionProgressStartsAtZero() {
+        let engine = ParakeetEngine()
+        XCTAssertEqual(engine.transcriptionProgress, 0, accuracy: 0.001)
+    }
+
+    // MARK: - Protocol Conformance
+
+    func testConformsToTranscribingEngine() {
+        let engine = ParakeetEngine()
+        // Assign to protocol type to verify conformance at compile time
+        let proto: TranscribingEngine = engine
+        XCTAssertNotNil(proto)
+    }
+
+    func testIsReferenceType() {
+        let engine = ParakeetEngine()
+        let ref: TranscribingEngine = engine
+        // Mutating the reference should be visible via the original variable
+        XCTAssertIdentical(engine, ref, "ParakeetEngine should be a reference type (class)")
+    }
+
+    // MARK: - Transcription Errors
+
+    func testTranscribeSegmentsThrowsForNonexistentFile() async {
+        let engine = ParakeetEngine()
+        let dummyURL = URL(fileURLWithPath: "/tmp/nonexistent_\(UUID()).wav")
+
+        do {
+            _ = try await engine.transcribeSegments(audioPath: dummyURL)
+            XCTFail("Expected transcribeSegments to throw for nonexistent file")
+        } catch {
+            // Either model load fails (TranscriptionError) or file open fails (AVFoundation)
+            // Both are acceptable — the key guarantee is it does NOT succeed silently
+            XCTAssertFalse(
+                "\(error)".isEmpty,
+                "Error should have a meaningful description",
+            )
+        }
+    }
+
+    // MARK: - MergeDualSourceSegments (protocol extension on TranscribingEngine)
+
+    func testMergeDualSourceSegmentsLabelsAndSorts() {
+        let engine = ParakeetEngine()
+
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from app")]
+        let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from mic")]
+
+        let result = engine.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].speaker, "Remote")
+        XCTAssertEqual(result[0].text, "Hello from app")
+        XCTAssertEqual(result[1].speaker, "Me")
+        XCTAssertEqual(result[1].text, "Hello from mic")
+    }
+
+    func testMergeDualSourceSegmentsAppliesMicDelay() {
+        let engine = ParakeetEngine()
+
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
+        let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
+
+        let result = engine.mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micDelay: 3.0,
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].text, "App")
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[1].text, "Mic")
+        XCTAssertEqual(result[1].start, 3.0)
+        XCTAssertEqual(result[1].end, 8.0)
+    }
+
+    func testMergeDualSourceSegmentsEmptyInputs() {
+        let engine = ParakeetEngine()
+
+        let result = engine.mergeDualSourceSegments(appSegments: [], micSegments: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMergeDualSourceSegmentsCustomMicLabel() {
+        let engine = ParakeetEngine()
+
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
+        let micSegs = [TimestampedSegment(start: 1, end: 6, text: "Mic")]
+
+        let result = engine.mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micLabel: "Alice",
+        )
+
+        XCTAssertEqual(result[1].speaker, "Alice")
+    }
+
+    // MARK: - Load Model State Transitions
+
+    func testLoadModelTransitionsToLoaded() async {
+        let engine = ParakeetEngine()
+        XCTAssertEqual(engine.modelState, .unloaded, "Pre-condition: model starts unloaded")
+
+        await engine.loadModel()
+
+        // Model loads successfully from cached CoreML files, or fails and resets to .unloaded.
+        // Either way it must not be stuck in .downloading or .loading.
+        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        XCTAssertTrue(
+            terminalStates.contains(engine.modelState),
+            "Model state should be terminal (.loaded or .unloaded), got: \(engine.modelState)",
+        )
+    }
+
+    func testDownloadProgressAfterLoad() async {
+        let engine = ParakeetEngine()
+
+        await engine.loadModel()
+
+        if engine.modelState == .loaded {
+            XCTAssertEqual(engine.downloadProgress, 1.0, accuracy: 0.001)
+        } else {
+            // Failed load resets progress to 0
+            XCTAssertEqual(engine.downloadProgress, 0, accuracy: 0.001)
+        }
+    }
+
+    func testLoadModelDeduplicatesConcurrentCalls() async {
+        let engine = ParakeetEngine()
+
+        // Start two concurrent loads — second should await the first, not start a new download
+        async let load1: Void = engine.loadModel()
+        async let load2: Void = engine.loadModel()
+        _ = await (load1, load2)
+
+        // Both complete without crash; state is terminal
+        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        XCTAssertTrue(
+            terminalStates.contains(engine.modelState),
+            "Model state should be terminal after concurrent loads, got: \(engine.modelState)",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -385,7 +385,7 @@ final class PipelineQueueTests: XCTestCase {
 
     private func makeProcessingQueue() -> PipelineQueue {
         PipelineQueue(
-            whisperKit: WhisperKitEngine(),
+            engine: WhisperKitEngine(),
             diarizationFactory: { MockDiarization() },
             protocolGeneratorFactory: { MockProtocolGen() },
             outputDir: tmpDir,

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -8,13 +8,13 @@ final class SettingsViewTests: XCTestCase {
 
     func testViewRendersWithDefaults() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         XCTAssertNoThrow(try sut.inspect())
     }
 
     func testDiarizeToggleExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Speaker Diarization"))
     }
@@ -24,7 +24,7 @@ final class SettingsViewTests: XCTestCase {
     func testDiarizeEnabledShowsExpectedSpeakers() throws {
         let settings = AppSettings()
         settings.diarize = true
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Expected Speakers"))
     }
@@ -33,7 +33,7 @@ final class SettingsViewTests: XCTestCase {
 
     func testNoMicToggleExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "No Microphone (app audio only)"))
     }
@@ -41,7 +41,7 @@ final class SettingsViewTests: XCTestCase {
     func testMicSectionShownWhenMicEnabled() throws {
         let settings = AppSettings()
         settings.noMic = false
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Mic Speaker Name"))
     }
@@ -49,7 +49,7 @@ final class SettingsViewTests: XCTestCase {
     func testMicSectionHiddenWhenNoMic() throws {
         let settings = AppSettings()
         settings.noMic = true
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertThrowsError(try body.find(text: "Mic Speaker Name"))
     }
@@ -58,7 +58,7 @@ final class SettingsViewTests: XCTestCase {
 
     func testAppsToWatchSection() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Microsoft Teams"))
         XCTAssertNoThrow(try body.find(text: "Zoom"))
@@ -69,21 +69,21 @@ final class SettingsViewTests: XCTestCase {
 
     func testPollIntervalFieldExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Poll Interval"))
     }
 
     func testGracePeriodFieldExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Grace Period"))
     }
 
     func testWhisperKitModelPickerExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Model"))
     }
@@ -92,7 +92,7 @@ final class SettingsViewTests: XCTestCase {
 
     func testProviderPickerExists() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Provider"))
     }
@@ -101,7 +101,7 @@ final class SettingsViewTests: XCTestCase {
         func testClaudeCLIProviderShowsBinaryPicker() throws {
             let settings = AppSettings()
             settings.protocolProvider = .claudeCLI
-            let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+            let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
             let body = try sut.inspect()
             XCTAssertNoThrow(try body.find(text: "Claude CLI"))
         }
@@ -110,7 +110,7 @@ final class SettingsViewTests: XCTestCase {
     func testOpenAIProviderShowsEndpointField() throws {
         let settings = AppSettings()
         settings.protocolProvider = .openAICompatible
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Endpoint"))
         XCTAssertNoThrow(try body.find(text: "API Key"))
@@ -125,6 +125,7 @@ final class SettingsViewTests: XCTestCase {
         let sut = SettingsView(
             settings: settings,
             whisperKitEngine: WhisperKitEngine(),
+            parakeetEngine: ParakeetEngine(),
             updateChecker: checker,
         )
         let body = try sut.inspect()
@@ -134,7 +135,7 @@ final class SettingsViewTests: XCTestCase {
 
     func testUpdatesSectionHiddenWhenNoChecker() throws {
         let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine())
+        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
         let body = try sut.inspect()
         XCTAssertThrowsError(try body.find(text: "Check Now"))
     }
@@ -146,6 +147,7 @@ final class SettingsViewTests: XCTestCase {
         let sut = SettingsView(
             settings: settings,
             whisperKitEngine: WhisperKitEngine(),
+            parakeetEngine: ParakeetEngine(),
             updateChecker: checker,
         )
         let body = try sut.inspect()

--- a/app/MeetingTranscriber/Tests/TranscribingEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/TranscribingEngineTests.swift
@@ -1,0 +1,186 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class TranscribingEngineTests: XCTestCase {
+    private func makeEngine() -> WhisperKitEngine {
+        WhisperKitEngine()
+    }
+
+    // MARK: - Speaker Labels
+
+    func testLabelsAppSegmentsAsRemote() {
+        let appSegs = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "World"),
+        ]
+        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.speaker == "Remote" })
+    }
+
+    func testLabelsMicSegmentsWithDefaultMicLabel() {
+        let micSegs = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "World"),
+        ]
+        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.speaker == "Me" })
+    }
+
+    func testCustomMicLabelIsApplied() {
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
+        let micSegs = [TimestampedSegment(start: 1, end: 6, text: "Mic")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micLabel: "Alice",
+        )
+
+        let micResult = result.first { $0.text == "Mic" }
+        XCTAssertEqual(micResult?.speaker, "Alice")
+    }
+
+    // MARK: - Sorting
+
+    func testSortsMergedResultByStartTimestamp() {
+        let appSegs = [
+            TimestampedSegment(start: 0, end: 3, text: "First"),
+            TimestampedSegment(start: 10, end: 13, text: "Fourth"),
+        ]
+        let micSegs = [
+            TimestampedSegment(start: 3, end: 6, text: "Second"),
+            TimestampedSegment(start: 6, end: 9, text: "Third"),
+        ]
+
+        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+
+        XCTAssertEqual(result.map(\.text), ["First", "Second", "Third", "Fourth"])
+        XCTAssertEqual(result.map(\.start), [0, 3, 6, 10])
+    }
+
+    func testInterleavedTimestampsMergeCorrectly() {
+        let appSegs = [
+            TimestampedSegment(start: 0, end: 3, text: "A1"),
+            TimestampedSegment(start: 6, end: 9, text: "A2"),
+        ]
+        let micSegs = [
+            TimestampedSegment(start: 3, end: 6, text: "M1"),
+            TimestampedSegment(start: 9, end: 12, text: "M2"),
+        ]
+
+        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+
+        XCTAssertEqual(result.map(\.text), ["A1", "M1", "A2", "M2"])
+        XCTAssertEqual(result.map(\.speaker), ["Remote", "Me", "Remote", "Me"])
+    }
+
+    // MARK: - Mic Delay
+
+    func testAppliesMicDelayToMicSegments() throws {
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
+        let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micDelay: 3.0,
+        )
+
+        let micResult = try XCTUnwrap(result.first { $0.text == "Mic" })
+        XCTAssertEqual(micResult.start, 3.0, accuracy: 0.001)
+        XCTAssertEqual(micResult.end, 8.0, accuracy: 0.001)
+    }
+
+    func testMicDelayDoesNotAffectAppSegments() throws {
+        let appSegs = [TimestampedSegment(start: 5, end: 10, text: "App")]
+        let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micDelay: 2.0,
+        )
+
+        let appResult = try XCTUnwrap(result.first { $0.text == "App" })
+        XCTAssertEqual(appResult.start, 5.0, accuracy: 0.001)
+        XCTAssertEqual(appResult.end, 10.0, accuracy: 0.001)
+    }
+
+    func testZeroMicDelayDoesNotModifyTimestamps() {
+        let micSegs = [TimestampedSegment(start: 3, end: 8, text: "Mic")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: [], micSegments: micSegs, micDelay: 0,
+        )
+
+        XCTAssertEqual(result[0].start, 3.0, accuracy: 0.001)
+        XCTAssertEqual(result[0].end, 8.0, accuracy: 0.001)
+    }
+
+    func testNegativeMicDelayShiftsBackward() throws {
+        let appSegs = [TimestampedSegment(start: 5, end: 10, text: "App")]
+        let micSegs = [TimestampedSegment(start: 7, end: 12, text: "Mic")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: appSegs, micSegments: micSegs, micDelay: -2.0,
+        )
+
+        let micResult = try XCTUnwrap(result.first { $0.text == "Mic" })
+        XCTAssertEqual(micResult.start, 5.0, accuracy: 0.001)
+        XCTAssertEqual(micResult.end, 10.0, accuracy: 0.001)
+    }
+
+    // MARK: - Empty Inputs
+
+    func testEmptyAppSegmentsReturnsOnlyMicSegments() {
+        let micSegs = [
+            TimestampedSegment(start: 0, end: 5, text: "Mic1"),
+            TimestampedSegment(start: 5, end: 10, text: "Mic2"),
+        ]
+
+        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.speaker == "Me" })
+        XCTAssertEqual(result.map(\.text), ["Mic1", "Mic2"])
+    }
+
+    func testEmptyMicSegmentsReturnsOnlyAppSegments() {
+        let appSegs = [
+            TimestampedSegment(start: 0, end: 5, text: "App1"),
+            TimestampedSegment(start: 5, end: 10, text: "App2"),
+        ]
+
+        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.speaker == "Remote" })
+        XCTAssertEqual(result.map(\.text), ["App1", "App2"])
+    }
+
+    func testBothEmptyReturnsEmptyResult() {
+        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Text Preservation
+
+    func testPreservesSegmentTextThroughMerge() {
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from the app side")]
+        let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from the mic side")]
+
+        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+
+        XCTAssertEqual(result[0].text, "Hello from the app side")
+        XCTAssertEqual(result[1].text, "Hello from the mic side")
+    }
+
+    func testPreservesTextWithMicDelay() {
+        let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Delayed mic text")]
+
+        let result = makeEngine().mergeDualSourceSegments(
+            appSegments: [], micSegments: micSegs, micDelay: 10.0,
+        )
+
+        XCTAssertEqual(result[0].text, "Delayed mic text")
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -69,14 +69,14 @@ final class WatchLoopE2ETests: XCTestCase {
 
     /// Create a PipelineQueue with mocks for E2E testing.
     private func makeQueue(
-        whisperKit: WhisperKitEngine? = nil,
+        engine: (any TranscribingEngine)? = nil,
         diarization: MockDiarization = MockDiarization(),
         protocolGen: MockProtocolGen = MockProtocolGen(),
         diarizeEnabled: Bool = false,
         micLabel: String = "Roman",
     ) -> PipelineQueue {
         PipelineQueue(
-            whisperKit: whisperKit ?? WhisperKitEngine(),
+            engine: engine ?? WhisperKitEngine(),
             diarizationFactory: { diarization },
             protocolGeneratorFactory: { protocolGen },
             outputDir: tmpDir,
@@ -130,7 +130,7 @@ final class WatchLoopE2ETests: XCTestCase {
         engine.language = "de"
 
         let queue = makeQueue(
-            whisperKit: engine,
+            engine: engine,
             protocolGen: mockProtocol,
             diarizeEnabled: false,
         )
@@ -193,7 +193,7 @@ final class WatchLoopE2ETests: XCTestCase {
         engine.language = "de"
 
         let queue = makeQueue(
-            whisperKit: engine,
+            engine: engine,
             protocolGen: mockProtocol,
             diarizeEnabled: false,
             micLabel: "Roman",
@@ -239,7 +239,7 @@ final class WatchLoopE2ETests: XCTestCase {
 
         let mockProtocol = MockProtocolGen()
         let queue = makeQueue(
-            whisperKit: engine,
+            engine: engine,
             protocolGen: mockProtocol,
             diarizeEnabled: false,
         )
@@ -285,7 +285,7 @@ final class WatchLoopE2ETests: XCTestCase {
         engine.language = "de"
 
         let queue = makeQueue(
-            whisperKit: engine,
+            engine: engine,
             diarization: mockDiarize,
             protocolGen: mockProtocol,
             diarizeEnabled: true, // Enabled but not available
@@ -408,7 +408,7 @@ final class WatchLoopE2ETests: XCTestCase {
 
         // swiftlint:disable trailing_closure
         let queue = PipelineQueue(
-            whisperKit: engine,
+            engine: engine,
             diarizationFactory: { FluidDiarizer() },
             protocolGeneratorFactory: { mockProtocol },
             outputDir: tmpDir,

--- a/app/MeetingTranscriber/Tests/WhisperKitDualSourceTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitDualSourceTests.swift
@@ -129,7 +129,7 @@ final class TimestampedSegmentTests: XCTestCase {
         seg2.speaker = "Me"
 
         let merged = ([seg1] + [seg2]).sorted { $0.start < $1.start }
-        let output = merged.map { $0.formattedLine }.joined(separator: "\n")
+        let output = merged.map(\.formattedLine).joined(separator: "\n")
         XCTAssertEqual(output, "[00:00] Remote: Hello\n[00:05] Me: Hi there")
     }
 

--- a/app/MeetingTranscriber/Tests/WhisperKitDualSourceTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitDualSourceTests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 @MainActor
 final class TimestampedSegmentTests: XCTestCase {
+    /// Merge two segment arrays sorted by start timestamp (replaces removed WhisperKitEngine.mergeSegments).
+    private static func mergeSegments(_ a: [TimestampedSegment], _ b: [TimestampedSegment]) -> [TimestampedSegment] {
+        (a + b).sorted { $0.start < $1.start }
+    }
+
     // MARK: - Timestamp Formatting
 
     func testFormattedTimestampShort() {
@@ -56,7 +61,7 @@ final class TimestampedSegmentTests: XCTestCase {
             TimestampedSegment(start: 15, end: 20, text: "Fourth"),
         ]
 
-        let merged = WhisperKitEngine.mergeSegments(a, b)
+        let merged = Self.mergeSegments(a, b)
         XCTAssertEqual(merged.count, 4)
         XCTAssertEqual(merged[0].text, "First")
         XCTAssertEqual(merged[1].text, "Second")
@@ -66,19 +71,19 @@ final class TimestampedSegmentTests: XCTestCase {
 
     func testMergeSegmentsEmptyA() {
         let b = [TimestampedSegment(start: 0, end: 5, text: "Only")]
-        let merged = WhisperKitEngine.mergeSegments([], b)
+        let merged = Self.mergeSegments([], b)
         XCTAssertEqual(merged.count, 1)
         XCTAssertEqual(merged[0].text, "Only")
     }
 
     func testMergeSegmentsEmptyB() {
         let a = [TimestampedSegment(start: 0, end: 5, text: "Only")]
-        let merged = WhisperKitEngine.mergeSegments(a, [])
+        let merged = Self.mergeSegments(a, [])
         XCTAssertEqual(merged.count, 1)
     }
 
     func testMergeSegmentsBothEmpty() {
-        let merged = WhisperKitEngine.mergeSegments([], [])
+        let merged = Self.mergeSegments([], [])
         XCTAssertTrue(merged.isEmpty)
     }
 
@@ -89,7 +94,7 @@ final class TimestampedSegmentTests: XCTestCase {
         var b = [TimestampedSegment(start: 2, end: 7, text: "Mic")]
         b[0].speaker = "Me"
 
-        let merged = WhisperKitEngine.mergeSegments(a, b)
+        let merged = Self.mergeSegments(a, b)
         XCTAssertEqual(merged[0].speaker, "Remote")
         XCTAssertEqual(merged[1].speaker, "Me")
     }
@@ -110,7 +115,7 @@ final class TimestampedSegmentTests: XCTestCase {
             micSegs[i].speaker = "Me"
         }
 
-        let merged = WhisperKitEngine.mergeSegments(appSegs, micSegs)
+        let merged = (appSegs + micSegs).sorted { $0.start < $1.start }
         XCTAssertEqual(merged.map(\.speaker), ["Remote", "Me", "Remote", "Me"])
         XCTAssertEqual(merged.map(\.text), ["A1", "M1", "A2", "M2"])
     }
@@ -123,8 +128,8 @@ final class TimestampedSegmentTests: XCTestCase {
         var seg2 = TimestampedSegment(start: 5, end: 10, text: "Hi there")
         seg2.speaker = "Me"
 
-        let merged = WhisperKitEngine.mergeSegments([seg1], [seg2])
-        let output = merged.map(\.formattedLine).joined(separator: "\n")
+        let merged = ([seg1] + [seg2]).sorted { $0.start < $1.start }
+        let output = merged.map { $0.formattedLine }.joined(separator: "\n")
         XCTAssertEqual(output, "[00:00] Remote: Hello\n[00:05] Me: Hi there")
     }
 
@@ -161,7 +166,7 @@ final class TimestampedSegmentTests: XCTestCase {
             mic[i].speaker = micLabel
         }
 
-        return WhisperKitEngine.mergeSegments(app, mic)
+        return (app + mic).sorted { $0.start < $1.start }
     }
 
     func testDualSourceSegmentsLabelsRemoteAndMic() {

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -12,12 +12,11 @@ Native SwiftUI menu bar application that orchestrates meeting detection, recordi
 
 ```
 Meeting Window Detected (CGWindowListCopyWindowInfo)
-  → DualSourceRecorder (AudioTapLib + mic)
-    → AudioMixer (resample 48kHz → 16kHz)
-      → WhisperKit (CoreML/ANE transcription)
-        → [FluidDiarizer (CoreML/ANE speaker diarization)]
-          → ProtocolGenerator (Claude CLI)
-            → Markdown protocol + transcript
+  → DualSourceRecorder (AudioTapLib + mic, records at 16kHz)
+    → [WhisperKit | Parakeet] (CoreML/ANE transcription)
+      → [FluidDiarizer (CoreML/ANE speaker diarization)]
+        → ProtocolGenerator (Claude CLI / OpenAI-compatible API)
+          → Markdown protocol + transcript
 ```
 
 ---
@@ -43,7 +42,9 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | `MeetingDetector.swift` | Window polling, pattern matching, confirmation counting, cooldown |
 | `MeetingPatterns.swift` | Regex patterns for Teams, Zoom, Webex |
 | `DualSourceRecorder.swift` | Orchestrates AudioTapLib capture + mic, mixes tracks |
-| `WhisperKitEngine.swift` | Native WhisperKit transcription (single/dual-source/segments) |
+| `TranscribingEngine.swift` | `TranscribingEngine` protocol + `mergeDualSourceSegments` default impl |
+| `WhisperKitEngine.swift` | WhisperKit transcription engine (99+ languages, ~1 GB model) |
+| `ParakeetEngine.swift` | NVIDIA Parakeet TDT v3 via FluidAudio (25 EU languages, ~50 MB, ~10× faster) |
 | `PipelineQueue.swift` | Decouples recording from post-processing, sequential job pipeline |
 | `PipelineJob.swift` | Pipeline job model (waiting → transcribing → diarizing → generatingProtocol → done) |
 | `FluidDiarizer.swift` | On-device speaker diarization via FluidAudio CoreML/ANE |
@@ -106,33 +107,45 @@ AudioTapLib (CATapDescription)
 
 ```
 Raw float32 stereo → mono (channel average)
-  → Save app.wav (at actual hardware rate)
-  → Resample to 48kHz if hardware rate differs
-  → Load mic.wav
+  → Resample to 16kHz
+  → Save app.wav (16kHz mono)
+  → Load mic.wav (already 16kHz from MicCaptureHandler)
   → Apply mute mask (zero mic during muted periods)
   → Echo suppression (RMS-based gate, 20ms windows)
   → Delay alignment (prepend zeros by MIC_DELAY)
   → Mix (average tracks)
-  → Save mix.wav (48kHz mono)
+  → Save mix.wav (16kHz mono)
 ```
 
-### Resampling for WhisperKit
-
-```
-48kHz WAV → AudioMixer.resample(from: 48000, to: 16000) → 16kHz WAV
-```
-
-WhisperKit requires 16kHz mono input. Both app and mic tracks are resampled before transcription.
+All recordings are normalized to 16kHz at capture time — no resampling needed in the pipeline.
 
 ---
 
 ## Transcription
 
+### Engine Selection
+
+`TranscribingEngine` protocol abstracts ASR backends. `AppSettings.transcriptionEngine` selects the active engine.
+
+| | WhisperKit | Parakeet TDT v3 |
+|---|---|---|
+| **Languages** | 99+ | 25 European |
+| **Model size** | ~800 MB–1.5 GB | ~50 MB |
+| **Speed (M4 Pro)** | ~10–20× RTF | ~110× RTF |
+| **Language selection** | Manual or auto-detect | Auto-detect only |
+| **Hallucinations** | Can occur | Minimal |
+
 ### WhisperKit Engine
 
 - **Model:** `openai_whisper-large-v3-v20240930_turbo` (CoreML/ANE)
-- **Pre-loading:** Model downloaded and loaded at app launch
+- **Pre-loading:** Model downloaded and loaded at app launch (when selected)
 - **Lazy fallback:** `ensureModel()` loads on-demand if not ready
+
+### Parakeet Engine
+
+- **Model:** NVIDIA Parakeet TDT v3 via FluidAudio (CoreML/ANE)
+- **Pre-loading:** Model downloaded and loaded at app launch (when selected)
+- **Token grouping:** `groupTokensIntoSegments` groups per-token timings into sentence-level segments (split on `. ! ?` or 20 tokens)
 
 ### Modes
 
@@ -140,8 +153,9 @@ WhisperKit requires 16kHz mono input. Both app and mic tracks are resampled befo
 2. **Dual source:** `transcribeSegments(appAudio:)` + `transcribeSegments(micAudio:)` → `mergeDualSourceSegments(appSegments:micSegments:)` → `[TimestampedSegment]` merged by timestamp
    - App segments labeled "Remote"
    - Mic segments labeled with user's mic name (default "Me")
+   - `mergeDualSourceSegments` is a protocol extension on `TranscribingEngine` — shared by both engines
 
-### Post-processing
+### Post-processing (WhisperKit only)
 
 - **Token stripping:** Regex `<\|[^|]*\|>` removes `<|startoftranscript|>`, `<|en|>`, etc.
 - **Hallucination filtering:** Skip consecutive identical segments
@@ -279,7 +293,7 @@ AppSettings (UserDefaults)
 3. **AudioTapLib as SPM library** — Direct in-process audio capture via CATapDescription (App Store compatible)
 4. **Dual-source recording** — Enables speaker separation without diarization (app=Remote, mic=Me)
 5. **Graceful degradation** — Diarization optional, mute detection optional, continues on partial failure
-6. **Pre-loaded model** — WhisperKit loaded at app launch, prevents delay on first meeting
+6. **Pre-loaded model** — Selected engine (WhisperKit or Parakeet) loaded at app launch, prevents delay on first meeting
 7. **5s cooldown** — Prevents re-detecting same meeting after handling
 8. **FluidAudio on-device diarization** — Replaces Python pyannote subprocess, no external dependencies
 9. **Dual-track diarization** — App and mic tracks diarized separately, avoiding echo/cross-talk interference


### PR DESCRIPTION
## Summary

- Add `TranscribingEngine` protocol to abstract ASR backends (WhisperKit, Parakeet)
- Add `ParakeetEngine` wrapping FluidAudio's CoreML-based Parakeet TDT v3 (~50 MB model, ~10× faster than Whisper Large v3, 25 European languages)
- Add engine picker in Settings to switch between WhisperKit and Parakeet
- Normalize all recorded audio to 16kHz at capture time (removes redundant resampling in pipeline)

## Test plan

- [x] 597 tests passing (559 → 597), 0 failures
- [x] New `ParakeetEngineTests` (13 unit tests: state, conformance, merge, dedup)
- [x] New `TranscribingEngineTests` (14 tests: mergeDualSourceSegments protocol extension)
- [x] New `ParakeetE2ETests` (6 tests: model load, transcription, German content)
- [x] `AppStateTests` +5 engine switching tests
- [x] Manual: switch engine in Settings, verify model downloads and transcription works
- [x] Manual: verify dual-source recording works with both engines

Closes #47