### PR TITLE
feat(app): track speaker recency for picker ranking

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -6,8 +6,17 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Speaker
 struct StoredSpeaker: Codable {
     let name: String
     let embeddings: [[Float]]
+    /// Wall-clock time when this speaker was last confirmed by the user via
+    /// `updateDB`. Used to rank suggestion chips by recency. nil for entries
+    /// migrated from older DB versions that didn't track usage.
+    let lastUsed: Date?
+    /// Number of times this speaker has been confirmed by the user across
+    /// recordings. Defaults to 0 for entries that pre-date usage tracking.
+    let useCount: Int
 
-    // Migrate old single-embedding format automatically
+    // Migrate old single-embedding format automatically (legacy `embedding`
+    // key) and default lastUsed/useCount for entries written before recency
+    // tracking shipped.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
@@ -18,21 +27,31 @@ struct StoredSpeaker: Codable {
         } else {
             embeddings = []
         }
+        lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
+        useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
     }
 
-    init(name: String, embeddings: [[Float]]) {
+    init(name: String, embeddings: [[Float]], lastUsed: Date? = nil, useCount: Int = 0) {
         self.name = name
         self.embeddings = embeddings
+        self.lastUsed = lastUsed
+        self.useCount = useCount
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, embeddings, embedding
+        case name, embeddings, embedding, lastUsed, useCount
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(embeddings, forKey: .embeddings)
+        try container.encodeIfPresent(lastUsed, forKey: .lastUsed)
+        // Skip when 0 so entries that pre-date recency tracking round-trip
+        // byte-identical (no spurious useCount=0 field added on first save).
+        if useCount > 0 {
+            try container.encode(useCount, forKey: .useCount)
+        }
     }
 }
 
@@ -109,8 +128,11 @@ class SpeakerMatcher {
     }
 
     /// Update speaker DB with confirmed names and their embeddings.
-    /// Appends new embedding to the speaker's list (FIFO, max 5).
-    func updateDB(mapping: [String: String], embeddings: [String: [Float]]) {
+    /// Appends new embedding to the speaker's list (FIFO, max 5) and bumps
+    /// `lastUsed` / `useCount` so the picker can rank by recency.
+    func updateDB(
+        mapping: [String: String], embeddings: [String: [Float]], now: Date = Date(),
+    ) {
         var stored = loadDB()
 
         for (label, name) in mapping {
@@ -122,9 +144,16 @@ class SpeakerMatcher {
                 if updated.count > Self.maxEmbeddingsPerSpeaker {
                     updated.removeFirst(updated.count - Self.maxEmbeddingsPerSpeaker)
                 }
-                stored[idx] = StoredSpeaker(name: name, embeddings: updated)
+                stored[idx] = StoredSpeaker(
+                    name: name,
+                    embeddings: updated,
+                    lastUsed: now,
+                    useCount: stored[idx].useCount + 1,
+                )
             } else {
-                stored.append(StoredSpeaker(name: name, embeddings: [embedding]))
+                stored.append(StoredSpeaker(
+                    name: name, embeddings: [embedding], lastUsed: now, useCount: 1,
+                ))
             }
         }
 
@@ -136,11 +165,33 @@ class SpeakerMatcher {
         return (try? JSONDecoder().decode([StoredSpeaker].self, from: data)) ?? []
     }
 
-    /// Names of all stored speakers, sorted alphabetically. Used as suggestion
-    /// chips in the speaker-naming UI ("Known voices" row) so the user can
-    /// reuse names from previous meetings with one click.
+    /// Names of all stored speakers, ordered for picker display: most recently
+    /// used first, then by `useCount` descending, then alphabetically. Speakers
+    /// without `lastUsed` (legacy entries) are sorted alphabetically at the end.
+    /// This is the source-of-truth ordering for the "Known voices" row.
     func allSpeakerNames() -> [String] {
-        loadDB().map(\.name).sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        Self.rankByRecency(speakers: loadDB()).map(\.name)
+    }
+
+    /// Sort stored speakers for picker display. Pure for testability.
+    /// Tier order:
+    /// 1. Speakers with `lastUsed != nil`, most recent first.
+    /// 2. Within that group, ties (same timestamp) broken by `useCount` desc.
+    /// 3. Speakers without `lastUsed` come last, alphabetically.
+    static func rankByRecency(speakers: [StoredSpeaker]) -> [StoredSpeaker] {
+        let used = speakers.filter { $0.lastUsed != nil }
+        let unused = speakers.filter { $0.lastUsed == nil }
+        let sortedUsed = used.sorted { lhs, rhs in
+            let l = lhs.lastUsed ?? .distantPast
+            let r = rhs.lastUsed ?? .distantPast
+            if l != r { return l > r }
+            if lhs.useCount != rhs.useCount { return lhs.useCount > rhs.useCount }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        let sortedUnused = unused.sorted { lhs, rhs in
+            lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        return sortedUsed + sortedUnused
     }
 
     func saveDB(_ speakers: [StoredSpeaker]) {

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -1,8 +1,13 @@
+// swiftlint:disable file_length
 @testable import MeetingTranscriber
 import XCTest
 
 // swiftlint:disable:next type_body_length
 final class SpeakerMatcherTests: XCTestCase {
+    /// Fixed reference timestamp used by recency-tracking tests so assertions
+    /// don't depend on wall-clock time.
+    private static let testEpoch = Date(timeIntervalSince1970: 1_700_000_000)
+
     // swiftlint:disable implicitly_unwrapped_optional
     private var tmpDir: URL!
     private var dbPath: URL!
@@ -114,7 +119,7 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertTrue(matcher.allSpeakerNames().isEmpty)
     }
 
-    func testAllSpeakerNamesSortsAlphabeticallyCaseInsensitive() {
+    func testAllSpeakerNamesSortsAlphabeticallyCaseInsensitiveWhenUnused() {
         let matcher = SpeakerMatcher(dbPath: dbPath)
         matcher.saveDB([
             StoredSpeaker(name: "charlie", embeddings: [[1, 0, 0]]),
@@ -122,6 +127,82 @@ final class SpeakerMatcherTests: XCTestCase {
             StoredSpeaker(name: "bob", embeddings: [[0, 0, 1]]),
         ])
         XCTAssertEqual(matcher.allSpeakerNames(), ["Alice", "bob", "charlie"])
+    }
+
+    // MARK: - rankByRecency
+
+    func testRankByRecencyMostRecentFirst() {
+        let now = Date()
+        let speakers = [
+            StoredSpeaker(name: "Old", embeddings: [], lastUsed: now.addingTimeInterval(-3600), useCount: 5),
+            StoredSpeaker(name: "Newest", embeddings: [], lastUsed: now, useCount: 1),
+            StoredSpeaker(name: "Middle", embeddings: [], lastUsed: now.addingTimeInterval(-60), useCount: 2),
+        ]
+        let ranked = SpeakerMatcher.rankByRecency(speakers: speakers)
+        XCTAssertEqual(ranked.map(\.name), ["Newest", "Middle", "Old"])
+    }
+
+    func testRankByRecencyTiesBrokenByUseCount() {
+        let t = Date()
+        let speakers = [
+            StoredSpeaker(name: "Less", embeddings: [], lastUsed: t, useCount: 1),
+            StoredSpeaker(name: "More", embeddings: [], lastUsed: t, useCount: 10),
+        ]
+        let ranked = SpeakerMatcher.rankByRecency(speakers: speakers)
+        XCTAssertEqual(ranked.map(\.name), ["More", "Less"])
+    }
+
+    func testRankByRecencyLegacyEntriesAlphabeticAtEnd() {
+        let now = Date()
+        let speakers = [
+            StoredSpeaker(name: "zelda", embeddings: []), // legacy: no lastUsed
+            StoredSpeaker(name: "Newest", embeddings: [], lastUsed: now, useCount: 1),
+            StoredSpeaker(name: "anna", embeddings: []), // legacy
+        ]
+        let ranked = SpeakerMatcher.rankByRecency(speakers: speakers)
+        XCTAssertEqual(ranked.map(\.name), ["Newest", "anna", "zelda"])
+    }
+
+    // MARK: - updateDB recency tracking
+
+    func testUpdateDBSetsLastUsedAndIncrementsUseCount() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.updateDB(
+            mapping: ["S0": "Anna"],
+            embeddings: ["S0": [1, 0, 0]],
+            now: Self.testEpoch,
+        )
+        let stored = matcher.loadDB()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].name, "Anna")
+        XCTAssertEqual(stored[0].lastUsed, Self.testEpoch)
+        XCTAssertEqual(stored[0].useCount, 1)
+    }
+
+    func testUpdateDBIncrementsUseCountForExistingSpeaker() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let later = Self.testEpoch.addingTimeInterval(1000)
+        matcher.updateDB(mapping: ["S0": "Anna"], embeddings: ["S0": [1, 0, 0]], now: Self.testEpoch)
+        matcher.updateDB(mapping: ["S1": "Anna"], embeddings: ["S1": [0, 1, 0]], now: later)
+        let stored = matcher.loadDB()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].useCount, 2)
+        XCTAssertEqual(stored[0].lastUsed, later, "lastUsed should advance to most recent confirmation")
+    }
+
+    // MARK: - Backward-compat decode
+
+    func testLoadDBDecodesLegacyEntriesWithoutRecencyFields() throws {
+        // Older speakers.json predates lastUsed/useCount — decode must default them.
+        let legacy = """
+        [{"name":"Roman","embeddings":[[1,0,0]]}]
+        """
+        try legacy.data(using: .utf8)?.write(to: dbPath)
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let stored = matcher.loadDB()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertNil(stored[0].lastUsed)
+        XCTAssertEqual(stored[0].useCount, 0)
     }
 
     // MARK: - Update DB


### PR DESCRIPTION
## Summary

Step **E** of the speaker-recognition roadmap (see project memory). Replaces the alphabetic order of the "Known:" chip row in #123 with most-recently-used first.

### Schema (backward-compatible)

`StoredSpeaker` (`speakers.json`) gains:

- `lastUsed: Date?` — wall-clock time of the last confirmation
- `useCount: Int` — total confirmations across recordings (default 0)

Decoded with `decodeIfPresent`, so older entries load with `lastUsed = nil` / `useCount = 0`. `useCount` omitted from the encoded JSON when 0 to keep the on-disk file small.

### Behaviour

- `updateDB()` now sets `lastUsed = now` and increments `useCount` on every confirmation. Takes injectable `now: Date` for test determinism.
- `allSpeakerNames()` routes through a new pure-function `SpeakerMatcher.rankByRecency(speakers:)`:
  1. Most recent `lastUsed` first
  2. Tie-break by `useCount` descending
  3. Speakers without `lastUsed` (legacy entries) last, alphabetical

### User-visible effect

The "Known:" chips in the speaker-naming dialog now surface the people you actually meet most regularly first, instead of whoever happens to come first alphabetically. Combined with the auto-name + participant tier already in place, the right name is typically in the first slot.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations, 0 serious
- [x] `swift build` — clean
- [x] `swift test --filter SpeakerMatcher|SpeakerNaming` — 98 pass; 7 new tests:
   - `rankByRecency` most-recent-first / `useCount` tie-break / legacy alphabetic-at-end
   - `updateDB` sets `lastUsed`+`useCount`, increments on second confirmation
   - Backward-compat decode of pre-recency `speakers.json`
- [x] Manual: confirm a speaker named "Anna" today, restart app, open naming dialog → "Anna" appears as the first chip even if alphabetically late