### PR TITLE
ci: harden Dependabot pipeline against signing-secret absence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             scripts/generate_menu_bar_gifs.swift
       - name: SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging
+      - name: Build script regression tests
+        run: bash scripts/tests/test_build_release_signing.sh
 
   analyze:
     runs-on: macos-26

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe bumps
+        # Auto-merge: all github-actions bumps + patch/minor for swift packages.
+        # Major swift bumps still require manual review. Other ecosystems must
+        # be added explicitly here when introduced in dependabot.yml.
+        if: |
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          (steps.meta.outputs.package-ecosystem == 'swift' &&
+           (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+            steps.meta.outputs.update-type == 'version-update:semver-minor'))
+        run: gh pr merge --rebase --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -13,6 +13,21 @@
 
 set -euo pipefail
 
+# === Sourceable helpers (no side effects on source) ===
+
+# Returns first 40-hex codesigning identity SHA-1 hash, or empty string if none.
+# `|| true` guards against grep exit-1 (no match) propagating under pipefail.
+detect_sign_hash() {
+    security find-identity -v -p codesigning 2>/dev/null \
+        | grep -oE '[0-9A-F]{40}' | head -1 || true
+}
+
+# === Source guard: only run the build when executed, not when sourced ===
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    return 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -165,7 +180,7 @@ if [ "$NOTARIZE" = true ]; then
     fi
 else
     # Use local development certificate if available (extract 40-char hex SHA-1 hash)
-    SIGN_HASH=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '[0-9A-F]{40}' | head -1)
+    SIGN_HASH=$(detect_sign_hash)
     if [ -n "$SIGN_HASH" ]; then
         codesign --deep --force --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE"
         echo "  Signed with certificate: $SIGN_HASH"

--- a/scripts/tests/test_build_release_signing.sh
+++ b/scripts/tests/test_build_release_signing.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Regression test for scripts/build_release.sh codesign-identity detection.
+#
+# Bug history:
+#   `SIGN_HASH=$(security find-identity ... | grep | head -1)` aborted under
+#   `set -euo pipefail` when no codesign identity existed (grep exits 1 on
+#   no match → pipefail → set -e). Fixed by appending `|| true`.
+#
+# This test sources build_release.sh and calls detect_sign_hash() directly
+# with a PATH-stubbed `security` to simulate "no identity installed".
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$name"; then printf 'PASS\n'; else printf 'FAIL\n'; FAILED=1; fi
+}
+
+# Creates a stub PATH directory containing a no-op `security` and prints its path.
+# Caller is responsible for cleanup.
+make_security_stub() {
+    local dir
+    dir=$(mktemp -d)
+    cat > "$dir/security" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$dir/security"
+    printf '%s' "$dir"
+}
+
+test_detect_sign_hash_empty_when_no_identity() {
+    local stub_dir result rc
+    stub_dir=$(make_security_stub)
+    # Expand $stub_dir now (single command string), not at RETURN time —
+    # the local goes out of scope when the function returns.
+    trap "rm -rf -- '$stub_dir'" RETURN
+
+    result=$(PATH="$stub_dir:$PATH" bash -c "set -euo pipefail; source '$REPO_ROOT/scripts/build_release.sh'; detect_sign_hash")
+    rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo
+        echo "  detect_sign_hash aborted with exit $rc under set -euo pipefail"
+        return 1
+    fi
+    if [ -n "$result" ]; then
+        echo
+        echo "  expected empty result, got: $result"
+        return 1
+    fi
+    return 0
+}
+
+run_test test_detect_sign_hash_empty_when_no_identity
+
+exit "$FAILED"


### PR DESCRIPTION
## Summary
- Fix `build_release.sh` ad-hoc signing fallback (pipefail crash when no codesign identity exists)
- Extract `detect_sign_hash()` into a sourceable function with a source-guard, so tests can call it directly
- Regression test sources the script and calls the function with a PATH-stubbed `security`
- Wire the regression test into the existing `lint` CI job
- Add Dependabot auto-merge for patch/minor + github-actions bumps

## Why
PR #110 (`actions/github-script` 8 → 9, a harmless action bump) failed in `build (homebrew)` because `scripts/build_release.sh` aborted under `set -euo pipefail` before the ad-hoc signing fallback could run. Root cause: `grep` exits 1 on no match, `pipefail` propagates, `set -e` kills the script. Same latent bug bites any contributor without a Developer ID set up locally.

The initial fix was a one-line `|| true` append. The refactor that followed pulls the logic into a sourceable `detect_sign_hash()` function and adds a source-guard (`[[ "${BASH_SOURCE[0]}" != "${0}" ]]; then return 0; fi`), so tests can source the script and call the function directly instead of extracting a line via `grep` and evaluating it in a subshell.

The auto-merge workflow only fires for safe bumps (all github-actions ecosystem updates + patch/minor for swift packages). Major bumps still require manual review. Uses `gh pr merge --rebase --auto` to match the repo's "Rebase merge only" policy.

## Test plan
- [x] CI on this PR is green (proves the fix doesn't break authenticated builds)
- [ ] After merge, retrigger PR #110 with `@dependabot rebase` — `build (homebrew)` should be green and the PR should auto-merge
- [ ] Next Dependabot patch/minor PR auto-merges once required checks pass