### PR TITLE
ci: parallel Swift tests with cached ML models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,22 @@ jobs:
           path: app/MeetingTranscriber/.build
           key: spm-${{ runner.os }}-${{ matrix.variant }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-${{ matrix.variant }}-
+      # Cache the WhisperKit (HuggingFace) + FluidAudio model files. The
+      # HuggingFace download client races on cold-cache concurrent loads of
+      # the same variant; pre-warming sequentially populates the cache so
+      # the parallel run can hit it. After the first successful CI run the
+      # cache is populated and the preload step is skipped.
+      - name: Cache ML models
+        id: model-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Documents/huggingface
+            ~/Library/Application Support/FluidAudio
+          key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
+          restore-keys: ml-models-${{ runner.os }}-
+      - name: Pre-warm model cache (cache miss only)
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ matrix.swift-flags }}
       - name: Swift tests
-        run: cd app/MeetingTranscriber && swift test ${{ matrix.swift-flags }}
+        run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,8 @@ Single-source: Audio/Video → 16kHz mono (AVAudioFile → AVAsset → ffmpeg fa
 # Run menu bar app
 ./scripts/run_app.sh
 
-# Swift tests
-cd app/MeetingTranscriber && swift test
+# Swift tests (parallel — ~1.4× faster than sequential)
+cd app/MeetingTranscriber && swift test --parallel
 
 # Lint & format check (dry-run, no changes)
 ./scripts/lint.sh

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -5,15 +5,28 @@ import XCTest
 final class CustomVocabularyTests: XCTestCase {
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var settings: AppSettings!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var defaults: UserDefaults!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var testSuiteName: String!
 
+    /// Per-test isolated UserDefaults suite — see AppSettingsTests for why.
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.removeObject(forKey: "customVocabularyPath")
-        settings = AppSettings()
+        testSuiteName = "CustomVocabularyTests-\(getpid())-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: testSuiteName) else {
+            XCTFail("Could not create test UserDefaults suite")
+            return
+        }
+        defaults = suite
+        settings = AppSettings(defaults: defaults)
     }
 
     override func tearDown() {
         settings = nil
+        defaults.removePersistentDomain(forName: testSuiteName)
+        defaults = nil
+        testSuiteName = nil
         super.tearDown()
     }
 
@@ -29,9 +42,8 @@ final class CustomVocabularyTests: XCTestCase {
         settings.customVocabularyPath = "/tmp/vocab.txt"
         XCTAssertEqual(settings.customVocabularyPath, "/tmp/vocab.txt")
 
-        // Verify it persists to UserDefaults
-        let stored = UserDefaults.standard.string(forKey: "customVocabularyPath")
-        XCTAssertEqual(stored, "/tmp/vocab.txt")
+        // Verify it persists to the injected store.
+        XCTAssertEqual(defaults.string(forKey: "customVocabularyPath"), "/tmp/vocab.txt")
     }
 
     func testCustomVocabularyPathClear() {

--- a/app/MeetingTranscriber/Tests/ModelPreloadTests.swift
+++ b/app/MeetingTranscriber/Tests/ModelPreloadTests.swift
@@ -1,0 +1,39 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Cache pre-warmer for `swift test --parallel` against a cold ML model
+/// cache. Runs sequentially via `--filter ModelPreloadTests` before the
+/// main parallel suite (only on CI cache miss); subsequent concurrent
+/// loads hit the cache and don't race on the HuggingFace download client's
+/// `weight.bin.<hash>.incomplete → weights/` rename.
+///
+/// Local dev: cache is warm, this is a sub-10s cache check.
+@MainActor
+final class ModelPreloadTests: XCTestCase {
+    func testPreloadWhisperKitDefault() async {
+        let engine = WhisperKitEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded)
+    }
+
+    func testPreloadWhisperKitSmall() async {
+        // Variant used by WhisperKitEngineTests / WhisperKitE2ETests.
+        let engine = WhisperKitEngine()
+        engine.modelVariant = "openai_whisper-small"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded)
+    }
+
+    func testPreloadParakeet() async {
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded)
+    }
+
+    func testPreloadQwen3() async {
+        guard #available(macOS 15, *) else { return }
+        let engine = Qwen3AsrEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded)
+    }
+}


### PR DESCRIPTION
## Summary

After the test-isolation fixes on main (#140 ProtocolGenerator + SettingsViewTests, #143 AppSettings via constructor injection), the only remaining blocker for \`swift test --parallel\` in CI was the WhisperKit HuggingFace cache race on cold downloads — a bug in the HF download client where concurrent same-variant loads collide on \`weight.bin.<hash>.incomplete → weights/\` renames.

## Pattern (mirrors WhisperKit's own CI)

1. \`actions/cache@v5\` over \`~/Documents/huggingface\` and \`~/Library/Application Support/FluidAudio\`.
2. \`ModelPreloadTests\` — one test per engine (WhisperKit default + small variant, Parakeet, Qwen3) that calls \`loadModel()\`. Sequential pre-warmer.
3. CI flow:
   - Cache restore.
   - **On cache miss only:** \`swift test --filter ModelPreloadTests\` sequentially populates the cache.
   - **Always:** \`swift test --parallel --skip ModelPreloadTests\` runs the main suite.

After the first successful run the cache is populated; subsequent runs hit cache, skip preload, run \`--parallel\` directly.

## Test plan
- [x] \`swift test --parallel\` ×2 locally: 1113/1113, 0 failures
- [x] \`swift test --filter ModelPreloadTests\` locally: 4/4
- [x] Lint clean
- [x] CI first-run (cache miss): preload populates cache, parallel runs green
- [x] CI second-run (cache hit): preload skipped, parallel runs green