### PR TITLE
fix(app): resolve SwiftFormat 0.60.1 lint violations

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -45,6 +45,7 @@ enum ProtocolProvider: String, CaseIterable {
         #endif
 
         case .openAICompatible: "OpenAI-Compatible API"
+
         case .none: "None (Transcript Only)"
         }
     }

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 
 /// Pattern definition for detecting active meetings via window titles.
-struct AppMeetingPattern: Sendable {
+struct AppMeetingPattern {
     let appName: String
     let ownerNames: [String]
     let meetingPatterns: [String]

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum JobState: String, Codable, Sendable {
+enum JobState: String, Codable {
     case waiting
     case transcribing
     case diarizing
@@ -22,7 +22,7 @@ enum JobState: String, Codable, Sendable {
     }
 }
 
-struct PipelineJob: Identifiable, Codable, Sendable {
+struct PipelineJob: Identifiable, Codable {
     let id: UUID
     let meetingTitle: String
     let appName: String

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -68,7 +68,6 @@ enum ProtocolGenerator {
     Use these labels to identify participants. \
     In the Participants section, list them by name where possible. \
     In the Topics Discussed section, attribute key statements to speakers.
-
     """
 
     /// Load the protocol prompt, preferring a custom file over the built-in default.
@@ -148,12 +147,16 @@ enum ProtocolError: LocalizedError {
         switch self {
         #if !APPSTORE
             case let .cliNotFound(bin): "'\(bin)' CLI not found. Install: npm install -g @anthropic-ai/claude-code"
+
             case let .cliFailed(code, stderr): "Claude CLI exited with code \(code)\(stderr.isEmpty ? "" : ": \(stderr)")"
+
             case .timeout: "Claude CLI took too long (>10 min)"
         #endif
 
         case .emptyProtocol: "Protocol is empty. Tip: Test manually: echo Hello | claude --print"
+
         case let .httpError(code, body): "HTTP \(code)\(body.isEmpty ? "" : ": \(body)")"
+
         case let .connectionFailed(reason): "Connection failed: \(reason)"
         }
     }

--- a/app/MeetingTranscriber/Sources/UpdateChecker.swift
+++ b/app/MeetingTranscriber/Sources/UpdateChecker.swift
@@ -3,7 +3,7 @@ import Observation
 
 // MARK: - Models
 
-struct ReleaseInfo: Sendable, Equatable {
+struct ReleaseInfo: Equatable {
     let tagName: String
     let name: String
     let prerelease: Bool

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -16,7 +16,7 @@ struct ManualRecordingInfo {
 @MainActor
 @Observable
 class WatchLoop {
-    enum State: String, Sendable {
+    enum State: String {
         case idle
         case watching
         case recording


### PR DESCRIPTION
## Summary
- Remove redundant explicit `Sendable` conformances from non-public types (`redundantSendable` rule)
- Fix `consistentSwitchCaseSpacing` in switch statements with `#if` blocks
- Remove trailing whitespace in multiline string literal

CI runner upgraded to SwiftFormat 0.60.1 which introduced these new rules.

## Test plan
- [x] `./scripts/lint.sh` passes with SwiftFormat 0.60.1
- [x] No functional code changes