### PR TITLE
docs: update CLAUDE.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ```
 VERSION                    # App version (read by build scripts)
 app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
-  Package.swift            # SPM manifest (ViewInspector + SnapshotTesting test deps)
+  Package.swift            # SPM manifest (WhisperKit + FluidAudio + AudioTapLib runtime deps; ViewInspector + SnapshotTesting test deps)
   Sources/
     MeetingTranscriberApp.swift  # @main, UI shell (scenes, NSOpenPanel, NSWorkspace)
     AppState.swift         # @Observable @MainActor ViewModel (business state, badge logic, pipeline wiring)
@@ -65,6 +65,9 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
 tools/meeting-simulator/   # Meeting simulator tool for testing
   Package.swift
   Sources/main.swift
+tools/whisperkit-cli/      # WhisperKit CLI transcription tool (used by build_whisperkit.sh)
+  Package.swift
+  Sources/main.swift
 scripts/
   build_whisperkit.sh      # Build WhisperKit CLI tool
   build_release.sh         # Build self-contained .app bundle + DMG (--appstore for App Store variant)
@@ -88,7 +91,6 @@ docs/
     appstate-tests.md          # AppState test expansion plan
     2026-03-10-repo-review.md  # Repository review findings
     2026-03-21-workflow-integration-tests.md  # Workflow integration test plan
-FluidAudio/                # Local FluidAudio package (CoreML speaker diarization)
 protocols/                 # Output directory (gitignored)
 speakers.json              # Saved voice profiles (gitignored, created at runtime)
 .env                       # Environment variables (gitignored)


### PR DESCRIPTION
## Summary

- **Remove `FluidAudio/` from project structure** — it was listed as a local package directory, but `FluidAudio` is a remote git dependency (`https://github.com/FluidInference/FluidAudio.git`). The directory does not exist in the repo.
- **Add `tools/whisperkit-cli/`** — this tool exists in the codebase but was missing from the project structure tree.
- **Fix `Package.swift` description** — it only mentioned `ViewInspector + SnapshotTesting` (test deps), omitting the runtime dependencies `WhisperKit`, `FluidAudio`, and `AudioTapLib`.

No other docs needed changes: `README.md`, `CONTRIBUTING.md`, and `docs/architecture-macos.md` are all accurate.

## Test plan

- [x] Verify `FluidAudio/` directory does not exist locally (`ls FluidAudio` → not found)
- [x] Verify `tools/whisperkit-cli/` directory exists with `Package.swift` and `Sources/main.swift`
- [x] Verify `app/MeetingTranscriber/Package.swift` lists WhisperKit, FluidAudio, AudioTapLib as dependencies

https://claude.ai/code/session_01GzdM1vzuoxfCDELcRhAfpn