### PR TITLE
fix(app): keep Output Folder picker interactive in record-only mode

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -23,21 +23,9 @@ struct OutputSettingsView: View {
     var body: some View {
         // swiftlint:disable:next closure_body_length
         Form {
-            Section("Protocol Generation") {
-                Picker("LLM Provider", selection: $settings.protocolProvider) {
-                    ForEach(ProtocolProvider.allCases, id: \.self) { provider in
-                        Text(provider.label).tag(provider)
-                    }
-                }
-
-                providerConfigView
-
-                Picker("Protocol Language", selection: $settings.protocolLanguage) {
-                    ForEach(AppSettings.protocolLanguages, id: \.self) { lang in
-                        Text(lang).tag(lang)
-                    }
-                }
-
+            // Output folder applies to record-only AND protocol mode, so this
+            // section deliberately sits outside the .recordOnlyDisabled block.
+            Section("Output Folder") {
                 HStack {
                     Text("Output Folder")
                     Spacer()
@@ -58,6 +46,23 @@ struct OutputSettingsView: View {
                     .disabled(settings.customOutputDirBookmark == nil)
 
                     Spacer()
+                }
+            }
+            .accessibilityIdentifier("outputFolderSection")
+
+            Section("Protocol Generation") {
+                Picker("LLM Provider", selection: $settings.protocolProvider) {
+                    ForEach(ProtocolProvider.allCases, id: \.self) { provider in
+                        Text(provider.label).tag(provider)
+                    }
+                }
+
+                providerConfigView
+
+                Picker("Protocol Language", selection: $settings.protocolLanguage) {
+                    ForEach(AppSettings.protocolLanguages, id: \.self) { lang in
+                        Text(lang).tag(lang)
+                    }
                 }
 
                 promptControls

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -465,6 +465,16 @@ final class SettingsViewTests: XCTestCase {
         XCTAssertTrue(try section.isDisabled())
     }
 
+    func testRecordOnlyDoesNotDisableOutputFolderSection() throws {
+        // Output Folder is where WAVs land in record-only mode too,
+        // so it must remain interactive when the rest of Output is dimmed.
+        let settings = makeSettings()
+        settings.recordOnly = true
+        let body = try makeOutput(settings: settings).inspect()
+        let section = try body.find(viewWithAccessibilityIdentifier: "outputFolderSection")
+        XCTAssertFalse(try section.isDisabled())
+    }
+
     func testRecordOnlyDisablesDiarizationSection() throws {
         let settings = makeSettings()
         settings.recordOnly = true


### PR DESCRIPTION
## Summary

Output Folder picker on the Output Settings tab was greyed out in record-only mode, because it lived inside `Section("Protocol Generation")` which gets `.recordOnlyDisabled` applied. Workaround was toggling record-only off, changing the folder, toggling back on. Reported by ilyasst in #128.

Move it into its own `Section("Output Folder")` above Protocol Generation. The new section has no `.recordOnlyDisabled` modifier so it stays interactive in both modes. Protocol Generation keeps its modifier (LLM provider, language, prompt controls dim correctly when record-only is on).

Refs #128.

## Test plan

- [x] `swift test --filter SettingsViewTests` — 56 passed, incl. new `testRecordOnlyDoesNotDisableOutputFolderSection` regression
- [x] `swiftlint --strict` clean
- [x] Live: dev app launched with `recordOnly=true`, navigated to Output tab — Output Folder section interactive (Choose enabled), Protocol Generation section dimmed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->