### PR TITLE
chore(app): update FluidAudio to 0.13.4

### DIFF
--- a/app/MeetingTranscriber/Package.resolved
+++ b/app/MeetingTranscriber/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "4361d4e1c10df3bcee3d7f36d902159cda9fc4bb5b40cb1e65111d0cbc0603be",
+  "originHash" : "6323de4d59fb933b99af9c613ae08085cfee4710b6fa51f09ccda9215ed23485",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "9830ce835881c0d0d40f90aabfaae3a6da5bebfb",
-        "version" : "0.12.4"
+        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
+        "version" : "0.13.4"
       }
     },
     {

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.1"),
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.17.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
         .package(path: "../../tools/audiotap"),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- Update FluidAudio from 0.12.4 to 0.13.4
- FluidAudio 0.13.4 replaces `swift-transformers` with a minimal BPE tokenizer, eliminating the version conflict with WhisperKit

## Test plan
- [x] `swift build` compiles successfully
- [x] `swift test` — all tests pass except pre-existing snapshot test failures