### PR TITLE
fix: detect actual channel count to prevent Mickey Mouse with mono USB devices

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -119,12 +119,17 @@ class DualSourceRecorder: RecordingProvider {
 
         let micDelay = captureResult.micDelay
         let actualRate = captureResult.actualSampleRate
+        let actualChannels = captureResult.actualChannels
 
         if micDelay != 0 {
             logger.info("Mic delay: \(micDelay)s")
         }
+        logger.info("App audio: \(actualChannels)ch, \(actualRate) Hz (requested: \(self.appChannels)ch, \(self.recordRate) Hz)")
+        if actualChannels != appChannels {
+            logger.warning("App audio channel count differs: actual=\(actualChannels), expected=\(self.appChannels) — mono USB device?")
+        }
         if actualRate != recordRate {
-            logger.info("Actual app rate: \(actualRate) Hz")
+            logger.warning("App audio rate differs: actual=\(actualRate), expected=\(self.recordRate)")
         }
 
         let recDir = Self.recordingsDir
@@ -155,17 +160,7 @@ class DualSourceRecorder: RecordingProvider {
                 }
             }
 
-            // Stereo → mono
-            if appChannels == 2 && floats.count >= 2 {
-                let n = floats.count - (floats.count % 2)
-                var mono = [Float](repeating: 0, count: n / 2)
-                for i in 0 ..< mono.count {
-                    mono[i] = (floats[i * 2] + floats[i * 2 + 1]) / 2
-                }
-                appSamples = mono
-            } else {
-                appSamples = floats
-            }
+            appSamples = Self.downmixToMono(floats, channels: actualChannels)
 
             // Resample to 16kHz and save app track
             let appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: targetRate)
@@ -229,6 +224,22 @@ class DualSourceRecorder: RecordingProvider {
             micDelay: micDelay,
             recordingStart: recordingStart,
         )
+    }
+
+    /// Downmix interleaved multi-channel audio to mono. Passthrough if already mono.
+    static func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
+        guard channels >= 2, samples.count >= channels else { return samples }
+        let n = samples.count - (samples.count % channels)
+        var mono = [Float](repeating: 0, count: n / channels)
+        let scale = 1.0 / Float(channels)
+        for i in 0 ..< mono.count {
+            var sum: Float = 0
+            for ch in 0 ..< channels {
+                sum += samples[i * channels + ch]
+            }
+            mono[i] = sum * scale
+        }
+        return mono
     }
 
     private static let timestampFormatter: DateFormatter = {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -81,4 +81,48 @@ final class DualSourceRecorderTests: XCTestCase {
         XCTAssertNil(result.appPath)
         XCTAssertNil(result.micPath)
     }
+
+    // MARK: - downmixToMono
+
+    func testDownmixMonoPassthrough() {
+        let mono: [Float] = [0.1, 0.2, 0.3, 0.4]
+        let result = DualSourceRecorder.downmixToMono(mono, channels: 1)
+        XCTAssertEqual(result, mono)
+    }
+
+    func testDownmixStereoToMono() {
+        // Interleaved stereo: [L1, R1, L2, R2]
+        let stereo: [Float] = [0.2, 0.8, 0.4, 0.6]
+        let result = DualSourceRecorder.downmixToMono(stereo, channels: 2)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0], 0.5, accuracy: 0.001) // (0.2+0.8)/2
+        XCTAssertEqual(result[1], 0.5, accuracy: 0.001) // (0.4+0.6)/2
+    }
+
+    func testDownmixPreservesSampleCount() {
+        // Mono: N samples in → N samples out (no halving)
+        let samples = [Float](repeating: 0.5, count: 1000)
+        let result = DualSourceRecorder.downmixToMono(samples, channels: 1)
+        XCTAssertEqual(result.count, 1000, "Mono passthrough must not halve sample count")
+    }
+
+    func testDownmixStereoHalvesSampleCount() {
+        let samples = [Float](repeating: 0.5, count: 1000)
+        let result = DualSourceRecorder.downmixToMono(samples, channels: 2)
+        XCTAssertEqual(result.count, 500)
+    }
+
+    func testDownmixEmptyArray() {
+        let result = DualSourceRecorder.downmixToMono([], channels: 2)
+        XCTAssertEqual(result, [])
+    }
+
+    func testDownmixIncompleteFrame() {
+        // 5 samples with 2 channels → 4 used (2 frames), last sample dropped
+        let samples: [Float] = [1.0, 0.0, 0.0, 1.0, 0.5]
+        let result = DualSourceRecorder.downmixToMono(samples, channels: 2)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0], 0.5, accuracy: 0.001)
+        XCTAssertEqual(result[1], 0.5, accuracy: 0.001)
+    }
 }

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -35,6 +35,8 @@ public class AppAudioCapture {
     public private(set) var appFirstFrameTime: UInt64 = 0
     /// Actual sample rate of the aggregate device (may differ from requested).
     public private(set) var actualSampleRate: Int = 0
+    /// Actual channel count detected from first IOProc callback.
+    public private(set) var actualChannels: Int = 0
     private var didLogFormat = false
     /// Guard against re-entrant device change handling during async restart.
     private var isRestarting = false
@@ -165,9 +167,11 @@ public class AppAudioCapture {
             if !self.didLogFormat {
                 self.didLogFormat = true
                 self.appFirstFrameTime = mach_absolute_time()
-                let frames = Int(abl.mBuffers.mDataByteSize) / MemoryLayout<Float>.size
+                self.actualChannels = Int(abl.mBuffers.mNumberChannels)
+                let ch = max(self.actualChannels, 1)
+                let frames = Int(abl.mBuffers.mDataByteSize) / (MemoryLayout<Float>.size * ch)
                 logger.info(
-                    "Audio format: \(self.actualSampleRate) Hz, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
+                    "Audio format: \(self.actualSampleRate) Hz, \(self.actualChannels)ch, \(abl.mNumberBuffers) buffers, \(frames) frames/buffer",
                 )
             }
 

--- a/tools/audiotap/Sources/AudioCaptureResult.swift
+++ b/tools/audiotap/Sources/AudioCaptureResult.swift
@@ -8,6 +8,8 @@ public struct AudioCaptureResult: Sendable {
     public let micAudioFileURL: URL?
     /// Actual sample rate of the aggregate device (may differ from requested).
     public let actualSampleRate: Int
+    /// Actual channel count of the app audio (1=mono, 2=stereo).
+    public let actualChannels: Int
     /// Time delta between app and mic first frames (seconds, positive = mic started later).
     public let micDelay: TimeInterval
 }

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -84,7 +84,8 @@ public class AudioCaptureSession {
             }
         }
 
-        let actualRate = appCapture?.actualSampleRate ?? sampleRate
+        let actualRate = appCapture?.actualSampleRate ?? 0
+        let actualChannels = appCapture?.actualChannels ?? 0
 
         // Close file handle
         try? appFileHandle?.close()
@@ -94,13 +95,14 @@ public class AudioCaptureSession {
             appAudioFileURL: appOutputURL,
             micAudioFileURL: micCapture != nil ? micOutputURL : nil,
             actualSampleRate: actualRate > 0 ? actualRate : sampleRate,
+            actualChannels: actualChannels > 0 ? actualChannels : channels,
             micDelay: micDelay,
         )
 
         appCapture = nil
         micCapture = nil
 
-        logger.info("Capture session stopped (rate: \(result.actualSampleRate), micDelay: \(result.micDelay))")
+        logger.info("Capture session stopped (rate: \(result.actualSampleRate), channels: \(result.actualChannels), micDelay: \(result.micDelay))")
         return result
     }
 }


### PR DESCRIPTION
## Summary

- Detect actual channel count from IOProc `AudioBufferList.mNumberChannels` on first callback
- Propagate `actualChannels` through `AudioCaptureResult` → `AudioCaptureSession` → `DualSourceRecorder`
- Use detected channel count instead of hardcoded `appChannels=2` for stereo→mono conversion

**Root cause:** Jabra PRO 930 USB headset has 1 output channel (mono). The aggregate device delivers mono audio, but the code always assumed stereo interleaved — averaging consecutive mono samples as L/R pairs, halving the sample count, producing double-speed Mickey Mouse voice.

## Test Plan

- [x] Lint: 0 serious violations
- [x] Build passes
- [ ] Manual test with Jabra PRO 930 to verify correct mono passthrough