### PR TITLE
docs: update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@
 ```
 VERSION                    # App version (read by build scripts)
 app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
-  Package.swift            # SPM manifest (ViewInspector test dep)
+  Package.swift            # SPM manifest (ViewInspector + SnapshotTesting test deps)
   Sources/
     MeetingTranscriberApp.swift  # @main, UI shell (scenes, NSOpenPanel, NSWorkspace)
     AppState.swift         # @Observable @MainActor ViewModel (business state, badge logic, pipeline wiring)
+    AudioConstants.swift   # Shared audio pipeline constants (target sample rate)
     MenuBarView.swift      # Menu bar dropdown UI
     MenuBarIcon.swift      # Animated waveform menu bar icon + BadgeKind.compute() pure function
     SettingsView.swift     # Settings window
@@ -34,14 +35,16 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     OpenAIProtocolGenerator.swift # OpenAI-compatible API protocol generation (Ollama, LM Studio, etc.)
     WatchLoop.swift        # @MainActor watch loop: detect → record → enqueue PipelineJob
     DualSourceRecorder.swift  # App audio (AudioTapLib) + mic recording (captures startTime in start())
+    MeetingDetecting.swift # MeetingDetecting protocol + DetectedMeeting model
     MeetingDetector.swift  # Window title matching (counts each pattern once per poll)
     FFmpegHelper.swift     # ffmpeg CLI detection + audio extraction for MKV/WebM/OGG
     AudioMixer.swift       # Multi-format audio loading (WAV/MP3/M4A/MP4 via AVAsset fallback, MKV/WebM/OGG via ffmpeg) + mixing to 16kHz mono
     MicRecorder.swift      # Microphone recording via AVAudioEngine
-    MuteDetector.swift     # Mute state detection via accessibility API
+    PermissionRow.swift    # Permission status row UI component
     Permissions.swift      # Permission checks (mic, screen recording)
     ParticipantReader.swift # Reads meeting participants via accessibility
     MeetingPatterns.swift  # App-specific window title patterns
+    PowerAssertionDetector.swift  # Meeting detection via IOKit power assertions (sandbox-safe)
     UpdateChecker.swift    # GitHub release update checker
     Assets.xcassets        # App icon assets
     Info.plist             # Bundle metadata
@@ -58,6 +61,7 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     AudioCaptureSession.swift # Orchestrator (start/stop, computes micDelay)
     AudioCaptureResult.swift  # Result struct
     Helpers.swift          # machTicksToSeconds, getDefaultOutputDeviceUID, writeAllToFileHandle
+    MicRestartPolicy.swift # Pure decision logic for mic engine restart on device change
 tools/meeting-simulator/   # Meeting simulator tool for testing
   Package.swift
   Sources/main.swift
@@ -81,6 +85,9 @@ docs/
   menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol)
   plans/
     swift-architecture.md      # Detailed Swift pipeline architecture
+    appstate-tests.md          # AppState test expansion plan
+    2026-03-10-repo-review.md  # Repository review findings
+    2026-03-21-workflow-integration-tests.md  # Workflow integration test plan
 FluidAudio/                # Local FluidAudio package (CoreML speaker diarization)
 protocols/                 # Output directory (gitignored)
 speakers.json              # Saved voice profiles (gitignored, created at runtime)
@@ -155,7 +162,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 ## Conventions
 
 - All code and UI text in English
-- Protocol output generated in German (via Claude prompt)
+- Protocol output language configurable via `AppSettings.protocolLanguage` (default: German)
 
 ## Architecture Notes
 
@@ -187,6 +194,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - Grace period minimum is 1 second (enforced in `AppSettings.endGrace` setter).
 
 **Detection:**
+- `MeetingDetecting` protocol abstracts detection strategies. Two implementations: `MeetingDetector` (window title matching via `CGWindowListCopyWindowInfo`) and `PowerAssertionDetector` (IOKit power assertions — sandbox-safe, no Screen Recording permission needed).
 - `MeetingDetector` counts each pattern once per poll — prevents over-counting when multiple windows match the same app.
 
 **Diarization:**
@@ -197,7 +205,8 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 **Protocol generation:**
 - `ProtocolGenerating` protocol with two implementations: `ClaudeCLIProtocolGenerator` and `OpenAIProtocolGenerator`.
-- `AppSettings.protocolProvider` enum (`.claudeCLI` / `.openAICompatible`) selects the provider.
+- `AppSettings.protocolProvider` enum (`.claudeCLI` / `.openAICompatible` / `.none`) selects the provider. `.none` skips LLM generation and saves the transcript only.
+- `AppSettings.protocolLanguage` string (default `"German"`) is substituted into the prompt as `{LANGUAGE}`.
 - `ProtocolGenerator.loadPrompt()` loads custom prompt from `AppPaths.customPromptFile` (`~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`), falls back to built-in default.
 - `OpenAIProtocolGenerator` supports any OpenAI-compatible HTTP API (Ollama, LM Studio, llama.cpp, etc.).
 
@@ -220,7 +229,7 @@ Two build variants controlled by compile-time flag `APPSTORE` (`-Xswiftc -DAPPST
 | | Homebrew | App Store |
 |---|---|---|
 | **Claude CLI** | Yes (Process subprocess) | No (sandbox forbids Process) |
-| **OpenAI API** | Yes | Yes (only option) |
+| **OpenAI API** | Yes | Yes (only LLM option) |
 | **Entitlements** | Mic only | Sandbox + mic + network + file picker |
 | **Build** | `./scripts/build_release.sh` | `./scripts/build_release.sh --appstore` |
 | **Tests** | 618 | ~604 (14 CLI tests excluded) |

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -39,7 +39,9 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | File | Role |
 |------|------|
 | `WatchLoop.swift` | Main orchestrator: detect → record → enqueue PipelineJob |
-| `MeetingDetector.swift` | Window polling, pattern matching, confirmation counting, cooldown |
+| `MeetingDetecting.swift` | `MeetingDetecting` protocol + `DetectedMeeting` model |
+| `MeetingDetector.swift` | Window title polling, pattern matching, confirmation counting, cooldown |
+| `PowerAssertionDetector.swift` | IOKit power assertion–based meeting detection (sandbox-safe) |
 | `MeetingPatterns.swift` | Regex patterns for Teams, Zoom, Webex |
 | `DualSourceRecorder.swift` | Orchestrates AudioTapLib capture + mic, mixes tracks |
 | `TranscribingEngine.swift` | `TranscribingEngine` protocol + `mergeDualSourceSegments` default impl |
@@ -51,15 +53,17 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | `FluidDiarizer.swift` | On-device speaker diarization via FluidAudio CoreML/ANE |
 | `SpeakerMatcher.swift` | Speaker embedding DB + cosine similarity matching |
 | `DiarizationProcess.swift` | Diarization result types, DiarizationProvider protocol, speaker assignment (standard + dual-track) |
-| `ProtocolGenerator.swift` | Claude CLI invocation, stream-json parsing |
+| `ProtocolGenerator.swift` | Shared protocol utilities: `ProtocolGenerating` protocol, prompts, file I/O, `ProtocolError` |
+| `ClaudeCLIProtocolGenerator.swift` | Claude CLI subprocess protocol generation (`#if !APPSTORE`) |
+| `OpenAIProtocolGenerator.swift` | OpenAI-compatible API protocol generation (Ollama, LM Studio, etc.) |
 
 ### Audio Processing
 
 | File | Role |
 |------|------|
 | `AudioMixer.swift` | Resampling, mixing, echo suppression, mute masking, WAV I/O |
+| `AudioConstants.swift` | Shared audio pipeline constants (target sample rate) |
 | `MicRecorder.swift` | Microphone recording via AVAudioEngine |
-| `MuteDetector.swift` | Teams mute state via Accessibility API |
 | `tools/audiotap/Sources/` | AudioTapLib — CATapDescription-based app audio capture (SPM library) |
 
 ### Support
@@ -72,6 +76,7 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | `NotificationManager.swift` | macOS notifications |
 | `KeychainHelper.swift` | Legacy keychain CRUD (token now file-based) |
 | `Permissions.swift` | Mic/accessibility permissions, project root detection |
+| `PermissionRow.swift` | Permission status row UI component (icon, detail, help popover) |
 | `ParticipantReader.swift` | Teams participant extraction via Accessibility API |
 
 ---
@@ -214,13 +219,22 @@ When dual-source recording (app + mic) is available:
 
 ## Protocol Generation
 
+### Provider Selection
+
+`AppSettings.protocolProvider` selects the active provider:
+- **`.claudeCLI`** — Claude CLI subprocess (`#if !APPSTORE`)
+- **`.openAICompatible`** — Any OpenAI-compatible HTTP API (Ollama, LM Studio, llama.cpp, etc.)
+- **`.none`** — Skip LLM generation; save transcript only
+
+`AppSettings.protocolLanguage` (default `"German"`) is substituted into the prompt as `{LANGUAGE}`.
+
 ### Claude CLI Invocation
 
 ```bash
 /usr/bin/env claude -p - --output-format stream-json --verbose --model sonnet
 ```
 
-- **Input:** German protocol prompt + transcript piped to stdin
+- **Input:** Protocol prompt (with language substituted) + transcript piped to stdin
 - **Output:** Stream-json parsed line-by-line (content_block_delta + assistant message)
 - **Environment:** `CLAUDECODE` env var stripped to allow nested invocation
 - **Timeout:** 10 minutes
@@ -277,7 +291,7 @@ AppSettings (UserDefaults)
 | Component | Injection Point |
 |-----------|----------------|
 | MeetingDetector | `windowListProvider` closure (mock window list) |
-| MuteDetector | `muteStateProvider` closure |
+| PowerAssertionDetector | `assertionProvider` + `windowListProvider` closures |
 | DiarizationProvider | `diarizationFactory` closure in PipelineQueue |
 | ProtocolGenerating | `protocolGenerator` protocol in PipelineQueue |
 | RecordingProvider | `recorderFactory` closure in WatchLoop |


### PR DESCRIPTION
## Summary

Documentation was out of sync with the codebase after several recent feature additions. This PR updates `CLAUDE.md` and `docs/architecture-macos.md` to reflect the current state of the code.

### Changes

**New source files added to project structure:**
- `AudioConstants.swift` — shared audio pipeline constants (target sample rate)
- `MeetingDetecting.swift` — `MeetingDetecting` protocol + `DetectedMeeting` model
- `PermissionRow.swift` — permission status row UI component
- `PowerAssertionDetector.swift` — IOKit power assertion–based meeting detection
- `MicRestartPolicy.swift` (audiotap) — pure decision logic for mic engine restart on device change

**Removed stale entries:**
- `MuteDetector.swift` — file no longer exists in the codebase

**Protocol generation updates (from `feat(app): add None LLM provider` and `feat(app): make protocol output language configurable`):**
- `ProtocolProvider` enum now has `.none` option (transcript only, no LLM)
- `AppSettings.protocolLanguage` replaces the hardcoded "German" convention note
- Architecture doc updated with a new Provider Selection section and corrected language substitution description

**Other fixes:**
- `Package.swift` description now mentions `SnapshotTesting` test dependency
- Added three new plan files to `docs/plans/` listing
- `architecture-macos.md`: `ProtocolGenerator.swift` description corrected (it's shared utilities, not the CLI invoker); `ClaudeCLIProtocolGenerator.swift` and `OpenAIProtocolGenerator.swift` added as separate table rows
- Testing Hooks table: replaced stale `MuteDetector / muteStateProvider` row with `PowerAssertionDetector / assertionProvider + windowListProvider`

https://claude.ai/code/session_01Vrp4inxdcSo3sFFqWpdD2C