### PR TITLE
feat(app): configurable protocol output language

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -165,6 +165,18 @@ final class AppSettings {
         didSet { defaults.set(protocolProvider.rawValue, forKey: "protocolProvider") }
     }
 
+    var protocolLanguage: String = defaults.string(forKey: "protocolLanguage") ?? "German" {
+        didSet { defaults.set(protocolLanguage, forKey: "protocolLanguage") }
+    }
+
+    static let protocolLanguages = [
+        "German", "English", "French", "Spanish", "Italian",
+        "Dutch", "Portuguese", "Japanese", "Chinese", "Korean",
+        "Russian", "Arabic", "Turkish", "Hindi", "Swedish",
+        "Danish", "Finnish", "Polish", "Czech", "Greek",
+        "Hungarian", "Romanian",
+    ]
+
     #if !APPSTORE
         var claudeBin: String = defaults.object(forKey: "claudeBin") as? String ?? "claude" {
             didSet { defaults.set(claudeBin, forKey: "claudeBin") }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -289,7 +289,7 @@ final class AppState {
         switch settings.protocolProvider {
         #if !APPSTORE
             case .claudeCLI:
-                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin)
+                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin, language: settings.protocolLanguage)
         #endif
 
         case .openAICompatible:
@@ -299,6 +299,7 @@ final class AppState {
                     ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
                 model: settings.openAIModel,
                 apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
+                language: settings.protocolLanguage,
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -298,8 +298,8 @@ final class AppState {
                     // swiftlint:disable:next force_unwrapping
                     ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
                 model: settings.openAIModel,
-                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
                 language: settings.protocolLanguage,
+                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -8,6 +8,7 @@
     /// Claude CLI implementation that generates protocols via subprocess.
     struct ClaudeCLIProtocolGenerator: ProtocolGenerating {
         let claudeBin: String
+        let language: String
 
         static let timeoutSeconds: TimeInterval = 600
 
@@ -22,7 +23,7 @@
         // MARK: - ProtocolGenerating
 
         func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
-            var prompt = ProtocolGenerator.loadPrompt()
+            var prompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
             if diarized {
                 prompt += ProtocolGenerator.diarizationNote
             }

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -8,17 +8,25 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     let endpoint: URL
     let model: String
     let apiKey: String?
+    let language: String
     let timeoutSeconds: TimeInterval
 
-    init(endpoint: URL, model: String, apiKey: String? = nil, timeoutSeconds: TimeInterval = 600) {
+    init(
+        endpoint: URL,
+        model: String,
+        apiKey: String? = nil,
+        language: String = "German",
+        timeoutSeconds: TimeInterval = 600,
+    ) {
         self.endpoint = endpoint
         self.model = model
         self.apiKey = apiKey
+        self.language = language
         self.timeoutSeconds = timeoutSeconds
     }
 
     func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
-        var systemPrompt = ProtocolGenerator.loadPrompt()
+        var systemPrompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
         if diarized {
             systemPrompt += ProtocolGenerator.diarizationNote
         }

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -14,14 +14,14 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     init(
         endpoint: URL,
         model: String,
+        language: String,
         apiKey: String? = nil,
-        language: String = "German",
         timeoutSeconds: TimeInterval = 600,
     ) {
         self.endpoint = endpoint
         self.model = model
-        self.apiKey = apiKey
         self.language = language
+        self.apiKey = apiKey
         self.timeoutSeconds = timeoutSeconds
     }
 

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -12,7 +12,7 @@ protocol ProtocolGenerating {
 enum ProtocolGenerator {
     static let protocolPrompt = """
     You are a professional meeting minute taker.
-    Create a structured meeting protocol in German from the following transcript.
+    Create a structured meeting protocol in {LANGUAGE} from the following transcript.
 
     Return ONLY the finished Markdown document - no explanations, no introduction,
     no comments before or after.
@@ -75,6 +75,10 @@ enum ProtocolGenerator {
     ///
     /// Reads `AppPaths.customPromptFile` if it exists and is non-empty,
     /// otherwise falls back to the hardcoded `protocolPrompt`.
+    static func applyLanguage(_ prompt: String, language: String) -> String {
+        prompt.replacingOccurrences(of: "{LANGUAGE}", with: language)
+    }
+
     static func loadPrompt() -> String {
         let url = AppPaths.customPromptFile
         if let custom = try? String(contentsOf: url, encoding: .utf8),

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -281,6 +281,11 @@ struct SettingsView: View {
                         }
                     }
                 }
+                Picker("Protocol Language", selection: $settings.protocolLanguage) {
+                    ForEach(AppSettings.protocolLanguages, id: \.self) { lang in
+                        Text(lang).tag(lang)
+                    }
+                }
 
                 HStack {
                     Text("Output Folder")

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -73,6 +73,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase {
         let gen = try OpenAIProtocolGenerator(
             endpoint: XCTUnwrap(URL(string: "http://localhost:11434/v1/chat/completions")),
             model: "test",
+            language: "German",
         )
         XCTAssertEqual(gen.timeoutSeconds, 600)
     }
@@ -81,6 +82,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase {
         let gen = try OpenAIProtocolGenerator(
             endpoint: XCTUnwrap(URL(string: "http://localhost:11434/v1/chat/completions")),
             model: "test",
+            language: "German",
             timeoutSeconds: 120,
         )
         XCTAssertEqual(gen.timeoutSeconds, 120)
@@ -90,6 +92,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase {
         let gen = try OpenAIProtocolGenerator(
             endpoint: XCTUnwrap(URL(string: "http://localhost:11434/v1/chat/completions")),
             model: "test",
+            language: "German",
         )
         XCTAssertNil(gen.apiKey)
     }

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -57,7 +57,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase {
         // Verify the protocol prompt includes key structural elements
         let prompt = ProtocolGenerator.protocolPrompt
         XCTAssertTrue(prompt.contains("meeting minute taker"))
-        XCTAssertTrue(prompt.contains("German"))
+        XCTAssertTrue(prompt.contains("{LANGUAGE}"))
         XCTAssertTrue(prompt.contains("Markdown"))
     }
 

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -131,6 +131,24 @@ final class ProtocolGeneratorTests: XCTestCase {
         XCTAssertTrue(name.hasSuffix("_abcd.txt"))
     }
 
+    // MARK: - Language Substitution
+
+    func testApplyLanguageReplacesPlaceholder() {
+        let prompt = "Create protocol in {LANGUAGE} from transcript."
+        let result = ProtocolGenerator.applyLanguage(prompt, language: "English")
+        XCTAssertEqual(result, "Create protocol in English from transcript.")
+    }
+
+    func testApplyLanguageNoPlaceholderPassesThrough() {
+        let custom = "Custom prompt without placeholder."
+        let result = ProtocolGenerator.applyLanguage(custom, language: "French")
+        XCTAssertEqual(result, custom)
+    }
+
+    func testDefaultPromptContainsLanguagePlaceholder() {
+        XCTAssertTrue(ProtocolGenerator.protocolPrompt.contains("{LANGUAGE}"))
+    }
+
     // MARK: - File Save Operations
 
     func testSaveTranscript() throws {


### PR DESCRIPTION
## Summary

Inspired by [execsumo/meeting-transcriber](https://github.com/execsumo/meeting-transcriber) ([commits fae3632, 0adb1f8](https://github.com/execsumo/meeting-transcriber/commit/fae3632)).

Replace hardcoded "in German" in the protocol prompt with a configurable language setting.

- New `protocolLanguage` setting (default: German) with 22 language options
- `{LANGUAGE}` template in the built-in prompt, substituted at runtime via `applyLanguage()`
- Custom prompts also get `{LANGUAGE}` replaced if the placeholder is present
- Language picker in Settings under Protocol Generation section
- Both ClaudeCLI and OpenAI generators receive the language at init time

## Changes
- **AppSettings.swift**: `protocolLanguage` property + `protocolLanguages` list
- **ProtocolGenerator.swift**: `{LANGUAGE}` template + `applyLanguage()` method
- **ClaudeCLIProtocolGenerator.swift**: `language` stored property, applied in `generate()`
- **OpenAIProtocolGenerator.swift**: `language` stored property, applied in `generate()`
- **AppState.swift**: Pass `settings.protocolLanguage` to generator factories
- **SettingsView.swift**: Protocol Language picker

## Test plan
- [x] 3 new tests for `applyLanguage()` (replace, passthrough, placeholder exists)
- [x] Existing prompt test updated (`"German"` → `"{LANGUAGE}"`)
- [x] Full suite: 770 tests, 0 failures
- [x] Lint: 0 violations
- [x] AppStore build variant: OK