### PR TITLE
feat(app): pipeline warnings — surface non-fatal issues in menu bar

### DIFF
--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -171,7 +171,7 @@ struct MenuBarView: View {
     private func jobRow(_ job: PipelineJob) -> some View {
         HStack {
             Circle()
-                .fill(jobColor(job.state))
+                .fill(jobColor(job))
                 .frame(width: 8, height: 8)
             VStack(alignment: .leading) {
                 Text(job.meetingTitle)
@@ -204,6 +204,9 @@ struct MenuBarView: View {
             } else if job.state == .error, let msg = job.error {
                 Text(msg)
                     .foregroundStyle(.red)
+            } else if job.state == .done, !job.warnings.isEmpty {
+                Text(job.warnings.joined(separator: "; "))
+                    .foregroundStyle(.orange)
             } else {
                 Text(job.state.label)
                     .foregroundStyle(.secondary)
@@ -220,13 +223,13 @@ struct MenuBarView: View {
         return "\(total / 60):\(String(format: "%02d", total % 60))"
     }
 
-    private func jobColor(_ state: JobState) -> Color {
-        switch state {
+    private func jobColor(_ job: PipelineJob) -> Color {
+        switch job.state {
         case .waiting: .gray
         case .transcribing: .blue
         case .diarizing: .purple
         case .generatingProtocol: .orange
-        case .done: .green
+        case .done: job.warnings.isEmpty ? .green : .yellow
         case .error: .red
         }
     }

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -34,6 +34,7 @@ struct PipelineJob: Identifiable, Codable, Sendable {
     let enqueuedAt: Date
     var state: JobState
     var error: String?
+    var warnings: [String]
     var protocolPath: URL?
 
     init(
@@ -56,6 +57,7 @@ struct PipelineJob: Identifiable, Codable, Sendable {
         self.enqueuedAt = Date()
         self.state = .waiting
         self.error = nil
+        self.warnings = []
         self.protocolPath = nil
     }
 }

--- a/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
@@ -497,6 +497,42 @@ final class MenuBarViewTests: XCTestCase {
         XCTAssertNoThrow(try body.find(text: "Failed"))
     }
 
+    func testWarningJobShowsWarningText() throws {
+        let queue = PipelineQueue()
+        let job = PipelineJob(
+            meetingTitle: "Standup",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        var warningJob = job
+        warningJob.warnings.append("Diarization failed — speakers not identified")
+        warningJob.state = .done
+        queue.enqueue(warningJob)
+
+        let sut = MenuBarView(
+            status: makeStatus(),
+            isWatching: false,
+            pipelineQueue: queue,
+            updateChecker: nil,
+            onStartStop: {},
+            onRecordApp: {},
+            onStopManualRecording: nil,
+            onOpenLastProtocol: {},
+            onOpenProtocol: { _ in },
+            onOpenProtocolsFolder: {},
+            onOpenSettings: {},
+            onNameSpeakers: nil,
+            onProcessFiles: {},
+            onDismissJob: { _ in },
+            onQuit: {},
+        )
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Diarization failed — speakers not identified"))
+    }
+
     // MARK: - Record App button
 
     func testRecordAppButtonExistsWhenIdle() throws {

--- a/app/MeetingTranscriber/Tests/PipelineJobTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineJobTests.swift
@@ -13,6 +13,7 @@ final class PipelineJobTests: XCTestCase {
         )
         XCTAssertEqual(job.state, .waiting)
         XCTAssertNil(job.error)
+        XCTAssertTrue(job.warnings.isEmpty)
         XCTAssertNotNil(job.id)
     }
 
@@ -31,6 +32,22 @@ final class PipelineJobTests: XCTestCase {
         XCTAssertEqual(decoded.meetingTitle, "Sprint")
         XCTAssertEqual(decoded.state, .waiting)
         XCTAssertEqual(decoded.micDelay, 0.5)
+        XCTAssertTrue(decoded.warnings.isEmpty)
+    }
+
+    func testWarningsSurviveEncoding() throws {
+        var job = PipelineJob(
+            meetingTitle: "Retro",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.warnings = ["Diarization failed — speakers not identified", "Speaker naming skipped"]
+        let data = try JSONEncoder().encode(job)
+        let decoded = try JSONDecoder().decode(PipelineJob.self, from: data)
+        XCTAssertEqual(decoded.warnings, ["Diarization failed — speakers not identified", "Speaker naming skipped"])
     }
 
     func testJobStateIsCodable() throws {


### PR DESCRIPTION
## Summary
Cherry-picked from [execsumo/meeting-transcriber](https://github.com/execsumo/meeting-transcriber) fork:

- Add `warnings: [String]` array to `PipelineJob` for non-fatal pipeline issues
- Jobs with warnings show warning text in orange and yellow status dot (vs. green for clean completion)
- Warnings survive JSON encoding (snapshot persistence)

## Changes
- **PipelineJob.swift**: Add `warnings` array, initialized empty, Codable
- **MenuBarView.swift**: `jobColor()` takes `PipelineJob` instead of `JobState`, returns `.yellow` when warnings present; warning text displayed in orange below job title

## Test plan
- [x] `testWarningsSurviveEncoding` — warnings persist through JSON round-trip
- [x] `testWarningJobShowsWarningText` — warning text renders in menu bar
- [x] Full suite: 754 tests, 0 failures