### PR TITLE
feat(app): add VAD preprocessing via FluidAudio Silero v6

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -144,6 +144,14 @@ final class AppSettings {
         didSet { defaults.set(diarize, forKey: "diarize") }
     }
 
+    var vadEnabled: Bool = defaults.object(forKey: "vadEnabled") as? Bool ?? false {
+        didSet { defaults.set(vadEnabled, forKey: "vadEnabled") }
+    }
+
+    var vadThreshold: Float = defaults.object(forKey: "vadThreshold") as? Float ?? 0.5 {
+        didSet { defaults.set(vadThreshold, forKey: "vadThreshold") }
+    }
+
     /// Number of expected speakers. 0 = auto-detect.
     var numSpeakers: Int = defaults.object(forKey: "numSpeakers") as? Int ?? 0 {
         didSet {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -279,6 +279,7 @@ final class AppState {
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
+            vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
         )
         queue.loadSnapshot()
         queue.recoverOrphanedRecordings()

--- a/app/MeetingTranscriber/Sources/FluidVAD.swift
+++ b/app/MeetingTranscriber/Sources/FluidVAD.swift
@@ -1,0 +1,174 @@
+import FluidAudio
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "FluidVAD")
+
+// MARK: - VADConfig
+
+/// Configuration for Voice Activity Detection.
+/// Used by PipelineQueue: `nil` means disabled, non-nil means enabled.
+struct VADConfig {
+    let threshold: Float
+}
+
+// MARK: - SpeechRegion
+
+/// A contiguous region of detected speech.
+struct SpeechRegion {
+    let start: TimeInterval
+    let end: TimeInterval
+
+    var duration: TimeInterval {
+        end - start
+    }
+}
+
+// MARK: - VadSegmentMap
+
+/// Maps between trimmed (speech-only) and original audio timelines.
+/// Pure value type — no FluidAudio dependency, fully testable.
+struct VadSegmentMap {
+    let segments: [SpeechRegion]
+    let sampleRate: Int
+
+    /// Duration of the original audio (last segment's end, or 0).
+    var originalDuration: TimeInterval {
+        segments.last?.end ?? 0
+    }
+
+    /// Total duration of speech-only audio.
+    var trimmedDuration: TimeInterval {
+        segments.reduce(0) { $0 + $1.duration }
+    }
+
+    /// Convert a timestamp in trimmed audio back to the original timeline.
+    func toOriginalTime(_ trimmedTime: TimeInterval) -> TimeInterval {
+        var remaining = trimmedTime
+        for segment in segments {
+            let segDuration = segment.duration
+            if remaining <= segDuration {
+                return segment.start + remaining
+            }
+            remaining -= segDuration
+        }
+        // Past end — return last segment's end
+        return segments.last?.end ?? trimmedTime
+    }
+
+    /// Remap transcript segment timestamps from trimmed back to original timeline.
+    func remapTimestamps(_ transcript: [TimestampedSegment]) -> [TimestampedSegment] {
+        transcript.map { seg in
+            TimestampedSegment(
+                start: toOriginalTime(seg.start),
+                end: toOriginalTime(seg.end),
+                text: seg.text,
+                speaker: seg.speaker,
+            )
+        }
+    }
+
+    /// Extract speech-only samples from the full audio buffer.
+    func extractSpeechSamples(from audio: [Float]) -> [Float] {
+        let totalSamples = segments.reduce(0) { acc, seg in
+            acc + max(0, Int(seg.end * Double(sampleRate)) - Int(seg.start * Double(sampleRate)))
+        }
+        var result: [Float] = []
+        result.reserveCapacity(totalSamples)
+        for segment in segments {
+            let startSample = Int(segment.start * Double(sampleRate))
+            let endSample = min(Int(segment.end * Double(sampleRate)), audio.count)
+            guard startSample < endSample, startSample < audio.count else { continue }
+            result.append(contentsOf: audio[startSample ..< endSample])
+        }
+        return result
+    }
+}
+
+// MARK: - FluidVAD
+
+/// Voice Activity Detection using FluidAudio's Silero VAD v6.
+/// Lazily creates VadManager on first use.
+class FluidVAD {
+    private static let mergeGapSeconds: TimeInterval = 0.3
+    private static let minRegionSeconds: TimeInterval = 0.15
+
+    private let threshold: Float
+    private var manager: VadManager?
+
+    init(threshold: Float = 0.5) {
+        self.threshold = threshold
+    }
+
+    /// Ensure the VadManager is loaded, creating it lazily on first use.
+    private func ensureManager() async throws -> VadManager {
+        if let manager { return manager }
+        let config = VadConfig(defaultThreshold: threshold)
+        let mgr = try await VadManager(config: config)
+        manager = mgr
+        logger.info("VAD model loaded (threshold: \(self.threshold))")
+        return mgr
+    }
+
+    /// Detect speech regions from pre-loaded audio samples (16kHz Float32).
+    func detectSpeech(samples: [Float]) async throws -> VadSegmentMap {
+        let mgr = try await ensureManager()
+        let results = try await mgr.process(samples)
+        return buildSegmentMap(from: results)
+    }
+
+    /// Convert per-chunk VAD results into merged, filtered speech regions.
+    private func buildSegmentMap(from results: [VadResult]) -> VadSegmentMap {
+        // Convert per-chunk results to speech regions
+        let chunkDuration = Double(VadManager.chunkSize) / Double(VadManager.sampleRate) // ~0.256s
+        var regions: [SpeechRegion] = []
+        var speechStart: TimeInterval?
+
+        for (index, result) in results.enumerated() {
+            let chunkTime = Double(index) * chunkDuration
+            if result.probability >= threshold {
+                if speechStart == nil {
+                    speechStart = chunkTime
+                }
+            } else if let start = speechStart {
+                regions.append(SpeechRegion(start: start, end: chunkTime))
+                speechStart = nil
+            }
+        }
+        // Close any open region
+        if let start = speechStart {
+            let endTime = Double(results.count) * chunkDuration
+            regions.append(SpeechRegion(start: start, end: endTime))
+        }
+
+        // Merge regions with gaps < mergeGapSeconds
+        regions = mergeCloseRegions(regions, maxGap: Self.mergeGapSeconds)
+
+        // Filter regions shorter than minRegionSeconds
+        regions = regions.filter { $0.duration >= Self.minRegionSeconds }
+
+        let totalDuration = Double(results.count) * chunkDuration
+        let speechDuration = regions.reduce(0.0) { $0 + $1.duration }
+        let speechStr = String(format: "%.1f", speechDuration)
+        let totalStr = String(format: "%.1f", totalDuration)
+        logger.info("VAD: \(regions.count) speech regions, \(speechStr)s speech / \(totalStr)s total")
+
+        return VadSegmentMap(segments: regions, sampleRate: AudioConstants.targetSampleRate)
+    }
+
+    /// Merge regions that are closer together than maxGap seconds.
+    private func mergeCloseRegions(_ regions: [SpeechRegion], maxGap: TimeInterval) -> [SpeechRegion] {
+        guard !regions.isEmpty else { return [] }
+        var merged: [SpeechRegion] = [regions[0]]
+        for region in regions.dropFirst() {
+            // swiftlint:disable:next force_unwrapping
+            let last = merged.last!
+            if region.start - last.end < maxGap {
+                merged[merged.count - 1] = SpeechRegion(start: last.start, end: region.end)
+            } else {
+                merged.append(region)
+            }
+        }
+        return merged
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -20,8 +20,12 @@ class PipelineQueue {
     let numSpeakers: Int
     let micLabel: String
     let speakerMatcherFactory: () -> SpeakerMatcher
+    let vadConfig: VADConfig?
 
     let completedJobLifetime: TimeInterval
+
+    /// Cached FluidVAD instance — reused across jobs to avoid model reload.
+    private var vad: FluidVAD?
 
     /// Elapsed seconds since the current pipeline stage started.
     private(set) var activeJobElapsed: TimeInterval = 0
@@ -87,6 +91,7 @@ class PipelineQueue {
         self.numSpeakers = 0
         self.micLabel = "Me"
         self.speakerMatcherFactory = { SpeakerMatcher() }
+        self.vadConfig = nil
         self.completedJobLifetime = completedJobLifetime
     }
 
@@ -101,6 +106,7 @@ class PipelineQueue {
         numSpeakers: Int = 0,
         micLabel: String = "Me",
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = { SpeakerMatcher() },
+        vadConfig: VADConfig? = nil,
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
@@ -112,6 +118,7 @@ class PipelineQueue {
         self.numSpeakers = numSpeakers
         self.micLabel = micLabel
         self.speakerMatcherFactory = speakerMatcherFactory
+        self.vadConfig = vadConfig
         self.completedJobLifetime = completedJobLifetime
     }
 
@@ -285,8 +292,24 @@ class PipelineQueue {
                 let mix16k = workDir.appendingPathComponent("mix_16k.wav")
                 try await AudioMixer.resampleFile(from: mixPath, to: mix16k)
 
+                // Optional VAD preprocessing: trim silence before transcription
+                var vadMap: VadSegmentMap?
+                let transcriptionPath: URL
+                if vadConfig != nil, let vadResult = try await preprocessWithVAD(audioPath: mix16k, workDir: workDir) {
+                    transcriptionPath = vadResult.trimmedPath
+                    vadMap = vadResult.map
+                } else {
+                    transcriptionPath = mix16k
+                }
+
                 // Use transcribeSegments to cache results for diarization
-                let segments = try await engine.transcribeSegments(audioPath: mix16k)
+                var segments = try await engine.transcribeSegments(audioPath: transcriptionPath)
+
+                // Remap timestamps back to original timeline if VAD was used
+                if let map = vadMap {
+                    segments = map.remapTimestamps(segments)
+                }
+
                 cachedSegments = segments
                 transcript = segments.map { "\($0.formattedTimestamp) \($0.text)" }.joined(separator: "\n")
             }
@@ -549,6 +572,43 @@ class PipelineQueue {
 
         isProcessing = false
         triggerProcessing()
+    }
+
+    // MARK: - VAD Preprocessing
+
+    /// Run VAD on a 16kHz audio file. Returns trimmed audio path and segment map,
+    /// or nil if no speech regions are detected.
+    private func preprocessWithVAD(audioPath: URL, workDir: URL) async throws
+        -> (trimmedPath: URL, map: VadSegmentMap)? {
+        guard let vadConfig else { return nil }
+
+        // Lazily create FluidVAD on first use, reuse across jobs
+        if vad == nil {
+            vad = FluidVAD(threshold: vadConfig.threshold)
+        }
+
+        // Load audio once, pass samples to VAD to avoid double file load
+        let (samples, _) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
+
+        // swiftlint:disable:next force_unwrapping
+        let map = try await vad!.detectSpeech(samples: samples)
+
+        guard !map.segments.isEmpty else {
+            logger.info("VAD: no speech detected")
+            return nil
+        }
+
+        let speechSamples = map.extractSpeechSamples(from: samples)
+        guard !speechSamples.isEmpty else { return nil }
+
+        let trimmedPath = workDir.appendingPathComponent("vad_trimmed.wav")
+        try AudioMixer.saveWAV(samples: speechSamples, sampleRate: AudioConstants.targetSampleRate, url: trimmedPath)
+
+        let origStr = String(format: "%.1f", map.originalDuration)
+        let trimStr = String(format: "%.1f", map.trimmedDuration)
+        logger.info("VAD trimmed: \(origStr)s → \(trimStr)s")
+
+        return (trimmedPath, map)
     }
 
     // MARK: - Snapshot Recovery

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -191,6 +191,19 @@ struct SettingsView: View {
                             .labelsHidden()
                     }
                 }
+
+                Toggle("Voice Activity Detection (VAD)", isOn: $settings.vadEnabled)
+                    .help("Remove silence before transcription for better results")
+
+                if settings.vadEnabled {
+                    HStack {
+                        Text("Threshold:")
+                        Slider(value: $settings.vadThreshold, in: 0.3 ... 0.9, step: 0.05)
+                        Text(String(format: "%.2f", settings.vadThreshold))
+                            .monospacedDigit()
+                            .frame(width: 35)
+                    }
+                }
             }
 
             // swiftlint:disable:next closure_body_length

--- a/app/MeetingTranscriber/Tests/FluidVADTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidVADTests.swift
@@ -1,0 +1,124 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class FluidVADTests: XCTestCase {
+    // MARK: - VadSegmentMap Tests
+
+    func testSegmentMapEmpty() {
+        let map = VadSegmentMap(segments: [], sampleRate: 16000)
+        XCTAssertEqual(map.originalDuration, 0)
+        XCTAssertEqual(map.trimmedDuration, 0)
+    }
+
+    func testSegmentMapSingleSegment() {
+        // Single speech region from 1.0s to 3.0s (duration = 2.0s)
+        let map = VadSegmentMap(
+            segments: [SpeechRegion(start: 1.0, end: 3.0)],
+            sampleRate: 16000,
+        )
+
+        XCTAssertEqual(map.originalDuration, 3.0)
+        XCTAssertEqual(map.trimmedDuration, 2.0, accuracy: 1e-9)
+
+        // Trimmed time 0.0 maps to original time 1.0 (start of first segment)
+        XCTAssertEqual(map.toOriginalTime(0.0), 1.0, accuracy: 1e-9)
+
+        // Trimmed time 1.5 maps to original time 2.5 (1.0 + 1.5)
+        XCTAssertEqual(map.toOriginalTime(1.5), 2.5, accuracy: 1e-9)
+
+        // Trimmed time 2.0 maps to original time 3.0 (end of segment)
+        XCTAssertEqual(map.toOriginalTime(2.0), 3.0, accuracy: 1e-9)
+    }
+
+    func testSegmentMapMultipleSegments() {
+        // Two speech regions: 1.0–2.0 (1s) and 4.0–5.0 (1s)
+        let map = VadSegmentMap(
+            segments: [
+                SpeechRegion(start: 1.0, end: 2.0),
+                SpeechRegion(start: 4.0, end: 5.0),
+            ],
+            sampleRate: 16000,
+        )
+
+        XCTAssertEqual(map.originalDuration, 5.0)
+        XCTAssertEqual(map.trimmedDuration, 2.0, accuracy: 1e-9)
+
+        // Trimmed 0.0 → original 1.0 (start of first segment)
+        XCTAssertEqual(map.toOriginalTime(0.0), 1.0, accuracy: 1e-9)
+
+        // Trimmed 0.5 → original 1.5 (middle of first segment)
+        XCTAssertEqual(map.toOriginalTime(0.5), 1.5, accuracy: 1e-9)
+
+        // Trimmed 1.0 → original 2.0 (end of first segment)
+        XCTAssertEqual(map.toOriginalTime(1.0), 2.0, accuracy: 1e-9)
+
+        // Trimmed 1.5 → original 4.5 (middle of second segment)
+        XCTAssertEqual(map.toOriginalTime(1.5), 4.5, accuracy: 1e-9)
+
+        // Trimmed 2.0 → original 5.0 (end of second segment)
+        XCTAssertEqual(map.toOriginalTime(2.0), 5.0, accuracy: 1e-9)
+    }
+
+    func testSegmentMapRemapsTranscriptSegments() {
+        // Speech regions: 1.0–2.0 and 4.0–5.0
+        let map = VadSegmentMap(
+            segments: [
+                SpeechRegion(start: 1.0, end: 2.0),
+                SpeechRegion(start: 4.0, end: 5.0),
+            ],
+            sampleRate: 16000,
+        )
+
+        let transcript = [
+            TimestampedSegment(start: 0.0, end: 0.8, text: "Hello"),
+            TimestampedSegment(start: 1.0, end: 1.8, text: "World"),
+        ]
+
+        let remapped = map.remapTimestamps(transcript)
+
+        // First segment: 0.0 → 1.0, 0.8 → 1.8
+        XCTAssertEqual(remapped[0].start, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(remapped[0].end, 1.8, accuracy: 1e-9)
+        XCTAssertEqual(remapped[0].text, "Hello")
+
+        // Second segment: 1.0 → 2.0 (end of first speech region),
+        // but actually 1.0 maps to end of first region = 2.0
+        // 1.8 maps into second region: 1.8 - 1.0 = 0.8 into second region → 4.0 + 0.8 = 4.8
+        XCTAssertEqual(remapped[1].start, 2.0, accuracy: 1e-9)
+        XCTAssertEqual(remapped[1].end, 4.8, accuracy: 1e-9)
+        XCTAssertEqual(remapped[1].text, "World")
+    }
+
+    func testExtractSpeechSamples() {
+        // Use 100 Hz sample rate for easy math
+        let map = VadSegmentMap(
+            segments: [
+                SpeechRegion(start: 1.0, end: 2.0), // samples 100–199
+                SpeechRegion(start: 3.0, end: 4.0), // samples 300–399
+            ],
+            sampleRate: 100,
+        )
+
+        // Create audio: 500 samples (5 seconds at 100 Hz)
+        // Each sample = its index for easy verification
+        let audio = (0 ..< 500).map { Float($0) }
+
+        let extracted = map.extractSpeechSamples(from: audio)
+
+        // Should have 200 samples (100 from each region)
+        XCTAssertEqual(extracted.count, 200)
+
+        // First 100 samples should be from indices 100–199
+        XCTAssertEqual(extracted[0], 100.0)
+        XCTAssertEqual(extracted[99], 199.0)
+
+        // Next 100 samples should be from indices 300–399
+        XCTAssertEqual(extracted[100], 300.0)
+        XCTAssertEqual(extracted[199], 399.0)
+    }
+
+    func testSpeechRegionDuration() {
+        let region = SpeechRegion(start: 1.5, end: 3.5)
+        XCTAssertEqual(region.duration, 2.0, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Voice Activity Detection (VAD) using FluidAudio's Silero v6 model (CoreML/ANE)
- Removes silence before transcription, improving accuracy and speed
- New types: `SpeechRegion`, `VadSegmentMap` (pure, testable), `FluidVAD` (wrapper)
- Settings: `vadEnabled` (default off), `vadThreshold` (0.3–0.9 slider)
- Pipeline: single-source path preprocesses with VAD when enabled

Inspired by @execsumo's work in #70.

## Test plan
- [x] 6 unit tests for VadSegmentMap (empty, single, multi, remap, extract, duration)
- [x] Build passes
- [x] Lint clean (0 violations)
- [x] Manual: enable VAD in Settings, record a meeting, verify transcript quality