### PR TITLE
chore(app): update dependencies to latest compatible versions

### DIFF
--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.1"),
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.2"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
         .package(path: "../../tools/audiotap"),
     ],
     targets: [

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MeetingTranscriber",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.0"),
+        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.2"),

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.1"),
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.2"),
         .package(path: "../../tools/audiotap"),

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.1"),
-        .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.17.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
         .package(path: "../../tools/audiotap"),
     ],


### PR DESCRIPTION
## Summary
- Update ViewInspector 0.10.0 → 0.10.3
- Update swift-snapshot-testing 1.17.0 → 1.19.1
- Update FluidAudio 0.12.2 → 0.12.4 (0.12.5 conflicts with WhisperKit via swift-transformers 1.2.0 vs 1.1.x)
- Update WhisperKit 0.9.0 → 0.17.0

## Test plan
- [x] `swift test` passes (772 tests, 0 failures)
- [x] `swift build` passes
- [ ] CI passes