### PR TITLE
feat(app): persistent file-based diagnostic logs (~30 day retention)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -110,7 +110,7 @@ final class AppState {
                 forName: NSApplication.willTerminateNotification,
                 object: nil, queue: .main,
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
+                Task { @MainActor in
                     self?.stopPersistentLogStreamer()
                 }
             }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Observation
+import os.log
 
 // MARK: - AppNotifying
 
@@ -89,7 +90,13 @@ final class AppState {
             observeDebugRPCSetting()
 
             PersistentDiagnosticLog.cleanup()
-            self.persistentLogStreamer = try? PersistentDiagnosticLog.startForToday()
+            do {
+                self.persistentLogStreamer = try PersistentDiagnosticLog.startForToday()
+            } catch {
+                Logger(subsystem: AppPaths.logSubsystem, category: "AppState")
+                    .error("persistent_log_streamer_failed_to_start error=\(error.localizedDescription, privacy: .public)")
+                self.persistentLogStreamer = nil
+            }
             // Stop the streamer cleanly when the app terminates so the file
             // handle flushes and the child `log` process exits. Done via
             // NotificationCenter rather than a SwiftUI `.onReceive` so the

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -49,6 +49,11 @@ final class AppState {
         /// Lazy-started debug RPC server. Only constructed if the env var is
         /// set — otherwise `nil` and zero overhead.
         var debugRPCServer: DebugRPCServer?
+
+        /// Background `log stream` subprocess that mirrors our subsystems to
+        /// `~/Library/Logs/MeetingTranscriber/diagnostics-YYYY-MM-DD.log`.
+        /// Survives longer than OSLogStore retention (~1h for `.info`).
+        private(set) var persistentLogStreamer: PersistentDiagnosticLog.Streamer?
     #endif
 
     // MARK: - Init
@@ -81,8 +86,20 @@ final class AppState {
                 startDebugRPCServer()
             }
             observeDebugRPCSetting()
+
+            PersistentDiagnosticLog.cleanup()
+            self.persistentLogStreamer = try? PersistentDiagnosticLog.startForToday()
         #endif
     }
+
+    #if !APPSTORE
+        /// Stop the persistent log streamer cleanly. Called from the
+        /// `NSApplication.willTerminateNotification` handler.
+        func stopPersistentLogStreamer() {
+            persistentLogStreamer?.stop()
+            persistentLogStreamer = nil
+        }
+    #endif
 
     #if !APPSTORE
         /// Reconcile the debug RPC server with the current setting.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -89,6 +90,23 @@ final class AppState {
 
             PersistentDiagnosticLog.cleanup()
             self.persistentLogStreamer = try? PersistentDiagnosticLog.startForToday()
+            // Stop the streamer cleanly when the app terminates so the file
+            // handle flushes and the child `log` process exits. Done via
+            // NotificationCenter rather than a SwiftUI `.onReceive` so the
+            // observer doesn't churn through the SwiftUI modifier-chain
+            // `#if APPSTORE` minefield.
+            // AppState lives for the entire process lifetime, so leaking
+            // this notification observer until app exit is intentional —
+            // there's no point removing it in a deinit that won't run.
+            // swiftlint:disable:next discarded_notification_center_observer
+            NotificationCenter.default.addObserver(
+                forName: NSApplication.willTerminateNotification,
+                object: nil, queue: .main,
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.stopPersistentLogStreamer()
+                }
+            }
         #endif
     }
 

--- a/app/MeetingTranscriber/Sources/Bundle+AppVersion.swift
+++ b/app/MeetingTranscriber/Sources/Bundle+AppVersion.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Bundle {
+    /// `CFBundleShortVersionString` from `Info.plist`, or `"?"` if missing.
+    /// Surfaced in Settings → Advanced → About and stamped into diagnostic
+    /// log exports for support context.
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
+    /// `GitCommitHash` injected at build time by `scripts/build_release.sh`,
+    /// or `"dev"` for unsigned dev builds.
+    var gitCommitHash: String {
+        infoDictionary?["GitCommitHash"] as? String ?? "dev"
+    }
+}

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -4,10 +4,13 @@ import OSLog
 /// Reads recent unified-log entries for the app's subsystems and writes them
 /// to a shareable `.log` file with a header describing the app build state.
 /// Used by Settings → Advanced → "Export Diagnostics…".
+///
+/// Source preference: when `PersistentDiagnosticLog` is active and today's
+/// file exists, read from that (survives longer than OSLogStore retention).
+/// Otherwise fall back to `OSLogStore` (~1h window for `.info`-level entries).
 enum DiagnosticExporter {
     /// Shared formatter — `ISO8601DateFormatter` init is non-trivial, so we
-    /// keep one instance for both the header timestamp and per-entry timestamps
-    /// in `export(...)`.
+    /// keep one instance for both the header timestamp and per-entry timestamps.
     private static let formatter = ISO8601DateFormatter()
 
     /// Build the header that prefixes every exported diagnostic file.
@@ -35,7 +38,8 @@ enum DiagnosticExporter {
 
     /// Reads the last `windowSeconds` of unified-log entries for our subsystems
     /// and writes them to `outputURL`. Returns the number of log entries
-    /// written (excluding the header). Throws on store-open or write failures.
+    /// written (excluding the header). Prefers the persistent file source
+    /// when available, falls back to `OSLogStore`.
     @available(macOS 12, *)
     static func export(
         to outputURL: URL,
@@ -44,6 +48,70 @@ enum DiagnosticExporter {
         macOSVersion: String,
         settings: [String: String],
         windowSeconds: TimeInterval = 1800,
+    ) throws -> Int {
+        let todayFile = PersistentDiagnosticLog.logDirectory
+            .appendingPathComponent(PersistentDiagnosticLog.logFileName(for: Date()))
+        if FileManager.default.fileExists(atPath: todayFile.path) {
+            return try exportFromFile(
+                sourceFile: todayFile,
+                to: outputURL,
+                windowSeconds: windowSeconds,
+                appVersion: appVersion,
+                commit: commit,
+                macOSVersion: macOSVersion,
+                settings: settings,
+            )
+        }
+        return try exportFromOSLogStore(
+            to: outputURL,
+            windowSeconds: windowSeconds,
+            appVersion: appVersion,
+            commit: commit,
+            macOSVersion: macOSVersion,
+            settings: settings,
+        )
+    }
+
+    /// File-source path: read the persistent diagnostic-log file, tail-filter
+    /// to entries within `windowSeconds`, write header + body to `outputURL`.
+    /// Returns the number of body lines (excludes header).
+    static func exportFromFile(
+        sourceFile: URL,
+        to outputURL: URL,
+        windowSeconds: TimeInterval,
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String],
+    ) throws -> Int {
+        let header = makeHeader(
+            appVersion: appVersion, commit: commit,
+            macOSVersion: macOSVersion, settings: settings,
+        )
+
+        let raw = (try? String(contentsOf: sourceFile, encoding: .utf8)) ?? ""
+        let cutoff = Date().addingTimeInterval(-windowSeconds)
+        let kept = raw.split(separator: "\n", omittingEmptySubsequences: true).filter { line in
+            // Lines without a parseable syslog timestamp (continuation lines,
+            // prelude noise) are kept — only filter when we can identify
+            // they're definitely older than the cutoff.
+            guard let lineDate = parseSyslogDate(String(line)) else { return true }
+            return lineDate >= cutoff
+        }
+        let body = kept.joined(separator: "\n")
+        try (header + "\n" + body).write(to: outputURL, atomically: true, encoding: .utf8)
+        return kept.count
+    }
+
+    /// OSLogStore-source path (legacy / App Store fallback).
+    @available(macOS 12, *)
+    static func exportFromOSLogStore(
+        to outputURL: URL,
+        windowSeconds: TimeInterval,
+        appVersion: String,
+        commit: String,
+        macOSVersion: String,
+        settings: [String: String],
     ) throws -> Int {
         let store = try OSLogStore(scope: .currentProcessIdentifier)
         let position = store.position(date: Date().addingTimeInterval(-windowSeconds))
@@ -68,5 +136,25 @@ enum DiagnosticExporter {
 
         try lines.joined(separator: "\n").write(to: outputURL, atomically: true, encoding: .utf8)
         return count
+    }
+
+    /// Parses `syslog` style line prefix `Mmm d HH:mm:ss` (15 chars) to a
+    /// `Date` in the current year. Returns nil for lines without that prefix
+    /// (e.g. multi-line continuations). Locale-pinned to `en_US_POSIX` so
+    /// `log stream` output is parsed consistently regardless of user locale.
+    static func parseSyslogDate(_ line: String) -> Date? {
+        guard line.count >= 15 else { return nil }
+        let prefix = String(line.prefix(15))
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d HH:mm:ss"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+        guard let parsed = fmt.date(from: prefix) else { return nil }
+        // The parsed date defaults to year 2000; rebuild with current year.
+        var components = Calendar.current.dateComponents(
+            [.month, .day, .hour, .minute, .second], from: parsed,
+        )
+        components.year = Calendar.current.component(.year, from: Date())
+        return Calendar.current.date(from: components)
     }
 }

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -107,13 +107,20 @@ enum DiagnosticExporter {
 
         let raw = (try? String(contentsOf: sourceFile, encoding: .utf8)) ?? ""
         let cutoff = Date().addingTimeInterval(-windowSeconds)
-        let kept = raw.split(separator: "\n", omittingEmptySubsequences: true).filter { line in
-            // Lines without a parseable syslog timestamp (continuation lines,
-            // prelude noise) are kept — only filter when we can identify
-            // they're definitely older than the cutoff.
-            guard let lineDate = parseSyslogDate(String(line)) else { return true }
-            return lineDate >= cutoff
-        }
+        // omittingEmptySubsequences: false so blank lines in the source are
+        // preserved verbatim — they may be intentional separators in the
+        // streamed log output and dropping them changes the file shape.
+        // Empty source short-circuits to no body lines (split would otherwise
+        // return [""] for the empty string).
+        let kept: [Substring] = raw.isEmpty
+            ? []
+            : raw.split(separator: "\n", omittingEmptySubsequences: false).filter { line in
+                // Lines without a parseable syslog timestamp (continuation lines,
+                // prelude noise, blanks) are kept — only filter when we can
+                // identify them as definitely older than the cutoff.
+                guard let lineDate = parseSyslogDate(String(line)) else { return true }
+                return lineDate >= cutoff
+            }
         let body = kept.joined(separator: "\n")
         try (header + "\n" + body).write(to: outputURL, atomically: true, encoding: .utf8)
         return kept.count
@@ -149,19 +156,30 @@ enum DiagnosticExporter {
     }
 
     /// Parses `syslog` style line prefix `Mmm d HH:mm:ss` (15 chars) to a
-    /// `Date` in the current year. Returns nil for lines without that prefix
-    /// (e.g. multi-line continuations). Uses the cached `syslogFormatter` —
-    /// avoids per-call DateFormatter allocation when filtering thousands of
-    /// lines in `exportFromFile`.
-    static func parseSyslogDate(_ line: String) -> Date? {
+    /// `Date`. Returns nil for lines without that prefix (e.g. multi-line
+    /// continuations). Uses the cached `syslogFormatter` — avoids per-call
+    /// DateFormatter allocation when filtering thousands of lines.
+    ///
+    /// Year inference: syslog format omits the year. Default to the current
+    /// year, but if the resulting date is more than ~30 days in the future
+    /// relative to `now`, we're likely parsing a December log on a January
+    /// day — in that case roll back one year.
+    static func parseSyslogDate(_ line: String, now: Date = Date()) -> Date? {
         guard line.count >= 15 else { return nil }
         let prefix = String(line.prefix(15))
         guard let parsed = syslogFormatter.date(from: prefix) else { return nil }
-        // The parsed date defaults to year 2000; rebuild with current year.
         var components = Calendar.current.dateComponents(
             [.month, .day, .hour, .minute, .second], from: parsed,
         )
-        components.year = Calendar.current.component(.year, from: Date())
-        return Calendar.current.date(from: components)
+        let nowYear = Calendar.current.component(.year, from: now)
+        components.year = nowYear
+        guard let candidate = Calendar.current.date(from: components) else { return nil }
+        // If the candidate is far in the future, the log line is from the
+        // previous year (year-boundary export, e.g. Jan 1 reading Dec 31).
+        if candidate.timeIntervalSince(now) > 30 * 86400 {
+            components.year = nowYear - 1
+            return Calendar.current.date(from: components)
+        }
+        return candidate
     }
 }

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -22,6 +22,18 @@ enum DiagnosticExporter {
     /// keep one instance for both the header timestamp and per-entry timestamps.
     private static let formatter = ISO8601DateFormatter()
 
+    /// Cached `DateFormatter` for syslog-style line prefixes (`MMM d HH:mm:ss`).
+    /// Reused for every line in `exportFromFile`'s filter loop — at thousands
+    /// of lines the per-call allocation cost matters. Locale-pinned to
+    /// `en_US_POSIX` so output of `log stream` is parsed consistently.
+    private static let syslogFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d HH:mm:ss"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+        return fmt
+    }()
+
     /// Build the header that prefixes every exported diagnostic file.
     /// Pure function — settings dict is stringified verbatim into `key=value`
     /// pairs, sorted alphabetically for deterministic output. No PII is
@@ -138,16 +150,13 @@ enum DiagnosticExporter {
 
     /// Parses `syslog` style line prefix `Mmm d HH:mm:ss` (15 chars) to a
     /// `Date` in the current year. Returns nil for lines without that prefix
-    /// (e.g. multi-line continuations). Locale-pinned to `en_US_POSIX` so
-    /// `log stream` output is parsed consistently regardless of user locale.
+    /// (e.g. multi-line continuations). Uses the cached `syslogFormatter` —
+    /// avoids per-call DateFormatter allocation when filtering thousands of
+    /// lines in `exportFromFile`.
     static func parseSyslogDate(_ line: String) -> Date? {
         guard line.count >= 15 else { return nil }
         let prefix = String(line.prefix(15))
-        let fmt = DateFormatter()
-        fmt.dateFormat = "MMM d HH:mm:ss"
-        fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone.current
-        guard let parsed = fmt.date(from: prefix) else { return nil }
+        guard let parsed = syslogFormatter.date(from: prefix) else { return nil }
         // The parsed date defaults to year 2000; rebuild with current year.
         var components = Calendar.current.dateComponents(
             [.month, .day, .hour, .minute, .second], from: parsed,

--- a/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
+++ b/app/MeetingTranscriber/Sources/DiagnosticExporter.swift
@@ -9,6 +9,15 @@ import OSLog
 /// file exists, read from that (survives longer than OSLogStore retention).
 /// Otherwise fall back to `OSLogStore` (~1h window for `.info`-level entries).
 enum DiagnosticExporter {
+    /// Bundle of identity fields stamped into the export header. Keeps the
+    /// `export(...)` parameter count manageable.
+    struct HeaderInfo {
+        let appVersion: String
+        let commit: String
+        let macOSVersion: String
+        let settings: [String: String]
+    }
+
     /// Shared formatter — `ISO8601DateFormatter` init is non-trivial, so we
     /// keep one instance for both the header timestamp and per-entry timestamps.
     private static let formatter = ISO8601DateFormatter()
@@ -36,6 +45,16 @@ enum DiagnosticExporter {
         """
     }
 
+    /// Build header from a `HeaderInfo` bundle.
+    static func makeHeader(_ info: HeaderInfo) -> String {
+        makeHeader(
+            appVersion: info.appVersion,
+            commit: info.commit,
+            macOSVersion: info.macOSVersion,
+            settings: info.settings,
+        )
+    }
+
     /// Reads the last `windowSeconds` of unified-log entries for our subsystems
     /// and writes them to `outputURL`. Returns the number of log entries
     /// written (excluding the header). Prefers the persistent file source
@@ -43,10 +62,7 @@ enum DiagnosticExporter {
     @available(macOS 12, *)
     static func export(
         to outputURL: URL,
-        appVersion: String,
-        commit: String,
-        macOSVersion: String,
-        settings: [String: String],
+        info: HeaderInfo,
         windowSeconds: TimeInterval = 1800,
     ) throws -> Int {
         let todayFile = PersistentDiagnosticLog.logDirectory
@@ -55,20 +71,14 @@ enum DiagnosticExporter {
             return try exportFromFile(
                 sourceFile: todayFile,
                 to: outputURL,
+                info: info,
                 windowSeconds: windowSeconds,
-                appVersion: appVersion,
-                commit: commit,
-                macOSVersion: macOSVersion,
-                settings: settings,
             )
         }
         return try exportFromOSLogStore(
             to: outputURL,
+            info: info,
             windowSeconds: windowSeconds,
-            appVersion: appVersion,
-            commit: commit,
-            macOSVersion: macOSVersion,
-            settings: settings,
         )
     }
 
@@ -78,16 +88,10 @@ enum DiagnosticExporter {
     static func exportFromFile(
         sourceFile: URL,
         to outputURL: URL,
+        info: HeaderInfo,
         windowSeconds: TimeInterval,
-        appVersion: String,
-        commit: String,
-        macOSVersion: String,
-        settings: [String: String],
     ) throws -> Int {
-        let header = makeHeader(
-            appVersion: appVersion, commit: commit,
-            macOSVersion: macOSVersion, settings: settings,
-        )
+        let header = makeHeader(info)
 
         let raw = (try? String(contentsOf: sourceFile, encoding: .utf8)) ?? ""
         let cutoff = Date().addingTimeInterval(-windowSeconds)
@@ -107,11 +111,8 @@ enum DiagnosticExporter {
     @available(macOS 12, *)
     static func exportFromOSLogStore(
         to outputURL: URL,
+        info: HeaderInfo,
         windowSeconds: TimeInterval,
-        appVersion: String,
-        commit: String,
-        macOSVersion: String,
-        settings: [String: String],
     ) throws -> Int {
         let store = try OSLogStore(scope: .currentProcessIdentifier)
         let position = store.position(date: Date().addingTimeInterval(-windowSeconds))
@@ -120,10 +121,7 @@ enum DiagnosticExporter {
         )
         let entries = try store.getEntries(at: position, matching: predicate)
 
-        var lines: [String] = [makeHeader(
-            appVersion: appVersion, commit: commit,
-            macOSVersion: macOSVersion, settings: settings,
-        )]
+        var lines: [String] = [makeHeader(info)]
         var count = 0
         for entry in entries {
             guard let log = entry as? OSLogEntryLog else { continue }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -85,6 +85,11 @@ struct MeetingTranscriberApp: App {
             .onReceive(NotificationCenter.default.publisher(for: .closeSettings)) { _ in
                 closeWindow(id: "settings")
             }
+            #if !APPSTORE
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                    appState.stopPersistentLogStreamer()
+                }
+            #endif
             .task {
                 switch appState.settings.transcriptionEngine {
                 case .whisperKit:

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -85,11 +85,6 @@ struct MeetingTranscriberApp: App {
             .onReceive(NotificationCenter.default.publisher(for: .closeSettings)) { _ in
                 closeWindow(id: "settings")
             }
-            #if !APPSTORE
-                .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
-                    appState.stopPersistentLogStreamer()
-                }
-            #endif
             .task {
                 switch appState.settings.transcriptionEngine {
                 case .whisperKit:

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -1,4 +1,9 @@
 import Foundation
+import os.log
+
+private let logger = Logger(
+    subsystem: AppPaths.logSubsystem, category: "PersistentDiagnosticLog",
+)
 
 /// Manages a rolling on-disk mirror of `os.Logger` output for the
 /// `com.meetingtranscriber*` subsystems. Files are written by a background
@@ -43,6 +48,16 @@ enum PersistentDiagnosticLog {
         return name.range(of: pattern, options: .regularExpression) != nil
     }
 
+    /// Convenience: open today's log file as the stream target. Returns the
+    /// running streamer so the caller can stop it on app shutdown.
+    @discardableResult
+    static func startForToday() throws -> Streamer {
+        let target = logDirectory.appendingPathComponent(logFileName(for: Date()))
+        let streamer = try Streamer(targetURL: target)
+        try streamer.start()
+        return streamer
+    }
+
     /// Delete diagnostic-log files older than `retentionDays`. Non-matching files
     /// (anything not `diagnostics-YYYY-MM-DD.log`) are left alone. Safe to call
     /// multiple times; idempotent. Silently no-ops if the directory is missing.
@@ -64,6 +79,68 @@ enum PersistentDiagnosticLog {
                   isExpired(modifiedAt: mtime, retentionDays: retentionDays)
             else { continue }
             try? fm.removeItem(at: url)
+        }
+    }
+
+    /// Wraps a running `log stream` subprocess that mirrors our subsystems
+    /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
+    /// `init(targetURL:)` opens the file, `start()` launches the subprocess
+    /// and pipes its stdout into the file, `stop()` terminates the process
+    /// and closes the file handle.
+    final class Streamer {
+        private let process = Process()
+        private let logFileHandle: FileHandle
+        private let pipe = Pipe()
+        private(set) var isRunning = false
+
+        init(targetURL: URL) throws {
+            let fm = FileManager.default
+            if !fm.fileExists(atPath: targetURL.path) {
+                fm.createFile(atPath: targetURL.path, contents: nil)
+            }
+            self.logFileHandle = try FileHandle(forWritingTo: targetURL)
+            try self.logFileHandle.seekToEnd()
+        }
+
+        func start() throws {
+            guard !isRunning else { return }
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+            process.arguments = [
+                "stream",
+                "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
+                "--style", "syslog",
+                "--info",
+            ]
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            let handle = pipe.fileHandleForReading
+            handle.readabilityHandler = { [weak self] fh in
+                let data = fh.availableData
+                guard !data.isEmpty else { return }
+                try? self?.logFileHandle.write(contentsOf: data)
+            }
+
+            try process.run()
+            isRunning = true
+            logger.info(
+                "persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)",
+            )
+        }
+
+        func stop() {
+            guard isRunning else { return }
+            process.terminate()
+            try? logFileHandle.close()
+            isRunning = false
+            logger.info("persistent_log_streamer_stopped")
+        }
+
+        deinit {
+            if isRunning {
+                process.terminate()
+                try? logFileHandle.close()
+            }
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -42,4 +42,28 @@ enum PersistentDiagnosticLog {
         let pattern = #"^diagnostics-\d{4}-\d{2}-\d{2}\.log$"#
         return name.range(of: pattern, options: .regularExpression) != nil
     }
+
+    /// Delete diagnostic-log files older than `retentionDays`. Non-matching files
+    /// (anything not `diagnostics-YYYY-MM-DD.log`) are left alone. Safe to call
+    /// multiple times; idempotent. Silently no-ops if the directory is missing.
+    static func cleanup(
+        in directory: URL = logDirectory,
+        retentionDays: Int = defaultRetentionDays,
+    ) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+        ) else {
+            return
+        }
+        for url in entries {
+            guard isOurLogFile(url.lastPathComponent) else { continue }
+            guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+                  let mtime = attrs[.modificationDate] as? Date,
+                  isExpired(modifiedAt: mtime, retentionDays: retentionDays)
+            else { continue }
+            try? fm.removeItem(at: url)
+        }
+    }
 }

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Manages a rolling on-disk mirror of `os.Logger` output for the
+/// `com.meetingtranscriber*` subsystems. Files are written by a background
+/// `log stream` subprocess (see `Streamer`) and rotated daily.
+/// `DiagnosticExporter` reads from these files when present, so users can
+/// reproduce a bug, wait, and still export hours-old logs — beyond the
+/// macOS unified-log retention window for `.info`-level entries.
+enum PersistentDiagnosticLog {
+    /// `~/Library/Logs/MeetingTranscriber/` — Apple convention, picked up
+    /// by Console.app's "Log Reports" tab and not auto-cleaned by macOS.
+    static var logDirectory: URL {
+        let logs = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("MeetingTranscriber", isDirectory: true)
+        try? FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        return logs
+    }
+
+    /// Default retention in days. Older files are deleted on app launch.
+    static let defaultRetentionDays = 30
+
+    /// File name for a given date, rotating daily. UTC so the file boundary
+    /// is stable regardless of where the user travels.
+    static func logFileName(for date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return "diagnostics-\(fmt.string(from: date)).log"
+    }
+
+    /// True when the file's mtime is older than `retentionDays` ago.
+    static func isExpired(modifiedAt date: Date, retentionDays: Int) -> Bool {
+        let cutoff = Date().addingTimeInterval(-Double(retentionDays) * 86400)
+        return date < cutoff
+    }
+
+    /// Filter for files we own — only delete things matching our naming pattern,
+    /// never random files a user dropped in the directory.
+    static func isOurLogFile(_ name: String) -> Bool {
+        let pattern = #"^diagnostics-\d{4}-\d{2}-\d{2}\.log$"#
+        return name.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -26,13 +26,18 @@ enum PersistentDiagnosticLog {
     /// Default retention in days. Older files are deleted on app launch.
     static let defaultRetentionDays = 30
 
-    /// File name for a given date, rotating daily. UTC so the file boundary
-    /// is stable regardless of where the user travels.
-    static func logFileName(for date: Date) -> String {
+    /// Cached file-name formatter. UTC so the file boundary is stable
+    /// regardless of where the user travels.
+    private static let fileNameFormatter: DateFormatter = {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd"
         fmt.timeZone = TimeZone(identifier: "UTC")
-        return "diagnostics-\(fmt.string(from: date)).log"
+        return fmt
+    }()
+
+    /// File name for a given date, rotating daily.
+    static func logFileName(for date: Date) -> String {
+        "diagnostics-\(fileNameFormatter.string(from: date)).log"
     }
 
     /// True when the file's mtime is older than `retentionDays` ago.

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -102,7 +102,7 @@ enum PersistentDiagnosticLog {
             private let process = Process()
             private let logFileHandle: FileHandle
             private let pipe = Pipe()
-            private(set) var isRunning = false
+            private var isRunning = false
 
             init(targetURL: URL) throws {
                 let fm = FileManager.default

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -48,15 +48,17 @@ enum PersistentDiagnosticLog {
         return name.range(of: pattern, options: .regularExpression) != nil
     }
 
-    /// Convenience: open today's log file as the stream target. Returns the
-    /// running streamer so the caller can stop it on app shutdown.
-    @discardableResult
-    static func startForToday() throws -> Streamer {
-        let target = logDirectory.appendingPathComponent(logFileName(for: Date()))
-        let streamer = try Streamer(targetURL: target)
-        try streamer.start()
-        return streamer
-    }
+    #if !APPSTORE
+        /// Convenience: open today's log file as the stream target. Returns the
+        /// running streamer so the caller can stop it on app shutdown.
+        @discardableResult
+        static func startForToday() throws -> Streamer {
+            let target = logDirectory.appendingPathComponent(logFileName(for: Date()))
+            let streamer = try Streamer(targetURL: target)
+            try streamer.start()
+            return streamer
+        }
+    #endif
 
     /// Delete diagnostic-log files older than `retentionDays`. Non-matching files
     /// (anything not `diagnostics-YYYY-MM-DD.log`) are left alone. Safe to call
@@ -82,11 +84,15 @@ enum PersistentDiagnosticLog {
         }
     }
 
+    #if !APPSTORE
     /// Wraps a running `log stream` subprocess that mirrors our subsystems
     /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
     /// `init(targetURL:)` opens the file, `start()` launches the subprocess
     /// and pipes its stdout into the file, `stop()` terminates the process
     /// and closes the file handle.
+    ///
+    /// Gated `#if !APPSTORE` because `Process` is forbidden under sandbox.
+    /// The App Store variant falls back to `OSLogStore` in `DiagnosticExporter`.
     final class Streamer {
         private let process = Process()
         private let logFileHandle: FileHandle
@@ -143,4 +149,5 @@ enum PersistentDiagnosticLog {
             }
         }
     }
+    #endif
 }

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -85,69 +85,69 @@ enum PersistentDiagnosticLog {
     }
 
     #if !APPSTORE
-    /// Wraps a running `log stream` subprocess that mirrors our subsystems
-    /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
-    /// `init(targetURL:)` opens the file, `start()` launches the subprocess
-    /// and pipes its stdout into the file, `stop()` terminates the process
-    /// and closes the file handle.
-    ///
-    /// Gated `#if !APPSTORE` because `Process` is forbidden under sandbox.
-    /// The App Store variant falls back to `OSLogStore` in `DiagnosticExporter`.
-    final class Streamer {
-        private let process = Process()
-        private let logFileHandle: FileHandle
-        private let pipe = Pipe()
-        private(set) var isRunning = false
+        /// Wraps a running `log stream` subprocess that mirrors our subsystems
+        /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
+        /// `init(targetURL:)` opens the file, `start()` launches the subprocess
+        /// and pipes its stdout into the file, `stop()` terminates the process
+        /// and closes the file handle.
+        ///
+        /// Gated `#if !APPSTORE` because `Process` is forbidden under sandbox.
+        /// The App Store variant falls back to `OSLogStore` in `DiagnosticExporter`.
+        final class Streamer {
+            private let process = Process()
+            private let logFileHandle: FileHandle
+            private let pipe = Pipe()
+            private(set) var isRunning = false
 
-        init(targetURL: URL) throws {
-            let fm = FileManager.default
-            if !fm.fileExists(atPath: targetURL.path) {
-                fm.createFile(atPath: targetURL.path, contents: nil)
-            }
-            self.logFileHandle = try FileHandle(forWritingTo: targetURL)
-            try self.logFileHandle.seekToEnd()
-        }
-
-        func start() throws {
-            guard !isRunning else { return }
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
-            process.arguments = [
-                "stream",
-                "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
-                "--style", "syslog",
-                "--info",
-            ]
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            let handle = pipe.fileHandleForReading
-            handle.readabilityHandler = { [weak self] fh in
-                let data = fh.availableData
-                guard !data.isEmpty else { return }
-                try? self?.logFileHandle.write(contentsOf: data)
+            init(targetURL: URL) throws {
+                let fm = FileManager.default
+                if !fm.fileExists(atPath: targetURL.path) {
+                    fm.createFile(atPath: targetURL.path, contents: nil)
+                }
+                self.logFileHandle = try FileHandle(forWritingTo: targetURL)
+                try self.logFileHandle.seekToEnd()
             }
 
-            try process.run()
-            isRunning = true
-            logger.info(
-                "persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)",
-            )
-        }
+            func start() throws {
+                guard !isRunning else { return }
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+                process.arguments = [
+                    "stream",
+                    "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
+                    "--style", "syslog",
+                    "--info",
+                ]
+                process.standardOutput = pipe
+                process.standardError = pipe
 
-        func stop() {
-            guard isRunning else { return }
-            process.terminate()
-            try? logFileHandle.close()
-            isRunning = false
-            logger.info("persistent_log_streamer_stopped")
-        }
+                let handle = pipe.fileHandleForReading
+                handle.readabilityHandler = { [weak self] fh in
+                    let data = fh.availableData
+                    guard !data.isEmpty else { return }
+                    try? self?.logFileHandle.write(contentsOf: data)
+                }
 
-        deinit {
-            if isRunning {
+                try process.run()
+                isRunning = true
+                logger.info(
+                    "persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)",
+                )
+            }
+
+            func stop() {
+                guard isRunning else { return }
                 process.terminate()
                 try? logFileHandle.close()
+                isRunning = false
+                logger.info("persistent_log_streamer_stopped")
+            }
+
+            deinit {
+                if isRunning {
+                    process.terminate()
+                    try? logFileHandle.close()
+                }
             }
         }
-    }
     #endif
 }

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -136,8 +136,8 @@ struct AdvancedSettingsView: View {
     #endif
 
     private static let versionString: String = {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
+        let version = Bundle.main.appVersion
+        let commit = Bundle.main.gitCommitHash
         #if APPSTORE
             let variant = "App Store"
         #else
@@ -167,11 +167,9 @@ struct AdvancedSettingsView: View {
         let outURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingTranscriber-diagnostics-\(stamp).log")
         do {
-            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-            let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
             let info = DiagnosticExporter.HeaderInfo(
-                appVersion: appVersion,
-                commit: commit,
+                appVersion: Bundle.main.appVersion,
+                commit: Bundle.main.gitCommitHash,
                 macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
                 settings: [
                     "verboseDiagnostics": "\(settings.verboseDiagnostics)",

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -87,6 +87,18 @@ struct AdvancedSettingsView: View {
                 }
 
                 #if !APPSTORE
+                    Button("Open Diagnostic Logs Folder") {
+                        NSWorkspace.shared.activateFileViewerSelecting([PersistentDiagnosticLog.logDirectory])
+                    }
+                    Text(
+                        "Persistent logs are kept for 30 days at"
+                            + " ~/Library/Logs/MeetingTranscriber/. Useful when"
+                            + " you need to attach logs from a session that"
+                            + " happened earlier today (or yesterday).",
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                     Toggle("Debug RPC Server", isOn: $settings.debugRPCEnabled)
                     Text(
                         "Exposes pipeline state on 127.0.0.1:9876 for `mt-cli`."
@@ -157,8 +169,7 @@ struct AdvancedSettingsView: View {
         do {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
             let commit = Bundle.main.infoDictionary?["GitCommitHash"] as? String ?? "dev"
-            let count = try DiagnosticExporter.export(
-                to: outURL,
+            let info = DiagnosticExporter.HeaderInfo(
                 appVersion: appVersion,
                 commit: commit,
                 macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
@@ -171,6 +182,7 @@ struct AdvancedSettingsView: View {
                     "recordOnly": "\(settings.recordOnly)",
                 ],
             )
+            let count = try DiagnosticExporter.export(to: outURL, info: info)
             lastExportFile = outURL.lastPathComponent
             lastExportError = nil
             NSWorkspace.shared.activateFileViewerSelecting([outURL])

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -81,6 +81,30 @@ final class DiagnosticExporterTests: XCTestCase {
         XCTAssertNil(DiagnosticExporter.parseSyslogDate(""))
     }
 
+    func test_parseSyslogDate_yearBoundary_rollsBackToPreviousYear() throws {
+        // Pretend it's Jan 2 2027 and we're parsing a Dec 31 log line.
+        // Without year-rollback, the line would parse as Dec 31 2027 (in
+        // the future), then get filtered out as "too new" by the window
+        // filter — making the export empty for cross-year diagnostics.
+        let now = try XCTUnwrap(makeDate(year: 2027, month: 1, day: 2, hour: 10))
+        let parsed = try XCTUnwrap(DiagnosticExporter.parseSyslogDate(
+            "Dec 31 23:59:00 some log line", now: now,
+        ))
+        let comps = Calendar.current.dateComponents([.year, .month, .day], from: parsed)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 12)
+        XCTAssertEqual(comps.day, 31)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int) -> Date? {
+        var c = DateComponents()
+        c.year = year
+        c.month = month
+        c.day = day
+        c.hour = hour
+        return Calendar.current.date(from: c)
+    }
+
     // MARK: - exportFromFile
 
     func test_exportFromFile_writesHeaderPlusBody_withinWindow() throws {

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -55,4 +55,117 @@ final class DiagnosticExporterTests: XCTestCase {
         )
         XCTAssertFalse(header.isEmpty)
     }
+
+    // MARK: - parseSyslogDate
+
+    func test_parseSyslogDate_validPrefix_returnsDateInCurrentYear() throws {
+        let date = try XCTUnwrap(DiagnosticExporter.parseSyslogDate("May 04 21:25:34 MeetingTranscriber"))
+        let comps = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second], from: date,
+        )
+        XCTAssertEqual(comps.year, Calendar.current.component(.year, from: Date()))
+        XCTAssertEqual(comps.month, 5)
+        XCTAssertEqual(comps.day, 4)
+        XCTAssertEqual(comps.hour, 21)
+        XCTAssertEqual(comps.minute, 25)
+        XCTAssertEqual(comps.second, 34)
+    }
+
+    func test_parseSyslogDate_singleDigitDay_works() throws {
+        XCTAssertNotNil(DiagnosticExporter.parseSyslogDate("May  4 21:25:34 rest of line"))
+    }
+
+    func test_parseSyslogDate_invalidPrefix_returnsNil() {
+        XCTAssertNil(DiagnosticExporter.parseSyslogDate("abc"))
+        XCTAssertNil(DiagnosticExporter.parseSyslogDate("not a date at all here"))
+        XCTAssertNil(DiagnosticExporter.parseSyslogDate(""))
+    }
+
+    // MARK: - exportFromFile
+
+    func test_exportFromFile_writesHeaderPlusBody_withinWindow() throws {
+        let tmpSrc = FileManager.default.temporaryDirectory
+            .appendingPathComponent("src-\(UUID().uuidString).log")
+        let tmpDst = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dst-\(UUID().uuidString).log")
+        defer {
+            try? FileManager.default.removeItem(at: tmpSrc)
+            try? FileManager.default.removeItem(at: tmpDst)
+        }
+        let now = Date()
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d HH:mm:ss"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        let stamp = fmt.string(from: now)
+        let line = "\(stamp) MeetingTranscriber[1234]: hello world"
+        try line.write(to: tmpSrc, atomically: true, encoding: .utf8)
+
+        let count = try DiagnosticExporter.exportFromFile(
+            sourceFile: tmpSrc,
+            to: tmpDst,
+            windowSeconds: 60,
+            appVersion: "1.0",
+            commit: "abc",
+            macOSVersion: "14.5",
+            settings: [:],
+        )
+        XCTAssertEqual(count, 1)
+        let written = try String(contentsOf: tmpDst, encoding: .utf8)
+        XCTAssertTrue(written.contains("MeetingTranscriber 1.0"))
+        XCTAssertTrue(written.contains("hello world"))
+    }
+
+    func test_exportFromFile_filtersOutEntriesOlderThanWindow() throws {
+        let tmpSrc = FileManager.default.temporaryDirectory
+            .appendingPathComponent("src-\(UUID().uuidString).log")
+        let tmpDst = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dst-\(UUID().uuidString).log")
+        defer {
+            try? FileManager.default.removeItem(at: tmpSrc)
+            try? FileManager.default.removeItem(at: tmpDst)
+        }
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d HH:mm:ss"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        let now = Date()
+        let recentStamp = fmt.string(from: now)
+        let oldStamp = fmt.string(from: now.addingTimeInterval(-7200))
+
+        let body = """
+        \(oldStamp) MeetingTranscriber[1234]: too-old line
+        \(recentStamp) MeetingTranscriber[1234]: recent line
+        """
+        try body.write(to: tmpSrc, atomically: true, encoding: .utf8)
+
+        let count = try DiagnosticExporter.exportFromFile(
+            sourceFile: tmpSrc,
+            to: tmpDst,
+            windowSeconds: 1800,
+            appVersion: "1.0", commit: "abc",
+            macOSVersion: "14.5", settings: [:],
+        )
+        XCTAssertEqual(count, 1)
+        let written = try String(contentsOf: tmpDst, encoding: .utf8)
+        XCTAssertTrue(written.contains("recent line"))
+        XCTAssertFalse(written.contains("too-old line"))
+    }
+
+    func test_exportFromFile_missingSource_writesHeaderOnly() throws {
+        let bogusSrc = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).log")
+        let tmpDst = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dst-\(UUID().uuidString).log")
+        defer { try? FileManager.default.removeItem(at: tmpDst) }
+
+        let count = try DiagnosticExporter.exportFromFile(
+            sourceFile: bogusSrc,
+            to: tmpDst,
+            windowSeconds: 60,
+            appVersion: "1.0", commit: "abc",
+            macOSVersion: "14.5", settings: [:],
+        )
+        XCTAssertEqual(count, 0)
+        let written = try String(contentsOf: tmpDst, encoding: .utf8)
+        XCTAssertTrue(written.contains("MeetingTranscriber 1.0"))
+    }
 }

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -71,7 +71,7 @@ final class DiagnosticExporterTests: XCTestCase {
         XCTAssertEqual(comps.second, 34)
     }
 
-    func test_parseSyslogDate_singleDigitDay_works() throws {
+    func test_parseSyslogDate_singleDigitDay_works() {
         XCTAssertNotNil(DiagnosticExporter.parseSyslogDate("May  4 21:25:34 rest of line"))
     }
 
@@ -100,14 +100,14 @@ final class DiagnosticExporterTests: XCTestCase {
         let line = "\(stamp) MeetingTranscriber[1234]: hello world"
         try line.write(to: tmpSrc, atomically: true, encoding: .utf8)
 
+        let info = DiagnosticExporter.HeaderInfo(
+            appVersion: "1.0", commit: "abc", macOSVersion: "14.5", settings: [:],
+        )
         let count = try DiagnosticExporter.exportFromFile(
             sourceFile: tmpSrc,
             to: tmpDst,
+            info: info,
             windowSeconds: 60,
-            appVersion: "1.0",
-            commit: "abc",
-            macOSVersion: "14.5",
-            settings: [:],
         )
         XCTAssertEqual(count, 1)
         let written = try String(contentsOf: tmpDst, encoding: .utf8)
@@ -137,12 +137,14 @@ final class DiagnosticExporterTests: XCTestCase {
         """
         try body.write(to: tmpSrc, atomically: true, encoding: .utf8)
 
+        let info = DiagnosticExporter.HeaderInfo(
+            appVersion: "1.0", commit: "abc", macOSVersion: "14.5", settings: [:],
+        )
         let count = try DiagnosticExporter.exportFromFile(
             sourceFile: tmpSrc,
             to: tmpDst,
+            info: info,
             windowSeconds: 1800,
-            appVersion: "1.0", commit: "abc",
-            macOSVersion: "14.5", settings: [:],
         )
         XCTAssertEqual(count, 1)
         let written = try String(contentsOf: tmpDst, encoding: .utf8)
@@ -157,12 +159,14 @@ final class DiagnosticExporterTests: XCTestCase {
             .appendingPathComponent("dst-\(UUID().uuidString).log")
         defer { try? FileManager.default.removeItem(at: tmpDst) }
 
+        let info = DiagnosticExporter.HeaderInfo(
+            appVersion: "1.0", commit: "abc", macOSVersion: "14.5", settings: [:],
+        )
         let count = try DiagnosticExporter.exportFromFile(
             sourceFile: bogusSrc,
             to: tmpDst,
+            info: info,
             windowSeconds: 60,
-            appVersion: "1.0", commit: "abc",
-            macOSVersion: "14.5", settings: [:],
         )
         XCTAssertEqual(count, 0)
         let written = try String(contentsOf: tmpDst, encoding: .utf8)

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -37,4 +37,53 @@ final class PersistentDiagnosticLogTests: XCTestCase {
         XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("diagnostics-2026-05-04.txt"))
         XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile(""))
     }
+
+    // MARK: - cleanup
+
+    func test_cleanup_removesExpiredFiles_keepsRecentOnes_doesNotTouchOthers() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PersistentDiagnosticLogTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let expiredFile = tmp.appendingPathComponent("diagnostics-2026-04-01.log")
+        let recentFile = tmp.appendingPathComponent("diagnostics-2026-05-01.log")
+        let foreign = tmp.appendingPathComponent("readme.md")
+
+        try "old".write(to: expiredFile, atomically: true, encoding: .utf8)
+        try "new".write(to: recentFile, atomically: true, encoding: .utf8)
+        try "huh".write(to: foreign, atomically: true, encoding: .utf8)
+
+        let oldDate = Date().addingTimeInterval(-31 * 86400)
+        try FileManager.default.setAttributes(
+            [.modificationDate: oldDate], ofItemAtPath: expiredFile.path,
+        )
+        // Backdate foreign file too — cleanup must still leave it alone.
+        try FileManager.default.setAttributes(
+            [.modificationDate: oldDate], ofItemAtPath: foreign.path,
+        )
+
+        PersistentDiagnosticLog.cleanup(in: tmp, retentionDays: 30)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expiredFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recentFile.path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: foreign.path),
+            "Cleanup must not touch non-matching files even when expired",
+        )
+    }
+
+    func test_cleanup_emptyDirectory_doesNotCrash() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PersistentDiagnosticLogTests-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        PersistentDiagnosticLog.cleanup(in: tmp, retentionDays: 30)
+    }
+
+    func test_cleanup_missingDirectory_doesNotCrash() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PersistentDiagnosticLogTests-missing-\(UUID().uuidString)")
+        PersistentDiagnosticLog.cleanup(in: bogus, retentionDays: 30)
+    }
 }

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -1,0 +1,40 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class PersistentDiagnosticLogTests: XCTestCase {
+    func test_logFileName_isYYYYMMDD() {
+        let date = ISO8601DateFormatter().date(from: "2026-05-04T12:00:00Z") ?? Date()
+        XCTAssertEqual(
+            PersistentDiagnosticLog.logFileName(for: date),
+            "diagnostics-2026-05-04.log",
+        )
+    }
+
+    func test_isExpired_olderThan30Days_returnsTrue() {
+        let cutoff = Date().addingTimeInterval(-31 * 86400)
+        XCTAssertTrue(PersistentDiagnosticLog.isExpired(modifiedAt: cutoff, retentionDays: 30))
+    }
+
+    func test_isExpired_youngerThan30Days_returnsFalse() {
+        let recent = Date().addingTimeInterval(-15 * 86400)
+        XCTAssertFalse(PersistentDiagnosticLog.isExpired(modifiedAt: recent, retentionDays: 30))
+    }
+
+    func test_isExpired_atBoundary_returnsTrue() {
+        let edge = Date().addingTimeInterval(-30 * 86400 - 1)
+        XCTAssertTrue(PersistentDiagnosticLog.isExpired(modifiedAt: edge, retentionDays: 30))
+    }
+
+    func test_isOurLogFile_matchesExpectedPattern() {
+        XCTAssertTrue(PersistentDiagnosticLog.isOurLogFile("diagnostics-2026-05-04.log"))
+        XCTAssertTrue(PersistentDiagnosticLog.isOurLogFile("diagnostics-2026-12-31.log"))
+    }
+
+    func test_isOurLogFile_rejectsForeignNames() {
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("readme.md"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("diagnostics-bad.log"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("diagnostics-26-05-04.log"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("diagnostics-2026-05-04.txt"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile(""))
+    }
+}

--- a/docs/plans/2026-05-05-persistent-diagnostic-log.md
+++ b/docs/plans/2026-05-05-persistent-diagnostic-log.md
@@ -1,0 +1,603 @@
+# Persistent Diagnostic Log Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Persist `os.Logger` output to file-based logs in `~/Library/Logs/MeetingTranscriber/` so diagnostic data survives longer than the macOS unified-log retention window (~1 hour for `.info`-level entries). Existing `Logger` call sites remain unchanged.
+
+**Architecture:** A background `log stream` subprocess writes app-subsystem entries to a daily-rotated text file. `DiagnosticExporter` is taught to read from these files (fallback to `OSLogStore` only when file source is empty/missing). A 30-day cleanup runs on app launch.
+
+**Tech Stack:** Swift `Process` (`log stream` subprocess — same pattern as `ClaudeCLIProtocolGenerator`), `FileHandle` for rolling-write, `os.Logger` API surface stays identical for callers. App-Store variant gets a `#if !APPSTORE` gate (Process is forbidden under sandbox).
+
+**Why subprocess over wrapper-type:** A wrapper around `Logger` (e.g. custom `MTLogger`) would require re-implementing Apple's `OSLogInterpolation` + `OSLogMessage` to preserve `\(thing, privacy: .public)` style interpolation on the file-log side. That's hundreds of lines of fragile code mirroring private API. `log stream` already delivers exactly the same string Apple's unified logger renders — zero call-site churn, automatic privacy-preservation (Apple already redacts `<private>` in the streamed output).
+
+---
+
+## Conventions
+
+- **One task = one atomic commit.** Conventional Commits, scopes `app` / `audiotap` / `docs` / `ci`.
+- **TDD where unit-testable** (cleanup logic, file-name parsing, retention math). Subprocess lifecycle and live `log stream` integration verified manually.
+- **Branch:** `feat/persistent-diagnostic-log` from latest `origin/main` (which by then includes the diagnostic-logging PR #152).
+- **PR strategy:** all phases in one PR (per user preference); commits stay atomic.
+
+Run before starting:
+
+```bash
+git fetch origin
+git checkout -b feat/persistent-diagnostic-log origin/main
+```
+
+---
+
+## Phase 1: PersistentDiagnosticLog infrastructure
+
+### Task 1.1: Define paths + cleanup policy as pure helpers
+
+**Files:**
+- Create: `app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift`
+- Test: `app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift`
+
+**Step 1: Write failing tests for pure helpers**
+
+```swift
+@testable import MeetingTranscriber
+import XCTest
+
+final class PersistentDiagnosticLogTests: XCTestCase {
+    func test_logFileName_isYYYYMMDD() {
+        let date = ISO8601DateFormatter().date(from: "2026-05-04T12:00:00Z")!
+        XCTAssertEqual(
+            PersistentDiagnosticLog.logFileName(for: date),
+            "diagnostics-2026-05-04.log",
+        )
+    }
+
+    func test_isExpired_olderThan30Days_returnsTrue() {
+        let cutoff = Date().addingTimeInterval(-31 * 86400)
+        XCTAssertTrue(PersistentDiagnosticLog.isExpired(modifiedAt: cutoff, retentionDays: 30))
+    }
+
+    func test_isExpired_youngerThan30Days_returnsFalse() {
+        let recent = Date().addingTimeInterval(-15 * 86400)
+        XCTAssertFalse(PersistentDiagnosticLog.isExpired(modifiedAt: recent, retentionDays: 30))
+    }
+
+    func test_isOurLogFile_matchesExpectedPattern() {
+        XCTAssertTrue(PersistentDiagnosticLog.isOurLogFile("diagnostics-2026-05-04.log"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("readme.md"))
+        XCTAssertFalse(PersistentDiagnosticLog.isOurLogFile("diagnostics-bad.log"))
+    }
+}
+```
+
+**Step 2: Run → fail**
+
+```bash
+cd app/MeetingTranscriber && swift test --filter PersistentDiagnosticLogTests
+```
+
+Expected: missing-symbol errors.
+
+**Step 3: Implement skeleton**
+
+Create `Sources/PersistentDiagnosticLog.swift`:
+
+```swift
+import Foundation
+
+/// Manages a rolling on-disk mirror of `os.Logger` output for the
+/// `com.meetingtranscriber*` subsystems. Files are written by a background
+/// `log stream` subprocess (see `start(...)` / `stop()`) and rotated daily.
+/// `DiagnosticExporter` reads from these files when present, so users can
+/// reproduce a bug, wait, and still export hours-old logs.
+enum PersistentDiagnosticLog {
+    /// Where rotated log files live. `~/Library/Logs/MeetingTranscriber/`
+    /// follows Apple's convention and is what `Console.app`'s "Log Reports"
+    /// tab surfaces. Not auto-cleaned by macOS.
+    static var logDirectory: URL {
+        let logs = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("MeetingTranscriber", isDirectory: true)
+        try? FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        return logs
+    }
+
+    /// Default retention in days. Older files are deleted on app launch.
+    static let defaultRetentionDays = 30
+
+    /// File name for a given date, rotating daily.
+    static func logFileName(for date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return "diagnostics-\(fmt.string(from: date)).log"
+    }
+
+    static func isExpired(modifiedAt date: Date, retentionDays: Int) -> Bool {
+        let cutoff = Date().addingTimeInterval(-Double(retentionDays) * 86400)
+        return date < cutoff
+    }
+
+    /// Filter for files we own — only delete things matching our naming pattern.
+    static func isOurLogFile(_ name: String) -> Bool {
+        // diagnostics-YYYY-MM-DD.log
+        let pattern = #"^diagnostics-\d{4}-\d{2}-\d{2}\.log$"#
+        return name.range(of: pattern, options: .regularExpression) != nil
+    }
+}
+```
+
+**Step 4: Run tests → pass**
+
+**Step 5: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift \
+        app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+git commit -m "feat(app): add PersistentDiagnosticLog path + cleanup policy helpers"
+```
+
+---
+
+### Task 1.2: Cleanup of expired files
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift`
+- Test: `app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift`
+
+**Step 1: Failing test for cleanup**
+
+```swift
+func test_cleanup_removesExpiredFiles_keepsRecentOnes_doesNotTouchOthers() throws {
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("PersistentDiagnosticLogTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    let expiredFile = tmp.appendingPathComponent("diagnostics-2026-04-01.log")
+    let recentFile = tmp.appendingPathComponent("diagnostics-2026-05-01.log")
+    let foreign = tmp.appendingPathComponent("readme.md")
+
+    try "old".write(to: expiredFile, atomically: true, encoding: .utf8)
+    try "new".write(to: recentFile, atomically: true, encoding: .utf8)
+    try "huh".write(to: foreign, atomically: true, encoding: .utf8)
+
+    // Backdate
+    let oldDate = Date().addingTimeInterval(-31 * 86400)
+    try FileManager.default.setAttributes(
+        [.modificationDate: oldDate], ofItemAtPath: expiredFile.path,
+    )
+
+    PersistentDiagnosticLog.cleanup(in: tmp, retentionDays: 30)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: expiredFile.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: recentFile.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: foreign.path), "Cleanup must not touch non-matching files")
+}
+```
+
+**Step 2: Implement**
+
+Add to `PersistentDiagnosticLog.swift`:
+
+```swift
+/// Delete diagnostic-log files older than `retentionDays`. Non-matching files
+/// (anything not `diagnostics-YYYY-MM-DD.log`) are left alone. Safe to call
+/// multiple times; idempotent.
+static func cleanup(in directory: URL = logDirectory, retentionDays: Int = defaultRetentionDays) {
+    let fm = FileManager.default
+    guard let entries = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.contentModificationDateKey]) else {
+        return
+    }
+    for url in entries {
+        guard isOurLogFile(url.lastPathComponent) else { continue }
+        guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+              let mtime = attrs[.modificationDate] as? Date,
+              isExpired(modifiedAt: mtime, retentionDays: retentionDays) else { continue }
+        try? fm.removeItem(at: url)
+    }
+}
+```
+
+**Step 3: Test → pass + commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift \
+        app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+git commit -m "feat(app): clean up persistent diagnostic logs older than 30 days"
+```
+
+---
+
+### Task 1.3: Background `log stream` subprocess management
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift`
+
+**Step 1: Manual verification only** — subprocess + live unified-log streaming can't be reliably unit-tested.
+
+**Step 2: Add `start(...)` / `stop()` API**
+
+```swift
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PersistentDiagnosticLog")
+
+extension PersistentDiagnosticLog {
+    /// Wraps the running `log stream` subprocess. Lifetime owned by AppState.
+    final class Streamer {
+        private let process = Process()
+        private let logFileHandle: FileHandle
+        private let pipe = Pipe()
+        private(set) var isRunning = false
+
+        init(targetURL: URL) throws {
+            let fm = FileManager.default
+            if !fm.fileExists(atPath: targetURL.path) {
+                fm.createFile(atPath: targetURL.path, contents: nil)
+            }
+            self.logFileHandle = try FileHandle(forWritingTo: targetURL)
+            try self.logFileHandle.seekToEnd()
+        }
+
+        func start() throws {
+            guard !isRunning else { return }
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+            process.arguments = [
+                "stream",
+                "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
+                "--style", "syslog",
+                "--info",
+            ]
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            let handle = pipe.fileHandleForReading
+            handle.readabilityHandler = { [weak self] fh in
+                let data = fh.availableData
+                guard !data.isEmpty else { return }
+                try? self?.logFileHandle.write(contentsOf: data)
+            }
+
+            try process.run()
+            isRunning = true
+            logger.info("persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)")
+        }
+
+        func stop() {
+            guard isRunning else { return }
+            process.terminate()
+            try? logFileHandle.close()
+            isRunning = false
+            logger.info("persistent_log_streamer_stopped")
+        }
+    }
+
+    /// Convenience: start streaming into today's log file, returning the
+    /// running streamer so the caller can stop it on app shutdown.
+    static func startForToday() throws -> Streamer {
+        let target = logDirectory.appendingPathComponent(logFileName(for: Date()))
+        let streamer = try Streamer(targetURL: target)
+        try streamer.start()
+        return streamer
+    }
+}
+```
+
+**Step 3: Build + smoke test**
+
+```bash
+cd app/MeetingTranscriber && swift build
+```
+
+Manual: in `MeetingTranscriberApp.swift`, temporarily call `PersistentDiagnosticLog.startForToday()` at launch; verify `~/Library/Logs/MeetingTranscriber/diagnostics-YYYY-MM-DD.log` grows when other parts of the app log.
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+git commit -m "feat(app): background log-stream subprocess writes to rotated file"
+```
+
+---
+
+## Phase 2: Wire into AppState lifecycle
+
+### Task 2.1: Start streamer at launch, stop at shutdown
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/AppState.swift`
+- Modify: `app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift` (cleanup hook)
+
+**Step 1: AppState owns the streamer**
+
+In `AppState.swift`, add:
+
+```swift
+#if !APPSTORE
+    private(set) var persistentLogStreamer: PersistentDiagnosticLog.Streamer?
+#endif
+```
+
+In init:
+
+```swift
+#if !APPSTORE
+    PersistentDiagnosticLog.cleanup()
+    self.persistentLogStreamer = try? PersistentDiagnosticLog.startForToday()
+#endif
+```
+
+Add a `shutdown()` method on AppState:
+
+```swift
+#if !APPSTORE
+    func stopPersistentLogStreamer() {
+        persistentLogStreamer?.stop()
+        persistentLogStreamer = nil
+    }
+#endif
+```
+
+**Step 2: Wire to scene lifecycle**
+
+In `MeetingTranscriberApp.swift`, observe `NSApplicationWillTerminate` (or `.scenePhase` becoming `.background`):
+
+```swift
+.onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+    appState.stopPersistentLogStreamer()
+}
+```
+
+**Step 3: Build + smoke test**
+
+```bash
+./scripts/run_app.sh
+# Observe: ~/Library/Logs/MeetingTranscriber/diagnostics-2026-05-05.log grows in real time.
+# Quit the app via menu → file should be closed cleanly.
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/AppState.swift \
+        app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+git commit -m "feat(app): start/stop persistent log streamer with AppState lifecycle"
+```
+
+---
+
+## Phase 3: Teach DiagnosticExporter to prefer the file source
+
+### Task 3.1: Read from persistent log when available
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/DiagnosticExporter.swift`
+- Test: `app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift`
+
+**Step 1: Add a file-source path**
+
+The existing `export(to:appVersion:commit:macOSVersion:settings:windowSeconds:)` currently reads `OSLogStore`. Add a sibling that reads from a file:
+
+```swift
+@available(macOS 12, *)
+static func exportFromFile(
+    sourceFile: URL,
+    to outputURL: URL,
+    windowSeconds: TimeInterval,
+    appVersion: String,
+    commit: String,
+    macOSVersion: String,
+    settings: [String: String],
+) throws -> Int {
+    let header = makeHeader(
+        appVersion: appVersion, commit: commit,
+        macOSVersion: macOSVersion, settings: settings,
+    )
+
+    // Crude but sufficient: read entire file (rotated daily, capped at ~30MB),
+    // tail-filter to entries within `windowSeconds` of now via syslog timestamp.
+    let raw = (try? String(contentsOf: sourceFile, encoding: .utf8)) ?? ""
+    let lines = raw.split(separator: "\n").suffix(while: { line in
+        // syslog format starts with `Mmm dd hh:mm:ss` — parsed in helper
+        guard let lineDate = parseSyslogDate(String(line)) else { return true }
+        return lineDate >= Date().addingTimeInterval(-windowSeconds)
+    })
+    let body = lines.joined(separator: "\n")
+    try (header + "\n" + body).write(to: outputURL, atomically: true, encoding: .utf8)
+    return lines.count
+}
+
+private static func parseSyslogDate(_ line: String) -> Date? {
+    // implement: take first 15 chars (`May  5 21:14:33`), parse with current year
+    let fmt = DateFormatter()
+    fmt.dateFormat = "MMM d HH:mm:ss"
+    fmt.locale = Locale(identifier: "en_US_POSIX")
+    let prefix = String(line.prefix(15))
+    var components = fmt.date(from: prefix).flatMap { Calendar.current.dateComponents([.month, .day, .hour, .minute, .second], from: $0) }
+    components?.year = Calendar.current.component(.year, from: Date())
+    return components.flatMap { Calendar.current.date(from: $0) }
+}
+```
+
+(Refine: use `String.suffix(while:)` from end, since logs are append-ordered.)
+
+**Step 2: Update the public `export(...)` to dispatch**
+
+```swift
+@available(macOS 12, *)
+static func export(
+    to outputURL: URL,
+    appVersion: String,
+    commit: String,
+    macOSVersion: String,
+    settings: [String: String],
+    windowSeconds: TimeInterval = 1800,
+) throws -> Int {
+    // Prefer persistent file source — survives longer than OSLogStore retention.
+    let todayFile = PersistentDiagnosticLog.logDirectory
+        .appendingPathComponent(PersistentDiagnosticLog.logFileName(for: Date()))
+    if FileManager.default.fileExists(atPath: todayFile.path) {
+        return try exportFromFile(
+            sourceFile: todayFile,
+            to: outputURL,
+            windowSeconds: windowSeconds,
+            appVersion: appVersion,
+            commit: commit,
+            macOSVersion: macOSVersion,
+            settings: settings,
+        )
+    }
+    return try exportFromOSLogStore(
+        to: outputURL, windowSeconds: windowSeconds,
+        appVersion: appVersion, commit: commit,
+        macOSVersion: macOSVersion, settings: settings,
+    )
+}
+```
+
+(Rename existing implementation to `exportFromOSLogStore`.)
+
+**Step 3: Test**
+
+Existing `DiagnosticExporterTests` tests the header — still passes. Add test for `exportFromFile`:
+
+```swift
+func test_exportFromFile_writesHeaderPlusLines() throws {
+    let tmpSrc = FileManager.default.temporaryDirectory
+        .appendingPathComponent("src-\(UUID().uuidString).log")
+    let tmpDst = FileManager.default.temporaryDirectory
+        .appendingPathComponent("dst-\(UUID().uuidString).log")
+    defer {
+        try? FileManager.default.removeItem(at: tmpSrc)
+        try? FileManager.default.removeItem(at: tmpDst)
+    }
+    let now = Date()
+    let fmt = DateFormatter()
+    fmt.dateFormat = "MMM d HH:mm:ss"
+    fmt.locale = Locale(identifier: "en_US_POSIX")
+    let stamp = fmt.string(from: now)
+    let line = "\(stamp) MeetingTranscriber[1234]: hello world"
+    try line.write(to: tmpSrc, atomically: true, encoding: .utf8)
+
+    let count = try DiagnosticExporter.exportFromFile(
+        sourceFile: tmpSrc, to: tmpDst, windowSeconds: 60,
+        appVersion: "1.0", commit: "abc", macOSVersion: "14.5", settings: [:],
+    )
+    XCTAssertEqual(count, 1)
+    let written = try String(contentsOf: tmpDst, encoding: .utf8)
+    XCTAssertTrue(written.contains("MeetingTranscriber 1.0"))
+    XCTAssertTrue(written.contains("hello world"))
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/DiagnosticExporter.swift \
+        app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+git commit -m "feat(app): DiagnosticExporter reads persistent file when available"
+```
+
+---
+
+## Phase 4: AppStore variant fallback
+
+### Task 4.1: `#if !APPSTORE` gates around subprocess code
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift`
+- Modify: `app/MeetingTranscriber/Sources/AppState.swift`
+- Modify: `app/MeetingTranscriber/Sources/DiagnosticExporter.swift`
+
+**Step 1: Wrap subprocess sections**
+
+In `PersistentDiagnosticLog.swift`, wrap the `Streamer` class and `startForToday()` in `#if !APPSTORE`. Path/cleanup helpers stay public (no Process use).
+
+In `AppState.swift`, the streamer property + start call already inside `#if !APPSTORE`.
+
+In `DiagnosticExporter.swift`, the file-source path is fine to keep universal — App Store builds simply won't have a file to read because the streamer never starts, so the `fileExists(atPath:)` check falls through to OSLogStore.
+
+**Step 2: Verify both build variants**
+
+```bash
+./scripts/build_release.sh                      # Homebrew
+./scripts/build_release.sh --appstore --no-notarize
+```
+
+**Step 3: Commit**
+
+```bash
+git add app/MeetingTranscriber/Sources/
+git commit -m "build(app): gate persistent-log subprocess behind !APPSTORE"
+```
+
+---
+
+## Phase 5: Settings-side affordance (optional)
+
+### Task 5.1: "Open Diagnostic Logs Folder" button
+
+**Files:**
+- Modify: `app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift`
+
+A small UX win: a button next to "Export Diagnostics…" that reveals the persistent-log directory in Finder. Lets users browse historical logs without exporting a 30-min snapshot.
+
+```swift
+Button("Open Diagnostic Logs Folder") {
+    NSWorkspace.shared.activateFileViewerSelecting([PersistentDiagnosticLog.logDirectory])
+}
+```
+
+Commit:
+
+```bash
+git add app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+git commit -m "feat(app): add 'Open Diagnostic Logs Folder' button in Advanced settings"
+```
+
+---
+
+## Phase 6: Open the PR
+
+```bash
+git push -u origin feat/persistent-diagnostic-log
+gh pr create --title "feat(app): persistent file-based diagnostic logs (~30 day retention)" --body "$(cat <<'EOF'
+## Summary
+
+Persistent file-based diagnostic logs that survive longer than the macOS unified-log retention window (~1 hour for `.info`-level entries). A background `log stream` subprocess mirrors the `com.meetingtranscriber*` subsystems to a daily-rotated file under `~/Library/Logs/MeetingTranscriber/`. Files older than 30 days are cleaned up on app launch.
+
+`DiagnosticExporter` is taught to prefer the file source over `OSLogStore`, falling back to `OSLogStore` only when no persistent file exists (e.g. App Store sandbox build, or first launch).
+
+## Test plan
+
+- [ ] Swift tests pass: `swift test --parallel`
+- [ ] Lint clean: `./scripts/lint.sh`
+- [ ] Manually: launch app, do a recording; verify `~/Library/Logs/MeetingTranscriber/diagnostics-YYYY-MM-DD.log` grows in real time
+- [ ] Wait > 1 hour, click Export Diagnostics — verify the exported `.log` still contains the older entries
+- [ ] Backdate one of the log files to >30 days; relaunch app; verify it gets deleted on cleanup
+- [ ] Verify App Store build (`./scripts/build_release.sh --appstore --no-notarize`) compiles and runs (subprocess gated off, falls back to OSLogStore)
+EOF
+)"
+```
+
+---
+
+## Open questions to resolve during execution
+
+1. **`log stream` syslog format vs. compact format:** plan picks `--style syslog` for stable timestamp parsing. Compact format is human-friendlier but date format isn't documented stable. Confirm during implementation; if syslog format is deprecated, switch to `--style ndjson` (machine-parseable JSON).
+
+2. **File ownership when log file already exists from previous session:** `Streamer.init` opens with `FileHandle(forWritingTo:)` and seeks to end — appends. If a stale lock from a crashed previous run exists, the open might fail. Test this case manually.
+
+3. **Subprocess restart on log rotation midnight:** today's plan creates the file on session start and writes to it for the whole session. If the app stays open across midnight, today's events go into yesterday's file. Acceptable for v1 — daily rotation matters more for the cleanup policy than per-day file accuracy. A timer-based rotate-on-midnight is a future iteration.
+
+4. **App Store builds get nothing:** the file-based source doesn't exist in App Store sandbox. Export still works via OSLogStore (1-hour window). Future iteration could explore an in-process file logger that doesn't need Process.
+
+---
+
+## Skill references
+
+- @superpowers:test-driven-development — pure helpers (path, cleanup, expiry math) get tests.
+- @superpowers:requesting-code-review — final code review per phase.
+- @superpowers:finishing-a-development-branch — used after Phase 6.


### PR DESCRIPTION
## Summary

Persistent file-based diagnostic logs that survive longer than the macOS unified-log retention window (~1 hour for `.info`-level entries). A background `log stream` subprocess mirrors the `com.meetingtranscriber*` subsystems to a daily-rotated file under `~/Library/Logs/MeetingTranscriber/`. Files older than 30 days are cleaned up on app launch.

`DiagnosticExporter` now prefers the file source over `OSLogStore`, falling back to `OSLogStore` only when the persistent file doesn't exist (App Store sandbox build, or first launch).

## Changes

- **`PersistentDiagnosticLog.swift`** (new): pure helpers (logDirectory, logFileName, isExpired, isOurLogFile, cleanup) + `Streamer` class wrapping a `Process`. Subprocess code gated `#if !APPSTORE` since `Process` is forbidden under sandbox.
- **`DiagnosticExporter.swift`**: extended with `exportFromFile` + `parseSyslogDate`; refactored signature to use a `HeaderInfo` struct (was hitting SwiftLint's function_parameter_count limit).
- **`AppState.swift`**: owns the running `Streamer`, registers a `willTerminateNotification` observer so the file handle flushes cleanly on quit.
- **`Settings/AdvancedSettingsView.swift`**: "Open Diagnostic Logs Folder" button reveals `~/Library/Logs/MeetingTranscriber/` in Finder so users can browse historical logs without exporting a 30-min snapshot.
- **`Bundle+AppVersion.swift`** (new): consolidates `Bundle.main.infoDictionary?["CFBundleShortVersionString"]` reads behind `Bundle.appVersion` / `Bundle.gitCommitHash`.

## /simplify review fixes

- Cached `DateFormatter` instances in both `DiagnosticExporter.parseSyslogDate` and `PersistentDiagnosticLog.logFileName` — was allocating a fresh formatter per call (measurable when filtering thousands of lines).
- Replaced `try?` swallow on `startForToday()` with an explicit `do/catch` that logs the underlying error.

## Test plan

- [x] Swift unit tests pass: 1129/1129 (3 skipped slow E2E)
- [x] Both build variants compile: `swift build` (Homebrew) and `swift build -Xswiftc -DAPPSTORE`
- [x] Lint clean: `./scripts/lint.sh` — 0 violations across 136 files
- [x] Manual: launch app, verify `~/Library/Logs/MeetingTranscriber/diagnostics-YYYY-MM-DD.log` grows in real time
- [ ] Manual: wait > 1 hour, click Export Diagnostics — verify the exported log still contains the older entries (vs. the OSLogStore-only path that would lose them)
- [x] Manual: backdate one of the log files to >30 days, relaunch — verify it gets deleted on cleanup
- [x] Manual: click "Open Diagnostic Logs Folder" — Finder reveals the directory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->