### PR TITLE
feat(app): None LLM provider + graceful protocol generation fallback

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -36,6 +36,7 @@ enum ProtocolProvider: String, CaseIterable {
         case claudeCLI
     #endif
     case openAICompatible
+    case none // swiftlint:disable:this discouraged_none_name
 
     var label: String {
         switch self {
@@ -44,6 +45,7 @@ enum ProtocolProvider: String, CaseIterable {
         #endif
 
         case .openAICompatible: "OpenAI-Compatible API"
+        case .none: "None (Transcript Only)"
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -285,7 +285,7 @@ final class AppState {
         return queue
     }
 
-    func makeProtocolGenerator() -> ProtocolGenerating {
+    func makeProtocolGenerator() -> ProtocolGenerating? {
         switch settings.protocolProvider {
         #if !APPSTORE
             case .claudeCLI:
@@ -301,6 +301,9 @@ final class AppState {
                 language: settings.protocolLanguage,
                 apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
             )
+
+        case .none:
+            nil
         }
     }
 
@@ -308,7 +311,8 @@ final class AppState {
         pipelineQueue.onJobStateChange = { [notifier] job, _, newState in
             switch newState {
             case .done:
-                notifier.notify(title: "Protocol Ready", body: job.meetingTitle)
+                let title = job.protocolPath != nil ? "Protocol Ready" : "Transcript Saved"
+                notifier.notify(title: title, body: job.meetingTitle)
 
             case .error:
                 if let err = job.error {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -160,7 +160,7 @@ struct MeetingTranscriberApp: App {
 
     private func openLastProtocol() {
         if let job = appState.pipelineQueue.completedJobs.last,
-           let path = job.protocolPath {
+           let path = job.protocolPath ?? job.transcriptPath {
             NSWorkspace.shared.open(path)
         }
     }

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -179,7 +179,7 @@ struct MenuBarView: View {
                 jobStateLabel(job)
             }
             Spacer()
-            if job.state == .done, let path = job.protocolPath {
+            if job.state == .done, let path = job.protocolPath ?? job.transcriptPath {
                 Button("Open") { onOpenProtocol(path) }
                     .font(.caption2)
             }

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -35,6 +35,7 @@ struct PipelineJob: Identifiable, Codable, Sendable {
     var state: JobState
     var error: String?
     var warnings: [String]
+    var transcriptPath: URL?
     var protocolPath: URL?
 
     init(
@@ -58,6 +59,7 @@ struct PipelineJob: Identifiable, Codable, Sendable {
         self.state = .waiting
         self.error = nil
         self.warnings = []
+        self.transcriptPath = nil
         self.protocolPath = nil
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -14,7 +14,7 @@ class PipelineQueue {
     // Dependencies for processing
     let engine: (any TranscribingEngine)?
     let diarizationFactory: (() -> DiarizationProvider)?
-    let protocolGeneratorFactory: (() -> ProtocolGenerating)?
+    let protocolGeneratorFactory: (() -> ProtocolGenerating?)?
     let outputDir: URL?
     let diarizeEnabled: Bool
     let numSpeakers: Int
@@ -94,7 +94,7 @@ class PipelineQueue {
     init(
         engine: any TranscribingEngine,
         diarizationFactory: @escaping () -> DiarizationProvider,
-        protocolGeneratorFactory: @escaping () -> ProtocolGenerating,
+        protocolGeneratorFactory: @escaping () -> ProtocolGenerating?,
         outputDir: URL,
         logDir: URL? = nil,
         diarizeEnabled: Bool = false,
@@ -230,7 +230,7 @@ class PipelineQueue {
             isProcessing = false
             return
         }
-        guard let engine, let protocolGeneratorFactory, let outputDir else {
+        guard let engine, let outputDir else {
             logger.warning("Processing dependencies not configured — skipping")
             isProcessing = false
             return
@@ -490,46 +490,49 @@ class PipelineQueue {
                 }
             }
 
-            // Save transcript
+            // --- Save Transcript & Audio (always) ---
             let protocolsDir = outputDir.appendingPathComponent("protocols")
             let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: title, dir: protocolsDir)
             logger.info("Transcript saved: \(txtPath.lastPathComponent)")
 
-            // --- Protocol Generation ---
-            updateJobState(id: jobID, to: .generatingProtocol)
-            startElapsedTimer()
+            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
+                jobs[idx].transcriptPath = txtPath
+            }
 
-            let diarized = finalTranscript.range(of: #"\[\w[\w\s]*\]"#, options: .regularExpression) != nil
-            let protocolGenerator = protocolGeneratorFactory()
-            let protocolMD = try await protocolGenerator.generate(
-                transcript: finalTranscript,
-                title: title,
-                diarized: diarized,
-            )
-
-            let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + finalTranscript
-            let mdPath = try ProtocolGenerator.saveProtocol(fullMD, title: title, dir: protocolsDir)
-            logger.info("Protocol saved: \(mdPath.lastPathComponent)")
-
-            // Move audio files to recordings subdirectory
             let recordingsDir = outputDir.appendingPathComponent("recordings")
             Self.copyAudioToOutput(
                 mixPath: mixPath, appPath: appPath, micPath: micPath,
                 title: title, outputDir: recordingsDir,
             )
 
-            // Update job with protocol path and mark done
-            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
-                jobs[idx].protocolPath = mdPath
+            // --- Protocol Generation (optional) ---
+            if let protocolGeneratorFactory, let generator = protocolGeneratorFactory() {
+                do {
+                    updateJobState(id: jobID, to: .generatingProtocol)
+                    startElapsedTimer()
+
+                    let diarized = finalTranscript.range(of: #"\[\w[\w\s]*\]"#, options: .regularExpression) != nil
+                    let protocolMD = try await generator.generate(
+                        transcript: finalTranscript,
+                        title: title,
+                        diarized: diarized,
+                    )
+
+                    let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + finalTranscript
+                    let mdPath = try ProtocolGenerator.saveProtocol(fullMD, title: title, dir: protocolsDir)
+                    logger.info("Protocol saved: \(mdPath.lastPathComponent)")
+
+                    if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
+                        jobs[idx].protocolPath = mdPath
+                    }
+                } catch {
+                    logger.warning("Protocol generation failed: \(error.localizedDescription)")
+                    addWarning(id: jobID, "Protocol generation failed — transcript saved")
+                }
             }
+
             stopElapsedTimer()
             updateJobState(id: jobID, to: .done)
-            if let job = jobs.first(where: { $0.id == jobID }), !job.warnings.isEmpty {
-                NotificationManager.shared.notify(
-                    title: "Protocol Ready (with warnings)",
-                    body: job.warnings.joined(separator: "; "),
-                )
-            }
         } catch is CancellationError {
             stopElapsedTimer()
             logger.info("Job \(jobID) cancelled")

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -195,7 +195,7 @@ struct SettingsView: View {
 
             // swiftlint:disable:next closure_body_length
             Section("Protocol Generation") {
-                Picker("Provider", selection: $settings.protocolProvider) {
+                Picker("LLM Provider", selection: $settings.protocolProvider) {
                     ForEach(ProtocolProvider.allCases, id: \.self) { provider in
                         Text(provider.label).tag(provider)
                     }
@@ -280,6 +280,11 @@ struct SettingsView: View {
                             testConnection()
                         }
                     }
+
+                case .none:
+                    Text("Only the raw transcript will be saved — no LLM summarization.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
                 Picker("Protocol Language", selection: $settings.protocolLanguage) {
                     ForEach(AppSettings.protocolLanguages, id: \.self) { lang in

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -399,7 +399,8 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
         state.configurePipelineCallbacks()
 
-        let job = makeJob(title: "Sprint Review")
+        var job = makeJob(title: "Sprint Review")
+        job.protocolPath = URL(fileURLWithPath: "/tmp/protocol.md")
         state.pipelineQueue.onJobStateChange?(job, .transcribing, .done)
 
         XCTAssertEqual(notifier.calls.count, 1)

--- a/app/MeetingTranscriber/Tests/PipelineJobTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineJobTests.swift
@@ -50,6 +50,21 @@ final class PipelineJobTests: XCTestCase {
         XCTAssertEqual(decoded.warnings, ["Diarization failed — speakers not identified", "Speaker naming skipped"])
     }
 
+    func testTranscriptPathSurvivesEncoding() throws {
+        var job = PipelineJob(
+            meetingTitle: "Transcript Test",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.transcriptPath = URL(fileURLWithPath: "/tmp/transcript.txt")
+        let data = try JSONEncoder().encode(job)
+        let decoded = try JSONDecoder().decode(PipelineJob.self, from: data)
+        XCTAssertEqual(decoded.transcriptPath, job.transcriptPath)
+    }
+
     func testJobStateIsCodable() throws {
         for state in [
             JobState.waiting,

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -102,7 +102,7 @@ final class SettingsViewTests: XCTestCase {
     func testProviderPickerExists() throws {
         let sut = makeSUT()
         let body = try sut.inspect()
-        XCTAssertNoThrow(try body.find(text: "Provider"))
+        XCTAssertNoThrow(try body.find(text: "LLM Provider"))
     }
 
     #if !APPSTORE

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -221,7 +221,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertFalse(h.protocolGen.generateCalled)
     }
 
-    func testWorkflowProtocolGenerationFailsEndsInError() async throws {
+    func testWorkflowProtocolGenerationFailsSavesTranscriptWithWarning() async throws {
         let (h, _) = try makeHarness()
         h.protocolGen.shouldThrow = true
 
@@ -229,7 +229,11 @@ final class WorkflowIntegrationTests: XCTestCase {
         h.queue.enqueue(job)
         await h.queue.processNext()
 
-        XCTAssertEqual(h.queue.jobs.first?.state, .error)
+        // Job completes with warning (graceful fallback), transcript saved
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
+        XCTAssertNil(h.queue.jobs.first?.protocolPath)
+        XCTAssertFalse(h.queue.jobs.first?.warnings.isEmpty ?? true)
     }
 
     // MARK: - Diarization Scenarios

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -348,4 +348,43 @@ final class WorkflowIntegrationTests: XCTestCase {
         await h.queue.processNext()
         XCTAssertEqual(h.queue.jobs.first { $0.id == job2.id }?.state, .done)
     }
+
+    // MARK: - None LLM Provider (Transcript Only)
+
+    func testWorkflowNoneProviderSavesTranscriptOnly() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello world"),
+        ]
+        let collector = TransitionCollector()
+
+        // Factory returns nil → no protocol generation
+        let queue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+        )
+        queue.onJobStateChange = { [collector] _, old, new in
+            collector.transitions.append((old, new))
+        }
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = makeJob(title: "Transcript Only", audioPath: audioPath)
+        queue.enqueue(job)
+        await queue.processNext()
+
+        // Job completes without .generatingProtocol state
+        let states = collector.transitions.map(\.1)
+        XCTAssertFalse(states.contains(.generatingProtocol))
+        XCTAssertEqual(queue.jobs.first?.state, .done)
+
+        // Transcript saved, no protocol
+        XCTAssertNotNil(queue.jobs.first?.transcriptPath)
+        XCTAssertNil(queue.jobs.first?.protocolPath)
+
+        // No warnings (this is intentional, not a failure)
+        XCTAssertTrue(queue.jobs.first?.warnings.isEmpty ?? false)
+    }
 }


### PR DESCRIPTION
## Summary

Inspired by [execsumo/meeting-transcriber](https://github.com/execsumo/meeting-transcriber) ([commit 7a04dc2](https://github.com/execsumo/meeting-transcriber/commit/7a04dc2)).

- **"None (Transcript Only)"** option in LLM Provider picker — skips protocol generation, saves only transcripts
- **Graceful LLM fallback** — if protocol generation fails, transcript + audio are still saved, job completes with warning instead of error
- **Decoupled pipeline** — transcript and audio always saved first, protocol generation is optional
- `transcriptPath` on PipelineJob for transcript-only job access (menu bar "Open" button, notifications)

## Changes
- **AppSettings.swift**: `.none` case on `ProtocolProvider`
- **PipelineJob.swift**: `transcriptPath` property
- **PipelineQueue.swift**: Transcript/audio saved before optional LLM; LLM errors caught gracefully with warning
- **AppState.swift**: Factory returns `nil` for `.none`; notification title adapts ("Protocol Ready" vs "Transcript Saved")
- **MenuBarView.swift**: Open button falls back to `transcriptPath`
- **SettingsView.swift**: Info text for None mode, renamed to "LLM Provider"
- **MeetingTranscriberApp.swift**: Open last protocol falls back to transcript

## Test plan
- [x] `testWorkflowNoneProviderSavesTranscriptOnly` — no `.generatingProtocol` state, transcript saved, no protocol, no warnings
- [x] `testWorkflowProtocolGenerationFailsSavesTranscriptWithWarning` — graceful fallback (`.done` + warning + transcript, no protocol)
- [x] `testTranscriptPathSurvivesEncoding` — JSON round-trip for transcriptPath
- [x] Updated `testConfigurePipelineCallbacksDoneFiresNotification` — adaptive notification title
- [x] Updated `testProviderPickerExists` — renamed picker label
- [x] Full suite: 772 tests, 0 failures
- [x] Lint: 0 violations
- [x] AppStore build: OK