### PR TITLE
docs: add PermissionHealthCheck.swift to project structure and architecture notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     FFmpegHelper.swift     # ffmpeg CLI detection + audio extraction for MKV/WebM/OGG
     AudioMixer.swift       # Multi-format audio loading (WAV/MP3/M4A/MP4 via AVAsset fallback, MKV/WebM/OGG via ffmpeg) + mixing to 16kHz mono
     MicRecorder.swift      # Microphone recording via AVAudioEngine
+    PermissionHealthCheck.swift # Permission health check (TCC verdict + live probe → PermissionStatus)
     PermissionRow.swift    # Permission status row UI component
     Permissions.swift      # Permission checks (mic, screen recording)
     ParticipantReader.swift # Reads meeting participants via accessibility
@@ -231,6 +232,11 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - `MenuBarIcon` renders animated waveform reflecting pipeline state (idle, recording, transcribing, diarizing, protocol).
 - `AppPickerView` enables manual recording of any app via app picker.
 - `UpdateChecker` checks GitHub releases for newer versions, shows badge on menu bar icon.
+
+**Permission health check:**
+- `PermissionHealthCheck` verifies each TCC permission by combining the system verdict with a live probe. Each resolves to `PermissionStatus` (`.healthy | .denied | .broken | .notDetermined`). `.broken` means TCC says allowed but the probe disagrees — fix is to toggle the permission off and on in System Settings.
+- `WatchLoop` runs the check on startup; `AppState` re-runs on app activation.
+- When unhealthy: `MenuBarIcon` composites a red "!" badge over the current icon (non-template, stays red in dark mode). `BadgeKind.compute()` returns `.error` when idle with a problem. A deduped notification is posted via `NotificationManager`.
 
 ## Critical Notes
 

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -78,6 +78,7 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | `KeychainHelper.swift` | Legacy keychain CRUD (token now file-based) |
 | `Permissions.swift` | Mic/accessibility permissions, project root detection |
 | `PermissionRow.swift` | Permission status row UI component (icon, detail, help popover) |
+| `PermissionHealthCheck.swift` | TCC verdict + live probe → `PermissionStatus`; drives exclamation badge overlay |
 | `ParticipantReader.swift` | Teams participant extraction via Accessibility API |
 
 ---


### PR DESCRIPTION
## Summary

- Add `PermissionHealthCheck.swift` to the Sources file list in `CLAUDE.md`
- Add a **Permission health check** architecture note in `CLAUDE.md` covering `PermissionStatus`, startup/activation re-check, and the badge overlay behavior
- Add `PermissionHealthCheck.swift` to the Support table in `docs/architecture-macos.md`

`PermissionHealthCheck` was introduced in recent commits (`feat(app): check permissions before recording` through `feat(app): dedup permission notifications and re-check on app activation`) but was not reflected in any documentation file.

`README.md` and `CONTRIBUTING.md` were reviewed and require no changes — they describe permissions at the feature/user level only, which remains accurate.

## Test plan

- [x] Verified `PermissionHealthCheck.swift` exists in `app/MeetingTranscriber/Sources/`
- [x] Confirmed no other new/renamed/deleted source files are missing from docs
- [x] Confirmed scripts, workflows, and Package.swift dependencies are unchanged

https://claude.ai/code/session_01KuaYoix9z8n7jQQZ1XDiN4