### PR TITLE
test: harden two test-isolation bugs surfaced by --parallel

### DIFF
--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -78,8 +78,11 @@ enum ProtocolGenerator {
         prompt.replacingOccurrences(of: "{LANGUAGE}", with: language)
     }
 
-    static func loadPrompt() -> String {
-        let url = AppPaths.customPromptFile
+    /// Load the protocol generation prompt. Reads from `url` (default
+    /// `AppPaths.customPromptFile`) when present and non-empty; falls back
+    /// to the built-in `protocolPrompt`. The `url` parameter exists so tests
+    /// can use unique per-test paths instead of racing on the shared one.
+    static func loadPrompt(from url: URL = AppPaths.customPromptFile) -> String {
         if let custom = try? String(contentsOf: url, encoding: .utf8),
            !custom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             logger.info("Using custom protocol prompt from \(url.path)")

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -264,61 +264,42 @@ final class ProtocolGeneratorTests: XCTestCase {
 
     // MARK: - Custom Prompt Loading
 
-    /// Run a test block with a temporary custom prompt file, restoring the original state afterwards.
-    private func withCustomPromptFile(_ body: (URL) throws -> Void) throws {
-        let url = AppPaths.customPromptFile
-        let fm = FileManager.default
-        let backup = fm.fileExists(atPath: url.path)
-            ? try? String(contentsOf: url, encoding: .utf8)
-            : nil
-        defer {
-            if let backup {
-                try? backup.write(to: url, atomically: true, encoding: .utf8)
-            } else {
-                try? fm.removeItem(at: url)
-            }
-        }
-        try body(url)
+    /// Unique-per-test prompt file path. Avoids racing on the shared
+    /// `AppPaths.customPromptFile` location under `swift test --parallel`.
+    private func makeTempPromptFile() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-prompt-\(UUID().uuidString).md")
     }
 
-    func testLoadPromptReturnsDefaultWhenNoFile() throws {
-        try withCustomPromptFile { url in
-            try? FileManager.default.removeItem(at: url)
-
-            let prompt = ProtocolGenerator.loadPrompt()
-            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
-        }
+    func testLoadPromptReturnsDefaultWhenNoFile() {
+        let url = makeTempPromptFile()
+        // File doesn't exist → loadPrompt falls back to the built-in default.
+        XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)
     }
 
     func testLoadPromptReadsCustomFile() throws {
-        try withCustomPromptFile { url in
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            let custom = "Custom prompt for testing"
-            try custom.write(to: url, atomically: true, encoding: .utf8)
+        let url = makeTempPromptFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let custom = "Custom prompt for testing"
+        try custom.write(to: url, atomically: true, encoding: .utf8)
 
-            let prompt = ProtocolGenerator.loadPrompt()
-            XCTAssertEqual(prompt, custom)
-        }
+        XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), custom)
     }
 
     func testLoadPromptIgnoresEmptyFile() throws {
-        try withCustomPromptFile { url in
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try "".write(to: url, atomically: true, encoding: .utf8)
+        let url = makeTempPromptFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "".write(to: url, atomically: true, encoding: .utf8)
 
-            let prompt = ProtocolGenerator.loadPrompt()
-            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
-        }
+        XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)
     }
 
     func testLoadPromptIgnoresWhitespaceOnlyFile() throws {
-        try withCustomPromptFile { url in
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try "   \n  \n  ".write(to: url, atomically: true, encoding: .utf8)
+        let url = makeTempPromptFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "   \n  \n  ".write(to: url, atomically: true, encoding: .utf8)
 
-            let prompt = ProtocolGenerator.loadPrompt()
-            XCTAssertEqual(prompt, ProtocolGenerator.protocolPrompt)
-        }
+        XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)
     }
 
     #if !APPSTORE

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -4,6 +4,31 @@ import XCTest
 
 @MainActor
 final class SettingsViewTests: XCTestCase {
+    /// Keys that other test classes may have written to the shared on-disk
+    /// plist; cleared at setUp + tearDown so parallel test processes don't
+    /// leak state into each other.
+    private static let pollutedDefaultsKeys = [
+        "transcriptionEngine", "protocolProvider",
+        "diarize", "vadEnabled", "diarizerMode",
+        "whisperKitModel", "whisperKitLanguage",
+        "qwen3Language", "customVocabularyPath",
+        "checkForUpdates", "includePreReleases",
+    ]
+
+    override func setUp() {
+        super.setUp()
+        for key in Self.pollutedDefaultsKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDown() {
+        for key in Self.pollutedDefaultsKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
     // MARK: - Helpers
 
     private func makeSettingsView(


### PR DESCRIPTION
## Summary

Two test-isolation bugfixes that are valuable independent of \`--parallel\`, surfaced while exploring \`swift test --parallel\`:

1. **fix(test): reset UserDefaults in SettingsViewTests setUp/tearDown** — Engine-conditional view tests previously relied on \`AppSettings()\`'s schema default, which leaks across parallel test processes via the on-disk plist.
2. **fix(test): isolate ProtocolGenerator prompt tests with temp paths** — \`testLoadPrompt*\` wrote to the shared \`AppPaths.customPromptFile\`. Refactor: \`loadPrompt\` takes an optional \`from: URL\` (default unchanged for prod). Tests use unique temp paths.

## Why no \`--parallel\` flag flip

I tried (a) a process-wide WhisperKit download dedup actor and (b) \`actions/cache\` + \`ModelPreloadTests\`. Both helped CI past the WhisperKit cache race but uncovered more flakes (\`ResamplingIntegrationTests\` pipeline-error race, \`AppSettingsTests\` UserDefaults race in cold-cache local runs). The codebase has multiple latent shared-state assumptions that \`--parallel\` exposes; chasing each one is whack-a-mole and the CI gain is only ~10–30 s.

The two fixes here are the ones that turned out to be unambiguous test-hygiene bugs — keeping them stand-alone is worth shipping. Anyone who wants full parallel-clean should systematically audit shared state next time.

## Test plan
- [x] \`swift test --filter SettingsViewTests\` 44/44
- [x] \`swift test --filter ProtocolGeneratorTests\` 77/77
- [x] Lint clean