### PR TITLE
feat(app): enroll speakers from existing recordings

### DIFF
--- a/app/MeetingTranscriber/Sources/KnownVoicesView.swift
+++ b/app/MeetingTranscriber/Sources/KnownVoicesView.swift
@@ -7,8 +7,17 @@ struct KnownVoicesView: View {
     @State private var selection: String?
     @State private var filter = ""
     @State private var modal: ActiveModal?
+    @State private var showingEnrollment = false
 
     private let matcher: SpeakerMatcher
+    private let diarizerFactory: (() -> DiarizationProvider)?
+    /// Set by the parent when a meeting is currently waiting on a naming
+    /// dialog — we then disable the enroll button to avoid two
+    /// SpeakerNamingViews fighting for the user's attention.
+    private let namingDialogActive: Bool
+    /// Soft hint when the pipeline is busy (transcribing / diarizing).
+    /// Doesn't block enrollment; just shows a caption.
+    private let pipelineBusy: Bool
     @Environment(\.dismiss)
     private var dismiss
 
@@ -18,8 +27,16 @@ struct KnownVoicesView: View {
         return f
     }()
 
-    init(matcher: SpeakerMatcher) {
+    init(
+        matcher: SpeakerMatcher,
+        diarizerFactory: (() -> DiarizationProvider)? = nil,
+        namingDialogActive: Bool = false,
+        pipelineBusy: Bool = false,
+    ) {
         self.matcher = matcher
+        self.diarizerFactory = diarizerFactory
+        self.namingDialogActive = namingDialogActive
+        self.pipelineBusy = pipelineBusy
     }
 
     enum ActiveModal: Identifiable {
@@ -54,18 +71,11 @@ struct KnownVoicesView: View {
             }
             .frame(minHeight: 280)
 
-            HStack {
-                Button("Rename") { startRename() }
-                    .disabled(selection == nil)
-                Button("Merge into…") { startMerge() }
-                    .disabled(selection == nil || speakers.count < 2)
-                Button("Delete", role: .destructive) {
-                    if let selection { modal = .delete(name: selection) }
-                }
-                .disabled(selection == nil)
-                Spacer()
-                Button("Done") { dismiss() }
-                    .keyboardShortcut(.defaultAction)
+            actionButtonsRow
+            if pipelineBusy, diarizerFactory != nil {
+                Text("Pipeline busy — diarization may be slower.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(20)
@@ -85,6 +95,17 @@ struct KnownVoicesView: View {
             Text("\(deletingName) will be removed. This cannot be undone.")
         }
         .sheet(isPresented: isMerge) { mergeSheet }
+        .sheet(isPresented: $showingEnrollment) {
+            if let diarizerFactory {
+                VoiceEnrollmentView(
+                    matcher: matcher,
+                    diarizerFactory: diarizerFactory,
+                ) {
+                    showingEnrollment = false
+                    reload()
+                }
+            }
+        }
     }
 
     // MARK: - Modal bindings
@@ -183,6 +204,31 @@ struct KnownVoicesView: View {
     }
 
     // MARK: - Actions
+
+    private var actionButtonsRow: some View {
+        HStack {
+            if diarizerFactory != nil {
+                Button("Add from Recording…") { showingEnrollment = true }
+                    .disabled(namingDialogActive)
+                    .help(
+                        namingDialogActive
+                            ? "Finish the open naming dialog before enrolling new voices."
+                            : "Diarize an existing audio file and seed speaker DB entries.",
+                    )
+            }
+            Button("Rename") { startRename() }
+                .disabled(selection == nil)
+            Button("Merge into…") { startMerge() }
+                .disabled(selection == nil || speakers.count < 2)
+            Button("Delete", role: .destructive) {
+                if let selection { modal = .delete(name: selection) }
+            }
+            .disabled(selection == nil)
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+    }
 
     private func reload() {
         speakers = SpeakerMatcher.rankByRecency(speakers: matcher.loadDB())

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -137,6 +137,9 @@ struct MeetingTranscriberApp: App {
                     return nil
                 }(),
                 updateChecker: appState.updateChecker,
+                enrollmentDiarizerFactory: { FluidDiarizer(mode: appState.settings.diarizerMode) },
+                namingDialogActive: appState.pipelineQueue.pendingSpeakerNaming != nil,
+                pipelineBusy: appState.pipelineQueue.isProcessing,
             )
         }
         .windowResizability(.contentSize)

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -26,6 +26,13 @@ struct SettingsView: View {
     var qwen3Engine: (any TranscribingEngine)? // nil on macOS < 15
     var updateChecker: UpdateChecker?
     var recognitionStatsLog: RecognitionStatsLog = .init()
+    /// Factory for the voice-enrollment diarizer. nil → enroll button hidden.
+    var enrollmentDiarizerFactory: (() -> DiarizationProvider)?
+    /// True when a meeting is currently waiting on a naming dialog. We gate
+    /// the enroll button to avoid two `SpeakerNamingView` instances.
+    var namingDialogActive: Bool = false
+    /// True when the pipeline is processing a job — soft hint only.
+    var pipelineBusy: Bool = false
 
     enum ConnectionTestResult {
         case success(String)
@@ -531,7 +538,12 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .frame(width: 520)
         .sheet(isPresented: $showKnownVoices) {
-            KnownVoicesView(matcher: SpeakerMatcher())
+            KnownVoicesView(
+                matcher: SpeakerMatcher(),
+                diarizerFactory: enrollmentDiarizerFactory,
+                namingDialogActive: namingDialogActive,
+                pipelineBusy: pipelineBusy,
+            )
         }
         .onAppear {
             #if !APPSTORE

--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -1,0 +1,263 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Three-stage sheet that seeds `speakers.json` from an existing audio file:
+/// 1. Pick file → 2. Diarize → 3. Name speakers (reuses `SpeakerNamingView`)
+/// → persists embeddings via the same path as a real meeting.
+///
+/// Engine-independent: never touches the ASR pipeline, only the FluidAudio
+/// diarization side.
+struct VoiceEnrollmentView: View {
+    let matcher: SpeakerMatcher
+    let diarizerFactory: () -> DiarizationProvider
+    let onClose: () -> Void
+
+    @State private var stage: Stage = .pickFile
+    @State private var diarizeStart: Date?
+    @State private var elapsed: TimeInterval = 0
+    @State private var elapsedTimer: Task<Void, Never>?
+    @State private var diarizationTask: Task<Void, Never>?
+
+    enum Stage {
+        case pickFile
+        case diarizing(URL)
+        /// Snapshot of everything the naming stage needs — computed once on
+        /// entry, NOT re-derived inside the view body on every render.
+        case naming(NamingPayload)
+        case done(savedNames: [String])
+        case error(String)
+    }
+
+    struct NamingPayload {
+        let url: URL
+        let diarization: DiarizationResult
+        let namingData: PipelineQueue.SpeakerNamingData
+        let knownNames: [String]
+        let speakerCount: Int
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Add Voice from Recording").font(.title2).bold()
+                Spacer()
+                Button("Cancel", role: .cancel) { onClose() }
+                    .keyboardShortcut(.cancelAction)
+            }
+
+            Divider()
+
+            switch stage {
+            case .pickFile: pickFileBody
+            case let .diarizing(url): diarizingBody(url: url)
+            case let .naming(payload): namingBody(payload: payload)
+            case let .done(names): doneBody(savedNames: names)
+            case let .error(message): errorBody(message: message)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 600, minHeight: 420)
+        .onDisappear {
+            diarizationTask?.cancel()
+            stopElapsedTimer()
+        }
+    }
+
+    // MARK: - Stage views
+
+    private var pickFileBody: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Pick an audio file with the speaker(s) you want to enroll.")
+                .foregroundStyle(.secondary)
+            HStack {
+                Button("Choose File…") { pickFile(initialDirectory: nil) }
+                Button("Browse Past Recordings…") {
+                    pickFile(initialDirectory: AppPaths.recordingsDir)
+                }
+            }
+            Text(
+                "The file is diarized to find speakers, then you name them. "
+                    + "Embeddings + centroid land in your speaker DB exactly as if "
+                    + "the meeting had just happened.",
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func diarizingBody(url: URL) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Diarizing \(url.lastPathComponent)…").font(.headline)
+            HStack {
+                ProgressView()
+                Text(String(format: "%.0f s elapsed", elapsed))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func namingBody(payload: NamingPayload) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Found \(payload.speakerCount) speakers in \(payload.url.lastPathComponent)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            SpeakerNamingView(
+                data: payload.namingData,
+                knownSpeakerNames: payload.knownNames,
+            ) { result in
+                handleNamingResult(result, payload: payload)
+            }
+            .frame(minHeight: 320)
+        }
+    }
+
+    private func doneBody(savedNames: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Enrolled \(savedNames.count) speaker\(savedNames.count == 1 ? "" : "s")")
+                .font(.headline)
+            if !savedNames.isEmpty {
+                Text(savedNames.joined(separator: ", "))
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Spacer()
+                Button("Done") { onClose() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    private func errorBody(message: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Enrollment failed").font(.headline).foregroundStyle(.red)
+            Text(message).foregroundStyle(.secondary)
+            HStack {
+                Button("Try Again") { stage = .pickFile }
+                Spacer()
+                Button("Close") { onClose() }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func pickFile(initialDirectory: URL?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.audio, .mpeg4Audio, .mp3, .wav]
+        panel.allowsMultipleSelection = false
+        if let initialDirectory {
+            try? FileManager.default.createDirectory(
+                at: initialDirectory, withIntermediateDirectories: true,
+            )
+            panel.directoryURL = initialDirectory
+        }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        startDiarization(url: url, numSpeakers: 0)
+    }
+
+    private func startDiarization(url: URL, numSpeakers: Int) {
+        stage = .diarizing(url)
+        diarizeStart = Date()
+        elapsed = 0
+        startElapsedTimer()
+        diarizationTask?.cancel()
+        diarizationTask = Task {
+            do {
+                let result = try await diarizerFactory().run(
+                    audioPath: url, numSpeakers: numSpeakers, meetingTitle: url.lastPathComponent,
+                )
+                guard !Task.isCancelled else { return }
+                stopElapsedTimer()
+                if result.segments.isEmpty {
+                    stage = .error("No speakers detected in this recording.")
+                } else {
+                    stage = .naming(buildNamingPayload(url: url, diarization: result))
+                }
+            } catch is CancellationError {
+                // sheet dismissed mid-diarization; nothing to do
+            } catch {
+                guard !Task.isCancelled else { return }
+                stopElapsedTimer()
+                stage = .error(error.localizedDescription)
+            }
+        }
+    }
+
+    private func handleNamingResult(
+        _ result: PipelineQueue.SpeakerNamingResult,
+        payload: NamingPayload,
+    ) {
+        switch result {
+        case let .confirmed(mapping):
+            guard let embeddings = payload.diarization.embeddings else {
+                stage = .error("Diarization produced no embeddings; cannot enroll.")
+                return
+            }
+            matcher.updateDB(
+                mapping: mapping,
+                embeddings: embeddings,
+                speakingTimes: payload.diarization.speakingTimes,
+            )
+            let saved = Set(mapping.values.filter { !$0.isEmpty }).sorted()
+            stage = .done(savedNames: saved)
+
+        case .skipped:
+            stage = .done(savedNames: [])
+
+        case let .rerun(count):
+            startDiarization(url: payload.url, numSpeakers: count)
+        }
+    }
+
+    private func buildNamingPayload(
+        url: URL, diarization: DiarizationResult,
+    ) -> NamingPayload {
+        let knownNames = matcher.allSpeakerNames()
+        // Pre-fill auto-name suggestions by running a match against the
+        // existing DB. Same flow as a real meeting.
+        let autoNames = diarization.embeddings.map { matcher.match(embeddings: $0) } ?? [:]
+        let mapping = autoNames.isEmpty
+            ? Dictionary(uniqueKeysWithValues: diarization.speakingTimes.keys.map { ($0, $0) })
+            : autoNames
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: url.lastPathComponent,
+            mapping: mapping,
+            speakingTimes: diarization.speakingTimes,
+            embeddings: diarization.embeddings ?? [:],
+            audioPath: url,
+            segments: diarization.segments,
+            participants: [],
+        )
+        let speakerCount = Set(diarization.segments.map(\.speaker)).count
+        return NamingPayload(
+            url: url,
+            diarization: diarization,
+            namingData: data,
+            knownNames: knownNames,
+            speakerCount: speakerCount,
+        )
+    }
+
+    // MARK: - Elapsed timer
+
+    private func startElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(500))
+                if let start = diarizeStart {
+                    elapsed = Date().timeIntervalSince(start)
+                }
+            }
+        }
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = nil
+    }
+}

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -1,0 +1,67 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+@MainActor
+final class VoiceEnrollmentViewTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var tmpDir: URL!
+    private var dbPath: URL!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VoiceEnrollmentViewTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        dbPath = tmpDir.appendingPathComponent("speakers.json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    func testRendersInPickFileStage() throws {
+        let view = VoiceEnrollmentView(
+            matcher: SpeakerMatcher(dbPath: dbPath),
+            diarizerFactory: { MockDiarization() },
+            onClose: {},
+        )
+        XCTAssertNoThrow(try view.inspect())
+    }
+
+    func testKnownVoicesViewShowsEnrollButtonWhenFactoryProvided() throws {
+        let view = KnownVoicesView(
+            matcher: SpeakerMatcher(dbPath: dbPath),
+            diarizerFactory: { MockDiarization() } as (() -> DiarizationProvider),
+        )
+        let inspected = try view.inspect()
+        XCTAssertNoThrow(try inspected.find(button: "Add from Recording…"))
+    }
+
+    func testKnownVoicesViewHidesEnrollButtonWhenNoFactory() throws {
+        let view = KnownVoicesView(matcher: SpeakerMatcher(dbPath: dbPath))
+        let inspected = try view.inspect()
+        XCTAssertThrowsError(try inspected.find(button: "Add from Recording…"))
+    }
+
+    func testKnownVoicesViewDisablesEnrollButtonWhenNamingDialogActive() throws {
+        let view = KnownVoicesView(
+            matcher: SpeakerMatcher(dbPath: dbPath),
+            diarizerFactory: { MockDiarization() },
+            namingDialogActive: true,
+        )
+        let inspected = try view.inspect()
+        let button = try inspected.find(button: "Add from Recording…")
+        XCTAssertTrue(try button.isDisabled())
+    }
+
+    func testKnownVoicesViewShowsBusyHintWhenPipelineBusy() throws {
+        let view = KnownVoicesView(
+            matcher: SpeakerMatcher(dbPath: dbPath),
+            diarizerFactory: { MockDiarization() },
+            pipelineBusy: true,
+        )
+        let inspected = try view.inspect()
+        XCTAssertNoThrow(try inspected.find(text: "Pipeline busy — diarization may be slower."))
+    }
+}


### PR DESCRIPTION
## Summary

Settings → Known Voices → **"Add from Recording…"** — a 3-stage sheet that:
1. Picks an audio file (or browses `~/Library/Application Support/MeetingTranscriber/recordings/`).
2. Diarizes it via the existing `FluidDiarizer`.
3. Reuses the existing `SpeakerNamingView` (with the live-filter chips from #132) to let the user name each cluster.
4. Persists embeddings + centroid through the same `SpeakerMatcher.updateDB(...)` path as a real meeting confirmation.

Solves: legacy speakers without centroids (~7 entries with `lastUsed=nil`, `centroidCount=0`) where auto-match probably won't trigger. After enrollment they have a real centroid right away — no need to wait for those people to show up in another meeting.

### Engine-independent

Never touches the ASR pipeline, only FluidAudio diarization. Works identically with WhisperKit / Parakeet / Qwen3.

### Concurrency / side effects

- `speakers.json` writes are `@MainActor`-serialised + atomic (`saveDB` writes via tmp + `replaceItemAt`). No race with active meeting confirmations.
- **Hard gate** the "Add from Recording…" button when `pipelineQueue.pendingSpeakerNaming != nil` — avoids two `SpeakerNamingView` instances colliding visually. Tooltip explains why.
- **Soft hint** when `pipelineQueue.isProcessing` — caption "Pipeline busy — diarization may be slower." Doesn't block.
- Sheet dismiss cancels the diarization `Task` and elapsed timer (no orphan FluidDiarizer kept alive).
- `.rerun(N)` from the naming dialog re-triggers diarization with that count, same as a real meeting.

### Code reuse

Everything except the orchestrator already existed:
- `FluidDiarizer.run(audioPath:numSpeakers:meetingTitle:)`
- `SpeakerNamingView` (no changes — the new "Speaker A" sheet just hosts an instance)
- `SpeakerMatcher.updateDB(mapping:embeddings:speakingTimes:)`

The new `NamingPayload` struct caches the matcher results once on entering the naming stage so they don't re-run on every SwiftUI re-render.

## Test plan

- [x] 5 ViewInspector tests: renders pick-file stage, button visible/hidden by factory, button disabled when naming-active, busy-hint shown when pipeline busy.
- [x] `swift test` — 0 non-snapshot failures.
- [x] `./scripts/lint.sh` — clean.
- [x] `/simplify` review pass — fixes: redundant sort, silent `.rerun` swallow, missing Task cancel on dismiss, recomputing matcher results in view body, gating the busy hint on enrollment availability.
- [x] Manual: pick `~/Library/Application Support/MeetingTranscriber/recordings/*_mix.wav` from a past meeting → name speakers → verify `speakers.json` reflects the new centroid + use count.
- [ ] Manual: open enrollment while a meeting's naming dialog is up → verify button is disabled with tooltip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->