### PR TITLE
fix(build): staple notarization ticket to .app and DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,13 @@ jobs:
           TEAM_ID: ${{ secrets.TEAM_ID }}
           APP_PASSWORD: ${{ secrets.APP_PASSWORD }}
         run: |
-          # Use tag name as version (v0.3.0-rc1 → 0.3.0-rc1), fall back to VERSION file
+          # Tag builds: use tag as version and staple notarization for offline Gatekeeper
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             BUILD_VERSION="--version=${GITHUB_REF_NAME#v}"
+            STAPLE_FLAG="--staple"
           fi
           if [ "${{ matrix.variant }}" = "homebrew" ] && [ -n "${DEVELOPER_ID:-}" ]; then
-            ./scripts/build_release.sh ${BUILD_VERSION:-}
+            ./scripts/build_release.sh $STAPLE_FLAG ${BUILD_VERSION:-}
           else
             ./scripts/build_release.sh ${{ matrix.build-flags }} --no-notarize ${BUILD_VERSION:-}
           fi

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -2,7 +2,7 @@
 # Build a self-contained MeetingTranscriber.app bundle.
 #
 # Usage:
-#   ./scripts/build_release.sh [--no-notarize] [--appstore]
+#   ./scripts/build_release.sh [--no-notarize] [--staple] [--appstore]
 #
 # Output:
 #   .build/release/MeetingTranscriber.dmg
@@ -30,11 +30,13 @@ MACOS_DIR="$CONTENTS/MacOS"
 RESOURCES="$CONTENTS/Resources"
 
 NOTARIZE=true
+STAPLE=false
 APPSTORE=false
 OVERRIDE_VERSION=""
 for arg in "$@"; do
     case "$arg" in
         --no-notarize) NOTARIZE=false ;;
+        --staple) STAPLE=true ;;
         --appstore) APPSTORE=true ;;
         --version=*) OVERRIDE_VERSION="${arg#--version=}" ;;
     esac
@@ -48,6 +50,7 @@ else
 fi
 echo "Building MeetingTranscriber v${VERSION}"
 echo "  Notarize:    $NOTARIZE"
+echo "  Staple:      $STAPLE"
 echo "  App Store:   $APPSTORE"
 echo "======================================="
 
@@ -135,6 +138,31 @@ if [ "$NOTARIZE" = true ]; then
         --options runtime --timestamp --entitlements "$ENTITLEMENTS" \
         "$APP_BUNDLE"
     echo "  Signed with Developer ID for notarization"
+
+    # When --staple is set, notarize and staple the .app itself so Gatekeeper
+    # does not need to contact Apple online when the app is launched (cask
+    # installs strip the DMG context, so the DMG ticket alone is not sufficient).
+    if [ "$STAPLE" = true ]; then
+        if [ -z "${APPLE_ID:-}" ] || [ -z "${TEAM_ID:-}" ] || [ -z "${APP_PASSWORD:-}" ]; then
+            echo "  ERROR: APPLE_ID, TEAM_ID, and APP_PASSWORD must be set for notarization."
+            exit 1
+        fi
+
+        echo "  Notarizing .app bundle..."
+        APP_ZIP="$BUILD_DIR/MeetingTranscriber-app.zip"
+        rm -f "$APP_ZIP"
+        ditto -c -k --keepParent "$APP_BUNDLE" "$APP_ZIP"
+        xcrun notarytool submit "$APP_ZIP" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$TEAM_ID" \
+            --password "$APP_PASSWORD" \
+            --wait
+        rm -f "$APP_ZIP"
+
+        echo "  Stapling notarization ticket to .app..."
+        xcrun stapler staple "$APP_BUNDLE"
+        xcrun stapler validate "$APP_BUNDLE"
+    fi
 else
     # Use local development certificate if available (extract 40-char hex SHA-1 hash)
     SIGN_HASH=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '[0-9A-F]{40}' | head -1)
@@ -187,13 +215,22 @@ if [ -z "${HOMEBREW_TEMP:-}" ]; then
             exit 1
         fi
 
+        WAIT_FLAG=""
+        [ "$STAPLE" = true ] && WAIT_FLAG="--wait"
+
         xcrun notarytool submit "$DMG_PATH" \
             --apple-id "$APPLE_ID" \
             --team-id "$TEAM_ID" \
-            --password "$APP_PASSWORD"
+            --password "$APP_PASSWORD" \
+            $WAIT_FLAG
 
-        echo "  DMG submitted for notarization (no --wait, no staple)"
-        echo "  Gatekeeper will verify online when users open the DMG"
+        if [ "$STAPLE" = true ]; then
+            echo "  Stapling notarization ticket to DMG..."
+            xcrun stapler staple "$DMG_PATH"
+            xcrun stapler validate "$DMG_PATH"
+        else
+            echo "  DMG submitted for notarization (Gatekeeper will verify online)"
+        fi
     fi
 else
     echo ""


### PR DESCRIPTION
## Summary
- Notarize and staple the `.app` bundle directly (via ditto+zip submit) so Gatekeeper does not need an online check on first launch
- Add `--wait` + `xcrun stapler staple` to the DMG notarization step

## Why
A user reported the "MeetingTranscriber Not Opened — Apple could not verify..." dialog after a fresh Cask install, even though the build is correctly signed and notarized.

Investigation showed:
- `spctl`: Notarized Developer ID ✅
- `stapler validate`: ❌ no ticket stapled to either `.app` or DMG

Without a stapled ticket, Gatekeeper must contact Apple online on first launch. When that check fails (no network, captive portal, slow notary servers), users see the scary dialog. Cask installs are especially affected because the cask discards the DMG context after copying the `.app`, so any ticket on the DMG alone is lost.

## Trade-off
The build now waits for Apple's notary service to finish (typically 1–5 min, occasionally up to ~15 min) before stapling. This makes releases slower but means users never hit the online-check failure path.

## Test plan
- [x] Run `./scripts/build_release.sh` locally with valid `APPLE_ID`/`TEAM_ID`/`APP_PASSWORD`
- [x] Verify `xcrun stapler validate MeetingTranscriber.app` succeeds
- [x] Verify `xcrun stapler validate MeetingTranscriber-<version>.dmg` succeeds
- [ ] Install via cask on a fresh Mac (or one that has never seen the app) with network disabled and confirm no Gatekeeper dialog