### PR TITLE
feat: allow re-opening speaker naming dialog after dismissal

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -42,6 +42,7 @@ final class AppState {
     var watchLoop: WatchLoop?
     var pipelineQueue: PipelineQueue
     var updateChecker: UpdateChecker
+    var selectedNamingJobID: UUID?
     var permissionHealth: HealthCheckResult?
 
     // MARK: - Init

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -46,7 +46,7 @@ struct MeetingTranscriberApp: App {
                 onOpenSettings: {
                     bringWindowToFront(id: "settings")
                 },
-                onNameSpeakers: {
+                onNameSpeakers: appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty ? nil : {
                     bringWindowToFront(id: "speaker-naming")
                 },
                 onProcessFiles: processAudioFiles,
@@ -110,18 +110,13 @@ struct MeetingTranscriberApp: App {
         }
 
         Window("Name Speakers", id: "speaker-naming") {
-            if let data = appState.pipelineQueue.pendingSpeakerNaming {
-                SpeakerNamingView(
-                    data: data,
-                    knownSpeakerNames: appState.pipelineQueue.speakerMatcherFactory().allSpeakerNames(),
-                ) { result in
-                    appState.pipelineQueue.completeSpeakerNaming(result: result)
-                    closeWindow(id: "speaker-naming")
+            speakerNamingContent
+                .onAppear {
+                    // Close restored window if no naming data available (macOS state restoration)
+                    if appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
+                        closeWindow(id: "speaker-naming")
+                    }
                 }
-            } else {
-                Text("No speaker data available.")
-                    .padding()
-            }
         }
         .windowResizability(.contentSize)
 
@@ -154,6 +149,58 @@ struct MeetingTranscriberApp: App {
             )
         }
         .windowResizability(.contentSize)
+    }
+
+    // MARK: - Speaker Naming Window
+
+    @ViewBuilder private var speakerNamingContent: some View {
+        if let data = appState.pipelineQueue.speakerNamingData(
+            forJobID: appState.selectedNamingJobID,
+        ) {
+            VStack(spacing: 0) {
+                speakerNamingPicker
+                speakerNamingForm(data: data)
+            }
+        } else {
+            Text("No speaker data available.")
+                .padding()
+        }
+    }
+
+    @ViewBuilder private var speakerNamingPicker: some View {
+        if appState.pipelineQueue.pendingSpeakerNamingJobs.count > 1 {
+            Picker("Meeting", selection: Binding(
+                get: {
+                    appState.selectedNamingJobID
+                        ?? appState.pipelineQueue.pendingSpeakerNamingJobs.first?.id
+                },
+                set: { appState.selectedNamingJobID = $0 },
+            )) {
+                ForEach(appState.pipelineQueue.pendingSpeakerNamingJobs) { job in
+                    Text(job.meetingTitle).tag(Optional(job.id))
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.top, 8)
+        }
+    }
+
+    private func speakerNamingForm(
+        data: PipelineQueue.SpeakerNamingData,
+    ) -> some View {
+        SpeakerNamingView(
+            data: data,
+            knownSpeakerNames: appState.pipelineQueue.speakerMatcherFactory().allSpeakerNames(),
+        ) { result in
+            appState.pipelineQueue.completeSpeakerNaming(jobID: data.jobID, result: result)
+            if appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
+                closeWindow(id: "speaker-naming")
+            } else {
+                appState.selectedNamingJobID =
+                    appState.pipelineQueue.pendingSpeakerNamingJobs.first?.id
+            }
+        }
     }
 
     // MARK: - UI Actions

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -88,7 +88,7 @@ struct MenuBarView: View {
             .keyboardShortcut("r")
         }
 
-        if state == .waitingForSpeakerNames, let onNameSpeakers {
+        if let onNameSpeakers {
             Button {
                 onNameSpeakers()
             } label: {
@@ -183,12 +183,16 @@ struct MenuBarView: View {
                 Button("Open") { onOpenProtocol(path) }
                     .font(.caption2)
             }
+            if job.state == .speakerNamingPending {
+                Button("Name Speakers") { onNameSpeakers?() }
+                    .font(.caption2)
+            }
             if job.state == .waiting || job.state == .transcribing
                 || job.state == .diarizing || job.state == .generatingProtocol {
                 Button("Cancel") { pipelineQueue.cancelJob(id: job.id) }
                     .font(.caption2)
             }
-            if job.state == .done || job.state == .error {
+            if job.state == .done || job.state == .error || job.state == .speakerNamingPending {
                 Button("Dismiss") { onDismissJob(job.id) }
                     .font(.caption2)
             }
@@ -229,6 +233,7 @@ struct MenuBarView: View {
         case .transcribing: .blue
         case .diarizing: .purple
         case .generatingProtocol: .orange
+        case .speakerNamingPending: .purple
         case .done: job.warnings.isEmpty ? .green : .yellow
         case .error: .red
         }

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -6,6 +6,8 @@ enum JobState: String, Codable {
     case diarizing
     // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
     case generatingProtocol
+    // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
+    case speakerNamingPending
     case done
     case error
 
@@ -16,6 +18,7 @@ enum JobState: String, Codable {
         case .transcribing: "Transcribing..."
         case .diarizing: "Diarizing..."
         case .generatingProtocol: "Generating Protocol..."
+        case .speakerNamingPending: "Name Speakers..."
         case .done: "Done"
         case .error: "Error"
         }
@@ -37,6 +40,7 @@ struct PipelineJob: Identifiable, Codable {
     var warnings: [String]
     var transcriptPath: URL?
     var protocolPath: URL?
+    var namingSlug: String?
 
     init(
         meetingTitle: String,
@@ -61,5 +65,6 @@ struct PipelineJob: Identifiable, Codable {
         self.warnings = []
         self.transcriptPath = nil
         self.protocolPath = nil
+        self.namingSlug = nil
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -43,15 +43,22 @@ class PipelineQueue {
     // MARK: - Speaker Naming
 
     /// Data for the speaker naming popup.
-    struct SpeakerNamingData {
+    struct SpeakerNamingData: Codable {
         let jobID: UUID
         let meetingTitle: String
         let mapping: [String: String] // label → auto-matched name or label
         let speakingTimes: [String: TimeInterval]
         let embeddings: [String: [Float]]
         let audioPath: URL? // 16kHz mix for playback
-        let segments: [DiarizationResult.Segment] // for extracting speaker snippets
+        let segments: [Segment] // for extracting speaker snippets
         let participants: [String] // Teams participant names as suggestions
+        let isDualSource: Bool
+
+        struct Segment: Codable {
+            let start: TimeInterval
+            let end: TimeInterval
+            let speaker: String
+        }
     }
 
     /// Result from the speaker naming popup.
@@ -61,29 +68,128 @@ class PipelineQueue {
         case skipped // user skipped
     }
 
-    /// Set when the pipeline is waiting for the user to name speakers.
-    var pendingSpeakerNaming: SpeakerNamingData?
-    private var speakerNamingContinuation: CheckedContinuation<SpeakerNamingResult, Never>?
+    /// RAM cache of naming data, rebuilt from disk on loadSnapshot().
+    /// Internal setter allows test access via @testable import.
+    var speakerNamingDataByJob: [UUID: SpeakerNamingData] = [:]
 
-    /// Timeout for the speaker naming popup (seconds). If the user does not respond
-    /// within this time, the continuation resumes with `.skipped`.
-    static let speakerNamingTimeout: TimeInterval = 120
+    /// Per-job snapshot of the auto-name suggestions shown in the dialog,
+    /// kept until the user confirms/skips so `recordRecognition` can write
+    /// the JSONL row. Cleared on completion. Not persisted across launches —
+    /// if the user confirms in a fresh session, the recognition log row will
+    /// have nil/empty `autoName` (acceptable; user data is the real signal).
+    private var stashedSuggestedAtDialog: [UUID: [String: String]] = [:]
+    private var stashedTopCandidates: [UUID: [String: [TopCandidate]]] = [:]
 
-    /// Test seam: install a CheckedContinuation that the test will await for
-    /// `cancelJob`-during-naming to resume.
-    func setSpeakerNamingContinuationForTesting(
-        _ continuation: CheckedContinuation<SpeakerNamingResult, Never>,
+    /// The currently displayed naming data (first pending item).
+    var pendingSpeakerNaming: SpeakerNamingData? {
+        guard let firstPendingJob = pendingSpeakerNamingJobs.first else { return nil }
+        return speakerNamingDataByJob[firstPendingJob.id]
+    }
+
+    /// Returns naming data for a specific job ID, or the first pending job as fallback.
+    func speakerNamingData(forJobID jobID: UUID?) -> SpeakerNamingData? {
+        if let jobID, let data = speakerNamingDataByJob[jobID] { return data }
+        return pendingSpeakerNaming
+    }
+
+    /// Jobs in speakerNamingPending state.
+    var pendingSpeakerNamingJobs: [PipelineJob] {
+        jobs.filter { $0.state == .speakerNamingPending }
+    }
+
+    /// Called by the UI when the user confirms, skips, or re-runs speaker naming.
+    /// Always handles "late" completion — the pipeline never blocks on naming.
+    func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
+        guard let data = speakerNamingDataByJob[jobID] else { return }
+        let slug = jobs.first { $0.id == jobID }?.namingSlug
+
+        switch result {
+        case let .confirmed(userMapping):
+            recordRecognition(
+                jobID: jobID, title: data.meetingTitle,
+                userMapping: userMapping, fallback: data.mapping,
+            )
+            // Transition out of .speakerNamingPending synchronously so the
+            // UI's close-when-empty check sees the change immediately. The
+            // transcript rewrite + protocol generation happens async below.
+            if let idx = jobs.firstIndex(where: { $0.id == jobID }),
+               jobs[idx].state == .speakerNamingPending {
+                updateJobState(id: jobID, to: .generatingProtocol)
+            }
+            Task { await reapplySpeakerNames(jobID: jobID, mapping: userMapping) }
+
+        case let .rerun(count):
+            Task { await lateDiarization(jobID: jobID, speakerCount: count) }
+
+        case .skipped:
+            recordRecognition(
+                jobID: jobID, title: data.meetingTitle,
+                userMapping: nil, fallback: data.mapping,
+            )
+            acceptAutoNames(jobID: jobID, slug: slug)
+        }
+    }
+
+    /// Pull stashed forensics for a job and write the recognition-stats row.
+    /// Falls back to the original SpeakerNamingData mapping when the stash is
+    /// missing (e.g. the user confirmed in a fresh app session).
+    private func recordRecognition(
+        jobID: UUID, title: String,
+        // swiftlint:disable:next discouraged_optional_collection
+        userMapping: [String: String]?, fallback: [String: String],
     ) {
-        speakerNamingContinuation = continuation
+        recordRecognition(
+            suggested: stashedSuggestedAtDialog[jobID] ?? fallback,
+            userMapping: userMapping,
+            topCandidates: stashedTopCandidates[jobID] ?? [:],
+            jobID: jobID,
+            title: title,
+        )
+    }
+
+    /// Skipped or stale-cleanup path: the user accepted (implicitly or by
+    /// timeout) the auto-names. Drops sidecar files synchronously, transitions
+    /// to .done. If a protocol generator is configured AND the transcript file
+    /// exists, fires off protocol generation in the background; the job
+    /// transitions through .generatingProtocol → .done as that completes.
+    private func acceptAutoNames(jobID: UUID, slug: String?) {
+        let canGenerateProtocol = protocolGeneratorFactory != nil
+            && outputDir != nil
+            && jobs.first { $0.id == jobID }?.transcriptPath != nil
+
+        removeNamingData(jobID: jobID, slug: slug)
+
+        if canGenerateProtocol {
+            Task { await generateProtocolForExistingJob(jobID: jobID) }
+        } else if let idx = jobs.firstIndex(where: { $0.id == jobID }),
+                  jobs[idx].state == .speakerNamingPending {
+            updateJobState(id: jobID, to: .done)
+        }
+    }
+
+    private func generateProtocolForExistingJob(jobID: UUID) async {
+        guard let jobIndex = jobs.firstIndex(where: { $0.id == jobID }),
+              let transcriptPath = jobs[jobIndex].transcriptPath,
+              let outputDir,
+              let transcript = try? String(contentsOf: transcriptPath, encoding: .utf8)
+        else { return }
+        await generateProtocol(
+            jobID: jobID,
+            transcript: transcript,
+            title: jobs[jobIndex].meetingTitle,
+            protocolsDir: outputDir.appendingPathComponent("protocols"),
+        )
+        if let idx = jobs.firstIndex(where: { $0.id == jobID }),
+           jobs[idx].state == .generatingProtocol {
+            updateJobState(id: jobID, to: .done)
+        }
     }
 
     /// Called by the UI when the user confirms or skips speaker naming.
     func completeSpeakerNaming(result: SpeakerNamingResult) {
-        pendingSpeakerNaming = nil
-        // Guard against double-resume: only resume if continuation is still set
-        guard let continuation = speakerNamingContinuation else { return }
-        speakerNamingContinuation = nil
-        continuation.resume(returning: result)
+        if let jobID = pendingSpeakerNamingJobs.first?.id ?? speakerNamingDataByJob.keys.first {
+            completeSpeakerNaming(jobID: jobID, result: result)
+        }
     }
 
     /// Handler for speaker naming. When set, called instead of the default
@@ -174,11 +280,12 @@ class PipelineQueue {
         saveSnapshot()
     }
 
-    /// Cancel a job. Removes waiting/active jobs from the queue and cancels the
-    /// processing task if the job is currently active. Done/error jobs are not affected.
+    /// Cancel a job. Removes the job + cleans up sidecar files if naming was
+    /// pending. Done/error jobs are not affected.
     func cancelJob(id: UUID) {
         guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
         let state = jobs[index].state
+        let slug = jobs[index].namingSlug
         switch state {
         case .waiting:
             jobs.remove(at: index)
@@ -186,13 +293,15 @@ class PipelineQueue {
 
         case .transcribing, .diarizing, .generatingProtocol:
             cancelledJobIDs.insert(id)
-            // If this job is waiting on speaker-naming UI, resolve the continuation
-            // before cancelling the task. Otherwise the continuation only resumes via
-            // the 120 s timeout, leaving the pipeline frozen and the popup on screen.
-            if pendingSpeakerNaming?.jobID == id {
-                completeSpeakerNaming(result: .skipped)
-            }
             processTask?.cancel()
+            removeNamingData(jobID: id, slug: slug)
+            jobs.remove(at: index)
+            saveSnapshot()
+
+        case .speakerNamingPending:
+            // User cancelled while waiting for late-confirm — drop the sidecar
+            // files and the in-memory state so it doesn't sit around.
+            removeNamingData(jobID: id, slug: slug)
             jobs.remove(at: index)
             saveSnapshot()
 
@@ -290,6 +399,9 @@ class PipelineQueue {
                 .appendingPathComponent("pipeline_\(jobID.uuidString)")
             try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
             defer { try? FileManager.default.removeItem(at: workDir) }
+
+            // Compute slug early so it's available for persisted file names
+            let slug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
 
             let transcript: String
             // Segments cached for potential diarization reuse (avoids double transcription)
@@ -439,72 +551,79 @@ class PipelineQueue {
                                 "[recognition] \(matched.count) speakers, \(autoMatched) auto, \(unknown) unknown",
                             )
 
+                            // Use persisted 16kHz path (survives workDir cleanup)
+                            let recordingsDir = outputDir.appendingPathComponent("recordings")
+                            let persistedAudioPath = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
+
                             let namingData = SpeakerNamingData(
                                 jobID: jobID,
                                 meetingTitle: title,
                                 mapping: autoNames,
                                 speakingTimes: currentDiarization.speakingTimes,
                                 embeddings: embeddings,
-                                audioPath: mix16k,
-                                segments: currentDiarization.segments,
+                                audioPath: persistedAudioPath,
+                                segments: currentDiarization.segments.map { seg in
+                                    SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
+                                },
                                 participants: participants,
+                                isDualSource: isDualSource,
                             )
 
+                            // Persist naming data and set slug early
+                            saveNamingData(namingData, slug: slug)
+                            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
+                                jobs[idx].namingSlug = slug
+                            }
+
                             stopElapsedTimer()
-                            let namingResult: SpeakerNamingResult
+
+                            // Stash recognition forensics on the job so the late-confirm
+                            // path can write the JSONL row when the user actually
+                            // confirms (which may be later via the re-openable dialog).
+                            stashedSuggestedAtDialog[jobID] = suggestedAtDialog
+                            stashedTopCandidates[jobID] = topCandidates
+
+                            // Non-blocking: allow test handler to confirm synchronously,
+                            // otherwise proceed with auto-names immediately.
+                            // User can confirm/re-run later via the naming dialog.
                             if let handler = speakerNamingHandler {
-                                namingResult = await handler(namingData)
-                            } else {
-                                // Start a timeout task that auto-skips if user doesn't respond
-                                let timeoutTask = Task { [weak self] in
-                                    try await Task.sleep(for: .seconds(Self.speakerNamingTimeout))
-                                    await self?.completeSpeakerNaming(result: .skipped)
-                                }
-                                namingResult = await withCheckedContinuation { continuation in
-                                    self.speakerNamingContinuation = continuation
-                                    self.pendingSpeakerNaming = namingData
-                                    NotificationCenter.default.post(
-                                        name: .showSpeakerNaming,
-                                        object: nil,
+                                let namingResult = await handler(namingData)
+                                switch namingResult {
+                                case let .confirmed(userMapping):
+                                    for (label, name) in userMapping where !name.isEmpty {
+                                        autoNames[label] = name
+                                    }
+                                    matcher.updateDB(
+                                        mapping: autoNames,
+                                        embeddings: embeddings,
+                                        speakingTimes: currentDiarization.speakingTimes,
                                     )
+                                    recordRecognition(
+                                        suggested: suggestedAtDialog,
+                                        userMapping: userMapping,
+                                        topCandidates: topCandidates,
+                                        jobID: jobID, title: title,
+                                    )
+                                    removeNamingData(jobID: jobID, slug: nil)
+
+                                case let .rerun(count):
+                                    speakerCount = count
+                                    updateJobState(id: jobID, to: .diarizing)
+                                    startElapsedTimer()
+                                    logger.info("Re-running diarization with \(count) speakers")
+                                    continue diarizationLoop
+
+                                case .skipped:
+                                    break
                                 }
-                                timeoutTask.cancel()
+                            } else {
+                                // Production: stash data, don't block pipeline. Notification
+                                // is posted later — after the job transitions to
+                                // .speakerNamingPending — so the window's onAppear
+                                // doesn't auto-close it on a state mismatch.
+                                speakerNamingDataByJob[jobID] = namingData
                             }
-
-                            switch namingResult {
-                            case let .confirmed(userMapping):
-                                for (label, name) in userMapping where !name.isEmpty {
-                                    autoNames[label] = name
-                                }
-                                matcher.updateDB(
-                                    mapping: autoNames,
-                                    embeddings: embeddings,
-                                    speakingTimes: currentDiarization.speakingTimes,
-                                )
-                                recordRecognition(
-                                    suggested: suggestedAtDialog,
-                                    userMapping: userMapping,
-                                    topCandidates: topCandidates,
-                                    jobID: jobID, title: title,
-                                )
-                                break diarizationLoop
-
-                            case let .rerun(count):
-                                speakerCount = count
-                                updateJobState(id: jobID, to: .diarizing)
-                                startElapsedTimer()
-                                logger.info("Re-running diarization with \(count) speakers")
-                                continue diarizationLoop
-
-                            case .skipped:
-                                recordRecognition(
-                                    suggested: suggestedAtDialog,
-                                    userMapping: nil,
-                                    topCandidates: topCandidates,
-                                    jobID: jobID, title: title,
-                                )
-                                break diarizationLoop
-                            }
+                            break diarizationLoop
                         }
 
                         // Apply speaker names to segments
@@ -575,6 +694,7 @@ class PipelineQueue {
 
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                 jobs[idx].transcriptPath = txtPath
+                jobs[idx].namingSlug = slug
             }
 
             let recordingsDir = outputDir.appendingPathComponent("recordings")
@@ -583,34 +703,52 @@ class PipelineQueue {
                 title: title, outputDir: recordingsDir,
             )
 
-            // --- Protocol Generation (optional) ---
-            if let protocolGeneratorFactory, let generator = protocolGeneratorFactory() {
-                do {
-                    updateJobState(id: jobID, to: .generatingProtocol)
-                    startElapsedTimer()
+            // --- Persist 16kHz audio for re-diarization (move instead of copy to avoid double I/O) ---
+            try? FileManager.default.moveItem(
+                at: workDir.appendingPathComponent("mix_16k.wav"),
+                to: recordingsDir.appendingPathComponent("\(slug)_16k.wav"),
+            )
 
-                    let diarized = finalTranscript.range(of: #"\[\w[\w\s]*\]"#, options: .regularExpression) != nil
-                    let protocolMD = try await generator.generate(
-                        transcript: finalTranscript,
-                        title: title,
-                        diarized: diarized,
+            if isDualSource {
+                for (name, suffix) in [("app_16k.wav", "_app_16k.wav"), ("mic_16k.wav", "_mic_16k.wav")] {
+                    try? FileManager.default.moveItem(
+                        at: workDir.appendingPathComponent(name),
+                        to: recordingsDir.appendingPathComponent("\(slug)\(suffix)"),
                     )
-
-                    let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + finalTranscript
-                    let mdPath = try ProtocolGenerator.saveProtocol(fullMD, title: title, dir: protocolsDir)
-                    logger.info("Protocol saved: \(mdPath.lastPathComponent)")
-
-                    if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
-                        jobs[idx].protocolPath = mdPath
-                    }
-                } catch {
-                    logger.warning("Protocol generation failed: \(error.localizedDescription)")
-                    addWarning(id: jobID, "Protocol generation failed — transcript saved")
                 }
             }
 
+            // --- Persist transcript segments for late re-assignment ---
+            if let cachedSegments {
+                let segPath = recordingsDir.appendingPathComponent("\(slug)_segments.json")
+                if let data = try? JSONEncoder().encode(cachedSegments) {
+                    try? data.write(to: segPath, options: .atomic)
+                }
+            }
+
+            // --- Protocol Generation (optional) ---
+            // Skip when naming is pending — protocol will be generated on
+            // confirm (with the right names) or on skip/stale-cleanup (with
+            // the current auto-names). Saves an LLM call we'd otherwise
+            // have to redo.
+            if speakerNamingDataByJob[jobID] == nil {
+                await generateProtocol(
+                    jobID: jobID, transcript: finalTranscript, title: title,
+                    protocolsDir: protocolsDir,
+                )
+            }
+
             stopElapsedTimer()
-            updateJobState(id: jobID, to: .done)
+            if speakerNamingDataByJob[jobID] != nil {
+                updateJobState(id: jobID, to: .speakerNamingPending)
+                // Auto-pop the dialog now that the job is in the right state.
+                // The window's onAppear guard reads pendingSpeakerNamingJobs,
+                // which only includes .speakerNamingPending jobs, so the
+                // notification has to come after the transition above.
+                NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
+            } else {
+                updateJobState(id: jobID, to: .done)
+            }
         } catch is CancellationError {
             stopElapsedTimer()
             logger.info("Job \(jobID) cancelled")
@@ -627,6 +765,279 @@ class PipelineQueue {
 
         isProcessing = false
         triggerProcessing()
+    }
+
+    // MARK: - Protocol generation
+
+    /// Run the LLM protocol generator over a transcript, save the .md file,
+    /// stash its path on the job. No-op if no protocol generator is configured.
+    /// Used by: main pipeline (if no naming pending), reapplySpeakerNames
+    /// (after confirm), skipped/stale paths (with current auto-names).
+    private func generateProtocol(
+        jobID: UUID, transcript: String, title: String, protocolsDir: URL,
+    ) async {
+        guard let protocolGeneratorFactory, let generator = protocolGeneratorFactory() else {
+            return
+        }
+        do {
+            updateJobState(id: jobID, to: .generatingProtocol)
+            startElapsedTimer()
+            let diarized = transcript.range(
+                of: #"\[\w[\w\s]*\]"#, options: .regularExpression,
+            ) != nil
+            let protocolMD = try await generator.generate(
+                transcript: transcript, title: title, diarized: diarized,
+            )
+            let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + transcript
+            let mdPath = try ProtocolGenerator.saveProtocol(
+                fullMD, title: title, dir: protocolsDir,
+            )
+            logger.info("Protocol saved: \(mdPath.lastPathComponent)")
+            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
+                jobs[idx].protocolPath = mdPath
+            }
+            stopElapsedTimer()
+        } catch {
+            logger.warning("Protocol generation failed: \(error.localizedDescription)")
+            addWarning(id: jobID, "Protocol generation failed — transcript saved")
+            stopElapsedTimer()
+        }
+    }
+
+    // MARK: - Late re-apply speaker names
+
+    /// Late-confirm path: read the saved transcript, replace generic speaker
+    /// labels with user-provided names, update the matcher DB, regenerate the
+    /// protocol with the correct names.
+    private func reapplySpeakerNames(jobID: UUID, mapping: [String: String]) async {
+        guard let namingData = speakerNamingDataByJob[jobID],
+              let jobIndex = jobs.firstIndex(where: { $0.id == jobID }) else { return }
+
+        let slug = jobs[jobIndex].namingSlug
+
+        // Update speaker matcher DB
+        let matcher = speakerMatcherFactory()
+        var fullMapping = namingData.mapping
+        for (label, name) in mapping where !name.isEmpty {
+            fullMapping[label] = name
+        }
+        matcher.updateDB(mapping: fullMapping, embeddings: namingData.embeddings)
+
+        if let transcriptPath = jobs[jobIndex].transcriptPath {
+            do {
+                var transcript = try String(contentsOf: transcriptPath, encoding: .utf8)
+                for (label, name) in mapping where !name.isEmpty {
+                    transcript = transcript.replacingOccurrences(of: "[\(label)]", with: "[\(name)]")
+                    // Replace auto-matched name too, to cover both raw label and matched variant
+                    if let autoName = namingData.mapping[label], autoName != label, autoName != name {
+                        transcript = transcript.replacingOccurrences(of: "[\(autoName)]", with: "[\(name)]")
+                    }
+                }
+                try transcript.write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+                if let outputDir {
+                    await generateProtocol(
+                        jobID: jobID,
+                        transcript: transcript,
+                        title: jobs[jobIndex].meetingTitle,
+                        protocolsDir: outputDir.appendingPathComponent("protocols"),
+                    )
+                }
+            } catch {
+                logger.error("Failed to re-apply speaker names: \(error)")
+            }
+        }
+
+        removeNamingData(jobID: jobID, slug: slug)
+        updateJobState(id: jobID, to: .done)
+    }
+
+    // MARK: - Late Re-diarization
+
+    /// Re-run diarization from persisted 16kHz audio after pipeline completed.
+    private func lateDiarization(jobID: UUID, speakerCount: Int) async {
+        guard let namingData = speakerNamingDataByJob[jobID],
+              let jobIndex = jobs.firstIndex(where: { $0.id == jobID }),
+              let diarizationFactory,
+              let slug = jobs[jobIndex].namingSlug,
+              let outputDir else {
+            logger.warning("Cannot re-diarize: missing data or configuration")
+            return
+        }
+
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        let diarizeProcess = diarizationFactory()
+        guard diarizeProcess.isAvailable else {
+            logger.warning("Diarization not available for late re-run")
+            return
+        }
+
+        updateJobState(id: jobID, to: .diarizing)
+        startElapsedTimer()
+
+        do {
+            let title = jobs[jobIndex].meetingTitle
+            let diarization: DiarizationResult
+
+            if namingData.isDualSource {
+                let app16k = recordingsDir.appendingPathComponent("\(slug)_app_16k.wav")
+                let mic16k = recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav")
+                async let appDiar = diarizeProcess.run(
+                    audioPath: app16k, numSpeakers: speakerCount, meetingTitle: title,
+                )
+                async let micDiar = diarizeProcess.run(
+                    audioPath: mic16k, numSpeakers: nil, meetingTitle: title,
+                )
+                diarization = try await DiarizationProcess.mergeDualTrackDiarization(
+                    appDiarization: appDiar, micDiarization: micDiar,
+                )
+            } else {
+                let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
+                diarization = try await diarizeProcess.run(
+                    audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
+                )
+            }
+
+            stopElapsedTimer()
+
+            guard let newNamingData = buildNamingData(
+                jobID: jobID, title: title,
+                diarization: diarization, prior: namingData,
+            ) else {
+                logger.warning("Late re-diarization produced no embeddings")
+                updateJobState(id: jobID, to: .speakerNamingPending)
+                return
+            }
+
+            // Update disk + RAM
+            speakerNamingDataByJob[jobID] = newNamingData
+            saveNamingData(newNamingData, slug: slug)
+
+            // Show naming dialog again
+            updateJobState(id: jobID, to: .speakerNamingPending)
+            NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
+
+            // If test handler is set, call it directly
+            if let handler = speakerNamingHandler {
+                let result = await handler(newNamingData)
+                completeSpeakerNaming(jobID: jobID, result: result)
+            }
+        } catch {
+            logger.error("Late re-diarization failed: \(error)")
+            stopElapsedTimer()
+            updateJobState(id: jobID, to: .speakerNamingPending)
+        }
+    }
+
+    /// Build SpeakerNamingData from fresh diarization, reusing context from prior naming data.
+    private func buildNamingData(
+        jobID: UUID, title: String,
+        diarization: DiarizationResult, prior: SpeakerNamingData,
+    ) -> SpeakerNamingData? {
+        guard let embeddings = diarization.embeddings else { return nil }
+
+        let matcher = speakerMatcherFactory()
+        var autoNames = matcher.match(embeddings: embeddings)
+        if !prior.participants.isEmpty {
+            autoNames = SpeakerMatcher.preMatchParticipants(
+                mapping: autoNames,
+                speakingTimes: diarization.speakingTimes,
+                participants: prior.participants,
+            )
+        }
+
+        return SpeakerNamingData(
+            jobID: jobID, meetingTitle: title, mapping: autoNames,
+            speakingTimes: diarization.speakingTimes, embeddings: embeddings,
+            audioPath: prior.audioPath,
+            segments: diarization.segments.map { seg in
+                SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
+            },
+            participants: prior.participants, isDualSource: prior.isDualSource,
+        )
+    }
+
+    // MARK: - Speaker Naming Persistence
+
+    func saveNamingData(_ data: SpeakerNamingData, slug: String) {
+        guard let outputDir else { return }
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        try? FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let path = recordingsDir.appendingPathComponent("\(slug)_naming.json")
+        do {
+            // FluidAudio embeddings can contain NaN/Inf for short or silent
+            // segments. Default JSON encoder rejects them — use the string
+            // round-trip strategy so the data still makes it to disk.
+            let encoder = JSONEncoder()
+            encoder.nonConformingFloatEncodingStrategy = .convertToString(
+                positiveInfinity: "Infinity",
+                negativeInfinity: "-Infinity",
+                nan: "NaN",
+            )
+            let json = try encoder.encode(data)
+            try json.write(to: path, options: .atomic)
+        } catch {
+            // Silent failure here means late-confirm won't work after a
+            // restart. Make it visible: log + warning on the job.
+            logger.error("Failed to save naming data: \(error.localizedDescription)")
+            addWarning(id: data.jobID, "Late re-confirm unavailable — naming data could not be persisted")
+        }
+    }
+
+    func loadNamingData(slug: String) -> SpeakerNamingData? {
+        guard let outputDir else { return nil }
+        let path = outputDir.appendingPathComponent("recordings/\(slug)_naming.json")
+        guard let json = try? Data(contentsOf: path) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+            positiveInfinity: "Infinity",
+            negativeInfinity: "-Infinity",
+            nan: "NaN",
+        )
+        return try? decoder.decode(SpeakerNamingData.self, from: json)
+    }
+
+    func deleteNamingData(slug: String?) {
+        guard let slug, let outputDir else { return }
+        let path = outputDir.appendingPathComponent("recordings/\(slug)_naming.json")
+        try? FileManager.default.removeItem(at: path)
+    }
+
+    /// Remove all naming-related data for a job: RAM caches, disk JSON, and
+    /// sidecar files. Also clears the recognition-stats stash dicts so they
+    /// don't leak across rerun / stale-cleanup paths.
+    private func removeNamingData(jobID: UUID, slug: String?) {
+        speakerNamingDataByJob.removeValue(forKey: jobID)
+        stashedSuggestedAtDialog.removeValue(forKey: jobID)
+        stashedTopCandidates.removeValue(forKey: jobID)
+        deleteNamingData(slug: slug)
+        cleanupSidecarFiles(slug: slug)
+    }
+
+    /// Delete 16kHz audio and segment sidecar files for a slug.
+    func cleanupSidecarFiles(slug: String?) {
+        guard let slug, let outputDir else { return }
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        let suffixes = ["_16k.wav", "_app_16k.wav", "_mic_16k.wav", "_segments.json"]
+        for suffix in suffixes {
+            let path = recordingsDir.appendingPathComponent("\(slug)\(suffix)")
+            try? FileManager.default.removeItem(at: path)
+        }
+    }
+
+    /// Auto-resolve pending naming items older than maxAge (default: 24h).
+    /// Generates the protocol with auto-names, transitions them to .done,
+    /// deletes sidecar files.
+    func cleanupStalePending(maxAge: TimeInterval = 86400) {
+        let now = Date()
+        for job in jobs where job.state == .speakerNamingPending {
+            if now.timeIntervalSince(job.enqueuedAt) > maxAge {
+                logger.info("Auto-resolving stale pending naming for \(job.meetingTitle)")
+                let jobID = job.id
+                let slug = job.namingSlug
+                acceptAutoNames(jobID: jobID, slug: slug)
+            }
+        }
     }
 
     // MARK: - VAD Preprocessing
@@ -693,8 +1104,13 @@ class PipelineQueue {
             // Discard done jobs
             loaded.removeAll { $0.state == .done }
 
-            // Discard jobs whose audio file no longer exists
-            loaded.removeAll { !FileManager.default.fileExists(atPath: $0.mixPath.path) }
+            // Discard jobs whose audio file no longer exists, EXCEPT
+            // .speakerNamingPending — those have their own slug-based
+            // `_16k.wav` sidecar and don't need the original mix.wav.
+            loaded.removeAll { job in
+                job.state != .speakerNamingPending
+                    && !FileManager.default.fileExists(atPath: job.mixPath.path)
+            }
 
             guard !loaded.isEmpty else {
                 logger.info("Snapshot loaded but no recoverable jobs")
@@ -702,9 +1118,30 @@ class PipelineQueue {
             }
 
             jobs = loaded
+
+            // Rebuild speaker naming cache from disk for .speakerNamingPending jobs
+            for job in jobs where job.state == .speakerNamingPending {
+                if let slug = job.namingSlug, let data = loadNamingData(slug: slug) {
+                    speakerNamingDataByJob[job.id] = data
+                } else {
+                    // Naming data lost — transition to done
+                    logger.warning("Naming data not found for job \(job.id), marking as done")
+                    if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
+                        jobs[idx].state = .done
+                    }
+                }
+            }
+
             saveSnapshot()
+            cleanupStalePending()
             logger.info("Restored \(loaded.count) jobs from snapshot")
             triggerProcessing()
+            // Auto-popup the naming dialog if any restored job is still
+            // waiting for confirmation. Same notification as the in-pipeline
+            // pop, so MeetingTranscriberApp brings the window forward.
+            if !pendingSpeakerNamingJobs.isEmpty {
+                NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
+            }
         } catch {
             logger.error("Failed to load pipeline snapshot: \(error)")
         }

--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -229,8 +229,13 @@ struct VoiceEnrollmentView: View {
             speakingTimes: diarization.speakingTimes,
             embeddings: diarization.embeddings ?? [:],
             audioPath: url,
-            segments: diarization.segments,
+            segments: diarization.segments.map { seg in
+                PipelineQueue.SpeakerNamingData.Segment(
+                    start: seg.start, end: seg.end, speaker: seg.speaker,
+                )
+            },
             participants: [],
+            isDualSource: false,
         )
         let speakerCount = Set(diarization.segments.map(\.speaker)).count
         return NamingPayload(

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -3,7 +3,7 @@ import Foundation
 import WhisperKit
 
 /// A transcribed segment with timestamps and optional speaker label.
-struct TimestampedSegment {
+struct TimestampedSegment: Codable {
     let start: TimeInterval // seconds
     let end: TimeInterval // seconds
     let text: String

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -134,11 +134,11 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(queue.jobs.count, 0)
     }
 
-    func testCancelDuringSpeakerNamingResumesContinuation() async {
+    func testCancelDuringSpeakerNamingClearsData() {
         let job = makeJob()
         queue.enqueue(job)
         queue.updateJobState(id: job.id, to: .diarizing)
-        queue.pendingSpeakerNaming = PipelineQueue.SpeakerNamingData(
+        queue.speakerNamingDataByJob[job.id] = PipelineQueue.SpeakerNamingData(
             jobID: job.id,
             meetingTitle: "Test",
             mapping: [:],
@@ -147,18 +147,11 @@ final class PipelineQueueTests: XCTestCase {
             audioPath: nil,
             segments: [],
             participants: [],
+            isDualSource: false,
         )
-        // Drive the actual fix path: a pending continuation that must resume.
-        let result = await withCheckedContinuation { (continuation: CheckedContinuation<PipelineQueue.SpeakerNamingResult, Never>) in
-            queue.setSpeakerNamingContinuationForTesting(continuation)
-            queue.cancelJob(id: job.id)
-        }
 
-        if case .skipped = result {
-            // expected
-        } else {
-            XCTFail("expected .skipped, got \(result)")
-        }
+        queue.cancelJob(id: job.id)
+
         XCTAssertNil(queue.pendingSpeakerNaming, "popup data must be cleared on cancel")
         XCTAssertEqual(queue.jobs.count, 0)
     }
@@ -958,5 +951,557 @@ final class PipelineQueueTests: XCTestCase {
 
         await queue2.processNext()
         XCTAssertEqual(queue2.jobs.first?.state, .done)
+    }
+
+    func testJobStateSpeakerNamingPendingLabel() {
+        XCTAssertEqual(JobState.speakerNamingPending.label, "Name Speakers...")
+    }
+
+    func testJobStateSpeakerNamingPendingIsCodable() throws {
+        let state = JobState.speakerNamingPending
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(JobState.self, from: data)
+        XCTAssertEqual(decoded, state)
+    }
+
+    // MARK: - SpeakerNamingData Codable
+
+    func testSpeakerNamingDataRoundTripsThroughJSON() throws {
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: "Test Meeting",
+            mapping: ["SPEAKER_0": "Alice", "SPEAKER_1": "Bob"],
+            speakingTimes: ["SPEAKER_0": 120.5, "SPEAKER_1": 85.3],
+            embeddings: ["SPEAKER_0": [0.1, 0.2], "SPEAKER_1": [0.3, 0.4]],
+            audioPath: URL(fileURLWithPath: "/tmp/test_16k.wav"),
+            segments: [
+                .init(start: 0.0, end: 5.0, speaker: "SPEAKER_0"),
+                .init(start: 5.0, end: 10.0, speaker: "SPEAKER_1"),
+            ],
+            participants: ["Alice", "Bob", "Charlie"],
+            isDualSource: false,
+        )
+
+        let encoded = try JSONEncoder().encode(data)
+        let decoded = try JSONDecoder().decode(PipelineQueue.SpeakerNamingData.self, from: encoded)
+
+        XCTAssertEqual(decoded.jobID, data.jobID)
+        XCTAssertEqual(decoded.meetingTitle, data.meetingTitle)
+        XCTAssertEqual(decoded.mapping, data.mapping)
+        XCTAssertEqual(decoded.participants, data.participants)
+        XCTAssertFalse(decoded.isDualSource)
+        XCTAssertEqual(decoded.segments.count, 2)
+    }
+
+    func testPendingSpeakerNamingJobsReturnsNamingPendingJobs() {
+        let queue = PipelineQueue(logDir: tmpDir)
+        XCTAssertTrue(queue.pendingSpeakerNamingJobs.isEmpty)
+    }
+
+    // MARK: - Pipeline Timeout → speakerNamingPending
+
+    func testPipelineSetsSpeakerNamingPendingAfterTimeout() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+        // Don't set speakerNamingHandler — pipeline proceeds with auto-names immediately
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Timeout Test",
+            appName: "TestApp",
+            mixPath: audioPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        pQueue.enqueue(job)
+
+        let expectation = XCTestExpectation(description: "Pipeline completes")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending {
+                expectation.fulfill()
+            }
+        }
+
+        await pQueue.processNext()
+
+        await fulfillment(of: [expectation], timeout: 10)
+
+        let finalJob = pQueue.jobs.first
+        XCTAssertEqual(
+            finalJob?.state, .speakerNamingPending,
+            "Job should be speakerNamingPending when naming was not confirmed",
+        )
+        XCTAssertNotNil(
+            pQueue.speakerNamingDataByJob[job.id],
+            "Naming data should still be available",
+        )
+    }
+
+    func testPipelineSetsDoneWhenNamingConfirmed() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        pQueue.speakerNamingHandler = { _ in .confirmed(["SPEAKER_0": "Alice"]) }
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Confirm Test",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        await pQueue.processNext()
+
+        let finalState = pQueue.jobs.first?.state
+        XCTAssertEqual(finalState, .done, "Confirmed naming should end as .done")
+    }
+
+    func testCompleteSpeakerNamingLateConfirmedTransitionsToDone() async {
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Late Naming",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        queue.enqueue(job)
+
+        // Simulate naming data still present
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Late Naming",
+            mapping: [:],
+            speakingTimes: [:],
+            embeddings: [:],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+        queue.speakerNamingDataByJob[job.id] = namingData
+
+        let doneExpectation = XCTestExpectation(description: "Job transitions to done")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        // Late completion: no continuation, pipeline done → spawns async re-apply
+        queue.completeSpeakerNaming(jobID: job.id, result: .confirmed([:]))
+
+        await fulfillment(of: [doneExpectation], timeout: 5)
+
+        XCTAssertEqual(queue.jobs.first?.state, .done)
+        XCTAssertNil(queue.speakerNamingDataByJob[job.id])
+    }
+
+    func testCompleteSpeakerNamingLateSkipTransitionsToDone() {
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Late Skip",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        queue.enqueue(job)
+
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Late Skip",
+            mapping: [:],
+            speakingTimes: [:],
+            embeddings: [:],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+        queue.speakerNamingDataByJob[job.id] = namingData
+
+        // Late skip: synchronous cleanup
+        queue.completeSpeakerNaming(jobID: job.id, result: .skipped)
+
+        XCTAssertEqual(queue.jobs.first?.state, .done)
+        XCTAssertNil(queue.speakerNamingDataByJob[job.id])
+    }
+
+    // MARK: - Late Re-apply Speaker Names
+
+    func testLateConfirmationRewritesTranscript() async throws {
+        // Create a transcript file with speaker labels
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        try FileManager.default.createDirectory(at: protocolsDir, withIntermediateDirectories: true)
+        let transcriptPath = protocolsDir.appendingPathComponent("test_transcript.txt")
+        let originalTranscript = "[00:00 - 00:05] [SPEAKER_0] Hello world\n[00:05 - 00:10] [SPEAKER_1] Hi there"
+        try originalTranscript.write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Rewrite Test",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.transcriptPath = transcriptPath
+        queue.enqueue(job)
+
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Rewrite Test",
+            mapping: ["SPEAKER_0": "SPEAKER_0", "SPEAKER_1": "SPEAKER_1"],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5],
+            embeddings: ["SPEAKER_0": [1, 0], "SPEAKER_1": [0, 1]],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+        queue.speakerNamingDataByJob[job.id] = namingData
+
+        let doneExpectation = XCTestExpectation(description: "Job transitions to done")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        queue.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice", "SPEAKER_1": "Bob"]))
+
+        await fulfillment(of: [doneExpectation], timeout: 5)
+
+        XCTAssertEqual(queue.jobs.first?.state, .done)
+        XCTAssertNil(queue.speakerNamingDataByJob[job.id])
+
+        // Verify transcript was rewritten with user-provided names
+        let rewritten = try String(contentsOf: transcriptPath, encoding: .utf8)
+        XCTAssertTrue(rewritten.contains("[Alice]"), "Transcript should contain user-provided name Alice")
+        XCTAssertTrue(rewritten.contains("[Bob]"), "Transcript should contain user-provided name Bob")
+        XCTAssertFalse(rewritten.contains("[SPEAKER_0]"), "Generic label should be replaced")
+        XCTAssertFalse(rewritten.contains("[SPEAKER_1]"), "Generic label should be replaced")
+    }
+
+    func testLateConfirmationReplacesAutoMatchedNames() async throws {
+        // Test that auto-matched names (from SpeakerMatcher) are also replaced
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        try FileManager.default.createDirectory(at: protocolsDir, withIntermediateDirectories: true)
+        let transcriptPath = protocolsDir.appendingPathComponent("auto_match_transcript.txt")
+        // Transcript already has auto-matched name "John" for SPEAKER_0
+        let originalTranscript = "[00:00 - 00:05] [John] Hello world"
+        try originalTranscript.write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Auto Match Test",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.transcriptPath = transcriptPath
+        queue.enqueue(job)
+
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Auto Match Test",
+            mapping: ["SPEAKER_0": "John"], // auto-matched to John
+            speakingTimes: ["SPEAKER_0": 5],
+            embeddings: ["SPEAKER_0": [1, 0]],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+        queue.speakerNamingDataByJob[job.id] = namingData
+
+        let doneExpectation = XCTestExpectation(description: "done")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        // User corrects John → Jonathan
+        queue.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Jonathan"]))
+
+        await fulfillment(of: [doneExpectation], timeout: 5)
+
+        let rewritten = try String(contentsOf: transcriptPath, encoding: .utf8)
+        XCTAssertTrue(rewritten.contains("[Jonathan]"), "Auto-matched name should be replaced with user correction")
+        XCTAssertFalse(rewritten.contains("[John]"), "Old auto-matched name should be gone")
+    }
+
+    // MARK: - Late Re-diarization
+
+    func testLateRerunDiarizesFromPersistedAudio() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+        // No handler → pipeline proceeds immediately with auto-names
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Late Rerun Test",
+            appName: "TestApp",
+            mixPath: audioPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        pQueue.enqueue(job)
+
+        // Wait for speakerNamingPending (timeout path leaves naming data intact)
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending {
+                pendingExpectation.fulfill()
+            }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+
+        XCTAssertEqual(pQueue.jobs.first?.state, .speakerNamingPending)
+        XCTAssertNotNil(pQueue.speakerNamingDataByJob[job.id])
+
+        // Now set handler to confirm after re-run
+        var rerunHandlerCalled = false
+        pQueue.speakerNamingHandler = { _ in
+            rerunHandlerCalled = true
+            return .confirmed([:])
+        }
+
+        // Request re-run with 3 speakers
+        let doneExpectation = XCTestExpectation(description: "done after rerun")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        await fulfillment(of: [doneExpectation], timeout: 60)
+
+        XCTAssertTrue(rerunHandlerCalled, "Handler should be called with new diarization results")
+        XCTAssertEqual(pQueue.jobs.first?.state, .done)
+    }
+
+    func testLateConfirmationWithNoNamingDataIsNoOp() {
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "No Data Test",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        queue.enqueue(job)
+
+        // No naming data set — should be a no-op
+        queue.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+
+        // State should NOT change since guard fails
+        XCTAssertEqual(queue.jobs.first?.state, .speakerNamingPending)
+    }
+
+    // MARK: - Snapshot Restore + Speaker Naming Cache
+
+    func testLoadSnapshotRebuildsSpeakerNamingCache() throws {
+        let outputDir = tmpDir.appendingPathComponent("output")
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+
+        let mixPath = tmpDir.appendingPathComponent("mix.wav")
+        try Data([0]).write(to: mixPath)
+
+        // Create a job in speakerNamingPending state and write snapshot JSON directly
+        var job = PipelineJob(
+            meetingTitle: "Snapshot Test",
+            appName: "App",
+            mixPath: mixPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.namingSlug = "snapshot_test"
+        let snapshotData = try JSONEncoder().encode([job])
+        try snapshotData.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+
+        // Save naming data as sidecar JSON
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Snapshot Test",
+            mapping: ["SPEAKER_0": "Alice"],
+            speakingTimes: ["SPEAKER_0": 60.0],
+            embeddings: ["SPEAKER_0": [0.1, 0.2]],
+            audioPath: recordingsDir.appendingPathComponent("snapshot_test_16k.wav"),
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            participants: [],
+            isDualSource: false,
+        )
+        let json = try JSONEncoder().encode(namingData)
+        try json.write(to: recordingsDir.appendingPathComponent("snapshot_test_naming.json"))
+
+        // Load snapshot in a new queue that has outputDir set
+        let mockEngine = MockEngine()
+        let freshQueue = PipelineQueue(
+            engine: mockEngine,
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: outputDir,
+            logDir: tmpDir,
+            diarizeEnabled: true,
+        )
+        freshQueue.loadSnapshot()
+
+        // Verify: job still in speakerNamingPending, naming data loaded
+        XCTAssertEqual(freshQueue.jobs.first?.state, .speakerNamingPending)
+        XCTAssertNotNil(try freshQueue.speakerNamingDataByJob[XCTUnwrap(freshQueue.jobs.first?.id)])
+        XCTAssertEqual(
+            try freshQueue.speakerNamingDataByJob[XCTUnwrap(freshQueue.jobs.first?.id)]?.mapping["SPEAKER_0"],
+            "Alice",
+        )
+    }
+
+    func testLoadSnapshotFallsToDoneWhenNamingDataMissing() throws {
+        let mixPath = tmpDir.appendingPathComponent("mix.wav")
+        try Data([0]).write(to: mixPath)
+
+        var job = PipelineJob(
+            meetingTitle: "Missing Data Test",
+            appName: "App",
+            mixPath: mixPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.namingSlug = "missing_data_test"
+        let snapshotData = try JSONEncoder().encode([job])
+        try snapshotData.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+
+        // Load without saving naming JSON — should fall back to .done
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        freshQueue.loadSnapshot()
+
+        // Job transitions to .done in the naming rebuild loop (after removeAll ran),
+        // so it remains in the list as .done
+        let finalJob = freshQueue.jobs.first
+        XCTAssertEqual(finalJob?.state, .done)
+    }
+
+    // MARK: - Stale Pending Cleanup
+
+    func testCleanupStalePendingTransitionsToDone() {
+        var job = PipelineJob(
+            meetingTitle: "Old Meeting",
+            appName: "App",
+            mixPath: tmpDir.appendingPathComponent("mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        queue.enqueue(job)
+
+        // enqueuedAt is "now" — calling with maxAge: 0 should clean it up
+        queue.cleanupStalePending(maxAge: 0)
+
+        XCTAssertEqual(queue.jobs.first?.state, .done)
+        XCTAssertNil(queue.speakerNamingDataByJob[job.id])
+    }
+
+    func testCleanupStalePendingKeepsRecentJobs() {
+        var job = PipelineJob(
+            meetingTitle: "Recent Meeting",
+            appName: "App",
+            mixPath: tmpDir.appendingPathComponent("mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        queue.enqueue(job)
+
+        // With default 24h maxAge, a fresh job should not be cleaned up
+        queue.cleanupStalePending()
+
+        XCTAssertEqual(queue.jobs.first?.state, .speakerNamingPending)
+    }
+
+    func testCleanupSidecarFilesDeletesPersistedFiles() throws {
+        let outputDir = tmpDir.appendingPathComponent("output")
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+
+        let slug = "test_cleanup"
+        for suffix in ["_16k.wav", "_segments.json", "_naming.json"] {
+            try Data([0]).write(to: recordingsDir.appendingPathComponent("\(slug)\(suffix)"))
+        }
+
+        let localQueue = PipelineQueue(
+            engine: MockEngine(),
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: outputDir,
+            logDir: self.tmpDir,
+        )
+
+        localQueue.cleanupSidecarFiles(slug: slug)
+        localQueue.deleteNamingData(slug: slug)
+
+        for suffix in ["_16k.wav", "_segments.json", "_naming.json"] {
+            let path = recordingsDir.appendingPathComponent("\(slug)\(suffix)")
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: path.path),
+                "\(suffix) should be deleted",
+            )
+        }
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -19,6 +19,7 @@ final class SpeakerNamingViewTests: XCTestCase {
             audioPath: nil,
             segments: [],
             participants: [],
+            isDualSource: false,
         )
     }
 
@@ -354,6 +355,7 @@ final class SpeakerNamingViewTests: XCTestCase {
             audioPath: URL(fileURLWithPath: "/tmp/audio.wav"),
             segments: [.init(start: 0, end: 5, speaker: "SPEAKER_00")],
             participants: [],
+            isDualSource: false,
         )
         let sut = SpeakerNamingView(data: dataWithAudio) { _ in }
         let body = try sut.inspect()


### PR DESCRIPTION
## Summary

Closes #106. Rebased onto current main (was 2 weeks behind, with conflicts in `PipelineQueue.swift` around the speaker-naming flow).

- New `JobState.speakerNamingPending` state for jobs awaiting confirmation.
- Pipeline no longer blocks on the naming dialog: auto-names are applied immediately, transcript saved.
- **Protocol generation deferred** until naming is resolved — saves an LLM call for the common case where the user does confirm.
- All naming data persisted to disk (`_naming.json`, `_16k.wav`, `_segments.json`) — survives crashes and app restart.
- Late confirmation: re-applies names to transcript + generates protocol with correct names (single LLM call).
- Late re-diarization with a different speaker count from the persisted 16 kHz audio.
- Multi-meeting picker when several jobs queue up.
- 24h auto-cleanup: stale pending → generate protocol with auto-names as fallback, mark done.
- Snapshot restore rebuilds the in-memory cache from disk.

### Resolved against main

Main moved a lot since the PR was opened (recognition stats logging #126/#129, voice enrollment #133, type-ahead chip filter #132). Conflicts resolved by:

- Taking the PR's non-blocking design (replaces `withCheckedContinuation` + `pendingSpeakerNaming` setter with `speakerNamingDataByJob[jobID]` dict + computed property).
- Dropping the `setSpeakerNamingContinuationForTesting` test seam — `cancelJob` now calls `completeSpeakerNaming(.skipped)` directly.
- Preserving recognition stats logging by stashing `suggestedAtDialog` and `topCandidates` per-job at dialog-show time, writing the JSONL row in the late-confirm path.
- Threading `knownSpeakerNames:` through the new `speakerNamingContent` view (the chip filter from #123/#132).
- `VoiceEnrollmentView` (#133) updated to use the new Codable `Segment` type + `isDualSource: false`.

### Bug fixes that landed during rebase

- **Auto-popup timing**: `.showSpeakerNaming` notification now fires AFTER `updateJobState(.speakerNamingPending)`. Without this, the window opened mid-pipeline, hit the `onAppear` close-when-empty guard (state was still `.diarizing`), and auto-closed itself.
- **Confirm doesn't close window**: `completeSpeakerNaming(.confirmed)` now transitions out of `.speakerNamingPending` synchronously (to `.generatingProtocol`) before kicking off the async transcript+protocol work, so the UI's close-when-empty check sees the change immediately.
- **Protocol generated twice**: pipeline now skips the initial protocol generation when naming is pending; it runs once, with the right names, on confirm. Auto-names are used only as a fallback on skip / 24h timeout.

## Test plan

- [x] `swift test` — 1084 tests, 0 non-snapshot failures
- [x] `./scripts/lint.sh` — clean
- [x] Local manual: meeting → dialog auto-pops at end of pipeline → confirm → window closes → protocol generated with confirmed names
- [x] Manual: kill app during pending naming → restart → dialog reappears
- [x] Manual: multi-meeting picker (queue two meetings)
- [ ] Manual: late re-diarize with different speaker count