### PR TITLE
fix(app): warn about missing speaker recognition in Sortformer mode

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -23,6 +23,15 @@ struct SpeakersSettingsView: View {
                     }
                     .pickerStyle(.segmented)
 
+                    if settings.diarizerMode == .sortformer {
+                        Label(
+                            "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
+                            systemImage: "exclamationmark.triangle.fill",
+                        )
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                    }
+
                     HStack {
                         Text("Expected Speakers")
                         Spacer()

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -270,6 +270,26 @@ final class SettingsViewTests: XCTestCase {
         XCTAssertThrowsError(try body.find(text: "Mic Speaker Name"))
     }
 
+    func testSortformerWarningShownWhenSelected() throws {
+        let settings = AppSettings()
+        settings.diarize = true
+        settings.diarizerMode = .sortformer
+        let body = try makeSpeakers(settings: settings).inspect()
+        XCTAssertNoThrow(try body.find(
+            text: "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
+        ))
+    }
+
+    func testSortformerWarningHiddenForOfflineMode() throws {
+        let settings = AppSettings()
+        settings.diarize = true
+        settings.diarizerMode = .offline
+        let body = try makeSpeakers(settings: settings).inspect()
+        XCTAssertThrowsError(try body.find(
+            text: "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
+        ))
+    }
+
     // MARK: - Output tab
 
     func testProviderPickerExists() throws {


### PR DESCRIPTION
## Summary

- Adds an inline warning in **Settings → Speakers** when the diarizer
  is set to *Sortformer (Overlap-aware)*: speaker naming and
  auto-recognition are disabled in that mode.
- Documents the technical reason and a proposed full fix (post-hoc
  WeSpeaker extraction) in `docs/plans/2026-05-03-sortformer-embeddings.md`.

Closes part of #109. Full embedding-extraction path is deferred and
tracked in the plan file — that is a larger investment (≈1 day).

## Why

`SortformerDiarizer` from FluidAudio does not expose a public
embedding output. `FluidDiarizer.runSortformer()` therefore returns
`speakerDatabase: nil`, which causes `PipelineQueue.swift:530` to
break out of the naming flow. Result today: users see generic
"Speaker 0/1" labels with no UI feedback explaining why the naming
dialog never appears.

This PR doesn't fix the underlying limitation — it makes the
limitation visible so users can pick **Offline (Clustering)** if
they need recognition.

## Test plan

- [x] `swift test --filter SettingsViewTests` (46 passed, incl. two new
      tests for warning shown/hidden)
- [x] `./scripts/lint.sh` (0 violations)
- [ ] Manual: open Settings → Speakers, switch diarizer to Sortformer,
      confirm orange warning row appears; switch back to Offline,
      confirm it disappears.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->