### PR TITLE
feat(app): centroid-based speaker matching + embedding quality filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 **Diarization:**
 - `FluidDiarizer` uses FluidAudio (CoreML/ANE) for on-device speaker diarization — no HuggingFace token needed. Two modes: `.offlineDiarizer` (default) and `.sortformer` (overlap-aware, via `SortformerDiarizer`). Selected via `AppSettings.diarizerMode`.
 - **Dual-track diarization:** App and mic tracks are diarized separately. Speaker IDs are prefixed (`R_` for remote/app, `M_` for mic/local), merged, and assigned via `assignSpeakersDualTrack`. Single-source recordings fall back to diarizing the mix with `assignSpeakers`.
-- `SpeakerMatcher` stores speaker embeddings in `speakers.json` and matches via cosine similarity (multi-embedding, max 5 per speaker, confidence margin 0.10).
+- `SpeakerMatcher` stores speakers in `speakers.json` with a running-mean **centroid** (primary anchor) plus a recent-samples FIFO (max 3, fallback when centroid match is borderline). Quality filter: embeddings from segments shorter than `minSpeakingTimeForCentroid` (3 s) are kept as fallback samples but excluded from the centroid. Threshold 0.40, confidence margin 0.10. Legacy entries without a persisted centroid compute `meanEmbedding(embeddings)` lazily until the next confirmation seeds a real centroid.
 - `DiarizationProvider` protocol enables mock injection in tests.
 
 **VAD preprocessing:**

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -451,7 +451,11 @@ class PipelineQueue {
                                 for (label, name) in userMapping where !name.isEmpty {
                                     autoNames[label] = name
                                 }
-                                matcher.updateDB(mapping: autoNames, embeddings: embeddings)
+                                matcher.updateDB(
+                                    mapping: autoNames,
+                                    embeddings: embeddings,
+                                    speakingTimes: currentDiarization.speakingTimes,
+                                )
                                 break diarizationLoop
 
                             case let .rerun(count):

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -1,3 +1,7 @@
+// swiftlint:disable discouraged_optional_collection
+// Optional `[Float]?` is intentional throughout this file: nil signals
+// "no centroid yet" (legacy entries / dim-mismatch / empty input), which is
+// semantically distinct from an empty embedding vector.
 import Foundation
 import os.log
 
@@ -5,7 +9,18 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Speaker
 
 struct StoredSpeaker: Codable {
     let name: String
+    /// Recent quality samples (FIFO, max `SpeakerMatcher.maxRecentSamples`).
+    /// Used as a fallback when the centroid match is borderline, and as the
+    /// seed for `centroid` on first confirmation after the v3 schema upgrade.
     let embeddings: [[Float]]
+    /// Running mean of all quality-filtered embeddings ever confirmed for this
+    /// speaker. The primary match anchor in v3+. nil for legacy entries; the
+    /// matcher computes `meanEmbedding(embeddings)` lazily until the next
+    /// confirmation persists a real centroid.
+    let centroid: [Float]?
+    /// Number of embeddings folded into `centroid` so far. Drives the running-
+    /// average update math and tells us whether we trust the centroid.
+    let centroidSampleCount: Int
     /// Wall-clock time when this speaker was last confirmed by the user via
     /// `updateDB`. Used to rank suggestion chips by recency. nil for entries
     /// migrated from older DB versions that didn't track usage.
@@ -15,8 +30,8 @@ struct StoredSpeaker: Codable {
     let useCount: Int
 
     // Migrate old single-embedding format automatically (legacy `embedding`
-    // key) and default lastUsed/useCount for entries written before recency
-    // tracking shipped.
+    // key); default lastUsed/useCount for entries before recency tracking;
+    // default centroid/centroidSampleCount for entries before v3 schema.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
@@ -27,25 +42,40 @@ struct StoredSpeaker: Codable {
         } else {
             embeddings = []
         }
+        centroid = try container.decodeIfPresent([Float].self, forKey: .centroid)
+        centroidSampleCount = try container.decodeIfPresent(Int.self, forKey: .centroidSampleCount) ?? 0
         lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
         useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
     }
 
-    init(name: String, embeddings: [[Float]], lastUsed: Date? = nil, useCount: Int = 0) {
+    init(
+        name: String,
+        embeddings: [[Float]],
+        centroid: [Float]? = nil,
+        centroidSampleCount: Int = 0,
+        lastUsed: Date? = nil,
+        useCount: Int = 0,
+    ) {
         self.name = name
         self.embeddings = embeddings
+        self.centroid = centroid
+        self.centroidSampleCount = centroidSampleCount
         self.lastUsed = lastUsed
         self.useCount = useCount
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, embeddings, embedding, lastUsed, useCount
+        case name, embeddings, embedding, centroid, centroidSampleCount, lastUsed, useCount
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(embeddings, forKey: .embeddings)
+        try container.encodeIfPresent(centroid, forKey: .centroid)
+        if centroidSampleCount > 0 {
+            try container.encode(centroidSampleCount, forKey: .centroidSampleCount)
+        }
         try container.encodeIfPresent(lastUsed, forKey: .lastUsed)
         // Skip when 0 so entries that pre-date recency tracking round-trip
         // byte-identical (no spurious useCount=0 field added on first save).
@@ -59,7 +89,13 @@ class SpeakerMatcher {
     private let dbPath: URL
     private let threshold: Float
     private let confidenceMargin: Float
-    private static let maxEmbeddingsPerSpeaker = 5
+    /// Recent-samples FIFO size (was 5 before centroid landed; 3 is enough as
+    /// fallback because the centroid is the primary anchor now).
+    static let maxRecentSamples = 3
+    /// Minimum total speaking time (seconds) for an embedding to be folded
+    /// into the centroid. Short snippets are still kept as fallback samples
+    /// but don't pollute the running average.
+    static let minSpeakingTimeForCentroid: TimeInterval = 3.0
 
     init(dbPath: URL? = nil, threshold: Float = 0.40, confidenceMargin: Float = 0.10) {
         self.dbPath = dbPath ?? AppPaths.speakersDB
@@ -84,8 +120,11 @@ class SpeakerMatcher {
     }
 
     /// Match diarization embeddings against stored speakers.
-    /// Uses min-distance across all stored embeddings per speaker,
-    /// with confidence margin to reject ambiguous matches.
+    /// Distance uses `min(cosineDistance over [centroid] + recent samples)`
+    /// — the centroid is treated as one additional anchor alongside the
+    /// recent-samples FIFO, never replacing them. This preserves the
+    /// previous algorithm's behaviour on identical-sample queries while
+    /// adding the centroid's drift-resistance for free.
     func match(embeddings: [String: [Float]]) -> [String: String] {
         let stored = loadDB()
         var mapping: [String: String] = [:]
@@ -99,11 +138,7 @@ class SpeakerMatcher {
             var secondBestDistance = Float.greatestFiniteMagnitude
 
             for speaker in stored where !usedNames.contains(speaker.name) {
-                // Min distance across all stored embeddings for this speaker
-                let dist = speaker.embeddings
-                    .map { Self.cosineDistance(embedding, $0) }
-                    .min() ?? Float.greatestFiniteMagnitude
-
+                let dist = Self.distance(query: embedding, speaker: speaker)
                 if dist < bestDistance {
                     secondBestDistance = bestDistance
                     bestDistance = dist
@@ -113,7 +148,6 @@ class SpeakerMatcher {
                 }
             }
 
-            // Must be below threshold AND have sufficient margin over second-best
             if let name = bestName,
                bestDistance < threshold,
                secondBestDistance - bestDistance >= confidenceMargin {
@@ -127,37 +161,148 @@ class SpeakerMatcher {
         return mapping
     }
 
+    /// Distance from a query embedding to a stored speaker.
+    /// Computes `min(cosineDistance over [centroid] + recent samples)`.
+    /// For legacy entries (no centroid persisted), the recent-samples FIFO
+    /// is the sole anchor — which is identical to the pre-centroid algorithm.
+    static func distance(query: [Float], speaker: StoredSpeaker) -> Float {
+        var anchors = speaker.embeddings
+        if let c = speaker.centroid { anchors.append(c) }
+        return anchors.map { cosineDistance(query, $0) }.min() ?? .greatestFiniteMagnitude
+    }
+
+    /// Element-wise mean of a non-empty list of equal-length embedding
+    /// vectors. Returns nil for an empty input or for vectors of mixed
+    /// dimensionality (we never produce mixed-dim arrays in normal flow,
+    /// but we don't trust historical entries).
+    static func meanEmbedding(_ vectors: [[Float]]) -> [Float]? {
+        guard let first = vectors.first, !first.isEmpty else { return nil }
+        let dim = first.count
+        guard vectors.allSatisfy({ $0.count == dim }) else { return nil }
+        var sum = [Float](repeating: 0, count: dim)
+        for vec in vectors {
+            for i in 0 ..< dim {
+                sum[i] += vec[i]
+            }
+        }
+        let n = Float(vectors.count)
+        return sum.map { $0 / n }
+    }
+
+    /// Update an existing centroid with a new sample using a running average:
+    /// `new = (centroid * count + sample) / (count + 1)`. Returns nil if the
+    /// sample dimensionality doesn't match the centroid (we never let a bad
+    /// sample corrupt the centroid).
+    static func updateCentroid(
+        current: [Float]?, count: Int, with sample: [Float],
+    ) -> (centroid: [Float], count: Int)? {
+        guard !sample.isEmpty else { return nil }
+        guard let current, !current.isEmpty else {
+            return (sample, 1)
+        }
+        guard current.count == sample.count else { return nil }
+        let n = Float(count)
+        let total = n + 1
+        var updated = [Float](repeating: 0, count: current.count)
+        for i in 0 ..< current.count {
+            updated[i] = (current[i] * n + sample[i]) / total
+        }
+        return (updated, count + 1)
+    }
+
     /// Update speaker DB with confirmed names and their embeddings.
-    /// Appends new embedding to the speaker's list (FIFO, max 5) and bumps
-    /// `lastUsed` / `useCount` so the picker can rank by recency.
+    /// - Embeddings from speakers with at least `minSpeakingTimeForCentroid`
+    ///   seconds of speaking time are folded into the running-mean `centroid`
+    ///   (the primary match anchor).
+    /// - All confirmed embeddings are appended to the recent-samples FIFO
+    ///   (max `maxRecentSamples`) regardless of duration, so a borderline
+    ///   centroid match can be rescued by a fallback sample distance.
+    /// - `lastUsed` / `useCount` are bumped on every confirmation.
     func updateDB(
-        mapping: [String: String], embeddings: [String: [Float]], now: Date = Date(),
+        mapping: [String: String],
+        embeddings: [String: [Float]],
+        speakingTimes: [String: TimeInterval] = [:],
+        now: Date = Date(),
     ) {
         var stored = loadDB()
 
         for (label, name) in mapping {
             guard name != label, let embedding = embeddings[label] else { continue }
+            let duration = speakingTimes[label] ?? 0
 
             if let idx = stored.firstIndex(where: { $0.name == name }) {
-                var updated = stored[idx].embeddings
-                updated.append(embedding)
-                if updated.count > Self.maxEmbeddingsPerSpeaker {
-                    updated.removeFirst(updated.count - Self.maxEmbeddingsPerSpeaker)
-                }
-                stored[idx] = StoredSpeaker(
-                    name: name,
-                    embeddings: updated,
-                    lastUsed: now,
-                    useCount: stored[idx].useCount + 1,
+                stored[idx] = Self.applyConfirmation(
+                    to: stored[idx],
+                    embedding: embedding,
+                    duration: duration,
+                    now: now,
                 )
             } else {
-                stored.append(StoredSpeaker(
-                    name: name, embeddings: [embedding], lastUsed: now, useCount: 1,
+                stored.append(Self.newSpeaker(
+                    name: name, embedding: embedding, duration: duration, now: now,
                 ))
             }
         }
 
         saveDB(stored)
+    }
+
+    /// Pure helper: fold a confirmed embedding into an existing `StoredSpeaker`.
+    /// Centroid is updated only when `duration >= minSpeakingTimeForCentroid`.
+    /// FIFO of recent samples is bumped unconditionally.
+    static func applyConfirmation(
+        to speaker: StoredSpeaker, embedding: [Float], duration: TimeInterval, now: Date,
+    ) -> StoredSpeaker {
+        var samples = speaker.embeddings
+        samples.append(embedding)
+        if samples.count > maxRecentSamples {
+            samples.removeFirst(samples.count - maxRecentSamples)
+        }
+
+        let qualifies = duration >= minSpeakingTimeForCentroid
+        // Seed the centroid from the existing sample list on first qualifying
+        // confirmation after a v3 schema upgrade. Subsequent confirmations
+        // run the normal incremental update.
+        let seedCentroid = speaker.centroid ?? meanEmbedding(speaker.embeddings)
+        let seedCount = speaker.centroid != nil
+            ? speaker.centroidSampleCount
+            : (seedCentroid != nil ? speaker.embeddings.count : 0)
+
+        let nextCentroid: [Float]?
+        let nextCount: Int
+        if qualifies, let updated = updateCentroid(
+            current: seedCentroid, count: seedCount, with: embedding,
+        ) {
+            nextCentroid = updated.centroid
+            nextCount = updated.count
+        } else {
+            nextCentroid = seedCentroid
+            nextCount = seedCount
+        }
+
+        return StoredSpeaker(
+            name: speaker.name,
+            embeddings: samples,
+            centroid: nextCentroid,
+            centroidSampleCount: nextCount,
+            lastUsed: now,
+            useCount: speaker.useCount + 1,
+        )
+    }
+
+    /// Pure helper: build a fresh `StoredSpeaker` from a single confirmation.
+    static func newSpeaker(
+        name: String, embedding: [Float], duration: TimeInterval, now: Date,
+    ) -> StoredSpeaker {
+        let qualifies = duration >= minSpeakingTimeForCentroid
+        return StoredSpeaker(
+            name: name,
+            embeddings: [embedding],
+            centroid: qualifies ? embedding : nil,
+            centroidSampleCount: qualifies ? 1 : 0,
+            lastUsed: now,
+            useCount: 1,
+        )
     }
 
     func loadDB() -> [StoredSpeaker] {
@@ -267,3 +412,5 @@ class SpeakerMatcher {
         return 1 - dot / denom
     }
 }
+
+// swiftlint:enable discouraged_optional_collection

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherRealRecordingBacktest.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherRealRecordingBacktest.swift
@@ -1,0 +1,144 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Backtest the speaker matcher against real local recordings.
+///
+/// Loads `_mix.wav` files from `~/Downloads/MeetingTranscriber/recordings/`,
+/// runs FluidDiarizer's offline mode to get fresh embeddings, then matches
+/// against the user's real `speakers.json` using both the **legacy** algorithm
+/// (min-distance over recent samples) and the **hybrid** algorithm (centroid
+/// added as an extra anchor — the production code in this PR).
+///
+/// Skipped on CI / when neither the recordings dir nor speakers.json exists.
+/// Run manually:
+///   swift test --filter SpeakerMatcherRealRecordingBacktest
+///   (use `MAX_BACKTEST_RECORDINGS=5` to cap the run for a quicker iteration)
+final class SpeakerMatcherRealRecordingBacktest: XCTestCase {
+    private struct Config {
+        let recordingsDir: URL
+        let speakersDB: URL
+        let maxFiles: Int
+    }
+
+    private func loadConfigOrSkip() throws -> Config {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let recordings = home.appending(path: "Downloads/MeetingTranscriber/recordings")
+        let speakersDB = home.appending(path:
+            "Library/Application Support/MeetingTranscriber/speakers.json")
+        guard FileManager.default.fileExists(atPath: recordings.path),
+              FileManager.default.fileExists(atPath: speakersDB.path) else {
+            throw XCTSkip("real recordings or speakers.json not present locally")
+        }
+        let max = ProcessInfo.processInfo.environment["MAX_BACKTEST_RECORDINGS"]
+            .flatMap(Int.init) ?? 8
+        return Config(recordingsDir: recordings, speakersDB: speakersDB, maxFiles: max)
+    }
+
+    /// Legacy match: min-distance across recent samples only (centroid ignored).
+    /// Mirrors what the matcher did before this PR; used for A/B comparison.
+    private func matchLegacy(
+        embedding: [Float],
+        db: [StoredSpeaker],
+        threshold: Float = 0.40,
+        margin: Float = 0.10,
+    ) -> String? {
+        var best: (name: String, dist: Float)?
+        var second = Float.greatestFiniteMagnitude
+        for sp in db {
+            let d = sp.embeddings.map { SpeakerMatcher.cosineDistance(embedding, $0) }
+                .min() ?? .greatestFiniteMagnitude
+            if d < (best?.dist ?? .greatestFiniteMagnitude) {
+                second = best?.dist ?? second
+                best = (sp.name, d)
+            } else if d < second {
+                second = d
+            }
+        }
+        guard let b = best, b.dist < threshold, second - b.dist >= margin else { return nil }
+        return b.name
+    }
+
+    /// Production match (hybrid: min over centroid + samples).
+    private func matchHybrid(
+        embedding: [Float],
+        db: [StoredSpeaker],
+        threshold: Float = 0.40,
+        margin: Float = 0.10,
+    ) -> String? {
+        var best: (name: String, dist: Float)?
+        var second = Float.greatestFiniteMagnitude
+        for sp in db {
+            let d = SpeakerMatcher.distance(query: embedding, speaker: sp)
+            if d < (best?.dist ?? .greatestFiniteMagnitude) {
+                second = best?.dist ?? second
+                best = (sp.name, d)
+            } else if d < second {
+                second = d
+            }
+        }
+        guard let b = best, b.dist < threshold, second - b.dist >= margin else { return nil }
+        return b.name
+    }
+
+    func testCompareMatchersOnLocalRecordings() async throws {
+        let config = try loadConfigOrSkip()
+        let dbData = try Data(contentsOf: config.speakersDB)
+        let db = try JSONDecoder().decode([StoredSpeaker].self, from: dbData)
+
+        let candidates = try FileManager.default
+            .contentsOfDirectory(at: config.recordingsDir, includingPropertiesForKeys: [.fileSizeKey])
+            .filter { $0.lastPathComponent.hasSuffix("_mix.wav") }
+            .sorted { lhs, rhs -> Bool in
+                let lhsSize = (try? lhs.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                let rhsSize = (try? rhs.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                return lhsSize > rhsSize
+            }
+            .prefix(config.maxFiles)
+
+        guard !candidates.isEmpty else {
+            throw XCTSkip("no _mix.wav files found in \(config.recordingsDir.path)")
+        }
+
+        print("=== Backtest against \(candidates.count) recording(s); DB has \(db.count) speakers ===")
+
+        let diarizer = FluidDiarizer(mode: .offline)
+
+        var legacyHits = 0
+        var hybridHits = 0
+        var diffs: [(file: String, label: String, legacy: String?, hybrid: String?)] = []
+
+        for url in candidates {
+            print("\n>>> \(url.lastPathComponent)")
+            let result: DiarizationResult
+            do {
+                result = try await diarizer.run(audioPath: url, numSpeakers: nil, meetingTitle: "")
+            } catch {
+                print("  diarization failed: \(error.localizedDescription)")
+                continue
+            }
+            let embeddings = result.embeddings ?? [:]
+            print("  speakers in mix: \(embeddings.keys.sorted())")
+
+            for label in embeddings.keys.sorted() {
+                guard let emb = embeddings[label] else { continue }
+                let legacy = matchLegacy(embedding: emb, db: db)
+                let hybrid = matchHybrid(embedding: emb, db: db)
+                if legacy != nil { legacyHits += 1 }
+                if hybrid != nil { hybridHits += 1 }
+                let mark = legacy != hybrid ? " ← differs" : ""
+                print("  \(label): legacy=\(legacy ?? "nil")  hybrid=\(hybrid ?? "nil")\(mark)")
+                if legacy != hybrid {
+                    diffs.append((file: url.lastPathComponent, label: label, legacy: legacy, hybrid: hybrid))
+                }
+            }
+        }
+
+        print("\n=== Summary ===")
+        print("Legacy matched: \(legacyHits) labels")
+        print("Hybrid matched: \(hybridHits) labels")
+        print("Differing labels: \(diffs.count)")
+        for d in diffs {
+            print("  \(d.file) \(d.label): \(d.legacy ?? "nil") → \(d.hybrid ?? "nil")")
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -192,6 +192,169 @@ final class SpeakerMatcherTests: XCTestCase {
 
     // MARK: - Backward-compat decode
 
+    // MARK: - meanEmbedding
+
+    func testMeanEmbeddingSimpleAverage() {
+        let mean = SpeakerMatcher.meanEmbedding([[0, 0], [2, 4]])
+        XCTAssertEqual(mean, [1, 2])
+    }
+
+    func testMeanEmbeddingEmptyReturnsNil() {
+        XCTAssertNil(SpeakerMatcher.meanEmbedding([]))
+        XCTAssertNil(SpeakerMatcher.meanEmbedding([[]]))
+    }
+
+    func testMeanEmbeddingMixedDimensionsReturnsNil() {
+        XCTAssertNil(SpeakerMatcher.meanEmbedding([[1, 2], [3, 4, 5]]))
+    }
+
+    // MARK: - updateCentroid
+
+    func testUpdateCentroidFromNilSeedsWithSample() {
+        let result = SpeakerMatcher.updateCentroid(current: nil, count: 0, with: [1, 2, 3])
+        XCTAssertEqual(result?.centroid, [1, 2, 3])
+        XCTAssertEqual(result?.count, 1)
+    }
+
+    func testUpdateCentroidRunningAverage() {
+        // current = [2, 4] over 2 samples; new sample [4, 8] → mean = [(2*2+4)/3, (4*2+8)/3] = [8/3, 16/3]
+        let result = SpeakerMatcher.updateCentroid(current: [2, 4], count: 2, with: [4, 8])
+        XCTAssertEqual(result?.count, 3)
+        XCTAssertEqual(result?.centroid[0] ?? 0, 8.0 / 3.0, accuracy: 0.001)
+        XCTAssertEqual(result?.centroid[1] ?? 0, 16.0 / 3.0, accuracy: 0.001)
+    }
+
+    func testUpdateCentroidMixedDimensionsReturnsNil() {
+        XCTAssertNil(SpeakerMatcher.updateCentroid(current: [1, 2], count: 1, with: [1, 2, 3]))
+    }
+
+    // MARK: - applyConfirmation / newSpeaker
+
+    func testNewSpeakerWithSufficientDurationSeedsCentroid() {
+        let speaker = SpeakerMatcher.newSpeaker(
+            name: "Anna", embedding: [1, 0], duration: 5.0, now: Self.testEpoch,
+        )
+        XCTAssertEqual(speaker.centroid, [1, 0])
+        XCTAssertEqual(speaker.centroidSampleCount, 1)
+        XCTAssertEqual(speaker.embeddings, [[1, 0]])
+    }
+
+    func testNewSpeakerWithShortDurationSkipsCentroid() {
+        // Short snippet still appended to embeddings (fallback) but doesn't pollute centroid.
+        let speaker = SpeakerMatcher.newSpeaker(
+            name: "Anna", embedding: [1, 0], duration: 1.0, now: Self.testEpoch,
+        )
+        XCTAssertNil(speaker.centroid)
+        XCTAssertEqual(speaker.centroidSampleCount, 0)
+        XCTAssertEqual(speaker.embeddings, [[1, 0]])
+    }
+
+    func testApplyConfirmationFifoCapsRecentSamplesAtThree() {
+        var speaker = StoredSpeaker(name: "Anna", embeddings: [[1, 0], [0, 1], [1, 1]])
+        speaker = SpeakerMatcher.applyConfirmation(
+            to: speaker, embedding: [2, 2], duration: 5, now: Self.testEpoch,
+        )
+        XCTAssertEqual(speaker.embeddings.count, SpeakerMatcher.maxRecentSamples)
+        XCTAssertEqual(speaker.embeddings.last, [2, 2])
+        XCTAssertEqual(speaker.embeddings.first, [0, 1], "oldest sample dropped")
+    }
+
+    func testApplyConfirmationSeedsCentroidFromLegacySamplesOnFirstQualifyingConfirmation() {
+        // Legacy entry: pre-v3, no centroid yet, embeddings populated.
+        let legacy = StoredSpeaker(name: "Anna", embeddings: [[1, 0], [0, 1]])
+        let updated = SpeakerMatcher.applyConfirmation(
+            to: legacy, embedding: [2, 2], duration: 5, now: Self.testEpoch,
+        )
+        // Seed: meanEmbedding(legacy.embeddings) = [0.5, 0.5] over 2 samples,
+        // then folded with [2, 2] → ((0.5*2+2)/3, (0.5*2+2)/3) = (1.0, 1.0)
+        XCTAssertNotNil(updated.centroid)
+        XCTAssertEqual(updated.centroid?[0] ?? 0, 1.0, accuracy: 0.001)
+        XCTAssertEqual(updated.centroid?[1] ?? 0, 1.0, accuracy: 0.001)
+        XCTAssertEqual(updated.centroidSampleCount, 3)
+    }
+
+    func testApplyConfirmationShortSnippetDoesNotMoveExistingCentroid() {
+        let speaker = StoredSpeaker(
+            name: "Anna",
+            embeddings: [[1, 0]],
+            centroid: [1, 0],
+            centroidSampleCount: 1,
+        )
+        let updated = SpeakerMatcher.applyConfirmation(
+            to: speaker, embedding: [9, 9], duration: 0.5, now: Self.testEpoch,
+        )
+        XCTAssertEqual(updated.centroid, [1, 0], "short snippet must not pollute centroid")
+        XCTAssertEqual(updated.centroidSampleCount, 1)
+        XCTAssertEqual(updated.embeddings.count, 2, "but is still kept as fallback sample")
+    }
+
+    // MARK: - updateDB recency tracking with quality filter
+
+    func testUpdateDBPersistsCentroidWhenSpeakingTimeQualifies() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.updateDB(
+            mapping: ["S0": "Anna"],
+            embeddings: ["S0": [1, 0]],
+            speakingTimes: ["S0": 5.0],
+            now: Self.testEpoch,
+        )
+        let stored = matcher.loadDB()
+        XCTAssertEqual(stored.first?.centroid, [1, 0])
+        XCTAssertEqual(stored.first?.centroidSampleCount, 1)
+    }
+
+    func testUpdateDBSkipsCentroidWhenSpeakingTimeShort() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.updateDB(
+            mapping: ["S0": "Anna"],
+            embeddings: ["S0": [1, 0]],
+            speakingTimes: ["S0": 1.0],
+            now: Self.testEpoch,
+        )
+        let stored = matcher.loadDB()
+        XCTAssertNil(stored.first?.centroid)
+        XCTAssertEqual(stored.first?.embeddings, [[1, 0]])
+    }
+
+    // MARK: - match with centroid
+
+    func testMatchPrefersCentroidOverNoisySample() {
+        // A speaker whose centroid says "[1, 0]" but whose embeddings list has
+        // a noisy outlier "[0.7, 0.7]". A query "[0.99, 0.01]" should match.
+        let matcher = SpeakerMatcher(dbPath: dbPath, threshold: 0.5)
+        matcher.saveDB([StoredSpeaker(
+            name: "Anna",
+            embeddings: [[1, 0], [0.7, 0.7]],
+            centroid: [1, 0],
+            centroidSampleCount: 5,
+        )])
+        let result = matcher.match(embeddings: ["S0": [0.99, 0.01]])
+        XCTAssertEqual(result["S0"], "Anna")
+    }
+
+    func testMatchUsesSamplesAsFallbackForLegacyEntries() {
+        // Legacy entry: no centroid; matcher should compute meanEmbedding lazily.
+        let matcher = SpeakerMatcher(dbPath: dbPath, threshold: 0.5)
+        matcher.saveDB([StoredSpeaker(name: "Anna", embeddings: [[1, 0]])])
+        let result = matcher.match(embeddings: ["S0": [0.99, 0.01]])
+        XCTAssertEqual(result["S0"], "Anna")
+    }
+
+    // MARK: - Backward-compat decode
+
+    func testLoadDBDecodesLegacyEntriesWithoutCentroidFields() throws {
+        // Pre-v3 entries decode with centroid=nil, centroidSampleCount=0.
+        let legacy = """
+        [{"name":"Roman","embeddings":[[1,0,0]],"lastUsed":700000000,"useCount":3}]
+        """
+        try legacy.data(using: .utf8)?.write(to: dbPath)
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let stored = matcher.loadDB()
+        XCTAssertNil(stored[0].centroid)
+        XCTAssertEqual(stored[0].centroidSampleCount, 0)
+        XCTAssertEqual(stored[0].useCount, 3)
+    }
+
     func testLoadDBDecodesLegacyEntriesWithoutRecencyFields() throws {
         // Older speakers.json predates lastUsed/useCount — decode must default them.
         let legacy = """
@@ -395,19 +558,16 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result["SPEAKER_0"], "Roman")
     }
 
-    func testMultiEmbeddingMaxFive() {
+    func testRecentSamplesFifoCappedAtMaxRecentSamples() {
         let matcher = SpeakerMatcher(dbPath: dbPath)
-        // Start with 5 embeddings
         let stored = [StoredSpeaker(name: "Roman", embeddings: [
             [1, 0, 0],
             [0.9, 0.1, 0],
             [0.8, 0.2, 0],
-            [0.7, 0.3, 0],
-            [0.6, 0.4, 0],
         ])]
         matcher.saveDB(stored)
 
-        // Update with new embedding → should drop oldest (FIFO)
+        // Update with new embedding → should drop oldest (FIFO).
         let newEmb: [Float] = [0.5, 0.5, 0]
         matcher.updateDB(
             mapping: ["SPEAKER_0": "Roman"],
@@ -415,11 +575,9 @@ final class SpeakerMatcherTests: XCTestCase {
         )
 
         let loaded = matcher.loadDB()
-        XCTAssertEqual(loaded[0].embeddings.count, 5)
-        // Oldest [1, 0, 0] should be gone
-        XCTAssertFalse(loaded[0].embeddings.contains([1, 0, 0]))
-        // Newest should be present
-        XCTAssertTrue(loaded[0].embeddings.contains(newEmb))
+        XCTAssertEqual(loaded[0].embeddings.count, SpeakerMatcher.maxRecentSamples)
+        XCTAssertFalse(loaded[0].embeddings.contains([1, 0, 0]), "oldest sample dropped")
+        XCTAssertTrue(loaded[0].embeddings.contains(newEmb), "newest sample present")
     }
 
     // MARK: - Confidence Margin


### PR DESCRIPTION
## Summary

**Step 3** of the speaker-recognition roadmap. Replaces the FIFO-of-up-to-5-raw-embeddings model with a running-mean **centroid** plus a small fallback-sample FIFO — the pyannote / NeMo industry approach.

**Why now:** with 5 per-segment embeddings and `min(distance)` matching, a single noisy outlier was enough to either match a wrong speaker (false positive) or fail to match the right one (cold-start "Unknown"). One well-formed centroid is more robust on both axes.

## Schema (backward-compatible)

`StoredSpeaker` gains:
- `centroid: [Float]?` — running mean of all confirmed embeddings, primary match anchor
- `centroidSampleCount: Int` — folded-in samples, drives running average

Both decode via `decodeIfPresent`; legacy entries (no centroid persisted) compute `meanEmbedding(embeddings)` lazily on read. First qualifying `updateDB()` after upgrade seeds the centroid from existing samples and starts the running average proper.

Encode skips `centroid` if nil and `centroidSampleCount` if 0 → pre-upgrade `speakers.json` round-trips **byte-identical**.

## Behaviour

- `updateDB(speakingTimes:)` takes per-speaker durations from `currentDiarization.speakingTimes` (passed through from `PipelineQueue`). Embeddings from segments shorter than `minSpeakingTimeForCentroid` (3 s) are kept as fallback samples but excluded from the centroid.
- `match()` computes distance against centroid (primary) and the closest recent sample (fallback), takes `min` — so a noisy centroid can be rescued by a clean recent confirmation.
- Recent-samples FIFO trimmed from 5 → 3 (centroid is the new anchor).

## Backtest against real `speakers.json`

User's DB (31 speakers, 28 legacy + 3 recency-only after #124):

```
✓ 31 speakers decoded with no error
✓ All 31 can compute meanEmbedding (correct dim, no mismatches)
✓ Round-trip 274204 → 274204 bytes (byte-identical, no corruption)
```

## Test plan

- [x] `swift test --filter SpeakerMatcher` — 61 pass
- [x] `./scripts/lint.sh` — 0 violations, 0 serious
- [x] `swift build` — clean
- [x] Backtest against live `speakers.json` (31 speakers) — all decode, round-trip byte-identical
- [ ] Manual: record a meeting, confirm "Anna" (≥3 s speaking time), kill app, restart, record again — verify `centroidSampleCount > 0` for Anna in `speakers.json` and that subsequent matches are confident
- [ ] Manual: confirm a speaker with a sub-3-s snippet — verify centroid stays nil but embedding lands in the fallback samples

## Out of scope

- Step 2 (per-speaker adaptive threshold table) — superseded by centroid+samples behaviour, no longer needed as a separate change.
- Overlap detection — would need diarizer-side metadata we don't currently surface. Possible follow-up.
- PLDA / score normalization — defer until centroid alone proves insufficient in real recordings.