### PR TITLE
feat(app): show recognition stats in Settings

### DIFF
--- a/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftUI
+
+/// Surfaces aggregate counts from `recognition_log.jsonl` so the user can
+/// verify whether `SpeakerMatcher` quality drifts over time. The JSONL file
+/// remains the source of truth; this view is read-only.
+struct RecognitionStatsView: View {
+    @State private var aggregate: RecognitionStats.Aggregate?
+    @State private var windowDays: WindowChoice = .thirty
+
+    private let log: RecognitionStatsLog
+
+    init(log: RecognitionStatsLog) {
+        self.log = log
+    }
+
+    enum WindowChoice: Int, CaseIterable, Identifiable {
+        case seven = 7, thirty = 30, ninety = 90
+        var id: Int {
+            rawValue
+        }
+
+        var label: String {
+            "Last \(rawValue) days"
+        }
+    }
+
+    var body: some View {
+        Section("Recognition Stats") {
+            Picker("Window", selection: $windowDays) {
+                ForEach(WindowChoice.allCases) { choice in
+                    Text(choice.label).tag(choice)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if let aggregate {
+                if aggregate.total > 0 {
+                    statsBody(aggregate)
+                } else {
+                    Text("No data yet — confirm a meeting to start collecting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                ProgressView().frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            HStack {
+                Button("Open Log Folder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([RecognitionStatsLog.defaultPath])
+                }
+                Spacer()
+                Button("Reload") {
+                    Task { await reload() }
+                }
+            }
+        }
+        .task(id: windowDays) { await reload() }
+    }
+
+    @ViewBuilder
+    private func statsBody(_ agg: RecognitionStats.Aggregate) -> some View {
+        LabeledContent("Total confirmations", value: "\(agg.total)")
+        statRow(.accepted, count: agg.counts[.accepted] ?? 0, total: agg.total)
+        statRow(.corrected, count: agg.counts[.corrected] ?? 0, total: agg.total)
+        statRow(.added, count: agg.counts[.added] ?? 0, total: agg.total)
+        statRow(.skipped, count: agg.counts[.skipped] ?? 0, total: agg.total)
+        statRow(.dismissed, count: agg.counts[.dismissed] ?? 0, total: agg.total)
+    }
+
+    @ViewBuilder
+    private func statRow(_ action: RecognitionAction, count: Int, total: Int) -> some View {
+        let pct = Int((Double(count) / Double(total) * 100).rounded())
+        LabeledContent(action.rawValue.capitalized) {
+            HStack(spacing: 8) {
+                Text("\(count)")
+                Text("(\(pct)%)").foregroundStyle(.secondary).font(.caption)
+                ProgressView(value: Double(count), total: Double(total))
+                    .frame(width: 80)
+            }
+        }
+    }
+
+    private func reload() async {
+        let now = Date()
+        let interval = TimeInterval(windowDays.rawValue * 86400)
+        let events = await log.loadRecent(within: interval, now: now)
+        aggregate = RecognitionStats.aggregate(
+            events: events,
+            from: now.addingTimeInterval(-interval),
+            to: now,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     var parakeetEngine: ParakeetEngine
     var qwen3Engine: (any TranscribingEngine)? // nil on macOS < 15
     var updateChecker: UpdateChecker?
+    var recognitionStatsLog: RecognitionStatsLog = .init()
 
     enum ConnectionTestResult {
         case success(String)
@@ -479,6 +480,8 @@ struct SettingsView: View {
                     }
                 }
             }
+
+            RecognitionStatsView(log: recognitionStatsLog)
 
             Section("Diagnostics") {
                 Toggle("Verbose Audio Logging", isOn: $settings.audioDebugLogging)

--- a/app/MeetingTranscriber/Tests/RecognitionStatsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/RecognitionStatsViewTests.swift
@@ -1,0 +1,47 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+@MainActor
+final class RecognitionStatsViewTests: XCTestCase {
+    func testViewRendersEmpty() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let view = RecognitionStatsView(log: RecognitionStatsLog(path: tmp))
+        XCTAssertNoThrow(try view.inspect())
+    }
+
+    func testViewLoadsAggregateFromLog() async {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let log = RecognitionStatsLog(path: tmp)
+        let now = Date()
+        await log.append([
+            RecognitionEvent(
+                ts: now, jobID: UUID(), meetingTitle: "M",
+                track: .single, label: "S0",
+                autoName: "Speaker A", userName: "Speaker A",
+                action: .accepted, topCandidates: nil,
+            ),
+            RecognitionEvent(
+                ts: now, jobID: UUID(), meetingTitle: "M",
+                track: .single, label: "S1",
+                autoName: "Speaker A", userName: "Speaker B",
+                action: .corrected, topCandidates: nil,
+            ),
+        ])
+
+        let loaded = await log.loadRecent(within: 60, now: now)
+        let agg = RecognitionStats.aggregate(
+            events: loaded,
+            from: now.addingTimeInterval(-60), to: now,
+        )
+        XCTAssertEqual(agg.total, 2)
+        XCTAssertEqual(agg.acceptanceRate, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(agg.correctionRate, 0.5, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Settings → "Recognition Stats" section that aggregates the JSONL recognition log over a configurable 7 / 30 / 90-day window:

- Total confirmations
- Per-action counts + percentages + tiny progress bars (`accepted` / `corrected` / `added` / `skipped` / `dismissed`)
- "Open Log Folder" reveals the JSONL in Finder
- "Reload" re-reads the file

Pure additive — uses the existing `RecognitionStatsLog.loadRecent` and `RecognitionStats.aggregate` (both shipped in #126). No new persistence surface, no changes to the matcher.

## Test plan

- [x] 2 new ViewInspector tests (renders empty state, loads aggregate from log)
- [x] `swift test` — 0 non-snapshot failures
- [x] `./scripts/lint.sh` — clean
- [x] Manual: open Settings, verify stats render with current log; toggle the 7/30/90 window picker and confirm reload

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->