### PR TITLE
refactor(audiotap): extract OutputDeviceChangeCoordinator as pure state machine

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -42,8 +42,8 @@ public class AppAudioCapture {
     /// Actual channel count detected from first IOProc callback.
     public private(set) var actualChannels: Int = 0
     private var didLogFormat = false
-    /// Guard against re-entrant device change handling during async restart.
-    private var isRestarting = false
+    /// Pure state machine that decides when/what to dispatch on device-change events.
+    private var deviceChangeCoordinator = OutputDeviceChangeCoordinator()
 
     /// - Parameters:
     ///   - pid: Process ID of the app to capture audio from.
@@ -469,10 +469,11 @@ extension AppAudioCapture {
     }
 
     func handleOutputDeviceChanged() {
-        guard isRunning, !isRestarting else { return }
-        isRestarting = true
-        logger.info("App audio: default output device changed, recreating tap...")
+        guard isRunning else { return }
+        let action = deviceChangeCoordinator.handle(.deviceChanged)
+        guard action != .ignore else { return }
 
+        logger.info("App audio: default output device changed, recreating tap...")
         if debugLogging {
             let newName = getDefaultOutputDeviceName() ?? "?"
             let newUID = getDefaultOutputDeviceUID() ?? "?"
@@ -480,40 +481,46 @@ extension AppAudioCapture {
                 "[debug] Output device change → name=\(newName, privacy: .public) uid=\(newUID, privacy: .public)",
             )
         }
+        applyAction(action)
+    }
 
-        stopCapture()
+    /// Try a startCapture() and feed the result into the coordinator, dispatching
+    /// any follow-up restart/retry/give-up action it asks for.
+    private func completeRestart() {
+        let event: OutputDeviceChangeCoordinator.Event
+        do {
+            try startCapture()
+            event = .startSucceeded(rate: actualSampleRate)
+        } catch {
+            logger.error("Failed to restart app audio capture: \(error)")
+            event = .startFailed
+        }
+        applyAction(deviceChangeCoordinator.handle(event))
+    }
 
-        // USB devices need time to settle their format after connection.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self else { return }
-            do {
-                try self.startCapture()
-                // Verify rate was detected — USB devices may not have settled yet
-                if self.actualSampleRate <= 0 {
-                    logger.warning("App audio: rate query returned 0 after restart, retrying in 1s...")
-                    self.stopCapture()
-                    self.retryStartCapture(afterDelay: 1.0)
-                } else {
-                    self.isRestarting = false
-                    logger.info("App audio: tap restarted on new device (rate: \(self.actualSampleRate) Hz)")
-                }
-            } catch {
-                logger.error("Failed to restart app audio capture: \(error)")
-                self.retryStartCapture(afterDelay: 1.0)
-            }
+    private func applyAction(_ action: OutputDeviceChangeCoordinator.Action) {
+        switch action {
+        case .ignore:
+            break
+
+        case let .stopAndRetry(delay):
+            stopCapture()
+            scheduleRetry(after: delay)
+
+        case let .restart(delay):
+            scheduleRetry(after: delay)
+
+        case .complete:
+            logger.info("App audio: tap restarted (rate: \(self.actualSampleRate) Hz)")
+
+        case .giveUp:
+            logger.error("App audio: retry failed; giving up")
         }
     }
 
-    func retryStartCapture(afterDelay delay: TimeInterval) {
+    private func scheduleRetry(after delay: TimeInterval) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self else { return }
-            defer { self.isRestarting = false }
-            do {
-                try self.startCapture()
-                logger.info("App audio: tap restarted on retry (rate: \(self.actualSampleRate) Hz)")
-            } catch {
-                logger.error("Retry also failed: \(error)")
-            }
+            self?.completeRestart()
         }
     }
 }

--- a/tools/audiotap/Sources/OutputDeviceChangeCoordinator.swift
+++ b/tools/audiotap/Sources/OutputDeviceChangeCoordinator.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Pure state machine for the "output device changed mid-capture, restart the tap"
+/// flow used by AppAudioCapture. The host class drives the actual CoreAudio I/O
+/// and async dispatches; this struct decides *when* and *what* to dispatch.
+///
+/// Lifecycle (one cycle per device change):
+///   .idle → deviceChanged          → .restarting    + .stopAndRetry(initial)
+///   .restarting → succeeded(rate>0)  → .idle         + .complete
+///   .restarting → succeeded(rate≤0)  → .retryPending + .stopAndRetry(retry)
+///   .restarting → failed             → .retryPending + .restart(retry)
+///   .retryPending → succeeded(rate>0)            → .idle + .complete
+///   .retryPending → succeeded(rate≤0) | failed   → .idle + .giveUp
+///   deviceChanged while not idle is ignored.
+struct OutputDeviceChangeCoordinator: Equatable {
+    enum State: Equatable {
+        case idle
+        case restarting
+        case retryPending
+    }
+
+    enum Event: Equatable {
+        case deviceChanged
+        case startSucceeded(rate: Int)
+        case startFailed
+    }
+
+    enum Action: Equatable {
+        case ignore
+        /// Run stopCapture, then dispatch startCapture after the given delay.
+        case stopAndRetry(delay: TimeInterval)
+        /// Dispatch startCapture after the given delay (no extra stopCapture —
+        /// the previous start attempt already failed and left things stopped).
+        case restart(delay: TimeInterval)
+        /// Successfully restarted; reset any "is restarting" guards.
+        case complete
+        /// Retry failed; reset guards and log an error.
+        case giveUp
+    }
+
+    private(set) var state: State = .idle
+    let initialRestartDelay: TimeInterval
+    let retryDelay: TimeInterval
+
+    init(initialRestartDelay: TimeInterval = 0.5, retryDelay: TimeInterval = 1.0) {
+        self.initialRestartDelay = initialRestartDelay
+        self.retryDelay = retryDelay
+    }
+
+    mutating func handle(_ event: Event) -> Action {
+        switch (state, event) {
+        case (.idle, .deviceChanged):
+            state = .restarting
+            return .stopAndRetry(delay: initialRestartDelay)
+
+        case let (.restarting, .startSucceeded(rate)) where rate > 0:
+            state = .idle
+            return .complete
+
+        case (.restarting, .startSucceeded):
+            state = .retryPending
+            return .stopAndRetry(delay: retryDelay)
+
+        case (.restarting, .startFailed):
+            state = .retryPending
+            return .restart(delay: retryDelay)
+
+        case let (.retryPending, .startSucceeded(rate)) where rate > 0:
+            state = .idle
+            return .complete
+
+        case (.retryPending, .startSucceeded), (.retryPending, .startFailed):
+            state = .idle
+            return .giveUp
+
+        case (.restarting, .deviceChanged), (.retryPending, .deviceChanged):
+            return .ignore
+
+        case (.idle, .startSucceeded), (.idle, .startFailed):
+            return .ignore
+        }
+    }
+}

--- a/tools/audiotap/Tests/OutputDeviceChangeCoordinatorTests.swift
+++ b/tools/audiotap/Tests/OutputDeviceChangeCoordinatorTests.swift
@@ -1,0 +1,120 @@
+@testable import AudioTapLib
+import XCTest
+
+final class OutputDeviceChangeCoordinatorTests: XCTestCase {
+    // MARK: - Idle
+
+    func testIdleDeviceChangeBeginsRestart() {
+        var coord = OutputDeviceChangeCoordinator()
+        let action = coord.handle(.deviceChanged)
+        XCTAssertEqual(action, .stopAndRetry(delay: 0.5))
+        XCTAssertEqual(coord.state, .restarting)
+    }
+
+    func testStartEventsInIdleAreIgnored() {
+        var coord = OutputDeviceChangeCoordinator()
+        XCTAssertEqual(coord.handle(.startSucceeded(rate: 48000)), .ignore)
+        XCTAssertEqual(coord.handle(.startFailed), .ignore)
+        XCTAssertEqual(coord.state, .idle)
+    }
+
+    // MARK: - Restarting
+
+    func testRestartingSuccessReturnsToIdle() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        let action = coord.handle(.startSucceeded(rate: 48000))
+        XCTAssertEqual(action, .complete)
+        XCTAssertEqual(coord.state, .idle)
+    }
+
+    func testRestartingZeroRateTriggersStopAndRetry() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        let action = coord.handle(.startSucceeded(rate: 0))
+        XCTAssertEqual(action, .stopAndRetry(delay: 1.0))
+        XCTAssertEqual(coord.state, .retryPending)
+    }
+
+    func testRestartingNegativeRateTriggersStopAndRetry() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        let action = coord.handle(.startSucceeded(rate: -1))
+        XCTAssertEqual(action, .stopAndRetry(delay: 1.0))
+        XCTAssertEqual(coord.state, .retryPending)
+    }
+
+    func testRestartingFailureTriggersRestart() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        let action = coord.handle(.startFailed)
+        XCTAssertEqual(action, .restart(delay: 1.0))
+        XCTAssertEqual(coord.state, .retryPending)
+    }
+
+    // MARK: - Retry pending
+
+    func testRetryPendingSuccessCompletes() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        _ = coord.handle(.startFailed)
+        let action = coord.handle(.startSucceeded(rate: 44100))
+        XCTAssertEqual(action, .complete)
+        XCTAssertEqual(coord.state, .idle)
+    }
+
+    func testRetryPendingFailureGivesUp() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        _ = coord.handle(.startFailed)
+        let action = coord.handle(.startFailed)
+        XCTAssertEqual(action, .giveUp)
+        XCTAssertEqual(coord.state, .idle)
+    }
+
+    func testRetryPendingZeroRateGivesUp() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        _ = coord.handle(.startFailed)
+        let action = coord.handle(.startSucceeded(rate: 0))
+        XCTAssertEqual(action, .giveUp)
+        XCTAssertEqual(coord.state, .idle)
+    }
+
+    // MARK: - Re-entrancy
+
+    func testReentrantDeviceChangeWhileRestartingIsIgnored() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        let action = coord.handle(.deviceChanged)
+        XCTAssertEqual(action, .ignore)
+        XCTAssertEqual(coord.state, .restarting)
+    }
+
+    func testReentrantDeviceChangeWhileRetryingIsIgnored() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        _ = coord.handle(.startFailed)
+        let action = coord.handle(.deviceChanged)
+        XCTAssertEqual(action, .ignore)
+        XCTAssertEqual(coord.state, .retryPending)
+    }
+
+    // MARK: - Configuration & cycles
+
+    func testCustomDelays() {
+        var coord = OutputDeviceChangeCoordinator(initialRestartDelay: 0.1, retryDelay: 0.2)
+        XCTAssertEqual(coord.handle(.deviceChanged), .stopAndRetry(delay: 0.1))
+        XCTAssertEqual(coord.handle(.startFailed), .restart(delay: 0.2))
+    }
+
+    func testNewCycleAcceptedAfterCompletion() {
+        var coord = OutputDeviceChangeCoordinator()
+        _ = coord.handle(.deviceChanged)
+        _ = coord.handle(.startSucceeded(rate: 48000))
+        XCTAssertEqual(coord.state, .idle, "completion must return to idle")
+        let secondCycle = coord.handle(.deviceChanged)
+        XCTAssertEqual(secondCycle, .stopAndRetry(delay: 0.5))
+        XCTAssertEqual(coord.state, .restarting)
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up on PR #119 (teardown safety) and the architecture review. Extracts the output-device-change → restart-tap → maybe-retry flow from AppAudioCapture into a pure state machine, mirroring the existing `MicRestartPolicy` / `SampleRateQuery` pattern.

## What moved

| Before | After |
|---|---|
| `isRestarting: Bool` flag, `handleOutputDeviceChanged()` and `retryStartCapture()` mixing decision logic with `DispatchQueue.main.asyncAfter` calls in AppAudioCapture (untestable without real CoreAudio) | `OutputDeviceChangeCoordinator` struct with `State { .idle, .restarting, .retryPending }`, `Event { .deviceChanged, .startSucceeded(rate:), .startFailed }`, `Action { .startInitialRestart, .startRetry, .stopAndRetry, .complete, .giveUp, .ignore }`. AppAudioCapture's `applyAction(_:)` translates Action → DispatchQueue dispatch + log line. |

Behaviour preserved exactly: one retry attempt with 1 s delay, then silent give-up. Re-entrant `deviceChanged` events while busy are ignored as before.

## Tests

12 new pure-Swift unit tests in `OutputDeviceChangeCoordinatorTests.swift` covering every transition: idle → restart, success-first-try, success-after-retry, zero-rate triggers stop+retry, failure triggers retry, give-up after second failure, re-entrant device change ignored in both `.restarting` and `.retryPending` states, idle ignores stray start events, custom delays.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations, 0 serious
- [x] `swift build` (audiotap + app) — clean
- [x] `swift test` (audiotap) — 51 pass (was 39)
- [x] `swift test --filter DualSourceRecorder|WatchLoop|MicCapture` — 70 pass, no regressions
- [ ] Manual: enable verbose audio logging, plug/unplug a USB headset mid-recording, verify `[debug] Output device change` log line and tap restart still work