### PR TITLE
fix(app): keep naming sidecar when window closes without confirm

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -164,12 +164,10 @@ struct SpeakerNamingView: View {
             names = Self.computeInitialNames(speakers: speakers)
             rerunCount = max(2, speakers.count + 1)
         }
-        .onDisappear {
-            if !completed {
-                completed = true
-                onComplete(.skipped)
-            }
-        }
+        // No onDisappear → .skipped: in the non-blocking architecture closing
+        // the window (Cmd+Q, click X, app quit) leaves the job in
+        // .speakerNamingPending so the user can re-open later. Explicit Skip
+        // button still calls onComplete(.skipped).
     }
 
     private func speakerRow(


### PR DESCRIPTION
Follow-up to #108. The onDisappear → .skipped handler was a leftover from the pre-#108 blocking architecture and slipped out of the rebase squash. Without this fix, Cmd+Q before confirming a meeting routed through `removeNamingData` and deleted the `_naming.json` sidecar, so the next app launch had nothing to restore and the "re-openable dialog" feature was broken for any unsaved exit.

## What changed

- Removed the `onDisappear { onComplete(.skipped) }` block.
- Explicit Skip button still works.
- Closing the window (Cmd+Q, click X, app quit) now leaves the job in `.speakerNamingPending`, sidecars survive, dialog auto-popups on next launch.

## Test plan

- [x] `swift test` — 0 non-snapshot failures
- [x] `./scripts/lint.sh` — clean
- [x] Manual: meeting → dialog → Cmd+Q without confirming → restart → dialog reappears with the same speakers (verified locally)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->