### PR TITLE
feat(app): add Sortformer diarizer mode for overlap-aware speaker diarization

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -31,6 +31,18 @@ enum TranscriptionEngineSetting: String, CaseIterable {
     }
 }
 
+enum DiarizerMode: String, CaseIterable {
+    case offline
+    case sortformer
+
+    var label: String {
+        switch self {
+        case .offline: "Offline (Clustering)"
+        case .sortformer: "Sortformer (Overlap-aware)"
+        }
+    }
+}
+
 enum ProtocolProvider: String, CaseIterable {
     #if !APPSTORE
         case claudeCLI
@@ -155,6 +167,16 @@ final class AppSettings {
 
     var vadThreshold: Float = defaults.object(forKey: "vadThreshold") as? Float ?? 0.5 {
         didSet { defaults.set(vadThreshold, forKey: "vadThreshold") }
+    }
+
+    var diarizerMode: DiarizerMode = {
+        if let raw = defaults.string(forKey: "diarizerMode"),
+           let mode = DiarizerMode(rawValue: raw) {
+            return mode
+        }
+        return .offline
+    }() {
+        didSet { defaults.set(diarizerMode.rawValue, forKey: "diarizerMode") }
     }
 
     /// Number of expected speakers. 0 = auto-detect.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -276,7 +276,7 @@ final class AppState {
     func makePipelineQueue() -> PipelineQueue {
         let queue = PipelineQueue(
             engine: activeTranscriptionEngine,
-            diarizationFactory: { FluidDiarizer() },
+            diarizationFactory: { [self] in FluidDiarizer(mode: settings.diarizerMode) },
             protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
             outputDir: settings.effectiveOutputDir,
             diarizeEnabled: settings.diarize,

--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -6,11 +6,18 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "FluidDi
 
 /// CoreML-based speaker diarization using FluidAudio (on-device, no HuggingFace token needed).
 class FluidDiarizer: DiarizationProvider {
-    private var manager: OfflineDiarizerManager?
+    let mode: DiarizerMode
+
+    private var offlineManager: OfflineDiarizerManager?
+    private var sortformerDiarizer: SortformerDiarizer?
     private var currentNumSpeakers: Int?
 
     var isAvailable: Bool {
         true
+    }
+
+    init(mode: DiarizerMode = .offline) {
+        self.mode = mode
     }
 
     /// Normalize FluidAudio's "Speaker 0" format to "SPEAKER_0".
@@ -18,23 +25,42 @@ class FluidDiarizer: DiarizationProvider {
         id.replacingOccurrences(of: "Speaker ", with: "SPEAKER_")
     }
 
-    func run(audioPath: URL, numSpeakers: Int?, meetingTitle _: String) async throws -> MeetingTranscriber.DiarizationResult {
+    func run(
+        audioPath: URL,
+        numSpeakers: Int?,
+        meetingTitle _: String,
+    ) async throws -> MeetingTranscriber.DiarizationResult {
+        switch mode {
+        case .offline:
+            try await runOffline(audioPath: audioPath, numSpeakers: numSpeakers)
+
+        case .sortformer:
+            try await runSortformer(audioPath: audioPath)
+        }
+    }
+
+    // MARK: - Offline Mode (OfflineDiarizerManager)
+
+    private func runOffline(
+        audioPath: URL,
+        numSpeakers: Int?,
+    ) async throws -> MeetingTranscriber.DiarizationResult {
         // Recreate manager if numSpeakers changed
-        if manager == nil || numSpeakers != currentNumSpeakers {
+        if offlineManager == nil || numSpeakers != currentNumSpeakers {
             var config = OfflineDiarizerConfig()
             if let n = numSpeakers, n > 0 {
                 config = config.withSpeakers(exactly: n)
             }
             let newManager = OfflineDiarizerManager(config: config)
             try await newManager.prepareModels()
-            manager = newManager
+            offlineManager = newManager
             currentNumSpeakers = numSpeakers
-            logger.info("FluidAudio models ready")
+            logger.info("FluidAudio offline models ready")
         }
 
-        logger.info("Starting diarization: \(audioPath.lastPathComponent)")
+        logger.info("Starting offline diarization: \(audioPath.lastPathComponent)")
         // swiftlint:disable:next force_unwrapping
-        let fluidResult = try await manager!.process(audioPath)
+        let fluidResult = try await offlineManager!.process(audioPath)
 
         let segments = fluidResult.segments.map { seg in
             MeetingTranscriber.DiarizationResult.Segment(
@@ -44,13 +70,53 @@ class FluidDiarizer: DiarizationProvider {
             )
         }
 
+        return buildResult(segments: segments, speakerDatabase: fluidResult.speakerDatabase)
+    }
+
+    // MARK: - Sortformer Mode (SortformerDiarizer)
+
+    private func runSortformer(audioPath: URL) async throws -> MeetingTranscriber.DiarizationResult {
+        if sortformerDiarizer == nil {
+            let diarizer = SortformerDiarizer()
+            let models = try await SortformerModels.loadFromHuggingFace(config: .default)
+            diarizer.initialize(models: models)
+            sortformerDiarizer = diarizer
+            logger.info("FluidAudio Sortformer models ready")
+        }
+
+        logger.info("Starting Sortformer diarization: \(audioPath.lastPathComponent)")
+        // swiftlint:disable:next force_unwrapping
+        let timeline = try sortformerDiarizer!.processComplete(audioFileURL: audioPath)
+
+        let segments = timeline.speakers.flatMap { index, speaker in
+            let label = Self.normalizeSpeakerId(speaker.name ?? "Speaker \(index)")
+            return speaker.finalizedSegments.map { seg in
+                MeetingTranscriber.DiarizationResult.Segment(
+                    start: TimeInterval(seg.startTime),
+                    end: TimeInterval(seg.endTime),
+                    speaker: label,
+                )
+            }
+        }
+
+        return buildResult(segments: segments, speakerDatabase: nil)
+    }
+
+    // MARK: - Shared Result Conversion
+
+    private func buildResult(
+        segments unsorted: [MeetingTranscriber.DiarizationResult.Segment],
+        speakerDatabase: [String: [Float]]?, // swiftlint:disable:this discouraged_optional_collection
+    ) -> MeetingTranscriber.DiarizationResult {
+        let segments = unsorted.sorted { $0.start < $1.start }
+
         var speakingTimes: [String: TimeInterval] = [:]
         for seg in segments {
             speakingTimes[seg.speaker, default: 0] += seg.end - seg.start
         }
 
         var embeddings: [String: [Float]]? // swiftlint:disable:this discouraged_optional_collection
-        if let db = fluidResult.speakerDatabase {
+        if let db = speakerDatabase {
             embeddings = [:]
             for (id, emb) in db {
                 embeddings?[Self.normalizeSpeakerId(id)] = emb

--- a/app/MeetingTranscriber/Sources/FluidVAD.swift
+++ b/app/MeetingTranscriber/Sources/FluidVAD.swift
@@ -119,7 +119,6 @@ class FluidVAD {
 
     /// Convert per-chunk VAD results into merged, filtered speech regions.
     private func buildSegmentMap(from results: [VadResult]) -> VadSegmentMap {
-        // Convert per-chunk results to speech regions
         let chunkDuration = Double(VadManager.chunkSize) / Double(VadManager.sampleRate) // ~0.256s
         var regions: [SpeechRegion] = []
         var speechStart: TimeInterval?
@@ -141,10 +140,7 @@ class FluidVAD {
             regions.append(SpeechRegion(start: start, end: endTime))
         }
 
-        // Merge regions with gaps < mergeGapSeconds
         regions = mergeCloseRegions(regions, maxGap: Self.mergeGapSeconds)
-
-        // Filter regions shorter than minRegionSeconds
         regions = regions.filter { $0.duration >= Self.minRegionSeconds }
 
         let totalDuration = Double(results.count) * chunkDuration

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -117,8 +117,8 @@ final class ParakeetEngine: TranscribingEngine {
         audioPath: URL,
     ) async throws -> ASRResult {
         guard let booster = vocabularyBooster else { return result }
-        let audioConverter = AudioConverter()
-        let audioSamples = try audioConverter.resampleAudioFile(audioPath)
+        // Audio is already 16kHz mono at this point (resampled by PipelineQueue)
+        let (audioSamples, _) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
 
         let spotResult = try await booster.spotter.spotKeywordsWithLogProbs(
             audioSamples: audioSamples,

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -311,7 +311,7 @@ class PipelineQueue {
                 }
 
                 cachedSegments = segments
-                transcript = segments.map { "\($0.formattedTimestamp) \($0.text)" }.joined(separator: "\n")
+                transcript = segments.map(\.formattedLine).joined(separator: "\n")
             }
 
             stopElapsedTimer()
@@ -582,16 +582,14 @@ class PipelineQueue {
         -> (trimmedPath: URL, map: VadSegmentMap)? {
         guard let vadConfig else { return nil }
 
-        // Lazily create FluidVAD on first use, reuse across jobs
-        if vad == nil {
-            vad = FluidVAD(threshold: vadConfig.threshold)
-        }
+        let vadInstance = vad ?? {
+            let v = FluidVAD(threshold: vadConfig.threshold)
+            vad = v
+            return v
+        }()
 
-        // Load audio once, pass samples to VAD to avoid double file load
         let (samples, _) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
-
-        // swiftlint:disable:next force_unwrapping
-        let map = try await vad!.detectSpeech(samples: samples)
+        let map = try await vadInstance.detectSpeech(samples: samples)
 
         guard !map.segments.isEmpty else {
             logger.info("VAD: no speech detected")

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -197,6 +197,13 @@ struct SettingsView: View {
                 Toggle("Speaker Diarization", isOn: $settings.diarize)
 
                 if settings.diarize {
+                    Picker("Diarizer", selection: $settings.diarizerMode) {
+                        ForEach(DiarizerMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
                     HStack {
                         Text("Expected Speakers")
                         Spacer()

--- a/app/MeetingTranscriber/Tests/FluidDiarizerSortformerTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidDiarizerSortformerTests.swift
@@ -1,0 +1,24 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class FluidDiarizerSortformerTests: XCTestCase {
+    func testDiarizerModeDefault() {
+        let settings = AppSettings()
+        XCTAssertEqual(settings.diarizerMode, .offline)
+    }
+
+    func testDiarizerModeLabels() {
+        XCTAssertEqual(DiarizerMode.offline.label, "Offline (Clustering)")
+        XCTAssertEqual(DiarizerMode.sortformer.label, "Sortformer (Overlap-aware)")
+    }
+
+    func testFluidDiarizerDefaultModeIsOffline() {
+        let diarizer = FluidDiarizer()
+        XCTAssertEqual(diarizer.mode, .offline)
+    }
+
+    func testFluidDiarizerAcceptsSortformerMode() {
+        let diarizer = FluidDiarizer(mode: .sortformer)
+        XCTAssertEqual(diarizer.mode, .sortformer)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Sortformer (NVIDIA) as alternative diarizer mode alongside existing Offline (Clustering)
- Sortformer handles overlapping speech better than clustering-based diarization
- Settings: segmented picker for diarizer mode when diarization is enabled
- Default remains Offline (produces speaker embeddings for cross-meeting matching)

Inspired by @execsumo's work in #70.

**Stacked on #77 (Vocab) → #76 (VAD)**

## Test plan
- [x] 4 unit tests (mode defaults, labels, FluidDiarizer init)
- [x] Build passes
- [x] Lint clean (0 violations)
- [ ] Manual: switch to Sortformer in Settings, record a meeting, verify speaker labels