### PR TITLE
feat(app): permission health check — detect broken TCC entries

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -265,10 +265,15 @@ final class AppState {
     // MARK: - Permission Health
 
     func handlePermissionHealth(_ result: HealthCheckResult) {
+        let previousProblems = permissionHealth?.problems ?? []
         permissionHealth = result
-        print("[PermissionHealthCheck] screen=\(result.screenRecording) mic=\(result.microphone) healthy=\(result.isHealthy) problems=\(result.problems)")
-        if !result.isHealthy {
-            print("[PermissionHealthCheck] Sending notification: \(result.notificationBody)")
+        let line = "[PermissionHealthCheck] screen=\(result.screenRecording) mic=\(result.microphone) " +
+            "ax=\(result.accessibility) healthy=\(result.isHealthy) problems=\(result.problems)"
+        PermissionHealthCheck.debugLog(line)
+
+        let problems = result.problems
+        if !problems.isEmpty, problems != previousProblems {
+            PermissionHealthCheck.debugLog("[PermissionHealthCheck] Sending notification: \(result.notificationBody)")
             notifier.notify(
                 title: "Permission Problem",
                 body: result.notificationBody,
@@ -276,8 +281,24 @@ final class AppState {
         }
     }
 
-    func checkPermissions() async {
+    /// Timestamp of the last completed `checkPermissions()` run. Used to debounce repeated
+    /// calls triggered by `NSApplication.didBecomeActiveNotification` so the 500 ms mic
+    /// probe doesn't churn the audio HAL on every Cmd-Tab.
+    private var lastPermissionCheckAt: Date?
+
+    /// Run the live permission health check.
+    ///
+    /// - Parameter minimumInterval: if non-nil, skip the run when the last completed check
+    ///   happened less than `minimumInterval` seconds ago. The initial startup call passes
+    ///   `nil` so it always runs; the `didBecomeActive` handler passes a small value to
+    ///   avoid HAL churn on rapid re-activations.
+    func checkPermissions(minimumInterval: TimeInterval? = nil) async {
+        if let minimumInterval, let last = lastPermissionCheckAt,
+           Date().timeIntervalSince(last) < minimumInterval {
+            return
+        }
         let result = await PermissionHealthCheck.runLive()
+        lastPermissionCheckAt = Date()
         handlePermissionHealth(result)
     }
 

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -42,6 +42,7 @@ final class AppState {
     var watchLoop: WatchLoop?
     var pipelineQueue: PipelineQueue
     var updateChecker: UpdateChecker
+    var permissionHealth: HealthCheckResult?
 
     // MARK: - Init
 
@@ -97,6 +98,7 @@ final class AppState {
             transcriberState: watchLoop?.transcriberState ?? .idle,
             activeJobState: pipelineQueue.activeJobs.first?.state,
             updateAvailable: updateChecker.availableUpdate != nil,
+            permissionProblem: permissionHealth?.isHealthy == false,
         )
     }
 
@@ -187,6 +189,10 @@ final class AppState {
                     }
                 }
 
+                if let health = permissionHealth {
+                    loop.permissionChecker = { health }
+                }
+
                 configurePipelineCallbacks()
 
                 watchLoop = loop
@@ -216,8 +222,13 @@ final class AppState {
             )
             watchLoop = loop
 
+            // Use cached health check result instead of live probe
+            if let health = permissionHealth {
+                loop.permissionChecker = { health }
+            }
+
             do {
-                try loop.startManualRecording(pid: pid, appName: appName, title: title)
+                try await loop.startManualRecording(pid: pid, appName: appName, title: title)
                 notifier.notify(
                     title: "Manual Recording",
                     body: "Recording: \(title)",
@@ -249,6 +260,23 @@ final class AppState {
             )
             pipelineQueue.enqueue(job)
         }
+    }
+
+    // MARK: - Permission Health
+
+    func handlePermissionHealth(_ result: HealthCheckResult) {
+        permissionHealth = result
+        if !result.isHealthy {
+            notifier.notify(
+                title: "Permission Problem",
+                body: result.notificationBody,
+            )
+        }
+    }
+
+    func checkPermissions() async {
+        let result = await PermissionHealthCheck.runLive()
+        handlePermissionHealth(result)
     }
 
     // MARK: - Pipeline

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -266,7 +266,9 @@ final class AppState {
 
     func handlePermissionHealth(_ result: HealthCheckResult) {
         permissionHealth = result
+        print("[PermissionHealthCheck] screen=\(result.screenRecording) mic=\(result.microphone) healthy=\(result.isHealthy) problems=\(result.problems)")
         if !result.isHealthy {
+            print("[PermissionHealthCheck] Sending notification: \(result.notificationBody)")
             notifier.notify(
                 title: "Permission Problem",
                 body: result.notificationBody,

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -257,12 +257,14 @@ enum RecorderError: LocalizedError {
     case notRecording
     case noAudioData
     case unsupportedOS
+    case permissionDenied(String)
 
     var errorDescription: String? {
         switch self {
         case .notRecording: "Not currently recording"
         case .noAudioData: "No audio data recorded"
         case .unsupportedOS: "macOS 14.2+ required for audio capture"
+        case let .permissionDenied(reason): "Permission problem: \(reason)"
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -99,6 +99,14 @@ struct MeetingTranscriberApp: App {
             .task {
                 await appState.checkPermissions()
             }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                // Re-check permissions when the user returns to the app (e.g. from System
+                // Settings after toggling a permission). Debounced so rapid Cmd-Tab cycles
+                // don't repeatedly churn the mic HAL via the 500 ms probe.
+                Task { @MainActor in
+                    await appState.checkPermissions(minimumInterval: 3)
+                }
+            }
         }
 
         Window("Name Speakers", id: "speaker-naming") {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -60,6 +60,7 @@ struct MeetingTranscriberApp: App {
                 Image(nsImage: MenuBarIcon.image(
                     badge: appState.currentBadge,
                     animationFrame: iconAnimationFrame,
+                    permissionOverlay: appState.permissionHealth?.isHealthy == false,
                 ))
             }
             .onReceive(iconTimer) { _ in

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -95,6 +95,9 @@ struct MeetingTranscriberApp: App {
             .task {
                 appState.updateChecker.startPeriodicChecks(settings: appState.settings)
             }
+            .task {
+                await appState.checkPermissions()
+            }
         }
 
         Window("Name Speakers", id: "speaker-naming") {

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -95,6 +95,14 @@ enum MenuBarIcon {
             case .processing:
                 drawProtocolAnimation(in: rect, frame: frame)
 
+            case .error:
+                // Use menu bar foreground color since this badge is non-template
+                let isDark = NSApp?.effectiveAppearance
+                    .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                (isDark ? NSColor.white : NSColor.black).setFill()
+                drawRecordingAnimation(in: rect, frame: 0)
+                drawExclamationBadge(in: rect)
+
             case .updateAvailable:
                 drawRecordingAnimation(in: rect, frame: 0)
                 drawUpdateArrow(in: rect)
@@ -105,7 +113,7 @@ enum MenuBarIcon {
 
             return true
         }
-        image.isTemplate = true
+        image.isTemplate = badge != .error
         return image
     }
 
@@ -198,6 +206,38 @@ enum MenuBarIcon {
                 yRadius: barWidth / 2,
             ).fill()
         }
+    }
+
+    // MARK: - Error Badge (exclamation mark in bottom-right)
+
+    private static func drawExclamationBadge(in rect: NSRect) {
+        let size: CGFloat = 7.0
+        let margin: CGFloat = 0.5
+        let cx = rect.maxX - size / 2 - margin
+        let cy = rect.minY + size / 2 + margin
+
+        // Red circle
+        NSColor.systemRed.setFill()
+        NSBezierPath(
+            ovalIn: NSRect(x: cx - size / 2, y: cy - size / 2, width: size, height: size),
+        ).fill()
+
+        // White "!" on top
+        NSColor.white.setFill()
+
+        // Stem
+        let stemW: CGFloat = 1.3
+        let stemH: CGFloat = 2.8
+        let stemY = cy + size / 2 - 1.8 - stemH
+        NSBezierPath(
+            roundedRect: NSRect(x: cx - stemW / 2, y: stemY, width: stemW, height: stemH),
+            xRadius: stemW / 2, yRadius: stemW / 2,
+        ).fill()
+
+        // Dot
+        let dotSize: CGFloat = 1.3
+        let dotY = cy - size / 2 + 1.0
+        NSBezierPath(ovalIn: NSRect(x: cx - dotSize / 2, y: dotY, width: dotSize, height: dotSize)).fill()
     }
 
     // MARK: - Update Available (small upward arrow badge in bottom-right)

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -73,17 +73,42 @@ enum MenuBarIcon {
     // MARK: - Public
 
     /// Returns a pre-rendered 18x18pt template `NSImage` for the given badge and animation frame.
-    static func image(badge: BadgeKind, animationFrame: Int = 0) -> NSImage {
+    ///
+    /// If `permissionOverlay` is true, a red exclamation badge is composited over the base icon
+    /// to signal a permission problem — this bypasses the pre-rendered cache and forces a
+    /// non-template image, because the overlay is red (template rendering is monochrome).
+    static func image(
+        badge: BadgeKind,
+        animationFrame: Int = 0,
+        permissionOverlay: Bool = false,
+    ) -> NSImage {
+        if permissionOverlay {
+            return renderImage(badge: badge, frame: animationFrame, permissionOverlay: true)
+        }
         guard let frames = cache[badge] else { return renderImage(badge: badge, frame: animationFrame) }
         return frames[animationFrame % frames.count]
     }
 
     // MARK: - Rendering
 
-    private static func renderImage(badge: BadgeKind, frame: Int) -> NSImage {
+    private static func renderImage(
+        badge: BadgeKind,
+        frame: Int,
+        permissionOverlay: Bool = false,
+    ) -> NSImage {
         let size = NSSize(width: 18, height: 18)
+        // The `.error` badge and the permission overlay both need an explicit foreground color
+        // (matching the menu bar appearance), because the image is non-template (the red dot
+        // must stay red in both light and dark mode).
+        let needsExplicitForeground = badge == .error || permissionOverlay
         let image = NSImage(size: size, flipped: false) { rect in
-            NSColor.black.setFill()
+            if needsExplicitForeground {
+                let isDark = NSApp?.effectiveAppearance
+                    .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                (isDark ? NSColor.white : NSColor.black).setFill()
+            } else {
+                NSColor.black.setFill()
+            }
 
             switch badge {
             case .transcribing:
@@ -96,12 +121,7 @@ enum MenuBarIcon {
                 drawProtocolAnimation(in: rect, frame: frame)
 
             case .error:
-                // Use menu bar foreground color since this badge is non-template
-                let isDark = NSApp?.effectiveAppearance
-                    .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                (isDark ? NSColor.white : NSColor.black).setFill()
                 drawRecordingAnimation(in: rect, frame: 0)
-                drawExclamationBadge(in: rect)
 
             case .updateAvailable:
                 drawRecordingAnimation(in: rect, frame: 0)
@@ -111,9 +131,13 @@ enum MenuBarIcon {
                 drawRecordingAnimation(in: rect, frame: frame)
             }
 
+            if needsExplicitForeground {
+                drawExclamationBadge(in: rect)
+            }
+
             return true
         }
-        image.isTemplate = badge != .error
+        image.isTemplate = !needsExplicitForeground
         return image
     }
 

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -254,6 +254,7 @@ extension BadgeKind {
         transcriberState: TranscriberState,
         activeJobState: JobState?,
         updateAvailable: Bool,
+        permissionProblem: Bool = false,
     ) -> BadgeKind {
         if watchLoopActive {
             if watchLoopState == .recording { return .recording }
@@ -272,6 +273,7 @@ extension BadgeKind {
         case .some: return .processing
         case .none: break
         }
+        if permissionProblem { return .error }
         if updateAvailable { return .updateAvailable }
         return .inactive
     }

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import AVFoundation
 import CoreGraphics
 import os.log
@@ -16,11 +17,45 @@ enum PermissionProblem: Equatable {
     case screenRecordingBroken
     case microphoneDenied
     case microphoneBroken
+    case accessibilityDenied
+    case accessibilityBroken
+
+    var permissionName: String {
+        switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: "Screen Recording"
+        case .microphoneDenied, .microphoneBroken: "Microphone"
+        case .accessibilityDenied, .accessibilityBroken: "Accessibility"
+        }
+    }
+
+    var isBroken: Bool {
+        switch self {
+        case .screenRecordingBroken, .microphoneBroken, .accessibilityBroken: true
+        case .screenRecordingDenied, .microphoneDenied, .accessibilityDenied: false
+        }
+    }
+
+    var description: String {
+        isBroken
+            ? "\(permissionName) looks enabled but isn't working — toggle it off and on in System Settings"
+            : "\(permissionName) permission denied"
+    }
 }
 
 struct HealthCheckResult: Equatable {
     let screenRecording: PermissionStatus
     let microphone: PermissionStatus
+    let accessibility: PermissionStatus
+
+    init(
+        screenRecording: PermissionStatus,
+        microphone: PermissionStatus,
+        accessibility: PermissionStatus = .healthy,
+    ) {
+        self.screenRecording = screenRecording
+        self.microphone = microphone
+        self.accessibility = accessibility
+    }
 
     var problems: [PermissionProblem] {
         var result: [PermissionProblem] = []
@@ -34,64 +69,82 @@ struct HealthCheckResult: Equatable {
         case .broken: result.append(.microphoneBroken)
         default: break
         }
+        switch accessibility {
+        case .denied: result.append(.accessibilityDenied)
+        case .broken: result.append(.accessibilityBroken)
+        default: break
+        }
         return result
     }
 
     var isHealthy: Bool {
-        screenRecording != .denied && screenRecording != .broken
-            && microphone != .denied && microphone != .broken
+        problems.isEmpty
     }
 
     var notificationBody: String {
-        let parts = problems.map { problem -> String in
-            switch problem {
-            case .screenRecordingDenied:
-                "Screen Recording permission denied"
-
-            case .screenRecordingBroken:
-                "Screen Recording permission appears broken — please reset in System Settings"
-
-            case .microphoneDenied:
-                "Microphone permission denied"
-
-            case .microphoneBroken:
-                "Microphone permission appears broken — please reset in System Settings"
-            }
-        }
-        return parts.joined(separator: "\n")
+        problems.map(\.description).joined(separator: "\n")
     }
 }
 
 enum PermissionHealthCheck {
     // MARK: - Screen Recording (pure, testable)
 
+    /// Pure decision function: combines the TCC system verdict with a window-title probe.
+    ///
+    /// - `systemAllowed`: whether macOS says the process has the Screen Recording entitlement
+    ///   (via `CGPreflightScreenCaptureAccess()` or equivalent).
+    /// - `hasForeignWithTitle`: whether `CGWindowListCopyWindowInfo` returned at least one
+    ///   window from another process that has a non-empty `kCGWindowName`.
+    ///
+    /// Outcomes:
+    /// - `denied`: system says no
+    /// - `healthy`: system says yes AND we can read foreign window titles
+    /// - `broken`: system says yes BUT we cannot read any foreign window titles (TCC mismatch)
     static func checkScreenRecording(
+        systemAllowed: Bool,
+        hasForeignWithTitle: Bool,
+    ) -> PermissionStatus {
+        if !systemAllowed { return .denied }
+        return hasForeignWithTitle ? .healthy : .broken
+    }
+
+    /// Parses a raw window list and reports whether any foreign window has a non-empty title.
+    static func hasForeignWindowWithTitle(
         windowList: [[String: Any]]?, // swiftlint:disable:this discouraged_optional_collection
         ownPID: Int32,
-    ) -> PermissionStatus {
-        guard let windows = windowList else { return .denied }
-
-        let foreignWithTitle = windows.contains { info in
+    ) -> Bool {
+        guard let windows = windowList else { return false }
+        return windows.contains { info in
             guard let pid = info[kCGWindowOwnerPID as String] as? Int32,
                   pid != ownPID
             else { return false }
             let name = info[kCGWindowName as String] as? String
             return name != nil && !(name?.isEmpty ?? true)
         }
-
-        if foreignWithTitle { return .healthy }
-        return .broken
     }
 
     static func checkScreenRecordingLive() -> PermissionStatus {
+        // CGPreflightScreenCaptureAccess does NOT trigger the TCC prompt — it only reports status.
+        let systemAllowed = CGPreflightScreenCaptureAccess()
+
         let list = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly],
             kCGNullWindowID,
         ) as? [[String: Any]]
-        return checkScreenRecording(
-            windowList: list,
-            ownPID: ProcessInfo.processInfo.processIdentifier,
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        let windowCount = list?.count ?? -1
+        let foreignCount = (list ?? []).count { info in
+            (info[kCGWindowOwnerPID as String] as? Int32) != ownPID
+        }
+        let hasForeignTitle = hasForeignWindowWithTitle(windowList: list, ownPID: ownPID)
+
+        let result = checkScreenRecording(
+            systemAllowed: systemAllowed,
+            hasForeignWithTitle: hasForeignTitle,
         )
+        debugLog("checkScreenRecordingLive: systemAllowed=\(systemAllowed) ownPID=\(ownPID) " +
+            "windows=\(windowCount) foreign=\(foreignCount) hasForeignTitle=\(hasForeignTitle) → \(result)")
+        return result
     }
 
     // MARK: - Microphone (pure, testable)
@@ -115,36 +168,118 @@ enum PermissionHealthCheck {
         }
     }
 
+    /// Thread-safe counter for mic probe buffer arrival (tap callback runs on audio thread).
+    private final class BufferCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+        func increment() {
+            lock.lock(); count += 1; lock.unlock()
+        }
+
+        func value() -> Int {
+            lock.lock(); defer { lock.unlock() }; return count
+        }
+    }
+
+    /// Maximum time to wait for the first mic buffer to arrive.
+    static let probeTimeout: TimeInterval = 0.5
+    /// Poll interval while waiting for the first buffer.
+    static let probePollInterval: TimeInterval = 0.02
+
     static func probeMicrophone() async -> Bool {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
 
         guard format.sampleRate > 0, format.channelCount > 0 else {
+            debugLog("probeMicrophone: invalid format sampleRate=\(format.sampleRate) " +
+                "channels=\(format.channelCount)")
             return false
         }
 
-        var gotSamples = false
+        let counter = BufferCounter()
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
-            if buffer.frameLength > 0 { gotSamples = true }
+            if buffer.frameLength > 0 { counter.increment() }
         }
 
         do {
             try engine.start()
-            try? await Task.sleep(for: .milliseconds(50))
-            engine.stop()
-            inputNode.removeTap(onBus: 0)
-            return gotSamples
         } catch {
-            logger.warning("Mic probe failed: \(error.localizedDescription)")
+            inputNode.removeTap(onBus: 0)
+            debugLog("probeMicrophone: engine.start() threw: \(error.localizedDescription)")
             return false
         }
+
+        // Poll until the first buffer arrives or the timeout elapses.
+        let deadline = Date().addingTimeInterval(probeTimeout)
+        let startedAt = Date()
+        while counter.value() == 0, Date() < deadline {
+            try? await Task.sleep(for: .seconds(probePollInterval))
+        }
+        let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        let buffersSeen = counter.value()
+
+        engine.stop()
+        inputNode.removeTap(onBus: 0)
+
+        debugLog("probeMicrophone: buffers=\(buffersSeen) elapsed=\(elapsedMs)ms " +
+            "sampleRate=\(format.sampleRate) channels=\(format.channelCount)")
+        return buffersSeen > 0
     }
 
     static func checkMicrophoneLive() async -> PermissionStatus {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
-        if status != .authorized { return checkMicrophone(authStatus: status, probeSucceeds: false) }
-        return await checkMicrophone(authStatus: status, probeSucceeds: probeMicrophone())
+        if status != .authorized {
+            let r = checkMicrophone(authStatus: status, probeSucceeds: false)
+            debugLog("checkMicrophoneLive: authStatus=\(status.rawValue) probe=skipped → \(r)")
+            return r
+        }
+        let probe = await probeMicrophone()
+        let r = checkMicrophone(authStatus: status, probeSucceeds: probe)
+        debugLog("checkMicrophoneLive: authStatus=authorized probe=\(probe) → \(r)")
+        return r
+    }
+
+    // MARK: - Accessibility (pure, testable)
+
+    /// Pure decision function for Accessibility permission state.
+    ///
+    /// - `trusted`: whether `AXIsProcessTrusted()` returns true.
+    /// - `probeSucceeds`: whether a concrete AX API call (e.g. reading the focused app of
+    ///   `AXUIElementCreateSystemWide`) returns `.success`.
+    static func checkAccessibility(
+        trusted: Bool,
+        probeSucceeds: Bool,
+    ) -> PermissionStatus {
+        if !trusted { return .denied }
+        return probeSucceeds ? .healthy : .broken
+    }
+
+    /// Probes the Accessibility API with a lightweight system-wide call.
+    /// Returns true if the call succeeds (and we either get a valid attribute or `noValue`).
+    static func probeAccessibility() -> Bool {
+        let systemWide = AXUIElementCreateSystemWide()
+        var value: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedApplicationAttribute as CFString,
+            &value,
+        )
+        // .success: got the focused app. .noValue: no focused app right now, but the API worked.
+        // Any other error (e.g. .cannotComplete, .apiDisabled) indicates AX isn't actually granted.
+        return err == .success || err == .noValue
+    }
+
+    static func checkAccessibilityLive() -> PermissionStatus {
+        let trusted = AXIsProcessTrusted()
+        if !trusted {
+            debugLog("checkAccessibilityLive: trusted=false → denied")
+            return .denied
+        }
+        let probe = probeAccessibility()
+        let r = checkAccessibility(trusted: trusted, probeSucceeds: probe)
+        debugLog("checkAccessibilityLive: trusted=true probe=\(probe) → \(r)")
+        return r
     }
 
     // MARK: - Overall Health
@@ -152,17 +287,62 @@ enum PermissionHealthCheck {
     static func overallHealth(
         screenRecording: PermissionStatus,
         microphone: PermissionStatus,
+        accessibility: PermissionStatus = .healthy,
     ) -> HealthCheckResult {
-        HealthCheckResult(screenRecording: screenRecording, microphone: microphone)
+        HealthCheckResult(
+            screenRecording: screenRecording,
+            microphone: microphone,
+            accessibility: accessibility,
+        )
     }
 
     static func runLive() async -> HealthCheckResult {
         let sr = checkScreenRecordingLive()
         let mic = await checkMicrophoneLive()
-        let result = overallHealth(screenRecording: sr, microphone: mic)
+        let ax = checkAccessibilityLive()
+        let result = overallHealth(screenRecording: sr, microphone: mic, accessibility: ax)
         if !result.isHealthy {
             logger.warning("Permission health check failed: \(result.problems)")
         }
         return result
+    }
+
+    // MARK: - Debug Logging
+
+    /// Appender for `/tmp/mt-permission.log` — independent of `os_log`, which is not visible
+    /// for ad-hoc signed dev bundles. The log file is truncated on first write per process
+    /// (via the one-shot `init` of the static instance) so it cannot grow unbounded across
+    /// long-running sessions.
+    private final class DebugLogFile: @unchecked Sendable {
+        private let path: String
+        private let formatter: ISO8601DateFormatter
+        private let lock = NSLock()
+
+        init(path: String) {
+            self.path = path
+            self.formatter = ISO8601DateFormatter()
+            try? FileManager.default.removeItem(atPath: path)
+        }
+
+        func append(_ line: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            let payload = "[\(formatter.string(from: Date()))] \(line)\n"
+            guard let data = payload.data(using: .utf8) else { return }
+            let url = URL(fileURLWithPath: path)
+            if let handle = try? FileHandle(forWritingTo: url) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                try? handle.close()
+            } else {
+                try? data.write(to: url)
+            }
+        }
+    }
+
+    private static let debugLogFile = DebugLogFile(path: "/tmp/mt-permission.log")
+
+    static func debugLog(_ line: String) {
+        debugLogFile.append(line)
     }
 }

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -1,0 +1,168 @@
+import AVFoundation
+import CoreGraphics
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PermissionHealthCheck")
+
+enum PermissionStatus: Equatable {
+    case healthy
+    case denied
+    case broken
+    case notDetermined
+}
+
+enum PermissionProblem: Equatable {
+    case screenRecordingDenied
+    case screenRecordingBroken
+    case microphoneDenied
+    case microphoneBroken
+}
+
+struct HealthCheckResult: Equatable {
+    let screenRecording: PermissionStatus
+    let microphone: PermissionStatus
+
+    var problems: [PermissionProblem] {
+        var result: [PermissionProblem] = []
+        switch screenRecording {
+        case .denied: result.append(.screenRecordingDenied)
+        case .broken: result.append(.screenRecordingBroken)
+        default: break
+        }
+        switch microphone {
+        case .denied: result.append(.microphoneDenied)
+        case .broken: result.append(.microphoneBroken)
+        default: break
+        }
+        return result
+    }
+
+    var isHealthy: Bool {
+        screenRecording != .denied && screenRecording != .broken
+            && microphone != .denied && microphone != .broken
+    }
+
+    var notificationBody: String {
+        let parts = problems.map { problem -> String in
+            switch problem {
+            case .screenRecordingDenied:
+                "Screen Recording permission denied"
+
+            case .screenRecordingBroken:
+                "Screen Recording permission appears broken — please reset in System Settings"
+
+            case .microphoneDenied:
+                "Microphone permission denied"
+
+            case .microphoneBroken:
+                "Microphone permission appears broken — please reset in System Settings"
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+}
+
+enum PermissionHealthCheck {
+    // MARK: - Screen Recording (pure, testable)
+
+    static func checkScreenRecording(
+        windowList: [[String: Any]]?, // swiftlint:disable:this discouraged_optional_collection
+        ownPID: Int32,
+    ) -> PermissionStatus {
+        guard let windows = windowList else { return .denied }
+
+        let foreignWithTitle = windows.contains { info in
+            guard let pid = info[kCGWindowOwnerPID as String] as? Int32,
+                  pid != ownPID
+            else { return false }
+            let name = info[kCGWindowName as String] as? String
+            return name != nil && !(name?.isEmpty ?? true)
+        }
+
+        if foreignWithTitle { return .healthy }
+        return .broken
+    }
+
+    static func checkScreenRecordingLive() -> PermissionStatus {
+        let list = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly],
+            kCGNullWindowID,
+        ) as? [[String: Any]]
+        return checkScreenRecording(
+            windowList: list,
+            ownPID: ProcessInfo.processInfo.processIdentifier,
+        )
+    }
+
+    // MARK: - Microphone (pure, testable)
+
+    static func checkMicrophone(
+        authStatus: AVAuthorizationStatus,
+        probeSucceeds: Bool,
+    ) -> PermissionStatus {
+        switch authStatus {
+        case .notDetermined:
+            return .notDetermined
+
+        case .denied, .restricted:
+            return .denied
+
+        case .authorized:
+            return probeSucceeds ? .healthy : .broken
+
+        @unknown default:
+            return .denied
+        }
+    }
+
+    static func probeMicrophone() async -> Bool {
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            return false
+        }
+
+        var gotSamples = false
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            if buffer.frameLength > 0 { gotSamples = true }
+        }
+
+        do {
+            try engine.start()
+            try? await Task.sleep(for: .milliseconds(50))
+            engine.stop()
+            inputNode.removeTap(onBus: 0)
+            return gotSamples
+        } catch {
+            logger.warning("Mic probe failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    static func checkMicrophoneLive() async -> PermissionStatus {
+        let status = AVCaptureDevice.authorizationStatus(for: .audio)
+        if status != .authorized { return checkMicrophone(authStatus: status, probeSucceeds: false) }
+        return await checkMicrophone(authStatus: status, probeSucceeds: probeMicrophone())
+    }
+
+    // MARK: - Overall Health
+
+    static func overallHealth(
+        screenRecording: PermissionStatus,
+        microphone: PermissionStatus,
+    ) -> HealthCheckResult {
+        HealthCheckResult(screenRecording: screenRecording, microphone: microphone)
+    }
+
+    static func runLive() async -> HealthCheckResult {
+        let sr = checkScreenRecordingLive()
+        let mic = await checkMicrophoneLive()
+        let result = overallHealth(screenRecording: sr, microphone: mic)
+        if !result.isHealthy {
+            logger.warning("Permission health check failed: \(result.problems)")
+        }
+        return result
+    }
+}

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -7,14 +7,7 @@ import os
 enum Permissions {
     /// Check if Screen Recording permission is granted.
     static func checkScreenRecording() -> Bool {
-        guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
-            return false
-        }
-        let ownPID = ProcessInfo.processInfo.processIdentifier
-        return windowList.contains { info in
-            guard let pid = info[kCGWindowOwnerPID as String] as? Int32, pid != ownPID else { return false }
-            return info[kCGWindowName as String] is String
-        }
+        PermissionHealthCheck.checkScreenRecordingLive() == .healthy
     }
 
     static func ensureMicrophoneAccess() async -> Bool {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -41,6 +41,7 @@ class WatchLoop {
     let detector: MeetingDetecting
     let recorderFactory: @MainActor () -> RecordingProvider
     var pipelineQueue: PipelineQueue?
+    var permissionChecker: () async -> HealthCheckResult = { await PermissionHealthCheck.runLive() }
 
     // Settings
     let pollInterval: TimeInterval
@@ -113,10 +114,15 @@ class WatchLoop {
 
     // MARK: - Manual Recording
 
-    func startManualRecording(pid: pid_t, appName: String, title: String) throws {
+    func startManualRecording(pid: pid_t, appName: String, title: String) async throws {
         guard state != .recording else {
             logger.warning("Cannot start manual recording — already recording")
             return
+        }
+
+        let health = await permissionChecker()
+        if !health.isHealthy {
+            throw RecorderError.permissionDenied(health.notificationBody)
         }
 
         // Stop auto-watch if active

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -86,11 +86,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertFalse(state.isWatching)
     }
 
-    func testIsWatchingFalseWhenManualRecording() throws {
+    func testIsWatchingFalseWhenManualRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertFalse(state.isWatching)
     }
@@ -106,11 +106,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertEqual(state.currentStateLabel, "Watching for Meetings...")
     }
 
-    func testCurrentStateLabelRecordingWhenManualRecording() throws {
+    func testCurrentStateLabelRecordingWhenManualRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertEqual(state.currentStateLabel, "Recording")
     }
@@ -170,11 +170,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertNil(state.currentStatus?.meeting)
     }
 
-    func testCurrentStatusMeetingFromManualRecordingInfo() throws {
+    func testCurrentStatusMeetingFromManualRecordingInfo() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
         defer { loop.stop() }
         let status = try XCTUnwrap(state.currentStatus)
         XCTAssertEqual(status.meeting?.app, "Chrome")
@@ -197,11 +197,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertEqual(state.currentBadge, .updateAvailable)
     }
 
-    func testCurrentBadgeRecordingWhenLoopRecording() throws {
+    func testCurrentBadgeRecordingWhenLoopRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertEqual(state.currentBadge, .recording)
     }
@@ -221,11 +221,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertFalse(state.isWatching)
     }
 
-    func testToggleWatchingWhileManualRecordingIsNoOp() throws {
+    func testToggleWatchingWhileManualRecordingIsNoOp() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
 
         state.toggleWatching() // must be a no-op
@@ -262,11 +262,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     // MARK: - stopManualRecording
 
-    func testStopManualRecordingClearsWatchLoop() throws {
+    func testStopManualRecordingClearsWatchLoop() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         state.watchLoop = loop
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
 
         state.stopManualRecording()
 
@@ -457,6 +457,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testStartManualRecordingSendsNotification() async {
         let (state, notifier) = makeState()
+        state.permissionHealth = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
         addTeardownBlock { state.watchLoop?.stop() }
 
         state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
@@ -471,6 +472,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testStartManualRecordingStopsExistingAutoWatchLoop() async {
         let (state, _) = makeState()
+        state.permissionHealth = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
         let (existingLoop, _) = makeTestWatchLoop()
         existingLoop.start()
         state.watchLoop = existingLoop
@@ -600,6 +602,39 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         state.settings.numSpeakers = 4
         let queue = state.makePipelineQueue()
         XCTAssertEqual(queue.numSpeakers, 4)
+    }
+
+    // MARK: - Permission Health Check
+
+    func testHandlePermissionHealthBrokenSendsNotification() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.handlePermissionHealth(HealthCheckResult(
+            screenRecording: .broken,
+            microphone: .healthy,
+        ))
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertTrue(notifier.calls.first?.title.contains("Permission") ?? false)
+    }
+
+    func testHandlePermissionHealthHealthyNoNotification() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.handlePermissionHealth(HealthCheckResult(
+            screenRecording: .healthy,
+            microphone: .healthy,
+        ))
+        XCTAssertTrue(notifier.calls.isEmpty)
+    }
+
+    func testHandlePermissionHealthStoresResult() {
+        let state = AppState(notifier: RecordingNotifier())
+        let result = HealthCheckResult(
+            screenRecording: .healthy,
+            microphone: .healthy,
+        )
+        state.handlePermissionHealth(result)
+        XCTAssertEqual(state.permissionHealth, result)
     }
 }
 

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -636,6 +636,47 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         state.handlePermissionHealth(result)
         XCTAssertEqual(state.permissionHealth, result)
     }
+
+    func testHandlePermissionHealthDedupsRepeatedProblem() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
+        state.handlePermissionHealth(broken)
+        state.handlePermissionHealth(broken)
+        state.handlePermissionHealth(broken)
+        XCTAssertEqual(notifier.calls.count, 1, "Identical problem set should only notify once")
+    }
+
+    func testHandlePermissionHealthReNotifiesAfterRecovery() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
+        let healthy = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        state.handlePermissionHealth(broken) // notify #1
+        state.handlePermissionHealth(healthy) // clears dedup memory
+        state.handlePermissionHealth(broken) // notify #2
+        XCTAssertEqual(notifier.calls.count, 2)
+    }
+
+    func testHandlePermissionHealthNotifiesWhenProblemChanges() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.handlePermissionHealth(HealthCheckResult(screenRecording: .healthy, microphone: .broken))
+        state.handlePermissionHealth(HealthCheckResult(screenRecording: .broken, microphone: .healthy))
+        XCTAssertEqual(notifier.calls.count, 2, "Different problem sets should each trigger a notification")
+    }
+
+    func testHandlePermissionHealthAccessibilityBrokenNotifies() {
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.handlePermissionHealth(HealthCheckResult(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .broken,
+        ))
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertTrue(notifier.calls.first?.body.contains("Accessibility") ?? false)
+    }
 }
 
 // MARK: - Private helpers

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -169,6 +169,11 @@ final class DualSourceRecorderTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: wav1.path))
     }
 
+    func testRecorderErrorPermissionDeniedDescription() {
+        let error = RecorderError.permissionDenied("Microphone broken")
+        XCTAssertEqual(error.errorDescription, "Permission problem: Microphone broken")
+    }
+
     func testCleanupEmptyDirectory() throws {
         let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("cleanup_empty_\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)

--- a/app/MeetingTranscriber/Tests/ManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/ManualRecordingTests.swift
@@ -16,22 +16,25 @@ final class ManualRecordingTests: XCTestCase {
             pollInterval: 0.05,
             maxDuration: 10,
         )
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
         return (loop, mock)
     }
 
     // MARK: - Start
 
-    func testStartManualRecordingTransitionsToRecording() throws {
+    func testStartManualRecordingTransitionsToRecording() async throws {
         let (loop, _) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertEqual(loop.state, .recording)
         XCTAssertTrue(loop.isActive)
         loop.stop()
     }
 
-    func testManualRecordingInfoIsSet() throws {
+    func testManualRecordingInfoIsSet() async throws {
         let (loop, _) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
         XCTAssertTrue(loop.isManualRecording)
         XCTAssertEqual(loop.manualRecordingInfo?.pid, 1234)
         XCTAssertEqual(loop.manualRecordingInfo?.appName, "Chrome")
@@ -39,30 +42,30 @@ final class ManualRecordingTests: XCTestCase {
         loop.stop()
     }
 
-    func testStartManualRecordingCallsRecorderStart() throws {
+    func testStartManualRecordingCallsRecorderStart() async throws {
         let (loop, mock) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertTrue(mock.startCalled)
         loop.stop()
     }
 
-    func testStartManualRecordingWhileAlreadyRecordingIsNoOp() throws {
+    func testStartManualRecordingWhileAlreadyRecordingIsNoOp() async throws {
         let (loop, _) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting 1")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting 1")
         XCTAssertEqual(loop.state, .recording)
 
         // Trying to start again on the same loop should be a no-op
-        try loop.startManualRecording(pid: 5678, appName: "Firefox", title: "Meeting 2")
+        try await loop.startManualRecording(pid: 5678, appName: "Firefox", title: "Meeting 2")
         XCTAssertEqual(loop.manualRecordingInfo?.pid, 1234)
         loop.stop()
     }
 
     // MARK: - Stop
 
-    func testStopManualRecordingEnqueuesJob() throws {
+    func testStopManualRecordingEnqueuesJob() async throws {
         let queue = PipelineQueue()
         let (loop, _) = makeLoop(pipelineQueue: queue)
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
 
         loop.stopManualRecording()
 
@@ -71,9 +74,9 @@ final class ManualRecordingTests: XCTestCase {
         XCTAssertEqual(queue.jobs.first?.appName, "Chrome")
     }
 
-    func testStopManualRecordingTransitionsToIdle() throws {
+    func testStopManualRecordingTransitionsToIdle() async throws {
         let (loop, _) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
 
         loop.stopManualRecording()
 
@@ -82,9 +85,9 @@ final class ManualRecordingTests: XCTestCase {
         XCTAssertNil(loop.manualRecordingInfo)
     }
 
-    func testStopManualRecordingCallsRecorderStop() throws {
+    func testStopManualRecordingCallsRecorderStop() async throws {
         let (loop, mock) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
 
         loop.stopManualRecording()
 
@@ -93,9 +96,9 @@ final class ManualRecordingTests: XCTestCase {
 
     // MARK: - Stop cleanup
 
-    func testStopCleansUpManualRecording() throws {
+    func testStopCleansUpManualRecording() async throws {
         let (loop, _) = makeLoop()
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertTrue(loop.isManualRecording)
 
         loop.stop()
@@ -107,14 +110,14 @@ final class ManualRecordingTests: XCTestCase {
 
     // MARK: - State change callback
 
-    func testManualRecordingTriggersStateChangeCallback() throws {
+    func testManualRecordingTriggersStateChangeCallback() async throws {
         let (loop, _) = makeLoop()
         var transitions: [(WatchLoop.State, WatchLoop.State)] = []
         loop.onStateChange = { old, new in
             transitions.append((old, new))
         }
 
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertEqual(transitions.count, 1)
         XCTAssertEqual(transitions[0].0, .idle)
         XCTAssertEqual(transitions[0].1, .recording)
@@ -127,12 +130,12 @@ final class ManualRecordingTests: XCTestCase {
 
     // MARK: - Auto-watch interaction
 
-    func testStartManualRecordingStopsAutoWatch() throws {
+    func testStartManualRecordingStopsAutoWatch() async throws {
         let (loop, _) = makeLoop()
         loop.start()
         XCTAssertEqual(loop.state, .watching)
 
-        try loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertEqual(loop.state, .recording)
         XCTAssertTrue(loop.isManualRecording)
         loop.stop()

--- a/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
@@ -16,7 +16,11 @@ final class MenuBarIconTests: XCTestCase {
     func testAllBadgeKindsProduceValidImages() {
         for badge in BadgeKind.allCases {
             let image = MenuBarIcon.image(badge: badge)
-            XCTAssertTrue(image.isTemplate, "Badge \(badge) should produce a template image")
+            if badge == .error {
+                XCTAssertFalse(image.isTemplate, "Error badge should be non-template (colored)")
+            } else {
+                XCTAssertTrue(image.isTemplate, "Badge \(badge) should produce a template image")
+            }
             XCTAssertEqual(image.size.width, 18, accuracy: 0.01, "Badge \(badge) width")
             XCTAssertEqual(image.size.height, 18, accuracy: 0.01, "Badge \(badge) height")
         }

--- a/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
@@ -348,4 +348,40 @@ final class MenuBarIconTests: XCTestCase {
         )
         XCTAssertEqual(result, .inactive)
     }
+
+    func testCompute_permissionBroken_returnsError() {
+        let result = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+            permissionProblem: true,
+        )
+        XCTAssertEqual(result, .error)
+    }
+
+    func testCompute_recordingOverridesPermissionProblem() {
+        let result = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .recording,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+            permissionProblem: true,
+        )
+        XCTAssertEqual(result, .recording)
+    }
+
+    func testCompute_permissionProblemOverridesUpdate() {
+        let result = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: true,
+            permissionProblem: true,
+        )
+        XCTAssertEqual(result, .error)
+    }
 }

--- a/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
@@ -58,6 +58,30 @@ final class MenuBarIconTests: XCTestCase {
         XCTAssertEqual(normal.size, wrapped.size)
     }
 
+    // MARK: - Permission Overlay
+
+    func testPermissionOverlayIsNonTemplate() {
+        // Recording is normally a template image — with the overlay it must become non-template
+        // because the red exclamation dot can't be monochrome.
+        let image = MenuBarIcon.image(badge: .recording, animationFrame: 0, permissionOverlay: true)
+        XCTAssertFalse(image.isTemplate)
+    }
+
+    func testPermissionOverlayAppliesToAllActiveBadges() {
+        for badge in BadgeKind.allCases {
+            let image = MenuBarIcon.image(badge: badge, animationFrame: 0, permissionOverlay: true)
+            XCTAssertFalse(image.isTemplate, "Overlay on \(badge) should be non-template")
+            XCTAssertEqual(image.size.width, 18, accuracy: 0.01)
+            XCTAssertEqual(image.size.height, 18, accuracy: 0.01)
+        }
+    }
+
+    func testPermissionOverlayDefaultsToFalse() {
+        let withoutParam = MenuBarIcon.image(badge: .recording, animationFrame: 0)
+        let explicitFalse = MenuBarIcon.image(badge: .recording, animationFrame: 0, permissionOverlay: false)
+        XCTAssertEqual(withoutParam.isTemplate, explicitFalse.isTemplate)
+    }
+
     func testLargeAnimationFrameDoesNotCrash() {
         for badge in BadgeKind.allCases where badge.isAnimated {
             let image = MenuBarIcon.image(badge: badge, animationFrame: 999)

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -1,0 +1,141 @@
+import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+final class PermissionHealthCheckTests: XCTestCase {
+    // MARK: - Screen Recording
+
+    func testScreenRecordingHealthy() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
+            [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: "Finder"],
+        ], ownPID: 123)
+        XCTAssertEqual(result, .healthy)
+    }
+
+    func testScreenRecordingDenied() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: nil, ownPID: 123)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testScreenRecordingBrokenNoTitles() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
+            [kCGWindowOwnerPID as String: Int32(999)],
+            [kCGWindowOwnerPID as String: Int32(888)],
+        ], ownPID: 123)
+        XCTAssertEqual(result, .broken)
+    }
+
+    func testScreenRecordingIgnoresOwnWindows() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
+            [kCGWindowOwnerPID as String: Int32(123), kCGWindowName as String: "My App"],
+        ], ownPID: 123)
+        XCTAssertEqual(result, .broken)
+    }
+
+    func testScreenRecordingBrokenEmptyTitle() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
+            [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: ""],
+        ], ownPID: 123)
+        XCTAssertEqual(result, .broken)
+    }
+
+    func testScreenRecordingEmptyWindowList() {
+        let result = PermissionHealthCheck.checkScreenRecording(windowList: [], ownPID: 123)
+        XCTAssertEqual(result, .broken)
+    }
+
+    // MARK: - Microphone
+
+    func testMicHealthy() {
+        let result = PermissionHealthCheck.checkMicrophone(authStatus: .authorized, probeSucceeds: true)
+        XCTAssertEqual(result, .healthy)
+    }
+
+    func testMicDenied() {
+        let result = PermissionHealthCheck.checkMicrophone(authStatus: .denied, probeSucceeds: false)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testMicRestricted() {
+        let result = PermissionHealthCheck.checkMicrophone(authStatus: .restricted, probeSucceeds: false)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testMicBroken() {
+        let result = PermissionHealthCheck.checkMicrophone(authStatus: .authorized, probeSucceeds: false)
+        XCTAssertEqual(result, .broken)
+    }
+
+    func testMicNotDetermined() {
+        let result = PermissionHealthCheck.checkMicrophone(authStatus: .notDetermined, probeSucceeds: false)
+        XCTAssertEqual(result, .notDetermined)
+    }
+
+    // MARK: - Overall Health
+
+    func testOverallHealthy() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertTrue(result.isHealthy)
+        XCTAssertTrue(result.problems.isEmpty)
+    }
+
+    func testOverallScreenBroken() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .healthy)
+        XCTAssertFalse(result.isHealthy)
+        XCTAssertEqual(result.problems, [.screenRecordingBroken])
+    }
+
+    func testOverallMicBroken() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .broken)
+        XCTAssertFalse(result.isHealthy)
+        XCTAssertEqual(result.problems, [.microphoneBroken])
+    }
+
+    func testOverallBothBroken() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .broken)
+        XCTAssertFalse(result.isHealthy)
+        XCTAssertEqual(result.problems.count, 2)
+    }
+
+    func testOverallMicNotDeterminedIsHealthy() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .notDetermined)
+        XCTAssertTrue(result.isHealthy)
+    }
+
+    func testOverallScreenDenied() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .denied, microphone: .healthy)
+        XCTAssertEqual(result.problems, [.screenRecordingDenied])
+    }
+
+    func testOverallMicDenied() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .denied)
+        XCTAssertEqual(result.problems, [.microphoneDenied])
+    }
+
+    // MARK: - Notification Message
+
+    func testBrokenScreenRecordingMessage() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .healthy)
+        XCTAssertTrue(result.notificationBody.contains("Screen Recording"))
+        XCTAssertTrue(result.notificationBody.contains("reset"))
+    }
+
+    func testBrokenMicMessage() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .broken)
+        XCTAssertTrue(result.notificationBody.contains("Microphone"))
+        XCTAssertTrue(result.notificationBody.contains("reset"))
+    }
+
+    func testHealthyNoMessage() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertTrue(result.notificationBody.isEmpty)
+    }
+
+    // MARK: - HealthCheckResult Equatable
+
+    func testHealthCheckResultEquality() {
+        let a = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        let b = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertEqual(a, b)
+    }
+}

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -3,45 +3,88 @@ import AVFoundation
 import XCTest
 
 final class PermissionHealthCheckTests: XCTestCase {
-    // MARK: - Screen Recording
+    // MARK: - Screen Recording (new split API)
 
     func testScreenRecordingHealthy() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
-            [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: "Finder"],
-        ], ownPID: 123)
+        let result = PermissionHealthCheck.checkScreenRecording(
+            systemAllowed: true,
+            hasForeignWithTitle: true,
+        )
         XCTAssertEqual(result, .healthy)
     }
 
-    func testScreenRecordingDenied() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: nil, ownPID: 123)
+    func testScreenRecordingDeniedWhenSystemSaysNo() {
+        let result = PermissionHealthCheck.checkScreenRecording(
+            systemAllowed: false,
+            hasForeignWithTitle: false,
+        )
         XCTAssertEqual(result, .denied)
     }
 
-    func testScreenRecordingBrokenNoTitles() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
-            [kCGWindowOwnerPID as String: Int32(999)],
-            [kCGWindowOwnerPID as String: Int32(888)],
-        ], ownPID: 123)
+    func testScreenRecordingDeniedEvenWithWindows() {
+        // System says no — we ignore the probe outcome.
+        let result = PermissionHealthCheck.checkScreenRecording(
+            systemAllowed: false,
+            hasForeignWithTitle: true,
+        )
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testScreenRecordingBrokenSystemAllowsButNoTitles() {
+        // TCC says yes but window probe can't see any foreign titles.
+        let result = PermissionHealthCheck.checkScreenRecording(
+            systemAllowed: true,
+            hasForeignWithTitle: false,
+        )
         XCTAssertEqual(result, .broken)
     }
 
-    func testScreenRecordingIgnoresOwnWindows() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
-            [kCGWindowOwnerPID as String: Int32(123), kCGWindowName as String: "My App"],
-        ], ownPID: 123)
-        XCTAssertEqual(result, .broken)
+    // MARK: - Screen Recording (window list parser)
+
+    func testHasForeignWindowWithTitleTrue() {
+        let result = PermissionHealthCheck.hasForeignWindowWithTitle(
+            windowList: [
+                [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: "Finder"],
+            ],
+            ownPID: 123,
+        )
+        XCTAssertTrue(result)
     }
 
-    func testScreenRecordingBrokenEmptyTitle() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: [
-            [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: ""],
-        ], ownPID: 123)
-        XCTAssertEqual(result, .broken)
+    func testHasForeignWindowWithTitleNilList() {
+        let result = PermissionHealthCheck.hasForeignWindowWithTitle(
+            windowList: nil,
+            ownPID: 123,
+        )
+        XCTAssertFalse(result)
     }
 
-    func testScreenRecordingEmptyWindowList() {
-        let result = PermissionHealthCheck.checkScreenRecording(windowList: [], ownPID: 123)
-        XCTAssertEqual(result, .broken)
+    func testHasForeignWindowWithTitleIgnoresOwnPID() {
+        let result = PermissionHealthCheck.hasForeignWindowWithTitle(
+            windowList: [
+                [kCGWindowOwnerPID as String: Int32(123), kCGWindowName as String: "My App"],
+            ],
+            ownPID: 123,
+        )
+        XCTAssertFalse(result)
+    }
+
+    func testHasForeignWindowWithTitleEmptyTitle() {
+        let result = PermissionHealthCheck.hasForeignWindowWithTitle(
+            windowList: [
+                [kCGWindowOwnerPID as String: Int32(999), kCGWindowName as String: ""],
+            ],
+            ownPID: 123,
+        )
+        XCTAssertFalse(result)
+    }
+
+    func testHasForeignWindowWithTitleEmptyList() {
+        let result = PermissionHealthCheck.hasForeignWindowWithTitle(
+            windowList: [],
+            ownPID: 123,
+        )
+        XCTAssertFalse(result)
     }
 
     // MARK: - Microphone
@@ -71,10 +114,37 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(result, .notDetermined)
     }
 
+    // MARK: - Accessibility
+
+    func testAccessibilityHealthy() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probeSucceeds: true)
+        XCTAssertEqual(result, .healthy)
+    }
+
+    func testAccessibilityDenied() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probeSucceeds: false)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testAccessibilityDeniedEvenIfProbeSucceeds() {
+        // Defensive: if the system says no, we never report healthy.
+        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probeSucceeds: true)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testAccessibilityBroken() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probeSucceeds: false)
+        XCTAssertEqual(result, .broken)
+    }
+
     // MARK: - Overall Health
 
     func testOverallHealthy() {
-        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .healthy,
+        )
         XCTAssertTrue(result.isHealthy)
         XCTAssertTrue(result.problems.isEmpty)
     }
@@ -91,14 +161,49 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(result.problems, [.microphoneBroken])
     }
 
-    func testOverallBothBroken() {
-        let result = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .broken)
+    func testOverallAccessibilityBroken() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .broken,
+        )
         XCTAssertFalse(result.isHealthy)
-        XCTAssertEqual(result.problems.count, 2)
+        XCTAssertEqual(result.problems, [.accessibilityBroken])
+    }
+
+    func testOverallAccessibilityDenied() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .denied,
+        )
+        XCTAssertEqual(result.problems, [.accessibilityDenied])
+    }
+
+    func testOverallAllThreeBroken() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .broken,
+            microphone: .broken,
+            accessibility: .broken,
+        )
+        XCTAssertFalse(result.isHealthy)
+        XCTAssertEqual(result.problems.count, 3)
+        XCTAssertTrue(result.problems.contains(.screenRecordingBroken))
+        XCTAssertTrue(result.problems.contains(.microphoneBroken))
+        XCTAssertTrue(result.problems.contains(.accessibilityBroken))
     }
 
     func testOverallMicNotDeterminedIsHealthy() {
         let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .notDetermined)
+        XCTAssertTrue(result.isHealthy)
+    }
+
+    func testOverallAccessibilityNotDeterminedIsHealthy() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .notDetermined,
+        )
         XCTAssertTrue(result.isHealthy)
     }
 
@@ -114,16 +219,39 @@ final class PermissionHealthCheckTests: XCTestCase {
 
     // MARK: - Notification Message
 
-    func testBrokenScreenRecordingMessage() {
-        let result = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .healthy)
-        XCTAssertTrue(result.notificationBody.contains("Screen Recording"))
-        XCTAssertTrue(result.notificationBody.contains("reset"))
+    func testBrokenScreenRecordingMessageDistinguishesFromDenied() {
+        let broken = PermissionHealthCheck.overallHealth(screenRecording: .broken, microphone: .healthy)
+        let denied = PermissionHealthCheck.overallHealth(screenRecording: .denied, microphone: .healthy)
+        XCTAssertTrue(broken.notificationBody.contains("Screen Recording"))
+        XCTAssertTrue(broken.notificationBody.contains("toggle"))
+        XCTAssertTrue(denied.notificationBody.contains("denied"))
+        XCTAssertNotEqual(broken.notificationBody, denied.notificationBody)
     }
 
-    func testBrokenMicMessage() {
-        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .broken)
-        XCTAssertTrue(result.notificationBody.contains("Microphone"))
-        XCTAssertTrue(result.notificationBody.contains("reset"))
+    func testBrokenMicMessageDistinguishesFromDenied() {
+        let broken = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .broken)
+        let denied = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .denied)
+        XCTAssertTrue(broken.notificationBody.contains("Microphone"))
+        XCTAssertTrue(broken.notificationBody.contains("toggle"))
+        XCTAssertTrue(denied.notificationBody.contains("denied"))
+        XCTAssertNotEqual(broken.notificationBody, denied.notificationBody)
+    }
+
+    func testBrokenAccessibilityMessageDistinguishesFromDenied() {
+        let broken = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .broken,
+        )
+        let denied = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .denied,
+        )
+        XCTAssertTrue(broken.notificationBody.contains("Accessibility"))
+        XCTAssertTrue(broken.notificationBody.contains("toggle"))
+        XCTAssertTrue(denied.notificationBody.contains("denied"))
+        XCTAssertNotEqual(broken.notificationBody, denied.notificationBody)
     }
 
     func testHealthyNoMessage() {
@@ -137,5 +265,19 @@ final class PermissionHealthCheckTests: XCTestCase {
         let a = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
         let b = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
         XCTAssertEqual(a, b)
+    }
+
+    func testHealthCheckResultEqualityDifferentAccessibility() {
+        let a = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .healthy,
+        )
+        let b = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .broken,
+        )
+        XCTAssertNotEqual(a, b)
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -25,6 +25,9 @@ func makeTestWatchLoop(
         pollInterval: 0.05,
         endGracePeriod: 0.1,
     )
+    loop.permissionChecker = {
+        HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+    }
     return (loop, recorder)
 }
 

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -230,27 +230,27 @@ final class WatchLoopTests: XCTestCase {
 
     // MARK: - Manual Recording
 
-    func testStartManualRecordingChangesState() throws {
+    func testStartManualRecordingChangesState() async throws {
         let (loop, recorder) = makeTestWatchLoop()
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
 
         XCTAssertTrue(loop.isManualRecording)
         XCTAssertTrue(recorder.startCalled)
     }
 
-    func testManualRecordingHasMeetingInfo() throws {
+    func testManualRecordingHasMeetingInfo() async throws {
         let (loop, _) = makeTestWatchLoop()
-        try loop.startManualRecording(pid: 42, appName: "Safari", title: "Standup")
+        try await loop.startManualRecording(pid: 42, appName: "Safari", title: "Standup")
         defer { loop.stop() }
 
         XCTAssertEqual(loop.manualRecordingInfo?.appName, "Safari")
         XCTAssertEqual(loop.manualRecordingInfo?.title, "Standup")
     }
 
-    func testStopManualRecordingClearsState() throws {
+    func testStopManualRecordingClearsState() async throws {
         let (loop, _) = makeTestWatchLoop()
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
         loop.stop()
 
         XCTAssertFalse(loop.isManualRecording)
@@ -276,12 +276,12 @@ final class WatchLoopTests: XCTestCase {
 
     // MARK: - Stop Manual Recording Enqueues Job
 
-    func testStopManualRecordingEnqueuesJob() throws {
+    func testStopManualRecordingEnqueuesJob() async throws {
         let queue = PipelineQueue()
         let (loop, recorder) = makeTestWatchLoop(pipelineQueue: queue)
         recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
 
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
         XCTAssertTrue(loop.isManualRecording)
 
         loop.stopManualRecording()
@@ -296,19 +296,52 @@ final class WatchLoopTests: XCTestCase {
 
     // MARK: - Double Start Manual Recording
 
-    func testStartManualRecordingWhileRecordingIsNoOp() throws {
+    func testStartManualRecordingWhileRecordingIsNoOp() async throws {
         let (loop, recorder) = makeTestWatchLoop()
 
-        try loop.startManualRecording(pid: 42, appName: "Chrome", title: "First")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "First")
         defer { loop.stop() }
 
         XCTAssertTrue(loop.isManualRecording)
         XCTAssertEqual(loop.manualRecordingInfo?.title, "First")
 
         // Second start should be ignored because state is already .recording
-        try loop.startManualRecording(pid: 99, appName: "Safari", title: "Second")
+        try await loop.startManualRecording(pid: 99, appName: "Safari", title: "Second")
 
         XCTAssertEqual(loop.manualRecordingInfo?.title, "First")
+        XCTAssertTrue(recorder.startCalled)
+    }
+
+    // MARK: - Permission Pre-Check
+
+    func testManualRecordingFailsWhenPermissionBroken() async {
+        let (loop, _) = makeTestWatchLoop()
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .broken)
+        }
+
+        do {
+            try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
+            XCTFail("Expected permissionDenied error")
+        } catch let error as RecorderError {
+            if case let .permissionDenied(reason) = error {
+                XCTAssertTrue(reason.contains("Microphone"))
+            } else {
+                XCTFail("Expected permissionDenied, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testManualRecordingProceedsWhenPermissionsHealthy() async throws {
+        let (loop, recorder) = makeTestWatchLoop()
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
+        recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+
+        try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
         XCTAssertTrue(recorder.startCalled)
     }
 }


### PR DESCRIPTION
## Summary

Detects when macOS permissions are "granted" in TCC but functionally broken (common after macOS updates). Instead of silently failing to record, the app now:

- **Startup check**: Probes Screen Recording (can we read foreign window titles?) and Microphone (does AVAudioEngine get samples?) on launch
- **Error badge**: Shows error icon on menu bar when permissions are broken
- **Pre-recording abort**: Throws clear error before attempting to record with broken permissions
- **Periodic re-check**: Every 5 minutes during watch loop
- **User notification**: "Screen Recording permission appears broken — please reset in System Settings"

## Architecture

`PermissionHealthCheck` enum with pure testable functions (injected window lists, auth status) + live wrappers. Integrated via:
- `AppState.permissionHealth` property + `checkPermissions()` 
- `BadgeKind.compute(permissionProblem:)` parameter
- `WatchLoop.permissionChecker` injectable closure
- `RecorderError.permissionDenied` case

## Test plan
- [x] 164 affected tests pass (0 failures)
- [x] 22 new PermissionHealthCheck unit tests
- [x] 3 AppState integration tests
- [x] 3 MenuBarIcon badge tests  
- [x] 3 WatchLoop/Recorder tests
- [x] Lint: 0 violations