### PR TITLE
fix: correct sample rate detection for Bluetooth devices

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -118,8 +118,28 @@ class DualSourceRecorder: RecordingProvider {
         captureSession = nil
 
         let micDelay = captureResult.micDelay
-        let actualRate = captureResult.actualSampleRate
         let actualChannels = captureResult.actualChannels
+
+        // Query raw file size before it gets deleted — needed for rate cross-check
+        let tempURL = captureResult.appAudioFileURL
+        let appRawBytes = (try? FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? Int) ?? 0
+
+        // Cross-check rate using mic duration (mic file is opened once here, reused below)
+        let micDuration: Double? = if let micURL = captureResult.micAudioFileURL,
+                                      let micFile = try? AVAudioFile(forReading: micURL),
+                                      micFile.processingFormat.sampleRate > 0 {
+            Double(micFile.length) / micFile.processingFormat.sampleRate
+        } else {
+            nil
+        }
+
+        let actualRate = Self.crossCheckAppRate(
+            deviceRate: captureResult.actualSampleRate,
+            appRawBytes: appRawBytes,
+            appChannels: actualChannels,
+            micDurationSeconds: micDuration,
+            micDelay: micDelay,
+        )
 
         if micDelay != 0 {
             logger.info("Mic delay: \(micDelay)s")
@@ -140,10 +160,7 @@ class DualSourceRecorder: RecordingProvider {
         var appPath: URL?
         var appSamples: [Float] = []
 
-        let tempURL = captureResult.appAudioFileURL
-
-        if FileManager.default.fileExists(atPath: tempURL.path),
-           (try? FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? Int) ?? 0 > 0 {
+        if appRawBytes > 0 {
             let raw = try Data(contentsOf: tempURL)
             try? FileManager.default.removeItem(at: tempURL)
 
@@ -240,6 +257,40 @@ class DualSourceRecorder: RecordingProvider {
             mono[i] = sum * scale
         }
         return mono
+    }
+
+    /// Cross-check the device-reported sample rate against raw file size and mic duration.
+    /// Returns the corrected rate (snapped to standard), or the device rate if cross-check
+    /// is unavailable or agrees.
+    static func crossCheckAppRate(
+        deviceRate: Int,
+        appRawBytes: Int,
+        appChannels: Int,
+        micDurationSeconds: Double?,
+        micDelay: TimeInterval,
+    ) -> Int {
+        guard let micDuration = micDurationSeconds, micDuration > 3.0 else {
+            return deviceRate
+        }
+        let appDuration = micDuration + micDelay
+        guard appDuration > 3.0 else { return deviceRate }
+
+        guard let inferred = SampleRateQuery.inferRateFromDuration(
+            rawBytes: appRawBytes,
+            bytesPerSample: MemoryLayout<Float>.size,
+            channels: max(appChannels, 1),
+            durationSeconds: appDuration,
+        ) else { return deviceRate }
+
+        let snapped = SampleRateQuery.snapToStandardRate(inferred)
+
+        // Only override if significantly different (> 5% deviation)
+        let deviation = abs(Double(snapped - deviceRate)) / Double(max(deviceRate, 1))
+        if deviation > 0.05 {
+            logger.warning("Rate cross-check: device=\(deviceRate), inferred=\(inferred), snapped=\(snapped) — overriding")
+            return snapped
+        }
+        return deviceRate
     }
 
     private static let timestampFormatter: DateFormatter = {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -180,4 +180,66 @@ final class DualSourceRecorderTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tmpDir) }
         DualSourceRecorder.cleanupTempFiles(recordingsDir: tmpDir)
     }
+
+    // MARK: - crossCheckAppRate
+
+    func testCrossCheckCorrectRateUnchanged() {
+        // 60s of 48kHz stereo float32 = 23,040,000 bytes
+        let result = DualSourceRecorder.crossCheckAppRate(
+            deviceRate: 48000,
+            appRawBytes: 23_040_000,
+            appChannels: 2,
+            micDurationSeconds: 60.0,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result, 48000)
+    }
+
+    func testCrossCheckDetectsMismatch() {
+        // 60s of 48kHz stereo float32 = 23,040,000 bytes
+        // Device wrongly reports 24000 → cross-check computes ~48000 → overrides
+        let result = DualSourceRecorder.crossCheckAppRate(
+            deviceRate: 24000,
+            appRawBytes: 23_040_000,
+            appChannels: 2,
+            micDurationSeconds: 60.0,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result, 48000)
+    }
+
+    func testCrossCheckWithMicDelay() {
+        // mic started 0.5s after app → app recorded 60.5s
+        // 60.5s of 48kHz stereo float32 = 60.5 * 48000 * 2 * 4 = 23,232,000
+        let result = DualSourceRecorder.crossCheckAppRate(
+            deviceRate: 24000,
+            appRawBytes: 23_232_000,
+            appChannels: 2,
+            micDurationSeconds: 60.0,
+            micDelay: 0.5,
+        )
+        XCTAssertEqual(result, 48000)
+    }
+
+    func testCrossCheckNoMicReturnsDeviceRate() {
+        let result = DualSourceRecorder.crossCheckAppRate(
+            deviceRate: 24000,
+            appRawBytes: 23_040_000,
+            appChannels: 2,
+            micDurationSeconds: nil,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result, 24000)
+    }
+
+    func testCrossCheckShortRecordingReturnsDeviceRate() {
+        let result = DualSourceRecorder.crossCheckAppRate(
+            deviceRate: 24000,
+            appRawBytes: 48000 * 2 * 4 * 2,
+            appChannels: 2,
+            micDurationSeconds: 2.0,
+            micDelay: 0,
+        )
+        XCTAssertEqual(result, 24000)
+    }
 }

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -118,8 +118,61 @@ public class AppAudioCapture {
         return Int(asbd.mSampleRate)
     }
 
+    /// Query the tap's own format — most authoritative source for tap data rate.
+    /// Uses kAudioTapPropertyFormat which returns the ASBD the tap delivers.
+    private static func queryTapSampleRate(tapID: AudioObjectID) -> Int {
+        guard tapID != kAudioObjectUnknown else { return 0 }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var asbd = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        let status = AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &asbd)
+        if status != noErr {
+            logger.warning("queryTapSampleRate failed (status: \(status))")
+            return 0
+        }
+        return Int(asbd.mSampleRate)
+    }
+
+    /// Query the actual measured sample rate from a running device.
+    /// Only valid after AudioDeviceStart — returns the hardware-measured rate.
+    private static func queryActualSampleRate(deviceID: AudioObjectID) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyActualSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var rate: Float64 = 0
+        var size = UInt32(MemoryLayout<Float64>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &rate)
+        if status != noErr { return 0 }
+        return Int(rate)
+    }
+
     /// Query, cross-validate, and return the best available sample rate for a device.
-    private static func resolveActualSampleRate(deviceID: AudioObjectID, requestedRate: Int) -> Int {
+    /// Priority: tap format > nominal rate > stream format > requested rate.
+    private static func resolveActualSampleRate(
+        deviceID: AudioObjectID,
+        tapID: AudioObjectID,
+        requestedRate: Int,
+    ) -> Int {
+        // 1. Query the tap directly — most authoritative
+        let tapRate = queryTapSampleRate(tapID: tapID)
+        if tapRate > 0 {
+            let validated = SampleRateQuery.validateSampleRate(
+                queriedRate: tapRate, requestedRate: requestedRate,
+            )
+            if validated.source == .queriedDiffersFromRequested {
+                logger.warning("Tap rate \(tapRate) Hz differs from requested \(requestedRate) Hz")
+            }
+            logger.info("Using tap format rate: \(tapRate) Hz")
+            return validated.rate
+        }
+
+        // 2. Fallback: nominal + stream cross-validation
         let nominalRate = queryNominalSampleRate(deviceID: deviceID)
         let streamRate = queryStreamSampleRate(deviceID: deviceID)
 
@@ -134,8 +187,9 @@ public class AppAudioCapture {
             bestRate = rate
 
         case let .mismatch(nominal, stream):
-            logger.warning("Rate mismatch: nominal=\(nominal), stream=\(stream) — using stream rate")
-            bestRate = stream
+            // Prefer nominal over stream — stream on output scope can return BT HFP rate
+            logger.warning("Rate mismatch: nominal=\(nominal), stream=\(stream) — using nominal rate (stream scope may reflect BT HFP)")
+            bestRate = nominal
 
         case let .onlyNominal(rate):
             bestRate = rate
@@ -144,7 +198,7 @@ public class AppAudioCapture {
             bestRate = rate
 
         case .neitherAvailable:
-            logger.warning("Cannot query aggregate device sample rate, using requested \(requestedRate) Hz")
+            logger.warning("Cannot query sample rate, using requested \(requestedRate) Hz")
             return requestedRate
         }
 
@@ -242,13 +296,13 @@ public class AppAudioCapture {
                 self.appFirstFrameTime = mach_absolute_time()
                 self.actualChannels = Int(abl.mBuffers.mNumberChannels)
 
-                // Verify rate from device — may have changed since startCapture() query
-                let callbackRate = Self.queryNominalSampleRate(deviceID: self.aggregateID)
-                if callbackRate > 0, callbackRate != self.actualSampleRate {
+                // Device is running — query the measured actual rate
+                let measuredRate = Self.queryActualSampleRate(deviceID: self.aggregateID)
+                if measuredRate > 0, measuredRate != self.actualSampleRate {
                     logger.warning(
-                        "Rate drift detected at first callback: cached=\(self.actualSampleRate), device=\(callbackRate) — updating",
+                        "Measured rate \(measuredRate) Hz differs from cached \(self.actualSampleRate) Hz — updating",
                     )
-                    self.actualSampleRate = callbackRate
+                    self.actualSampleRate = measuredRate
                 }
 
                 let ch = max(self.actualChannels, 1)
@@ -292,7 +346,7 @@ public class AppAudioCapture {
         isRunning = true
 
         actualSampleRate = Self.resolveActualSampleRate(
-            deviceID: aggregateID, requestedRate: sampleRate,
+            deviceID: aggregateID, tapID: tapID, requestedRate: sampleRate,
         )
         logger.info("Audio capture started (PID \(self.pid), rate: \(self.actualSampleRate) Hz)")
     }

--- a/tools/audiotap/Sources/SampleRateQuery.swift
+++ b/tools/audiotap/Sources/SampleRateQuery.swift
@@ -71,4 +71,32 @@ public enum SampleRateQuery {
             return .neitherAvailable
         }
     }
+
+    /// Standard audio sample rates for snap-to-nearest matching.
+    private static let standardRates = [
+        8000, 11025, 16000, 22050, 24000, 32000, 44100, 48000,
+        88200, 96000, 176_400, 192_000,
+    ]
+
+    /// Snap an inferred rate to the nearest standard audio sample rate.
+    public static func snapToStandardRate(_ raw: Int) -> Int {
+        standardRates.min { abs($0 - raw) < abs($1 - raw) } ?? raw
+    }
+
+    /// Infer sample rate from raw PCM file size and known recording duration.
+    /// Returns nil if data is insufficient or result is implausible.
+    public static func inferRateFromDuration(
+        rawBytes: Int,
+        bytesPerSample: Int,
+        channels: Int,
+        durationSeconds: Double,
+    ) -> Int? {
+        guard rawBytes > 0, bytesPerSample > 0, channels > 0, durationSeconds > 1.0 else {
+            return nil
+        }
+        let totalSamples = rawBytes / bytesPerSample / channels
+        let rate = Double(totalSamples) / durationSeconds
+        guard rate > 7000, rate < Double(maxPlausibleRate) else { return nil }
+        return Int(rate.rounded())
+    }
 }

--- a/tools/audiotap/Tests/SampleRateQueryTests.swift
+++ b/tools/audiotap/Tests/SampleRateQueryTests.swift
@@ -101,4 +101,77 @@ final class SampleRateQueryTests: XCTestCase {
         )
         XCTAssertEqual(result, .neitherAvailable)
     }
+
+    // MARK: - snapToStandardRate
+
+    func testSnapExact48000() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(48000), 48000)
+    }
+
+    func testSnapExact44100() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(44100), 44100)
+    }
+
+    func testSnapNear48000() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(47950), 48000)
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(48050), 48000)
+    }
+
+    func testSnapNear44100() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(44000), 44100)
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(44200), 44100)
+    }
+
+    func testSnapNear24000() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(23900), 24000)
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(24100), 24000)
+    }
+
+    func testSnapNear16000() {
+        XCTAssertEqual(SampleRateQuery.snapToStandardRate(15900), 16000)
+    }
+
+    // MARK: - inferRateFromDuration
+
+    func testInferRate48kStereo60s() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 23_040_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+        )
+        XCTAssertEqual(result, 48000)
+    }
+
+    func testInferRate44100Stereo60s() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 21_168_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+        )
+        XCTAssertEqual(result, 44100)
+    }
+
+    func testInferRate24kMono30s() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 30 * 24000 * 1 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 30.0
+        )
+        XCTAssertEqual(result, 24000)
+    }
+
+    func testInferRateZeroBytesReturnsNil() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 0, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+        )
+        XCTAssertNil(result)
+    }
+
+    func testInferRateTooShortReturnsNil() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 48000 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 0.5
+        )
+        XCTAssertNil(result)
+    }
+
+    func testInferRateImplausibleHighReturnsNil() {
+        let result = SampleRateQuery.inferRateFromDuration(
+            rawBytes: 500_000 * 4 * 2 * 60, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+        )
+        XCTAssertNil(result)
+    }
 }


### PR DESCRIPTION
## Summary

- Fix wrong-scope `kAudioStreamPropertyPhysicalFormat` query that returned BT HFP rate (24kHz) instead of tap delivery rate (48kHz) on AirPods
- Add `kAudioTapPropertyFormat` query on tap directly — authoritative source for actual data rate
- Add `kAudioDevicePropertyActualSampleRate` verification at first IOProc callback
- Add post-hoc mic-duration cross-check as safety net in `DualSourceRecorder.stop()`
- On nominal/stream rate mismatch, prefer nominal over stream (stream scope reflects BT HFP, not tap rate)

Fixes #82

## Root Cause

`queryStreamSampleRate` queried `kAudioStreamPropertyPhysicalFormat` with `kAudioObjectPropertyScopeOutput` on the aggregate device. Tap audio arrives as an **input stream** — output scope returns the physical output device's format, which on BT HFP/SCO drops to 24kHz. The cross-validation then incorrectly preferred this 24kHz, causing `AudioMixer.resample(from: 24000, to: 16000)` on data that was actually at 48kHz → 2x speedup.

## Fix (3 layers)

1. **Primary:** `kAudioTapPropertyFormat` on tap object — same approach as AudioCap and Recap
2. **Secondary:** `kAudioDevicePropertyActualSampleRate` at first IOProc callback — hardware-measured rate
3. **Tertiary:** Post-hoc cross-check comparing raw file size to mic WAV duration, snapped to nearest standard rate

## Test plan

- [x] 12 new unit tests for `snapToStandardRate` and `inferRateFromDuration` (SampleRateQuery)
- [x] 5 new unit tests for `crossCheckAppRate` (DualSourceRecorder)
- [x] All 31 AudioTapLib tests pass
- [x] All 800 app tests pass
- [x] All 53 E2E/integration tests pass
- [x] Manual test with meeting-simulator: detection → recording → transcription → protocol (correct duration, no Mickey Mouse)
- [x] Lint clean