### PR TITLE
docs: update project structure for scripts/tests, dependabot workflow, and permission gif

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ scripts/
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
+  tests/
+    test_build_release_signing.sh   # Regression tests for codesign pipeline
 Casks/meeting-transcriber.rb # Homebrew Cask formula (stable)
 Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
 .github/workflows/
@@ -93,9 +95,10 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E tests on self-hosted macOS runner (workflow_dispatch + v* tags)
+  dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
 docs/
   architecture-macos.md        # High-level architecture quick-reference
-  menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol)
+  menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol, permission)
   plans/
     swift-architecture.md      # Detailed Swift pipeline architecture
     appstate-tests.md          # AppState test expansion plan


### PR DESCRIPTION
## Summary

Three entries were missing from the `CLAUDE.md` project structure tree — all present in the codebase but not yet documented:

- `scripts/tests/test_build_release_signing.sh` — codesign pipeline regression tests, added in f561f10
- `.github/workflows/dependabot-auto-merge.yml` — auto-merges Dependabot patch/minor and github-actions bumps, added in 8c9ee2d
- `permission` added to `menu-bar-*.gif` state list — `menu-bar-permission.gif` exists in `docs/` and is referenced in README and architecture doc, but was missing from the CLAUDE.md gif comment

No other docs (`README.md`, `CONTRIBUTING.md`, `docs/architecture-macos.md`) required changes — all are accurate against the current codebase.

## Test plan

- [ ] Verify `scripts/tests/` directory listing matches `ls scripts/tests/`
- [ ] Verify `.github/workflows/` listing matches `ls .github/workflows/`
- [ ] Verify `docs/menu-bar-permission.gif` exists

https://claude.ai/code/session_01HBPXyvPPFVooasFCsXkwzN