### PR TITLE
fix(app): guard against missing mic hardware

### DIFF
--- a/app/MeetingTranscriber/Sources/MicRecorder.swift
+++ b/app/MeetingTranscriber/Sources/MicRecorder.swift
@@ -22,6 +22,12 @@ class MicRecorder {
     ///   - deviceUID: CoreAudio device UID (nil = system default)
     ///   - sampleRate: Target sample rate (default 48000)
     func start(outputPath: URL, deviceUID: String? = nil, sampleRate: Double = 48000) throws { // swiftlint:disable:this unused_declaration
+        // No input device available (e.g. Mac Mini server without mic hardware) —
+        // accessing AVAudioEngine.inputNode would throw an uncatchable NSException.
+        guard AVCaptureDevice.default(for: .audio) != nil else {
+            throw MicRecorderError.noInputDevice
+        }
+
         let engine = AVAudioEngine()
 
         // Select input device if specified
@@ -221,12 +227,14 @@ class MicRecorder {
 }
 
 enum MicRecorderError: LocalizedError {
+    case noInputDevice
     case formatCreationFailed
     case deviceNotFound(String)
     case deviceSetFailed(String, OSStatus)
 
     var errorDescription: String? {
         switch self {
+        case .noInputDevice: "No microphone hardware available"
         case .formatCreationFailed: "Failed to create audio format"
         case let .deviceNotFound(uid): "Audio device not found: \(uid)"
         case let .deviceSetFailed(uid, status): "Failed to set device \(uid): OSStatus \(status)"

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -187,6 +187,13 @@ enum PermissionHealthCheck {
     static let probePollInterval: TimeInterval = 0.02
 
     static func probeMicrophone() async -> Bool {
+        // No input device available (e.g. Mac Mini server without mic hardware) —
+        // accessing AVAudioEngine.inputNode would throw an uncatchable NSException.
+        guard AVCaptureDevice.default(for: .audio) != nil else {
+            debugLog("probeMicrophone: no input device available")
+            return false
+        }
+
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)

--- a/app/MeetingTranscriber/Tests/MicRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/MicRecorderTests.swift
@@ -51,4 +51,11 @@ final class MicRecorderTests: XCTestCase {
             "Expected description to contain '-50', got: \(error.errorDescription ?? "nil")",
         )
     }
+
+    // MARK: - No Input Device Guard (#104)
+
+    func testErrorNoInputDevice() {
+        let error = MicRecorderError.noInputDevice
+        XCTAssertEqual(error.errorDescription, "No microphone hardware available")
+    }
 }

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -66,6 +66,12 @@ public class MicCaptureHandler {
 
     // swiftlint:disable:next function_body_length
     private func startEngine(deviceUID: String? = nil) throws {
+        // No input device available (e.g. Mac Mini server without mic hardware) —
+        // accessing AVAudioEngine.inputNode would throw an uncatchable NSException.
+        guard AVCaptureDevice.default(for: .audio) != nil else {
+            throw MicCaptureError.noInputDevice
+        }
+
         let inputNode = engine.inputNode
 
         if let uid = deviceUID {
@@ -284,5 +290,15 @@ public class MicCaptureHandler {
         engine.reset()
         outputFile = nil
         logger.info("Mic recording stopped")
+    }
+}
+
+public enum MicCaptureError: LocalizedError {
+    case noInputDevice
+
+    public var errorDescription: String? {
+        switch self {
+        case .noInputDevice: "No microphone hardware available"
+        }
     }
 }

--- a/tools/audiotap/Tests/MicCaptureErrorTests.swift
+++ b/tools/audiotap/Tests/MicCaptureErrorTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import XCTest
+
+@testable import AudioTapLib
+
+final class MicCaptureErrorTests: XCTestCase {
+    func testNoInputDeviceDescription() {
+        let error = MicCaptureError.noInputDevice
+        XCTAssertEqual(error.errorDescription, "No microphone hardware available")
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes crash on launch on Macs without microphone hardware (e.g. Mac Mini server) where `AVAudioEngine.inputNode` throws an uncatchable `NSException` → SIGABRT
- Added `AVCaptureDevice.default(for: .audio)` guard before any `inputNode` / `installTap` access in all three call sites:
  - `PermissionHealthCheck.probeMicrophone()` — the crash site from the issue
  - `MicRecorder.start()` — currently unused but would have the same crash
  - `MicCaptureHandler.startEngine()` (AudioTapLib) — used by `DualSourceRecorder`

Closes #104

## Test plan

- [x] Verify app launches without crash on a Mac without microphone hardware (Mac Mini server, or with all audio inputs disabled)
- [x] Verify `probeMicrophone()` returns `false` gracefully when no input device is available
- [x] Verify normal mic recording still works on Macs with microphone hardware
- [x] All 996 existing tests pass (1 pre-existing snapshot test failure unrelated to this change)