### PR TITLE
test(app): add minor view test gap coverage

### DIFF
--- a/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
@@ -87,6 +87,20 @@ final class AppPickerViewTests: XCTestCase {
         XCTAssertNoThrow(try body.find(ViewType.TextField.self))
     }
 
+    // MARK: - Refresh button
+
+    func testRefreshButtonExists() throws {
+        let sut = AppPickerView(
+            appsProvider: MockAppsProvider(apps: testApps),
+            onStartRecording: { _, _, _ in },
+            onCancel: {},
+        )
+        let body = try sut.inspect()
+        let images = body.findAll(ViewType.Image.self)
+        let hasRefreshIcon = images.contains { (try? $0.actualImage().name()) == "arrow.clockwise" }
+        XCTAssertTrue(hasRefreshIcon, "Refresh button should exist in header")
+    }
+
     // MARK: - Empty State
 
     func testEmptyAppListStillShowsButtons() throws {

--- a/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
@@ -43,6 +43,24 @@ final class MenuBarIconTests: XCTestCase {
         }
     }
 
+    // MARK: - Frame Wrapping
+
+    func testAnimationFrameWrapsAroundFrameCount() {
+        let badge = BadgeKind.recording
+        let normal = MenuBarIcon.image(badge: badge, animationFrame: 2)
+        let wrapped = MenuBarIcon.image(badge: badge, animationFrame: 2 + MenuBarIcon.frameCount)
+        XCTAssertTrue(normal.isTemplate)
+        XCTAssertTrue(wrapped.isTemplate)
+        XCTAssertEqual(normal.size, wrapped.size)
+    }
+
+    func testLargeAnimationFrameDoesNotCrash() {
+        for badge in BadgeKind.allCases where badge.isAnimated {
+            let image = MenuBarIcon.image(badge: badge, animationFrame: 999)
+            XCTAssertTrue(image.isTemplate, "Large frame index should wrap safely for \(badge)")
+        }
+    }
+
     // MARK: - Layout Math
 
     func testBarsLayoutCentersHorizontally() {

--- a/app/MeetingTranscriber/Tests/PermissionRowTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionRowTests.swift
@@ -4,44 +4,33 @@ import XCTest
 
 @MainActor
 final class PermissionRowTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func iconNames(for row: PermissionRow) throws -> [String] {
+        let images = try row.inspect().findAll(ViewType.Image.self)
+        return images.compactMap { try? $0.actualImage().name() }
+    }
+
     // MARK: - Icon Tests
 
     func testGrantedShowsCheckmarkIcon() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Granted", granted: true)
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertTrue(systemNames.contains("checkmark.circle.fill"), "Expected checkmark.circle.fill, got: \(systemNames)")
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Granted", granted: true))
+        XCTAssertTrue(names.contains("checkmark.circle.fill"))
     }
 
     func testDeniedShowsXmarkIcon() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Denied", granted: false)
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertTrue(systemNames.contains("xmark.circle.fill"), "Expected xmark.circle.fill, got: \(systemNames)")
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Denied", granted: false))
+        XCTAssertTrue(names.contains("xmark.circle.fill"))
     }
 
     func testWarningShowsTriangleIcon() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Warning", granted: false, warning: true)
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertTrue(
-            systemNames.contains("exclamationmark.triangle.fill"),
-            "Expected exclamationmark.triangle.fill, got: \(systemNames)",
-        )
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Warning", granted: false, warning: true))
+        XCTAssertTrue(names.contains("exclamationmark.triangle.fill"))
     }
 
     func testOptionalShowsTriangleIcon() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Optional", granted: false, optional: true)
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertTrue(
-            systemNames.contains("exclamationmark.triangle.fill"),
-            "Expected exclamationmark.triangle.fill, got: \(systemNames)",
-        )
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Optional", granted: false, optional: true))
+        XCTAssertTrue(names.contains("exclamationmark.triangle.fill"))
     }
 
     // MARK: - Label & Detail
@@ -56,18 +45,31 @@ final class PermissionRowTests: XCTestCase {
     // MARK: - Help Button
 
     func testHelpButtonShownWhenHelpNonEmpty() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Detail", granted: true, help: "some text")
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertTrue(systemNames.contains("questionmark.circle"), "Expected questionmark.circle when help is non-empty")
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Detail", granted: true, help: "some text"))
+        XCTAssertTrue(names.contains("questionmark.circle"))
     }
 
     func testHelpButtonHiddenWhenHelpEmpty() throws {
-        let sut = PermissionRow(label: "Mic", detail: "Detail", granted: true, help: "")
-        let body = try sut.inspect()
-        let images = try body.findAll(ViewType.Image.self)
-        let systemNames = images.compactMap { try? $0.actualImage().name() }
-        XCTAssertFalse(systemNames.contains("questionmark.circle"), "Expected no questionmark.circle when help is empty")
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Detail", granted: true, help: ""))
+        XCTAssertFalse(names.contains("questionmark.circle"))
+    }
+
+    // MARK: - Icon Priority
+
+    func testGrantedTakesPriorityOverWarning() throws {
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Detail", granted: true, warning: true))
+        XCTAssertTrue(names.contains("checkmark.circle.fill"))
+        XCTAssertFalse(names.contains("exclamationmark.triangle.fill"))
+    }
+
+    func testGrantedTakesPriorityOverOptional() throws {
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Detail", granted: true, optional: true))
+        XCTAssertTrue(names.contains("checkmark.circle.fill"))
+    }
+
+    func testWarningTakesPriorityOverDenied() throws {
+        let names = try iconNames(for: PermissionRow(label: "Mic", detail: "Detail", granted: false, warning: true))
+        XCTAssertTrue(names.contains("exclamationmark.triangle.fill"))
+        XCTAssertFalse(names.contains("xmark.circle.fill"))
     }
 }


### PR DESCRIPTION
## Summary

- **PermissionRow**: Icon priority tests — granted overrides warning/optional, warning overrides denied
- **MenuBarIcon**: Frame wrapping tests — animationFrame modulo works for values > frameCount (including 999)
- **AppPickerView**: Refresh button existence test

## Notes

Some AppPickerView gaps (list content, icon fallback) can't be tested with ViewInspector because `List` content depends on `@State` populated in `onAppear`.

`formattedElapsed` and `jobColor` in MenuBarView are `private` — identical logic in the public `formattedTime()` is already tested. Not worth changing visibility.

## Test plan
- [x] 50 targeted tests pass (0 failures)
- [x] Lint: 0 violations