### PR TITLE
feat(app): persistent toggle for debug RPC server in Settings → Advanced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - When unhealthy: `MenuBarIcon` composites a red "!" badge over the current icon (non-template, stays red in dark mode). `BadgeKind.compute()` returns `.error` when idle with a problem. A deduped notification is posted via `NotificationManager`.
 
 **Debug RPC server (dev-only):**
-- `DebugRPCServer` is an embedded HTTP server bound to `127.0.0.1:9876` that exposes app state, screenshots, and scene actions for shell-driven inspection. Whole file is `#if !APPSTORE`; opt-in per session via `MEETINGTRANSCRIBER_DEBUG_RPC=1`.
+- `DebugRPCServer` is an embedded HTTP server bound to `127.0.0.1:9876` that exposes app state, screenshots, and scene actions for shell-driven inspection. Whole file is `#if !APPSTORE`. Two enable paths: persistent `Settings → Advanced → Debug RPC Server` toggle (off by default), or per-session `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var (force-starts at launch). `AppState.applyDebugRPCSetting()` reconciles the running server with both signals at startup and on toggle changes.
 - Endpoints: `GET /state` (pipeline + speaker DB JSON), `GET /healthz`, `GET /screenshot` (PNG of the largest visible window), `POST /action/openSettings`, `POST /action/closeSettings`.
 - Two-layer auth: 32-byte hex bearer token at `~/Library/Application Support/MeetingTranscriber/.rpc-token` (chmod 0600) + reject on any non-empty browser `Origin` header.
 - Action endpoints post `Notification.Name.showSettings` / `.closeSettings` that the `@main` scene observes and routes to `bringWindowToFront(id: "settings")` / `closeWindow(id: "settings")` — same path the menu bar uses.

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -289,6 +289,12 @@ final class AppSettings {
         didSet { defaults.set(audioDebugLogging, forKey: "audioDebugLogging") }
     }
 
+    #if !APPSTORE
+        var debugRPCEnabled: Bool {
+            didSet { defaults.set(debugRPCEnabled, forKey: "debugRPCEnabled") }
+        }
+    #endif
+
     // MARK: - Updates
 
     var checkForUpdates: Bool {
@@ -355,6 +361,9 @@ final class AppSettings {
         openAIModel = defaults.object(forKey: "openAIModel") as? String ?? "llama3.1"
 
         audioDebugLogging = defaults.object(forKey: "audioDebugLogging") as? Bool ?? false
+        #if !APPSTORE
+            debugRPCEnabled = defaults.object(forKey: "debugRPCEnabled") as? Bool ?? false
+        #endif
         checkForUpdates = defaults.object(forKey: "checkForUpdates") as? Bool ?? true
         includePreReleases = defaults.object(forKey: "includePreReleases") as? Bool ?? false
     }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -73,15 +73,44 @@ final class AppState {
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
         #if !APPSTORE
-            if DebugRPCServer.enabled {
+            applyDebugRPCSetting()
+            observeDebugRPCSetting()
+        #endif
+    }
+
+    #if !APPSTORE
+        /// Reconcile the debug RPC server with the current setting + env var.
+        /// The env var force-starts the server regardless of the setting,
+        /// preserving back-compat with `scripts/test_rpc.sh` and CI.
+        func applyDebugRPCSetting() {
+            let shouldRun = DebugRPCServer.enabled || settings.debugRPCEnabled
+            if shouldRun, debugRPCServer == nil {
                 let server = DebugRPCServer { [weak self] in
                     self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
                 }
                 server.start()
-                self.debugRPCServer = server
+                debugRPCServer = server
+            } else if !shouldRun, let server = debugRPCServer {
+                server.stop()
+                debugRPCServer = nil
             }
-        #endif
-    }
+        }
+
+        /// `withObservationTracking` is one-shot — re-arm after each fire so
+        /// the AppState reacts to every toggle of `settings.debugRPCEnabled`,
+        /// not just the first one.
+        private func observeDebugRPCSetting() {
+            withObservationTracking {
+                _ = settings.debugRPCEnabled
+            } onChange: { [weak self] in
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.applyDebugRPCSetting()
+                    self.observeDebugRPCSetting()
+                }
+            }
+        }
+    #endif
 
     #if !APPSTORE
         /// Build a snapshot of state for the debug RPC. Read-only.

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -107,6 +107,13 @@
             }
         }
 
+        /// Cancel the listener and free the port. Idempotent.
+        func stop() {
+            listener?.cancel()
+            listener = nil
+            boundPort = nil
+        }
+
         // MARK: - Connection handling
 
         private func handle(_ connection: NWConnection) {

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -65,6 +65,17 @@ struct AdvancedSettingsView: View {
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+                #if !APPSTORE
+                    Toggle("Debug RPC Server", isOn: $settings.debugRPCEnabled)
+                    Text(
+                        "Exposes pipeline state on 127.0.0.1:9876 for `mt-cli`."
+                            + " Localhost-only, bearer-token auth. Off by default;"
+                            + " enable only when you need shell-driven inspection.",
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                #endif
             }
 
             Section("About") {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -136,6 +136,18 @@ final class AppSettingsTests: XCTestCase {
             settings.claudeBin = "claude-work"
             XCTAssertEqual(defaults.string(forKey: "claudeBin"), "claude-work")
         }
+
+        func testDebugRPCEnabledDefault() {
+            XCTAssertFalse(settings.debugRPCEnabled)
+        }
+
+        func testDebugRPCEnabledPersistence() {
+            settings.debugRPCEnabled = true
+            XCTAssertTrue(defaults.bool(forKey: "debugRPCEnabled"))
+            // Verify a fresh instance reads it back from the same suite.
+            let fresh = AppSettings(defaults: defaults)
+            XCTAssertTrue(fresh.debugRPCEnabled)
+        }
     #endif
 
     // MARK: - WhisperKit Model

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -184,6 +184,20 @@
             XCTAssertEqual(DebugRPCServer.enabled, value == "1")
         }
 
+        // MARK: - Lifecycle
+
+        @MainActor
+        func testStopIsIdempotent() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            // Safe to call before start.
+            server.stop()
+            server.stop()
+            // Safe to call after start.
+            server.start()
+            server.stop()
+            server.stop()
+        }
+
         // MARK: - Token persistence
 
         func testLoadOrCreateTokenIsStableAndChmod600() throws {

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -13,6 +13,7 @@ final class SettingsViewTests: XCTestCase {
         "whisperKitModel", "whisperKitLanguage",
         "qwen3Language", "customVocabularyPath",
         "checkForUpdates", "includePreReleases",
+        "debugRPCEnabled",
     ]
 
     override func setUp() {
@@ -404,6 +405,24 @@ final class SettingsViewTests: XCTestCase {
         let body = try makeAdvanced().inspect()
         XCTAssertNoThrow(try body.find(text: "ffmpeg"))
     }
+
+    #if !APPSTORE
+        func testDebugRPCToggleExists() throws {
+            let body = try makeAdvanced().inspect()
+            XCTAssertNoThrow(try body.find(text: "Debug RPC Server"))
+        }
+
+        func testDebugRPCToggleBindsToSetting() throws {
+            let settings = AppSettings()
+            settings.debugRPCEnabled = false
+            let view = AdvancedSettingsView(settings: settings)
+            let toggle = try view.inspect().find(ViewType.Toggle.self) { toggle in
+                try toggle.labelView().text().string() == "Debug RPC Server"
+            }
+            try toggle.tap()
+            XCTAssertTrue(settings.debugRPCEnabled)
+        }
+    #endif
 
     // MARK: - Record-only mode
 

--- a/tools/mt-cli/skill.md
+++ b/tools/mt-cli/skill.md
@@ -17,12 +17,16 @@ machen" / "ist das im Menü sichtbar".
 - You're debugging a UI bug and would otherwise have to ask the user to describe state
 - You're verifying a fix end-to-end after editing code
 
-Don't use it for production debugging — RPC is `#if !APPSTORE` only and gated
-by the `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var.
+Don't use it for production debugging — RPC is `#if !APPSTORE` only.
 
 ## How to enable
 
-The user must launch the dev app with the env flag set:
+Either persistent (preferred for repeated dev sessions):
+
+- Settings → Advanced → toggle **Debug RPC Server** on. The server starts
+  immediately and survives app relaunches.
+
+Or per-session (one-shot, e.g. for `scripts/test_rpc.sh`):
 
 ```bash
 MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh
@@ -51,8 +55,9 @@ cd tools/mt-cli && swift build
 
 ## Failure modes
 
-- **"app is not running on http://127.0.0.1:9876"** → user hasn't launched
-  the dev app, or didn't set the env flag. Ask them to run
+- **"app is not running on http://127.0.0.1:9876"** → either the dev app
+  isn't running, or the toggle / env flag was off when it launched. Ask the
+  user to enable Settings → Advanced → Debug RPC Server, or relaunch with
   `MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh`.
 - **"RPC token not found"** → same as above; the token is created on first
   successful start.


### PR DESCRIPTION
## Summary

- Adds a persistent **Debug RPC Server** toggle to Settings → Advanced →
  Diagnostics. Off by default. When on, the localhost RPC server starts
  immediately and survives app relaunches.
- Existing env-var path (`MEETINGTRANSCRIBER_DEBUG_RPC=1`) still
  force-starts the server at launch — preserves
  `scripts/test_rpc.sh` and any CI/automation that relies on it.
- `AppState.applyDebugRPCSetting()` reconciles the running server with
  both signals (start when either is on, stop when both off). New
  `DebugRPCServer.stop()` cancels the listener.

## Why

The env-var path is awkward: every dev session needs the variable set
before launch, and there is no in-app indication that the server is
even running. Putting the control in Settings makes it discoverable
and toggleable at runtime.

## Test plan

- [x] Build clean for both Homebrew and App Store variants
  (`-Xswiftc -DAPPSTORE`)
- [x] `swift test --filter "AppSettingsTests|DebugRPCServerTests|SettingsViewTests"` — 113 tests passed
- [x] `swift test --filter DebugRPCServerIntegrationTests` — 7 tests passed
- [x] `./scripts/lint.sh` — 0 violations
- [x] Manual: launched dev app, RPC server reachable via mt-cli when
      setting was on; off after relaunch with cleared default

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->