### PR TITLE
feat: diagnostic logging end-to-end (toggle + export + redaction)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: Report a bug in Meeting Transcriber
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! To help diagnose the issue, please attach a diagnostic log:
+
+        1. Open Meeting Transcriber → **Settings → Advanced → Diagnostics**
+        2. Toggle **Verbose Diagnostic Logging** ON
+        3. Reproduce the problem
+        4. Click **Export Diagnostics…** — Finder will reveal a `.log` file
+        5. Drag that `.log` file into the **Diagnostic log** field below
+
+        Speaker names in the log are pseudonymised (e.g. `speaker_a3f2`) and
+        transcript text is **not** included.
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: From Settings → Advanced → About
+      placeholder: "1.2.3 (abcdef) · Homebrew"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Build variant
+      options:
+        - Homebrew (stable)
+        - Homebrew (beta / RC)
+        - App Store
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "14.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen, and what actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start a Zoom meeting with two participants
+        2. Click Record in the menu bar
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Diagnostic log
+      description: Drag the exported `.log` file here. GitHub will upload it automatically.
+    validations:
+      required: false

--- a/app/MeetingTranscriber/Sources/AXHelper.swift
+++ b/app/MeetingTranscriber/Sources/AXHelper.swift
@@ -1,11 +1,21 @@
 import ApplicationServices
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AXHelper")
 
 /// Shared Accessibility API helpers used by ParticipantReader.
 enum AXHelper {
     /// Read a single AX attribute value from an element.
+    /// Logs a warning if the call fails with a status other than `noValue`
+    /// (which is a normal "attribute is empty" outcome and not a failure).
     static func getAttribute(_ element: AXUIElement, attribute: String) -> AnyObject? {
         var value: AnyObject?
         let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        if err != .success && err != .noValue && err != .attributeUnsupported {
+            logger.warning(
+                "ax_call_failed attribute=\(attribute, privacy: .public) error=\(err.rawValue, privacy: .public)",
+            )
+        }
         return err == .success ? value : nil
     }
 }

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -280,13 +280,16 @@ final class AppSettings {
 
     // MARK: - Diagnostics
 
-    /// Enables verbose logging in the audio-capture path: process/device identity,
-    /// periodic RMS energy of the captured stream, output-device-change details.
-    /// Off by default; toggle for forensic debugging when audio recordings are silent
-    /// or otherwise unexpected. Logs go to the unified log subsystem
-    /// `com.meetingtranscriber.audiotap`.
-    var audioDebugLogging: Bool {
-        didSet { defaults.set(audioDebugLogging, forKey: "audioDebugLogging") }
+    /// Enables verbose diagnostic logging across **all** pipelines: audio
+    /// capture (process/device identity, periodic RMS), transcription
+    /// (segment counts, input RMS, sample-rate validation), VAD (segment
+    /// boundaries, round-trip checks), diarization, speaker matching
+    /// (top-2 candidates + margins), and protocol generation. Off by
+    /// default. Logs go to `com.meetingtranscriber` and
+    /// `com.meetingtranscriber.audiotap`. Use the "Export Diagnostics"
+    /// button in Settings → Advanced to attach a log to a bug report.
+    var verboseDiagnostics: Bool {
+        didSet { defaults.set(verboseDiagnostics, forKey: "verboseDiagnostics") }
     }
 
     #if !APPSTORE
@@ -360,7 +363,16 @@ final class AppSettings {
             ?? "http://localhost:11434/v1/chat/completions"
         openAIModel = defaults.object(forKey: "openAIModel") as? String ?? "llama3.1"
 
-        audioDebugLogging = defaults.object(forKey: "audioDebugLogging") as? Bool ?? false
+        // Migrate legacy "audioDebugLogging" key (renamed to "verboseDiagnostics" 2026-05-04).
+        // New key wins if both are set; legacy value seeds the new key on first launch.
+        if let new = defaults.object(forKey: "verboseDiagnostics") as? Bool {
+            verboseDiagnostics = new
+        } else if let legacy = defaults.object(forKey: "audioDebugLogging") as? Bool {
+            verboseDiagnostics = legacy
+            defaults.set(legacy, forKey: "verboseDiagnostics")
+        } else {
+            verboseDiagnostics = false
+        }
         #if !APPSTORE
             debugRPCEnabled = defaults.object(forKey: "debugRPCEnabled") as? Bool ?? false
         #endif

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -247,7 +247,7 @@ final class AppState {
                     endGracePeriod: settings.endGrace,
                     noMic: settings.noMic,
                     micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                    audioDebugLogging: { [settings] in settings.audioDebugLogging },
+                    verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
                     recordOnly: { [settings] in settings.recordOnly },
                     recordOnlyOutputDir: { [settings] in
                         settings.effectiveOutputDir.appendingPathComponent("recordings")
@@ -305,7 +305,7 @@ final class AppState {
                 pollInterval: settings.pollInterval,
                 noMic: settings.noMic,
                 micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                audioDebugLogging: { [settings] in settings.audioDebugLogging },
+                verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
                 recordOnly: { [settings] in settings.recordOnly },
                 recordOnlyOutputDir: { [settings] in
                     settings.effectiveOutputDir.appendingPathComponent("recordings")

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -335,6 +335,22 @@ enum AudioMixer {
         return try readSamplesFromAudioFile(file)
     }
 
+    /// RMS in dBFS for a Float32 PCM sample buffer.
+    /// Returns `-Float.infinity` for an empty buffer (true silence).
+    static func rmsDecibels(samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return -.infinity }
+        let sumSq = samples.reduce(Float(0)) { $0 + $1 * $1 }
+        let rms = (sumSq / Float(samples.count)).squareRoot()
+        return 20 * log10(max(rms, 1e-10))
+    }
+
+    /// Convenience: RMS in dBFS for a WAV / AVAudioFile-readable file.
+    /// Returns `nil` if the file cannot be read.
+    static func rmsDecibels(forFileAt url: URL) -> Float? {
+        guard let samples = try? loadAudioFileAsFloat32(url: url) else { return nil }
+        return rmsDecibels(samples: samples)
+    }
+
     /// Read mono Float32 samples from an already-opened AVAudioFile.
     private static func readSamplesFromAudioFile(_ file: AVAudioFile) throws -> [Float] {
         let format = file.processingFormat

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -12,6 +12,21 @@ enum AudioMixer {
     /// a corrupted timestamp (e.g. device restart mid-recording, see #99).
     static let maxMicDelay: TimeInterval = 30
 
+    /// Clamps `delay` to ±`maxMicDelay`. Logs a warning if clamping occurred —
+    /// excessive deltas usually mean the output device was switched mid-recording,
+    /// resetting the first-frame timestamp on one but not the other source.
+    static func clampMicDelay(_ delay: TimeInterval) -> TimeInterval {
+        let clamped = min(max(delay, -maxMicDelay), maxMicDelay)
+        if clamped != delay {
+            let delayStr = String(format: "%.2f", delay)
+            let clampedStr = String(format: "%.2f", clamped)
+            logger.warning(
+                "mic_delay_clamped original=\(delayStr, privacy: .public)s clamped=\(clampedStr, privacy: .public)s — possible output-device switch during recording",
+            )
+        }
+        return clamped
+    }
+
     /// Mix app and mic audio tracks into a single mono WAV.
     ///
     /// Applies echo suppression, delay alignment, then averages the two tracks.
@@ -25,11 +40,7 @@ enum AudioMixer {
         var appSamples = try loadAudioFileAsFloat32(url: appAudioPath)
         var micSamples = try loadAudioFileAsFloat32(url: micAudioPath)
 
-        // Clamp to ±maxMicDelay (see #99).
-        let clampedDelay = min(max(micDelay, -maxMicDelay), maxMicDelay)
-        if clampedDelay != micDelay {
-            logger.warning("micDelay \(micDelay)s outside ±\(Self.maxMicDelay)s — clamped to \(clampedDelay)s")
-        }
+        let clampedDelay = clampMicDelay(micDelay)
 
         // Apply echo suppression
         if !appSamples.isEmpty && !micSamples.isEmpty {

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -69,6 +69,9 @@
             do {
                 try process.run()
             } catch {
+                logger.error(
+                    "claude_cli_not_found bin=\(self.claudeBin, privacy: .public) resolvedPath=\(resolvedBin, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
+                )
                 throw ProtocolError.cliNotFound(claudeBin)
             }
 
@@ -77,12 +80,11 @@
             // but AsyncStream buffers the yield so we won't miss it.
             // No additional check needed — AsyncStream handles the race.
 
-            logger.info("Generating protocol with Claude CLI ...")
-
             // C6 fix: Write stdin in a detached task to avoid deadlock on large transcripts.
             // The pipe buffer is finite (~64KB); if the prompt exceeds it, a synchronous
             // write blocks until the reader drains — but we haven't started reading yet.
             let promptData = Data(prompt.utf8)
+            logger.info("claude_cli_subprocess_start prompt_bytes=\(promptData.count, privacy: .public)")
             let stdinWriteTask = Task.detached {
                 stdinPipe.fileHandleForWriting.write(promptData)
                 stdinPipe.fileHandleForWriting.closeFile()
@@ -107,11 +109,15 @@
             if process.terminationStatus != 0 {
                 let stderrData = await stderrRead
                 let stderrText = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                logger.error(
+                    "claude_cli_failed exit=\(process.terminationStatus, privacy: .public) stderr=\(stderrText, privacy: .public)",
+                )
                 throw ProtocolError.cliFailed(Int(process.terminationStatus), stderrText)
             }
 
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else {
+                logger.error("claude_cli_empty_response — subprocess exited 0 with empty output")
                 throw ProtocolError.emptyProtocol
             }
 
@@ -130,6 +136,11 @@
             var buffer = Data()
             while true {
                 if ProcessInfo.processInfo.systemUptime - startTime > timeoutSeconds {
+                    let elapsed = ProcessInfo.processInfo.systemUptime - startTime
+                    let elapsedStr = String(format: "%.1f", elapsed)
+                    logger.error(
+                        "claude_cli_timeout elapsed=\(elapsedStr, privacy: .public)s parts_received=\(parts.count, privacy: .public)",
+                    )
                     process.terminate()
                     throw ProtocolError.timeout
                 }

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -22,6 +22,7 @@
 
         // MARK: - ProtocolGenerating
 
+        // swiftlint:disable:next function_body_length
         func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
             var prompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
             if diarized {

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -5,6 +5,11 @@ import OSLog
 /// to a shareable `.log` file with a header describing the app build state.
 /// Used by Settings → Advanced → "Export Diagnostics…".
 enum DiagnosticExporter {
+    /// Shared formatter — `ISO8601DateFormatter` init is non-trivial, so we
+    /// keep one instance for both the header timestamp and per-entry timestamps
+    /// in `export(...)`.
+    private static let formatter = ISO8601DateFormatter()
+
     /// Build the header that prefixes every exported diagnostic file.
     /// Pure function — settings dict is stringified verbatim into `key=value`
     /// pairs, sorted alphabetically for deterministic output. No PII is
@@ -18,7 +23,7 @@ enum DiagnosticExporter {
         let pairs = settings.sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: " ")
-        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let timestamp = formatter.string(from: Date())
         return """
         # MeetingTranscriber \(appVersion) (\(commit))
         # macOS \(macOSVersion)
@@ -52,7 +57,6 @@ enum DiagnosticExporter {
             macOSVersion: macOSVersion, settings: settings,
         )]
         var count = 0
-        let formatter = ISO8601DateFormatter()
         for entry in entries {
             guard let log = entry as? OSLogEntryLog else { continue }
             let timestamp = formatter.string(from: log.date)

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -1,0 +1,68 @@
+import Foundation
+import OSLog
+
+/// Reads recent unified-log entries for the app's subsystems and writes them
+/// to a shareable `.log` file with a header describing the app build state.
+/// Used by Settings → Advanced → "Export Diagnostics…".
+enum DiagnosticExporter {
+    /// Build the header that prefixes every exported diagnostic file.
+    /// Pure function — settings dict is stringified verbatim into `key=value`
+    /// pairs, sorted alphabetically for deterministic output. No PII is
+    /// expected in `settings` (UI flags only).
+    static func makeHeader(
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String],
+    ) -> String {
+        let pairs = settings.sorted(by: { $0.key < $1.key })
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: " ")
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        return """
+        # MeetingTranscriber \(appVersion) (\(commit))
+        # macOS \(macOSVersion)
+        # exported_at=\(timestamp)
+        # settings: \(pairs)
+        # ---
+        """
+    }
+
+    /// Reads the last `windowSeconds` of unified-log entries for our subsystems
+    /// and writes them to `outputURL`. Returns the number of log entries
+    /// written (excluding the header). Throws on store-open or write failures.
+    @available(macOS 12, *)
+    static func export(
+        to outputURL: URL,
+        windowSeconds: TimeInterval = 1800,
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String],
+    ) throws -> Int {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let position = store.position(date: Date().addingTimeInterval(-windowSeconds))
+        let predicate = NSPredicate(
+            format: "subsystem CONTAINS 'com.meetingtranscriber'",
+        )
+        let entries = try store.getEntries(at: position, matching: predicate)
+
+        var lines: [String] = [makeHeader(
+            appVersion: appVersion, commit: commit,
+            macOSVersion: macOSVersion, settings: settings,
+        )]
+        var count = 0
+        let formatter = ISO8601DateFormatter()
+        for entry in entries {
+            guard let log = entry as? OSLogEntryLog else { continue }
+            let timestamp = formatter.string(from: log.date)
+            let line = "\(timestamp) [\(log.level.rawValue)] " +
+                "\(log.subsystem)/\(log.category): \(log.composedMessage)"
+            lines.append(line)
+            count += 1
+        }
+
+        try lines.joined(separator: "\n").write(to: outputURL, atomically: true, encoding: .utf8)
+        return count
+    }
+}

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -15,7 +15,7 @@ enum DiagnosticExporter {
         macOSVersion: String,
         settings: [String: String],
     ) -> String {
-        let pairs = settings.sorted(by: { $0.key < $1.key })
+        let pairs = settings.sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: " ")
         let timestamp = ISO8601DateFormatter().string(from: Date())
@@ -34,11 +34,11 @@ enum DiagnosticExporter {
     @available(macOS 12, *)
     static func export(
         to outputURL: URL,
-        windowSeconds: TimeInterval = 1800,
         appVersion: String,
         commit: String,
         macOSVersion: String,
         settings: [String: String],
+        windowSeconds: TimeInterval = 1800,
     ) throws -> Int {
         let store = try OSLogStore(scope: .currentProcessIdentifier)
         let position = store.position(date: Date().addingTimeInterval(-windowSeconds))

--- a/app/MeetingTranscriber/Sources/FluidVAD.swift
+++ b/app/MeetingTranscriber/Sources/FluidVAD.swift
@@ -147,9 +147,31 @@ class FluidVAD {
         let speechDuration = regions.reduce(0.0) { $0 + $1.duration }
         let speechStr = String(format: "%.1f", speechDuration)
         let totalStr = String(format: "%.1f", totalDuration)
-        logger.info("VAD: \(regions.count) speech regions, \(speechStr)s speech / \(totalStr)s total")
+        let trimRatio = totalDuration > 0 ? (1.0 - speechDuration / totalDuration) : 0
+        let trimRatioStr = String(format: "%.2f", trimRatio)
+        logger.info(
+            "vad_extract regions=\(regions.count, privacy: .public) speech=\(speechStr, privacy: .public)s total=\(totalStr, privacy: .public)s trimRatio=\(trimRatioStr, privacy: .public)",
+        )
 
-        return VadSegmentMap(segments: regions, sampleRate: AudioConstants.targetSampleRate)
+        let map = VadSegmentMap(segments: regions, sampleRate: AudioConstants.targetSampleRate)
+
+        // Round-trip sanity: pick the midpoint of the trimmed timeline, map back
+        // to the original timeline, verify the result lands inside one of the
+        // detected speech regions. If it doesn't, the mapping is inconsistent.
+        if !regions.isEmpty {
+            let probe = speechDuration / 2.0
+            let mapped = map.toOriginalTime(probe)
+            let inRegion = regions.contains { mapped >= $0.start && mapped <= $0.end }
+            if !inRegion {
+                let probeStr = String(format: "%.3f", probe)
+                let mappedStr = String(format: "%.3f", mapped)
+                logger.warning(
+                    "vad_roundtrip_drift probe=\(probeStr, privacy: .public)s mapped=\(mappedStr, privacy: .public)s — VadSegmentMap may be inconsistent",
+                )
+            }
+        }
+
+        return map
     }
 
     /// Merge regions that are closer together than maxGap seconds.

--- a/app/MeetingTranscriber/Sources/LogRedaction.swift
+++ b/app/MeetingTranscriber/Sources/LogRedaction.swift
@@ -1,0 +1,31 @@
+import CryptoKit
+import Foundation
+
+extension String {
+    /// Deterministic 4-hex-char pseudonym derived from SHA-256.
+    /// Stable across runs (same input → same output) so logs can be correlated
+    /// without exposing the clear name. Used for speaker IDs in diagnostic logs.
+    var pseudonymized: String {
+        guard !isEmpty else { return "speaker_anon" }
+        let hash = SHA256.hash(data: Data(utf8))
+        let prefix = hash.prefix(2).map { String(format: "%02x", $0) }.joined()
+        return "speaker_\(prefix)"
+    }
+
+    /// First-and-last-char redaction: "Roman" → "R***n", "Tom" → "T**", "Li" → "L*".
+    /// Less privacy-preserving than `pseudonymized` (length leaks); use for UI-adjacent
+    /// logs where the user actively benefits from recognising "their" name. For
+    /// machine-readable forensic logs, prefer `pseudonymized`.
+    var redactedName: String {
+        let chars = Array(self)
+        switch chars.count {
+        case 0: return ""
+        case 1: return "*"
+        case 2: return "\(chars[0])*"
+        case 3: return "\(chars[0])**"
+        default:
+            let middle = String(repeating: "*", count: chars.count - 2)
+            return "\(chars[0])\(middle)\(chars.last!)"
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/LogRedaction.swift
+++ b/app/MeetingTranscriber/Sources/LogRedaction.swift
@@ -23,6 +23,7 @@ extension String {
         case 1: return "*"
         case 2: return "\(chars[0])*"
         case 3: return "\(chars[0])**"
+
         default:
             let middle = String(repeating: "*", count: chars.count - 2)
             return "\(chars[0])\(middle)\(chars.last!)"

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os.log
 import UserNotifications
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "NotificationManager")
 
 /// Sends macOS notifications for meeting state transitions.
 final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, AppNotifying {
@@ -16,7 +19,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         guard !isSetUp else { return }
         // UNUserNotificationCenter crashes without a proper app bundle
         guard Bundle.main.bundleIdentifier != nil else {
-            print("NotificationManager: skipping setup (no app bundle)")
+            logger.warning("Skipping setup — no app bundle")
             return
         }
         isSetUp = true
@@ -25,10 +28,10 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         center.delegate = self
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
-                print("Notification permission error: \(error)")
+                logger.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
             }
             if !granted {
-                print("Notification permission denied")
+                logger.warning("Notification permission denied")
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -62,10 +62,14 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         do {
             (bytes, response) = try await session.bytes(for: request)
         } catch {
+            logger.error(
+                "openai_connection_failed endpoint=\(self.endpoint.absoluteString, privacy: .public) model=\(self.model, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
+            )
             throw ProtocolError.connectionFailed(error.localizedDescription)
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
+            logger.error("openai_invalid_response endpoint=\(self.endpoint.absoluteString, privacy: .public)")
             throw ProtocolError.connectionFailed("Invalid response")
         }
 
@@ -76,6 +80,9 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
                 errorBody += line
                 if errorBody.count > 500 { break }
             }
+            logger.error(
+                "openai_http_error status=\(httpResponse.statusCode, privacy: .public) endpoint=\(self.endpoint.absoluteString, privacy: .public) body=\(errorBody, privacy: .public)",
+            )
             throw ProtocolError.httpError(httpResponse.statusCode, errorBody)
         }
 

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -3,19 +3,33 @@ import AVFoundation
 import CoreGraphics
 import Foundation
 import os
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Permissions")
 
 enum Permissions {
     /// Check if Screen Recording permission is granted.
     static func checkScreenRecording() -> Bool {
-        PermissionHealthCheck.checkScreenRecordingLive() == .healthy
+        let granted = PermissionHealthCheck.checkScreenRecordingLive() == .healthy
+        if !granted {
+            logger.warning("permission_denied resource=screen_recording — required for meeting detection")
+        }
+        return granted
     }
 
     static func ensureMicrophoneAccess() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         if status == .authorized { return true }
         if status == .notDetermined {
-            return await AVCaptureDevice.requestAccess(for: .audio)
+            let granted = await AVCaptureDevice.requestAccess(for: .audio)
+            if !granted {
+                logger.warning("permission_denied resource=microphone status=user_denied_prompt")
+            }
+            return granted
         }
+        logger.warning(
+            "permission_denied resource=microphone status=\(status.rawValue, privacy: .public)",
+        )
         return false
     }
 
@@ -28,8 +42,15 @@ enum Permissions {
             prompted = true
             return false
         }
-        guard !alreadyPrompted else { return false }
+        guard !alreadyPrompted else {
+            logger.warning("permission_denied resource=accessibility status=already_prompted")
+            return false
+        }
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
-        return AXIsProcessTrustedWithOptions(options)
+        let granted = AXIsProcessTrustedWithOptions(options)
+        if !granted {
+            logger.warning("permission_denied resource=accessibility status=user_denied_prompt")
+        }
+        return granted
     }
 }

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -3,7 +3,6 @@ import AVFoundation
 import CoreGraphics
 import Foundation
 import os
-import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Permissions")
 

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -27,6 +27,14 @@ enum JobState: String, Codable {
 
 struct PipelineJob: Identifiable, Codable {
     let id: UUID
+
+    /// Short 8-hex-char form of `id`, used as a `[xxxxxxxx]` log prefix to
+    /// correlate diagnostic lines across the transcribe → diarize → protocol
+    /// stages of the same job.
+    var shortID: String {
+        String(id.uuidString.prefix(8).lowercased())
+    }
+
     let meetingTitle: String
     let appName: String
     let mixPath: URL

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -460,7 +460,17 @@ class PipelineQueue {
 
             stopElapsedTimer()
 
+            let segCount = cachedSegments?.count ?? 0
+            let totalSecs = cachedSegments?.last?.end ?? 0
+            let inputRMS = AudioMixer.rmsDecibels(forFileAt: mixPath) ?? .nan
+            logger.info(
+                "[\(shortID, privacy: .public)] transcription_complete segments=\(segCount, privacy: .public) duration=\(totalSecs, privacy: .public)s inputRMSdBFS=\(inputRMS, privacy: .public)",
+            )
+
             guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                logger.warning(
+                    "[\(shortID, privacy: .public)] transcription_empty inputRMSdBFS=\(inputRMS, privacy: .public). Likely silent input or ASR misconfiguration — check microphone level and engine settings.",
+                )
                 updateJobState(id: jobID, to: .error, error: "Empty transcript")
                 isProcessing = false
                 triggerProcessing()

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -462,12 +462,15 @@ class PipelineQueue {
 
             let segCount = cachedSegments?.count ?? 0
             let totalSecs = cachedSegments?.last?.end ?? 0
-            let inputRMS = AudioMixer.rmsDecibels(forFileAt: mixPath) ?? .nan
             logger.info(
-                "[\(shortID, privacy: .public)] transcription_complete segments=\(segCount, privacy: .public) duration=\(totalSecs, privacy: .public)s inputRMSdBFS=\(inputRMS, privacy: .public)",
+                "[\(shortID, privacy: .public)] transcription_complete segments=\(segCount, privacy: .public) duration=\(totalSecs, privacy: .public)s",
             )
 
             guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                // Compute input RMS only on the failure path — loading the whole
+                // mix file is expensive (~MB-per-minute) and we only need it when
+                // diagnosing why transcription produced nothing.
+                let inputRMS = AudioMixer.rmsDecibels(forFileAt: mixPath) ?? .nan
                 logger.warning(
                     "[\(shortID, privacy: .public)] transcription_empty inputRMSdBFS=\(inputRMS, privacy: .public). Likely silent input or ASR misconfiguration — check microphone level and engine settings.",
                 )

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -382,6 +382,7 @@ class PipelineQueue {
             return
         }
         let jobID = jobs[index].id
+        let shortID = jobs[index].shortID
         let title = jobs[index].meetingTitle
         let mixPath = jobs[index].mixPath
         let appPath = jobs[index].appPath
@@ -393,6 +394,7 @@ class PipelineQueue {
             // --- Transcription ---
             updateJobState(id: jobID, to: .transcribing)
             startElapsedTimer()
+            logger.info("[\(shortID, privacy: .public)] transcription_start title=\(title, privacy: .private)")
 
             // Create a temp directory for intermediate 16kHz files
             let workDir = FileManager.default.temporaryDirectory
@@ -676,21 +678,21 @@ class PipelineQueue {
                             finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
                         }
                         let segCount = diarization?.segments.count ?? 0
-                        logger.info("Diarization complete: \(segCount) segments")
+                        logger.info("[\(shortID, privacy: .public)] diarization_complete segments=\(segCount, privacy: .public)")
                     } catch {
-                        logger.warning("Diarization failed, using undiarized transcript: \(error.localizedDescription)")
+                        logger.warning("[\(shortID, privacy: .public)] diarization_failed error=\(error.localizedDescription, privacy: .public)")
                         addWarning(id: jobID, "Diarization failed — speakers not identified")
                         // Continue with original transcript
                     }
                 } else {
-                    logger.info("Diarization not available")
+                    logger.info("[\(shortID, privacy: .public)] diarization_skipped")
                 }
             }
 
             // --- Save Transcript & Audio (always) ---
             let protocolsDir = outputDir.appendingPathComponent("protocols")
             let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: title, dir: protocolsDir)
-            logger.info("Transcript saved: \(txtPath.lastPathComponent)")
+            logger.info("[\(shortID, privacy: .public)] transcript_saved file=\(txtPath.lastPathComponent, privacy: .public)")
 
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                 jobs[idx].transcriptPath = txtPath
@@ -779,6 +781,7 @@ class PipelineQueue {
         guard let protocolGeneratorFactory, let generator = protocolGeneratorFactory() else {
             return
         }
+        let shortID = String(jobID.uuidString.prefix(8).lowercased())
         do {
             updateJobState(id: jobID, to: .generatingProtocol)
             startElapsedTimer()
@@ -792,13 +795,13 @@ class PipelineQueue {
             let mdPath = try ProtocolGenerator.saveProtocol(
                 fullMD, title: title, dir: protocolsDir,
             )
-            logger.info("Protocol saved: \(mdPath.lastPathComponent)")
+            logger.info("[\(shortID, privacy: .public)] protocol_saved file=\(mdPath.lastPathComponent, privacy: .public)")
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                 jobs[idx].protocolPath = mdPath
             }
             stopElapsedTimer()
         } catch {
-            logger.warning("Protocol generation failed: \(error.localizedDescription)")
+            logger.warning("[\(shortID, privacy: .public)] protocol_generation_failed error=\(error.localizedDescription, privacy: .public)")
             addWarning(id: jobID, "Protocol generation failed — transcript saved")
             stopElapsedTimer()
         }

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -1,6 +1,9 @@
 import FluidAudio
 import Foundation
+import os.log
 import WhisperKit
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Qwen3AsrEngine")
 
 /// Transcription engine backed by Qwen3-ASR 0.6B via FluidAudio CoreML.
 ///
@@ -44,7 +47,7 @@ final class Qwen3AsrEngine: TranscribingEngine {
                 asrManager = manager
                 modelState = .loaded
             } catch {
-                NSLog("Qwen3-ASR model load failed: \(error)")
+                logger.error("Qwen3-ASR model load failed: \(error.localizedDescription, privacy: .public)")
                 modelState = .unloaded
                 downloadProgress = 0
             }
@@ -56,13 +59,13 @@ final class Qwen3AsrEngine: TranscribingEngine {
 
     private func ensureModel() async throws {
         if asrManager != nil { return }
-        NSLog("Qwen3-ASR: model not loaded, loading...")
+        logger.info("Qwen3-ASR: model not loaded, loading...")
         await loadModel()
         guard asrManager != nil else {
-            NSLog("Qwen3-ASR: model load FAILED, state=\(modelState)")
+            logger.error("Qwen3-ASR: model load FAILED, state=\(String(describing: self.modelState), privacy: .public)")
             throw TranscriptionError.modelNotLoaded
         }
-        NSLog("Qwen3-ASR: model loaded successfully")
+        logger.info("Qwen3-ASR: model loaded successfully")
     }
 
     func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment] {

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -56,12 +56,13 @@ struct AdvancedSettingsView: View {
             }
 
             Section("Diagnostics") {
-                Toggle("Verbose Audio Logging", isOn: $settings.audioDebugLogging)
+                Toggle("Verbose Diagnostic Logging", isOn: $settings.verboseDiagnostics)
                 Text(
-                    "Logs process and output-device identity, plus a 5-second RMS"
-                        + " energy report of the captured app audio. Use to"
-                        + " investigate silent recordings. Logs go to subsystem"
-                        + " com.meetingtranscriber.audiotap (view via Console.app).",
+                    "Logs detailed diagnostics across recording, transcription,"
+                        + " diarization, and protocol generation. Used to debug"
+                        + " issues. Off by default — toggle on, reproduce the"
+                        + " problem, then click \"Export Diagnostics…\" below to"
+                        + " attach a redacted log file to a bug report.",
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -1,6 +1,10 @@
+import AppKit
 import ApplicationServices
 import AVFoundation
+import os.log
 import SwiftUI
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AdvancedSettingsView")
 
 private enum PrivacyPane: String {
     case screenCapture = "Privacy_ScreenCapture"
@@ -18,6 +22,8 @@ struct AdvancedSettingsView: View {
     @State private var micPermission: AVAuthorizationStatus = .notDetermined
     @State private var screenRecordingOK = false
     @State private var accessibilityOK = false
+    @State private var lastExportFile: String?
+    @State private var lastExportError: String?
 
     var body: some View {
         // swiftlint:disable:next closure_body_length
@@ -66,6 +72,18 @@ struct AdvancedSettingsView: View {
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+                Button("Export Diagnostics…") { exportDiagnostics() }
+                if let file = lastExportFile {
+                    Text("Exported to: \(file)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let err = lastExportError {
+                    Text("Export failed: \(err)")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
 
                 #if !APPSTORE
                     Toggle("Debug RPC Server", isOn: $settings.debugRPCEnabled)
@@ -129,5 +147,41 @@ struct AdvancedSettingsView: View {
         micPermission = AVCaptureDevice.authorizationStatus(for: .audio)
         screenRecordingOK = Permissions.checkScreenRecording()
         accessibilityOK = AXIsProcessTrusted()
+    }
+
+    private func exportDiagnostics() {
+        let stamp = Int(Date().timeIntervalSince1970)
+        let outURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingTranscriber-diagnostics-\(stamp).log")
+        do {
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+            let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
+            let count = try DiagnosticExporter.export(
+                to: outURL,
+                appVersion: appVersion,
+                commit: commit,
+                macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                settings: [
+                    "verboseDiagnostics": "\(settings.verboseDiagnostics)",
+                    "diarize": "\(settings.diarize)",
+                    "vadEnabled": "\(settings.vadEnabled)",
+                    "transcriptionEngine": settings.transcriptionEngine.rawValue,
+                    "protocolProvider": settings.protocolProvider.rawValue,
+                    "recordOnly": "\(settings.recordOnly)",
+                ],
+            )
+            lastExportFile = outURL.lastPathComponent
+            lastExportError = nil
+            NSWorkspace.shared.activateFileViewerSelecting([outURL])
+            logger.info(
+                "diagnostics_exported lines=\(count, privacy: .public) file=\(outURL.lastPathComponent, privacy: .public)",
+            )
+        } catch {
+            lastExportFile = nil
+            lastExportError = error.localizedDescription
+            logger.error(
+                "diagnostics_export_failed error=\(error.localizedDescription, privacy: .public)",
+            )
+        }
     }
 }

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -61,6 +61,7 @@ struct AdvancedSettingsView: View {
                 .font(.caption)
             }
 
+            // swiftlint:disable:next closure_body_length
             Section("Diagnostics") {
                 Toggle("Verbose Diagnostic Logging", isOn: $settings.verboseDiagnostics)
                 Text(

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher+Logging.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher+Logging.swift
@@ -1,0 +1,43 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "SpeakerMatcher")
+
+extension SpeakerMatcher {
+    /// Forensic log for a single label match decision. Names are
+    /// SHA-256-pseudonymized via `String.pseudonymized` so the log can be
+    /// shared in bug reports without leaking real speaker names. Distances
+    /// and margins are public; the per-label classifier ID is public too.
+    static func logMatchDecision(
+        label: String,
+        best: TopCandidate?,
+        second: TopCandidate?,
+        assigned: String,
+        thresholds: (distance: Float, margin: Float),
+    ) {
+        guard let best else {
+            logger.info(
+                "speaker_match label=\(label, privacy: .public) result=no_candidates",
+            )
+            return
+        }
+        let bestPseudo = best.name.pseudonymized
+        let secondPseudo = second?.name.pseudonymized ?? "none"
+        let secondDist = second?.hybrid ?? .greatestFiniteMagnitude
+        let actualMargin = secondDist - best.hybrid
+
+        if assigned == best.name {
+            logger.info(
+                "speaker_match_assigned label=\(label, privacy: .public) speaker=\(bestPseudo, privacy: .public) bestDist=\(best.hybrid, privacy: .public) secondDist=\(secondDist, privacy: .public) margin=\(actualMargin, privacy: .public)",
+            )
+        } else if best.hybrid >= thresholds.distance {
+            logger.info(
+                "speaker_match_rejected label=\(label, privacy: .public) reason=above_threshold dist=\(best.hybrid, privacy: .public) threshold=\(thresholds.distance, privacy: .public) candidate=\(bestPseudo, privacy: .public)",
+            )
+        } else {
+            logger.info(
+                "speaker_match_rejected label=\(label, privacy: .public) reason=below_margin margin=\(actualMargin, privacy: .public) min=\(thresholds.margin, privacy: .public) candidate=\(bestPseudo, privacy: .public) runner_up=\(secondPseudo, privacy: .public)",
+            )
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -181,6 +181,11 @@ class SpeakerMatcher {
             } else {
                 assignedName = label
             }
+            Self.logMatchDecision(
+                label: label, best: best, second: second,
+                assigned: assignedName, threshold: threshold,
+                margin: confidenceMargin,
+            )
             result[label] = VerboseMatch(
                 assignedName: assignedName, topCandidates: Array(scored.prefix(topK)),
             )
@@ -544,6 +549,44 @@ class SpeakerMatcher {
         }
 
         return updated
+    }
+
+    /// Forensic log for a single label match decision. Names are
+    /// SHA-256-pseudonymized via `String.pseudonymized` so the log can be
+    /// shared in bug reports without leaking real speaker names. Distances
+    /// and margins are public; the per-label classifier ID is public too.
+    private static func logMatchDecision(
+        label: String,
+        best: TopCandidate?,
+        second: TopCandidate?,
+        assigned: String,
+        threshold: Float,
+        margin: Float,
+    ) {
+        guard let best else {
+            logger.info(
+                "speaker_match label=\(label, privacy: .public) result=no_candidates",
+            )
+            return
+        }
+        let bestPseudo = best.name.pseudonymized
+        let secondPseudo = second?.name.pseudonymized ?? "none"
+        let secondDist = second?.hybrid ?? .greatestFiniteMagnitude
+        let actualMargin = secondDist - best.hybrid
+
+        if assigned == best.name {
+            logger.info(
+                "speaker_match_assigned label=\(label, privacy: .public) speaker=\(bestPseudo, privacy: .public) bestDist=\(best.hybrid, privacy: .public) secondDist=\(secondDist, privacy: .public) margin=\(actualMargin, privacy: .public)",
+            )
+        } else if best.hybrid >= threshold {
+            logger.info(
+                "speaker_match_rejected label=\(label, privacy: .public) reason=above_threshold dist=\(best.hybrid, privacy: .public) threshold=\(threshold, privacy: .public) candidate=\(bestPseudo, privacy: .public)",
+            )
+        } else {
+            logger.info(
+                "speaker_match_rejected label=\(label, privacy: .public) reason=below_margin margin=\(actualMargin, privacy: .public) min=\(margin, privacy: .public) candidate=\(bestPseudo, privacy: .public) runner_up=\(secondPseudo, privacy: .public)",
+            )
+        }
     }
 
     /// Cosine distance: 0 = identical, 2 = opposite.

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -183,8 +183,8 @@ class SpeakerMatcher {
             }
             Self.logMatchDecision(
                 label: label, best: best, second: second,
-                assigned: assignedName, threshold: threshold,
-                margin: confidenceMargin,
+                assigned: assignedName,
+                thresholds: (distance: threshold, margin: confidenceMargin),
             )
             result[label] = VerboseMatch(
                 assignedName: assignedName, topCandidates: Array(scored.prefix(topK)),
@@ -549,44 +549,6 @@ class SpeakerMatcher {
         }
 
         return updated
-    }
-
-    /// Forensic log for a single label match decision. Names are
-    /// SHA-256-pseudonymized via `String.pseudonymized` so the log can be
-    /// shared in bug reports without leaking real speaker names. Distances
-    /// and margins are public; the per-label classifier ID is public too.
-    private static func logMatchDecision(
-        label: String,
-        best: TopCandidate?,
-        second: TopCandidate?,
-        assigned: String,
-        threshold: Float,
-        margin: Float,
-    ) {
-        guard let best else {
-            logger.info(
-                "speaker_match label=\(label, privacy: .public) result=no_candidates",
-            )
-            return
-        }
-        let bestPseudo = best.name.pseudonymized
-        let secondPseudo = second?.name.pseudonymized ?? "none"
-        let secondDist = second?.hybrid ?? .greatestFiniteMagnitude
-        let actualMargin = secondDist - best.hybrid
-
-        if assigned == best.name {
-            logger.info(
-                "speaker_match_assigned label=\(label, privacy: .public) speaker=\(bestPseudo, privacy: .public) bestDist=\(best.hybrid, privacy: .public) secondDist=\(secondDist, privacy: .public) margin=\(actualMargin, privacy: .public)",
-            )
-        } else if best.hybrid >= threshold {
-            logger.info(
-                "speaker_match_rejected label=\(label, privacy: .public) reason=above_threshold dist=\(best.hybrid, privacy: .public) threshold=\(threshold, privacy: .public) candidate=\(bestPseudo, privacy: .public)",
-            )
-        } else {
-            logger.info(
-                "speaker_match_rejected label=\(label, privacy: .public) reason=below_margin margin=\(actualMargin, privacy: .public) min=\(margin, privacy: .public) candidate=\(bestPseudo, privacy: .public) runner_up=\(secondPseudo, privacy: .public)",
-            )
-        }
     }
 
     /// Cosine distance: 0 = identical, 2 = opposite.

--- a/app/MeetingTranscriber/Sources/String+LogRedaction.swift
+++ b/app/MeetingTranscriber/Sources/String+LogRedaction.swift
@@ -18,15 +18,12 @@ extension String {
     /// machine-readable forensic logs, prefer `pseudonymized`.
     var redactedName: String {
         let chars = Array(self)
-        switch chars.count {
-        case 0: return ""
-        case 1: return "*"
-        case 2: return "\(chars[0])*"
-        case 3: return "\(chars[0])**"
-
-        default:
-            let middle = String(repeating: "*", count: chars.count - 2)
-            return "\(chars[0])\(middle)\(chars.last!)"
-        }
+        if chars.isEmpty { return "" }
+        if chars.count == 1 { return "*" }
+        if chars.count == 2 { return "\(chars[0])*" }
+        if chars.count == 3 { return "\(chars[0])**" }
+        let last = chars[chars.count - 1]
+        let middle = String(repeating: "*", count: chars.count - 2)
+        return "\(chars[0])\(middle)\(last)"
     }
 }

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -51,7 +51,7 @@ class WatchLoop {
     let micDeviceUID: String?
     /// Dynamic accessor — read at recording-start time so toggling the setting
     /// at runtime takes effect on the next recording without an app restart.
-    let audioDebugLogging: () -> Bool
+    let verboseDiagnostics: () -> Bool
     /// Dynamic accessor — when true, skip the post-processing pipeline and
     /// instead write a `<basename>_meta.json` sidecar next to the recording.
     let recordOnly: () -> Bool
@@ -78,7 +78,7 @@ class WatchLoop {
         maxDuration: TimeInterval = 14400,
         noMic: Bool = false,
         micDeviceUID: String? = nil,
-        audioDebugLogging: @escaping () -> Bool = { false },
+        verboseDiagnostics: @escaping () -> Bool = { false },
         recordOnly: @escaping () -> Bool = { false },
         recordOnlyOutputDir: @escaping () -> URL = { AppPaths.recordingsDir },
         notifier: any AppNotifying = SilentNotifier(),
@@ -91,7 +91,7 @@ class WatchLoop {
         self.maxDuration = maxDuration
         self.noMic = noMic
         self.micDeviceUID = micDeviceUID
-        self.audioDebugLogging = audioDebugLogging
+        self.verboseDiagnostics = verboseDiagnostics
         self.recordOnly = recordOnly
         self.recordOnlyOutputDir = recordOnlyOutputDir
         self.notifier = notifier
@@ -154,7 +154,7 @@ class WatchLoop {
         let recorder = recorderFactory()
         try recorder.start(
             appPID: pid, noMic: noMic, micDeviceUID: micDeviceUID,
-            debugLogging: audioDebugLogging(),
+            debugLogging: verboseDiagnostics(),
         )
 
         activeRecorder = recorder
@@ -262,7 +262,7 @@ class WatchLoop {
             appPID: meeting.windowPID,
             noMic: noMic,
             micDeviceUID: micDeviceUID,
-            debugLogging: audioDebugLogging(),
+            debugLogging: verboseDiagnostics(),
         )
 
         // Read participants (Teams)

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -1,6 +1,9 @@
 import AVFoundation
 import Foundation
+import os.log
 import WhisperKit
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "WhisperKitEngine")
 
 /// A transcribed segment with timestamps and optional speaker label.
 struct TimestampedSegment: Codable {
@@ -75,7 +78,7 @@ final class WhisperKitEngine: TranscribingEngine {
                 )
                 modelState = .loaded
             } catch {
-                NSLog("WhisperKit model load failed: \(error)")
+                logger.error("WhisperKit model load failed: \(error.localizedDescription, privacy: .public)")
                 modelState = .unloaded
                 downloadProgress = 0
             }
@@ -88,13 +91,13 @@ final class WhisperKitEngine: TranscribingEngine {
     /// Ensure model is loaded, loading it if necessary.
     private func ensureModel() async throws {
         if pipe != nil { return }
-        NSLog("WhisperKit: model not loaded, loading \(modelVariant)...")
+        logger.info("WhisperKit: model not loaded, loading \(self.modelVariant, privacy: .public)...")
         await loadModel()
         guard pipe != nil else {
-            NSLog("WhisperKit: model load FAILED, state=\(modelState)")
+            logger.error("WhisperKit: model load FAILED, state=\(String(describing: self.modelState), privacy: .public)")
             throw TranscriptionError.modelNotLoaded
         }
-        NSLog("WhisperKit: model loaded successfully")
+        logger.info("WhisperKit: model loaded successfully")
     }
 
     /// Transcribe a WAV file. Returns lines in `[MM:SS] text` format matching Python output.

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -247,6 +247,47 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "recordOnly"))
     }
 
+    // MARK: - Verbose Diagnostics (legacy audioDebugLogging migration)
+
+    func test_verboseDiagnostics_defaultsToFalse() {
+        XCTAssertFalse(settings.verboseDiagnostics)
+    }
+
+    func test_verboseDiagnostics_persistsUnderNewKey() {
+        settings.verboseDiagnostics = true
+        XCTAssertTrue(defaults.bool(forKey: "verboseDiagnostics"))
+    }
+
+    func test_verboseDiagnostics_migratesFromLegacyAudioDebugLoggingKey() {
+        let suiteName = "AppSettingsTests-migration-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        suite.set(true, forKey: "audioDebugLogging")
+
+        let migrated = AppSettings(defaults: suite)
+        XCTAssertTrue(migrated.verboseDiagnostics)
+        XCTAssertTrue(suite.bool(forKey: "verboseDiagnostics"))
+    }
+
+    func test_verboseDiagnostics_newKeyTakesPrecedenceOverLegacy() {
+        let suiteName = "AppSettingsTests-precedence-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        suite.set(true, forKey: "audioDebugLogging")
+        suite.set(false, forKey: "verboseDiagnostics")
+
+        let migrated = AppSettings(defaults: suite)
+        XCTAssertFalse(migrated.verboseDiagnostics)
+    }
+
     // MARK: - Keychain
 
     func testKeychainRoundTrip() {

--- a/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
@@ -92,4 +92,25 @@ final class AudioMixerDelayTests: XCTestCase {
             "50s positive delay on 60s track must be clamped (#99)",
         )
     }
+
+    // MARK: - clampMicDelay
+
+    func test_clampMicDelay_withinBound_unchanged() {
+        XCTAssertEqual(AudioMixer.clampMicDelay(5.0), 5.0)
+        XCTAssertEqual(AudioMixer.clampMicDelay(-5.0), -5.0)
+        XCTAssertEqual(AudioMixer.clampMicDelay(0), 0)
+    }
+
+    func test_clampMicDelay_excessivePositive_clampsToMax() {
+        XCTAssertEqual(AudioMixer.clampMicDelay(45.0), AudioMixer.maxMicDelay)
+    }
+
+    func test_clampMicDelay_excessiveNegative_clampsToNegMax() {
+        XCTAssertEqual(AudioMixer.clampMicDelay(-45.0), -AudioMixer.maxMicDelay)
+    }
+
+    func test_clampMicDelay_atBoundary_unchanged() {
+        XCTAssertEqual(AudioMixer.clampMicDelay(AudioMixer.maxMicDelay), AudioMixer.maxMicDelay)
+        XCTAssertEqual(AudioMixer.clampMicDelay(-AudioMixer.maxMicDelay), -AudioMixer.maxMicDelay)
+    }
 }

--- a/app/MeetingTranscriber/Tests/AudioMixerTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerTests.swift
@@ -473,6 +473,42 @@ final class AudioMixerTests: XCTestCase {
 
         XCTAssertEqual(peak, 440, accuracy: 440 * 0.05, "M4A→16k must preserve 440Hz (got \(peak)Hz)")
     }
+
+    // MARK: - RMS
+
+    func test_rmsDecibels_emptyBuffer_returnsNegativeInfinity() {
+        XCTAssertEqual(AudioMixer.rmsDecibels(samples: []), -.infinity)
+    }
+
+    func test_rmsDecibels_silentBuffer_isVeryLow() {
+        let silent = [Float](repeating: 0, count: 1024)
+        let rms = AudioMixer.rmsDecibels(samples: silent)
+        XCTAssertLessThan(rms, -190, "Silent buffer should be ~-200 dBFS, got \(rms)")
+    }
+
+    func test_rmsDecibels_fullScaleSine_isAroundMinus3() {
+        let sine = Self.generateSine(frequency: 440, sampleRate: 16000, duration: 0.5)
+        let rms = AudioMixer.rmsDecibels(samples: sine)
+        XCTAssertEqual(rms, -3, accuracy: 0.5, "Full-scale sine RMS should be ~-3 dBFS, got \(rms)")
+    }
+
+    func test_rmsDecibels_forFileAt_silentWAV() throws {
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rms_silent_\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: tmpURL) }
+
+        let silent = [Float](repeating: 0, count: 16000)
+        try AudioMixer.saveWAV(samples: silent, sampleRate: 16000, url: tmpURL)
+
+        let rms = AudioMixer.rmsDecibels(forFileAt: tmpURL)
+        XCTAssertNotNil(rms)
+        XCTAssertLessThan(rms ?? 0, -190)
+    }
+
+    func test_rmsDecibels_forFileAt_missingFile_returnsNil() {
+        let bogus = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).wav")
+        XCTAssertNil(AudioMixer.rmsDecibels(forFileAt: bogus))
+    }
 }
 
 // MARK: - FFT Helpers

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -37,14 +37,14 @@ final class DiagnosticExporterTests: XCTestCase {
         XCTAssertTrue(header.contains("diarize=false"))
     }
 
-    func test_makeHeader_settingsSortedAlphabetically() {
+    func test_makeHeader_settingsSortedAlphabetically() throws {
         let header = DiagnosticExporter.makeHeader(
             appVersion: "0", commit: "x", macOSVersion: "0",
             settings: ["zebra": "1", "apple": "2", "mango": "3"],
         )
-        let appleIdx = header.range(of: "apple=")!.lowerBound
-        let mangoIdx = header.range(of: "mango=")!.lowerBound
-        let zebraIdx = header.range(of: "zebra=")!.lowerBound
+        let appleIdx = try XCTUnwrap(header.range(of: "apple=")?.lowerBound)
+        let mangoIdx = try XCTUnwrap(header.range(of: "mango=")?.lowerBound)
+        let zebraIdx = try XCTUnwrap(header.range(of: "zebra=")?.lowerBound)
         XCTAssertLessThan(appleIdx, mangoIdx)
         XCTAssertLessThan(mangoIdx, zebraIdx)
     }

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -1,0 +1,58 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class DiagnosticExporterTests: XCTestCase {
+    func test_makeHeader_includesAppVersion() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "1.2.3",
+            commit: "abcdef",
+            macOSVersion: "14.5",
+            settings: [:],
+        )
+        XCTAssertTrue(header.contains("1.2.3"))
+    }
+
+    func test_makeHeader_includesCommit() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "0.1.0", commit: "deadbeef",
+            macOSVersion: "14.5", settings: [:],
+        )
+        XCTAssertTrue(header.contains("deadbeef"))
+    }
+
+    func test_makeHeader_includesMacOSVersion() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "0.1.0", commit: "x",
+            macOSVersion: "15.1.2", settings: [:],
+        )
+        XCTAssertTrue(header.contains("15.1.2"))
+    }
+
+    func test_makeHeader_includesSettings() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "0.1.0", commit: "x", macOSVersion: "14.0",
+            settings: ["verboseDiagnostics": "true", "diarize": "false"],
+        )
+        XCTAssertTrue(header.contains("verboseDiagnostics=true"))
+        XCTAssertTrue(header.contains("diarize=false"))
+    }
+
+    func test_makeHeader_settingsSortedAlphabetically() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "0", commit: "x", macOSVersion: "0",
+            settings: ["zebra": "1", "apple": "2", "mango": "3"],
+        )
+        let appleIdx = header.range(of: "apple=")!.lowerBound
+        let mangoIdx = header.range(of: "mango=")!.lowerBound
+        let zebraIdx = header.range(of: "zebra=")!.lowerBound
+        XCTAssertLessThan(appleIdx, mangoIdx)
+        XCTAssertLessThan(mangoIdx, zebraIdx)
+    }
+
+    func test_makeHeader_emptySettings_doesNotCrash() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "0.1.0", commit: "x", macOSVersion: "14.0", settings: [:],
+        )
+        XCTAssertFalse(header.isEmpty)
+    }
+}

--- a/app/MeetingTranscriber/Tests/LogRedactionTests.swift
+++ b/app/MeetingTranscriber/Tests/LogRedactionTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import MeetingTranscriber
+
+final class LogRedactionTests: XCTestCase {
+    func test_pseudonymized_isStable() {
+        XCTAssertEqual("Roman".pseudonymized, "Roman".pseudonymized)
+    }
+
+    func test_pseudonymized_differsAcrossNames() {
+        XCTAssertNotEqual("Roman".pseudonymized, "Anna".pseudonymized)
+    }
+
+    func test_pseudonymized_format() {
+        let p = "Roman".pseudonymized
+        XCTAssertTrue(p.hasPrefix("speaker_"))
+        XCTAssertEqual(p.count, "speaker_".count + 4)
+        XCTAssertTrue(p.dropFirst("speaker_".count).allSatisfy { "0123456789abcdef".contains($0) })
+    }
+
+    func test_pseudonymized_emptyString_returnsAnonymous() {
+        XCTAssertEqual("".pseudonymized, "speaker_anon")
+    }
+
+    func test_redactedName_long() {
+        XCTAssertEqual("Roman".redactedName, "R***n")
+    }
+
+    func test_redactedName_short3() {
+        XCTAssertEqual("Tom".redactedName, "T**")
+    }
+
+    func test_redactedName_two() {
+        XCTAssertEqual("Li".redactedName, "L*")
+    }
+
+    func test_redactedName_one() {
+        XCTAssertEqual("X".redactedName, "*")
+    }
+
+    func test_redactedName_empty() {
+        XCTAssertEqual("".redactedName, "")
+    }
+
+    func test_redactedName_unicode() {
+        XCTAssertEqual("Ümlaut".redactedName, "Ü****t")
+    }
+}

--- a/app/MeetingTranscriber/Tests/LogRedactionTests.swift
+++ b/app/MeetingTranscriber/Tests/LogRedactionTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import MeetingTranscriber
+import XCTest
 
 final class LogRedactionTests: XCTestCase {
     func test_pseudonymized_isStable() {

--- a/app/MeetingTranscriber/Tests/PipelineJobTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineJobTests.swift
@@ -80,6 +80,45 @@ final class PipelineJobTests: XCTestCase {
         }
     }
 
+    func test_shortID_isEightLowercaseHexChars() {
+        let job = PipelineJob(
+            meetingTitle: "Standup",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        XCTAssertEqual(job.shortID.count, 8)
+        XCTAssertTrue(job.shortID.allSatisfy { "0123456789abcdef".contains($0) })
+    }
+
+    func test_shortID_isStableForSameJob() {
+        let job = PipelineJob(
+            meetingTitle: "Standup",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        XCTAssertEqual(job.shortID, job.shortID)
+    }
+
+    func test_shortID_differsAcrossJobs() {
+        let a = PipelineJob(
+            meetingTitle: "A", appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        let b = PipelineJob(
+            meetingTitle: "B", appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        XCTAssertNotEqual(a.shortID, b.shortID)
+    }
+
     func testJobStateRawValues() {
         XCTAssertEqual(JobState.waiting.rawValue, "waiting")
         XCTAssertEqual(JobState.transcribing.rawValue, "transcribing")

--- a/docs/plans/2026-05-04-diagnostic-logging.md
+++ b/docs/plans/2026-05-04-diagnostic-logging.md
@@ -1,0 +1,1239 @@
+# Diagnostic Logging Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build an end-to-end "users attach a log file to GitHub issues" workflow — toggle in Settings turns on verbose diagnostics across all pipelines (audio, transcription, diarization, protocol), an "Export Diagnostics" button writes a redacted, pseudonymized log file the user can attach, and an issue template guides users to that file.
+
+**Architecture:** The existing `audioDebugLogging` flag is generalized to `verboseDiagnostics` and gates new logs across *all* pipelines, not just audiotap. PII (speaker names, transcripts) never appears in clear text — names are SHA-256-pseudonymized via a new `LogRedaction.swift` helper, and `os_log` `%{private}@` formatting is used as defense-in-depth. The export reads `OSLogStore.local()` for the last 30 min and writes to a tempfile, then reveals it in Finder.
+
+**Tech Stack:** Swift 6, `os.Logger` / `OSLogStore` (Apple-native unified logging), `CryptoKit.SHA256` (Apple-native, no external dep), SwiftUI for the export button, GitHub Issue Forms YAML for the template.
+
+---
+
+## Conventions for this plan
+
+- **One task = one atomic commit.** Each task ends with a `git commit` step.
+- **TDD where the unit can be tested in isolation** (redaction helpers, RMS calculations, status-code translation). Pure Swift logic gets a failing test first.
+- **Manual verification where it cannot** (UI buttons, OSLogStore reads, log-emission side effects). Each such task notes how to verify by hand.
+- **All commits use Conventional Commits** (`feat`, `fix`, `chore`, `test`, etc.) with scope `app`, `audiotap`, `ci`, or `docs`.
+- **Branch:** `feat/diagnostic-logging` from `origin/main`.
+- **PR strategy:** all phases in **one PR** at the end (per user request); commits stay atomic so the reviewer can read them top-to-bottom.
+
+Run before starting:
+
+```bash
+git fetch origin
+git checkout -b feat/diagnostic-logging origin/main
+```
+
+---
+
+## Phase 1: Infrastructure
+
+Foundation pieces every later phase depends on: redaction helpers, settings rename + migration, job-ID correlation.
+
+### Task 1.1: Add `LogRedaction.swift` with `pseudonymized` + `redactedName`
+
+**Files:**
+- Create: `app/MeetingTranscriber/Sources/LogRedaction.swift`
+- Test: `app/MeetingTranscriber/Tests/LogRedactionTests.swift`
+
+**Step 1: Write the failing test**
+
+Create `app/MeetingTranscriber/Tests/LogRedactionTests.swift`:
+
+```swift
+import XCTest
+@testable import MeetingTranscriber
+
+final class LogRedactionTests: XCTestCase {
+    // pseudonymized — stable, hex, 4 chars
+    func test_pseudonymized_isStable() {
+        XCTAssertEqual("Roman".pseudonymized, "Roman".pseudonymized)
+    }
+
+    func test_pseudonymized_differsAcrossNames() {
+        XCTAssertNotEqual("Roman".pseudonymized, "Anna".pseudonymized)
+    }
+
+    func test_pseudonymized_format() {
+        let p = "Roman".pseudonymized
+        XCTAssertTrue(p.hasPrefix("speaker_"))
+        XCTAssertEqual(p.count, "speaker_".count + 4)  // 4 hex chars
+        XCTAssertTrue(p.dropFirst("speaker_".count).allSatisfy { "0123456789abcdef".contains($0) })
+    }
+
+    func test_pseudonymized_emptyString_returnsAnonymous() {
+        XCTAssertEqual("".pseudonymized, "speaker_anon")
+    }
+
+    // redactedName — keeps first + last (when long enough)
+    func test_redactedName_long() {
+        XCTAssertEqual("Roman".redactedName, "R***n")
+    }
+
+    func test_redactedName_short3() {
+        // 3 chars: keep first only, mask rest
+        XCTAssertEqual("Tom".redactedName, "T**")
+    }
+
+    func test_redactedName_two() {
+        XCTAssertEqual("Li".redactedName, "L*")
+    }
+
+    func test_redactedName_one() {
+        XCTAssertEqual("X".redactedName, "*")
+    }
+
+    func test_redactedName_empty() {
+        XCTAssertEqual("".redactedName, "")
+    }
+
+    func test_redactedName_unicode() {
+        // Use Character count, not byte count
+        XCTAssertEqual("Ümlaut".redactedName, "Ü****t")
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter LogRedactionTests
+```
+
+Expected: compile error "no member 'pseudonymized'" / "no member 'redactedName'".
+
+**Step 3: Create the implementation**
+
+Create `app/MeetingTranscriber/Sources/LogRedaction.swift`:
+
+```swift
+import CryptoKit
+import Foundation
+
+extension String {
+    /// Deterministic 4-hex-char pseudonym derived from SHA-256.
+    /// Stable across runs (same input → same output) so logs can be correlated
+    /// without exposing the clear name. Used for speaker IDs in diagnostic logs.
+    var pseudonymized: String {
+        guard !isEmpty else { return "speaker_anon" }
+        let hash = SHA256.hash(data: Data(utf8))
+        let prefix = hash.prefix(2).map { String(format: "%02x", $0) }.joined()
+        return "speaker_\(prefix)"
+    }
+
+    /// First-and-last-char redaction: "Roman" → "R***n", "Tom" → "T**", "Li" → "L*".
+    /// Less privacy-preserving than `pseudonymized` (length leaks); use for UI-adjacent
+    /// logs where the user actively benefits from recognising "their" name. For
+    /// machine-readable forensic logs, prefer `pseudonymized`.
+    var redactedName: String {
+        let chars = Array(self)
+        switch chars.count {
+        case 0: return ""
+        case 1: return "*"
+        case 2: return "\(chars[0])*"
+        case 3: return "\(chars[0])**"
+        default:
+            let middle = String(repeating: "*", count: chars.count - 2)
+            return "\(chars[0])\(middle)\(chars.last!)"
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter LogRedactionTests
+```
+
+Expected: 8 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/LogRedaction.swift app/MeetingTranscriber/Tests/LogRedactionTests.swift
+git commit -m "feat(app): add LogRedaction with pseudonymized + redactedName helpers"
+```
+
+---
+
+### Task 1.2: Rename `audioDebugLogging` → `verboseDiagnostics` with UserDefaults migration
+
+Generalises the existing flag — same UserDefaults key reused so users keep their setting; new name reflects new scope.
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/AppSettings.swift:288-290, 363`
+- Modify: `app/MeetingTranscriber/Sources/AppState.swift:250, 308`
+- Modify: `app/MeetingTranscriber/Sources/WatchLoop.swift:54, 81, 94, 157, 265`
+- Modify: `app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift:59-65`
+- Modify: `app/MeetingTranscriber/Tests/AppSettingsTests.swift` (any tests touching `audioDebugLogging`)
+
+**Step 1: Update test for new name + migration**
+
+In `app/MeetingTranscriber/Tests/AppSettingsTests.swift`, find any test using `audioDebugLogging` and rename. Add a new test for migration:
+
+```swift
+func test_verboseDiagnostics_migratesFromAudioDebugLoggingKey() {
+    let suite = "AppSettingsTests-migration-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    // Simulate old install with the legacy key set
+    defaults.set(true, forKey: "audioDebugLogging")
+
+    let settings = AppSettings(defaults: defaults)
+
+    XCTAssertTrue(settings.verboseDiagnostics, "Should read the legacy key on first launch")
+
+    // Cleanup
+    UserDefaults().removePersistentDomain(forName: suite)
+}
+
+func test_verboseDiagnostics_persistsUnderNewKey() {
+    let suite = "AppSettingsTests-persist-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+
+    let settings = AppSettings(defaults: defaults)
+    settings.verboseDiagnostics = true
+
+    XCTAssertEqual(defaults.bool(forKey: "verboseDiagnostics"), true)
+
+    UserDefaults().removePersistentDomain(forName: suite)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter AppSettingsTests
+```
+
+Expected: failures on `verboseDiagnostics` (member not found) and migration test.
+
+**Step 3: Rename + add migration in `AppSettings.swift`**
+
+Replace lines 281-290:
+
+```swift
+    // MARK: - Diagnostics
+
+    /// Enables verbose diagnostic logging across **all** pipelines: audio
+    /// capture (process/device identity, periodic RMS), transcription
+    /// (segment counts, input RMS, sample-rate validation), VAD
+    /// (segment boundaries, round-trip checks), diarization, speaker
+    /// matching (top-2 candidates + margins), and protocol generation.
+    /// Off by default. Logs go to `com.meetingtranscriber` and
+    /// `com.meetingtranscriber.audiotap`. Use the "Export Diagnostics"
+    /// button in Settings → Advanced to attach a log to a bug report.
+    var verboseDiagnostics: Bool {
+        didSet { defaults.set(verboseDiagnostics, forKey: "verboseDiagnostics") }
+    }
+```
+
+Replace line 363 with:
+
+```swift
+        // Migrate legacy "audioDebugLogging" key (renamed to "verboseDiagnostics" 2026-05-04).
+        // Read either key; new key takes precedence if both are set.
+        if let new = defaults.object(forKey: "verboseDiagnostics") as? Bool {
+            verboseDiagnostics = new
+        } else if let legacy = defaults.object(forKey: "audioDebugLogging") as? Bool {
+            verboseDiagnostics = legacy
+            defaults.set(legacy, forKey: "verboseDiagnostics")
+        } else {
+            verboseDiagnostics = false
+        }
+```
+
+**Step 4: Update all call sites**
+
+Replace `audioDebugLogging` → `verboseDiagnostics` everywhere it occurs:
+
+```bash
+# Verify the changes
+grep -rn "audioDebugLogging" app/MeetingTranscriber/Sources/ tools/audiotap/Sources/
+```
+
+Expected after edit: no matches in `Sources/` (legacy key only appears in the migration block in `AppSettings.swift`).
+
+Files to edit (use `Edit` tool, one occurrence at a time):
+- `app/MeetingTranscriber/Sources/AppState.swift:250` — `audioDebugLogging:` parameter label and value
+- `app/MeetingTranscriber/Sources/AppState.swift:308` — same
+- `app/MeetingTranscriber/Sources/WatchLoop.swift:54` — property
+- `app/MeetingTranscriber/Sources/WatchLoop.swift:81, 94` — init param + assignment
+- `app/MeetingTranscriber/Sources/WatchLoop.swift:157, 265` — call sites still pass `debugLogging:` to AudioCaptureSession (unchanged param name there) — *only rename the source, not the audiotap-side parameter*
+
+In `app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift:59-65`:
+
+```swift
+                Toggle("Verbose Diagnostic Logging", isOn: $settings.verboseDiagnostics)
+                Text(
+                    "Logs detailed diagnostics across recording, transcription,"
+                        + " diarization, and protocol generation. Used to debug"
+                        + " issues. Off by default — toggle on, reproduce the"
+                        + " problem, then click \"Export Diagnostics\" below to"
+                        + " attach a redacted log file to a bug report.",
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+```
+
+**Step 5: Build + run tests**
+
+```bash
+cd app/MeetingTranscriber && swift build && swift test --filter AppSettingsTests
+```
+
+Expected: build succeeds, AppSettingsTests pass (including the two new migration tests).
+
+**Step 6: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/ app/MeetingTranscriber/Tests/AppSettingsTests.swift
+git commit -m "refactor(app): rename audioDebugLogging → verboseDiagnostics with UserDefaults migration"
+```
+
+---
+
+### Task 1.3: Add `PipelineJob.id` for cross-stage log correlation
+
+The pipeline runs transcription → diarization → protocol generation per job. Today the logs in each stage have no shared identifier. Add a UUID per job, log it at every stage entry/exit.
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/PipelineJob.swift`
+- Modify: `app/MeetingTranscriber/Sources/PipelineQueue.swift` (add `[\(job.shortID)]` prefix to existing log lines at stage boundaries — narrowed to ~5 spots, see Step 3)
+- Test: `app/MeetingTranscriber/Tests/PipelineJobTests.swift` (create if absent)
+
+**Step 1: Write the failing test**
+
+Create `app/MeetingTranscriber/Tests/PipelineJobTests.swift` if not present, otherwise extend it:
+
+```swift
+import XCTest
+@testable import MeetingTranscriber
+
+final class PipelineJobTests: XCTestCase {
+    func test_jobHasUniqueID() {
+        let a = PipelineJob.makeTestStub()
+        let b = PipelineJob.makeTestStub()
+        XCTAssertNotEqual(a.id, b.id)
+    }
+
+    func test_shortIDIsEightHexChars() {
+        let job = PipelineJob.makeTestStub()
+        XCTAssertEqual(job.shortID.count, 8)
+        XCTAssertTrue(job.shortID.allSatisfy { "0123456789abcdef".contains($0) })
+    }
+
+    func test_shortIDIsStableForSameJob() {
+        let job = PipelineJob.makeTestStub()
+        XCTAssertEqual(job.shortID, job.shortID)
+    }
+}
+```
+
+`PipelineJob.makeTestStub()` is a test-only factory — see implementation note in Step 3 (use a `#if DEBUG` extension or read existing test helpers in the file).
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter PipelineJobTests
+```
+
+Expected: missing-member error on `id` and `shortID`.
+
+**Step 3: Implement**
+
+In `app/MeetingTranscriber/Sources/PipelineJob.swift`, add:
+
+```swift
+struct PipelineJob: ... {  // existing properties unchanged
+    let id: UUID = UUID()  // unique per job, used for log correlation
+
+    /// Short 8-hex-char form of `id` for log prefixes — `[a3f29b71]`.
+    var shortID: String {
+        String(id.uuidString.prefix(8).lowercased())
+    }
+
+    // ... existing rest of struct
+}
+
+#if DEBUG
+extension PipelineJob {
+    static func makeTestStub() -> PipelineJob {
+        // Construct minimal valid PipelineJob with placeholder values
+        // (adapt based on the actual struct's required fields)
+        ...
+    }
+}
+#endif
+```
+
+If `PipelineJob` is decoded from disk (queue persistence), make `id` decodable but with a default-on-decode-failure (`UUID()`) so old persisted queues still load:
+
+```swift
+init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try c.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+    // ... rest of decode
+}
+```
+
+**Step 4: Run tests + build**
+
+```bash
+cd app/MeetingTranscriber && swift build && swift test --filter PipelineJobTests
+```
+
+Expected: tests pass, build clean.
+
+**Step 5: Add `[shortID]` prefix to stage-boundary logs in `PipelineQueue.swift`**
+
+Identify the ~5 stage entry/exit log statements (transcription start, transcription done, diarization start, diarization done, protocol generation start). Prepend `[\(job.shortID)] ` to each. Example:
+
+```swift
+logger.info("[\(job.shortID, privacy: .public)] Transcription start")
+```
+
+(Use `Logger`'s string-interpolation `privacy:` modifier — Apple-native, makes the ID public so it shows in Console/exports.)
+
+**Step 6: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/PipelineJob.swift \
+        app/MeetingTranscriber/Sources/PipelineQueue.swift \
+        app/MeetingTranscriber/Tests/PipelineJobTests.swift
+git commit -m "feat(app): add per-PipelineJob UUID + shortID for log correlation"
+```
+
+---
+
+## Phase 2: New Diagnostic Logs (HIGH-priority items)
+
+Each task adds one specific diagnostic that closed a known visibility gap. All gated by `verboseDiagnostics` unless the gap exists at *every* run (e.g., catch-block error logs are always on).
+
+### Task 2.1: Translate `AudioHardwareCreateProcessTap` OSStatus to human-readable
+
+**Files:**
+- Modify: `tools/audiotap/Sources/AppAudioCapture.swift:241-246`
+- Test: `tools/audiotap/Tests/AppAudioCaptureStatusTests.swift` (new)
+
+**Step 1: Write a failing test for the pure status-translation function**
+
+Create `tools/audiotap/Tests/AppAudioCaptureStatusTests.swift`:
+
+```swift
+import XCTest
+@testable import AudioTapLib
+
+final class AppAudioCaptureStatusTests: XCTestCase {
+    func test_describeTapError_knownStatus_returnsHumanHint() {
+        // -12988 is the historical "permission denied" / not-permitted code
+        let msg = AppAudioCapture.describeTapError(-12988)
+        XCTAssertTrue(msg.contains("permission") || msg.contains("Privacy"))
+    }
+
+    func test_describeTapError_unknown_includesCode() {
+        let msg = AppAudioCapture.describeTapError(-99999)
+        XCTAssertTrue(msg.contains("-99999"))
+    }
+}
+```
+
+**Step 2: Run test → fail**
+
+```bash
+cd tools/audiotap && swift test --filter AppAudioCaptureStatusTests
+```
+
+Expected: `describeTapError` not found.
+
+**Step 3: Add the translator**
+
+In `AppAudioCapture.swift`, add as a static helper:
+
+```swift
+/// Maps `AudioHardwareCreateProcessTap` OSStatus codes to a human hint.
+/// Exposed `static internal` for unit testing the translation table.
+static func describeTapError(_ status: OSStatus) -> String {
+    switch status {
+    case -12988:
+        return "OSStatus -12988: likely missing permission. " +
+               "Check System Settings → Privacy & Security → Screen Recording " +
+               "and enable Meeting Transcriber."
+    case -10851:
+        return "OSStatus -10851 (kAudioUnitErr_InvalidProperty): tap target may have exited."
+    case -50:
+        return "OSStatus -50 (paramErr): invalid CATapDescription parameters."
+    default:
+        return "OSStatus \(status): unrecognised — see CoreAudio headers."
+    }
+}
+```
+
+In the existing tap-creation error path (around line 245), replace the generic `"Failed to create process tap"` log with:
+
+```swift
+logger.error("Failed to create process tap (pid=\(pid, privacy: .public), bundle=\(bundleID ?? "?", privacy: .public)): \(Self.describeTapError(status), privacy: .public)")
+```
+
+**Step 4: Run tests → pass**
+
+```bash
+cd tools/audiotap && swift test --filter AppAudioCaptureStatusTests
+```
+
+**Step 5: Commit**
+
+```bash
+git add tools/audiotap/Sources/AppAudioCapture.swift tools/audiotap/Tests/AppAudioCaptureStatusTests.swift
+git commit -m "feat(audiotap): translate tap-creation OSStatus to human-readable hint"
+```
+
+---
+
+### Task 2.2: Empty-transcription detection + input-RMS log in `PipelineQueue`
+
+When transcription returns 0 segments, today the pipeline silently produces an empty protocol. Log a warning with input audio RMS so the cause is identifiable (silent input vs. ASR misconfiguration).
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/PipelineQueue.swift` (after the call site that runs transcription — find the line that calls `engine.transcribeSegments` or equivalent)
+- Reuse existing RMS computation from `tools/audiotap/Sources/DebugRMSReporter.swift` if exposed; otherwise use a small inline helper.
+
+**Step 1: Add a public test helper for RMS-from-PCM-buffer**
+
+Skip a separate test for this task — it's an additive log statement integrated into existing flow. Manual verification only.
+
+**Step 2: Add the diagnostic log**
+
+After the transcription call (in `PipelineQueue.swift`, around the spot where `segments` is bound from the engine result), add:
+
+```swift
+let totalWords = segments.reduce(0) { $0 + $1.text.split(separator: " ").count }
+let totalSecs = segments.last?.endTime ?? 0
+let inputRMSdBFS = AudioMixer.rmsDecibels(forFileAt: jobMixURL) ?? Float.nan
+logger.info("[\(job.shortID, privacy: .public)] transcription_complete segments=\(segments.count, privacy: .public) words=\(totalWords, privacy: .public) duration=\(totalSecs, privacy: .public)s inputRMSdBFS=\(inputRMSdBFS, privacy: .public)")
+if segments.isEmpty {
+    logger.warning("[\(job.shortID, privacy: .public)] transcription_empty engine=\(engineName, privacy: .public) inputRMSdBFS=\(inputRMSdBFS, privacy: .public). Consider checking audio quality or VAD threshold.")
+}
+```
+
+If `AudioMixer.rmsDecibels(forFileAt:)` does not yet exist, add it to `AudioMixer.swift`:
+
+```swift
+/// RMS in dBFS for a Float32 PCM file. Returns `nil` if the file cannot be read.
+static func rmsDecibels(forFileAt url: URL) -> Float? {
+    guard let samples = try? loadAudioAsFloat32(url: url) else { return nil }
+    guard !samples.isEmpty else { return -.infinity }
+    let sumSq = samples.reduce(Float(0)) { $0 + $1 * $1 }
+    let rms = (sumSq / Float(samples.count)).squareRoot()
+    return 20 * log10(max(rms, 1e-10))
+}
+```
+
+…and a test:
+
+```swift
+// In AudioMixerTests.swift
+func test_rmsDecibels_silentBuffer_returnsLow() {
+    // Generate a silent WAV via existing test helpers, assert rms < -90 dBFS
+    ...
+}
+```
+
+**Step 3: Run tests + manual verification**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter AudioMixerTests
+```
+
+Manual: launch the app with a known-silent WAV, verify the warning fires:
+
+```bash
+log stream --predicate 'subsystem == "com.meetingtranscriber" && category == "PipelineQueue"' --style compact
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/PipelineQueue.swift app/MeetingTranscriber/Sources/AudioMixer.swift app/MeetingTranscriber/Tests/AudioMixerTests.swift
+git commit -m "feat(app): log transcription summary + warn on empty result with input RMS"
+```
+
+---
+
+### Task 2.3: VAD round-trip validation log in `FluidVAD`
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/FluidVAD.swift:114-152` (around `extractSpeechSamples`)
+
+**Step 1: Manual verification only — no unit test**
+
+VAD logs are observational; behavior is unchanged. No new test required.
+
+**Step 2: Add diagnostic log**
+
+After speech-region extraction completes, add:
+
+```swift
+let originalSecs = Float(originalSampleCount) / Float(sampleRate)
+let trimmedSecs = Float(extractedSampleCount) / Float(sampleRate)
+let trimRatio = originalSecs > 0 ? (1 - trimmedSecs / originalSecs) : 0
+logger.info("vad_extract regions=\(regions.count, privacy: .public) original=\(originalSecs, privacy: .public)s trimmed=\(trimmedSecs, privacy: .public)s trimRatio=\(trimRatio, privacy: .public)")
+
+// Round-trip sanity: pick a midpoint in the trimmed timeline, map back, verify it's
+// inside one of the original regions.
+if !regions.isEmpty, let map = vadMap {
+    let probe: Float = trimmedSecs / 2
+    let mapped = map.toOriginalTime(probe)
+    let inSomeRegion = regions.contains { mapped >= $0.startSec && mapped <= $0.endSec }
+    if !inSomeRegion {
+        logger.warning("vad_roundtrip_drift probe=\(probe)s mapped=\(mapped)s — VadSegmentMap may be inconsistent")
+    }
+}
+```
+
+(Adjust types to match existing `VadSegmentMap` API — read the file first.)
+
+**Step 3: Build + run app, verify log appears**
+
+```bash
+cd app/MeetingTranscriber && swift build
+./scripts/run_app.sh
+# Trigger a recording with VAD enabled, check Console.app for vad_extract lines
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/FluidVAD.swift
+git commit -m "feat(app): log VAD trim summary + round-trip drift detection"
+```
+
+---
+
+### Task 2.4: Mic-delay clamp logging in `AudioMixer`
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/AudioMixer.swift` (around `maxMicDelay` clamp, line ~29)
+
+**Step 1: Write a failing test**
+
+In `AudioMixerDelayTests.swift`, add:
+
+```swift
+func test_clampMicDelay_withinBound_unchanged() {
+    XCTAssertEqual(AudioMixer.clampMicDelay(5.0), 5.0)
+}
+
+func test_clampMicDelay_excessivePositive_clampsToMax() {
+    XCTAssertEqual(AudioMixer.clampMicDelay(45.0), AudioMixer.maxMicDelay)
+}
+
+func test_clampMicDelay_excessiveNegative_clampsToNegMax() {
+    XCTAssertEqual(AudioMixer.clampMicDelay(-45.0), -AudioMixer.maxMicDelay)
+}
+```
+
+**Step 2: Run → fail**
+
+Expected: `clampMicDelay` not exposed (likely currently inline).
+
+**Step 3: Extract + log**
+
+In `AudioMixer.swift`:
+
+```swift
+static let maxMicDelay: TimeInterval = 30.0  // existing
+
+/// Clamps `delay` to ±`maxMicDelay`. Logs a warning if clamping occurred —
+/// excessive deltas usually mean the output device was switched mid-recording.
+static func clampMicDelay(_ delay: TimeInterval) -> TimeInterval {
+    let clamped = min(max(delay, -maxMicDelay), maxMicDelay)
+    if clamped != delay {
+        logger.warning("mic_delay_clamped original=\(delay)s clamped=\(clamped)s — possible output-device switch during recording")
+    }
+    return clamped
+}
+```
+
+Replace the existing inline clamp with `let micDelay = clampMicDelay(rawDelay)`.
+
+**Step 4: Run tests**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter AudioMixerDelayTests
+```
+
+**Step 5: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/AudioMixer.swift app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
+git commit -m "feat(app): warn when mic delay is clamped (likely device-switch artefact)"
+```
+
+---
+
+### Task 2.5: Log LLM errors in OpenAI + Claude CLI generators
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift:154`
+- Modify: `app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift:71` (and the silent declared-but-unused logger)
+
+**Step 1: Manual verification only**
+
+These are catch blocks already in place. Test would require mocking the LLM endpoint — skip for now.
+
+**Step 2: Edit `OpenAIProtocolGenerator.swift:154` (and surrounding catch)**
+
+Find the catch block at line 154. Add:
+
+```swift
+} catch {
+    logger.error("openai_generation_failed error=\(error.localizedDescription, privacy: .public) endpoint=\(endpoint, privacy: .public) model=\(model, privacy: .public)")
+    throw error
+}
+```
+
+**Step 3: Edit `ClaudeCLIProtocolGenerator.swift:71`**
+
+Replace the silent catch with:
+
+```swift
+} catch {
+    logger.error("claude_cli_generation_failed error=\(error.localizedDescription, privacy: .public)")
+    throw error
+}
+```
+
+Also instrument the subprocess flow at lines 107-111 (write stdin, read stdout). Add:
+
+```swift
+logger.info("claude_cli_subprocess_start prompt_bytes=\(promptData.count)")
+// ... existing code ...
+// in readStreamJSON loop:
+logger.debug("claude_cli_progress parts=\(parts.count) lines=\(linesSeen)")  // gated by verboseDiagnostics
+// on timeout:
+logger.warning("claude_cli_timeout elapsed=\(elapsed)s parts_received=\(parts.count)")
+```
+
+**Step 4: Build + smoke**
+
+```bash
+cd app/MeetingTranscriber && swift build
+```
+
+**Step 5: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+git commit -m "feat(app): log LLM generation errors and Claude CLI subprocess progress"
+```
+
+---
+
+### Task 2.6: Permission-denial logging in `Permissions` + `AXHelper`
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/Permissions.swift`
+- Modify: `app/MeetingTranscriber/Sources/AXHelper.swift`
+
+**Step 1: Read both files first**
+
+```bash
+cat app/MeetingTranscriber/Sources/Permissions.swift
+cat app/MeetingTranscriber/Sources/AXHelper.swift
+```
+
+(Adapt the snippets below to the actual function signatures.)
+
+**Step 2: Add a logger declaration to each file (if missing) + log denials**
+
+```swift
+// At top of each file:
+import os.log
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Permissions")  // or "AXHelper"
+
+// In the check function, log when denied/restricted/notDetermined:
+case .denied, .restricted:
+    logger.warning("permission_denied resource=microphone status=\(status.rawValue, privacy: .public)")
+    return false
+```
+
+For `AXHelper`: most calls return `nil` on failure. Add `logger.warning("ax_call_failed function=\(#function, privacy: .public)")` at each silent failure point.
+
+**Step 3: Build + manual smoke**
+
+```bash
+cd app/MeetingTranscriber && swift build
+./scripts/run_app.sh
+# Verify that a fresh install with mic permission denied logs to Console.app
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/Permissions.swift app/MeetingTranscriber/Sources/AXHelper.swift
+git commit -m "feat(app): log permission and accessibility-API denials"
+```
+
+---
+
+### Task 2.7: Speaker-matcher forensic logging with pseudonymization
+
+The Big One — logs top-2 candidates and which threshold check failed when a speaker is rejected. Uses `pseudonymized` from Task 1.1.
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/SpeakerMatcher.swift:176-182`
+
+**Step 1: Read SpeakerMatcher first to understand the current matching code**
+
+```bash
+sed -n '160,210p' app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+```
+
+**Step 2: Add forensic logs at the decision point**
+
+In the match function:
+
+```swift
+let bestPseudo = best.name.pseudonymized
+let secondPseudo = second?.name.pseudonymized ?? "none"
+let margin = (second.map { best.distance - $0.distance }) ?? .infinity
+
+logger.info("speaker_match label=\(label, privacy: .public) best=\(bestPseudo, privacy: .public) bestDist=\(best.distance, privacy: .public) second=\(secondPseudo, privacy: .public) secondDist=\(second?.distance ?? -1, privacy: .public) margin=\(margin, privacy: .public)")
+
+if best.distance >= threshold {
+    logger.info("speaker_match_rejected label=\(label, privacy: .public) reason=above_threshold dist=\(best.distance) threshold=\(threshold)")
+    return nil
+}
+if margin < confidenceMargin {
+    logger.info("speaker_match_rejected label=\(label, privacy: .public) reason=below_margin margin=\(margin) min=\(confidenceMargin)")
+    return nil
+}
+logger.info("speaker_match_assigned label=\(label, privacy: .public) speaker=\(bestPseudo, privacy: .public)")
+```
+
+(Adapt to the actual variable names — `best`, `second`, `threshold`, `confidenceMargin` may differ.)
+
+**Step 3: Build + smoke**
+
+```bash
+cd app/MeetingTranscriber && swift build && swift test --filter SpeakerMatcher
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+git commit -m "feat(app): log speaker-match decisions with pseudonymized names + reject reason"
+```
+
+---
+
+## Phase 3: Export UI
+
+### Task 3.1: `DiagnosticExporter.swift` reads `OSLogStore` and writes a redacted file
+
+**Files:**
+- Create: `app/MeetingTranscriber/Sources/DiagnosticExporter.swift`
+- Test: `app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift`
+
+**Step 1: Write a failing test for the header generator (pure function)**
+
+```swift
+import XCTest
+@testable import MeetingTranscriber
+
+final class DiagnosticExporterTests: XCTestCase {
+    func test_header_includesRequiredFields() {
+        let header = DiagnosticExporter.makeHeader(
+            appVersion: "1.2.3",
+            commit: "abcdef",
+            macOSVersion: "14.5",
+            settings: ["verboseDiagnostics": "true", "diarize": "true"]
+        )
+        XCTAssertTrue(header.contains("MeetingTranscriber 1.2.3"))
+        XCTAssertTrue(header.contains("abcdef"))
+        XCTAssertTrue(header.contains("macOS 14.5"))
+        XCTAssertTrue(header.contains("verboseDiagnostics=true"))
+    }
+}
+```
+
+**Step 2: Run → fail**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter DiagnosticExporterTests
+```
+
+**Step 3: Implement**
+
+Create `app/MeetingTranscriber/Sources/DiagnosticExporter.swift`:
+
+```swift
+import Foundation
+import OSLog
+
+enum DiagnosticExporter {
+    static func makeHeader(
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String]
+    ) -> String {
+        let pairs = settings.sorted(by: { $0.key < $1.key })
+            .map { "\($0.key)=\($0.value)" }.joined(separator: " ")
+        return """
+        # MeetingTranscriber \(appVersion) (\(commit))
+        # macOS \(macOSVersion)
+        # exported_at=\(ISO8601DateFormatter().string(from: Date()))
+        # settings: \(pairs)
+        # ---
+        """
+    }
+
+    /// Reads the last `windowSeconds` seconds of unified-log entries for our subsystems
+    /// and writes them to `outputURL`. Returns the number of lines written.
+    @available(macOS 12, *)
+    static func export(
+        to outputURL: URL,
+        windowSeconds: TimeInterval = 1800,  // last 30 min
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String]
+    ) throws -> Int {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let position = store.position(date: Date().addingTimeInterval(-windowSeconds))
+        let predicate = NSPredicate(
+            format: "subsystem CONTAINS 'com.meetingtranscriber'"
+        )
+        let entries = try store.getEntries(at: position, matching: predicate)
+
+        var lines = [makeHeader(
+            appVersion: appVersion, commit: commit,
+            macOSVersion: macOSVersion, settings: settings
+        )]
+
+        for entry in entries {
+            guard let log = entry as? OSLogEntryLog else { continue }
+            let ts = ISO8601DateFormatter().string(from: log.date)
+            lines.append("\(ts) [\(log.level.rawValue)] \(log.subsystem)/\(log.category): \(log.composedMessage)")
+        }
+
+        try lines.joined(separator: "\n").write(to: outputURL, atomically: true, encoding: .utf8)
+        return lines.count - 1
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter DiagnosticExporterTests
+```
+
+Note: integration test of `export(to:)` can't be reliably written in unit tests — it depends on live OSLogStore. Cover only `makeHeader` with unit tests; verify `export` manually in Task 3.2.
+
+**Step 5: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/DiagnosticExporter.swift app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+git commit -m "feat(app): add DiagnosticExporter to write last-30-min OSLogStore entries"
+```
+
+---
+
+### Task 3.2: "Export Diagnostics" button in `AdvancedSettingsView`
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift` (Diagnostics section)
+
+**Step 1: Add the button + state**
+
+After the verbose-diagnostics Toggle section, add:
+
+```swift
+@State private var lastExportPath: URL?
+@State private var exportError: String?
+
+// inside Section("Diagnostics") {
+Button("Export Diagnostics…") {
+    exportDiagnostics()
+}
+if let path = lastExportPath {
+    Text("Exported to: \(path.lastPathComponent)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+}
+if let err = exportError {
+    Text("Export failed: \(err)").font(.caption).foregroundStyle(.red)
+}
+// }
+
+private func exportDiagnostics() {
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("MeetingTranscriber-diagnostics-\(Int(Date().timeIntervalSince1970)).log")
+    do {
+        let count = try DiagnosticExporter.export(
+            to: tmp,
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?",
+            commit: Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev",
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            settings: [
+                "verboseDiagnostics": "\(settings.verboseDiagnostics)",
+                "diarize": "\(settings.diarize)",
+                "vadEnabled": "\(settings.vadEnabled)",
+                "transcriptionEngine": settings.transcriptionEngine.rawValue,
+                "protocolProvider": settings.protocolProvider.rawValue,
+                "recordOnly": "\(settings.recordOnly)",
+            ]
+        )
+        lastExportPath = tmp
+        exportError = nil
+        NSWorkspace.shared.activateFileViewerSelecting([tmp])
+        logger.info("diagnostics_exported lines=\(count) path=\(tmp.lastPathComponent, privacy: .public)")
+    } catch {
+        exportError = error.localizedDescription
+        lastExportPath = nil
+    }
+}
+```
+
+(Add `private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AdvancedSettingsView")` at top of file.)
+
+**Step 2: Build + manual verification**
+
+```bash
+./scripts/run_app.sh
+# In the app: Settings → Advanced → Diagnostics → "Export Diagnostics…"
+# Finder should open with the .log file selected. Open it and verify:
+# 1. Header with version, commit, macOS, settings
+# 2. Log lines from com.meetingtranscriber subsystems
+# 3. No clear-text speaker names — only "speaker_xxxx" pseudonyms
+```
+
+**Step 3: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+git commit -m "feat(app): add Export Diagnostics button revealing log file in Finder"
+```
+
+---
+
+## Phase 4: NSLog → Logger conversions
+
+### Task 4.1: WhisperKitEngine NSLog → Logger
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/WhisperKitEngine.swift`
+
+**Step 1: Find call sites**
+
+```bash
+grep -n "NSLog" app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+```
+
+**Step 2: Add logger + replace each NSLog**
+
+Add at top of file (if not present):
+
+```swift
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "WhisperKitEngine")
+```
+
+Replace each `NSLog("[WhisperKit] ...", arg)` with:
+
+```swift
+logger.info("...")  // for status messages
+logger.error("...")  // for failures
+```
+
+**Step 3: Build + commit**
+
+```bash
+cd app/MeetingTranscriber && swift build
+git add app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+git commit -m "chore(app): switch WhisperKitEngine from NSLog to os.Logger"
+```
+
+---
+
+### Task 4.2: Qwen3AsrEngine NSLog → Logger
+
+Same approach as Task 4.1, applied to `app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift`.
+
+```bash
+grep -n "NSLog" app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+```
+
+Replace, build, commit:
+
+```bash
+git add app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+git commit -m "chore(app): switch Qwen3AsrEngine from NSLog to os.Logger"
+```
+
+---
+
+### Task 4.3: NotificationManager print → Logger
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/NotificationManager.swift`
+
+```bash
+grep -n "print(" app/MeetingTranscriber/Sources/NotificationManager.swift
+```
+
+Replace `print("...")` with `logger.warning("...")` or `logger.error("...")` based on context.
+
+```bash
+git add app/MeetingTranscriber/Sources/NotificationManager.swift
+git commit -m "chore(app): switch NotificationManager from print to os.Logger"
+```
+
+---
+
+## Phase 5: Issue template
+
+### Task 5.1: Add `bug-report.yml` issue template referencing diagnostic export
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/bug-report.yml`
+- Create: `.github/ISSUE_TEMPLATE/config.yml` (if it doesn't already exist — pinning the form-only choice)
+
+**Step 1: Check existing templates**
+
+```bash
+ls -la .github/ISSUE_TEMPLATE/ 2>/dev/null
+```
+
+**Step 2: Create `bug-report.yml`**
+
+```yaml
+name: Bug Report
+description: Report a bug with Meeting Transcriber
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! To help us debug, please attach a diagnostic log:
+
+        1. Open Meeting Transcriber → Settings → Advanced → Diagnostics
+        2. Toggle **Verbose Diagnostic Logging** ON
+        3. Reproduce the problem
+        4. Click **Export Diagnostics…** — Finder will reveal a `.log` file
+        5. Drag the `.log` file into the "Diagnostic log" field below
+
+        Speaker names are pseudonymised (`speaker_a3f2`); transcript content is **not** included.
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Settings → Advanced → About
+      placeholder: "1.2.3 (abcdef) · Homebrew"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Build variant
+      options:
+        - Homebrew (stable)
+        - Homebrew (beta / RC)
+        - App Store
+        - Built from source
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect, what did you see instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start a Zoom meeting
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Diagnostic log
+      description: Drag the exported .log file here. (GitHub will upload it automatically.)
+    validations:
+      required: false
+```
+
+**Step 3: Commit**
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+git add .github/ISSUE_TEMPLATE/bug-report.yml
+git commit -m "docs(ci): add bug-report issue template requesting diagnostic log"
+```
+
+---
+
+## Phase 6: Open the PR
+
+After all tasks complete:
+
+```bash
+git push -u origin feat/diagnostic-logging
+gh pr create --title "feat: diagnostic logging end-to-end (toggle + export + redaction)" --body "$(cat <<'EOF'
+## Summary
+
+End-to-end "users attach a log file to GitHub issues" workflow.
+
+- **Phase 1:** infrastructure — `LogRedaction.swift` (pseudonymized + redactedName), renamed `audioDebugLogging` → `verboseDiagnostics` (with UserDefaults migration, no setting loss), per-PipelineJob UUID for cross-stage log correlation
+- **Phase 2:** new diagnostic logs — tap-status translation, empty-transcription detection with input RMS, VAD round-trip drift detection, mic-delay clamp warning, LLM error logging, permission denial logging, speaker-match forensics with pseudonymization
+- **Phase 3:** export UI — `DiagnosticExporter` reads `OSLogStore` (last 30 min), Settings → Advanced → "Export Diagnostics…" button writes a redacted file and reveals it in Finder
+- **Phase 4:** NSLog → os.Logger across WhisperKit, Qwen3, NotificationManager
+- **Phase 5:** `.github/ISSUE_TEMPLATE/bug-report.yml` guides users to attach the export
+
+## Test plan
+
+- [ ] All Swift tests pass: `cd app/MeetingTranscriber && swift test --parallel`
+- [ ] Lint clean: `./scripts/lint.sh`
+- [ ] Manually toggle Verbose Diagnostic Logging, run a recording, click Export Diagnostics, verify Finder opens to the .log file
+- [ ] Verify the .log file contains pseudonymised speaker names (no clear text)
+- [ ] Verify the legacy `audioDebugLogging=true` UserDefaults entry migrates to `verboseDiagnostics=true` on first launch
+- [ ] Verify pipeline job IDs appear in `[xxxxxxxx]` form across transcription/diarization/protocol logs
+
+EOF
+)"
+```
+
+---
+
+## Open questions to resolve during execution
+
+If any of these surface mid-implementation, pause and ask:
+
+1. **`PipelineJob` codable migration:** if existing persisted queues lack `id`, the decode-default makes them work. But test-stub creation requires checking the actual struct definition — if test stubs already exist (`PipelineJob.empty` or similar), reuse them; otherwise add `makeTestStub()`.
+2. **`OSLogStore.local()` vs `.currentProcessIdentifier`:** `.local()` requires the entitlement `com.apple.developer.os-logging.read` (granted by default to user-launched apps). If the App Store sandbox build can't read other processes' logs, fall back to `.currentProcessIdentifier` (covers our app only — sufficient for diagnostics).
+3. **`%{public}@` vs `%{private}@`:** any **clear name, transcript text, or path under `~/`** must use `%{private}@` (Logger string-interpolation `privacy: .private`). Pseudonyms, IDs, durations, counts, OSStatus codes are `.public`.
+4. **Dual-build (`#if APPSTORE`):** the Claude CLI logs in Task 2.5 are inside `#if !APPSTORE` — keep them there. The export button works in both variants.
+
+---
+
+## Skill references
+
+- @superpowers:test-driven-development — every task with a pure-function unit follows the red→green→refactor cadence above.
+- @superpowers:requesting-code-review — when each phase finishes, the implementer subagent runs spec + quality reviews via the subagent-driven-development workflow.
+- @superpowers:finishing-a-development-branch — used after Phase 6 to push, open the PR, and respond to review feedback.

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -265,12 +265,13 @@ public class AppAudioCapture {
         var newTapID = AudioObjectID(kAudioObjectUnknown)
         let tapStatus = AudioHardwareCreateProcessTap(tap, &newTapID)
         guard tapStatus == noErr else {
+            let hint = Self.describeTapError(tapStatus)
+            logger.error(
+                "Failed to create process tap (pid=\(self.pid, privacy: .public)): \(hint, privacy: .public)",
+            )
             throw NSError(
                 domain: "audiotap", code: Int(tapStatus),
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Failed to create process tap (status: \(tapStatus))",
-                ],
+                userInfo: [NSLocalizedDescriptionKey: hint],
             )
         }
         tapID = newTapID
@@ -443,6 +444,25 @@ public class AppAudioCapture {
             outputListenerInstalled = false
         }
         logger.info("Audio capture stopped")
+    }
+
+    /// Translates an `AudioHardwareCreateProcessTap` OSStatus to a human hint.
+    /// Exposed `internal` for unit tests.
+    static func describeTapError(_ status: OSStatus) -> String {
+        switch status {
+        case -12_988:
+            return "OSStatus -12988: likely missing permission. " +
+                "Check System Settings → Privacy & Security → Screen Recording " +
+                "and enable Meeting Transcriber."
+        case -10_851:
+            return "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +
+                "the tap target may have exited before the tap was created."
+        case -50:
+            return "OSStatus -50 (paramErr): invalid CATapDescription parameter " +
+                "(target process may not be capturable)."
+        default:
+            return "OSStatus \(status): unrecognised — see CoreAudio headers."
+        }
     }
 }
 

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -450,18 +450,21 @@ public class AppAudioCapture {
     /// Exposed `internal` for unit tests.
     static func describeTapError(_ status: OSStatus) -> String {
         switch status {
-        case -12_988:
-            return "OSStatus -12988: likely missing permission. " +
+        case -12988:
+            "OSStatus -12988: likely missing permission. " +
                 "Check System Settings → Privacy & Security → Screen Recording " +
                 "and enable Meeting Transcriber."
-        case -10_851:
-            return "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +
+
+        case -10851:
+            "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +
                 "the tap target may have exited before the tap was created."
+
         case -50:
-            return "OSStatus -50 (paramErr): invalid CATapDescription parameter " +
+            "OSStatus -50 (paramErr): invalid CATapDescription parameter " +
                 "(target process may not be capturable)."
+
         default:
-            return "OSStatus \(status): unrecognised — see CoreAudio headers."
+            "OSStatus \(status): unrecognised — see CoreAudio headers."
         }
     }
 }

--- a/tools/audiotap/Tests/AppAudioCaptureStatusTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureStatusTests.swift
@@ -1,0 +1,28 @@
+@testable import AudioTapLib
+import XCTest
+
+@available(macOS 14.2, *)
+final class AppAudioCaptureStatusTests: XCTestCase {
+    func test_describeTapError_permissionDenied_mentionsPermission() {
+        let msg = AppAudioCapture.describeTapError(-12_988)
+        XCTAssertTrue(
+            msg.lowercased().contains("permission") || msg.contains("Privacy"),
+            "Expected hint about permissions/Privacy, got: \(msg)",
+        )
+    }
+
+    func test_describeTapError_invalidProperty_mentionsTargetExited() {
+        let msg = AppAudioCapture.describeTapError(-10_851)
+        XCTAssertTrue(msg.contains("exited") || msg.contains("Invalid"))
+    }
+
+    func test_describeTapError_paramErr_mentionsInvalidParameters() {
+        let msg = AppAudioCapture.describeTapError(-50)
+        XCTAssertTrue(msg.contains("invalid") || msg.contains("parameter"))
+    }
+
+    func test_describeTapError_unknown_includesNumericCode() {
+        let msg = AppAudioCapture.describeTapError(-99_999)
+        XCTAssertTrue(msg.contains("-99999"))
+    }
+}


### PR DESCRIPTION
## Summary

End-to-end "users attach a log file to GitHub issues" workflow.

- **Phase 1 — Infrastructure:**
  - `String+LogRedaction` with `pseudonymized` (SHA-256, 4-hex chars, stable across runs) and `redactedName` (first/last char) helpers.
  - Renamed `audioDebugLogging` → `verboseDiagnostics` with UserDefaults migration so existing users keep their setting on first launch.
  - `PipelineJob.shortID` (8-hex) prefixes stage-boundary log lines so a single job's transcription → diarization → protocol output can be followed in unified log even when multiple jobs run back-to-back.

- **Phase 2 — New diagnostic logs (HIGH-priority gaps):**
  - Tap-creation OSStatus → human hint (`-12988` → "likely missing permission, check Screen Recording").
  - Transcription summary log + warn on empty result.
  - VAD trim ratio + round-trip drift detection.
  - Mic-delay clamp warning ("possible output-device switch during recording").
  - LLM connection / HTTP / subprocess errors logged before re-throw.
  - Permission and accessibility-API denials logged with resource + status.
  - Speaker-match decisions with **pseudonymised** speaker names + reject reason (`above_threshold` vs `below_margin`).

- **Phase 3 — Export UI:**
  - `DiagnosticExporter` reads `OSLogStore` for the last 30 min, writes a `.log` file with a header (app version, commit, macOS, current settings flags).
  - Settings → Advanced → Diagnostics → "Export Diagnostics…" button reveals the file in Finder.

- **Phase 4 — Hygiene:** WhisperKitEngine, Qwen3AsrEngine, NotificationManager moved from `NSLog`/`print` to `os.Logger` so they show up in the diagnostic export.

- **Phase 5 — Issue template:** `.github/ISSUE_TEMPLATE/bug-report.yml` walks users through enabling verbose logging, reproducing, exporting, and attaching the log.

## Privacy

Speaker names in the log appear only as `speaker_a3f2`-style hashes — clear text speaker names and transcript text are **never** written to the log. Bundle path/file names use `%{public}@`; descriptive content uses `%{private}@` for defense-in-depth in sysdiagnose contexts.

## Test plan

- [x] All Swift tests pass: `swift test --parallel` — 1169 tests, 0 failures (snapshot tests skipped due to local rendering env)
- [x] Lint clean: `./scripts/lint.sh` — 0 violations
- [x] Code review via `/simplify` agents — fixed: unconditional mix-file load for RMS (now only on failure path); cached `ISO8601DateFormatter` in `DiagnosticExporter`
- [ ] Manually toggle Verbose Diagnostic Logging, run a recording, click Export Diagnostics, verify Finder opens to the .log file
- [ ] Verify the .log file contains pseudonymised speaker names (no clear text)
- [ ] Verify legacy `audioDebugLogging=true` UserDefaults migrates to `verboseDiagnostics=true` on first launch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->