### PR TITLE
ci: skip macOS jobs and DMG build on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect whether anything outside docs/markdown changed. The filter only runs
+  # for PR events; for push/tag/dispatch the step is skipped, leaving the step
+  # output empty, and the job output falls back to 'true' so the full suite
+  # always runs on non-PR triggers. Skipped required checks count as success
+  # in branch protection, so docs-only PRs stay mergeable.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      code: ${{ steps.filter.outputs.code || 'true' }}
+    steps:
+      - if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 10
     steps:
@@ -34,6 +60,8 @@ jobs:
         run: bash scripts/tests/test_build_release_signing.sh
 
   analyze:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 30
     steps:
@@ -48,6 +76,8 @@ jobs:
           swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Mirror of CI's path filter — see ci.yml for the full rationale. Push to
+  # main, version tags, and workflow_dispatch fall through to `code = 'true'`
+  # so they always build.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      code: ${{ steps.filter.outputs.code || 'true' }}
+    steps:
+      - if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26  # Apple Silicon runner (Swift 6.0+)
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
## Summary

Adds a `dorny/paths-filter@v4`-driven `changes` job to **both** `ci.yml` and `release.yml`. PR events that touch only markdown / docs / LICENSE / .gitignore now skip:

- `lint` / `analyze` / `test (homebrew)` / `test (appstore)` (CI workflow)
- `build (homebrew)` / `build (appstore)` DMG matrix (release workflow)

Saves ~30 + ~20 = ~50 macOS-runner minutes per docs-only PR.

## Triggers — what runs when

| Event | `changes` job | macOS jobs |
|---|---|---|
| `pull_request` to `main`, only docs | runs, `code=false` | **skipped** (✓ green) |
| `pull_request` to `main`, any code | runs, `code=true` | full run |
| `push` to `main` / `mac` | skipped (`if: == 'pull_request'`) | **always full run** |
| `push` of `v*` tag | skipped | always full run |
| `workflow_dispatch` | skipped | always full run |

`if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')` — `always()` is required because skipped `needs` jobs would otherwise skip the dependent job by default.

## Why this pattern

`paths-ignore:` on `on:` blocks the workflow from starting → required status checks stay "expected" → PR unmergeable. The job-gating pattern lets skipped jobs report success and unblock merges.

## Test plan

- [ ] This PR touches `.github/workflows/*` → `changes.code == true` → full CI runs
- [ ] After merge: a docs-only follow-up PR shows all macOS jobs as "Skipped" with green checkmarks, mergeable
- [ ] After merge: a `push` to main (post-rebase) re-runs full CI + DMG build regardless of doc-vs-code