### PR TITLE
fix(app): hardening — crash prevention, thread safety, filename sanitization

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -8,13 +8,16 @@ enum AppPaths {
 
     /// App data directory: `~/Library/Application Support/MeetingTranscriber/`
     /// In sandbox, this automatically resolves to the container path.
+    /// Falls back to `~/.MeetingTranscriber/` if Application Support is unavailable.
     static let dataDir: URL = {
-        guard let appSupport = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        else {
-            fatalError("Application Support directory unavailable")
+        if let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return appSupport.appendingPathComponent("MeetingTranscriber")
         }
-        return appSupport.appendingPathComponent("MeetingTranscriber")
+        Logger(subsystem: logSubsystem, category: "AppPaths")
+            .error("Application Support directory unavailable — falling back to home directory")
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".MeetingTranscriber")
     }()
 
     /// IPC directory: under `dataDir` for sandbox compatibility.

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -2,7 +2,6 @@ import CoreGraphics
 import Foundation
 import os.log
 
-// swiftlint:disable:next unused_declaration
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "MeetingDetector")
 
 /// Polls window list to detect active meeting windows.
@@ -32,13 +31,21 @@ class MeetingDetector: MeetingDetecting {
         var meeting: [String: [NSRegularExpression]] = [:]
         var idle: [String: [NSRegularExpression]] = [:]
         for p in patterns {
-            meeting[p.appName] = p.meetingPatterns.map { pattern in
-                // swiftlint:disable:next force_try
-                try! NSRegularExpression(pattern: pattern)
+            meeting[p.appName] = p.meetingPatterns.compactMap { pattern in
+                do {
+                    return try NSRegularExpression(pattern: pattern)
+                } catch {
+                    logger.error("Invalid meeting regex for \(p.appName): \(pattern) — \(error.localizedDescription)")
+                    return nil
+                }
             }
-            idle[p.appName] = p.idlePatterns.map { pattern in
-                // swiftlint:disable:next force_try
-                try! NSRegularExpression(pattern: pattern)
+            idle[p.appName] = p.idlePatterns.compactMap { pattern in
+                do {
+                    return try NSRegularExpression(pattern: pattern)
+                } catch {
+                    logger.error("Invalid idle regex for \(p.appName): \(pattern) — \(error.localizedDescription)")
+                    return nil
+                }
             }
         }
         self.compiledMeetingPatterns = meeting

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -2,6 +2,7 @@ import ApplicationServices
 import AVFoundation
 import CoreGraphics
 import Foundation
+import os
 
 enum Permissions {
     /// Check if Screen Recording permission is granted.
@@ -25,12 +26,16 @@ enum Permissions {
         return false
     }
 
-    private static var hasPromptedAccessibility = false
+    private static let accessibilityPromptLock = OSAllocatedUnfairLock(initialState: false)
     // swiftlint:disable:next unused_declaration
     static func ensureAccessibilityAccess() -> Bool {
         if AXIsProcessTrusted() { return true }
-        guard !hasPromptedAccessibility else { return false }
-        hasPromptedAccessibility = true
+        let alreadyPrompted = accessibilityPromptLock.withLock { prompted -> Bool in
+            if prompted { return true }
+            prompted = true
+            return false
+        }
+        guard !alreadyPrompted else { return false }
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
         return AXIsProcessTrustedWithOptions(options)
     }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -780,10 +780,10 @@ class PipelineQueue {
             let line = String(data: data, encoding: .utf8)! + "\n"
             if FileManager.default.fileExists(atPath: logPath.path) {
                 let handle = try FileHandle(forWritingTo: logPath)
+                defer { handle.closeFile() }
                 handle.seekToEndOfFile()
                 // swiftlint:disable:next force_unwrapping
                 handle.write(line.data(using: .utf8)!)
-                handle.closeFile()
             } else {
                 try line.write(to: logPath, atomically: true, encoding: .utf8)
             }

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -113,12 +113,19 @@ enum ProtocolGenerator {
         return url
     }
 
+    private static let filenameFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyyMMdd_HHmm"
+        return fmt
+    }()
+
     /// Generate a filename: `{yyyyMMdd_HHmm}_{slug}.{ext}`
     static func filename(title: String, ext: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd_HHmm"
-        let date = formatter.string(from: Date())
-        let slug = title.lowercased().replacingOccurrences(of: " ", with: "_")
+        let date = filenameFormatter.string(from: Date())
+        let slug = title
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "_")
+            .filter { !"/:\\\u{0}".contains($0) }
         return "\(date)_\(slug).\(ext)"
     }
 }

--- a/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
@@ -400,4 +400,38 @@ final class MeetingDetectorTests: XCTestCase {
         // Should be detectable again immediately (no cooldown)
         XCTAssertNotNil(detector.checkOnce())
     }
+
+    // MARK: - Invalid Regex Graceful Handling
+
+    func testInvalidMeetingRegexSkippedGracefully() {
+        // Invalid regex should be silently skipped, not crash
+        let badPattern = AppMeetingPattern(
+            appName: "BadApp",
+            ownerNames: ["BadApp"],
+            meetingPatterns: ["[invalid(regex"],
+            idlePatterns: [],
+        )
+        let detector = MeetingDetector(patterns: [badPattern])
+        // Should not crash, and no windows match
+        detector.windowListProvider = {
+            [makeWindow(owner: "BadApp", name: "Some Title")]
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testMixedValidAndInvalidRegexKeepsValid() {
+        // Valid patterns still work even if some are invalid
+        let mixedPattern = AppMeetingPattern(
+            appName: "Microsoft Teams",
+            ownerNames: ["Microsoft Teams"],
+            meetingPatterns: ["[bad(", ".*\\| Microsoft Teams$"],
+            idlePatterns: [],
+        )
+        let detector = MeetingDetector(patterns: [mixedPattern], confirmationCount: 1)
+        detector.windowListProvider = {
+            [makeWindow(owner: "Microsoft Teams", name: "Standup | Microsoft Teams")]
+        }
+        // Valid regex should still match
+        XCTAssertNotNil(detector.checkOnce())
+    }
 }

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -100,6 +100,37 @@ final class ProtocolGeneratorTests: XCTestCase {
         XCTAssertTrue(txt.hasSuffix(".txt"))
     }
 
+    // MARK: - Filename Sanitization
+
+    func testFilenameSanitizesSlashes() {
+        let name = ProtocolGenerator.filename(title: "Code/Review", ext: "md")
+        XCTAssertFalse(name.contains("/"))
+        XCTAssertTrue(name.contains("codereview"))
+    }
+
+    func testFilenameSanitizesColons() {
+        let name = ProtocolGenerator.filename(title: "Meeting: Planning", ext: "md")
+        XCTAssertFalse(name.contains(":"))
+        XCTAssertTrue(name.contains("meeting_planning"))
+    }
+
+    func testFilenameSanitizesBackslashes() {
+        let name = ProtocolGenerator.filename(title: "Path\\Name", ext: "md")
+        XCTAssertFalse(name.contains("\\"))
+        XCTAssertTrue(name.contains("pathname"))
+    }
+
+    func testFilenameSanitizesNullBytes() {
+        let name = ProtocolGenerator.filename(title: "Test\0Title", ext: "md")
+        XCTAssertFalse(name.contains("\0"))
+        XCTAssertTrue(name.contains("testtitle"))
+    }
+
+    func testFilenameSanitizesMultipleForbiddenChars() {
+        let name = ProtocolGenerator.filename(title: "A/B:C\\D", ext: "txt")
+        XCTAssertTrue(name.hasSuffix("_abcd.txt"))
+    }
+
     // MARK: - File Save Operations
 
     func testSaveTranscript() throws {

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -5,11 +5,16 @@ import Foundation
 /// Must match `AudioConstants.targetSampleRate` in the app target.
 public let speechSampleRate: Double = 16000
 
-/// Convert mach_absolute_time() ticks to seconds.
-func machTicksToSeconds(_ ticks: UInt64) -> Double {
+/// Cached mach timebase info (constant per boot session).
+private let machTimebaseInfo: mach_timebase_info_data_t = {
     var info = mach_timebase_info_data_t()
     mach_timebase_info(&info)
-    let nanos = Double(ticks) * Double(info.numer) / Double(info.denom)
+    return info
+}()
+
+/// Convert mach_absolute_time() ticks to seconds.
+func machTicksToSeconds(_ ticks: UInt64) -> Double {
+    let nanos = Double(ticks) * Double(machTimebaseInfo.numer) / Double(machTimebaseInfo.denom)
     return nanos / 1_000_000_000.0
 }
 


### PR DESCRIPTION
## Summary
Cherry-picked hardening fixes from [execsumo/meeting-transcriber](https://github.com/execsumo/meeting-transcriber) fork:

- **AppPaths.dataDir**: Replace `fatalError` with fallback to `~/.MeetingTranscriber/` when Application Support unavailable
- **MeetingDetector**: Replace `try!` with `do/catch` for regex compilation — invalid patterns are silently skipped instead of crashing
- **Permissions**: Use `OSAllocatedUnfairLock` for thread-safe accessibility prompt guard
- **ProtocolGenerator**: Sanitize filenames (strip `/ : \ NUL`), cache `DateFormatter` as static property
- **PipelineQueue**: Use `defer` for `FileHandle.closeFile()` to prevent resource leaks
- **Helpers** (AudioTapLib): Cache `mach_timebase_info` (constant per boot, was re-queried on every call)

## Test plan
- [x] 5 new tests for filename sanitization (`/ : \ NUL` + combined)
- [x] 2 new tests for invalid regex graceful handling (skip bad + keep valid)
- [x] Full suite: 759 tests, 0 failures