### PR TITLE
feat(app): add audioDebugLogging setting for forensic capture diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,17 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - Audio capture (AudioTapLib) does NOT require Screen Recording — uses CATapDescription (purple dot indicator)
 - FluidAudio models are downloaded automatically on first run (~50 MB)
 
+## Diagnostics
+
+`AppSettings.audioDebugLogging` (Settings → Diagnostics → "Verbose Audio Logging") enables forensic logging in the audio-capture path:
+
+- `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` at start
+- `[debug] Default output device: name=… uid=…` at start and on device change
+- `[debug] App audio RMS (5s): … dBFS, samples=…, totalBytes=…` every 5 s during capture — live signal whether the tap is delivering real audio or zero/noise
+- `[debug] App audio capture stopping: totalBytes=…` at stop
+
+View via Console.app, subsystem `com.meetingtranscriber.audiotap`. Off by default; turn on when investigating silent recordings or unusual routing.
+
 ## Build Variants
 
 Two build variants controlled by compile-time flag `APPSTORE` (`-Xswiftc -DAPPSTORE`):

--- a/README.md
+++ b/README.md
@@ -202,6 +202,21 @@ Files are saved to `~/Library/Application Support/MeetingTranscriber/protocols/`
 | Models not loading | Models download on first run (WhisperKit ~1 GB, Parakeet ~50 MB, Qwen3 ~1.75 GB); check internet connectivity |
 | OpenAI-compatible API connection failed | Verify the endpoint URL and that the local model server is running |
 
+### Diagnosing silent app-audio recordings
+
+If a recording's `_app.wav` is silent or unexpectedly quiet, enable verbose audio logging to capture forensic detail during the next attempt:
+
+1. Open **Settings → Diagnostics** and turn on **Verbose Audio Logging**.
+2. Reproduce the failing recording.
+3. Open **Console.app**, filter by subsystem `com.meetingtranscriber.audiotap`, and look for `[debug]` lines:
+   - `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` — which process the tap targeted
+   - `[debug] Default output device: name=… uid=…` — output device at start
+   - `[debug] App audio RMS (5s): …dBFS, samples=…, totalBytes=…` — every 5 seconds; **tells you live whether the tap is delivering real audio (-40 dBFS or higher) or near-silence (≤ -90 dBFS)**
+   - `[debug] Output device change → name=… uid=…` — emitted when the system output device changes mid-recording
+4. Turn the toggle off again when done — the per-5 s RMS log is moderately chatty.
+
+The toggle persists in `UserDefaults` and takes effect on the next recording without an app restart.
+
 ---
 
 ## License

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -292,6 +292,17 @@ final class AppSettings {
         customOutputDir ?? AppPaths.downloadsProtocolsDir
     }
 
+    // MARK: - Diagnostics
+
+    /// Enables verbose logging in the audio-capture path: process/device identity,
+    /// periodic RMS energy of the captured stream, output-device-change details.
+    /// Off by default; toggle for forensic debugging when audio recordings are silent
+    /// or otherwise unexpected. Logs go to the unified log subsystem
+    /// `com.meetingtranscriber.audiotap`.
+    var audioDebugLogging: Bool = defaults.object(forKey: "audioDebugLogging") as? Bool ?? false {
+        didSet { defaults.set(audioDebugLogging, forKey: "audioDebugLogging") }
+    }
+
     // MARK: - Updates
 
     var checkForUpdates: Bool = defaults.object(forKey: "checkForUpdates") as? Bool ?? true {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -167,6 +167,8 @@ final class AppState {
                     endGracePeriod: settings.endGrace,
                     noMic: settings.noMic,
                     micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+                    // swiftlint:disable:next trailing_closure
+                    audioDebugLogging: { [settings] in settings.audioDebugLogging },
                 )
 
                 loop.onStateChange = { [weak loop, notifier] _, newState in
@@ -219,6 +221,8 @@ final class AppState {
                 pollInterval: settings.pollInterval,
                 noMic: settings.noMic,
                 micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+                // swiftlint:disable:next trailing_closure
+                audioDebugLogging: { [settings] in settings.audioDebugLogging },
             )
             watchLoop = loop
 

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -17,7 +17,7 @@ struct RecordingResult {
 /// Abstraction for recording, enabling mock injection in tests.
 @MainActor
 protocol RecordingProvider {
-    func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?) throws
+    func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging: Bool) throws
     func stop() throws -> RecordingResult
 }
 
@@ -65,6 +65,7 @@ class DualSourceRecorder: RecordingProvider {
         appPID: pid_t,
         noMic: Bool = false,
         micDeviceUID: String? = nil,
+        debugLogging: Bool = false,
     ) throws {
         guard !isRecording else { return }
         guard #available(macOS 14.2, *) else {
@@ -88,6 +89,7 @@ class DualSourceRecorder: RecordingProvider {
             channels: appChannels,
             micOutputURL: micURL,
             micDeviceUID: (micDeviceUID?.isEmpty ?? true) ? nil : micDeviceUID,
+            debugLogging: debugLogging,
         )
         try session.start()
         captureSession = session

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -480,6 +480,18 @@ struct SettingsView: View {
                 }
             }
 
+            Section("Diagnostics") {
+                Toggle("Verbose Audio Logging", isOn: $settings.audioDebugLogging)
+                Text(
+                    "Logs process and output-device identity, plus a 5-second RMS"
+                        + " energy report of the captured app audio. Use to"
+                        + " investigate silent recordings. Logs go to subsystem"
+                        + " com.meetingtranscriber.audiotap (view via Console.app).",
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
             Section("About") {
                 HStack {
                     Text("Version")

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -49,6 +49,9 @@ class WatchLoop {
     let maxDuration: TimeInterval
     let noMic: Bool
     let micDeviceUID: String?
+    /// Dynamic accessor — read at recording-start time so toggling the setting
+    /// at runtime takes effect on the next recording without an app restart.
+    let audioDebugLogging: () -> Bool
 
     private var watchTask: Task<Void, Never>?
 
@@ -64,6 +67,7 @@ class WatchLoop {
         maxDuration: TimeInterval = 14400,
         noMic: Bool = false,
         micDeviceUID: String? = nil,
+        audioDebugLogging: @escaping () -> Bool = { false },
     ) {
         self.detector = detector
         self.recorderFactory = recorderFactory
@@ -73,6 +77,7 @@ class WatchLoop {
         self.maxDuration = maxDuration
         self.noMic = noMic
         self.micDeviceUID = micDeviceUID
+        self.audioDebugLogging = audioDebugLogging
     }
 
     nonisolated static var defaultOutputDir: URL {
@@ -130,7 +135,10 @@ class WatchLoop {
         watchTask = nil
 
         let recorder = recorderFactory()
-        try recorder.start(appPID: pid, noMic: noMic, micDeviceUID: micDeviceUID)
+        try recorder.start(
+            appPID: pid, noMic: noMic, micDeviceUID: micDeviceUID,
+            debugLogging: audioDebugLogging(),
+        )
 
         activeRecorder = recorder
         manualRecordingInfo = ManualRecordingInfo(pid: pid, appName: appName, title: title)
@@ -237,6 +245,7 @@ class WatchLoop {
             appPID: meeting.windowPID,
             noMic: noMic,
             micDeviceUID: micDeviceUID,
+            debugLogging: audioDebugLogging(),
         )
 
         // Read participants (Teams)

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -53,7 +53,7 @@ class MockRecorder: RecordingProvider {
     var startCalled = false
     var stopCalled = false
 
-    func start(appPID _: pid_t, noMic _: Bool, micDeviceUID _: String?) {
+    func start(appPID _: pid_t, noMic _: Bool, micDeviceUID _: String?, debugLogging _: Bool) {
         startCalled = true
     }
 

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -13,6 +13,7 @@ public class AppAudioCapture {
     private let sampleRate: Int
     private let channels: Int
     private let outputFileDescriptor: Int32
+    private let debugLogging: Bool
     private var aggregateID = AudioObjectID(kAudioObjectUnknown)
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var procID: AudioDeviceIOProcID?
@@ -23,6 +24,12 @@ public class AppAudioCapture {
     private let writeQueue = DispatchQueue(
         label: "audiotap.writer", qos: .userInteractive,
     )
+
+    // Debug-only counters (only mutated in IOProc when debugLogging=true).
+    private var debugRMSAccumulator: Double = 0
+    private var debugSampleCount: Int = 0
+    private var debugLastReportTime: TimeInterval = 0
+    private var debugTotalBytes: UInt64 = 0
 
     /// CoreAudio property address for default output device changes.
     private var defaultOutputAddress = AudioObjectPropertyAddress(
@@ -46,11 +53,20 @@ public class AppAudioCapture {
     ///   - outputFileDescriptor: File descriptor to write raw PCM data to.
     ///   - sampleRate: Desired sample rate (default 48000).
     ///   - channels: Number of audio channels (default 2).
-    public init(pid: pid_t, outputFileDescriptor: Int32, sampleRate: Int = 48000, channels: Int = 2) {
+    ///   - debugLogging: When true, emit verbose forensic logs (process identity,
+    ///     output device, periodic RMS energy of captured samples).
+    public init(
+        pid: pid_t,
+        outputFileDescriptor: Int32,
+        sampleRate: Int = 48000,
+        channels: Int = 2,
+        debugLogging: Bool = false,
+    ) {
         self.pid = pid
         self.outputFileDescriptor = outputFileDescriptor
         self.sampleRate = sampleRate
         self.channels = channels
+        self.debugLogging = debugLogging
     }
 
     /// Translate PID to CoreAudio process AudioObjectID.
@@ -216,6 +232,14 @@ public class AppAudioCapture {
         let processObjectID = try translatePID()
         logger.info("Process audio object ID: \(processObjectID)")
 
+        if debugLogging {
+            let bundleID = getProcessBundleID(processObjectID) ?? "?"
+            let exeName = getExecutableName(pid: pid)
+            logger.info(
+                "[debug] Tap target: pid=\(self.pid, privacy: .public) exe=\(exeName, privacy: .public) bundle=\(bundleID, privacy: .public) audioObjectID=\(processObjectID, privacy: .public)",
+            )
+        }
+
         // Get default output device UID
         guard let systemOutputUID = getDefaultOutputDeviceUID() else {
             throw NSError(
@@ -224,6 +248,13 @@ public class AppAudioCapture {
             )
         }
         logger.info("System output device: \(systemOutputUID)")
+
+        if debugLogging {
+            let deviceName = getDefaultOutputDeviceName() ?? "?"
+            logger.info(
+                "[debug] Default output device: name=\(deviceName, privacy: .public) uid=\(systemOutputUID, privacy: .public)",
+            )
+        }
 
         // Create CATapDescription for the target process
         let tap = CATapDescription(stereoMixdownOfProcesses: [processObjectID])
@@ -320,7 +351,13 @@ public class AppAudioCapture {
 
             // CATapDescription delivers interleaved float32 — write directly
             guard let data = abl.mBuffers.mData else { return }
-            writeAllToFileHandle(fd, data, count: Int(abl.mBuffers.mDataByteSize))
+            let byteCount = Int(abl.mBuffers.mDataByteSize)
+            writeAllToFileHandle(fd, data, count: byteCount)
+
+            if self.debugLogging {
+                self.accumulateDebugRMS(data: data, byteCount: byteCount)
+                self.maybeReportDebugRMS()
+            }
         }
 
         guard ioProcStatus == noErr, let validProcID = newProcID else {
@@ -357,67 +394,14 @@ public class AppAudioCapture {
         logger.info("Audio capture started (PID \(self.pid), rate: \(self.actualSampleRate) Hz)")
     }
 
-    private func installOutputDeviceChangeListener() {
-        guard !outputListenerInstalled else { return }
-        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.handleOutputDeviceChanged()
-        }
-        let status = AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &defaultOutputAddress,
-            DispatchQueue.main,
-            listener,
-        )
-        if status == noErr {
-            outputDeviceChangeListener = listener
-            outputListenerInstalled = true
-            logger.info("App audio: listening for default output device changes")
-        }
-    }
-
-    private func handleOutputDeviceChanged() {
-        guard isRunning, !isRestarting else { return }
-        isRestarting = true
-        logger.info("App audio: default output device changed, recreating tap...")
-
-        stopCapture()
-
-        // USB devices need time to settle their format after connection.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self else { return }
-            do {
-                try self.startCapture()
-                // Verify rate was detected — USB devices may not have settled yet
-                if self.actualSampleRate <= 0 {
-                    logger.warning("App audio: rate query returned 0 after restart, retrying in 1s...")
-                    self.stopCapture()
-                    self.retryStartCapture(afterDelay: 1.0)
-                } else {
-                    self.isRestarting = false
-                    logger.info("App audio: tap restarted on new device (rate: \(self.actualSampleRate) Hz)")
-                }
-            } catch {
-                logger.error("Failed to restart app audio capture: \(error)")
-                self.retryStartCapture(afterDelay: 1.0)
-            }
-        }
-    }
-
-    private func retryStartCapture(afterDelay delay: TimeInterval) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self else { return }
-            defer { self.isRestarting = false }
-            do {
-                try self.startCapture()
-                logger.info("App audio: tap restarted on retry (rate: \(self.actualSampleRate) Hz)")
-            } catch {
-                logger.error("Retry also failed: \(error)")
-            }
-        }
-    }
-
     private func stopCapture() {
         isRunning = false
+
+        if debugLogging {
+            logger.info(
+                "[debug] App audio capture stopping: totalBytes=\(self.debugTotalBytes, privacy: .public)",
+            )
+        }
 
         if let procID {
             AudioDeviceStop(aggregateID, procID)
@@ -448,5 +432,125 @@ public class AppAudioCapture {
             outputListenerInstalled = false
         }
         logger.info("Audio capture stopped")
+    }
+}
+
+// MARK: - Output device change handling
+
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    func installOutputDeviceChangeListener() {
+        guard !outputListenerInstalled else { return }
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.handleOutputDeviceChanged()
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultOutputAddress,
+            DispatchQueue.main,
+            listener,
+        )
+        if status == noErr {
+            outputDeviceChangeListener = listener
+            outputListenerInstalled = true
+            logger.info("App audio: listening for default output device changes")
+        }
+    }
+
+    func handleOutputDeviceChanged() {
+        guard isRunning, !isRestarting else { return }
+        isRestarting = true
+        logger.info("App audio: default output device changed, recreating tap...")
+
+        if debugLogging {
+            let newName = getDefaultOutputDeviceName() ?? "?"
+            let newUID = getDefaultOutputDeviceUID() ?? "?"
+            logger.info(
+                "[debug] Output device change → name=\(newName, privacy: .public) uid=\(newUID, privacy: .public)",
+            )
+        }
+
+        stopCapture()
+
+        // USB devices need time to settle their format after connection.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self else { return }
+            do {
+                try self.startCapture()
+                // Verify rate was detected — USB devices may not have settled yet
+                if self.actualSampleRate <= 0 {
+                    logger.warning("App audio: rate query returned 0 after restart, retrying in 1s...")
+                    self.stopCapture()
+                    self.retryStartCapture(afterDelay: 1.0)
+                } else {
+                    self.isRestarting = false
+                    logger.info("App audio: tap restarted on new device (rate: \(self.actualSampleRate) Hz)")
+                }
+            } catch {
+                logger.error("Failed to restart app audio capture: \(error)")
+                self.retryStartCapture(afterDelay: 1.0)
+            }
+        }
+    }
+
+    func retryStartCapture(afterDelay delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self else { return }
+            defer { self.isRestarting = false }
+            do {
+                try self.startCapture()
+                logger.info("App audio: tap restarted on retry (rate: \(self.actualSampleRate) Hz)")
+            } catch {
+                logger.error("Retry also failed: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Debug logging helpers
+
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    /// Accumulate squared-sample sum and count for the next periodic RMS report.
+    /// Called from the IOProc (serial writeQueue) only when debugLogging=true.
+    func accumulateDebugRMS(data: UnsafeMutableRawPointer, byteCount: Int) {
+        let count = byteCount / MemoryLayout<Float>.size
+        guard count > 0 else { return }
+        let buf = UnsafeBufferPointer(
+            start: data.assumingMemoryBound(to: Float.self), count: count,
+        )
+        var sumSq: Double = 0
+        for sample in buf {
+            sumSq += Double(sample) * Double(sample)
+        }
+        debugRMSAccumulator += sumSq
+        debugSampleCount += count
+        debugTotalBytes += UInt64(byteCount)
+    }
+
+    /// Emit a single RMS-energy log line every ~5 s of capture, with reset.
+    /// Provides a live signal whether the tap is delivering real audio or zero/noise.
+    func maybeReportDebugRMS() {
+        let now = Date().timeIntervalSinceReferenceDate
+        if debugLastReportTime == 0 {
+            debugLastReportTime = now
+            return
+        }
+        guard now - debugLastReportTime >= 5.0 else { return }
+        let dB: Double
+        if debugSampleCount > 0 {
+            let meanSq = debugRMSAccumulator / Double(debugSampleCount)
+            let rms = meanSq > 0 ? sqrt(meanSq) : 0
+            dB = rms > 0 ? 20 * log10(rms) : -120
+        } else {
+            dB = -120
+        }
+        let dBStr = String(format: "%.1f", dB)
+        logger.info(
+            "[debug] App audio RMS (5s): \(dBStr, privacy: .public) dBFS, samples=\(self.debugSampleCount, privacy: .public), totalBytes=\(self.debugTotalBytes, privacy: .public)",
+        )
+        debugRMSAccumulator = 0
+        debugSampleCount = 0
+        debugLastReportTime = now
     }
 }

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -13,6 +13,7 @@ public class AudioCaptureSession {
     private let appOutputURL: URL
     private let micOutputURL: URL?
     private let micDeviceUID: String?
+    private let debugLogging: Bool
 
     private var appCapture: AppAudioCapture?
     private var micCapture: MicCaptureHandler?
@@ -25,6 +26,7 @@ public class AudioCaptureSession {
         channels: Int = 2,
         micOutputURL: URL? = nil,
         micDeviceUID: String? = nil,
+        debugLogging: Bool = false,
     ) {
         self.pid = pid
         self.sampleRate = sampleRate
@@ -32,6 +34,7 @@ public class AudioCaptureSession {
         self.appOutputURL = appOutputURL
         self.micOutputURL = micOutputURL
         self.micDeviceUID = micDeviceUID
+        self.debugLogging = debugLogging
     }
 
     /// Start capturing app audio (and optionally mic audio).
@@ -50,6 +53,7 @@ public class AudioCaptureSession {
             outputFileDescriptor: handle.fileDescriptor,
             sampleRate: sampleRate,
             channels: channels,
+            debugLogging: debugLogging,
         )
         do {
             try capture.start()

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -59,3 +59,50 @@ func getDefaultOutputDeviceUID() -> String? {
     guard uidStatus == noErr, let cfUID = uid?.takeRetainedValue() else { return nil }
     return cfUID as String
 }
+
+/// Read a CFString-valued audio property. Returns nil if the property is unavailable.
+func readCFStringAudioProperty(
+    _ id: AudioObjectID,
+    _ selector: AudioObjectPropertySelector,
+    scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+) -> String? {
+    var addr = AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: scope,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    var s: Unmanaged<CFString>?
+    var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+    let status = AudioObjectGetPropertyData(id, &addr, 0, nil, &size, &s)
+    guard status == noErr, let cf = s?.takeRetainedValue() else { return nil }
+    return cf as String
+}
+
+/// Bundle ID of a CoreAudio process AudioObject (e.g. "com.microsoft.teams2").
+public func getProcessBundleID(_ processObjectID: AudioObjectID) -> String? {
+    readCFStringAudioProperty(processObjectID, kAudioProcessPropertyBundleID)
+}
+
+/// Human-readable name of the default output device (e.g. "AirPods Pro", "MacBook Pro Speakers").
+public func getDefaultOutputDeviceName() -> String? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    var deviceID = AudioObjectID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioObjectID>.size)
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID,
+    )
+    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return readCFStringAudioProperty(deviceID, kAudioObjectPropertyName)
+}
+
+/// Process executable name (e.g. "MSTeams") for a PID. Returns "?" on lookup failure.
+public func getExecutableName(pid: pid_t) -> String {
+    var name = [CChar](repeating: 0, count: 1024)
+    let result = proc_name(pid, &name, UInt32(name.count))
+    if result <= 0 { return "?" }
+    return String(cString: name)
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in **Verbose Audio Logging** toggle (Settings → Diagnostics) that emits forensic detail in the audio-capture path: tap-target identity, output device, periodic 5 s RMS energy of the captured stream, output-device-change events, and final byte counts.
- Off by default; takes effect on the next recording without an app restart (closure-based dynamic lookup, not a frozen Bool).
- Background: while investigating Issue #84 we hit a silent `_app.wav` whose root cause we couldn't pin down because the existing logs lacked context (process bundle, output device, per-second energy). With this on, the next silent recording carries its own forensics. We also evaluated and **rejected** a multi-PID-tap fix — the empirical evidence is documented inline in the relevant commit message.

## Test plan

- [x] `./scripts/lint.sh` — 0 serious violations
- [x] `cd app/MeetingTranscriber && swift build` — green
- [x] `swift test --filter "WatchLoop"` — 28/28 pass; full suite passes excluding pre-existing `MenuBarIconSnapshotTests` (unrelated, see existing memory)
- [x] Live verification on a Teams 2.x call: `[debug]` log lines appear in Console.app filtered by subsystem `com.meetingtranscriber.audiotap`, with all values rendered as plain text (e.g. `[debug] App audio RMS (5s): -21.8 dBFS, samples=481280, totalBytes=1925120`)
- [x] Toggle works dynamically — flipping it in the UI affects the next recording, no relaunch needed