### PR TITLE
feat: add Qwen3-ASR as third transcription engine (macOS 15+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     TranscribingEngine.swift # TranscribingEngine protocol + mergeDualSourceSegments default impl
     WhisperKitEngine.swift # WhisperKit transcription engine (CoreML/ANE, 99+ languages)
     ParakeetEngine.swift   # NVIDIA Parakeet TDT v3 engine via FluidAudio (CoreML/ANE, 25 EU languages)
+    Qwen3AsrEngine.swift   # Qwen3-ASR 0.6B engine via FluidAudio (CoreML/ANE, 30 languages, macOS 15+)
     FluidDiarizer.swift    # CoreML-based speaker diarization via FluidAudio (on-device)
     SpeakerMatcher.swift   # Speaker embedding DB + cosine similarity matching
     DiarizationProcess.swift  # DiarizationProvider protocol + result types
@@ -89,8 +90,8 @@ speakers.json              # Saved voice profiles (gitignored, created at runtim
 ## Pipeline
 
 ```
-Dual-source: AudioTapLib (CATapDescription + AVAudioEngine) → separate 16kHz audio → [WhisperKit | Parakeet] per track → FluidAudio diarization per track (CoreML/ANE) → merge speakers → Claude CLI / OpenAI-compatible API → Markdown protocol
-Single-source: Audio/Video → 16kHz mono (AVAudioFile → AVAsset → ffmpeg fallback) → [WhisperKit | Parakeet] → FluidAudio diarization → Claude CLI / OpenAI-compatible API → Markdown protocol
+Dual-source: AudioTapLib (CATapDescription + AVAudioEngine) → separate 16kHz audio → [WhisperKit | Parakeet | Qwen3] per track → FluidAudio diarization per track (CoreML/ANE) → merge speakers → Claude CLI / OpenAI-compatible API → Markdown protocol
+Single-source: Audio/Video → 16kHz mono (AVAudioFile → AVAsset → ffmpeg fallback) → [WhisperKit | Parakeet | Qwen3] → FluidAudio diarization → Claude CLI / OpenAI-compatible API → Markdown protocol
 ```
 
 ## Setup
@@ -159,14 +160,15 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 ## Architecture Notes
 
 **Transcription engines:**
-- `TranscribingEngine` protocol abstracts ASR backends. Two implementations: `WhisperKitEngine` (99+ languages, ~1 GB model) and `ParakeetEngine` (25 EU languages, ~50 MB model, ~10× faster).
-- `AppSettings.transcriptionEngine` enum (`.whisperKit` / `.parakeet`) selects the engine. Settings UI shows engine picker; WhisperKit-specific options (model, language) hidden when Parakeet is selected.
-- Parakeet does NOT support explicit language selection — it auto-detects from audio. Only WhisperKit has a language parameter.
+- `TranscribingEngine` protocol abstracts ASR backends. Three implementations: `WhisperKitEngine` (99+ languages, ~1 GB model), `ParakeetEngine` (25 EU languages, ~50 MB model, ~10× faster), and `Qwen3AsrEngine` (30 languages, ~1.75 GB model, macOS 15+).
+- `AppSettings.transcriptionEngine` enum (`.whisperKit` / `.parakeet` / `.qwen3`) selects the engine. Settings UI shows engine picker; engine-specific options hidden when not selected. `availableCases` filters by macOS version.
+- Parakeet auto-detects language (no parameter). WhisperKit and Qwen3 support explicit language selection.
+- `Qwen3AsrEngine` requires macOS 15+ (`@available`). Returns plain text (no timestamps) — emits single `TimestampedSegment`. Chunks audio into <=30s windows (`Qwen3AsrConfig.maxAudioSeconds`). Type-erased in AppState via `_qwen3Engine: AnyObject?` for macOS <15 compatibility.
 - `AppState.activeTranscriptionEngine` returns the selected engine, used by `PipelineQueue`.
 
 **Concurrency:**
 - `WatchLoop` is `@MainActor`. Tests for this class must also be `@MainActor`.
-- `WhisperKitEngine.loadModel()` and `ParakeetEngine.loadModel()` both deduplicate concurrent calls via `loadingTask` — second caller awaits the first's task. Safe to call from multiple places.
+- All three engine `loadModel()` methods deduplicate concurrent calls via `loadingTask` — second caller awaits the first's task. Safe to call from multiple places.
 - `ProtocolGenerator` uses async process I/O: `terminationHandler` + `withCheckedContinuation` instead of `process.waitUntilExit()`. stdout/stderr are read in detached `Task`s.
 
 **View architecture:**
@@ -221,7 +223,7 @@ Two build variants controlled by compile-time flag `APPSTORE` (`-Xswiftc -DAPPST
 | **OpenAI API** | Yes | Yes (only option) |
 | **Entitlements** | Mic only | Sandbox + mic + network + file picker |
 | **Build** | `./scripts/build_release.sh` | `./scripts/build_release.sh --appstore` |
-| **Tests** | 597 | ~583 (14 CLI tests excluded) |
+| **Tests** | 618 | ~604 (14 CLI tests excluded) |
 
 - CLI-specific code lives in `ClaudeCLIProtocolGenerator.swift` (entire file `#if !APPSTORE`)
 - `ProtocolProvider` enum uses `CaseIterable` — `.claudeCLI` case excluded at compile time, picker adapts automatically

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -5,12 +5,29 @@ private let defaults = UserDefaults.standard
 enum TranscriptionEngineSetting: String, CaseIterable {
     case whisperKit
     case parakeet
+    case qwen3
 
     var label: String {
         switch self {
         case .whisperKit: "WhisperKit (Whisper)"
         case .parakeet: "Parakeet TDT v3 (NVIDIA)"
+        case .qwen3: "Qwen3-ASR (Alibaba)"
         }
+    }
+
+    /// Whether this engine is available on the current macOS version.
+    var isAvailable: Bool {
+        switch self {
+        case .whisperKit, .parakeet: true
+
+        case .qwen3:
+            if #available(macOS 15, *) { true } else { false }
+        }
+    }
+
+    /// Cases available on the current platform. Used in UI pickers instead of allCases.
+    static var availableCases: [Self] {
+        allCases.filter(\.isAvailable)
     }
 }
 
@@ -108,6 +125,16 @@ final class AppSettings {
     /// Language as Optional for WhisperKit. Empty string → nil (auto-detect).
     var whisperLanguageOrNil: String? {
         whisperLanguage.isEmpty ? nil : whisperLanguage
+    }
+
+    /// Qwen3-ASR language hint (ISO 639-1 code). Empty string = auto-detect.
+    var qwen3Language: String = defaults.object(forKey: "qwen3Language") as? String ?? "" {
+        didSet { defaults.set(qwen3Language, forKey: "qwen3Language") }
+    }
+
+    /// Language as Optional for Qwen3. Empty string → nil (auto-detect).
+    var qwen3LanguageOrNil: String? {
+        qwen3Language.isEmpty ? nil : qwen3Language
     }
 
     var diarize: Bool = defaults.object(forKey: "diarize") as? Bool ?? true {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -26,7 +26,16 @@ final class AppState {
     let settings: AppSettings
     let whisperKit: WhisperKitEngine
     let parakeetEngine: ParakeetEngine
+    // Only created on macOS 15+ where Qwen3-ASR is available.
+    private let _qwen3Engine: AnyObject?
     private let notifier: any AppNotifying
+
+    /// Typed accessor (only callable under @available(macOS 15, *) checks).
+    @available(macOS 15, *)
+    var qwen3Engine: Qwen3AsrEngine {
+        // swiftlint:disable:next force_cast
+        _qwen3Engine as! Qwen3AsrEngine
+    }
 
     // MARK: - State
 
@@ -40,12 +49,18 @@ final class AppState {
         settings: AppSettings = AppSettings(),
         whisperKit: WhisperKitEngine? = nil,
         parakeetEngine: ParakeetEngine? = nil,
+        qwen3Engine: AnyObject? = nil,
         notifier: any AppNotifying = SilentNotifier(),
         updateChecker: UpdateChecker? = nil,
     ) {
         self.settings = settings
         self.whisperKit = whisperKit ?? WhisperKitEngine()
         self.parakeetEngine = parakeetEngine ?? ParakeetEngine()
+        if #available(macOS 15, *) {
+            self._qwen3Engine = (qwen3Engine as? Qwen3AsrEngine) ?? Qwen3AsrEngine()
+        } else {
+            self._qwen3Engine = nil
+        }
         self.notifier = notifier
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
@@ -53,7 +68,20 @@ final class AppState {
 
     /// The active transcription engine based on the current settings.
     var activeTranscriptionEngine: any TranscribingEngine {
-        settings.transcriptionEngine == .parakeet ? parakeetEngine : whisperKit
+        switch settings.transcriptionEngine {
+        case .parakeet:
+            parakeetEngine
+
+        case .qwen3:
+            if #available(macOS 15, *) {
+                qwen3Engine
+            } else {
+                whisperKit // Fallback (should not happen -- UI prevents selection)
+            }
+
+        case .whisperKit:
+            whisperKit
+        }
     }
 
     // MARK: - Derived properties
@@ -125,9 +153,7 @@ final class AppState {
             Task { @MainActor in
                 _ = await Permissions.ensureMicrophoneAccess()
 
-                if settings.transcriptionEngine == .whisperKit {
-                    whisperKit.language = settings.whisperLanguageOrNil
-                }
+                syncLanguageSettings()
                 pipelineQueue = makePipelineQueue()
 
                 let detector: MeetingDetecting = PowerAssertionDetector()
@@ -227,11 +253,19 @@ final class AppState {
 
     // MARK: - Pipeline
 
-    func ensurePipelineQueue() {
-        guard pipelineQueue.engine == nil else { return }
+    /// Apply language settings to the active engine before creating a pipeline.
+    private func syncLanguageSettings() {
         if settings.transcriptionEngine == .whisperKit {
             whisperKit.language = settings.whisperLanguageOrNil
         }
+        if #available(macOS 15, *), settings.transcriptionEngine == .qwen3 {
+            qwen3Engine.language = settings.qwen3LanguageOrNil
+        }
+    }
+
+    func ensurePipelineQueue() {
+        guard pipelineQueue.engine == nil else { return }
+        syncLanguageSettings()
         pipelineQueue = makePipelineQueue()
         configurePipelineCallbacks()
     }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -84,6 +84,12 @@ struct MeetingTranscriberApp: App {
 
                 case .parakeet:
                     await appState.parakeetEngine.loadModel()
+
+                case .qwen3:
+                    if #available(macOS 15, *) {
+                        appState.qwen3Engine.language = appState.settings.qwen3LanguageOrNil
+                        await appState.qwen3Engine.loadModel()
+                    }
                 }
             }
             .task {
@@ -109,6 +115,12 @@ struct MeetingTranscriberApp: App {
                 settings: appState.settings,
                 whisperKitEngine: appState.whisperKit,
                 parakeetEngine: appState.parakeetEngine,
+                qwen3Engine: {
+                    if #available(macOS 15, *) {
+                        return appState.qwen3Engine
+                    }
+                    return nil
+                }(),
                 updateChecker: appState.updateChecker,
             )
         }

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -1,0 +1,128 @@
+import FluidAudio
+import Foundation
+import WhisperKit
+
+/// Transcription engine backed by Qwen3-ASR 0.6B via FluidAudio CoreML.
+///
+/// Supports 30 languages with explicit language selection.
+/// Requires macOS 15+ (CoreML stateful model API).
+/// Model download is ~1.75 GB (CoreML f32 variant).
+@available(macOS 15, *)
+@MainActor
+@Observable
+final class Qwen3AsrEngine: TranscribingEngine {
+    private(set) var modelState: ModelState = .unloaded
+    private(set) var downloadProgress: Double = 0
+    private(set) var transcriptionProgress: Double = 0
+
+    /// Language hint for transcription (ISO 639-1 code, e.g. "de", "en").
+    /// nil = auto-detect.
+    var language: String?
+
+    private var asrManager: Qwen3AsrManager?
+    private var loadingTask: Task<Void, Never>?
+
+    func loadModel() async {
+        if let existing = loadingTask {
+            await existing.value
+            return
+        }
+
+        let task = Task {
+            modelState = .downloading
+            downloadProgress = 0
+            do {
+                let modelDir = try await Qwen3AsrModels.download { [weak self] progress in
+                    Task { @MainActor in
+                        self?.downloadProgress = progress.fractionCompleted
+                    }
+                }
+                modelState = .loading
+                downloadProgress = 1.0
+                let manager = Qwen3AsrManager()
+                try await manager.loadModels(from: modelDir)
+                asrManager = manager
+                modelState = .loaded
+            } catch {
+                NSLog("Qwen3-ASR model load failed: \(error)")
+                modelState = .unloaded
+                downloadProgress = 0
+            }
+            loadingTask = nil
+        }
+        loadingTask = task
+        await task.value
+    }
+
+    private func ensureModel() async throws {
+        if asrManager != nil { return }
+        NSLog("Qwen3-ASR: model not loaded, loading...")
+        await loadModel()
+        guard asrManager != nil else {
+            NSLog("Qwen3-ASR: model load FAILED, state=\(modelState)")
+            throw TranscriptionError.modelNotLoaded
+        }
+        NSLog("Qwen3-ASR: model loaded successfully")
+    }
+
+    func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment] {
+        try await ensureModel()
+        guard let manager = asrManager else {
+            throw TranscriptionError.modelNotLoaded
+        }
+
+        transcriptionProgress = 0
+
+        // Load audio as 16kHz mono Float32 samples
+        let (samples, sampleRate) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
+        let resampled: [Float] = if sampleRate != 16000 {
+            AudioMixer.resample(samples, from: sampleRate, to: 16000)
+        } else {
+            samples
+        }
+
+        guard !resampled.isEmpty else {
+            transcriptionProgress = 1.0
+            return []
+        }
+
+        // Resolve language from ISO code string
+        let resolvedLanguage: Qwen3AsrConfig.Language? = if let lang = language {
+            Qwen3AsrConfig.Language(from: lang)
+        } else {
+            nil
+        }
+
+        // Chunk audio into <=30s segments (Qwen3AsrConfig.maxAudioSeconds)
+        let maxSamples = Int(Qwen3AsrConfig.maxAudioSeconds * 16000)
+        var allText: [String] = []
+        var offset = 0
+        let totalChunks = max(1, (resampled.count + maxSamples - 1) / maxSamples)
+        var chunkIndex = 0
+
+        while offset < resampled.count {
+            let end = min(offset + maxSamples, resampled.count)
+            let chunk = Array(resampled[offset ..< end])
+            let chunkText = try await manager.transcribe(
+                audioSamples: chunk,
+                language: resolvedLanguage,
+            )
+            let trimmed = chunkText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                allText.append(trimmed)
+            }
+            chunkIndex += 1
+            transcriptionProgress = Double(chunkIndex) / Double(totalChunks)
+            offset = end
+        }
+        transcriptionProgress = 1.0
+
+        let fullText = allText.joined(separator: " ")
+        guard !fullText.isEmpty else { return [] }
+
+        // Qwen3 returns plain text without timestamps.
+        // Emit a single segment spanning the full audio duration.
+        let duration = TimeInterval(resampled.count) / 16000.0
+        return [TimestampedSegment(start: 0, end: duration, text: fullText)]
+    }
+}

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
     @State private var hasCustomPrompt = FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path)
     var whisperKitEngine: WhisperKitEngine
     var parakeetEngine: ParakeetEngine
+    var qwen3Engine: (any TranscribingEngine)? // nil on macOS < 15
     var updateChecker: UpdateChecker?
 
     enum ConnectionTestResult {
@@ -49,6 +50,39 @@ struct SettingsView: View {
         ("pt", "Portugu\u{00EA}s"),
         ("ja", "日本語"),
         ("zh", "中文"),
+    ]
+
+    private let qwen3Languages: [(code: String, label: String)] = [
+        ("de", "Deutsch"),
+        ("en", "English"),
+        ("fr", "Fran\u{00E7}ais"),
+        ("es", "Espa\u{00F1}ol"),
+        ("it", "Italiano"),
+        ("nl", "Nederlands"),
+        ("pt", "Portugu\u{00EA}s"),
+        ("ja", "\u{65E5}\u{672C}\u{8A9E}"),
+        ("zh", "\u{4E2D}\u{6587}"),
+        ("ko", "\u{D55C}\u{AD6D}\u{C5B4}"),
+        ("ru", "\u{0420}\u{0443}\u{0441}\u{0441}\u{043A}\u{0438}\u{0439}"),
+        ("ar", "\u{0627}\u{0644}\u{0639}\u{0631}\u{0628}\u{064A}\u{0629}"),
+        ("tr", "T\u{00FC}rk\u{00E7}e"),
+        ("hi", "\u{0939}\u{093F}\u{0928}\u{094D}\u{0926}\u{0940}"),
+        ("th", "\u{0E44}\u{0E17}\u{0E22}"),
+        ("vi", "Ti\u{1EBF}ng Vi\u{1EC7}t"),
+        ("id", "Bahasa Indonesia"),
+        ("ms", "Bahasa Melayu"),
+        ("sv", "Svenska"),
+        ("da", "Dansk"),
+        ("fi", "Suomi"),
+        ("pl", "Polski"),
+        ("cs", "\u{010C}e\u{0161}tina"),
+        ("el", "\u{0395}\u{03BB}\u{03BB}\u{03B7}\u{03BD}\u{03B9}\u{03BA}\u{03AC}"),
+        ("hu", "Magyar"),
+        ("ro", "Rom\u{00E2}n\u{0103}"),
+        ("fa", "\u{0641}\u{0627}\u{0631}\u{0633}\u{06CC}"),
+        ("fil", "Filipino"),
+        ("mk", "\u{041C}\u{0430}\u{043A}\u{0435}\u{0434}\u{043E}\u{043D}\u{0441}\u{043A}\u{0438}"),
+        ("yue", "\u{7CB5}\u{8A9E}"),
     ]
 
     var body: some View {
@@ -110,9 +144,10 @@ struct SettingsView: View {
                 }
             }
 
+            // swiftlint:disable:next closure_body_length
             Section("Transcription") {
                 Picker("Engine", selection: $settings.transcriptionEngine) {
-                    ForEach(TranscriptionEngineSetting.allCases, id: \.self) { engine in
+                    ForEach(TranscriptionEngineSetting.availableCases, id: \.self) { engine in
                         Text(engine.label).tag(engine)
                     }
                 }
@@ -126,6 +161,15 @@ struct SettingsView: View {
 
                     Picker("Language", selection: $settings.whisperLanguage) {
                         ForEach(whisperLanguages, id: \.code) { lang in
+                            Text(lang.label).tag(lang.code)
+                        }
+                    }
+                }
+
+                if settings.transcriptionEngine == .qwen3 {
+                    Picker("Language", selection: $settings.qwen3Language) {
+                        Text("Auto-detect").tag("")
+                        ForEach(qwen3Languages, id: \.code) { lang in
                             Text(lang.label).tag(lang.code)
                         }
                     }
@@ -427,7 +471,11 @@ struct SettingsView: View {
 
     /// Active engine for status display.
     private var activeEngine: any TranscribingEngine {
-        settings.transcriptionEngine == .parakeet ? parakeetEngine : whisperKitEngine
+        switch settings.transcriptionEngine {
+        case .parakeet: parakeetEngine
+        case .qwen3: qwen3Engine ?? whisperKitEngine // Fallback for macOS < 15
+        case .whisperKit: whisperKitEngine
+        }
     }
 
     @ViewBuilder
@@ -458,6 +506,10 @@ struct SettingsView: View {
             Button("Load Model") {
                 if settings.transcriptionEngine == .whisperKit {
                     whisperKitEngine.modelVariant = settings.whisperKitModel
+                }
+                if #available(macOS 15, *), settings.transcriptionEngine == .qwen3,
+                   let qe = qwen3Engine as? Qwen3AsrEngine {
+                    qe.language = settings.qwen3LanguageOrNil
                 }
                 Task { await engine.loadModel() }
             }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 @MainActor
-final class AppStateTests: XCTestCase {
+final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_length
     // MARK: - Helpers
 
     /// Yields repeatedly until `condition()` is true or the timeout elapses.
@@ -517,6 +517,47 @@ final class AppStateTests: XCTestCase {
     func testEnsurePipelineQueueWithParakeet() {
         let settings = AppSettings()
         settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+
+        state.ensurePipelineQueue()
+
+        XCTAssertNotNil(state.pipelineQueue.engine)
+    }
+
+    func testActiveTranscriptionEngineReturnsQwen3WhenSet() {
+        guard #available(macOS 15, *) else { return }
+        let settings = AppSettings()
+        settings.transcriptionEngine = .qwen3
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.activeTranscriptionEngine is Qwen3AsrEngine)
+    }
+
+    func testActiveTranscriptionEngineSwitchesToQwen3AndBack() {
+        guard #available(macOS 15, *) else { return }
+        let settings = AppSettings()
+        settings.transcriptionEngine = .whisperKit
+        let state = AppState(settings: settings)
+        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+
+        settings.transcriptionEngine = .qwen3
+        XCTAssertTrue(state.activeTranscriptionEngine is Qwen3AsrEngine)
+
+        settings.transcriptionEngine = .parakeet
+        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+    }
+
+    func testMakePipelineQueueUsesQwen3Engine() {
+        guard #available(macOS 15, *) else { return }
+        let settings = AppSettings()
+        settings.transcriptionEngine = .qwen3
+        let state = AppState(settings: settings)
+        XCTAssertNotNil(state.makePipelineQueue().engine, "Qwen3 engine should be set")
+    }
+
+    func testEnsurePipelineQueueWithQwen3() {
+        guard #available(macOS 15, *) else { return }
+        let settings = AppSettings()
+        settings.transcriptionEngine = .qwen3
         let state = AppState(settings: settings)
 
         state.ensurePipelineQueue()

--- a/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
@@ -1,0 +1,132 @@
+@testable import MeetingTranscriber
+import WhisperKit
+import XCTest
+
+@MainActor
+final class Qwen3AsrEngineTests: XCTestCase {
+    // MARK: - Initial State
+
+    func testModelStateStartsUnloaded() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        XCTAssertEqual(engine.modelState, .unloaded)
+    }
+
+    func testDownloadProgressStartsAtZero() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        XCTAssertEqual(engine.downloadProgress, 0, accuracy: 0.001)
+    }
+
+    func testTranscriptionProgressStartsAtZero() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        XCTAssertEqual(engine.transcriptionProgress, 0, accuracy: 0.001)
+    }
+
+    // MARK: - Protocol Conformance
+
+    func testConformsToTranscribingEngine() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        // Assign to protocol type to verify conformance at compile time
+        let proto: TranscribingEngine = engine
+        XCTAssertNotNil(proto)
+    }
+
+    func testIsReferenceType() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        let ref: TranscribingEngine = engine
+        // Mutating the reference should be visible via the original variable
+        XCTAssertIdentical(engine, ref, "Qwen3AsrEngine should be a reference type (class)")
+    }
+
+    // MARK: - Language Setting
+
+    func testLanguageDefaultsToNil() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        XCTAssertNil(engine.language)
+    }
+
+    func testLanguageCanBeSetFromISOCode() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        engine.language = "de"
+        XCTAssertEqual(engine.language, "de")
+    }
+
+    // MARK: - Transcription Errors
+
+    func testTranscribeSegmentsThrowsForNonexistentFile() async {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        let dummyURL = URL(fileURLWithPath: "/tmp/nonexistent_\(UUID()).wav")
+
+        do {
+            _ = try await engine.transcribeSegments(audioPath: dummyURL)
+            XCTFail("Expected transcribeSegments to throw for nonexistent file")
+        } catch {
+            // Either model load fails (TranscriptionError) or file open fails (AVFoundation)
+            // Both are acceptable — the key guarantee is it does NOT succeed silently
+            XCTAssertFalse(
+                "\(error)".isEmpty,
+                "Error should have a meaningful description",
+            )
+        }
+    }
+
+    // MARK: - MergeDualSourceSegments (protocol extension)
+
+    func testMergeDualSourceSegmentsLabelsAndSorts() {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+
+        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from app")]
+        let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from mic")]
+
+        let result = engine.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].speaker, "Remote")
+        XCTAssertEqual(result[0].text, "Hello from app")
+        XCTAssertEqual(result[1].speaker, "Me")
+        XCTAssertEqual(result[1].text, "Hello from mic")
+    }
+
+    // MARK: - Load Model State Transitions
+
+    func testLoadModelTransitionsToLoaded() async {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        XCTAssertEqual(engine.modelState, .unloaded, "Pre-condition: model starts unloaded")
+
+        await engine.loadModel()
+
+        // Model loads successfully from cached CoreML files, or fails and resets to .unloaded.
+        // Either way it must not be stuck in .downloading or .loading.
+        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        XCTAssertTrue(
+            terminalStates.contains(engine.modelState),
+            "Model state should be terminal (.loaded or .unloaded), got: \(engine.modelState)",
+        )
+    }
+
+    func testLoadModelDeduplicatesConcurrentCalls() async {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+
+        // Start two concurrent loads — second should await the first, not start a new download
+        async let load1: Void = engine.loadModel()
+        async let load2: Void = engine.loadModel()
+        _ = await (load1, load2)
+
+        // Both complete without crash; state is terminal
+        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        XCTAssertTrue(
+            terminalStates.contains(engine.modelState),
+            "Model state should be terminal after concurrent loads, got: \(engine.modelState)",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
@@ -1,0 +1,187 @@
+import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class Qwen3E2ETests: XCTestCase {
+    // MARK: - Model loading
+
+    func testQwen3ModelLoadsSuccessfully() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15+")
+        }
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+
+        let engine = Qwen3AsrEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+    }
+
+    // MARK: - Transcription with fixture
+
+    func testTranscribeSegmentsWithFixture() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15+")
+        }
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = Qwen3AsrEngine()
+        engine.language = "de"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        let segments = try await engine.transcribeSegments(audioPath: resampled16k)
+
+        // Qwen3 returns a single segment (no per-token timestamps)
+        XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
+
+        // Verify timestamps are non-negative and ordered
+        for segment in segments {
+            XCTAssertGreaterThanOrEqual(segment.start, 0, "Start should be non-negative")
+            XCTAssertGreaterThanOrEqual(segment.end, segment.start, "End should be >= start")
+        }
+
+        // Verify text is non-empty per segment
+        for segment in segments {
+            XCTAssertFalse(segment.text.isEmpty, "Segment text should not be empty")
+        }
+    }
+
+    func testTranscribeSegmentsProducesGermanContent() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15+")
+        }
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = Qwen3AsrEngine()
+        engine.language = "de"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        let segments = try await engine.transcribeSegments(audioPath: resampled16k)
+        XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
+
+        let fullText = segments.map(\.text).joined(separator: " ")
+        assertTranscriptContent(fullText)
+    }
+
+    // MARK: - Progress tracking
+
+    func testDownloadProgressReachesOne() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15+")
+        }
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+
+        let engine = Qwen3AsrEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+        XCTAssertEqual(engine.downloadProgress, 1.0, "Download progress should be 1.0 after model load")
+    }
+
+    func testTranscriptionProgressReachesOne() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15+")
+        }
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let engine = Qwen3AsrEngine()
+        engine.language = "de"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        let resampled16k = try resampleFixtureToTemp(fixture)
+        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
+
+        _ = try await engine.transcribeSegments(audioPath: resampled16k)
+        XCTAssertEqual(
+            engine.transcriptionProgress, 1.0,
+            "Transcription progress should be 1.0 after transcribeSegments completes",
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Keywords expected in the fixture's German transcript.
+    private let expectedKeywords = [
+        "willkommen", "Projekt", "Status", "Entwicklung", "Zeitplan",
+    ]
+
+    private func assertTranscriptContent(_ transcript: String) {
+        let lower = transcript.lowercased()
+        var matched = 0
+        for keyword in expectedKeywords where lower.contains(keyword.lowercased()) {
+            matched += 1
+        }
+        // At least 3 of 5 keywords should appear
+        XCTAssertGreaterThanOrEqual(
+            matched, 3,
+            "Expected at least 3 of \(expectedKeywords) in transcript, found \(matched). Transcript:\n\(transcript)",
+        )
+    }
+
+    private func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests/
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent(name)
+    }
+
+    /// Resample the 48kHz fixture to a 16kHz temp WAV file for Qwen3.
+    private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen3_e2e_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")
+
+        let samples = try AudioMixer.loadAudioFileAsFloat32(url: fixture)
+        XCTAssertFalse(samples.isEmpty, "Should load samples from fixture")
+
+        let file = try AVAudioFile(forReading: fixture)
+        let sourceSampleRate = Int(file.processingFormat.sampleRate)
+        let targetRate = 16000
+
+        let resampled: [Float]
+        if sourceSampleRate != targetRate {
+            resampled = AudioMixer.resample(samples, from: sourceSampleRate, to: targetRate)
+            XCTAssertFalse(resampled.isEmpty, "Resampled audio should not be empty")
+        } else {
+            resampled = samples
+        }
+
+        try AudioMixer.saveWAV(samples: resampled, sampleRate: targetRate, url: resampled16k)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resampled16k.path))
+
+        return resampled16k
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -4,17 +4,31 @@ import XCTest
 
 @MainActor
 final class SettingsViewTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func makeSUT(settings: AppSettings = AppSettings(), updateChecker: UpdateChecker? = nil) -> SettingsView {
+        let qwen3: (any TranscribingEngine)? = {
+            if #available(macOS 15, *) { return Qwen3AsrEngine() }
+            return nil
+        }()
+        return SettingsView(
+            settings: settings,
+            whisperKitEngine: WhisperKitEngine(),
+            parakeetEngine: ParakeetEngine(),
+            qwen3Engine: qwen3,
+            updateChecker: updateChecker,
+        )
+    }
+
     // MARK: - View rendering
 
     func testViewRendersWithDefaults() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         XCTAssertNoThrow(try sut.inspect())
     }
 
     func testDiarizeToggleExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Speaker Diarization"))
     }
@@ -24,7 +38,7 @@ final class SettingsViewTests: XCTestCase {
     func testDiarizeEnabledShowsExpectedSpeakers() throws {
         let settings = AppSettings()
         settings.diarize = true
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT(settings: settings)
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Expected Speakers"))
     }
@@ -32,8 +46,7 @@ final class SettingsViewTests: XCTestCase {
     // MARK: - Recording section
 
     func testNoMicToggleExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "No Microphone (app audio only)"))
     }
@@ -41,7 +54,7 @@ final class SettingsViewTests: XCTestCase {
     func testMicSectionShownWhenMicEnabled() throws {
         let settings = AppSettings()
         settings.noMic = false
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT(settings: settings)
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Mic Speaker Name"))
     }
@@ -49,7 +62,7 @@ final class SettingsViewTests: XCTestCase {
     func testMicSectionHiddenWhenNoMic() throws {
         let settings = AppSettings()
         settings.noMic = true
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT(settings: settings)
         let body = try sut.inspect()
         XCTAssertThrowsError(try body.find(text: "Mic Speaker Name"))
     }
@@ -57,8 +70,7 @@ final class SettingsViewTests: XCTestCase {
     // MARK: - Apps section
 
     func testAppsToWatchSection() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Microsoft Teams"))
         XCTAssertNoThrow(try body.find(text: "Zoom"))
@@ -68,22 +80,19 @@ final class SettingsViewTests: XCTestCase {
     // MARK: - Recording fields
 
     func testPollIntervalFieldExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Poll Interval"))
     }
 
     func testGracePeriodFieldExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Grace Period"))
     }
 
     func testWhisperKitModelPickerExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Model"))
     }
@@ -91,8 +100,7 @@ final class SettingsViewTests: XCTestCase {
     // MARK: - Protocol Provider
 
     func testProviderPickerExists() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Provider"))
     }
@@ -101,7 +109,7 @@ final class SettingsViewTests: XCTestCase {
         func testClaudeCLIProviderShowsBinaryPicker() throws {
             let settings = AppSettings()
             settings.protocolProvider = .claudeCLI
-            let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+            let sut = makeSUT(settings: settings)
             let body = try sut.inspect()
             XCTAssertNoThrow(try body.find(text: "Claude CLI"))
         }
@@ -110,7 +118,7 @@ final class SettingsViewTests: XCTestCase {
     func testOpenAIProviderShowsEndpointField() throws {
         let settings = AppSettings()
         settings.protocolProvider = .openAICompatible
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT(settings: settings)
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Endpoint"))
         XCTAssertNoThrow(try body.find(text: "API Key"))
@@ -120,22 +128,15 @@ final class SettingsViewTests: XCTestCase {
     // MARK: - Updates section
 
     func testUpdatesSectionShownWhenCheckerProvided() throws {
-        let settings = AppSettings()
         let checker = UpdateChecker(provider: MockUpdateProvider())
-        let sut = SettingsView(
-            settings: settings,
-            whisperKitEngine: WhisperKitEngine(),
-            parakeetEngine: ParakeetEngine(),
-            updateChecker: checker,
-        )
+        let sut = makeSUT(updateChecker: checker)
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Check for Updates"))
         XCTAssertNoThrow(try body.find(text: "Check Now"))
     }
 
     func testUpdatesSectionHiddenWhenNoChecker() throws {
-        let settings = AppSettings()
-        let sut = SettingsView(settings: settings, whisperKitEngine: WhisperKitEngine(), parakeetEngine: ParakeetEngine())
+        let sut = makeSUT()
         let body = try sut.inspect()
         XCTAssertThrowsError(try body.find(text: "Check Now"))
     }
@@ -144,13 +145,20 @@ final class SettingsViewTests: XCTestCase {
         let settings = AppSettings()
         settings.checkForUpdates = true
         let checker = UpdateChecker(provider: MockUpdateProvider())
-        let sut = SettingsView(
-            settings: settings,
-            whisperKitEngine: WhisperKitEngine(),
-            parakeetEngine: ParakeetEngine(),
-            updateChecker: checker,
-        )
+        let sut = makeSUT(settings: settings, updateChecker: checker)
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(text: "Include Pre-Releases"))
+    }
+
+    // MARK: - Qwen3 engine
+
+    func testQwen3LanguagePickerShownWhenQwen3Selected() throws {
+        guard #available(macOS 15, *) else { return }
+        let settings = AppSettings()
+        settings.transcriptionEngine = .qwen3
+        let sut = makeSUT(settings: settings)
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Language"))
+        XCTAssertNoThrow(try body.find(text: "Auto-detect"))
     }
 }


### PR DESCRIPTION
## Summary

- Add **Qwen3-ASR** (Alibaba) as third transcription engine via FluidAudio's `Qwen3AsrManager`
- 30 languages with explicit selection, ~1.75 GB CoreML model, requires macOS 15+
- Returns plain text (no per-token timestamps) — single `TimestampedSegment` per file
- Audio chunking into <=30s windows for Qwen3's max audio limit
- Engine picker filters by macOS version (`availableCases`)
- Language picker shown when Qwen3 is selected (30 languages + auto-detect)
- Type-erased `_qwen3Engine: AnyObject?` in AppState for macOS <15 compatibility

## Test plan

- [x] 618 tests passing, 0 failures
- [x] SwiftFormat + SwiftLint lint + SwiftLint analyze --strict: 0 violations
- [x] 11 unit tests (Qwen3AsrEngineTests)
- [x] 5 E2E tests (Qwen3E2ETests, skipped on CI/macOS <15)
- [x] 4 AppState engine switching tests
- [x] 1 SettingsView language picker test
- [x] Manual: select Qwen3 in Settings, verify model download and transcription
- [x] Manual: verify language selection works (German, English, auto-detect)