### PR TITLE
docs(rpc): document debug RPC + restore pipeline diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     MeetingPatterns.swift  # App-specific window title patterns
     PowerAssertionDetector.swift  # Meeting detection via IOKit power assertions (sandbox-safe)
     UpdateChecker.swift    # GitHub release update checker
+    DebugRPCServer.swift   # Localhost HTTP RPC for shell-driven inspection (#if !APPSTORE, env-gated by MEETINGTRANSCRIBER_DEBUG_RPC=1)
     Assets.xcassets        # App icon assets
     Info.plist             # Bundle metadata
   Entitlements/
@@ -77,6 +78,13 @@ tools/meeting-simulator/   # Meeting simulator tool for testing
 tools/whisperkit-cli/      # WhisperKit CLI transcription tool (used by build_whisperkit.sh)
   Package.swift
   Sources/main.swift
+tools/mt-cli/              # Thin Swift client for DebugRPCServer (state, screenshot, open-settings, …)
+  Package.swift
+  Sources/
+    MTCLI.swift            # ArgumentParser entrypoint
+    RPCClient.swift        # HTTP client; reads token from AppPaths-equivalent path
+  Tests/RPCClientTests.swift
+  skill.md                 # Claude skill: when to use mt-cli, with examples
 scripts/
   build_whisperkit.sh      # Build WhisperKit CLI tool
   build_release.sh         # Build self-contained .app bundle + DMG (--appstore for App Store variant)
@@ -85,6 +93,7 @@ scripts/
   generate_test_audio.sh   # Generate 2-speaker test WAV fixture (requires sox)
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
+  test_rpc.sh               # Live smoketest for DebugRPCServer (build + launch + drive via mt-cli + assert)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
 Casks/meeting-transcriber.rb # Homebrew Cask formula (stable)
 Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
@@ -137,6 +146,15 @@ cd app/MeetingTranscriber && swift test
 
 # Build self-contained .app + DMG for distribution (Homebrew)
 ./scripts/build_release.sh
+
+# Run app with debug RPC server enabled (dev-only; binds 127.0.0.1:9876)
+MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh
+
+# Build mt-cli (talks to the running RPC server)
+cd tools/mt-cli && swift build && .build/debug/mt-cli state
+
+# Live smoketest of the RPC server (kills + builds + launches + asserts)
+./scripts/test_rpc.sh
 
 # Build App Store variant (sandbox, no Claude CLI)
 ./scripts/build_release.sh --appstore --no-notarize
@@ -242,6 +260,13 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - `WatchLoop` runs the check on startup; `AppState` re-runs on app activation.
 - When unhealthy: `MenuBarIcon` composites a red "!" badge over the current icon (non-template, stays red in dark mode). `BadgeKind.compute()` returns `.error` when idle with a problem. A deduped notification is posted via `NotificationManager`.
 
+**Debug RPC server (dev-only):**
+- `DebugRPCServer` is an embedded HTTP server bound to `127.0.0.1:9876` that exposes app state, screenshots, and scene actions for shell-driven inspection. Whole file is `#if !APPSTORE`; opt-in per session via `MEETINGTRANSCRIBER_DEBUG_RPC=1`.
+- Endpoints: `GET /state` (pipeline + speaker DB JSON), `GET /healthz`, `GET /screenshot` (PNG of the largest visible window), `POST /action/openSettings`, `POST /action/closeSettings`.
+- Two-layer auth: 32-byte hex bearer token at `~/Library/Application Support/MeetingTranscriber/.rpc-token` (chmod 0600) + reject on any non-empty browser `Origin` header.
+- Action endpoints post `Notification.Name.showSettings` / `.closeSettings` that the `@main` scene observes and routes to `bringWindowToFront(id: "settings")` / `closeWindow(id: "settings")` — same path the menu bar uses.
+- `tools/mt-cli` is the matching CLI client; `scripts/test_rpc.sh` is a live end-to-end smoketest. In-process integration tests live in `Tests/DebugRPCServerIntegrationTests.swift` (real sockets via OS-assigned port exposed through `DebugRPCServer.boundPort`).
+
 ## Critical Notes
 
 - AudioTapLib (CATapDescription) requires macOS 14.2+ — compiled as SPM library, no separate binary needed
@@ -268,11 +293,12 @@ Two build variants controlled by compile-time flag `APPSTORE` (`-Xswiftc -DAPPST
 |---|---|---|
 | **Claude CLI** | Yes (Process subprocess) | No (sandbox forbids Process) |
 | **OpenAI API** | Yes | Yes (only LLM option) |
+| **Debug RPC server** | Yes (env-gated) | No (`#if !APPSTORE`) |
 | **Entitlements** | Mic only | Sandbox + mic + network + file picker |
 | **Build** | `./scripts/build_release.sh` | `./scripts/build_release.sh --appstore` |
-| **Tests** | ~996 | fewer (CLI tests excluded via `#if !APPSTORE`) |
+| **Tests** | ~996 | fewer (CLI + RPC tests excluded via `#if !APPSTORE`) |
 
-- CLI-specific code lives in `ClaudeCLIProtocolGenerator.swift` (entire file `#if !APPSTORE`)
+- CLI-specific code lives in `ClaudeCLIProtocolGenerator.swift` and `DebugRPCServer.swift` (each entire file `#if !APPSTORE`)
 - `ProtocolProvider` enum uses `CaseIterable` — `.claudeCLI` case excluded at compile time, picker adapts automatically
 - `ProtocolError` has `#if !APPSTORE` around CLI error cases (enum cases cannot be added via extension)
 - FFmpegHelper also uses `Process()` but falls back gracefully to `nil` — no `#if` needed

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -11,13 +11,70 @@ Native SwiftUI menu bar application that orchestrates meeting detection, recordi
 ## Pipeline
 
 ```
-Meeting Window Detected (CGWindowListCopyWindowInfo)
-  → DualSourceRecorder (AudioTapLib + mic, records at 16kHz)
-    → [WhisperKit | Parakeet | Qwen3] (CoreML/ANE transcription)
-      → [FluidDiarizer (CoreML/ANE speaker diarization)]
-        → ProtocolGenerator (Claude CLI / OpenAI-compatible API)
-          → Markdown protocol + transcript
+                ┌──────────────────────────────────────────────────┐
+                │           MeetingTranscriberApp (@main)          │
+                │   SwiftUI: MenuBarExtra + Settings + Naming      │
+                └──────────────────────────┬───────────────────────┘
+                                           │ owns
+                ┌──────────────────────────▼───────────────────────┐
+                │            AppState (@Observable @MainActor)     │
+                │   watchLoop, pipelineQueue, settings, engines    │
+                └────────┬─────────────────────────────────┬───────┘
+                         │                                 │ optional
+                         │                                 │ (#if !APPSTORE
+                         │                                 │  + env flag)
+                         │                                 ▼
+                         │                  ┌──────────────────────────┐
+                         │                  │  DebugRPCServer          │
+                         │                  │  127.0.0.1:9876          │
+                         │                  │  /state /healthz         │
+                         │                  │  /screenshot             │
+                         │                  │  /action/openSettings    │
+                         │                  │  /action/closeSettings   │
+                         │                  │  Bearer-token + Origin   │
+                         │                  │  reject. Driven by mt-cli│
+                         │                  └──────────────────────────┘
+                         │
+                         ▼
+                ┌─────────────────────────────────────────────────┐
+                │           WatchLoop (@MainActor)                │
+                │   idle → watching → recording → watching        │
+                └────┬───────────────┬────────────────────┬───────┘
+                     │ polls         │ starts/stops       │ enqueues
+                     ▼               ▼                    ▼
+        ┌─────────────────────┐  ┌────────────────┐  ┌────────────────────┐
+        │ MeetingDetecting    │  │ DualSource-    │  │   PipelineQueue    │
+        │  • MeetingDetector  │  │   Recorder     │  │   (@MainActor)     │
+        │    (CGWindowList +  │  │                │  │                    │
+        │     regex)          │  │  AudioTapLib   │  │  Sequential job    │
+        │  • PowerAssertion-  │  │  (CATap +      │  │  processing →      │
+        │    Detector (IOKit, │  │   AVAudioEng.) │  │  see breakdown     │
+        │    sandbox-safe)    │  │  + AudioMixer  │  │  below             │
+        └─────────────────────┘  └────────────────┘  └─────────┬──────────┘
+                                                               │
+        PipelineQueue per-job processing:                      │
+        ┌──────────────────────────────────────────────────────▼─────────┐
+        │ 1. Resample to 16 kHz mono (AudioMixer; AVAsset / ffmpeg fb)   │
+        │ 2. (opt) FluidVAD silence-trim + timeline remap                │
+        │ 3. Transcribe via active engine                                │
+        │      └─ TranscribingEngine: WhisperKit | Parakeet | Qwen3      │
+        │         (dual-source: each track separately, then merge)       │
+        │ 4. (opt) Diarize via FluidDiarizer                             │
+        │      └─ Mode: .offlineDiarizer | .sortformer                   │
+        │      └─ Dual-source: app + mic diarized separately,            │
+        │         IDs prefixed R_ (remote) / M_ (mic), then merged       │
+        │ 5. SpeakerMatcher: cosine match against speakers.json          │
+        │      (centroid + recent-FIFO, threshold 0.40, margin 0.10)     │
+        │ 6. Speaker naming UI (suspended via CheckedContinuation)       │
+        │ 7. Assign speakers to transcript by temporal overlap           │
+        │ 8. Save transcript (.txt)                                      │
+        │ 9. Protocol generation                                         │
+        │      └─ ProtocolProvider: .claudeCLI | .openAICompatible | .none│
+        │ 10. Save protocol (.md, transcript appended)                   │
+        └────────────────────────────────────────────────────────────────┘
 ```
+
+State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 
 ---
 
@@ -27,7 +84,7 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 
 | File | Role |
 |------|------|
-| `MeetingTranscriberApp.swift` | `@main` UI shell — SwiftUI scenes, windows, NSOpenPanel, NSWorkspace |
+| `MeetingTranscriberApp.swift` | `@main` UI shell — SwiftUI scenes, windows, NSOpenPanel, NSWorkspace. Observes `.showSettings` / `.closeSettings` / `.showSpeakerNaming` notifications for RPC- and pipeline-driven scene control |
 | `AppState.swift` | `@Observable @MainActor` ViewModel — business state, badge logic, pipeline wiring |
 | `MenuBarView.swift` | Menu bar dropdown (state, actions, meeting info) |
 | `SettingsView.swift` | Settings window (apps, recording, transcription, diarization) |
@@ -80,6 +137,15 @@ Meeting Window Detected (CGWindowListCopyWindowInfo)
 | `PermissionRow.swift` | Permission status row UI component (icon, detail, help popover) |
 | `PermissionHealthCheck.swift` | TCC verdict + live probe → `PermissionStatus`; drives exclamation badge overlay |
 | `ParticipantReader.swift` | Teams participant extraction via Accessibility API |
+| `DebugRPCServer.swift` | Embedded HTTP RPC server for shell-driven inspection. `#if !APPSTORE`, opt-in via `MEETINGTRANSCRIBER_DEBUG_RPC=1`. Bearer-token + Origin reject; binds 127.0.0.1 only |
+
+### Companion CLIs
+
+| Path | Role |
+|------|------|
+| `tools/mt-cli/` | Thin Swift client for `DebugRPCServer`. Subcommands: `state`, `healthz`, `screenshot`, `open-settings`, `close-settings`. Reads token from `~/Library/Application Support/MeetingTranscriber/.rpc-token`. Skill doc at `tools/mt-cli/skill.md`. |
+| `tools/whisperkit-cli/` | WhisperKit transcription CLI (used by `scripts/build_whisperkit.sh`) |
+| `tools/meeting-simulator/` | Test fixture: spawns a fake meeting window for E2E detection tests |
 
 ---
 
@@ -304,6 +370,7 @@ AppSettings (UserDefaults)
 | ProtocolGenerator | `claudeBin` parameter |
 | AppNotifying | `notifier` parameter in `AppState.init` (`SilentNotifier` default, `RecordingNotifier` in tests) |
 | BadgeKind.compute | Pure static function — call directly with any input combination, no WatchLoop needed |
+| DebugRPCServer | Out-of-process inspection via HTTP. Endpoints: `GET /state /healthz /screenshot`, `POST /action/openSettings /action/closeSettings`. `#if !APPSTORE` + env-gated. `boundPort` exposes OS-assigned port for in-process integration tests. `tools/mt-cli/` is the matching CLI. `scripts/test_rpc.sh` is a live smoketest (build + launch + drive + assert). |
 
 ---
 
@@ -345,3 +412,4 @@ The overlay lives over the *currently active* animation (idle, recording, transc
 7. **5s cooldown** — Prevents re-detecting same meeting after handling
 8. **FluidAudio on-device diarization** — Replaces Python pyannote subprocess, no external dependencies
 9. **Dual-track diarization** — App and mic tracks diarized separately, avoiding echo/cross-talk interference
+10. **Embedded debug RPC** — In-process HTTP server (`DebugRPCServer`) exposes state + screenshot + scene actions for shell-driven inspection and integration tests. Off by default, opt-in via `MEETINGTRANSCRIBER_DEBUG_RPC=1`, excluded from App Store builds via `#if !APPSTORE`. Action endpoints route through existing `Notification.Name` observers in `MeetingTranscriberApp`, so RPC-driven flows mirror real menu-bar paths.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** caught up with PR #136: project tree, key commands, new "Debug RPC server (dev-only)" subsection in Architecture Notes, Build Variants row.
- **docs/architecture-macos.md** caught up with PR #136 + replaces the ASCII pipeline diagram lost when PR #137 deleted \`swift-architecture.md\`. The new diagram reflects the actual current architecture (FluidVAD, three ASR engines, three protocol providers, dual-track diarization, optional DebugRPCServer sidecar).

Stacked on \`origin/main\`. Independent of PR #136 (RPC feature) and #137 (drop swift-architecture.md) — can merge in any order.

## Test plan
- [x] CLAUDE.md still loads cleanly into Claude context
- [x] Markdown renders OK in GitHub preview
- [x] Source files referenced in the diagram all exist on this branch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->