### PR TITLE
feat(app): record top-3 match candidates per recognition event

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -408,8 +408,10 @@ class PipelineQueue {
                             guard let embeddings = currentDiarization.embeddings else { break }
 
                             let matcher = speakerMatcherFactory()
-                            let matched = matcher.match(embeddings: embeddings)
+                            let verbose = matcher.matchVerbose(embeddings: embeddings)
+                            let matched = verbose.mapValues(\.assignedName)
                             autoNames = matched
+                            let topCandidates = verbose.mapValues(\.topCandidates)
 
                             // Pre-match participants to remaining speakers
                             if !participants.isEmpty {
@@ -472,6 +474,7 @@ class PipelineQueue {
                                 recordRecognition(
                                     suggested: suggestedAtDialog,
                                     userMapping: userMapping,
+                                    topCandidates: topCandidates,
                                     jobID: jobID, title: title,
                                 )
                                 break diarizationLoop
@@ -487,6 +490,7 @@ class PipelineQueue {
                                 recordRecognition(
                                     suggested: suggestedAtDialog,
                                     userMapping: nil,
+                                    topCandidates: topCandidates,
                                     jobID: jobID, title: title,
                                 )
                                 break diarizationLoop
@@ -915,11 +919,13 @@ class PipelineQueue {
         suggested: [String: String],
         // swiftlint:disable:next discouraged_optional_collection
         userMapping: [String: String]?,
+        topCandidates: [String: [TopCandidate]],
         jobID: UUID,
         title: String,
     ) {
         let events = RecognitionStats.buildEvents(
             suggested: suggested, userMapping: userMapping,
+            topCandidates: topCandidates,
             jobID: jobID, meetingTitle: title,
         )
         var counts: [RecognitionAction: Int] = [:]

--- a/app/MeetingTranscriber/Sources/RecognitionStats.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStats.swift
@@ -27,6 +27,27 @@ struct RecognitionEvent: Codable, Equatable {
     let autoName: String?
     let userName: String?
     let action: RecognitionAction
+    // Top candidates the matcher considered, with per-anchor distances.
+    // Optional so old log lines without this field still decode.
+    // swiftlint:disable:next discouraged_optional_collection
+    let topCandidates: [TopCandidate]?
+}
+
+/// Per-candidate distance forensics for a single match decision. Used both
+/// as the matcher's ranked-candidate value and as the JSONL log schema.
+struct TopCandidate: Codable, Equatable {
+    let name: String
+    /// Min cosine distance over the speaker's recent samples.
+    let sample: Float
+    /// Cosine distance to the speaker's centroid; nil for legacy speakers
+    /// without a persisted centroid.
+    let centroid: Float?
+
+    /// Ranking metric: the closer of the two anchors. Matches what
+    /// `SpeakerMatcher.distance(query:speaker:)` returns.
+    var hybrid: Float {
+        min(sample, centroid ?? .greatestFiniteMagnitude)
+    }
 }
 
 enum RecognitionStats {
@@ -49,6 +70,7 @@ enum RecognitionStats {
         suggested: [String: String],
         // swiftlint:disable:next discouraged_optional_collection
         userMapping: [String: String]?,
+        topCandidates: [String: [TopCandidate]],
         jobID: UUID,
         meetingTitle: String,
         now: Date = Date(),
@@ -69,6 +91,7 @@ enum RecognitionStats {
                 autoName: auto,
                 userName: user,
                 action: action,
+                topCandidates: topCandidates[label],
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -126,39 +126,63 @@ class SpeakerMatcher {
     /// previous algorithm's behaviour on identical-sample queries while
     /// adding the centroid's drift-resistance for free.
     func match(embeddings: [String: [Float]]) -> [String: String] {
+        matchVerbose(embeddings: embeddings).mapValues(\.assignedName)
+    }
+
+    /// Per-label match result. Reuses `TopCandidate` so the matcher and the
+    /// JSONL log share one shape — eliminates a field-by-field re-pack at the
+    /// call site.
+    struct VerboseMatch {
+        /// Real speaker name when the threshold + margin checks pass; the
+        /// label itself otherwise.
+        let assignedName: String
+        /// Candidates sorted by `hybrid` ascending; empty if the DB is empty.
+        let topCandidates: [TopCandidate]
+    }
+
+    /// Match each label against the stored DB, returning the top candidates
+    /// with their per-anchor distances.
+    func matchVerbose(embeddings: [String: [Float]], topK: Int = 3)
+        -> [String: VerboseMatch] {
         let stored = loadDB()
-        var mapping: [String: String] = [:]
+        var result: [String: VerboseMatch] = [:]
         var usedNames: Set<String> = []
 
         let sorted = embeddings.sorted { $0.key < $1.key }
 
         for (label, embedding) in sorted {
-            var bestName: String?
-            var bestDistance = Float.greatestFiniteMagnitude
-            var secondBestDistance = Float.greatestFiniteMagnitude
-
-            for speaker in stored where !usedNames.contains(speaker.name) {
-                let dist = Self.distance(query: embedding, speaker: speaker)
-                if dist < bestDistance {
-                    secondBestDistance = bestDistance
-                    bestDistance = dist
-                    bestName = speaker.name
-                } else if dist < secondBestDistance {
-                    secondBestDistance = dist
+            let scored = stored
+                .filter { !usedNames.contains($0.name) }
+                .map { speaker -> TopCandidate in
+                    let sampleDist = speaker.embeddings
+                        .map { Self.cosineDistance(embedding, $0) }.min()
+                        ?? Float.greatestFiniteMagnitude
+                    let centroidDist = speaker.centroid.map { vec in
+                        Self.cosineDistance(embedding, vec)
+                    }
+                    return TopCandidate(
+                        name: speaker.name, sample: sampleDist, centroid: centroidDist,
+                    )
                 }
-            }
+                .sorted { $0.hybrid < $1.hybrid }
 
-            if let name = bestName,
-               bestDistance < threshold,
-               secondBestDistance - bestDistance >= confidenceMargin {
-                mapping[label] = name
-                usedNames.insert(name)
+            let best = scored.first
+            let second = scored.count > 1 ? scored[1] : nil
+            let assignedName: String
+            if let best,
+               best.hybrid < threshold,
+               (second?.hybrid ?? .greatestFiniteMagnitude) - best.hybrid >= confidenceMargin {
+                assignedName = best.name
+                usedNames.insert(best.name)
             } else {
-                mapping[label] = label
+                assignedName = label
             }
+            result[label] = VerboseMatch(
+                assignedName: assignedName, topCandidates: Array(scored.prefix(topK)),
+            )
         }
 
-        return mapping
+        return result
     }
 
     /// Distance from a query embedding to a stored speaker.

--- a/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
@@ -6,28 +6,28 @@ final class RecognitionStatsTests: XCTestCase {
     // MARK: - classify
 
     func testClassifyAccepted() {
-        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "Roman"), .accepted)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Speaker A", userName: "Speaker A"), .accepted)
     }
 
     func testClassifyCorrected() {
-        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "Alex"), .corrected)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Speaker A", userName: "Speaker B"), .corrected)
     }
 
     func testClassifyAdded() {
-        XCTAssertEqual(RecognitionStats.classify(autoName: nil, userName: "Roman"), .added)
-        XCTAssertEqual(RecognitionStats.classify(autoName: "", userName: "Roman"), .added)
+        XCTAssertEqual(RecognitionStats.classify(autoName: nil, userName: "Speaker A"), .added)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "", userName: "Speaker A"), .added)
     }
 
     func testClassifySkipped() {
-        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: nil), .skipped)
-        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: ""), .skipped)
-        XCTAssertEqual(RecognitionStats.classify(autoName: "Roman", userName: "   "), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Speaker A", userName: nil), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Speaker A", userName: ""), .skipped)
+        XCTAssertEqual(RecognitionStats.classify(autoName: "Speaker A", userName: "   "), .skipped)
         XCTAssertEqual(RecognitionStats.classify(autoName: nil, userName: nil), .skipped)
     }
 
     func testClassifyTrimsWhitespace() {
         XCTAssertEqual(
-            RecognitionStats.classify(autoName: " Roman ", userName: "Roman"), .accepted,
+            RecognitionStats.classify(autoName: " Speaker A ", userName: "Speaker A"), .accepted,
         )
     }
 
@@ -83,14 +83,14 @@ final class RecognitionStatsTests: XCTestCase {
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
         let events: [RecognitionEvent] = [
-            event(name: "Roman", action: .accepted, ts: now),
-            event(name: "Alex", action: .corrected, ts: now),
+            event(name: "Speaker A", action: .accepted, ts: now),
+            event(name: "Speaker B", action: .corrected, ts: now),
         ]
         await log.append(events)
 
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 2)
-        XCTAssertEqual(loaded.map(\.userName).sorted { ($0 ?? "") < ($1 ?? "") }, ["Alex", "Roman"])
+        XCTAssertEqual(loaded.map(\.userName).sorted { ($0 ?? "") < ($1 ?? "") }, ["Speaker A", "Speaker B"])
 
         try? FileManager.default.removeItem(at: tmp)
     }
@@ -112,7 +112,7 @@ final class RecognitionStatsTests: XCTestCase {
         let tmp = uniqueTempPath()
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
-        await log.append([event(name: "Roman", action: .accepted, ts: now)])
+        await log.append([event(name: "Speaker A", action: .accepted, ts: now)])
 
         // Append a garbage line
         let handle = try FileHandle(forWritingTo: tmp)
@@ -122,7 +122,7 @@ final class RecognitionStatsTests: XCTestCase {
 
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 1)
-        XCTAssertEqual(loaded.first?.userName, "Roman")
+        XCTAssertEqual(loaded.first?.userName, "Speaker A")
 
         try? FileManager.default.removeItem(at: tmp)
     }
@@ -147,19 +147,20 @@ final class RecognitionStatsTests: XCTestCase {
 
     func testBuildEventsClassifiesAllActions() {
         let suggested = [
-            "R_S1": "Roman", // accepted
-            "R_S2": "Alex", // corrected
+            "R_S1": "Speaker A", // accepted
+            "R_S2": "Speaker B", // corrected
             "R_S3": "R_S3", // added (no auto)
-            "M_S1": "Susi", // skipped (user clears)
+            "M_S1": "Speaker C", // skipped (user clears)
         ]
         let userMapping = [
-            "R_S1": "Roman",
-            "R_S2": "Bob",
-            "R_S3": "Charlie",
+            "R_S1": "Speaker A",
+            "R_S2": "Speaker D",
+            "R_S3": "Speaker E",
             "M_S1": "",
         ]
         let events = RecognitionStats.buildEvents(
             suggested: suggested, userMapping: userMapping,
+            topCandidates: [:],
             jobID: UUID(), meetingTitle: "Test",
         )
         let byLabel = Dictionary(uniqueKeysWithValues: events.map { ($0.label, $0) })
@@ -174,16 +175,17 @@ final class RecognitionStatsTests: XCTestCase {
     }
 
     func testBuildEventsDismissedWhenUserMappingNil() {
-        let suggested = ["R_S1": "Roman", "R_S2": "R_S2"]
+        let suggested = ["R_S1": "Speaker A", "R_S2": "R_S2"]
         let events = RecognitionStats.buildEvents(
             suggested: suggested, userMapping: nil,
+            topCandidates: [:],
             jobID: UUID(), meetingTitle: "Test",
         )
         XCTAssertEqual(events.count, 2)
         XCTAssertTrue(events.allSatisfy { $0.action == .dismissed })
         XCTAssertTrue(events.allSatisfy { $0.userName == nil })
         let s1 = events.first { $0.label == "R_S1" }
-        XCTAssertEqual(s1?.autoName, "Roman")
+        XCTAssertEqual(s1?.autoName, "Speaker A")
         let s2 = events.first { $0.label == "R_S2" }
         XCTAssertNil(s2.flatMap(\.autoName))
     }
@@ -198,8 +200,28 @@ final class RecognitionStatsTests: XCTestCase {
             track: .single, label: "S1",
             autoName: action == .added ? nil : name,
             userName: action == .skipped || action == .dismissed ? nil : name,
-            action: action,
+            action: action, topCandidates: nil,
         )
+    }
+
+    func testBuildEventsThreadsTopCandidates() {
+        let suggested = ["R_S1": "Speaker A"]
+        let userMapping = ["R_S1": "Speaker A"]
+        let candidates = [
+            "R_S1": [
+                TopCandidate(name: "Speaker A", sample: 0.10, centroid: 0.22),
+                TopCandidate(name: "Speaker B", sample: 0.40, centroid: nil),
+            ],
+        ]
+        let events = RecognitionStats.buildEvents(
+            suggested: suggested, userMapping: userMapping,
+            topCandidates: candidates,
+            jobID: UUID(), meetingTitle: "Test",
+        )
+        XCTAssertEqual(events.first?.topCandidates?.count, 2)
+        XCTAssertEqual(events.first?.topCandidates?.first?.name, "Speaker A")
+        let lastCentroid: Float? = events.first?.topCandidates?.last?.centroid
+        XCTAssertNil(lastCentroid)
     }
 
     private func uniqueTempPath() -> URL {

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -797,4 +797,66 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result["SPEAKER_0"], "Roman", "First key alphabetically should win the match")
         XCTAssertEqual(result["SPEAKER_1"], "SPEAKER_1", "Second speaker left unmatched")
     }
+
+    // MARK: - matchVerbose
+
+    func testMatchVerboseReturnsRankedCandidates() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let stored = [
+            StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]]),
+            StoredSpeaker(name: "Speaker B", embeddings: [[0, 1, 0]]),
+            StoredSpeaker(name: "Speaker C", embeddings: [[0, 0, 1]]),
+        ]
+        matcher.saveDB(stored)
+
+        let result = matcher.matchVerbose(embeddings: ["SPEAKER_0": [0.99, 0.01, 0]])
+        let entry = result["SPEAKER_0"]
+
+        XCTAssertEqual(entry?.assignedName, "Speaker A")
+        XCTAssertEqual(entry?.topCandidates.count, 3)
+        XCTAssertEqual(entry?.topCandidates.first?.name, "Speaker A")
+        // Speaker A is closest; the other two are orthogonal at distance 1.
+        XCTAssertLessThan(entry?.topCandidates.first?.hybrid ?? 1, 0.1)
+    }
+
+    func testMatchVerboseExposesCentroidDistance() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let stored = [
+            StoredSpeaker(
+                name: "Speaker A", embeddings: [[1, 0, 0]],
+                centroid: [0.9, 0.1, 0], centroidSampleCount: 5,
+            ),
+        ]
+        matcher.saveDB(stored)
+
+        let result = matcher.matchVerbose(embeddings: ["S0": [1, 0, 0]])
+        let cand = result["S0"]?.topCandidates.first
+        XCTAssertEqual(cand?.name, "Speaker A")
+        XCTAssertNotNil(cand?.centroid, "Centroid distance should be reported when stored")
+        XCTAssertEqual(cand?.sample ?? 1, 0, accuracy: 0.001)
+    }
+
+    func testMatchVerboseLegacyEntriesHaveNilCentroid() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        // No centroid persisted (legacy entry)
+        let stored = [StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]])]
+        matcher.saveDB(stored)
+
+        let result = matcher.matchVerbose(embeddings: ["S0": [1, 0, 0]])
+        XCTAssertNil(result["S0"]?.topCandidates.first?.centroid)
+    }
+
+    func testMatchVerboseAssignsLabelWhenBelowConfidenceMargin() {
+        let matcher = SpeakerMatcher(dbPath: dbPath, confidenceMargin: 0.5)
+        let stored = [
+            StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]]),
+            StoredSpeaker(name: "Speaker B", embeddings: [[0.99, 0.01, 0]]),
+        ]
+        matcher.saveDB(stored)
+
+        let result = matcher.matchVerbose(embeddings: ["S0": [1, 0, 0]])
+        XCTAssertEqual(result["S0"]?.assignedName, "S0")
+        // Both candidates still surfaced
+        XCTAssertEqual(result["S0"]?.topCandidates.count, 2)
+    }
 }


### PR DESCRIPTION
## Summary

Adds `SpeakerMatcher.matchVerbose` returning per-label top-K candidates with per-anchor distances (sample min + centroid). `PipelineQueue` threads these into the JSONL recognition log as a new optional `topCandidates` field on `RecognitionEvent`.

This unlocks offline A/B analysis once data accumulates — e.g. "would centroid-only matching have produced the same answer?" Answer is in the log row.

```json
{
  "action": "accepted",
  "label": "R_S1",
  "autoName": "Speaker A",
  "topCandidates": [
    {"name": "Speaker A", "sample": 0.10, "centroid": 0.22},
    {"name": "Speaker B", "sample": 0.40, "centroid": 0.55},
    {"name": "Speaker C", "sample": 0.42, "centroid": null}
  ]
}
```

The legacy `match(embeddings:)` API is preserved as a one-line wrapper around `matchVerbose`, so existing callers and tests keep working unchanged.

## Test plan

- [x] 4 new `SpeakerMatcherTests` for `matchVerbose` (ranked candidates, centroid distance exposure, legacy nil-centroid, label-fallback when below confidence margin)
- [x] 1 new `RecognitionStatsTests` for top-candidate threading through `buildEvents`
- [x] `swift test` — 0 non-snapshot failures
- [x] `./scripts/lint.sh` — clean
- [ ] Manual: confirm next real meeting writes a JSONL row with `topCandidates` populated