### PR TITLE
fix(app): improve mic device change handling with testable restart policy

### DIFF
--- a/tools/audiotap/Package.swift
+++ b/tools/audiotap/Package.swift
@@ -13,5 +13,11 @@ let package = Package(
             path: "Sources",
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        .testTarget(
+            name: "AudioTapLibTests",
+            dependencies: ["AudioTapLib"],
+            path: "Tests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
     ]
 )

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -6,24 +6,25 @@ import os.log
 private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "MicCapture")
 
 /// Records microphone audio to a WAV file via AVAudioEngine.
-/// Monitors for default input device changes (e.g. AirPods connected) via
-/// CoreAudio property listener and automatically restarts the engine.
+/// Monitors for device changes via CoreAudio property listener (default input device)
+/// and AVAudioEngine configuration change notification (format/route changes).
+/// Automatically restarts the engine on device switch, preserving the selected device
+/// when still available or falling back to system default with a warning.
 public class MicCaptureHandler {
     private var engine = AVAudioEngine()
     private var outputFile: AVAudioFile?
     private let outputURL: URL
     private var isRecording = false
-    private var listenerInstalled = false
-    /// Stored listener block so we can pass the same instance to remove.
+    private var isRestarting = false
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
-    /// Sample rate of the WAV file (set on first start, stays fixed).
+    private var configChangeObserver: NSObjectProtocol?
+    private var selectedDeviceUID: String?
     private var fileSampleRate: Double = 0
-    /// Resampler for when device sample rate differs from file sample rate.
     private var converter: AVAudioConverter?
-    /// mach_absolute_time() of first audio callback.
+    /// Pre-computed resampling ratio (fileSampleRate / tapSampleRate), avoids division in audio callback.
+    private var resampleRatio: Double = 1.0
     public private(set) var firstFrameTime: UInt64 = 0
 
-    /// CoreAudio property address for default input device changes.
     private var defaultInputAddress = AudioObjectPropertyAddress(
         mSelector: kAudioHardwarePropertyDefaultInputDevice,
         mScope: kAudioObjectPropertyScopeGlobal,
@@ -32,6 +33,10 @@ public class MicCaptureHandler {
 
     public init(outputURL: URL) {
         self.outputURL = outputURL
+    }
+
+    deinit {
+        stop()
     }
 
     private static func deviceIDForUID(_ uid: String) -> AudioDeviceID {
@@ -53,8 +58,10 @@ public class MicCaptureHandler {
     }
 
     public func start(deviceUID: String? = nil) throws {
+        selectedDeviceUID = deviceUID
         try startEngine(deviceUID: deviceUID)
         installDeviceChangeListener()
+        installConfigChangeObserver()
     }
 
     // swiftlint:disable:next function_body_length
@@ -85,8 +92,7 @@ public class MicCaptureHandler {
         )! // swiftlint:disable:this force_unwrapping
         logger.info("Mic tap format: \(tapFormat.sampleRate) Hz, \(tapFormat.channelCount)ch")
 
-        // Create WAV file on first start; always at 16kHz (WhisperKit target rate).
-        // The AVAudioConverter below handles resampling from any hardware rate.
+        // Always 16kHz — WhisperKit target rate
         if outputFile == nil {
             fileSampleRate = speechSampleRate
             let wavSettings: [String: Any] = [
@@ -101,13 +107,14 @@ public class MicCaptureHandler {
             outputFile = try AVAudioFile(forWriting: outputURL, settings: wavSettings)
         }
 
-        // Set up resampler if device sample rate differs from file sample rate
         converter = nil
+        resampleRatio = 1.0
         if tapFormat.sampleRate != fileSampleRate {
             let outputFormat = AVAudioFormat(
                 standardFormatWithSampleRate: fileSampleRate, channels: 1,
             )! // swiftlint:disable:this force_unwrapping
             converter = AVAudioConverter(from: tapFormat, to: outputFormat)
+            resampleRatio = fileSampleRate / tapFormat.sampleRate
             logger.info("Mic: resampling \(Int(tapFormat.sampleRate))→\(Int(self.fileSampleRate)) Hz")
         }
 
@@ -121,10 +128,8 @@ public class MicCaptureHandler {
             }
             do {
                 if let converter = self.converter {
-                    // Resample to match the WAV file's sample rate
-                    let ratio = self.fileSampleRate / tapFormat.sampleRate
                     let outputFrames = AVAudioFrameCount(
-                        Double(buffer.frameLength) * ratio,
+                        Double(buffer.frameLength) * self.resampleRatio,
                     )
                     guard let outputBuffer = AVAudioPCMBuffer(
                         pcmFormat: converter.outputFormat,
@@ -160,9 +165,8 @@ public class MicCaptureHandler {
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
     }
 
-    /// Listen for default input device changes via CoreAudio property listener.
     private func installDeviceChangeListener() {
-        guard !listenerInstalled else { return }
+        guard deviceChangeListener == nil else { return }
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             self?.handleDefaultInputDeviceChanged()
         }
@@ -174,37 +178,86 @@ public class MicCaptureHandler {
         )
         if status == noErr {
             deviceChangeListener = listener
-            listenerInstalled = true
             logger.info("Mic: listening for default input device changes")
         } else {
             logger.warning("Failed to install device change listener (status: \(status))")
         }
     }
 
-    private func handleDefaultInputDeviceChanged() {
-        guard isRecording else { return }
-        logger.info("Mic: default input device changed, restarting engine...")
+    /// Listen for AVAudioEngine configuration changes (format changes on current device).
+    private func installConfigChangeObserver() {
+        guard configChangeObserver == nil else { return }
+        configChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main,
+        ) { [weak self] _ in
+            self?.handleEngineConfigChange()
+        }
+        logger.info("Mic: listening for engine configuration changes")
+    }
 
-        // Stop current engine
+    private func handleEngineConfigChange() {
+        logger.info("Mic: engine configuration changed (format/route change)")
+        handleDeviceChange()
+    }
+
+    private func handleDefaultInputDeviceChanged() {
+        logger.info("Mic: default input device changed")
+        handleDeviceChange()
+    }
+
+    private func handleDeviceChange() {
+        let isDeviceAvailable = selectedDeviceUID.map { Self.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: isRecording,
+            isRestarting: isRestarting,
+            selectedDeviceUID: selectedDeviceUID,
+            isSelectedDeviceAvailable: isDeviceAvailable,
+        )
+
+        switch action {
+        case let .restart(deviceUID):
+            executeRestart(deviceUID: deviceUID)
+
+        case .skip:
+            break
+        }
+    }
+
+    private func executeRestart(deviceUID: String?) {
+        isRestarting = true
+        defer { isRestarting = false }
+
+        if deviceUID == nil, let uid = selectedDeviceUID {
+            logger.warning("Mic: selected device '\(uid)' no longer available, falling back to system default")
+        }
+
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         engine.reset()
 
-        // Create a fresh engine (AVAudioEngine can be in a bad state after config change)
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
+
+        // AVAudioEngine can be in a bad state after config change — must recreate
         engine = AVAudioEngine()
 
-        // Restart with new system default
         do {
-            try startEngine(deviceUID: nil)
-            logger.info("Mic: engine restarted on new default device")
+            try startEngine(deviceUID: deviceUID)
+            installConfigChangeObserver()
+            logger.info("Mic: engine restarted on \(deviceUID != nil ? "selected" : "default") device")
         } catch {
+            isRecording = false
             logger.error("Failed to restart mic after device change: \(error)")
         }
     }
 
     public func stop() {
         isRecording = false
-        if listenerInstalled, let listener = deviceChangeListener {
+        if let listener = deviceChangeListener {
             AudioObjectRemovePropertyListenerBlock(
                 AudioObjectID(kAudioObjectSystemObject),
                 &defaultInputAddress,
@@ -212,7 +265,10 @@ public class MicCaptureHandler {
                 listener,
             )
             deviceChangeListener = nil
-            listenerInstalled = false
+        }
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
         }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()

--- a/tools/audiotap/Sources/MicRestartPolicy.swift
+++ b/tools/audiotap/Sources/MicRestartPolicy.swift
@@ -1,0 +1,35 @@
+/// Action to take when a mic device change is detected.
+public enum MicRestartAction: Equatable {
+    /// Restart the engine with the given device UID (nil = system default).
+    case restart(deviceUID: String?)
+    /// Skip the restart (not recording, or already restarting).
+    case skip
+}
+
+/// Pure decision logic for mic engine restarts.
+/// Separated from MicCaptureHandler to enable unit testing without hardware.
+public enum MicRestartPolicy {
+    /// Decide whether and how to restart the mic engine after a device change.
+    ///
+    /// - Parameters:
+    ///   - isRecording: Whether the handler is currently recording.
+    ///   - isRestarting: Whether a restart is already in progress.
+    ///   - selectedDeviceUID: The device UID the user explicitly selected (nil = system default).
+    ///   - isSelectedDeviceAvailable: Whether the selected device is still connected.
+    /// - Returns: The action to take.
+    public static func decideRestart(
+        isRecording: Bool,
+        isRestarting: Bool,
+        selectedDeviceUID: String?,
+        isSelectedDeviceAvailable: Bool,
+    ) -> MicRestartAction {
+        guard isRecording else { return .skip }
+        guard !isRestarting else { return .skip }
+
+        if let uid = selectedDeviceUID, isSelectedDeviceAvailable {
+            return .restart(deviceUID: uid)
+        }
+        // No selected device, or selected device gone → use system default
+        return .restart(deviceUID: nil)
+    }
+}

--- a/tools/audiotap/Tests/MicRestartPolicyTests.swift
+++ b/tools/audiotap/Tests/MicRestartPolicyTests.swift
@@ -1,0 +1,97 @@
+@testable import AudioTapLib
+import XCTest
+
+final class MicRestartPolicyTests: XCTestCase {
+    // MARK: - Skip Cases
+
+    func testSkipsWhenNotRecording() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: false,
+            isRestarting: false,
+            selectedDeviceUID: nil,
+            isSelectedDeviceAvailable: false,
+        )
+        XCTAssertEqual(action, .skip)
+    }
+
+    func testSkipsWhenAlreadyRestarting() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: true,
+            isRestarting: true,
+            selectedDeviceUID: nil,
+            isSelectedDeviceAvailable: false,
+        )
+        XCTAssertEqual(action, .skip)
+    }
+
+    func testSkipsWhenNotRecordingEvenWithSelectedDevice() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: false,
+            isRestarting: false,
+            selectedDeviceUID: "com.apple.airpods",
+            isSelectedDeviceAvailable: true,
+        )
+        XCTAssertEqual(action, .skip)
+    }
+
+    // MARK: - Restart with System Default
+
+    func testRestartsWithDefaultWhenNoDeviceSelected() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: true,
+            isRestarting: false,
+            selectedDeviceUID: nil,
+            isSelectedDeviceAvailable: false,
+        )
+        XCTAssertEqual(action, .restart(deviceUID: nil))
+    }
+
+    // MARK: - Restart with Selected Device
+
+    func testRestartsWithSelectedDeviceWhenAvailable() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: true,
+            isRestarting: false,
+            selectedDeviceUID: "com.apple.airpods",
+            isSelectedDeviceAvailable: true,
+        )
+        XCTAssertEqual(action, .restart(deviceUID: "com.apple.airpods"))
+    }
+
+    // MARK: - Device Fallback
+
+    func testFallsBackToDefaultWhenSelectedDeviceGone() {
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: true,
+            isRestarting: false,
+            selectedDeviceUID: "com.apple.airpods",
+            isSelectedDeviceAvailable: false,
+        )
+        XCTAssertEqual(action, .restart(deviceUID: nil))
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmptyDeviceUIDTreatedAsSelected() {
+        // Empty string is still a non-nil selectedDeviceUID
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: true,
+            isRestarting: false,
+            selectedDeviceUID: "",
+            isSelectedDeviceAvailable: false,
+        )
+        // Empty UID not available → falls back to default
+        XCTAssertEqual(action, .restart(deviceUID: nil))
+    }
+
+    func testBothFlagsBlockRestart() {
+        // Not recording AND already restarting
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: false,
+            isRestarting: true,
+            selectedDeviceUID: "com.apple.airpods",
+            isSelectedDeviceAvailable: true,
+        )
+        XCTAssertEqual(action, .skip)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AVAudioEngine.configurationChangeNotification` observer to catch format/route changes (not just default device changes)
- Preserve selected device UID across restarts; verify availability before reuse, fall back to system default with warning
- Extract restart decision logic into pure `MicRestartPolicy.decideRestart()` function (Functional Core, Imperative Shell)
- Add reentrancy guard (`isRestarting`), `deinit { stop() }` safety net, `isRecording = false` on restart failure
- Pre-compute resampling ratio to avoid division in audio callback hot path
- Remove redundant `listenerInstalled` state (replaced by `deviceChangeListener != nil`)
- Add 8 unit tests for `MicRestartPolicy` (first tests in AudioTapLib)

## Test plan
- [x] `swift test` passes (745 app tests + 8 AudioTapLib tests)
- [x] `./scripts/lint.sh` passes (0 violations)
- [x] Manual test: AirPods → Mac mic switch during recording — transcript continuous, no gap
- [x] CI passes