### PR TITLE
docs: remove non-existent generate_test_audio_10speakers.sh from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,6 @@ scripts/
   run_app.sh               # Build + sign + launch menu bar app bundle
   generate_test_audio.sh   # Generate 2-speaker test WAV fixture (requires sox)
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
-  generate_test_audio_10speakers.sh # Generate 10-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
 Casks/meeting-transcriber.rb # Homebrew Cask formula


### PR DESCRIPTION
## Summary

- Removes `generate_test_audio_10speakers.sh` from the project structure in `CLAUDE.md` — the script was listed but never created and does not exist in `scripts/`

## What changed and why

`scripts/generate_test_audio_10speakers.sh` is referenced in the CLAUDE.md project structure but does not exist on disk. The actual test fixtures only go up to 3 speakers (`three_speakers_de.wav`). This was a stale entry.

All other documentation (`README.md`, `CONTRIBUTING.md`, `docs/architecture-macos.md`) was reviewed and found to be accurate and up to date.

## Test plan

- [x] Verify `scripts/generate_test_audio_10speakers.sh` does not exist
- [x] Confirm all other scripts listed in CLAUDE.md exist in `scripts/`

https://claude.ai/code/session_01DAPvHqrYrrXWCJ6YqfzGTD