### PR TITLE
fix(app): add KMeans crash recovery for FluidDiarizer

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -179,10 +179,12 @@ enum DiarizationProcess {
 
 enum DiarizationError: LocalizedError {
     case notAvailable
+    case notPrepared
 
     var errorDescription: String? {
         switch self {
         case .notAvailable: "Diarization not available"
+        case .notPrepared: "Offline diarization manager not prepared"
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -4,20 +4,25 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "FluidDiarizer")
 
+protocol OfflineDiarizationProcessing {
+    mutating func prepare(numSpeakers: Int?) async throws
+    func process(audioPath: URL) async throws -> DiarizationResult
+}
+
 /// CoreML-based speaker diarization using FluidAudio (on-device, no HuggingFace token needed).
 class FluidDiarizer: DiarizationProvider {
     let mode: DiarizerMode
+    private var offlineProcessor: OfflineDiarizationProcessing
 
-    private var offlineManager: OfflineDiarizerManager?
     private var sortformerDiarizer: SortformerDiarizer?
-    private var currentNumSpeakers: Int?
 
     var isAvailable: Bool {
         true
     }
 
-    init(mode: DiarizerMode = .offline) {
+    init(mode: DiarizerMode = .offline, offlineProcessor: OfflineDiarizationProcessing? = nil) {
         self.mode = mode
+        self.offlineProcessor = offlineProcessor ?? FluidOfflineProcessor()
     }
 
     /// Normalize FluidAudio's "Speaker 0" format to "SPEAKER_0".
@@ -39,38 +44,31 @@ class FluidDiarizer: DiarizationProvider {
         }
     }
 
-    // MARK: - Offline Mode (OfflineDiarizerManager)
+    // MARK: - Offline Mode
 
     private func runOffline(
         audioPath: URL,
         numSpeakers: Int?,
     ) async throws -> MeetingTranscriber.DiarizationResult {
-        // Recreate manager if numSpeakers changed
-        if offlineManager == nil || numSpeakers != currentNumSpeakers {
-            var config = OfflineDiarizerConfig()
-            if let n = numSpeakers, n > 0 {
-                config = config.withSpeakers(exactly: n)
-            }
-            let newManager = OfflineDiarizerManager(config: config)
-            try await newManager.prepareModels()
-            offlineManager = newManager
-            currentNumSpeakers = numSpeakers
-            logger.info("FluidAudio offline models ready")
-        }
+        try await offlineProcessor.prepare(numSpeakers: numSpeakers)
 
         logger.info("Starting offline diarization: \(audioPath.lastPathComponent)")
-        // swiftlint:disable:next force_unwrapping
-        let fluidResult = try await offlineManager!.process(audioPath)
 
-        let segments = fluidResult.segments.map { seg in
-            MeetingTranscriber.DiarizationResult.Segment(
-                start: TimeInterval(seg.startTimeSeconds),
-                end: TimeInterval(seg.endTimeSeconds),
-                speaker: Self.normalizeSpeakerId(seg.speakerId),
+        do {
+            return try await offlineProcessor.process(audioPath: audioPath)
+        } catch {
+            // If numSpeakers was specified, retry with auto-detect as fallback
+            guard let numSpeakers, numSpeakers > 0 else {
+                throw error
+            }
+
+            logger.warning(
+                "Diarization failed with numSpeakers=\(numSpeakers), retrying with auto-detect: \(error.localizedDescription)",
             )
-        }
 
-        return buildResult(segments: segments, speakerDatabase: fluidResult.speakerDatabase)
+            try await offlineProcessor.prepare(numSpeakers: nil)
+            return try await offlineProcessor.process(audioPath: audioPath)
+        }
     }
 
     // MARK: - Sortformer Mode (SortformerDiarizer)
@@ -99,12 +97,12 @@ class FluidDiarizer: DiarizationProvider {
             }
         }
 
-        return buildResult(segments: segments, speakerDatabase: nil)
+        return Self.buildResult(segments: segments, speakerDatabase: nil)
     }
 
     // MARK: - Shared Result Conversion
 
-    func buildResult(
+    static func buildResult(
         segments unsorted: [MeetingTranscriber.DiarizationResult.Segment],
         speakerDatabase: [String: [Float]]?, // swiftlint:disable:this discouraged_optional_collection
     ) -> MeetingTranscriber.DiarizationResult {
@@ -131,5 +129,43 @@ class FluidDiarizer: DiarizationProvider {
             autoNames: [:],
             embeddings: embeddings,
         )
+    }
+}
+
+// MARK: - FluidAudio Offline Processor (production implementation)
+
+struct FluidOfflineProcessor: OfflineDiarizationProcessing {
+    private var manager: OfflineDiarizerManager?
+    private var currentNumSpeakers: Int?
+
+    mutating func prepare(numSpeakers: Int?) async throws {
+        guard manager == nil || numSpeakers != currentNumSpeakers else { return }
+
+        // Explicitly deallocate previous manager to prevent resource conflicts
+        manager = nil
+        var config = OfflineDiarizerConfig()
+        if let n = numSpeakers, n > 0 {
+            config = config.withSpeakers(min: 1, max: n)
+        }
+        let newManager = OfflineDiarizerManager(config: config)
+        try await newManager.prepareModels()
+        manager = newManager
+        currentNumSpeakers = numSpeakers
+        logger.info("FluidAudio offline models ready")
+    }
+
+    func process(audioPath: URL) async throws -> DiarizationResult {
+        guard let manager else {
+            throw DiarizationError.notPrepared
+        }
+        let fluidResult = try await manager.process(audioPath)
+        let segments = fluidResult.segments.map { seg in
+            DiarizationResult.Segment(
+                start: TimeInterval(seg.startTimeSeconds),
+                end: TimeInterval(seg.endTimeSeconds),
+                speaker: FluidDiarizer.normalizeSpeakerId(seg.speakerId),
+            )
+        }
+        return FluidDiarizer.buildResult(segments: segments, speakerDatabase: fluidResult.speakerDatabase)
     }
 }

--- a/app/MeetingTranscriber/Tests/FluidDiarizerTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidDiarizerTests.swift
@@ -28,41 +28,134 @@ final class FluidDiarizerTests: XCTestCase {
     // MARK: - buildResult
 
     func testBuildResultSortsByStartTime() {
-        let diarizer = FluidDiarizer()
         let segments: [DiarizationResult.Segment] = [
             .init(start: 5, end: 10, speaker: "SPEAKER_0"),
             .init(start: 0, end: 5, speaker: "SPEAKER_1"),
         ]
-        let result = diarizer.buildResult(segments: segments, speakerDatabase: nil)
+        let result = FluidDiarizer.buildResult(segments: segments, speakerDatabase: nil)
         XCTAssertEqual(result.segments[0].start, 0)
         XCTAssertEqual(result.segments[1].start, 5)
     }
 
     func testBuildResultComputesSpeakingTimes() {
-        let diarizer = FluidDiarizer()
         let segments: [DiarizationResult.Segment] = [
             .init(start: 0, end: 5, speaker: "SPEAKER_0"),
             .init(start: 5, end: 10, speaker: "SPEAKER_1"),
             .init(start: 10, end: 20, speaker: "SPEAKER_0"),
         ]
-        let result = diarizer.buildResult(segments: segments, speakerDatabase: nil)
+        let result = FluidDiarizer.buildResult(segments: segments, speakerDatabase: nil)
         XCTAssertEqual(result.speakingTimes["SPEAKER_0"], 15.0)
         XCTAssertEqual(result.speakingTimes["SPEAKER_1"], 5.0)
     }
 
     func testBuildResultEmptySegments() {
-        let diarizer = FluidDiarizer()
-        let result = diarizer.buildResult(segments: [], speakerDatabase: nil)
+        let result = FluidDiarizer.buildResult(segments: [], speakerDatabase: nil)
         XCTAssertTrue(result.segments.isEmpty)
         XCTAssertTrue(result.speakingTimes.isEmpty)
     }
 
     func testBuildResultNilEmbeddings() {
-        let diarizer = FluidDiarizer()
-        let result = diarizer.buildResult(
+        let result = FluidDiarizer.buildResult(
             segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
             speakerDatabase: nil,
         )
         XCTAssertNil(result.embeddings)
+    }
+
+    // MARK: - Crash Recovery (retry with auto-detect)
+
+    private static let dummyURL = URL(fileURLWithPath: "/tmp/test.wav")
+
+    fileprivate static func makeResult(speaker: String = "SPEAKER_0") -> DiarizationResult {
+        DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: speaker)],
+            speakingTimes: [speaker: 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+    }
+
+    func testRetryWithAutoDetectOnFailure() async throws {
+        var mock = MockOfflineProcessor()
+        var callCount = 0
+        mock.onProcess = { _ in
+            callCount += 1
+            if callCount == 1 {
+                throw NSError(domain: "FluidAudio", code: 1, userInfo: [NSLocalizedDescriptionKey: "KMeans failed"])
+            }
+            return Self.makeResult()
+        }
+        let diarizer = FluidDiarizer(mode: .offline, offlineProcessor: mock)
+
+        let result = try await diarizer.run(
+            audioPath: Self.dummyURL, numSpeakers: 5, meetingTitle: "Test",
+        )
+        XCTAssertEqual(callCount, 2, "Should retry once after failure")
+        XCTAssertEqual(result.segments.count, 1)
+    }
+
+    func testNoRetryWithoutNumSpeakers() async {
+        var mock = MockOfflineProcessor()
+        mock.onProcess = { _ in
+            throw NSError(domain: "FluidAudio", code: 1, userInfo: [NSLocalizedDescriptionKey: "KMeans failed"])
+        }
+        let diarizer = FluidDiarizer(mode: .offline, offlineProcessor: mock)
+
+        do {
+            _ = try await diarizer.run(
+                audioPath: Self.dummyURL, numSpeakers: nil, meetingTitle: "Test",
+            )
+            XCTFail("Expected error to propagate when numSpeakers is nil")
+        } catch {
+            // Expected — no retry when numSpeakers is nil
+        }
+    }
+
+    func testNoRetryOnSuccess() async throws {
+        var mock = MockOfflineProcessor()
+        var callCount = 0
+        mock.onProcess = { _ in
+            callCount += 1
+            return Self.makeResult()
+        }
+        let diarizer = FluidDiarizer(mode: .offline, offlineProcessor: mock)
+
+        _ = try await diarizer.run(
+            audioPath: Self.dummyURL, numSpeakers: 3, meetingTitle: "Test",
+        )
+        XCTAssertEqual(callCount, 1, "Should not retry on success")
+    }
+
+    func testErrorPropagatesOnRetryFailure() async {
+        var mock = MockOfflineProcessor()
+        mock.onProcess = { _ in
+            throw NSError(domain: "FluidAudio", code: 1, userInfo: [NSLocalizedDescriptionKey: "Always fails"])
+        }
+        let diarizer = FluidDiarizer(mode: .offline, offlineProcessor: mock)
+
+        do {
+            _ = try await diarizer.run(
+                audioPath: Self.dummyURL, numSpeakers: 5, meetingTitle: "Test",
+            )
+            XCTFail("Expected error when both attempts fail")
+        } catch {
+            // Expected — retry also failed, error propagates
+        }
+    }
+}
+
+// MARK: - Mock
+
+private struct MockOfflineProcessor: OfflineDiarizationProcessing {
+    var onProcess: ((URL) async throws -> DiarizationResult)?
+
+    // swiftlint:disable:next async_without_await unneeded_throws_rethrows
+    mutating func prepare(numSpeakers _: Int?) async throws {}
+
+    func process(audioPath: URL) async throws -> DiarizationResult {
+        guard let onProcess else {
+            return FluidDiarizerTests.makeResult()
+        }
+        return try await onProcess(audioPath)
     }
 }


### PR DESCRIPTION
## Summary

- Use flexible speaker range (`min:1, max:n`) instead of exact count to prevent KMeans crash when audio has fewer segments than requested speakers
- Fall back to auto-detect mode if diarization still fails with the flexible range
- Extract `OfflineDiarizationProcessing` protocol for the offline processing step — `FluidOfflineProcessor` is the production impl, `MockOfflineProcessor` enables testing retry logic without CoreML models

Inspired by [@dagil-nvidia](https://github.com/dagil-nvidia)'s [fork](https://github.com/dagil-nvidia/meeting-transcriber).

## Test plan

- [x] 13 FluidDiarizer tests pass (9 existing + 4 new crash recovery)
- [x] `testRetryWithAutoDetectOnFailure` — first call fails, retry with auto-detect succeeds
- [x] `testNoRetryWithoutNumSpeakers` — error propagates without retry
- [x] `testNoRetryOnSuccess` — no retry when first call succeeds
- [x] `testErrorPropagatesOnRetryFailure` — error propagates when both attempts fail
- [ ] Optional: set numSpeakers=10 in Settings, record short meeting, verify log shows auto-detect fallback