### PR TITLE
feat(app): debug RPC server skeleton with /state endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
             app/MeetingTranscriber/Tests \
             tools/audiotap/Sources \
             tools/meeting-simulator/Sources \
+            tools/mt-cli/Sources \
+            tools/mt-cli/Tests \
             scripts/generate_menu_bar_gifs.swift
       - name: SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -45,6 +45,12 @@ final class AppState {
     var selectedNamingJobID: UUID?
     var permissionHealth: HealthCheckResult?
 
+    #if !APPSTORE
+        /// Lazy-started debug RPC server. Only constructed if the env var is
+        /// set — otherwise `nil` and zero overhead.
+        var debugRPCServer: DebugRPCServer?
+    #endif
+
     // MARK: - Init
 
     init(
@@ -66,7 +72,44 @@ final class AppState {
         self.notifier = notifier
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
+        #if !APPSTORE
+            if DebugRPCServer.enabled {
+                let server = DebugRPCServer { [weak self] in
+                    self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
+                }
+                server.start()
+                self.debugRPCServer = server
+            }
+        #endif
     }
+
+    #if !APPSTORE
+        /// Build a snapshot of state for the debug RPC. Read-only.
+        func rpcStateSnapshot() -> RPCStateSnapshot {
+            let stored = SpeakerMatcher().loadDB()
+            let recentNames = SpeakerMatcher.rankByRecency(speakers: stored)
+                .prefix(10).map(\.name)
+            let pendingJobs = pipelineQueue.pendingSpeakerNamingJobs.map { job in
+                let data = pipelineQueue.speakerNamingDataByJob[job.id]
+                return RPCStateSnapshot.PendingNaming(
+                    jobID: job.id.uuidString,
+                    meetingTitle: job.meetingTitle,
+                    speakerCount: data?.mapping.count ?? 0,
+                    namingSlug: job.namingSlug,
+                )
+            }
+            return RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: pipelineQueue.isProcessing,
+                    activeJobCount: pipelineQueue.activeJobs.count,
+                    waitingJobCount: pipelineQueue.pendingJobs.count,
+                    pendingNamingJobCount: pendingJobs.count,
+                ),
+                speakerDB: .init(count: stored.count, recentNames: recentNames),
+                pendingNamingJobs: pendingJobs,
+            )
+        }
+    #endif
 
     /// The active transcription engine based on the current settings.
     var activeTranscriptionEngine: any TranscribingEngine {

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -1,4 +1,5 @@
 #if !APPSTORE
+    import AppKit
     import Foundation
     import Network
     import os.log
@@ -144,8 +145,42 @@
             case ("GET", "/healthz"):
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
 
+            case ("GET", "/screenshot"):
+                if let png = Self.captureFrontmostWindowPNG() {
+                    return HTTPResponse.ok(body: png, contentType: "image/png")
+                }
+                return HTTPResponse(
+                    status: 503, reason: "Service Unavailable",
+                    body: Data("no window\n".utf8), contentType: "text/plain",
+                )
+
             default:
                 return HTTPResponse.notFound()
+            }
+        }
+
+        // MARK: - Screenshot
+
+        /// PNG of the app's frontmost window, or nil if no window is visible.
+        /// Uses the in-process NSWindow → bitmap path; no Screen Recording
+        /// permission needed (the app captures itself).
+        nonisolated static func captureFrontmostWindowPNG() -> Data? {
+            // Hop to the main thread synchronously — NSApp/NSWindow are
+            // main-thread-only and the receive() handler already lives there,
+            // but `nonisolated static` means callers from tests or background
+            // contexts can also reach this safely.
+            MainActor.assumeIsolated {
+                // NSApplication.shared lazily inits NSApp; access it first so
+                // headless test runs don't crash on the implicit-unwrap NSApp.
+                let app = NSApplication.shared
+                guard let window = app.keyWindow ?? app.windows.first(where: \.isVisible) else {
+                    return nil
+                }
+                guard let view = window.contentView,
+                      let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds)
+                else { return nil }
+                view.cacheDisplay(in: view.bounds, to: rep)
+                return rep.representation(using: .png, properties: [:])
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -9,16 +9,22 @@
     /// Gated by `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var; never started in
     /// production builds (the `#if !APPSTORE` wraps the whole file).
     ///
-    /// Bind: `127.0.0.1:9876`. No auth — relies on the loopback interface
-    /// being trusted (anyone with shell access on this box can already read
-    /// the underlying state files).
+    /// Bind: `127.0.0.1:9876`. Two layers of defense:
+    /// - Origin-header reject blocks browser CSRF / DNS-rebinding (`fetch()` from a
+    ///   page on the user's machine sends Origin; curl and native CLIs don't).
+    /// - Bearer-token auth read from `~/Library/Application Support/MeetingTranscriber/.rpc-token`
+    ///   (chmod 0600) keeps other local users on a shared Mac out and adds
+    ///   defense-in-depth against compromised processes that lack read access
+    ///   to the user's data dir.
     @MainActor
     final class DebugRPCServer {
         nonisolated static let envVar = "MEETINGTRANSCRIBER_DEBUG_RPC"
         nonisolated static let defaultPort: UInt16 = 9876
+        nonisolated static let tokenFileURL = AppPaths.dataDir.appendingPathComponent(".rpc-token")
 
         private let port: NWEndpoint.Port
         private let snapshot: () -> RPCStateSnapshot
+        private let expectedAuth: String
         private var listener: NWListener?
 
         /// True when the env flag is set. Use this from `AppState` to decide
@@ -27,13 +33,45 @@
             ProcessInfo.processInfo.environment[envVar] == "1"
         }
 
-        init(port: UInt16 = DebugRPCServer.defaultPort, snapshot: @escaping () -> RPCStateSnapshot) {
-            // 9876 is a known-valid port literal; if a caller passes 0 the
-            // listener picks a free port at bind time and we just need a
-            // non-nil placeholder until then.
-            let parsed = NWEndpoint.Port(rawValue: port == 0 ? 9876 : port)
-            self.port = parsed ?? NWEndpoint.Port.any
+        init(
+            port: UInt16 = DebugRPCServer.defaultPort,
+            token: String = DebugRPCServer.loadOrCreateToken(),
+            snapshot: @escaping () -> RPCStateSnapshot,
+        ) {
+            self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
+            self.expectedAuth = "Bearer \(token)"
             self.snapshot = snapshot
+        }
+
+        /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
+        /// Reuses an existing non-empty file so `mt-cli` survives across launches.
+        nonisolated static func loadOrCreateToken() -> String {
+            let url = tokenFileURL
+            if let data = try? Data(contentsOf: url),
+               let existing = String(data: data, encoding: .utf8)?
+               .trimmingCharacters(in: .whitespacesAndNewlines),
+               !existing.isEmpty {
+                return existing
+            }
+            var bytes = [UInt8](repeating: 0, count: 32)
+            // SecRandomCopyBytes returning non-zero means the buffer is
+            // unmodified (all zeros) — refuse to write that as a token.
+            guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+                logger.error("DebugRPCServer: SecRandomCopyBytes failed; using UUID fallback")
+                return UUID().uuidString
+            }
+            let token = bytes.map { String(format: "%02x", $0) }.joined()
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true,
+            )
+            // createFile with .posixPermissions sets mode at creation time —
+            // avoids the brief 0644 window that a write-then-chmod sequence has.
+            FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data(token.utf8),
+                attributes: [.posixPermissions: 0o600],
+            )
+            return token
         }
 
         /// Start listening. Failures (port in use, etc.) are logged and the
@@ -91,6 +129,13 @@
         // MARK: - Routing
 
         func route(_ request: HTTPRequest) -> HTTPResponse {
+            if let origin = request.headers["origin"], !origin.isEmpty, origin != "null" {
+                return HTTPResponse.forbidden()
+            }
+            guard request.headers["authorization"] == expectedAuth else {
+                return HTTPResponse.unauthorized()
+            }
+
             switch (request.method, request.path) {
             case ("GET", "/state"):
                 let json = try? snapshot().jsonData()
@@ -110,7 +155,15 @@
     struct HTTPRequest: Equatable {
         let method: String
         let path: String
+        let headers: [String: String]
         let body: Data
+
+        init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+            self.method = method
+            self.path = path
+            self.headers = headers
+            self.body = body
+        }
 
         static func parse(_ data: Data) -> Self? {
             // Need a complete header section before we can parse — the body
@@ -126,22 +179,21 @@
             let method = String(parts[0])
             let path = String(parts[1])
 
-            var contentLength = 0
+            var headers: [String: String] = [:]
             for line in lines.dropFirst() {
                 let pieces = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true)
                 guard pieces.count == 2 else { continue }
                 let key = pieces[0].trimmingCharacters(in: .whitespaces).lowercased()
                 let value = pieces[1].trimmingCharacters(in: .whitespaces)
-                if key == "content-length", let n = Int(value) {
-                    contentLength = n
-                }
+                headers[key] = value
             }
 
+            let contentLength = headers["content-length"].flatMap(Int.init) ?? 0
             let bodyStart = separatorRange.upperBound
             let availableBody = data.count - bodyStart
             guard availableBody >= contentLength else { return nil }
             let body = data.subdata(in: bodyStart ..< bodyStart + contentLength)
-            return Self(method: method, path: path, body: body)
+            return Self(method: method, path: path, headers: headers, body: body)
         }
     }
 
@@ -157,6 +209,14 @@
 
         static func notFound() -> Self {
             Self(status: 404, reason: "Not Found", body: Data(), contentType: "text/plain")
+        }
+
+        static func unauthorized() -> Self {
+            Self(status: 401, reason: "Unauthorized", body: Data(), contentType: "text/plain")
+        }
+
+        static func forbidden() -> Self {
+            Self(status: 403, reason: "Forbidden", body: Data(), contentType: "text/plain")
         }
 
         func serialize() -> Data {

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -23,13 +23,19 @@
         nonisolated static let defaultPort: UInt16 = 9876
         nonisolated static let tokenFileURL = AppPaths.dataDir.appendingPathComponent(".rpc-token")
 
+        /// Cap accumulated bytes per connection so a misbehaving client
+        /// streaming bytes without `\r\n\r\n` can't OOM the app.
+        private static let maxRequestBytes = 64 * 1024
+
+        /// Skip status-item-style windows. The menu-bar `keyWindow` at idle is a
+        /// 68×66 invisible rect — capturing it returns useless white pixels.
+        private static let minWindowAreaPx: CGFloat = 10000
+
         private let port: NWEndpoint.Port
         private let snapshot: () -> RPCStateSnapshot
         private let expectedAuth: String
         private var listener: NWListener?
 
-        /// True when the env flag is set. Use this from `AppState` to decide
-        /// whether to construct + start a server at all.
         nonisolated static var enabled: Bool {
             ProcessInfo.processInfo.environment[envVar] == "1"
         }
@@ -112,7 +118,10 @@
                     }
                     var buffer = accumulated
                     if let data { buffer.append(data) }
-                    // Wait for the full request line + headers (terminator \r\n\r\n)
+                    if buffer.count > Self.maxRequestBytes {
+                        connection.cancel()
+                        return
+                    }
                     if let request = HTTPRequest.parse(buffer) {
                         let response = self.route(request)
                         connection.send(content: response.serialize(), completion: .contentProcessed { _ in
@@ -145,6 +154,14 @@
             case ("GET", "/healthz"):
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
 
+            case ("POST", "/action/openSettings"):
+                Self.openSettings()
+                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+
+            case ("POST", "/action/closeSettings"):
+                Self.closeSettings()
+                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+
             case ("GET", "/screenshot"):
                 if let png = Self.captureFrontmostWindowPNG() {
                     return HTTPResponse.ok(body: png, contentType: "image/png")
@@ -159,29 +176,48 @@
             }
         }
 
+        // MARK: - Actions
+
+        /// Open the Settings window. Mirrors the menu-bar path:
+        /// the @main scene listens for `.showSettings` and calls `bringWindowToFront`.
+        @MainActor
+        static func openSettings() {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            NotificationCenter.default.post(name: .showSettings, object: nil)
+        }
+
+        /// Fire-and-forget close. SwiftUI no-ops when the window isn't open.
+        @MainActor
+        static func closeSettings() {
+            NotificationCenter.default.post(name: .closeSettings, object: nil)
+        }
+
         // MARK: - Screenshot
 
-        /// PNG of the app's frontmost window, or nil if no window is visible.
-        /// Uses the in-process NSWindow → bitmap path; no Screen Recording
-        /// permission needed (the app captures itself).
-        nonisolated static func captureFrontmostWindowPNG() -> Data? {
-            // Hop to the main thread synchronously — NSApp/NSWindow are
-            // main-thread-only and the receive() handler already lives there,
-            // but `nonisolated static` means callers from tests or background
-            // contexts can also reach this safely.
-            MainActor.assumeIsolated {
-                // NSApplication.shared lazily inits NSApp; access it first so
-                // headless test runs don't crash on the implicit-unwrap NSApp.
-                let app = NSApplication.shared
-                guard let window = app.keyWindow ?? app.windows.first(where: \.isVisible) else {
-                    return nil
-                }
-                guard let view = window.contentView,
-                      let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds)
-                else { return nil }
-                view.cacheDisplay(in: view.bounds, to: rep)
-                return rep.representation(using: .png, properties: [:])
+        /// PNG of the largest visible content window, or nil when none qualifies.
+        /// The app captures itself, so no Screen Recording permission is needed.
+        @MainActor
+        static func captureFrontmostWindowPNG() -> Data? {
+            let app = NSApplication.shared
+            let area: (NSWindow) -> CGFloat = { window in
+                let b = window.contentView?.bounds ?? .zero
+                return b.width * b.height
             }
+            let candidate = app.windows
+                .filter { $0.isVisible && $0.contentView != nil }
+                .max { area($0) < area($1) }
+            guard let window = candidate, area(window) >= minWindowAreaPx else { return nil }
+            // CGWindowListCreateImage composites real SwiftUI/Metal content;
+            // NSView.cacheDisplay produces blank PNGs for layer-backed views.
+            let windowID = CGWindowID(window.windowNumber)
+            guard let cgImage = CGWindowListCreateImage(
+                .null,
+                .optionIncludingWindow,
+                windowID,
+                [.bestResolution, .boundsIgnoreFraming],
+            ) else { return nil }
+            let rep = NSBitmapImageRep(cgImage: cgImage)
+            return rep.representation(using: .png, properties: [:])
         }
     }
 
@@ -201,8 +237,6 @@
         }
 
         static func parse(_ data: Data) -> Self? {
-            // Need a complete header section before we can parse — the body
-            // length is in Content-Length.
             let separator = Data("\r\n\r\n".utf8)
             guard let separatorRange = data.range(of: separator) else { return nil }
             let headerData = data.subdata(in: 0 ..< separatorRange.lowerBound)
@@ -268,8 +302,8 @@
 
     // MARK: - State snapshot
 
-    /// JSON-serialisable snapshot of the bits of app state useful for shell
-    /// inspection. Kept deliberately minimal — extend as endpoints need it.
+    /// JSON-serialisable snapshot of state useful for shell inspection.
+    /// Deliberately minimal — extend as endpoints need it.
     struct RPCStateSnapshot: Codable {
         let pipeline: Pipeline
         let speakerDB: SpeakerDB
@@ -284,7 +318,6 @@
 
         struct SpeakerDB: Codable {
             let count: Int
-            /// Top-N most recently used names — useful to confirm a confirm hit DB.
             let recentNames: [String]
         }
 

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -1,0 +1,218 @@
+#if !APPSTORE
+    import Foundation
+    import Network
+    import os.log
+
+    private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "DebugRPCServer")
+
+    /// Local-only HTTP server that exposes app state for shell-driven inspection.
+    /// Gated by `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var; never started in
+    /// production builds (the `#if !APPSTORE` wraps the whole file).
+    ///
+    /// Bind: `127.0.0.1:9876`. No auth — relies on the loopback interface
+    /// being trusted (anyone with shell access on this box can already read
+    /// the underlying state files).
+    @MainActor
+    final class DebugRPCServer {
+        nonisolated static let envVar = "MEETINGTRANSCRIBER_DEBUG_RPC"
+        nonisolated static let defaultPort: UInt16 = 9876
+
+        private let port: NWEndpoint.Port
+        private let snapshot: () -> RPCStateSnapshot
+        private var listener: NWListener?
+
+        /// True when the env flag is set. Use this from `AppState` to decide
+        /// whether to construct + start a server at all.
+        nonisolated static var enabled: Bool {
+            ProcessInfo.processInfo.environment[envVar] == "1"
+        }
+
+        init(port: UInt16 = DebugRPCServer.defaultPort, snapshot: @escaping () -> RPCStateSnapshot) {
+            // 9876 is a known-valid port literal; if a caller passes 0 the
+            // listener picks a free port at bind time and we just need a
+            // non-nil placeholder until then.
+            let parsed = NWEndpoint.Port(rawValue: port == 0 ? 9876 : port)
+            self.port = parsed ?? NWEndpoint.Port.any
+            self.snapshot = snapshot
+        }
+
+        /// Start listening. Failures (port in use, etc.) are logged and the
+        /// server stays down — the app still functions normally.
+        func start() {
+            guard listener == nil else { return }
+            do {
+                let params = NWParameters.tcp
+                params.acceptLocalOnly = true
+                let listener = try NWListener(using: params, on: port)
+                listener.newConnectionHandler = { [weak self] connection in
+                    Task { @MainActor in self?.handle(connection) }
+                }
+                listener.start(queue: .main)
+                self.listener = listener
+                logger.info("DebugRPCServer listening on 127.0.0.1:\(self.port.rawValue, privacy: .public)")
+            } catch {
+                logger.error("DebugRPCServer failed to start: \(error.localizedDescription)")
+            }
+        }
+
+        // MARK: - Connection handling
+
+        private func handle(_ connection: NWConnection) {
+            connection.start(queue: .main)
+            receive(connection: connection, accumulated: Data())
+        }
+
+        private func receive(connection: NWConnection, accumulated: Data) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, isComplete, error in
+                Task { @MainActor in
+                    guard let self else { return }
+                    if let error {
+                        logger.warning("RPC connection error: \(error.localizedDescription)")
+                        connection.cancel()
+                        return
+                    }
+                    var buffer = accumulated
+                    if let data { buffer.append(data) }
+                    // Wait for the full request line + headers (terminator \r\n\r\n)
+                    if let request = HTTPRequest.parse(buffer) {
+                        let response = self.route(request)
+                        connection.send(content: response.serialize(), completion: .contentProcessed { _ in
+                            connection.cancel()
+                        })
+                    } else if isComplete {
+                        connection.cancel()
+                    } else {
+                        self.receive(connection: connection, accumulated: buffer)
+                    }
+                }
+            }
+        }
+
+        // MARK: - Routing
+
+        func route(_ request: HTTPRequest) -> HTTPResponse {
+            switch (request.method, request.path) {
+            case ("GET", "/state"):
+                let json = try? snapshot().jsonData()
+                return HTTPResponse.ok(body: json ?? Data(), contentType: "application/json")
+
+            case ("GET", "/healthz"):
+                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+
+            default:
+                return HTTPResponse.notFound()
+            }
+        }
+    }
+
+    // MARK: - HTTP types
+
+    struct HTTPRequest: Equatable {
+        let method: String
+        let path: String
+        let body: Data
+
+        static func parse(_ data: Data) -> Self? {
+            // Need a complete header section before we can parse — the body
+            // length is in Content-Length.
+            let separator = Data("\r\n\r\n".utf8)
+            guard let separatorRange = data.range(of: separator) else { return nil }
+            let headerData = data.subdata(in: 0 ..< separatorRange.lowerBound)
+            guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
+            let lines = headerString.components(separatedBy: "\r\n")
+            guard let requestLine = lines.first else { return nil }
+            let parts = requestLine.split(separator: " ")
+            guard parts.count >= 2 else { return nil }
+            let method = String(parts[0])
+            let path = String(parts[1])
+
+            var contentLength = 0
+            for line in lines.dropFirst() {
+                let pieces = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true)
+                guard pieces.count == 2 else { continue }
+                let key = pieces[0].trimmingCharacters(in: .whitespaces).lowercased()
+                let value = pieces[1].trimmingCharacters(in: .whitespaces)
+                if key == "content-length", let n = Int(value) {
+                    contentLength = n
+                }
+            }
+
+            let bodyStart = separatorRange.upperBound
+            let availableBody = data.count - bodyStart
+            guard availableBody >= contentLength else { return nil }
+            let body = data.subdata(in: bodyStart ..< bodyStart + contentLength)
+            return Self(method: method, path: path, body: body)
+        }
+    }
+
+    struct HTTPResponse {
+        let status: Int
+        let reason: String
+        let body: Data
+        let contentType: String
+
+        static func ok(body: Data, contentType: String) -> Self {
+            Self(status: 200, reason: "OK", body: body, contentType: contentType)
+        }
+
+        static func notFound() -> Self {
+            Self(status: 404, reason: "Not Found", body: Data(), contentType: "text/plain")
+        }
+
+        func serialize() -> Data {
+            var response = "HTTP/1.1 \(status) \(reason)\r\n"
+            response += "Content-Type: \(contentType)\r\n"
+            response += "Content-Length: \(body.count)\r\n"
+            response += "Connection: close\r\n"
+            response += "\r\n"
+            var out = Data(response.utf8)
+            out.append(body)
+            return out
+        }
+    }
+
+    // MARK: - State snapshot
+
+    /// JSON-serialisable snapshot of the bits of app state useful for shell
+    /// inspection. Kept deliberately minimal — extend as endpoints need it.
+    struct RPCStateSnapshot: Codable {
+        let pipeline: Pipeline
+        let speakerDB: SpeakerDB
+        let pendingNamingJobs: [PendingNaming]
+
+        struct Pipeline: Codable {
+            let isProcessing: Bool
+            let activeJobCount: Int
+            let waitingJobCount: Int
+            let pendingNamingJobCount: Int
+        }
+
+        struct SpeakerDB: Codable {
+            let count: Int
+            /// Top-N most recently used names — useful to confirm a confirm hit DB.
+            let recentNames: [String]
+        }
+
+        struct PendingNaming: Codable {
+            let jobID: String
+            let meetingTitle: String
+            let speakerCount: Int
+            let namingSlug: String?
+        }
+
+        func jsonData() throws -> Data {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            return try encoder.encode(self)
+        }
+
+        static let empty = Self(
+            pipeline: .init(
+                isProcessing: false, activeJobCount: 0,
+                waitingJobCount: 0, pendingNamingJobCount: 0,
+            ),
+            speakerDB: .init(count: 0, recentNames: []),
+            pendingNamingJobs: [],
+        )
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -35,6 +35,9 @@
         private let snapshot: () -> RPCStateSnapshot
         private let expectedAuth: String
         private var listener: NWListener?
+        /// OS-assigned port once the listener is `.ready`. Useful for tests
+        /// that bind to port 0 and need to know where to connect back.
+        private(set) var boundPort: UInt16?
 
         nonisolated static var enabled: Bool {
             ProcessInfo.processInfo.environment[envVar] == "1"
@@ -91,6 +94,10 @@
                 let listener = try NWListener(using: params, on: port)
                 listener.newConnectionHandler = { [weak self] connection in
                     Task { @MainActor in self?.handle(connection) }
+                }
+                listener.stateUpdateHandler = { [weak self] state in
+                    guard case .ready = state, let self else { return }
+                    Task { @MainActor in self.boundPort = listener.port?.rawValue }
                 }
                 listener.start(queue: .main)
                 self.listener = listener

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -5,6 +5,8 @@ import UniformTypeIdentifiers
 extension Notification.Name {
     static let autoWatchStart = Notification.Name("autoWatchStart")
     static let showSpeakerNaming = Notification.Name("showSpeakerNaming")
+    static let showSettings = Notification.Name("showSettings")
+    static let closeSettings = Notification.Name("closeSettings")
 }
 
 @main
@@ -75,6 +77,12 @@ struct MeetingTranscriberApp: App {
             }
             .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
                 bringWindowToFront(id: "speaker-naming")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .showSettings)) { _ in
+                bringWindowToFront(id: "settings")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .closeSettings)) { _ in
+                closeWindow(id: "settings")
             }
             .task {
                 switch appState.settings.transcriptionEngine {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -1,0 +1,131 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Real socket roundtrips: build a server, hit it via URLSession on the
+    /// OS-assigned port, assert the response. Catches what the unit tests
+    /// can't — actual NWListener wiring, header bytes on the wire, the
+    /// receive() loop's framing logic.
+    @MainActor
+    final class DebugRPCServerIntegrationTests: XCTestCase {
+        private static let testToken = "integration-token-deadbeef"
+        private var server: DebugRPCServer?
+
+        override func setUp() async throws {
+            try await super.setUp()
+            server = nil
+        }
+
+        override func tearDown() async throws {
+            // Listener cancellation is fire-and-forget — give Network.framework
+            // a beat to release the port before the next test binds.
+            server = nil
+            try await Task.sleep(for: .milliseconds(50))
+            try await super.tearDown()
+        }
+
+        // MARK: - Setup
+
+        private func startServer(snapshot: RPCStateSnapshot = .empty) async throws -> URL {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
+            self.server = server
+            server.start()
+            // Wait for the listener's stateUpdateHandler to populate boundPort.
+            for _ in 0 ..< 50 {
+                if let port = server.boundPort,
+                   let url = URL(string: "http://127.0.0.1:\(port)") {
+                    return url
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            throw XCTestError(.timeoutWhileWaiting)
+        }
+
+        private func request(_ method: String, _ url: URL, headers: [String: String] = [:]) -> URLRequest {
+            var req = URLRequest(url: url)
+            req.httpMethod = method
+            for (k, v) in headers {
+                req.setValue(v, forHTTPHeaderField: k)
+            }
+            return req
+        }
+
+        private var authHeader: [String: String] {
+            ["Authorization": "Bearer \(Self.testToken)"]
+        }
+
+        // MARK: - Tests
+
+        func testHealthzRoundtripWithAuth() async throws {
+            let base = try await startServer()
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("healthz"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual(String(data: data, encoding: .utf8), "ok\n")
+        }
+
+        func testMissingAuthReturns401() async throws {
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("healthz")),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 401)
+        }
+
+        func testBrowserOriginReturns403() async throws {
+            let base = try await startServer()
+            var headers = authHeader
+            headers["Origin"] = "http://evil.example"
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("healthz"), headers: headers),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 403)
+        }
+
+        func testStateReturnsValidJSON() async throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(isProcessing: true, activeJobCount: 2, waitingJobCount: 0, pendingNamingJobCount: 1),
+                speakerDB: .init(count: 7, recentNames: ["Alice"]),
+                pendingNamingJobs: [],
+            )
+            let base = try await startServer(snapshot: snapshot)
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("state"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: data)
+            XCTAssertEqual(decoded.pipeline.activeJobCount, 2)
+            XCTAssertEqual(decoded.speakerDB.count, 7)
+        }
+
+        func testOpenSettingsReturns200() async throws {
+            // The notification fires into a test process with no SwiftUI
+            // scenes, so it's a no-op; we only verify the route plumbs through
+            // and the response is well-formed.
+            let base = try await startServer()
+            let (data, response) = try await URLSession.shared.data(
+                for: request("POST", base.appendingPathComponent("action/openSettings"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual(String(data: data, encoding: .utf8), "ok\n")
+        }
+
+        func testUnknownPathReturns404() async throws {
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("nope"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testScreenshotIdleReturns503() async throws {
+            // No SwiftUI scene → no window meets minWindowAreaPx → 503.
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("screenshot"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 503)
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -103,6 +103,15 @@
         }
 
         @MainActor
+        func testRouteScreenshotNoWindowReturns503() {
+            // Tests run headless — NSApp has no visible window, so the
+            // capture helper returns nil and the route maps to 503.
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(authedRequest(method: "GET", path: "/screenshot"))
+            XCTAssertEqual(response.status, 503)
+        }
+
+        @MainActor
         func testRouteUnknown() {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
             let response = server.route(authedRequest(method: "GET", path: "/nope"))

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -103,6 +103,23 @@
         }
 
         @MainActor
+        func testRouteOpenSettingsReturnsOk() {
+            // The actual AppKit selector is a no-op in the test harness (no
+            // Settings scene declared); we only verify the route plumbs through.
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(authedRequest(method: "POST", path: "/action/openSettings"))
+            XCTAssertEqual(response.status, 200)
+        }
+
+        @MainActor
+        func testRouteCloseSettingsReturnsOk() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(authedRequest(method: "POST", path: "/action/closeSettings"))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
+        }
+
+        @MainActor
         func testRouteScreenshotNoWindowReturns503() {
             // Tests run headless — NSApp has no visible window, so the
             // capture helper returns nil and the route maps to 503.

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -1,0 +1,110 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    final class DebugRPCServerTests: XCTestCase {
+        // MARK: - HTTPRequest parsing
+
+        func testParseGet() {
+            let raw = Data("GET /state HTTP/1.1\r\nHost: localhost\r\n\r\n".utf8)
+            let req = HTTPRequest.parse(raw)
+            XCTAssertEqual(req?.method, "GET")
+            XCTAssertEqual(req?.path, "/state")
+            XCTAssertEqual(req?.body.count, 0)
+        }
+
+        func testParsePostWithBody() {
+            let raw = Data("POST /action/click HTTP/1.1\r\nContent-Length: 13\r\n\r\n{\"id\":\"foo\"}\n".utf8)
+            let req = HTTPRequest.parse(raw)
+            XCTAssertEqual(req?.method, "POST")
+            XCTAssertEqual(req?.path, "/action/click")
+            XCTAssertEqual(req?.body.count, 13)
+        }
+
+        func testParseIncompleteHeaderReturnsNil() {
+            // No \r\n\r\n yet — parse must wait.
+            let raw = Data("GET /state HTTP/1.1\r\n".utf8)
+            XCTAssertNil(HTTPRequest.parse(raw))
+        }
+
+        func testParseIncompleteBodyReturnsNil() {
+            // Content-Length says 50 but only 5 body bytes present.
+            let raw = Data("POST /x HTTP/1.1\r\nContent-Length: 50\r\n\r\nhello".utf8)
+            XCTAssertNil(HTTPRequest.parse(raw))
+        }
+
+        // MARK: - HTTPResponse serialization
+
+        func testResponseShape() {
+            let body = Data("{}".utf8)
+            let resp = HTTPResponse.ok(body: body, contentType: "application/json")
+            let raw = resp.serialize()
+            let s = String(data: raw, encoding: .utf8) ?? ""
+            XCTAssertTrue(s.hasPrefix("HTTP/1.1 200 OK\r\n"))
+            XCTAssertTrue(s.contains("Content-Type: application/json\r\n"))
+            XCTAssertTrue(s.contains("Content-Length: 2\r\n"))
+            XCTAssertTrue(s.hasSuffix("\r\n\r\n{}"))
+        }
+
+        func testNotFoundShape() {
+            let resp = HTTPResponse.notFound()
+            let s = String(data: resp.serialize(), encoding: .utf8) ?? ""
+            XCTAssertTrue(s.hasPrefix("HTTP/1.1 404 Not Found\r\n"))
+            XCTAssertTrue(s.contains("Content-Length: 0\r\n"))
+        }
+
+        // MARK: - Routing
+
+        @MainActor
+        func testRouteState() {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(isProcessing: false, activeJobCount: 1, waitingJobCount: 0, pendingNamingJobCount: 0),
+                speakerDB: .init(count: 5, recentNames: ["Speaker A"]),
+                pendingNamingJobs: [],
+            )
+            let server = DebugRPCServer(port: 0) { snapshot }
+            let response = server.route(HTTPRequest(method: "GET", path: "/state", body: Data()))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(response.contentType, "application/json")
+            let decoded = try? JSONDecoder().decode(RPCStateSnapshot.self, from: response.body)
+            XCTAssertEqual(decoded?.pipeline.activeJobCount, 1)
+            XCTAssertEqual(decoded?.speakerDB.count, 5)
+        }
+
+        @MainActor
+        func testRouteHealthz() {
+            let server = DebugRPCServer(port: 0) { .empty }
+            let response = server.route(HTTPRequest(method: "GET", path: "/healthz", body: Data()))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
+        }
+
+        @MainActor
+        func testRouteUnknown() {
+            let server = DebugRPCServer(port: 0) { .empty }
+            let response = server.route(HTTPRequest(method: "GET", path: "/nope", body: Data()))
+            XCTAssertEqual(response.status, 404)
+        }
+
+        // MARK: - Enabled gate
+
+        func testEnabledFollowsEnvVar() {
+            // The runtime env value is whatever launched this test process —
+            // assert the API works rather than a specific value.
+            let value = ProcessInfo.processInfo.environment[DebugRPCServer.envVar]
+            XCTAssertEqual(DebugRPCServer.enabled, value == "1")
+        }
+
+        // MARK: - Snapshot JSON
+
+        func testSnapshotEncodesPretty() throws {
+            let snap = RPCStateSnapshot.empty
+            let data = try snap.jsonData()
+            let s = String(data: data, encoding: .utf8) ?? ""
+            // Pretty-printed → contains newlines + sorted keys.
+            XCTAssertTrue(s.contains("\n"))
+            XCTAssertTrue(s.contains("\"pipeline\""))
+            XCTAssertTrue(s.contains("\"speakerDB\""))
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -3,6 +3,9 @@
     import XCTest
 
     final class DebugRPCServerTests: XCTestCase {
+        private static let testToken = "testtoken1234"
+        private static let authHeaders: [String: String] = ["authorization": "Bearer \(testToken)"]
+
         // MARK: - HTTPRequest parsing
 
         func testParseGet() {
@@ -11,6 +14,7 @@
             XCTAssertEqual(req?.method, "GET")
             XCTAssertEqual(req?.path, "/state")
             XCTAssertEqual(req?.body.count, 0)
+            XCTAssertEqual(req?.headers["host"], "localhost")
         }
 
         func testParsePostWithBody() {
@@ -19,6 +23,15 @@
             XCTAssertEqual(req?.method, "POST")
             XCTAssertEqual(req?.path, "/action/click")
             XCTAssertEqual(req?.body.count, 13)
+        }
+
+        func testParseExtractsHeadersLowercase() {
+            let raw = Data(
+                "GET / HTTP/1.1\r\nOrigin: http://evil.example\r\nAuthorization: Bearer x\r\n\r\n".utf8,
+            )
+            let req = HTTPRequest.parse(raw)
+            XCTAssertEqual(req?.headers["origin"], "http://evil.example")
+            XCTAssertEqual(req?.headers["authorization"], "Bearer x")
         }
 
         func testParseIncompleteHeaderReturnsNil() {
@@ -53,6 +66,16 @@
             XCTAssertTrue(s.contains("Content-Length: 0\r\n"))
         }
 
+        func testUnauthorizedShape() {
+            let s = String(data: HTTPResponse.unauthorized().serialize(), encoding: .utf8) ?? ""
+            XCTAssertTrue(s.hasPrefix("HTTP/1.1 401 Unauthorized\r\n"))
+        }
+
+        func testForbiddenShape() {
+            let s = String(data: HTTPResponse.forbidden().serialize(), encoding: .utf8) ?? ""
+            XCTAssertTrue(s.hasPrefix("HTTP/1.1 403 Forbidden\r\n"))
+        }
+
         // MARK: - Routing
 
         @MainActor
@@ -62,8 +85,8 @@
                 speakerDB: .init(count: 5, recentNames: ["Speaker A"]),
                 pendingNamingJobs: [],
             )
-            let server = DebugRPCServer(port: 0) { snapshot }
-            let response = server.route(HTTPRequest(method: "GET", path: "/state", body: Data()))
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
+            let response = server.route(authedRequest(method: "GET", path: "/state"))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(response.contentType, "application/json")
             let decoded = try? JSONDecoder().decode(RPCStateSnapshot.self, from: response.body)
@@ -73,17 +96,57 @@
 
         @MainActor
         func testRouteHealthz() {
-            let server = DebugRPCServer(port: 0) { .empty }
-            let response = server.route(HTTPRequest(method: "GET", path: "/healthz", body: Data()))
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(authedRequest(method: "GET", path: "/healthz"))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
         }
 
         @MainActor
         func testRouteUnknown() {
-            let server = DebugRPCServer(port: 0) { .empty }
-            let response = server.route(HTTPRequest(method: "GET", path: "/nope", body: Data()))
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(authedRequest(method: "GET", path: "/nope"))
             XCTAssertEqual(response.status, 404)
+        }
+
+        // MARK: - Security
+
+        @MainActor
+        func testRouteRejectsMissingAuth() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(HTTPRequest(method: "GET", path: "/state"))
+            XCTAssertEqual(response.status, 401)
+        }
+
+        @MainActor
+        func testRouteRejectsWrongToken() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = server.route(HTTPRequest(
+                method: "GET", path: "/state",
+                headers: ["authorization": "Bearer nope"],
+            ))
+            XCTAssertEqual(response.status, 401)
+        }
+
+        @MainActor
+        func testRouteRejectsNonEmptyOrigin() {
+            // Browser CSRF: page on https://evil.example sends Origin.
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            var headers = Self.authHeaders
+            headers["origin"] = "http://evil.example"
+            let response = server.route(HTTPRequest(method: "GET", path: "/state", headers: headers))
+            XCTAssertEqual(response.status, 403)
+        }
+
+        @MainActor
+        func testRouteAcceptsNullOrigin() {
+            // Some user agents send literal "null" for sandboxed/file:// contexts —
+            // treat as absent so curl/native tools always work.
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            var headers = Self.authHeaders
+            headers["origin"] = "null"
+            let response = server.route(HTTPRequest(method: "GET", path: "/healthz", headers: headers))
+            XCTAssertEqual(response.status, 200)
         }
 
         // MARK: - Enabled gate
@@ -93,6 +156,22 @@
             // assert the API works rather than a specific value.
             let value = ProcessInfo.processInfo.environment[DebugRPCServer.envVar]
             XCTAssertEqual(DebugRPCServer.enabled, value == "1")
+        }
+
+        // MARK: - Token persistence
+
+        func testLoadOrCreateTokenIsStableAndChmod600() throws {
+            // We can't easily redirect AppPaths in a test, so just assert the
+            // function returns a 64-hex string and is idempotent.
+            let first = DebugRPCServer.loadOrCreateToken()
+            let second = DebugRPCServer.loadOrCreateToken()
+            XCTAssertEqual(first, second)
+            XCTAssertEqual(first.count, 64)
+            XCTAssertTrue(first.allSatisfy(\.isHexDigit))
+
+            let attrs = try FileManager.default.attributesOfItem(atPath: DebugRPCServer.tokenFileURL.path)
+            let perms = (attrs[.posixPermissions] as? Int) ?? -1
+            XCTAssertEqual(perms, 0o600)
         }
 
         // MARK: - Snapshot JSON
@@ -105,6 +184,12 @@
             XCTAssertTrue(s.contains("\n"))
             XCTAssertTrue(s.contains("\"pipeline\""))
             XCTAssertTrue(s.contains("\"speakerDB\""))
+        }
+
+        // MARK: - Helpers
+
+        private func authedRequest(method: String, path: String, body: Data = Data()) -> HTTPRequest {
+            HTTPRequest(method: method, path: path, headers: Self.authHeaders, body: body)
         }
     }
 #endif

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,8 @@ SWIFT_DIRS=(
     app/MeetingTranscriber/Tests
     tools/audiotap/Sources
     tools/meeting-simulator/Sources
+    tools/mt-cli/Sources
+    tools/mt-cli/Tests
     scripts/generate_menu_bar_gifs.swift
 )
 

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Live smoketest for the debug RPC server. Builds the dev app, launches it
+# with MEETINGTRANSCRIBER_DEBUG_RPC=1, drives every endpoint via mt-cli, and
+# asserts UI side-effects via window-size heuristics on the captured PNG.
+#
+# Useful before pushing RPC-related changes — catches things the in-process
+# integration tests can't (real SwiftUI rendering, window routing, codesign).
+#
+# Usage: ./scripts/test_rpc.sh
+#
+# Exit 0 on success, non-zero on first failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPM_DIR="$REPO_ROOT/app/MeetingTranscriber"
+APP_BUNDLE="$SPM_DIR/.build/MeetingTranscriber-Dev.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/MeetingTranscriber"
+MT_CLI_DIR="$REPO_ROOT/tools/mt-cli"
+MT_CLI_BIN="$MT_CLI_DIR/.build/debug/mt-cli"
+TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+
+step() { printf "\n\033[1;34m==> %s\033[0m\n" "$1"; }
+ok()   { printf "    \033[0;32m✓\033[0m %s\n" "$1"; }
+fail() { printf "    \033[0;31m✗\033[0m %s\n" "$1"; exit 1; }
+
+# --- Cleanup any prior dev instance so the rebuild picks up our binary. ---
+step "Stopping any running dev app"
+if pgrep -f MeetingTranscriber-Dev >/dev/null; then
+    pkill -f MeetingTranscriber-Dev || true
+    sleep 2
+fi
+
+# --- Build app + mt-cli. ---
+step "Building app (release) + mt-cli (debug)"
+(cd "$SPM_DIR" && swift build -c release >/dev/null)
+ok "app built"
+(cd "$MT_CLI_DIR" && swift build >/dev/null)
+ok "mt-cli built"
+
+# --- Assemble + sign bundle. ---
+cp "$SPM_DIR/.build/release/MeetingTranscriber" "$APP_BINARY"
+SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}')
+codesign --force --sign "$SIGN_HASH" "$APP_BUNDLE" 2>/dev/null
+ok "signed"
+
+# --- Launch with env var. ---
+step "Launching with MEETINGTRANSCRIBER_DEBUG_RPC=1"
+MEETINGTRANSCRIBER_DEBUG_RPC=1 open -gj "$APP_BUNDLE"
+# Poll for the listener instead of a fixed sleep.
+for _ in $(seq 1 30); do
+    if lsof -i :9876 >/dev/null 2>&1; then break; fi
+    sleep 0.2
+done
+lsof -i :9876 >/dev/null 2>&1 || fail "server did not bind to :9876 within 6s"
+ok "listening on :9876"
+
+# Cleanup on exit.
+trap 'pkill -f MeetingTranscriber-Dev 2>/dev/null || true' EXIT
+
+[ -s "$TOKEN_FILE" ] || fail "token file not created"
+TOKEN=$(cat "$TOKEN_FILE")
+ok "token file present (chmod $(stat -f '%Lp' "$TOKEN_FILE"))"
+
+# --- Endpoint roundtrips. ---
+step "Auth gate"
+code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:9876/healthz")
+[ "$code" = "401" ] || fail "no-auth: expected 401 got $code"
+ok "no-auth → 401"
+
+code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer wrong" "http://127.0.0.1:9876/healthz")
+[ "$code" = "401" ] || fail "wrong-token: expected 401 got $code"
+ok "wrong-token → 401"
+
+code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" -H "Origin: http://evil.example" "http://127.0.0.1:9876/healthz")
+[ "$code" = "403" ] || fail "browser-origin: expected 403 got $code"
+ok "browser-origin → 403"
+
+step "mt-cli roundtrips"
+"$MT_CLI_BIN" healthz | grep -q "^ok$" || fail "healthz output unexpected"
+ok "healthz"
+
+"$MT_CLI_BIN" state | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'pipeline' in d and 'speakerDB' in d" \
+    || fail "state JSON malformed"
+ok "state JSON parses"
+
+step "Action + screenshot loop"
+"$MT_CLI_BIN" close-settings >/dev/null  # ensure clean idle
+sleep 1
+
+# Idle should be 503 (no large window).
+out=$("$MT_CLI_BIN" screenshot /tmp/rpc-smoke-idle.png 2>&1 || true)
+echo "$out" | grep -q "503" || fail "idle screenshot: expected 503, got: $out"
+ok "idle → 503"
+
+# Open Settings → screenshot should be a real PNG.
+"$MT_CLI_BIN" open-settings >/dev/null
+sleep 2
+"$MT_CLI_BIN" screenshot /tmp/rpc-smoke-settings.png >/dev/null
+size=$(stat -f '%z' /tmp/rpc-smoke-settings.png)
+[ "$size" -gt 5000 ] || fail "settings screenshot too small ($size bytes)"
+dim=$(file /tmp/rpc-smoke-settings.png | grep -oE '[0-9]+ x [0-9]+' | head -1)
+ok "settings → PNG $dim, $size bytes"
+
+# Close Settings → back to 503.
+"$MT_CLI_BIN" close-settings >/dev/null
+sleep 1
+out=$("$MT_CLI_BIN" screenshot /tmp/rpc-smoke-after-close.png 2>&1 || true)
+echo "$out" | grep -q "503" || fail "after-close: expected 503, got: $out"
+ok "close → 503 again"
+
+step "All checks passed"

--- a/tools/mt-cli/Package.resolved
+++ b/tools/mt-cli/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "ebfe314d8a72d628def0d606f4f97a054e20874922dd05da76e469aef3af2e01",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tools/mt-cli/Package.swift
+++ b/tools/mt-cli/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "mt-cli",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "mt-cli",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources",
+        ),
+        .testTarget(
+            name: "mt-cli-tests",
+            dependencies: ["mt-cli"],
+            path: "Tests",
+        ),
+    ],
+)

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -1,0 +1,52 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct MTCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mt-cli",
+        abstract: "Thin client for the Meeting Transcriber debug RPC server.",
+        subcommands: [State.self, Healthz.self, Screenshot.self],
+    )
+}
+
+struct State: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Print the current pipeline + speaker DB state as JSON.",
+    )
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        let data = try await client.get("/state")
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+}
+
+struct Healthz: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Probe the RPC server. Exits 0 when reachable, non-zero otherwise.",
+    )
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        _ = try await client.get("/healthz")
+        print("ok")
+    }
+}
+
+struct Screenshot: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Save a PNG of the app's frontmost window.",
+    )
+
+    @Argument(help: "Output PNG path. Defaults to ./screenshot.png.")
+    var path: String = "screenshot.png"
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        let data = try await client.get("/screenshot")
+        try data.write(to: URL(fileURLWithPath: path))
+        print("wrote \(data.count) bytes to \(path)")
+    }
+}

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -6,7 +6,7 @@ struct MTCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mt-cli",
         abstract: "Thin client for the Meeting Transcriber debug RPC server.",
-        subcommands: [State.self, Healthz.self, Screenshot.self],
+        subcommands: [State.self, Healthz.self, Screenshot.self, OpenSettings.self, CloseSettings.self],
     )
 }
 
@@ -32,6 +32,32 @@ struct Healthz: AsyncParsableCommand {
         let client = try RPCClient.loadDefault()
         _ = try await client.get("/healthz")
         print("ok")
+    }
+}
+
+struct OpenSettings: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "open-settings",
+        abstract: "Open the app's Settings window.",
+    )
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        _ = try await client.post("/action/openSettings", json: [:])
+        print("ok")
+    }
+}
+
+struct CloseSettings: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "close-settings",
+        abstract: "Close the Settings window if it is open.",
+    )
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        let data = try await client.post("/action/closeSettings", json: [:])
+        FileHandle.standardOutput.write(data)
     }
 }
 

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Thin HTTP client for the running Meeting Transcriber app's debug RPC server.
+/// Reads the bearer token from disk at the same path the app writes it to.
+struct RPCClient {
+    let baseURL: URL
+    let token: String
+
+    enum RPCError: Error, CustomStringConvertible {
+        case appNotRunning(URL)
+        case http(status: Int, body: String)
+        case missingToken(URL)
+
+        var description: String {
+            switch self {
+            case let .appNotRunning(url):
+                "Meeting Transcriber app is not running on \(url.absoluteString) " +
+                    "(or MEETINGTRANSCRIBER_DEBUG_RPC=1 was not set when it launched)"
+            case let .http(status, body):
+                "RPC returned HTTP \(status): \(body)"
+            case let .missingToken(url):
+                "RPC token not found at \(url.path) — start the app with " +
+                    "MEETINGTRANSCRIBER_DEBUG_RPC=1 first"
+            }
+        }
+    }
+
+    /// Default app data dir on macOS. Mirrors `AppPaths.dataDir` in the app —
+    /// duplicated here so mt-cli has no dependency on the app's source.
+    static let defaultTokenURL: URL = {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support")
+        return appSupport
+            .appendingPathComponent("MeetingTranscriber")
+            .appendingPathComponent(".rpc-token")
+    }()
+
+    static let defaultBaseURL = URL(string: "http://127.0.0.1:9876")!
+
+    static func loadDefault() throws -> RPCClient {
+        let url = defaultTokenURL
+        guard let data = try? Data(contentsOf: url),
+              let token = String(data: data, encoding: .utf8)?
+              .trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty
+        else {
+            throw RPCError.missingToken(url)
+        }
+        return RPCClient(baseURL: defaultBaseURL, token: token)
+    }
+
+    func get(_ path: String) async throws -> Data {
+        try await request("GET", path: path, body: nil)
+    }
+
+    func post(_ path: String, json: [String: Any]) async throws -> Data {
+        let body = try JSONSerialization.data(withJSONObject: json)
+        return try await request("POST", path: path, body: body)
+    }
+
+    private func request(_ method: String, path: String, body: Data?) async throws -> Data {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse else { return data }
+            if (200 ..< 300).contains(http.statusCode) {
+                return data
+            }
+            throw RPCError.http(
+                status: http.statusCode,
+                body: String(data: data, encoding: .utf8) ?? "",
+            )
+        } catch let error as URLError where error.code == .cannotConnectToHost {
+            throw RPCError.appNotRunning(baseURL)
+        }
+    }
+}

--- a/tools/mt-cli/Tests/RPCClientTests.swift
+++ b/tools/mt-cli/Tests/RPCClientTests.swift
@@ -1,0 +1,25 @@
+@testable import mt_cli
+import XCTest
+
+final class RPCClientTests: XCTestCase {
+    func testDefaultTokenURLPointsAtAppDataDir() {
+        let path = RPCClient.defaultTokenURL.path
+        XCTAssertTrue(path.contains("MeetingTranscriber"))
+        XCTAssertTrue(path.hasSuffix(".rpc-token"))
+    }
+
+    func testDefaultBaseURLIsLoopback() {
+        XCTAssertEqual(RPCClient.defaultBaseURL.host, "127.0.0.1")
+        XCTAssertEqual(RPCClient.defaultBaseURL.port, 9876)
+    }
+
+    func testMissingTokenErrorMessageMentionsEnvVar() {
+        let err = RPCClient.RPCError.missingToken(URL(fileURLWithPath: "/tmp/nope"))
+        XCTAssertTrue(err.description.contains("MEETINGTRANSCRIBER_DEBUG_RPC"))
+    }
+
+    func testAppNotRunningErrorMessageMentionsURL() {
+        let err = RPCClient.RPCError.appNotRunning(RPCClient.defaultBaseURL)
+        XCTAssertTrue(err.description.contains("127.0.0.1:9876"))
+    }
+}

--- a/tools/mt-cli/skill.md
+++ b/tools/mt-cli/skill.md
@@ -1,0 +1,67 @@
+---
+name: meeting-transcriber
+description: Use when working on the Meeting Transcriber repo and you need to inspect or drive the running dev app from the shell instead of asking the user for screenshots.
+---
+
+# Meeting Transcriber — shell-driven inspection
+
+The dev build of Meeting Transcriber can run an embedded debug RPC server.
+When it's running, prefer `mt-cli` over asking the user "kannst du screenshot
+machen" / "ist das im Menü sichtbar".
+
+## When to use
+
+- You want to know what's in the speaker DB right now → `mt-cli state`
+- You want to verify the app is alive after a code change → `mt-cli healthz`
+- You want to see what the user sees → `mt-cli screenshot /tmp/x.png`, then Read it
+- You're debugging a UI bug and would otherwise have to ask the user to describe state
+- You're verifying a fix end-to-end after editing code
+
+Don't use it for production debugging — RPC is `#if !APPSTORE` only and gated
+by the `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var.
+
+## How to enable
+
+The user must launch the dev app with the env flag set:
+
+```bash
+MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh
+```
+
+The app writes a 64-hex bearer token to
+`~/Library/Application Support/MeetingTranscriber/.rpc-token` (chmod 0600).
+`mt-cli` reads it automatically — no config needed on your side.
+
+## Endpoints
+
+| HTTP                | mt-cli              | Returns                            |
+| ------------------- | ------------------- | ---------------------------------- |
+| `GET /healthz`      | `mt-cli healthz`    | "ok"                               |
+| `GET /state`        | `mt-cli state`      | Pipeline + speaker DB JSON         |
+| `GET /screenshot`   | `mt-cli screenshot` | PNG of frontmost window            |
+
+## Build mt-cli
+
+From the repo root:
+
+```bash
+cd tools/mt-cli && swift build
+.build/debug/mt-cli state | jq .
+```
+
+## Failure modes
+
+- **"app is not running on http://127.0.0.1:9876"** → user hasn't launched
+  the dev app, or didn't set the env flag. Ask them to run
+  `MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh`.
+- **"RPC token not found"** → same as above; the token is created on first
+  successful start.
+- **HTTP 401** → token rotated. Restart the app or delete the token file.
+- **HTTP 403 with Origin header** → You're hitting it from a browser. Use curl
+  or `mt-cli` instead.
+
+## Security model
+
+Loopback bind (`127.0.0.1` only) + Origin reject + bearer token. Two-layer
+defense against browser CSRF and cross-user access on shared Macs. See
+`app/MeetingTranscriber/Sources/DebugRPCServer.swift` for the threat model.


### PR DESCRIPTION
First slice of the [Debug RPC + mt-cli plan](docs/plans/2026-05-02-debug-rpc.md). Adds an opt-in HTTP server in dev builds so future shell-based test tooling can inspect the running app's state without bouncing screenshots through a human.

## What ships

- `DebugRPCServer` (new) — hand-rolled HTTP/1.1 over `Network.framework` `NWListener`. Bind: `127.0.0.1:9876`.
- Started by `AppState.init` when `MEETINGTRANSCRIBER_DEBUG_RPC=1` is set; otherwise zero overhead.
- Wrapped in `#if !APPSTORE` so the App Store variant never compiles it.
- Endpoints:
  - `GET /state` → JSON snapshot of pipeline + speaker DB summary + pending naming jobs
  - `GET /healthz` → `ok\n`
  - everything else → `404`
- 11 unit tests covering header parser, response serializer, routing table, snapshot JSON shape.

## Verified end-to-end

```
$ MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh
$ curl -s http://127.0.0.1:9876/healthz
ok
$ curl -s http://127.0.0.1:9876/state | jq .speakerDB
{
  "count": 25,
  "recentNames": ["Test 1", "Test 2", "Teams", ...]
}
```

## What's next (separate PRs)

- PR 2: `/action/click`, `/action/setText`, `/action/openWindow` (UI driving)
- PR 3: `/screenshot` (PNG of main window)
- PR 4: `mt-cli` thin client + Claude Code skill file

## Test plan

- [x] `swift test` — 1095 tests (+11 new), 0 non-snapshot failures
- [x] `./scripts/lint.sh` — clean
- [x] Manual: launched dev with env var, curled `/healthz`, `/state`, unknown path — all expected responses
- [x] Default-off: launched without env var, RPC server not started (verified by no listener log line)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->