### PR TITLE
test(app): add workflow integration tests for pipeline

### DIFF
--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -466,33 +466,6 @@ final class PipelineQueueTests: XCTestCase {
         return (q, engine)
     }
 
-    private func createTestAudioFile() throws -> URL {
-        // Create a minimal valid WAV file (44-byte header + some samples)
-        let audioPath = tmpDir.appendingPathComponent("test_audio.wav")
-        var header = Data(count: 44)
-        // RIFF header
-        header[0] = 0x52; header[1] = 0x49; header[2] = 0x46; header[3] = 0x46 // "RIFF"
-        let fileSize = UInt32(44 + 32000 - 8)
-        header.replaceSubrange(4 ..< 8, with: withUnsafeBytes(of: fileSize.littleEndian) { Data($0) })
-        header[8] = 0x57; header[9] = 0x41; header[10] = 0x56; header[11] = 0x45 // "WAVE"
-        // fmt chunk
-        header[12] = 0x66; header[13] = 0x6D; header[14] = 0x74; header[15] = 0x20 // "fmt "
-        header.replaceSubrange(16 ..< 20, with: withUnsafeBytes(of: UInt32(16).littleEndian) { Data($0) })
-        header.replaceSubrange(20 ..< 22, with: withUnsafeBytes(of: UInt16(3).littleEndian) { Data($0) }) // IEEE float
-        header.replaceSubrange(22 ..< 24, with: withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) }) // mono
-        header.replaceSubrange(24 ..< 28, with: withUnsafeBytes(of: UInt32(16000).littleEndian) { Data($0) }) // sample rate
-        header.replaceSubrange(28 ..< 32, with: withUnsafeBytes(of: UInt32(64000).littleEndian) { Data($0) }) // byte rate
-        header.replaceSubrange(32 ..< 34, with: withUnsafeBytes(of: UInt16(4).littleEndian) { Data($0) }) // block align
-        header.replaceSubrange(34 ..< 36, with: withUnsafeBytes(of: UInt16(32).littleEndian) { Data($0) }) // bits per sample
-        // data chunk
-        header[36] = 0x64; header[37] = 0x61; header[38] = 0x74; header[39] = 0x61 // "data"
-        header.replaceSubrange(40 ..< 44, with: withUnsafeBytes(of: UInt32(32000).littleEndian) { Data($0) })
-        var data = header
-        data.append(Data(repeating: 0, count: 32000)) // 0.5s of silence at 16kHz float32
-        try data.write(to: audioPath)
-        return audioPath
-    }
-
     func testProcessNextWithMockEngineTranscribes() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -500,7 +473,7 @@ final class PipelineQueueTests: XCTestCase {
         ]
         let (pQueue, _) = makeMockProcessingQueue(engine: engine)
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Mock Test",
             appName: "Teams",
@@ -518,7 +491,7 @@ final class PipelineQueueTests: XCTestCase {
         engine.segmentsToReturn = [] // empty = no speech
         let (pQueue, _) = makeMockProcessingQueue(engine: engine)
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Silent Meeting",
             appName: "Teams",
@@ -539,7 +512,7 @@ final class PipelineQueueTests: XCTestCase {
         ]
         let (pQueue, _) = makeMockProcessingQueue(engine: engine)
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let appPath = tmpDir.appendingPathComponent("app_audio.wav")
         let micPath = tmpDir.appendingPathComponent("mic_audio.wav")
         try FileManager.default.copyItem(at: audioPath, to: appPath)
@@ -584,7 +557,7 @@ final class PipelineQueueTests: XCTestCase {
             return .skipped
         }
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Naming Test",
             appName: "Teams",
@@ -617,7 +590,7 @@ final class PipelineQueueTests: XCTestCase {
 
         pQueue.speakerNamingHandler = { _ in .skipped }
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Skip Test",
             appName: "Teams",
@@ -659,7 +632,7 @@ final class PipelineQueueTests: XCTestCase {
             return .skipped
         }
 
-        let audioPath = try createTestAudioFile()
+        let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Rerun Test",
             appName: "Teams",

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -72,12 +72,16 @@ class MockRecorder: RecordingProvider {
 /// Mock diarization that returns pre-set segments.
 class MockDiarization: DiarizationProvider {
     var isAvailable: Bool = true
-    var runCalled = false
+    var runCount = 0
+    var shouldThrow = false
     var resultToReturn: DiarizationResult?
 
-    // swiftlint:disable:next async_without_await
-    func run(audioPath _: URL, numSpeakers _: Int?, meetingTitle _: String) async -> DiarizationResult {
-        runCalled = true
+    func run(audioPath _: URL, numSpeakers _: Int?, meetingTitle _: String) -> DiarizationResult {
+        runCount += 1
+        if shouldThrow {
+            // Return empty result to simulate failure path
+            return DiarizationResult(segments: [], speakingTimes: [:], autoNames: [:], embeddings: nil)
+        }
         if let result = resultToReturn {
             return result
         }
@@ -100,13 +104,20 @@ class MockProtocolGen: ProtocolGenerating {
     var capturedTitle: String?
     // swiftlint:disable:next discouraged_optional_boolean
     var capturedDiarized: Bool?
+    var shouldThrow = false
 
-    // swiftlint:disable:next async_without_await
-    func generate(transcript: String, title: String, diarized: Bool) async -> String {
+    func generate(transcript: String, title: String, diarized: Bool) throws -> String {
         generateCalled = true
         capturedTranscript = transcript
         capturedTitle = title
         capturedDiarized = diarized
+        if shouldThrow {
+            throw NSError(
+                domain: "MockProtocolGen",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Mock protocol error"],
+            )
+        }
         return """
         # Meeting Protocol - \(title)
         **Date:** 2026-03-06
@@ -140,4 +151,31 @@ class MockEngine: TranscribingEngine {
         }
         return segmentsToReturn
     }
+}
+
+// MARK: - Test Audio Fixture
+
+/// Create a minimal valid 16kHz Float32 mono WAV (0.5s silence).
+/// Uses UUID in filename to avoid collisions across concurrent tests.
+func createTestAudioFile(in dir: URL) throws -> URL {
+    let audioPath = dir.appendingPathComponent("test_audio_\(UUID().uuidString).wav")
+    var header = Data(count: 44)
+    header[0] = 0x52; header[1] = 0x49; header[2] = 0x46; header[3] = 0x46 // RIFF
+    let fileSize = UInt32(44 + 32000 - 8)
+    header.replaceSubrange(4 ..< 8, with: withUnsafeBytes(of: fileSize.littleEndian) { Data($0) })
+    header[8] = 0x57; header[9] = 0x41; header[10] = 0x56; header[11] = 0x45 // WAVE
+    header[12] = 0x66; header[13] = 0x6D; header[14] = 0x74; header[15] = 0x20 // fmt
+    header.replaceSubrange(16 ..< 20, with: withUnsafeBytes(of: UInt32(16).littleEndian) { Data($0) })
+    header.replaceSubrange(20 ..< 22, with: withUnsafeBytes(of: UInt16(3).littleEndian) { Data($0) }) // Float
+    header.replaceSubrange(22 ..< 24, with: withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) }) // mono
+    header.replaceSubrange(24 ..< 28, with: withUnsafeBytes(of: UInt32(16000).littleEndian) { Data($0) }) // 16kHz
+    header.replaceSubrange(28 ..< 32, with: withUnsafeBytes(of: UInt32(64000).littleEndian) { Data($0) }) // byte rate
+    header.replaceSubrange(32 ..< 34, with: withUnsafeBytes(of: UInt16(4).littleEndian) { Data($0) }) // block align
+    header.replaceSubrange(34 ..< 36, with: withUnsafeBytes(of: UInt16(32).littleEndian) { Data($0) }) // bits
+    header[36] = 0x64; header[37] = 0x61; header[38] = 0x74; header[39] = 0x61 // data
+    header.replaceSubrange(40 ..< 44, with: withUnsafeBytes(of: UInt32(32000).littleEndian) { Data($0) })
+    var data = header
+    data.append(Data(repeating: 0, count: 32000))
+    try data.write(to: audioPath)
+    return audioPath
 }

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -299,7 +299,7 @@ final class WatchLoopE2ETests: XCTestCase {
         // Protocol should still be generated (diarization skipped gracefully)
         XCTAssertTrue(mockProtocol.generateCalled, "Protocol should be generated even when diarization is unavailable")
         XCTAssertEqual(queue.jobs[0].state, .done, "Job should complete despite unavailable diarization")
-        XCTAssertFalse(mockDiarize.runCalled, "Diarization should NOT have been run")
+        XCTAssertEqual(mockDiarize.runCount, 0, "Diarization should NOT have been run")
 
         // Verify the transcript was passed as non-diarized
         XCTAssertFalse(mockProtocol.capturedDiarized ?? true, "Should be marked as non-diarized")

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -1,0 +1,141 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class WorkflowIntegrationTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("workflow_test_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    // swiftlint:disable:next unneeded_throws_rethrows
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - Harness
+
+    private struct Harness {
+        let queue: PipelineQueue
+        let engine: MockEngine
+        let diarization: MockDiarization
+        let protocolGen: MockProtocolGen
+        let audioPath: URL
+    }
+
+    /// Reference-type collector for state transitions captured via onJobStateChange.
+    private final class TransitionCollector {
+        var transitions: [(JobState, JobState)] = []
+    }
+
+    private func makeHarness(
+        diarizeEnabled: Bool = false,
+    ) throws -> (Harness, TransitionCollector) {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello world"),
+            TimestampedSegment(start: 5, end: 10, text: "This is a test"),
+        ]
+
+        let diarization = MockDiarization()
+        diarization.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_00"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_01"),
+            ],
+            speakingTimes: ["SPEAKER_00": 5.0, "SPEAKER_01": 5.0],
+            autoNames: [:],
+            embeddings: ["SPEAKER_00": [1, 0, 0], "SPEAKER_01": [0, 1, 0]],
+        )
+
+        let protocolGen = MockProtocolGen()
+        let collector = TransitionCollector()
+
+        let queue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { diarization },
+            protocolGeneratorFactory: { protocolGen },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            diarizeEnabled: diarizeEnabled,
+            micLabel: "Me",
+        )
+
+        queue.onJobStateChange = { [collector] _, old, new in
+            collector.transitions.append((old, new))
+        }
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+
+        let harness = Harness(
+            queue: queue, engine: engine, diarization: diarization,
+            protocolGen: protocolGen, audioPath: audioPath,
+        )
+        return (harness, collector)
+    }
+
+    // swiftlint:disable:next function_default_parameter_at_end
+    private func makeJob(title: String = "Test Meeting", audioPath: URL) -> PipelineJob {
+        PipelineJob(
+            meetingTitle: title,
+            appName: "Microsoft Teams",
+            mixPath: audioPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+    }
+
+    // swiftlint:disable:next function_default_parameter_at_end
+    private func makeDualSourceJob(title: String = "Dual Meeting", audioPath: URL) throws -> PipelineJob {
+        let appPath = tmpDir.appendingPathComponent("app_\(UUID().uuidString).wav")
+        let micPath = tmpDir.appendingPathComponent("mic_\(UUID().uuidString).wav")
+        try FileManager.default.copyItem(at: audioPath, to: appPath)
+        try FileManager.default.copyItem(at: audioPath, to: micPath)
+        return PipelineJob(
+            meetingTitle: title,
+            appName: "Microsoft Teams",
+            mixPath: audioPath,
+            appPath: appPath,
+            micPath: micPath,
+            micDelay: 0,
+        )
+    }
+
+    // MARK: - Happy Path: Single-Source, No Diarization
+
+    func testWorkflowSingleSourceNoDiarization() async throws {
+        let (h, collector) = try makeHarness(diarizeEnabled: false)
+        let job = makeJob(audioPath: h.audioPath)
+
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // State transitions: waiting → transcribing → generatingProtocol → done
+        XCTAssertEqual(
+            collector.transitions.map(\.1),
+            [.transcribing, .generatingProtocol, .done],
+        )
+
+        // Engine was called once, diarization not at all
+        XCTAssertEqual(h.engine.transcribeCallCount, 1)
+        XCTAssertEqual(h.diarization.runCount, 0)
+
+        // Protocol generator received transcript
+        XCTAssertTrue(h.protocolGen.generateCalled)
+        XCTAssertEqual(h.protocolGen.capturedTitle, "Test Meeting")
+        XCTAssertTrue(h.protocolGen.capturedTranscript?.contains("Hello world") ?? false)
+
+        // Job is done with protocol file on disk
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertNotNil(h.queue.jobs.first?.protocolPath)
+
+        if let path = h.queue.jobs.first?.protocolPath {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -231,4 +231,39 @@ final class WorkflowIntegrationTests: XCTestCase {
 
         XCTAssertEqual(h.queue.jobs.first?.state, .error)
     }
+
+    // MARK: - Diarization Scenarios
+
+    func testWorkflowDiarizationUnavailableSkips() async throws {
+        let (h, collector) = try makeHarness(diarizeEnabled: true)
+        h.diarization.isAvailable = false
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Should skip diarization — no .diarizing state, but protocol still generated
+        let states = collector.transitions.map(\.1)
+        XCTAssertFalse(states.contains(.diarizing))
+        XCTAssertTrue(h.protocolGen.generateCalled)
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
+
+    func testWorkflowDiarizationNoEmbeddingsFallsBack() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true)
+        h.diarization.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_00")],
+            speakingTimes: ["SPEAKER_00": 5],
+            autoNames: [:],
+            embeddings: nil, // no embeddings → naming loop breaks early
+        )
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Should complete despite no embeddings
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertTrue(h.protocolGen.generateCalled)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -138,4 +138,32 @@ final class WorkflowIntegrationTests: XCTestCase {
             XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
         }
     }
+
+    // MARK: - Happy Path: Single-Source, Diarization + Speaker Naming
+
+    func testWorkflowWithDiarizationAndNaming() async throws {
+        let (h, collector) = try makeHarness(diarizeEnabled: true)
+
+        h.queue.speakerNamingHandler = { data in
+            // Verify naming data is populated
+            XCTAssertFalse(data.mapping.isEmpty)
+            XCTAssertFalse(data.speakingTimes.isEmpty)
+            return .confirmed(["SPEAKER_00": "Alice", "SPEAKER_01": "Bob"])
+        }
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // State transitions: waiting → transcribing → diarizing → generatingProtocol → done
+        XCTAssertEqual(
+            collector.transitions.map(\.1),
+            [.transcribing, .diarizing, .generatingProtocol, .done],
+        )
+
+        // Diarization called once, protocol generated
+        XCTAssertEqual(h.diarization.runCount, 1)
+        XCTAssertTrue(h.protocolGen.generateCalled)
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -188,4 +188,47 @@ final class WorkflowIntegrationTests: XCTestCase {
 
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
     }
+
+    // MARK: - Error Scenarios
+
+    func testWorkflowEmptyTranscriptEndsInError() async throws {
+        let (h, collector) = try makeHarness()
+        h.engine.segmentsToReturn = [] // no speech
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // State: waiting → transcribing → error
+        XCTAssertEqual(collector.transitions.map(\.1), [.transcribing, .error])
+        XCTAssertEqual(h.queue.jobs.first?.state, .error)
+        XCTAssertEqual(h.queue.jobs.first?.error, "Empty transcript")
+
+        // Protocol was NOT generated
+        XCTAssertFalse(h.protocolGen.generateCalled)
+    }
+
+    func testWorkflowEngineThrowsEndsInError() async throws {
+        let (h, _) = try makeHarness()
+        h.engine.shouldThrow = true
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Job ends in error
+        XCTAssertEqual(h.queue.jobs.first?.state, .error)
+        XCTAssertFalse(h.protocolGen.generateCalled)
+    }
+
+    func testWorkflowProtocolGenerationFailsEndsInError() async throws {
+        let (h, _) = try makeHarness()
+        h.protocolGen.shouldThrow = true
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .error)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -300,4 +300,48 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(h.diarization.runCount, 2)
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
     }
+
+    // MARK: - Multi-Job
+
+    func testMultipleJobsProcessedSequentially() async throws {
+        let (h, _) = try makeHarness()
+
+        // Enqueue and process first job
+        let job1 = makeJob(title: "Meeting 1", audioPath: h.audioPath)
+        h.queue.enqueue(job1)
+        await h.queue.processNext()
+        XCTAssertEqual(h.queue.jobs.first { $0.id == job1.id }?.state, .done)
+
+        // Enqueue and process second job
+        let audio2 = try createTestAudioFile(in: tmpDir)
+        let job2 = makeJob(title: "Meeting 2", audioPath: audio2)
+        h.queue.enqueue(job2)
+        await h.queue.processNext()
+        XCTAssertEqual(h.queue.jobs.first { $0.id == job2.id }?.state, .done)
+
+        // Engine called twice total (once per job)
+        XCTAssertEqual(h.engine.transcribeCallCount, 2)
+    }
+
+    func testErrorJobDoesNotBlockNextJob() async throws {
+        let (h, _) = try makeHarness()
+
+        // First job will fail (empty transcript)
+        let audio1 = try createTestAudioFile(in: tmpDir)
+        let job1 = makeJob(title: "Silent", audioPath: audio1)
+        h.engine.segmentsToReturn = []
+        h.queue.enqueue(job1)
+        await h.queue.processNext()
+        XCTAssertEqual(h.queue.jobs.first?.state, .error)
+
+        // Second job should succeed
+        h.engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Now it works"),
+        ]
+        let audio2 = try createTestAudioFile(in: tmpDir)
+        let job2 = makeJob(title: "Working", audioPath: audio2)
+        h.queue.enqueue(job2)
+        await h.queue.processNext()
+        XCTAssertEqual(h.queue.jobs.first { $0.id == job2.id }?.state, .done)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -266,4 +266,38 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
         XCTAssertTrue(h.protocolGen.generateCalled)
     }
+
+    // MARK: - Speaker Naming Scenarios
+
+    func testWorkflowSpeakerNamingSkipped() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true)
+        h.queue.speakerNamingHandler = { _ in .skipped }
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Still completes even when naming is skipped
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertTrue(h.protocolGen.generateCalled)
+    }
+
+    func testWorkflowSpeakerNamingRerun() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true)
+
+        var callCount = 0
+        h.queue.speakerNamingHandler = { _ in
+            callCount += 1
+            return callCount == 1 ? .rerun(3) : .confirmed(["SPEAKER_00": "Alice"])
+        }
+
+        let job = makeJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Handler called twice (first rerun, then confirm), diarization ran twice
+        XCTAssertEqual(callCount, 2)
+        XCTAssertGreaterThanOrEqual(h.diarization.runCount, 2)
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -166,4 +166,26 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertTrue(h.protocolGen.generateCalled)
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
     }
+
+    // MARK: - Happy Path: Dual-Source
+
+    func testWorkflowDualSource() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: false)
+        let job = try makeDualSourceJob(audioPath: h.audioPath)
+
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        // Engine called twice (app + mic tracks)
+        XCTAssertEqual(h.engine.transcribeCallCount, 2)
+
+        // Protocol generated with merged transcript containing "Remote" label
+        XCTAssertTrue(h.protocolGen.generateCalled)
+        XCTAssertTrue(
+            h.protocolGen.capturedTranscript?.contains("Remote") ?? false,
+            "Dual-source transcript should contain 'Remote' speaker label",
+        )
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
 }


### PR DESCRIPTION
## Summary
- **12 new workflow integration tests** covering the full PipelineQueue pipeline end-to-end with mocks
- Enhanced `MockDiarization` (runCount counter, shouldThrow) and `MockProtocolGen` (shouldThrow + throws)
- Extracted shared `createTestAudioFile(in:)` to TestHelpers to eliminate duplication with PipelineQueueTests

## Test Scenarios
| Test | Scenario |
|------|----------|
| `testWorkflowSingleSourceNoDiarization` | Happy path, full state sequence, files saved |
| `testWorkflowWithDiarizationAndNaming` | Diarization + speaker naming confirmation |
| `testWorkflowDualSource` | Dual-source, engine called 2×, Remote label |
| `testWorkflowEmptyTranscriptEndsInError` | Empty transcript → error state |
| `testWorkflowEngineThrowsEndsInError` | Engine failure → error state |
| `testWorkflowProtocolGenerationFailsEndsInError` | Protocol gen failure → error state |
| `testWorkflowDiarizationUnavailableSkips` | Diarization unavailable → skipped |
| `testWorkflowDiarizationNoEmbeddingsFallsBack` | No embeddings → fallback |
| `testWorkflowSpeakerNamingSkipped` | User skips naming → completes |
| `testWorkflowSpeakerNamingRerun` | Rerun with N speakers → diarization 2× |
| `testMultipleJobsProcessedSequentially` | Two jobs in order |
| `testErrorJobDoesNotBlockNextJob` | Failed job doesn't block next |

## Test plan
- [x] All 737 tests pass (725 existing + 12 new)
- [x] Lint: 0 serious violations