### PR TITLE
ci(release): mention beta channel in RC release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,15 +164,17 @@ jobs:
           generateReleaseNotesPreviousTag: ${{ steps.prev.outputs.tag }}
           prerelease: ${{ steps.version.outputs.prerelease }}
           body: |
-            ## MeetingTranscriber ${{ steps.version.outputs.version }}
+            ## MeetingTranscriber ${{ steps.version.outputs.version }}${{ steps.version.outputs.prerelease == 'true' && ' (Pre-release)' || '' }}
 
             ### Installation
 
-            **Via Homebrew (recommended):**
+            **Via Homebrew (${{ steps.version.outputs.prerelease == 'true' && 'Beta channel' || 'recommended' }}):**
             ```bash
             brew tap pasrom/meeting-transcriber
-            brew install --cask meeting-transcriber
+            brew install --cask ${{ steps.version.outputs.prerelease == 'true' && 'meeting-transcriber@beta' || 'meeting-transcriber' }}
             ```
+
+            ${{ steps.version.outputs.prerelease == 'true' && '> Release candidate from the **beta channel**. The stable and beta casks conflict — uninstall one before installing the other.' || '' }}
 
             **Manual:**
             1. Download the DMG below


### PR DESCRIPTION
## Summary
- Pre-release tags (versions containing `-`, e.g. `v1.2.3-rc1`) now produce GitHub Release notes that:
  - append `(Pre-release)` to the version heading,
  - show `brew install --cask meeting-transcriber@beta` instead of the stable cask,
  - label the install section "Beta channel",
  - include the stable/beta cask conflict note.
- Stable releases are unchanged.

Implemented via inline `${{ … && … || … }}` ternaries in the release body template; no extra steps or duplicated bodies.

## Test plan
- [ ] Cut an RC tag (e.g. `vX.Y.Z-rc1`) and verify the resulting GitHub Release shows the `@beta` cask + beta-channel note.
- [ ] Cut a stable tag and verify release notes are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->