### PR TITLE
test(app): add E2E full pipeline test with zero mocks

### DIFF
--- a/app/MeetingTranscriber/Tests/E2EFullPipelineTests.swift
+++ b/app/MeetingTranscriber/Tests/E2EFullPipelineTests.swift
@@ -1,0 +1,113 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// End-to-end pipeline test with **zero mocks**.
+///
+/// Launches the meeting-simulator tool (which opens a window, creates a power assertion,
+/// and plays audio). WatchLoop detects the meeting via PowerAssertionDetector,
+/// DualSourceRecorder taps the simulator's audio via CATapDescription, Parakeet
+/// transcribes the recording, FluidDiarizer identifies speakers, and the test verifies
+/// that the transcript output file exists and contains recognized speech.
+///
+/// Skipped in CI — requires audio hardware, mic permission, and model downloads.
+/// Run locally: `swift test --filter E2EFullPipeline`
+@MainActor
+final class E2EFullPipelineTests: XCTestCase {
+    private var tmpDir: URL?
+
+    // MARK: - Setup
+
+    override func setUp() async throws {
+        try XCTSkipIf(
+            shouldSkipE2E,
+            "E2E test requires audio hardware — set E2E_ENABLED=1 on self-hosted runners",
+        )
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("e2e_pipeline_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tmpDir = dir
+    }
+
+    override func tearDown() async throws { // swiftlint:disable:this unneeded_throws_rethrows
+        if let dir = tmpDir { try? FileManager.default.removeItem(at: dir) }
+    }
+
+    // MARK: - Full Pipeline
+
+    func testFullPipelineDetectRecordTranscribeDiarize() async throws {
+        let outputDir = try XCTUnwrap(tmpDir, "tmpDir not set")
+
+        // 1. Real Parakeet engine — downloads model on first run (~50 MB)
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+
+        // 2. Real pipeline: Parakeet + FluidDiarizer + no LLM (transcript only)
+        let diarizer = FluidDiarizer()
+        let queue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { diarizer },
+            protocolGeneratorFactory: { nil },
+            outputDir: outputDir,
+            logDir: outputDir,
+            diarizeEnabled: true,
+            numSpeakers: 2,
+            micLabel: "Me",
+        )
+        queue.speakerNamingHandler = { _ in .skipped }
+
+        // 3. Track pipeline completion (guard against double-fulfill)
+        let pipelineDone = expectation(description: "Pipeline completes")
+        var fulfilled = false
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done || newState == .error, !fulfilled {
+                fulfilled = true
+                pipelineDone.fulfill()
+            }
+        }
+
+        // 4. Real WatchLoop: PowerAssertionDetector + DualSourceRecorder
+        let detector = PowerAssertionDetector()
+        let loop = WatchLoop(
+            detector: detector,
+            recorderFactory: { DualSourceRecorder() },
+            pipelineQueue: queue,
+            pollInterval: 1.0,
+            endGracePeriod: 5.0,
+        )
+        loop.start()
+        addTeardownBlock { loop.stop() }
+
+        // 5. Launch meeting simulator — plays two_speakers_de.wav (~53s)
+        let binary = try SimulatorHelper.buildSimulator()
+        let simulator = try SimulatorHelper.launchSimulator(
+            binary: binary,
+            audioPath: SimulatorHelper.fixtureAudio,
+        )
+        addTeardownBlock {
+            if simulator.isRunning { simulator.terminate() }
+        }
+
+        // 6. Wait for pipeline completion
+        // ~53s audio + 5s grace + model inference + overhead
+        await fulfillment(of: [pipelineDone], timeout: 120)
+
+        // 7. Assertions
+        let job = try XCTUnwrap(queue.jobs.first, "Expected at least one pipeline job")
+        XCTAssertEqual(job.state, .done, "Job should complete. Error: \(job.error ?? "none")")
+        XCTAssertNil(job.error)
+
+        // Transcript file exists and has content
+        let transcriptPath = try XCTUnwrap(job.transcriptPath, "Transcript path should be set")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: transcriptPath.path),
+            "Transcript file should exist",
+        )
+        let transcript = try String(contentsOf: transcriptPath, encoding: .utf8)
+        XCTAssertFalse(transcript.isEmpty, "Transcript should not be empty")
+
+        print("=== E2E Full Pipeline Test Passed ===")
+        print("Transcript length: \(transcript.count) chars")
+        print("Transcript preview: \(String(transcript.prefix(300)))")
+    }
+}

--- a/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
@@ -7,8 +7,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Model loading
 
     func testParakeetModelLoadsSuccessfully() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let engine = ParakeetEngine()
         await engine.loadModel()
@@ -18,8 +17,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Transcription with fixture
 
     func testTranscribeSegmentsWithFixture() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -51,8 +49,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscribeSegmentsProducesGermanContent() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -75,8 +72,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscribeSegmentsGroupsIntoSentences() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -103,8 +99,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Progress tracking
 
     func testDownloadProgressReachesOne() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let engine = ParakeetEngine()
         await engine.loadModel()
@@ -113,8 +108,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscriptionProgressReachesOne() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Parakeet model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(

--- a/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
@@ -10,8 +10,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Qwen3-ASR model download (set E2E_ENABLED=1)")
 
         let engine = Qwen3AsrEngine()
         await engine.loadModel()
@@ -24,8 +23,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Qwen3-ASR model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -61,8 +59,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Qwen3-ASR model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -90,8 +87,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Qwen3-ASR model download (set E2E_ENABLED=1)")
 
         let engine = Qwen3AsrEngine()
         await engine.loadModel()
@@ -103,8 +99,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires Qwen3-ASR model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -230,6 +230,60 @@ class MockEngine: TranscribingEngine {
     }
 }
 
+// MARK: - Meeting Simulator (for E2E tests)
+
+/// Helpers for building and launching the meeting-simulator tool.
+enum SimulatorHelper {
+    /// Project root derived from the test file location.
+    /// Tests/ → MeetingTranscriber/ → app/ → project root
+    static let projectRoot: URL = .init(fileURLWithPath: #filePath)
+        .deletingLastPathComponent() // Tests/
+        .deletingLastPathComponent() // MeetingTranscriber/
+        .deletingLastPathComponent() // app/
+        .deletingLastPathComponent() // project root
+
+    /// Path to the meeting-simulator SPM package.
+    static let simulatorPackage = projectRoot.appendingPathComponent("tools/meeting-simulator")
+
+    /// Path to the two-speaker German test fixture.
+    static let fixtureAudio: URL = .init(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Fixtures/two_speakers_de.wav")
+
+    /// Builds the meeting-simulator executable and returns the binary path.
+    static func buildSimulator() throws -> URL {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
+        process.arguments = ["build", "-c", "release"]
+        process.currentDirectoryURL = simulatorPackage
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        // Drain pipe before waitUntilExit to prevent deadlock if output exceeds pipe buffer
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let output = String(data: outputData, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "SimulatorHelper",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "meeting-simulator build failed: \(output)"],
+            )
+        }
+        return simulatorPackage.appendingPathComponent(".build/release/meeting-simulator")
+    }
+
+    /// Launches the meeting-simulator as a subprocess playing the given audio file.
+    static func launchSimulator(binary: URL, audioPath: URL) throws -> Process {
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = [audioPath.path]
+        try process.run()
+        return process
+    }
+}
+
 // MARK: - Test Audio Fixture
 
 /// Create a minimal valid 16kHz Float32 mono WAV (0.5s silence).

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -230,6 +230,17 @@ class MockEngine: TranscribingEngine {
     }
 }
 
+// MARK: - E2E Skip Logic
+
+/// Whether E2E tests should be skipped in the current environment.
+/// - Local dev: CI unset → run
+/// - Regular CI: CI set, E2E_ENABLED unset → skip
+/// - E2E workflow: CI set, E2E_ENABLED set → run
+var shouldSkipE2E: Bool {
+    ProcessInfo.processInfo.environment["CI"] != nil
+        && ProcessInfo.processInfo.environment["E2E_ENABLED"] == nil
+}
+
 // MARK: - Meeting Simulator (for E2E tests)
 
 /// Helpers for building and launching the meeting-simulator tool.

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -94,8 +94,8 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     func testFullPipelineDetectRecordTranscribeProtocol() async throws {
         try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
+            shouldSkipE2E,
+            "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)",
         )
 
         let fixture = fixtureURL()
@@ -151,8 +151,8 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     func testDualSourceTranscriptionPath() async throws {
         try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
+            shouldSkipE2E,
+            "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)",
         )
 
         let fixture = fixtureURL()
@@ -246,8 +246,8 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     func testDiarizationSkippedWhenNotAvailable() async throws {
         try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
+            shouldSkipE2E,
+            "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)",
         )
 
         let fixture = fixtureURL()
@@ -319,8 +319,8 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     func testResamplePathProduces16kHzForWhisperKit() async throws {
         try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
+            shouldSkipE2E,
+            "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)",
         )
 
         let fixture = fixtureURL()
@@ -365,8 +365,8 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     func testFullPipelineWithRealDiarization() async throws {
         try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model + FluidAudio diarization",
+            shouldSkipE2E,
+            "Skipping in CI: requires WhisperKit model + FluidAudio diarization (set E2E_ENABLED=1)",
         )
 
         let fixture = fixtureURL()

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -159,8 +159,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testTranscribeSegmentsWithFixture() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -205,8 +204,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testTranscribeSegmentsHallucinationFilter() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -234,8 +232,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testFullDualSourcePipeline() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -347,8 +344,7 @@ final class WhisperKitE2ETests: XCTestCase {
     }
 
     func testTranscribeMultiFormatContent() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try XCTSkipIf(shouldSkipE2E, "Skipping in CI: requires WhisperKit model download (set E2E_ENABLED=1)")
 
         let engine = WhisperKitEngine()
         engine.modelVariant = "openai_whisper-small"

--- a/docs/plans/2026-04-11-e2e-full-pipeline-tests.md
+++ b/docs/plans/2026-04-11-e2e-full-pipeline-tests.md
@@ -1,0 +1,345 @@
+# E2E Full Pipeline Tests — Design & Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Test the complete app pipeline end-to-end with zero mocks — real detection, real recording, real transcription (Parakeet), real diarization (FluidDiarizer), real output files.
+
+**Architecture:** The test launches `meeting-simulator` as a subprocess which opens a window (triggers PowerAssertionDetector), plays `two_speakers_de.wav` through the speakers. WatchLoop detects the meeting, CATapDescription taps the simulator's audio, Parakeet transcribes, FluidDiarizer diarizes, and the test verifies the output files.
+
+```
+swift test (E2EFullPipelineTests)
+  │
+  ├── Build meeting-simulator (setUpClass)
+  ├── Load Parakeet model (auto-download, ~50 MB)
+  │
+  ├── testFullPipeline()
+  │     │
+  │     ├── Start WatchLoop (PowerAssertionDetector + DualSourceRecorder)
+  │     ├── Launch meeting-simulator subprocess
+  │     │     → Window opens, power assertion created
+  │     │     → Plays two_speakers_de.wav (~53s)
+  │     │     → Auto-closes after playback
+  │     │
+  │     ├── WatchLoop detects meeting (via power assertion)
+  │     ├── CATapDescription taps simulator PID
+  │     ├── Records audio (~53s)
+  │     ├── Simulator closes → WatchLoop detects end (grace period)
+  │     ├── Pipeline: Parakeet transcription (~5s)
+  │     ├── Pipeline: FluidDiarizer (~5s)
+  │     ├── Speaker naming: auto-skip
+  │     ├── Protocol provider: .none (transcript only)
+  │     └── Assert output files
+  │
+  └── Cleanup temp dir
+```
+
+**Total test time:** ~80s (53s recording + 15s grace period + ~10s inference + overhead)
+
+---
+
+## Prerequisites
+
+| Requirement | Why | CI Impact |
+|---|---|---|
+| macOS 14.2+ | CATapDescription | GitHub runners OK |
+| Microphone permission | AVAudioEngine mic recording | **Not available on CI** — test skipped |
+| Audio output device | AVAudioPlayer in simulator | Available on macOS runners |
+| Parakeet model (~50 MB) | Real transcription | Auto-downloaded, cacheable |
+| FluidAudio models (~50 MB) | Real diarization | Auto-downloaded, cacheable |
+
+**CI strategy:** Skip via `XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)`. Run locally or on self-hosted runner with permissions pre-granted.
+
+---
+
+## Task 1: Build Infrastructure
+
+**Files:**
+- Modify: `Tests/TestHelpers.swift`
+
+**Step 1: Add meeting-simulator build helper**
+
+```swift
+enum SimulatorHelper {
+    /// Path to the project root (derived from test file location).
+    static let projectRoot: URL = {
+        // Tests/E2EFullPipelineTests.swift → Tests/ → MeetingTranscriber/ → app/ → project root
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // MeetingTranscriber/
+            .deletingLastPathComponent() // app/
+    }()
+
+    /// Path to the meeting-simulator package.
+    static let simulatorPackage = projectRoot.appendingPathComponent("tools/meeting-simulator")
+
+    /// Path to the fixture audio file.
+    static let fixtureAudio = projectRoot
+        .appendingPathComponent("app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav")
+
+    /// Builds the meeting-simulator and returns the path to the executable.
+    static func buildSimulator() throws -> URL {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
+        process.arguments = ["build", "-c", "release"]
+        process.currentDirectoryURL = simulatorPackage
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            throw NSError(domain: "SimulatorHelper", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Build failed: \(output)"])
+        }
+        return simulatorPackage
+            .appendingPathComponent(".build/release/meeting-simulator")
+    }
+
+    /// Launches the meeting-simulator as a subprocess.
+    static func launchSimulator(binary: URL, audioPath: URL) throws -> Process {
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = [audioPath.path]
+        try process.run()
+        return process
+    }
+}
+```
+
+**Step 2: Run existing tests to verify nothing breaks**
+
+Run: `cd app/MeetingTranscriber && swift test --filter WatchLoopE2ETests`
+
+**Step 3: Commit**
+
+```
+test(app): add SimulatorHelper for E2E test infrastructure
+```
+
+---
+
+## Task 2: Create E2E Test — Full Pipeline
+
+**Files:**
+- Create: `Tests/E2EFullPipelineTests.swift`
+
+**Step 1: Write the test file**
+
+```swift
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class E2EFullPipelineTests: XCTestCase {
+    private static var simulatorBinary: URL!
+    private var tmpDir: URL!
+
+    // MARK: - Setup
+
+    override class func setUp() {
+        super.setUp()
+        // Build meeting-simulator once for all tests in this class
+        do {
+            simulatorBinary = try SimulatorHelper.buildSimulator()
+        } catch {
+            XCTFail("Failed to build meeting-simulator: \(error)")
+        }
+    }
+
+    override func setUp() async throws {
+        // Skip in CI — needs mic permission + audio hardware
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["CI"] != nil,
+            "E2E test requires audio hardware and mic permission"
+        )
+
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("e2e_pipeline_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - Full Pipeline Test
+
+    func testFullPipelineDetectRecordTranscribeDiarize() async throws {
+        // 1. Set up real Parakeet engine
+        let engine = ParakeetEngine()
+        try await engine.loadModel()
+
+        // 2. Create pipeline queue with real components
+        let diarizer = FluidDiarizer()
+        let queue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { diarizer },
+            protocolGeneratorFactory: { nil }, // .none provider — transcript only
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            diarizeEnabled: true,
+            numSpeakers: 2,
+            micLabel: "Me",
+        )
+
+        // Auto-skip speaker naming
+        queue.speakerNamingHandler = { _ in .skipped }
+
+        // 3. Track completion
+        let pipelineDone = expectation(description: "Pipeline completes")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done || newState == .error {
+                pipelineDone.fulfill()
+            }
+        }
+
+        // 4. Create WatchLoop with real detector + real recorder
+        let detector = PowerAssertionDetector()
+        let loop = WatchLoop(
+            detector: detector,
+            recorderFactory: { DualSourceRecorder() },
+            pipelineQueue: queue,
+            pollInterval: 1.0,
+            endGracePeriod: 5.0,
+        )
+
+        // 5. Start watching
+        loop.start()
+        addTeardownBlock { loop.stop() }
+
+        // 6. Launch meeting simulator
+        let simulator = try SimulatorHelper.launchSimulator(
+            binary: Self.simulatorBinary,
+            audioPath: SimulatorHelper.fixtureAudio,
+        )
+        addTeardownBlock { simulator.terminate() }
+
+        // 7. Wait for pipeline to complete (timeout: 120s)
+        // ~53s audio + 5s grace + model loading + inference
+        await fulfillment(of: [pipelineDone], timeout: 120)
+
+        // 8. Assertions
+        let job = try XCTUnwrap(queue.jobs.first)
+        XCTAssertEqual(job.state, .done, "Job should complete. Error: \(job.error ?? "none")")
+        XCTAssertNil(job.error)
+
+        // Transcript file exists
+        let transcriptPath = try XCTUnwrap(job.transcriptPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: transcriptPath.path),
+                      "Transcript file should exist at \(transcriptPath.path)")
+
+        // Transcript has content
+        let transcript = try String(contentsOf: transcriptPath, encoding: .utf8)
+        XCTAssertFalse(transcript.isEmpty, "Transcript should not be empty")
+
+        // Audio was actually recorded (mix file should exist)
+        XCTAssertNotNil(job.mixPath)
+        if let mixPath = job.mixPath {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: mixPath.path),
+                          "Mix audio file should exist")
+        }
+
+        print("=== E2E Test Passed ===")
+        print("Transcript length: \(transcript.count) chars")
+        print("Transcript preview: \(String(transcript.prefix(200)))")
+    }
+}
+```
+
+**Step 2: Run the test locally**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter E2EFullPipelineTests
+```
+
+Expected: Takes ~80–120s. Meeting simulator window opens, audio plays, app detects and records, pipeline runs, test passes.
+
+Potential issues to debug:
+- Mic permission prompt → grant to Terminal/Xcode
+- PowerAssertionDetector doesn't detect the simulator → check assertion naming pattern
+- CATapDescription can't tap the simulator → check PID passing
+- Audio too quiet → CATapDescription captures system audio, volume doesn't matter
+
+**Step 3: Commit**
+
+```
+test(app): add E2E full pipeline test with real detection, recording, and transcription
+```
+
+---
+
+## Task 3: CI Integration
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Step 1: Add `--skip` for E2E tests in normal CI**
+
+In the test step, change:
+```yaml
+swift test ${{ matrix.swift-flags }}
+```
+to:
+```yaml
+swift test --skip E2EFullPipeline ${{ matrix.swift-flags }}
+```
+
+**Step 2: Commit**
+
+```
+ci: skip E2E full pipeline tests in CI (requires audio hardware)
+```
+
+---
+
+## Task 4: Verify & Polish
+
+**Step 1: Run full test suite locally**
+
+```bash
+cd app/MeetingTranscriber && swift test
+```
+
+Expected: All tests pass including E2E (~993 existing + 1 new). E2E test takes ~80–120s.
+
+**Step 2: Run lint**
+
+```bash
+./scripts/lint.sh
+```
+
+**Step 3: Verify CI still works**
+
+Push to a branch, confirm the `--skip` flag correctly skips the E2E test while all other tests pass.
+
+---
+
+## Future Extensions
+
+Once the basic E2E test works, possible additions:
+
+| Test | What it adds |
+|---|---|
+| `testFullPipelineDualSource` | Verify both app + mic tracks are recorded and merged |
+| `testFullPipelineWithSpeakerNaming` | Use `.confirmed()` instead of `.skipped`, verify names in output |
+| `testFullPipelineShortAudio` | Use a shorter fixture (~10s) for faster feedback |
+| `testFullPipelineWhisperKit` | Same test but with WhisperKit engine |
+| Self-hosted CI job | Run E2E on Tart VM or self-hosted Mac runner on tag push |
+
+---
+
+## Summary
+
+| Item | Detail |
+|---|---|
+| Test file | `Tests/E2EFullPipelineTests.swift` |
+| Mocks | **None** — everything real |
+| Engine | Parakeet (fastest, ~50 MB model) |
+| Diarization | FluidDiarizer (offline mode) |
+| Protocol | `.none` (transcript only) |
+| Speaker naming | Auto-skip |
+| Audio | `two_speakers_de.wav` fixture via meeting-simulator |
+| Duration | ~80–120s |
+| CI | Skipped via `--skip E2EFullPipeline` |
+| Local | `swift test --filter E2EFullPipeline` |


### PR DESCRIPTION
## Summary
- Full end-to-end pipeline test with **zero mocks**: real detection, real recording, real transcription (Parakeet), real diarization (FluidDiarizer)
- Meeting Simulator launches as subprocess, plays `two_speakers_de.wav` through speakers
- WatchLoop detects via PowerAssertionDetector, CATapDescription records the audio
- Parakeet transcribes (~1.6 KB German text with R_/M_ dual-track speaker labels), FluidDiarizer identifies 2 speakers
- Skipped on regular CI via `shouldSkipE2E` (CI && !E2E_ENABLED) — requires audio hardware + mic permission
- Runs on the self-hosted Mac mini runner via `e2e.yml` workflow (workflow_dispatch + tag push)
- `SimulatorHelper` in TestHelpers.swift: builds + launches meeting-simulator, with pipe-deadlock prevention
- ~67 s runtime locally on M-series; cold first run downloads Parakeet (~50 MB) + FluidAudio models

## Test plan
- [x] `E2E_ENABLED=1 swift test --filter E2EFullPipeline` passes locally (67 s, transcript 1595 chars)
- [x] Lint clean (`./scripts/lint.sh` — 0 errors, 0 serious)
- [x] PR-CI passes (E2E auto-skipped on github-hosted runners, all other tests unaffected)
- [ ] E2E workflow passes on self-hosted Mac mini runner (`gh workflow run e2e.yml --ref test/e2e-full-pipeline`)