### PR TITLE
docs: update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,14 +62,17 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     MicCaptureHandler.swift # AVAudioEngine → WAV
     AudioCaptureSession.swift # Orchestrator (start/stop, computes micDelay)
     AudioCaptureResult.swift  # Result struct
+    DebugRMSReporter.swift # Throttled RMS accumulator/reporter for debug logging paths
     Helpers.swift          # machTicksToSeconds, getDefaultOutputDeviceUID, writeAllToFileHandle
     MicRestartPolicy.swift # Pure decision logic for mic engine restart on device change
+    OutputDeviceChangeCoordinator.swift  # Pure state machine for output device change handling
     SampleRateQuery.swift  # Pure functions for sample rate detection and cross-validation
   Tests/
     AudioCaptureResultTests.swift
     HelpersTests.swift
     MicCaptureErrorTests.swift
     MicRestartPolicyTests.swift
+    OutputDeviceChangeCoordinatorTests.swift
     SampleRateQueryTests.swift
 tools/meeting-simulator/   # Meeting simulator tool for testing
   Package.swift
@@ -86,6 +89,8 @@ scripts/
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
+  tests/
+    test_build_release_signing.sh  # Regression tests for build script codesign pipeline
 Casks/meeting-transcriber.rb # Homebrew Cask formula (stable)
 Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
 .github/workflows/
@@ -93,6 +98,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E tests on self-hosted macOS runner (workflow_dispatch + v* tags)
+  dependabot-auto-merge.yml  # Auto-merge Dependabot patch/minor and github-actions bumps
 docs/
   architecture-macos.md        # High-level architecture quick-reference
   menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol)
@@ -254,9 +260,13 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 `AppSettings.audioDebugLogging` (Settings → Diagnostics → "Verbose Audio Logging") enables forensic logging in the audio-capture path:
 
 - `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` at start
-- `[debug] Default output device: name=… uid=…` at start and on device change
+- `[debug] Default output device: name=… uid=… transport=… rate=…` at start and on device change
+- `[debug] Tap format: rate=… Hz, tapID=…` after tap is configured
+- `[debug] Output device change → name=… uid=…` when system output device changes mid-capture
 - `[debug] App audio RMS (5s): … dBFS, samples=…, totalBytes=…` every 5 s during capture — live signal whether the tap is delivering real audio or zero/noise
 - `[debug] App audio capture stopping: totalBytes=…` at stop
+- `[debug] Mic input device: name=… uid=… hwRate=… hwChannels=…` at mic capture start
+- `[debug] Mic RMS (5s): … dBFS, samples=…` every 5 s during mic capture
 
 View via Console.app, subsystem `com.meetingtranscriber.audiotap`. Off by default; turn on when investigating silent recordings or unusual routing.
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,12 @@ If a recording's `_app.wav` is silent or unexpectedly quiet, enable verbose audi
 2. Reproduce the failing recording.
 3. Open **Console.app**, filter by subsystem `com.meetingtranscriber.audiotap`, and look for `[debug]` lines:
    - `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` — which process the tap targeted
-   - `[debug] Default output device: name=… uid=…` — output device at start
+   - `[debug] Default output device: name=… uid=… transport=… rate=…` — output device at start
+   - `[debug] Tap format: rate=… Hz, tapID=…` — sample rate and tap ID after the tap is configured
    - `[debug] App audio RMS (5s): …dBFS, samples=…, totalBytes=…` — every 5 seconds; **tells you live whether the tap is delivering real audio (-40 dBFS or higher) or near-silence (≤ -90 dBFS)**
    - `[debug] Output device change → name=… uid=…` — emitted when the system output device changes mid-recording
+   - `[debug] Mic input device: name=… uid=… hwRate=… hwChannels=…` — mic hardware device at capture start
+   - `[debug] Mic RMS (5s): …dBFS, samples=…` — every 5 seconds during mic capture
 4. Turn the toggle off again when done — the per-5 s RMS log is moderately chatty.
 
 The toggle persists in `UserDefaults` and takes effect on the next recording without an app restart.

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -195,7 +195,7 @@ Flow: `FluidDiarizer.run(audioPath, numSpeakers)` → selected diarizer → `Dia
 
 ### Speaker Matching
 
-`SpeakerMatcher` matches diarization speaker embeddings against a persistent speaker database (`speakers.json`) using cosine similarity (threshold: 0.40, confidence margin: 0.10). Stores up to 5 embeddings per speaker (FIFO). Enables recognition of returning speakers across meetings.
+`SpeakerMatcher` matches diarization speaker embeddings against a persistent speaker database (`speakers.json`) using cosine similarity (threshold: 0.40, confidence margin: 0.10). Stores a running-mean centroid (primary match anchor) plus a recent-samples FIFO (max 3, fallback when centroid match is borderline). Quality filter: embeddings from segments shorter than 3 s are excluded from the centroid but kept as fallback samples. Speakers are ranked by recency and use count in the naming UI. Enables recognition of returning speakers across meetings.
 
 ### Speaker Assignment
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add `DebugRMSReporter.swift` and `OutputDeviceChangeCoordinator.swift` to the audiotap Sources list; add `OutputDeviceChangeCoordinatorTests.swift` to Tests; add `scripts/tests/test_build_release_signing.sh`; add `dependabot-auto-merge.yml` to `.github/workflows`; expand the Diagnostics log list with four new `[debug]` entries (tap format, output device change, mic input device, mic RMS)
- **architecture-macos.md**: Update the SpeakerMatcher description to reflect the v3 centroid-based matching schema — removes stale "stores up to 5 embeddings (FIFO)" wording and documents the running-mean centroid, recent-samples FIFO fallback, quality filter, and recency/use-count ranking
- **README.md**: Add the four missing `[debug]` log entries to the troubleshooting section so users diagnosing silent recordings get the full picture

## What triggered each change

| Change | Commit |
|--------|--------|
| `OutputDeviceChangeCoordinator.swift` + tests | `refactor(audiotap): extract OutputDeviceChangeCoordinator as a pure state machine` |
| `DebugRMSReporter.swift` | `feat(audiotap): add debugLogging mode to AppAudioCapture` / `expand audioDebugLogging` |
| New debug log lines (tap format, mic, output-device change) | `feat(audiotap): expand audioDebugLogging with mic, output-device + tap-format details` |
| `scripts/tests/test_build_release_signing.sh` | `test(build): add regression test for codesign-pipeline pipefail bug` |
| `dependabot-auto-merge.yml` | `ci: auto-merge Dependabot patch/minor and github-actions bumps` |
| SpeakerMatcher centroid description | `feat(app): centroid-based speaker matching + embedding quality filter` |

## Test plan

- [ ] Confirm no code files were touched (docs-only PR)
- [ ] Spot-check that each listed source file actually exists on disk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGmfrKEh24N1GizLHZMit)_