### PR TITLE
feat(audiotap): expand audioDebugLogging with mic + device-detail + tap-format

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -25,10 +25,7 @@ public class AppAudioCapture {
         label: "audiotap.writer", qos: .userInteractive,
     )
 
-    // Debug-only counters (only mutated in IOProc when debugLogging=true).
-    private var debugRMSAccumulator: Double = 0
-    private var debugSampleCount: Int = 0
-    private var debugLastReportTime: TimeInterval = 0
+    private var debugRMS = DebugRMSReporter()
     private var debugTotalBytes: UInt64 = 0
 
     /// CoreAudio property address for default output device changes.
@@ -251,8 +248,10 @@ public class AppAudioCapture {
 
         if debugLogging {
             let deviceName = getDefaultOutputDeviceName() ?? "?"
+            let transport = getDefaultOutputDeviceTransportType() ?? "?"
+            let deviceRate = getDefaultOutputDeviceSampleRate() ?? 0
             logger.info(
-                "[debug] Default output device: name=\(deviceName, privacy: .public) uid=\(systemOutputUID, privacy: .public)",
+                "[debug] Default output device: name=\(deviceName, privacy: .public) uid=\(systemOutputUID, privacy: .public) transport=\(transport, privacy: .public) rate=\(deviceRate, privacy: .public)",
             )
         }
 
@@ -276,6 +275,13 @@ public class AppAudioCapture {
         }
         tapID = newTapID
         logger.info("Created process tap: \(self.tapID)")
+
+        if debugLogging {
+            let tapRate = Self.queryTapSampleRate(tapID: tapID)
+            logger.info(
+                "[debug] Tap format: rate=\(tapRate, privacy: .public) Hz, tapID=\(self.tapID, privacy: .public)",
+            )
+        }
 
         // Create aggregate device with the tap
         let desc: [String: Any] = [
@@ -511,8 +517,8 @@ extension AppAudioCapture {
 
 @available(macOS 14.2, *)
 extension AppAudioCapture {
-    /// Accumulate squared-sample sum and count for the next periodic RMS report.
     /// Called from the IOProc (serial writeQueue) only when debugLogging=true.
+    /// Sums squares of the interleaved Float32 buffer into the shared RMS reporter.
     func accumulateDebugRMS(data: UnsafeMutableRawPointer, byteCount: Int) {
         let count = byteCount / MemoryLayout<Float>.size
         guard count > 0 else { return }
@@ -523,34 +529,17 @@ extension AppAudioCapture {
         for sample in buf {
             sumSq += Double(sample) * Double(sample)
         }
-        debugRMSAccumulator += sumSq
-        debugSampleCount += count
+        debugRMS.add(sumSq: sumSq, samples: count)
         debugTotalBytes += UInt64(byteCount)
     }
 
-    /// Emit a single RMS-energy log line every ~5 s of capture, with reset.
-    /// Provides a live signal whether the tap is delivering real audio or zero/noise.
+    /// Emit a single RMS-energy log line every ~5 s of capture.
+    /// Live signal whether the tap is delivering real audio or zero/noise.
     func maybeReportDebugRMS() {
-        let now = Date().timeIntervalSinceReferenceDate
-        if debugLastReportTime == 0 {
-            debugLastReportTime = now
-            return
-        }
-        guard now - debugLastReportTime >= 5.0 else { return }
-        let dB: Double
-        if debugSampleCount > 0 {
-            let meanSq = debugRMSAccumulator / Double(debugSampleCount)
-            let rms = meanSq > 0 ? sqrt(meanSq) : 0
-            dB = rms > 0 ? 20 * log10(rms) : -120
-        } else {
-            dB = -120
-        }
-        let dBStr = String(format: "%.1f", dB)
+        guard let report = debugRMS.tick() else { return }
+        let dBStr = String(format: "%.1f", report.dBFS)
         logger.info(
-            "[debug] App audio RMS (5s): \(dBStr, privacy: .public) dBFS, samples=\(self.debugSampleCount, privacy: .public), totalBytes=\(self.debugTotalBytes, privacy: .public)",
+            "[debug] App audio RMS (5s): \(dBStr, privacy: .public) dBFS, samples=\(report.samples, privacy: .public), totalBytes=\(self.debugTotalBytes, privacy: .public)",
         )
-        debugRMSAccumulator = 0
-        debugSampleCount = 0
-        debugLastReportTime = now
     }
 }

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -66,7 +66,7 @@ public class AudioCaptureSession {
 
         // Start mic capture if requested
         if let micURL = micOutputURL {
-            let mic = MicCaptureHandler(outputURL: micURL)
+            let mic = MicCaptureHandler(outputURL: micURL, debugLogging: debugLogging)
             do {
                 try mic.start(deviceUID: micDeviceUID)
                 micCapture = mic

--- a/tools/audiotap/Sources/DebugRMSReporter.swift
+++ b/tools/audiotap/Sources/DebugRMSReporter.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Throttled RMS accumulator/reporter shared by the app-audio and mic-capture debug
+/// logging paths. Caller feeds in pre-computed sum-of-squares + sample count;
+/// `tick(intervalSeconds:)` returns a (dBFS, samples) snapshot at most once per
+/// interval and resets the accumulators each time it fires.
+struct DebugRMSReporter {
+    var accumulator: Double = 0
+    var sampleCount: Int = 0
+    private var nextReportTicks: UInt64 = 0
+
+    mutating func add(sumSq: Double, samples: Int) {
+        accumulator += sumSq
+        sampleCount += samples
+    }
+
+    /// Returns (dBFS, samples) when at least `intervalSeconds` have elapsed since the
+    /// previous report (or first call); otherwise nil.
+    mutating func tick(intervalSeconds: Double = 5.0) -> (dBFS: Double, samples: Int)? {
+        let now = mach_absolute_time()
+        if nextReportTicks == 0 {
+            nextReportTicks = now + secondsToMachTicks(intervalSeconds)
+            return nil
+        }
+        guard now >= nextReportTicks else { return nil }
+        let dBFS: Double
+        if sampleCount > 0 {
+            let meanSq = accumulator / Double(sampleCount)
+            let rms = meanSq > 0 ? sqrt(meanSq) : 0
+            dBFS = rms > 0 ? 20 * log10(rms) : -120
+        } else {
+            dBFS = -120
+        }
+        let snapshot = (dBFS: dBFS, samples: sampleCount)
+        accumulator = 0
+        sampleCount = 0
+        nextReportTicks = now + secondsToMachTicks(intervalSeconds)
+        return snapshot
+    }
+}

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -18,6 +18,12 @@ func machTicksToSeconds(_ ticks: UInt64) -> Double {
     return nanos / 1_000_000_000.0
 }
 
+/// Convert seconds to mach_absolute_time() ticks (inverse of machTicksToSeconds).
+func secondsToMachTicks(_ seconds: Double) -> UInt64 {
+    let nanos = seconds * 1_000_000_000
+    return UInt64(nanos * Double(machTimebaseInfo.denom) / Double(machTimebaseInfo.numer))
+}
+
 /// Write all bytes to a file descriptor using POSIX write() — no Data copy, no Foundation overhead.
 func writeAllToFileHandle(_ fd: Int32, _ ptr: UnsafeRawPointer, count: Int) {
     var remaining = count
@@ -105,4 +111,77 @@ public func getExecutableName(pid: pid_t) -> String {
     let result = proc_name(pid, &name, UInt32(name.count))
     if result <= 0 { return "?" }
     return String(cString: name)
+}
+
+/// Resolve the AudioObjectID of the system default input or output device.
+private func resolveDefaultDevice(selector: AudioObjectPropertySelector) -> AudioObjectID? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    var deviceID = AudioObjectID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioObjectID>.size)
+    guard AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID,
+    ) == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return deviceID
+}
+
+func getDefaultInputDeviceUID() -> String? {
+    resolveDefaultDevice(selector: kAudioHardwarePropertyDefaultInputDevice)
+        .flatMap { readCFStringAudioProperty($0, kAudioDevicePropertyDeviceUID) }
+}
+
+func getDefaultInputDeviceName() -> String? {
+    resolveDefaultDevice(selector: kAudioHardwarePropertyDefaultInputDevice)
+        .flatMap { readCFStringAudioProperty($0, kAudioObjectPropertyName) }
+}
+
+/// Transport type of the default output device as a short string
+/// (e.g. "Bluetooth", "USB", "Built-In", "AirPlay", "Aggregate").
+func getDefaultOutputDeviceTransportType() -> String? {
+    guard let deviceID = resolveDefaultDevice(selector: kAudioHardwarePropertyDefaultOutputDevice) else {
+        return nil
+    }
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyTransportType,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    var raw: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &raw) == noErr else { return nil }
+    return transportTypeNames[raw] ?? "Unknown(\(raw))"
+}
+
+private let transportTypeNames: [UInt32: String] = [
+    kAudioDeviceTransportTypeBuiltIn: "Built-In",
+    kAudioDeviceTransportTypeUSB: "USB",
+    kAudioDeviceTransportTypeBluetooth: "Bluetooth",
+    kAudioDeviceTransportTypeBluetoothLE: "Bluetooth-LE",
+    kAudioDeviceTransportTypeHDMI: "HDMI",
+    kAudioDeviceTransportTypeDisplayPort: "DisplayPort",
+    kAudioDeviceTransportTypeAirPlay: "AirPlay",
+    kAudioDeviceTransportTypeAVB: "AVB",
+    kAudioDeviceTransportTypeThunderbolt: "Thunderbolt",
+    kAudioDeviceTransportTypeAggregate: "Aggregate",
+    kAudioDeviceTransportTypeVirtual: "Virtual",
+    kAudioDeviceTransportTypeContinuityCaptureWired: "ContinuityCapture-Wired",
+    kAudioDeviceTransportTypeContinuityCaptureWireless: "ContinuityCapture-Wireless",
+]
+
+func getDefaultOutputDeviceSampleRate() -> Double? {
+    guard let deviceID = resolveDefaultDevice(selector: kAudioHardwarePropertyDefaultOutputDevice) else {
+        return nil
+    }
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyNominalSampleRate,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    var rate: Float64 = 0
+    var size = UInt32(MemoryLayout<Float64>.size)
+    guard AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, &rate) == noErr else { return nil }
+    return rate
 }

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -14,6 +14,7 @@ public class MicCaptureHandler {
     private var engine = AVAudioEngine()
     private var outputFile: AVAudioFile?
     private let outputURL: URL
+    private let debugLogging: Bool
     private var isRecording = false
     private var isRestarting = false
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
@@ -25,14 +26,17 @@ public class MicCaptureHandler {
     private var resampleRatio: Double = 1.0
     public private(set) var firstFrameTime: UInt64 = 0
 
+    private var debugRMS = DebugRMSReporter()
+
     private var defaultInputAddress = AudioObjectPropertyAddress(
         mSelector: kAudioHardwarePropertyDefaultInputDevice,
         mScope: kAudioObjectPropertyScopeGlobal,
         mElement: kAudioObjectPropertyElementMain,
     )
 
-    public init(outputURL: URL) {
+    public init(outputURL: URL, debugLogging: Bool = false) {
         self.outputURL = outputURL
+        self.debugLogging = debugLogging
     }
 
     deinit {
@@ -93,6 +97,14 @@ public class MicCaptureHandler {
         let hwFormat = inputNode.outputFormat(forBus: 0)
         logger.info("Mic hardware format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount)ch")
 
+        if debugLogging {
+            let inUID = getDefaultInputDeviceUID() ?? "?"
+            let inName = getDefaultInputDeviceName() ?? "?"
+            logger.info(
+                "[debug] Mic input device: name=\(inName, privacy: .public) uid=\(inUID, privacy: .public) hwRate=\(hwFormat.sampleRate, privacy: .public) hwChannels=\(hwFormat.channelCount, privacy: .public)",
+            )
+        }
+
         let tapFormat = AVAudioFormat(
             standardFormatWithSampleRate: hwFormat.sampleRate, channels: 1,
         )! // swiftlint:disable:this force_unwrapping
@@ -136,6 +148,10 @@ public class MicCaptureHandler {
             guard let self else { return }
             if self.firstFrameTime == 0 {
                 self.firstFrameTime = mach_absolute_time()
+            }
+            if self.debugLogging {
+                self.accumulateDebugRMS(buffer: buffer)
+                self.maybeReportDebugRMS()
             }
             do {
                 if let converter = self.converter {
@@ -291,6 +307,64 @@ public class MicCaptureHandler {
         outputFile = nil
         logger.info("Mic recording stopped")
     }
+}
+
+// MARK: - Debug logging helpers
+
+extension MicCaptureHandler {
+    /// Sum squares across all channels of an AVAudioPCMBuffer into the shared
+    /// reporter. AVAudioEngine taps deliver float buffers in practice; the int16
+    /// branch is a safety net.
+    func accumulateDebugRMS(buffer: AVAudioPCMBuffer) {
+        let frames = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        guard frames > 0, channelCount > 0 else { return }
+        let sumSq: Double
+        if let floatData = buffer.floatChannelData {
+            sumSq = sumOfSquaresFloat(floatData, frames: frames, channels: channelCount)
+        } else if let int16Data = buffer.int16ChannelData {
+            sumSq = sumOfSquaresInt16(int16Data, frames: frames, channels: channelCount)
+        } else {
+            return
+        }
+        debugRMS.add(sumSq: sumSq, samples: frames * channelCount)
+    }
+
+    func maybeReportDebugRMS() {
+        guard let report = debugRMS.tick() else { return }
+        let dBStr = String(format: "%.1f", report.dBFS)
+        logger.info(
+            "[debug] Mic RMS (5s): \(dBStr, privacy: .public) dBFS, samples=\(report.samples, privacy: .public)",
+        )
+    }
+}
+
+private func sumOfSquaresFloat(
+    _ data: UnsafePointer<UnsafeMutablePointer<Float>>, frames: Int, channels: Int,
+) -> Double {
+    var sumSq: Double = 0
+    for ch in 0 ..< channels {
+        let ptr = data[ch]
+        for i in 0 ..< frames {
+            sumSq += Double(ptr[i]) * Double(ptr[i])
+        }
+    }
+    return sumSq
+}
+
+private func sumOfSquaresInt16(
+    _ data: UnsafePointer<UnsafeMutablePointer<Int16>>, frames: Int, channels: Int,
+) -> Double {
+    let scale = 1.0 / 32768.0
+    var sumSq: Double = 0
+    for ch in 0 ..< channels {
+        let ptr = data[ch]
+        for i in 0 ..< frames {
+            let s = Double(ptr[i]) * scale
+            sumSq += s * s
+        }
+    }
+    return sumSq
 }
 
 public enum MicCaptureError: LocalizedError {


### PR DESCRIPTION
## Summary

Follow-up on #117, gated behind the same `audioDebugLogging` toggle. Three additions:

- **Mic-side debug logs** — input device name/UID, hardware sample-rate, channel count at start; periodic 5 s RMS report on captured mic samples (same shape as app side). If a future silent recording is on the mic, we'll see whether the engine produces silence or the file write drops samples.
- **Output-device transport + nominal rate** — extends the existing name/UID line with `transport=Bluetooth|USB|Built-In|…` and `rate=…`. Would have surfaced the BT-HFP 24 kHz race in the 2026-03-30 silent recording immediately.
- **Tap format snapshot** — log the rate that `CATapDescription`'s own `kAudioTapPropertyFormat` reports right after tap creation, separate from the aggregate device's rate. Reveals tap/aggregate rate mismatches that today only show up as a warning.

`Helpers.swift` gains `getDefaultInputDeviceUID/Name`, `getDefaultOutputDeviceTransportType`, `getDefaultOutputDeviceSampleRate`. Transport-type lookup uses a const dictionary so the function stays under cyclomatic-complexity limits.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations, 0 serious
- [x] `swift build` — clean
- [x] `swift test --filter DualSourceRecorder|MicCapture` — passes
- [x] Live verification: enable Settings → Diagnostics → Verbose Audio Logging, run a Teams call, confirm new `[debug] Mic input device …`, `[debug] Mic RMS (5s) …`, `[debug] Default output device: … transport=… rate=…`, and `[debug] Tap format: rate=…` lines appear in Console.app