### PR TITLE
feat(app): log speaker recognition outcomes to JSONL

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -338,6 +338,7 @@ final class AppState {
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
+            recognitionStatsLog: RecognitionStatsLog(),
         )
         queue.loadSnapshot()
         queue.recoverOrphanedRecordings()

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -21,6 +21,9 @@ class PipelineQueue {
     let micLabel: String
     let speakerMatcherFactory: () -> SpeakerMatcher
     let vadConfig: VADConfig?
+    /// nil disables JSONL logging. AppState injects a real instance for production;
+    /// tests leave it nil unless they explicitly want to assert on the log.
+    let recognitionStatsLog: RecognitionStatsLog?
 
     let completedJobLifetime: TimeInterval
 
@@ -100,6 +103,7 @@ class PipelineQueue {
         self.micLabel = "Me"
         self.speakerMatcherFactory = { SpeakerMatcher() }
         self.vadConfig = nil
+        self.recognitionStatsLog = nil
         self.completedJobLifetime = completedJobLifetime
     }
 
@@ -115,6 +119,7 @@ class PipelineQueue {
         micLabel: String = "Me",
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = { SpeakerMatcher() },
         vadConfig: VADConfig? = nil,
+        recognitionStatsLog: RecognitionStatsLog? = nil,
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
@@ -127,6 +132,7 @@ class PipelineQueue {
         self.micLabel = micLabel
         self.speakerMatcherFactory = speakerMatcherFactory
         self.vadConfig = vadConfig
+        self.recognitionStatsLog = recognitionStatsLog
         self.completedJobLifetime = completedJobLifetime
     }
 
@@ -414,6 +420,13 @@ class PipelineQueue {
                                 )
                             }
 
+                            let suggestedAtDialog = autoNames
+                            let autoMatched = matched.count { $0.key != $0.value }
+                            let unknown = matched.count - autoMatched
+                            logger.info(
+                                "[recognition] \(matched.count) speakers, \(autoMatched) auto, \(unknown) unknown",
+                            )
+
                             let namingData = SpeakerNamingData(
                                 jobID: jobID,
                                 meetingTitle: title,
@@ -456,6 +469,11 @@ class PipelineQueue {
                                     embeddings: embeddings,
                                     speakingTimes: currentDiarization.speakingTimes,
                                 )
+                                recordRecognition(
+                                    suggested: suggestedAtDialog,
+                                    userMapping: userMapping,
+                                    jobID: jobID, title: title,
+                                )
                                 break diarizationLoop
 
                             case let .rerun(count):
@@ -466,6 +484,11 @@ class PipelineQueue {
                                 continue diarizationLoop
 
                             case .skipped:
+                                recordRecognition(
+                                    suggested: suggestedAtDialog,
+                                    userMapping: nil,
+                                    jobID: jobID, title: title,
+                                )
                                 break diarizationLoop
                             }
                         }
@@ -883,6 +906,32 @@ class PipelineQueue {
             }
         } catch {
             logger.error("Failed to append pipeline log: \(error)")
+        }
+    }
+
+    /// Build recognition events and persist them off the pipeline path. Logs
+    /// outcome counts immediately; JSONL append runs in a detached Task.
+    private func recordRecognition(
+        suggested: [String: String],
+        // swiftlint:disable:next discouraged_optional_collection
+        userMapping: [String: String]?,
+        jobID: UUID,
+        title: String,
+    ) {
+        let events = RecognitionStats.buildEvents(
+            suggested: suggested, userMapping: userMapping,
+            jobID: jobID, meetingTitle: title,
+        )
+        var counts: [RecognitionAction: Int] = [:]
+        for e in events {
+            counts[e.action, default: 0] += 1
+        }
+        let parts = RecognitionAction.allCases
+            .map { "\($0.rawValue)=\(counts[$0] ?? 0)" }
+            .joined(separator: " ")
+        logger.info("[recognition] outcome \(parts, privacy: .public)")
+        if let recognitionStatsLog {
+            Task { await recognitionStatsLog.append(events) }
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/RecognitionStats.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStats.swift
@@ -1,0 +1,170 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "RecognitionStats")
+
+/// What the user did with the matcher's auto-name suggestion for one speaker label.
+enum RecognitionAction: String, Codable, CaseIterable {
+    case accepted, corrected, added, skipped, dismissed
+}
+
+/// Which diarized track the speaker label belongs to.
+enum RecognitionTrack: String, Codable {
+    case app, mic, single
+
+    init(label: String) {
+        if label.hasPrefix("R_") { self = .app } else if label.hasPrefix("M_") { self = .mic } else { self = .single }
+    }
+}
+
+/// One row in the JSONL recognition log: a single speaker-label decision.
+struct RecognitionEvent: Codable, Equatable {
+    let ts: Date
+    let jobID: UUID
+    let meetingTitle: String
+    let track: RecognitionTrack
+    let label: String
+    let autoName: String?
+    let userName: String?
+    let action: RecognitionAction
+}
+
+enum RecognitionStats {
+    /// Maps the (auto, user) pair to a RecognitionAction. Caller passes
+    /// `userName == nil` to signal `.dismissed` (timeout / cancel paths).
+    static func classify(autoName: String?, userName: String?) -> RecognitionAction {
+        let auto = autoName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let user = userName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        switch (auto.isEmpty, user.isEmpty) {
+        case (true, true): return .skipped
+        case (true, false): return .added
+        case (false, true): return .skipped
+        case (false, false): return auto == user ? .accepted : .corrected
+        }
+    }
+
+    /// Build one event per speaker label. Pass `userMapping == nil` to mark all
+    /// rows `.dismissed` (timeout / cancel); otherwise rows are classified.
+    static func buildEvents(
+        suggested: [String: String],
+        // swiftlint:disable:next discouraged_optional_collection
+        userMapping: [String: String]?,
+        jobID: UUID,
+        meetingTitle: String,
+        now: Date = Date(),
+    ) -> [RecognitionEvent] {
+        let labels = Set(suggested.keys).union(userMapping?.keys ?? [:].keys).sorted()
+        return labels.map { label in
+            let auto = nameOrNil(suggested[label], label: label)
+            let user = userMapping.flatMap { nameOrNil($0[label], label: label) }
+            let action: RecognitionAction = userMapping == nil
+                ? .dismissed
+                : classify(autoName: auto, userName: user)
+            return RecognitionEvent(
+                ts: now,
+                jobID: jobID,
+                meetingTitle: meetingTitle,
+                track: RecognitionTrack(label: label),
+                label: label,
+                autoName: auto,
+                userName: user,
+                action: action,
+            )
+        }
+    }
+
+    /// `value == label` is the sentinel "no auto-suggestion" (matcher returns the
+    /// label as fallback when no speaker matches), so we collapse it to nil.
+    private static func nameOrNil(_ value: String?, label: String) -> String? {
+        guard let value, !value.isEmpty, value != label else { return nil }
+        return value
+    }
+
+    struct Aggregate: Equatable {
+        let total: Int
+        let counts: [RecognitionAction: Int]
+
+        var acceptanceRate: Double {
+            guard total > 0 else { return 0 }
+            return Double(counts[.accepted] ?? 0) / Double(total)
+        }
+
+        var correctionRate: Double {
+            guard total > 0 else { return 0 }
+            return Double(counts[.corrected] ?? 0) / Double(total)
+        }
+    }
+
+    static func aggregate(events: [RecognitionEvent], from: Date, to: Date) -> Aggregate {
+        let inRange = events.filter { $0.ts >= from && $0.ts <= to }
+        var counts: [RecognitionAction: Int] = [:]
+        for e in inRange {
+            counts[e.action, default: 0] += 1
+        }
+        return Aggregate(total: inRange.count, counts: counts)
+    }
+}
+
+/// Append-only JSONL writer for recognition events. One file per app install,
+/// owner-readable (chmod 0600 on first creation). Production callers use the
+/// no-arg `init()`; tests should pass an explicit `path:` to avoid polluting
+/// the user's real log.
+actor RecognitionStatsLog {
+    static let defaultPath = AppPaths.dataDir.appendingPathComponent("recognition_log.jsonl")
+
+    private let path: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(path: URL = RecognitionStatsLog.defaultPath) {
+        self.path = path
+        self.encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func append(_ events: [RecognitionEvent]) {
+        guard !events.isEmpty else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: path.deletingLastPathComponent(), withIntermediateDirectories: true,
+            )
+
+            if !FileManager.default.fileExists(atPath: path.path) {
+                FileManager.default.createFile(
+                    atPath: path.path, contents: nil,
+                    attributes: [.posixPermissions: 0o600],
+                )
+            }
+
+            let handle = try FileHandle(forWritingTo: path)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            for event in events {
+                let line = try encoder.encode(event) + Data([0x0A])
+                try handle.write(contentsOf: line)
+            }
+            try handle.synchronize()
+        } catch {
+            logger.error("Failed to append recognition events: \(error.localizedDescription)")
+        }
+    }
+
+    /// Load events with `ts` within the last `interval` seconds. Skips lines that
+    /// fail to decode (forward-compat for future schema changes).
+    func loadRecent(within interval: TimeInterval, now: Date = Date()) -> [RecognitionEvent] {
+        guard let data = try? Data(contentsOf: path),
+              let text = String(data: data, encoding: .utf8) else { return [] }
+        let cutoff = now.addingTimeInterval(-interval)
+        var out: [RecognitionEvent] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let lineData = line.data(using: .utf8),
+                  let event = try? decoder.decode(RecognitionEvent.self, from: lineData),
+                  event.ts >= cutoff else { continue }
+            out.append(event)
+        }
+        return out
+    }
+}

--- a/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+@testable import MeetingTranscriber
+import XCTest
+
+final class RecognitionStatsTests: XCTestCase {
+    // MARK: - classify
+
+    func testClassifyAccepted() {
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "Roman"), .accepted)
+    }
+
+    func testClassifyCorrected() {
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "Alex"), .corrected)
+    }
+
+    func testClassifyAdded() {
+        XCTAssertEqual(RecognitionStats.classify(autoName: nil, userName: "Roman"), .added)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "", userName: "Roman"), .added)
+    }
+
+    func testClassifySkipped() {
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: nil), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: ""), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "   "), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: nil, userName: nil), .skipped)
+    }
+
+    func testClassifyTrimsWhitespace() {
+        XCTAssertEqual(
+            RecognitionStats.classify(autoName: " Roman ", userName: "Roman"), .accepted,
+        )
+    }
+
+    // MARK: - RecognitionTrack
+
+    func testTrackFromLabel() {
+        XCTAssertEqual(RecognitionTrack(label: "R_S1"), .app)
+        XCTAssertEqual(RecognitionTrack(label: "M_S1"), .mic)
+        XCTAssertEqual(RecognitionTrack(label: "S1"), .single)
+    }
+
+    // MARK: - aggregate
+
+    func testAggregateBinsByAction() {
+        let now = Date()
+        let events: [RecognitionEvent] = [
+            event(name: "a", action: .accepted, ts: now),
+            event(name: "b", action: .accepted, ts: now),
+            event(name: "c", action: .corrected, ts: now),
+            event(name: "d", action: .added, ts: now),
+        ]
+        let agg = RecognitionStats.aggregate(events: events, from: now.addingTimeInterval(-1), to: now.addingTimeInterval(1))
+        XCTAssertEqual(agg.total, 4)
+        XCTAssertEqual(agg.counts[.accepted], 2)
+        XCTAssertEqual(agg.counts[.corrected], 1)
+        XCTAssertEqual(agg.counts[.added], 1)
+        XCTAssertEqual(agg.acceptanceRate, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(agg.correctionRate, 0.25, accuracy: 1e-9)
+    }
+
+    func testAggregateRespectsTimeWindow() {
+        let now = Date()
+        let events: [RecognitionEvent] = [
+            event(name: "old", action: .accepted, ts: now.addingTimeInterval(-3600)),
+            event(name: "new", action: .accepted, ts: now),
+        ]
+        let agg = RecognitionStats.aggregate(events: events, from: now.addingTimeInterval(-60), to: now.addingTimeInterval(60))
+        XCTAssertEqual(agg.total, 1)
+    }
+
+    func testAggregateEmptyHasZeroRates() {
+        let now = Date()
+        let agg = RecognitionStats.aggregate(events: [], from: now.addingTimeInterval(-1), to: now)
+        XCTAssertEqual(agg.total, 0)
+        XCTAssertEqual(agg.acceptanceRate, 0)
+        XCTAssertEqual(agg.correctionRate, 0)
+    }
+
+    // MARK: - JSONL round-trip via RecognitionStatsLog
+
+    func testAppendAndLoadRoundTrip() async {
+        let tmp = uniqueTempPath()
+        let log = RecognitionStatsLog(path: tmp)
+        let now = Date()
+        let events: [RecognitionEvent] = [
+            event(name: "Roman", action: .accepted, ts: now),
+            event(name: "Alex", action: .corrected, ts: now),
+        ]
+        await log.append(events)
+
+        let loaded = await log.loadRecent(within: 60, now: now)
+        XCTAssertEqual(loaded.count, 2)
+        XCTAssertEqual(loaded.map(\.userName).sorted { ($0 ?? "") < ($1 ?? "") }, ["Alex", "Roman"])
+
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    func testAppendMultipleBatches() async {
+        let tmp = uniqueTempPath()
+        let log = RecognitionStatsLog(path: tmp)
+        let now = Date()
+        await log.append([event(name: "A", action: .accepted, ts: now)])
+        await log.append([event(name: "B", action: .added, ts: now)])
+
+        let loaded = await log.loadRecent(within: 60, now: now)
+        XCTAssertEqual(loaded.count, 2)
+
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    func testLoadRecentSkipsCorruptLines() async throws {
+        let tmp = uniqueTempPath()
+        let log = RecognitionStatsLog(path: tmp)
+        let now = Date()
+        await log.append([event(name: "Roman", action: .accepted, ts: now)])
+
+        // Append a garbage line
+        let handle = try FileHandle(forWritingTo: tmp)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("not-json\n".utf8))
+        try handle.close()
+
+        let loaded = await log.loadRecent(within: 60, now: now)
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded.first?.userName, "Roman")
+
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    func testLoadRecentFiltersByCutoff() async {
+        let tmp = uniqueTempPath()
+        let log = RecognitionStatsLog(path: tmp)
+        let now = Date()
+        await log.append([
+            event(name: "old", action: .accepted, ts: now.addingTimeInterval(-3600)),
+            event(name: "new", action: .accepted, ts: now),
+        ])
+
+        let loaded = await log.loadRecent(within: 60, now: now)
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded.first?.userName, "new")
+
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    // MARK: - buildEvents
+
+    func testBuildEventsClassifiesAllActions() {
+        let suggested = [
+            "R_S1": "Roman", // accepted
+            "R_S2": "Alex", // corrected
+            "R_S3": "R_S3", // added (no auto)
+            "M_S1": "Susi", // skipped (user clears)
+        ]
+        let userMapping = [
+            "R_S1": "Roman",
+            "R_S2": "Bob",
+            "R_S3": "Charlie",
+            "M_S1": "",
+        ]
+        let events = RecognitionStats.buildEvents(
+            suggested: suggested, userMapping: userMapping,
+            jobID: UUID(), meetingTitle: "Test",
+        )
+        let byLabel = Dictionary(uniqueKeysWithValues: events.map { ($0.label, $0) })
+        XCTAssertEqual(byLabel["R_S1"]?.action, .accepted)
+        XCTAssertEqual(byLabel["R_S2"]?.action, .corrected)
+        XCTAssertEqual(byLabel["R_S3"]?.action, .added)
+        XCTAssertNil(byLabel["R_S3"].flatMap(\.autoName))
+        XCTAssertEqual(byLabel["M_S1"]?.action, .skipped)
+        XCTAssertNil(byLabel["M_S1"].flatMap(\.userName))
+        XCTAssertEqual(byLabel["R_S1"]?.track, .app)
+        XCTAssertEqual(byLabel["M_S1"]?.track, .mic)
+    }
+
+    func testBuildEventsDismissedWhenUserMappingNil() {
+        let suggested = ["R_S1": "Roman", "R_S2": "R_S2"]
+        let events = RecognitionStats.buildEvents(
+            suggested: suggested, userMapping: nil,
+            jobID: UUID(), meetingTitle: "Test",
+        )
+        XCTAssertEqual(events.count, 2)
+        XCTAssertTrue(events.allSatisfy { $0.action == .dismissed })
+        XCTAssertTrue(events.allSatisfy { $0.userName == nil })
+        let s1 = events.first { $0.label == "R_S1" }
+        XCTAssertEqual(s1?.autoName, "Roman")
+        let s2 = events.first { $0.label == "R_S2" }
+        XCTAssertNil(s2.flatMap(\.autoName))
+    }
+
+    // MARK: - Helpers
+
+    private func event(
+        name: String, action: RecognitionAction, ts: Date,
+    ) -> RecognitionEvent {
+        RecognitionEvent(
+            ts: ts, jobID: UUID(), meetingTitle: "Test",
+            track: .single, label: "S1",
+            autoName: action == .added ? nil : name,
+            userName: action == .skipped || action == .dismissed ? nil : name,
+            action: action,
+        )
+    }
+
+    private func uniqueTempPath() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
+    }
+}


### PR DESCRIPTION
## Summary

Persist every speaker-naming decision (auto-match suggestion vs user action) to `~/Library/Application Support/MeetingTranscriber/recognition_log.jsonl` so we can empirically verify whether the new centroid-based matcher (#125) actually improves recognition over time, instead of relying on synthetic backtests.

- New `RecognitionStats` module: `RecognitionEvent` (Codable), `RecognitionAction` enum (`accepted | corrected | added | skipped | dismissed`), `RecognitionStatsLog` actor (append-only, fsync per record, chmod 0600), pure `classify` and `aggregate` helpers.
- Wired into `PipelineQueue`: builds events on every `.confirmed` and `.skipped` outcome and appends asynchronously.
- Adds two `os_log` lines per job for live visibility in Console.app:
  - `[recognition] N speakers, M auto, K unknown`
  - `[recognition] outcome accepted=… corrected=… added=… skipped=… dismissed=…`

This unlocks offline `jq` analysis today; a Settings UI surfacing acceptance/correction trend (Step C of the plan) can land as a follow-up.

## Schema

```json
{"ts":"2026-05-01T16:30:14Z","jobID":"…","meetingTitle":"…","track":"app","label":"R_S1","autoName":"Alex","userName":"Alex","action":"accepted"}
```

`track` is derived from the diarization label prefix: `R_` → `app`, `M_` → `mic`, otherwise `single`.

## Test plan

- [x] `swift test --filter RecognitionStatsTests` — 15 new tests pass (classify, track, aggregate, JSONL round-trip, corrupt-line tolerance, time-window filter, event builders for confirmed + dismissed paths)
- [x] Full `swift test` — only pre-existing snapshot tests fail (memory: needs PNG re-record locally)
- [x] `./scripts/lint.sh` — clean (0 violations)
- [x] Manual: enable a meeting, confirm 3 speakers, verify JSONL has 3 rows with correct `action` values, Console.app shows `[recognition]` lines