### PR TITLE
docs: update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,14 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     Helpers.swift          # machTicksToSeconds, getDefaultOutputDeviceUID, writeAllToFileHandle
     MicRestartPolicy.swift # Pure decision logic for mic engine restart on device change
     SampleRateQuery.swift  # Pure functions for sample rate detection and cross-validation
+    DebugRMSReporter.swift # Throttled RMS accumulator/reporter shared by app-audio and mic debug logging
+    OutputDeviceChangeCoordinator.swift # Pure state machine for output device change/restart flow
   Tests/
     AudioCaptureResultTests.swift
     HelpersTests.swift
     MicCaptureErrorTests.swift
     MicRestartPolicyTests.swift
+    OutputDeviceChangeCoordinatorTests.swift
     SampleRateQueryTests.swift
 tools/meeting-simulator/   # Meeting simulator tool for testing
   Package.swift
@@ -86,6 +89,8 @@ scripts/
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
+  tests/
+    test_build_release_signing.sh  # Regression tests for codesign pipeline in build_release.sh
 Casks/meeting-transcriber.rb # Homebrew Cask formula (stable)
 Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
 .github/workflows/
@@ -93,6 +98,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E tests on self-hosted macOS runner (workflow_dispatch + v* tags)
+  dependabot-auto-merge.yml # Auto-merge safe Dependabot bumps (patch/minor Swift + all GitHub Actions)
 docs/
   architecture-macos.md        # High-level architecture quick-reference
   menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol)
@@ -254,8 +260,10 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 `AppSettings.audioDebugLogging` (Settings → Diagnostics → "Verbose Audio Logging") enables forensic logging in the audio-capture path:
 
 - `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` at start
-- `[debug] Default output device: name=… uid=…` at start and on device change
+- `[debug] Default output device: name=… uid=… transport=… rate=…` at start and on device change
+- `[debug] Tap format: rate=… Hz, tapID=…` at start
 - `[debug] App audio RMS (5s): … dBFS, samples=…, totalBytes=…` every 5 s during capture — live signal whether the tap is delivering real audio or zero/noise
+- `[debug] Output device change → name=… uid=…` when the system output device changes mid-recording
 - `[debug] App audio capture stopping: totalBytes=…` at stop
 
 View via Console.app, subsystem `com.meetingtranscriber.audiotap`. Off by default; turn on when investigating silent recordings or unusual routing.


### PR DESCRIPTION
## Summary

- **New audiotap source files** — Added `DebugRMSReporter.swift` and `OutputDeviceChangeCoordinator.swift` to the `tools/audiotap/Sources/` file tree in CLAUDE.md (extracted in recent refactors: `feat(audiotap): expand audioDebugLogging` and `refactor(audiotap): extract OutputDeviceChangeCoordinator`)
- **New audiotap test file** — Added `OutputDeviceChangeCoordinatorTests.swift` to the audiotap test list
- **New build regression tests** — Added `scripts/tests/test_build_release_signing.sh` to the scripts section
- **New CI workflow** — Added `dependabot-auto-merge.yml` to the `.github/workflows/` section
- **Diagnostics section** — Added two new debug log entries (`[debug] Tap format: …` and `[debug] Output device change → …`) and updated the `Default output device` line to include `transport=… rate=…` fields, matching what `AppAudioCapture.swift` actually emits

## Files not changed

- `README.md` — Already up to date (includes the new debug log entries)
- `CONTRIBUTING.md` — No structural changes affect contribution guidelines
- `docs/architecture-macos.md` — References audiotap as a summary entry; no per-file detail to update

https://claude.ai/code/session_01WKdVmy5EtXQNiwqSPhWJse

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKdVmy5EtXQNiwqSPhWJse)_