### PR TITLE
fix: detect actual channel count to prevent Mickey Mouse with mono USB devices

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -119,14 +119,17 @@ class DualSourceRecorder: RecordingProvider {
 
         let micDelay = captureResult.micDelay
         let actualRate = captureResult.actualSampleRate
+        let actualChannels = captureResult.actualChannels
 
         if micDelay != 0 {
             logger.info("Mic delay: \(micDelay)s")
         }
-        // Log prominently — wrong rate here causes Mickey Mouse voice
-        logger.info("App audio actual rate: \(actualRate) Hz (requested: \(self.recordRate) Hz, target: \(self.targetRate) Hz)")
+        logger.info("App audio: \(actualChannels)ch, \(actualRate) Hz (requested: \(self.appChannels)ch, \(self.recordRate) Hz)")
+        if actualChannels != appChannels {
+            logger.warning("App audio channel count differs: actual=\(actualChannels), expected=\(self.appChannels) — mono USB device?")
+        }
         if actualRate != recordRate {
-            logger.warning("App audio rate differs from requested: \(actualRate) vs \(self.recordRate) — USB device may have negotiated different rate")
+            logger.warning("App audio rate differs: actual=\(actualRate), expected=\(self.recordRate) — USB device may have negotiated different rate")
         }
 
         let recDir = Self.recordingsDir
@@ -157,12 +160,17 @@ class DualSourceRecorder: RecordingProvider {
                 }
             }
 
-            // Stereo → mono
-            if appChannels == 2 && floats.count >= 2 {
-                let n = floats.count - (floats.count % 2)
-                var mono = [Float](repeating: 0, count: n / 2)
+            // Multi-channel → mono (passthrough if already mono)
+            if actualChannels >= 2 && floats.count >= actualChannels {
+                let n = floats.count - (floats.count % actualChannels)
+                var mono = [Float](repeating: 0, count: n / actualChannels)
+                let scale = 1.0 / Float(actualChannels)
                 for i in 0 ..< mono.count {
-                    mono[i] = (floats[i * 2] + floats[i * 2 + 1]) / 2
+                    var sum: Float = 0
+                    for ch in 0 ..< actualChannels {
+                        sum += floats[i * actualChannels + ch]
+                    }
+                    mono[i] = sum * scale
                 }
                 appSamples = mono
             } else {

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -35,6 +35,8 @@ public class AppAudioCapture {
     public private(set) var appFirstFrameTime: UInt64 = 0
     /// Actual sample rate of the aggregate device (may differ from requested).
     public private(set) var actualSampleRate: Int = 0
+    /// Actual channel count detected from first IOProc callback.
+    public private(set) var actualChannels: Int = 0
     private var didLogFormat = false
     /// Guard against re-entrant device change handling during async restart.
     private var isRestarting = false
@@ -239,6 +241,8 @@ public class AppAudioCapture {
                 self.didLogFormat = true
                 self.appFirstFrameTime = mach_absolute_time()
 
+                self.actualChannels = Int(abl.mBuffers.mNumberChannels)
+
                 // Verify rate from device — may have changed since startCapture() query
                 let callbackRate = Self.queryNominalSampleRate(deviceID: self.aggregateID)
                 if callbackRate > 0, callbackRate != self.actualSampleRate {
@@ -248,9 +252,10 @@ public class AppAudioCapture {
                     self.actualSampleRate = callbackRate
                 }
 
-                let frames = Int(abl.mBuffers.mDataByteSize) / MemoryLayout<Float>.size
+                let ch = max(self.actualChannels, 1)
+                let frames = Int(abl.mBuffers.mDataByteSize) / (MemoryLayout<Float>.size * ch)
                 logger.info(
-                    "Audio format: \(self.actualSampleRate) Hz, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
+                    "Audio format: \(self.actualSampleRate) Hz, \(self.actualChannels)ch, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
                 )
             }
 

--- a/tools/audiotap/Sources/AudioCaptureResult.swift
+++ b/tools/audiotap/Sources/AudioCaptureResult.swift
@@ -8,6 +8,8 @@ public struct AudioCaptureResult: Sendable {
     public let micAudioFileURL: URL?
     /// Actual sample rate of the aggregate device (may differ from requested).
     public let actualSampleRate: Int
+    /// Actual channel count of the app audio (1=mono, 2=stereo).
+    public let actualChannels: Int
     /// Time delta between app and mic first frames (seconds, positive = mic started later).
     public let micDelay: TimeInterval
 }

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -84,7 +84,9 @@ public class AudioCaptureSession {
             }
         }
 
-        let actualRate = appCapture?.actualSampleRate ?? sampleRate
+        // Fallback to requested values if capture never received audio frames
+        let actualRate = appCapture?.actualSampleRate ?? 0
+        let actualChannels = appCapture?.actualChannels ?? 0
 
         // Close file handle
         try? appFileHandle?.close()
@@ -94,13 +96,14 @@ public class AudioCaptureSession {
             appAudioFileURL: appOutputURL,
             micAudioFileURL: micCapture != nil ? micOutputURL : nil,
             actualSampleRate: actualRate > 0 ? actualRate : sampleRate,
+            actualChannels: actualChannels > 0 ? actualChannels : channels,
             micDelay: micDelay,
         )
 
         appCapture = nil
         micCapture = nil
 
-        logger.info("Capture session stopped (rate: \(result.actualSampleRate), micDelay: \(result.micDelay))")
+        logger.info("Capture session stopped (rate: \(result.actualSampleRate), channels: \(result.actualChannels), micDelay: \(result.micDelay))")
         return result
     }
 }

--- a/tools/audiotap/Tests/AudioCaptureResultTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureResultTests.swift
@@ -1,0 +1,26 @@
+@testable import AudioTapLib
+import XCTest
+
+final class AudioCaptureResultTests: XCTestCase {
+    func testResultStoresMonoChannels() {
+        let result = AudioCaptureResult(
+            appAudioFileURL: URL(fileURLWithPath: "/tmp/test.raw"),
+            micAudioFileURL: nil,
+            actualSampleRate: 48000,
+            actualChannels: 1,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result.actualChannels, 1)
+    }
+
+    func testResultStoresStereoChannels() {
+        let result = AudioCaptureResult(
+            appAudioFileURL: URL(fileURLWithPath: "/tmp/test.raw"),
+            micAudioFileURL: nil,
+            actualSampleRate: 48000,
+            actualChannels: 2,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result.actualChannels, 2)
+    }
+}


### PR DESCRIPTION
## Summary

- Detect actual channel count from IOProc `AudioBufferList.mNumberChannels` on first callback
- Propagate `actualChannels` through `AudioCaptureResult` → `AudioCaptureSession` → `DualSourceRecorder`
- Use detected channel count instead of hardcoded `appChannels=2` for stereo→mono conversion
- Mono devices (e.g. Jabra PRO 930) now correctly pass through as mono instead of halving samples

**Root cause:** The Jabra PRO 930 USB headset has 1 output channel (mono). When it's the system default output, the CATapDescription aggregate device delivers mono audio. The old code always treated raw app audio as stereo interleaved (`appChannels=2`), averaging every pair of consecutive mono samples → half the sample count → double playback speed → Mickey Mouse voice.

## Test Plan

- [x] 21 AudioTapLib tests pass (including 2 new AudioCaptureResult channel tests)
- [x] 743/772 app tests pass (29 pre-existing snapshot failures)
- [x] Lint: 0 serious violations
- [ ] Manual test with Jabra PRO 930 to verify correct mono passthrough