### PR TITLE
docs: update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ scripts/
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
+  tests/
+    test_build_release_signing.sh  # Regression tests for build_release.sh codesign-identity detection
 Casks/meeting-transcriber.rb # Homebrew Cask formula (stable)
 Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
 .github/workflows/
@@ -93,9 +95,10 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E tests on self-hosted macOS runner (workflow_dispatch + v* tags)
+  dependabot-auto-merge.yml  # Auto-merge Dependabot PRs (patch/minor Swift packages, all GitHub Actions bumps)
 docs/
   architecture-macos.md        # High-level architecture quick-reference
-  menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol)
+  menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol, permission)
   plans/
     swift-architecture.md      # Detailed Swift pipeline architecture
     appstate-tests.md          # AppState test expansion plan


### PR DESCRIPTION
## Summary

- Add `scripts/tests/test_build_release_signing.sh` to project structure (introduced in 61eca15 but missing from CLAUDE.md)
- Add `.github/workflows/dependabot-auto-merge.yml` to project structure (introduced in 8c9ee2d but missing from CLAUDE.md)
- Add `permission` to the `menu-bar-*.gif` states comment in the `docs/` file tree (`menu-bar-permission.gif` exists but wasn't listed)

## What was checked

- Compared all source files in `app/MeetingTranscriber/Sources/` and `tools/audiotap/Sources/` against CLAUDE.md — all present and accurate
- Checked `scripts/` directory — found undocumented `tests/` subdirectory
- Checked `.github/workflows/` — found undocumented `dependabot-auto-merge.yml`
- Checked `docs/` GIF files — `menu-bar-permission.gif` exists and is referenced in README and architecture doc, but wasn't listed in CLAUDE.md's file tree comment
- Reviewed README.md, CONTRIBUTING.md, and `docs/architecture-macos.md` — all accurate, no changes needed

https://claude.ai/code/session_01NkXKBL9he6CTkZ8Xm6wHJe