### PR TITLE
fix(app): prevent mix.wav 2x duration from device restart mid-recording

### DIFF
--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -11,6 +11,10 @@ enum AudioMixer {
     /// Mix app and mic audio tracks into a single mono WAV.
     ///
     /// Applies echo suppression, delay alignment, then averages the two tracks.
+    /// Maximum plausible mic-to-app delay (seconds). Values beyond this indicate
+    /// a corrupted timestamp (e.g. device restart mid-recording, see #99).
+    static let maxMicDelay: TimeInterval = 30
+
     static func mix(
         appAudioPath: URL,
         micAudioPath: URL,
@@ -21,25 +25,33 @@ enum AudioMixer {
         var appSamples = try loadAudioFileAsFloat32(url: appAudioPath)
         var micSamples = try loadAudioFileAsFloat32(url: micAudioPath)
 
+        // Clamp delay to a sane range — a device restart mid-recording can
+        // corrupt the first-frame timestamp, producing delays of hundreds of
+        // seconds which would double the mix duration (see #99).
+        let clampedDelay = min(max(micDelay, -maxMicDelay), maxMicDelay)
+        if clampedDelay != micDelay {
+            logger.warning("micDelay \(micDelay)s outside ±\(Self.maxMicDelay)s — clamped to \(clampedDelay)s")
+        }
+
         // Apply echo suppression
         if !appSamples.isEmpty && !micSamples.isEmpty {
             suppressEcho(
                 appSamples: appSamples,
                 micSamples: &micSamples,
                 sampleRate: sampleRate,
-                micDelay: micDelay,
+                micDelay: clampedDelay,
             )
         }
 
         // Align by mic delay (shift mic samples)
-        if micDelay > 0 {
-            let delaySamples = Int(micDelay * Double(sampleRate))
+        if clampedDelay > 0 {
+            let delaySamples = Int(clampedDelay * Double(sampleRate))
             if delaySamples > 0 && delaySamples < micSamples.count {
                 // Mic started later: prepend zeros
                 micSamples = [Float](repeating: 0, count: delaySamples) + micSamples
             }
-        } else if micDelay < 0 {
-            let delaySamples = Int(-micDelay * Double(sampleRate))
+        } else if clampedDelay < 0 {
+            let delaySamples = Int(-clampedDelay * Double(sampleRate))
             if delaySamples > 0 && delaySamples < appSamples.count {
                 // App started later: prepend zeros to app
                 appSamples = [Float](repeating: 0, count: delaySamples) + appSamples

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -8,13 +8,13 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AudioMi
 enum AudioMixer {
     // MARK: - Mix
 
-    /// Mix app and mic audio tracks into a single mono WAV.
-    ///
-    /// Applies echo suppression, delay alignment, then averages the two tracks.
     /// Maximum plausible mic-to-app delay (seconds). Values beyond this indicate
     /// a corrupted timestamp (e.g. device restart mid-recording, see #99).
     static let maxMicDelay: TimeInterval = 30
 
+    /// Mix app and mic audio tracks into a single mono WAV.
+    ///
+    /// Applies echo suppression, delay alignment, then averages the two tracks.
     static func mix(
         appAudioPath: URL,
         micAudioPath: URL,
@@ -25,9 +25,7 @@ enum AudioMixer {
         var appSamples = try loadAudioFileAsFloat32(url: appAudioPath)
         var micSamples = try loadAudioFileAsFloat32(url: micAudioPath)
 
-        // Clamp delay to a sane range — a device restart mid-recording can
-        // corrupt the first-frame timestamp, producing delays of hundreds of
-        // seconds which would double the mix duration (see #99).
+        // Clamp to ±maxMicDelay (see #99).
         let clampedDelay = min(max(micDelay, -maxMicDelay), maxMicDelay)
         if clampedDelay != micDelay {
             logger.warning("micDelay \(micDelay)s outside ±\(Self.maxMicDelay)s — clamped to \(clampedDelay)s")

--- a/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
@@ -57,4 +57,36 @@ final class AudioMixerDelayTests: XCTestCase {
         let output = try mixWithDelay(0)
         XCTAssertEqual(output.count, sampleCount)
     }
+
+    // MARK: - micDelay clamp (#99)
+
+    func testMixExcessivePositiveDelayIsClamped() throws {
+        // 500s delay would double a 1s track — must be clamped to maxMicDelay
+        let output = try mixWithDelay(500)
+        let maxPad = Int(AudioMixer.maxMicDelay * Double(sampleRate))
+        XCTAssertLessThanOrEqual(
+            output.count,
+            sampleCount + maxPad,
+            "Excessive positive delay must be clamped",
+        )
+    }
+
+    func testMixExcessiveNegativeDelayIsClamped() throws {
+        // -500s delay would double a 1s track — must be clamped
+        let output = try mixWithDelay(-500)
+        let maxPad = Int(AudioMixer.maxMicDelay * Double(sampleRate))
+        XCTAssertLessThanOrEqual(
+            output.count,
+            sampleCount + maxPad,
+            "Excessive negative delay must be clamped",
+        )
+    }
+
+    func testMaxMicDelayConstant() {
+        XCTAssertEqual(
+            AudioMixer.maxMicDelay,
+            30,
+            "maxMicDelay should be 30 seconds",
+        )
+    }
 }

--- a/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
@@ -5,7 +5,10 @@ final class AudioMixerDelayTests: XCTestCase {
     private let sampleRate = 16000
     private let sampleCount = 16000 // 1 second at 16kHz
 
-    private func mixWithDelay(_ micDelay: TimeInterval) throws -> [Float] {
+    private func mixWithDelay(
+        _ micDelay: TimeInterval,
+        trackSeconds: Int = 1,
+    ) throws -> [Float] {
         let tmpDir = FileManager.default.temporaryDirectory
         let id = UUID().uuidString
         let appURL = tmpDir.appendingPathComponent("delay_app_\(id).wav")
@@ -17,13 +20,14 @@ final class AudioMixerDelayTests: XCTestCase {
             try? FileManager.default.removeItem(at: outURL)
         }
 
+        let count = sampleRate * trackSeconds
         try AudioMixer.saveWAV(
-            samples: [Float](repeating: 0.5, count: sampleCount),
+            samples: [Float](repeating: 0.5, count: count),
             sampleRate: sampleRate,
             url: appURL,
         )
         try AudioMixer.saveWAV(
-            samples: [Float](repeating: 0.3, count: sampleCount),
+            samples: [Float](repeating: 0.3, count: count),
             sampleRate: sampleRate,
             url: micURL,
         )
@@ -60,33 +64,32 @@ final class AudioMixerDelayTests: XCTestCase {
 
     // MARK: - micDelay clamp (#99)
 
-    func testMixExcessivePositiveDelayIsClamped() throws {
-        // 500s delay would double a 1s track — must be clamped to maxMicDelay
-        let output = try mixWithDelay(500)
-        let maxPad = Int(AudioMixer.maxMicDelay * Double(sampleRate))
+    func testMixExcessiveNegativeDelayDoesNotInflateDuration() throws {
+        // Reproduce #99: 60s tracks with -50s delay.
+        // Without fix: delaySamples=800k < trackSamples=960k → padding applied
+        //   → app becomes 1,760,000 samples (110s) — ~1.83x bloat
+        // With fix (±30s clamp): delay clamped to -30s → padding = 480k
+        //   → app becomes 1,440,000 (90s) — within tolerance
+        let trackSec = 60
+        let trackSamples = sampleRate * trackSec
+        let maxAcceptable = trackSamples + 31 * sampleRate
+        let output = try mixWithDelay(-50, trackSeconds: trackSec)
         XCTAssertLessThanOrEqual(
             output.count,
-            sampleCount + maxPad,
-            "Excessive positive delay must be clamped",
+            maxAcceptable,
+            "50s negative delay on 60s track must be clamped (#99)",
         )
     }
 
-    func testMixExcessiveNegativeDelayIsClamped() throws {
-        // -500s delay would double a 1s track — must be clamped
-        let output = try mixWithDelay(-500)
-        let maxPad = Int(AudioMixer.maxMicDelay * Double(sampleRate))
+    func testMixExcessivePositiveDelayDoesNotInflateDuration() throws {
+        let trackSec = 60
+        let trackSamples = sampleRate * trackSec
+        let maxAcceptable = trackSamples + 31 * sampleRate
+        let output = try mixWithDelay(50, trackSeconds: trackSec)
         XCTAssertLessThanOrEqual(
             output.count,
-            sampleCount + maxPad,
-            "Excessive negative delay must be clamped",
-        )
-    }
-
-    func testMaxMicDelayConstant() {
-        XCTAssertEqual(
-            AudioMixer.maxMicDelay,
-            30,
-            "maxMicDelay should be 30 seconds",
+            maxAcceptable,
+            "50s positive delay on 60s track must be clamped (#99)",
         )
     }
 }

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -293,7 +293,13 @@ public class AppAudioCapture {
             // Log format on first callback
             if !self.didLogFormat {
                 self.didLogFormat = true
-                self.appFirstFrameTime = mach_absolute_time()
+                // Only record the very first frame time — not after device restarts.
+                // MicCaptureHandler uses the same guard. Without this, a device change
+                // mid-recording overwrites the timestamp, corrupting the micDelay
+                // calculation and producing a mix.wav at 2× duration (see #99).
+                if self.appFirstFrameTime == 0 {
+                    self.appFirstFrameTime = mach_absolute_time()
+                }
                 self.actualChannels = Int(abl.mBuffers.mNumberChannels)
 
                 // Device is running — query the measured actual rate


### PR DESCRIPTION
## Summary

Fixes #99 — mix.wav produced at 2× expected duration when an audio device change occurs mid-recording (e.g. Bluetooth connect/disconnect, Teams audio mode switch).

- **Root cause:** `AppAudioCapture.appFirstFrameTime` was overwritten on every tap restart (device change resets `didLogFormat`), corrupting the `micDelay` calculation to ≈ −recording duration. `AudioMixer.mix()` then prepended the app track with zeros equal to its own length, doubling the output.
- **Fix 1:** Guard `appFirstFrameTime` to only set once (`if == 0`), matching `MicCaptureHandler`'s existing pattern.
- **Fix 2:** Clamp `micDelay` to ±30s in `AudioMixer.mix()` as a secondary safeguard against future timing corruption.

## Test plan

- [x] New `AudioMixerDelayTests` with 60s tracks + ±50s delay — verified red-green (FAIL without fix: 1,760,000 > 1,456,000 samples; PASS with fix)
- [x] All 6 `AudioMixerDelayTests` pass
- [x] Full test suite: 996 tests pass (1 pre-existing snapshot failure unrelated)
- [x] Lint clean