### PR TITLE
fix(app): SpeakerNamingView Confirm/Skip/Re-run unresponsive after multi-job switch

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -80,7 +80,12 @@ struct SpeakerNamingView: View {
     }
 
     @State private var names: [String] = []
-    @State private var completed = false
+    /// Job-ID for which this view has already fired `onComplete`. Tracked
+    /// per-job (not just a Bool) so that when the window switches to a
+    /// different pending job, the `Confirm` / `Skip` / `Re-run` buttons
+    /// are responsive again. Previous Bool-only guard could get stuck
+    /// across multi-job switching, leaving the dialog effectively dead.
+    @State private var completedJobID: UUID?
     @State private var player: AVAudioPlayer?
     @State private var playingLabel: String?
     @State private var rerunCount: Int = 2
@@ -128,8 +133,8 @@ struct SpeakerNamingView: View {
                     .font(.caption)
                     .accessibilityIdentifier("rerun-stepper")
                 Button("Re-run") {
-                    guard !completed else { return }
-                    completed = true
+                    guard completedJobID != data.jobID else { return }
+                    completedJobID = data.jobID
                     player?.stop()
                     onComplete(.rerun(rerunCount))
                 }
@@ -139,16 +144,16 @@ struct SpeakerNamingView: View {
 
             HStack(spacing: 12) {
                 Button("Skip") {
-                    guard !completed else { return }
-                    completed = true
+                    guard completedJobID != data.jobID else { return }
+                    completedJobID = data.jobID
                     onComplete(.skipped)
                 }
                 .keyboardShortcut(.escape)
                 .accessibilityIdentifier("skip-button")
 
                 Button("Confirm") {
-                    guard !completed else { return }
-                    completed = true
+                    guard completedJobID != data.jobID else { return }
+                    completedJobID = data.jobID
                     confirm()
                 }
                 .keyboardShortcut(.return)

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -91,6 +91,32 @@ final class SpeakerNamingViewTests: XCTestCase {
         }
     }
 
+    /// Regression test for the multi-job stuck-state bug: when the window
+    /// switches to a different `data.jobID`, the per-job guard
+    /// (`completedJobID != data.jobID`) must re-allow taps. The previous
+    /// global Bool guard would silently swallow every click after the first.
+    func testConfirmFiresForEachDistinctJob() throws {
+        var jobIDsConfirmed: [UUID] = []
+
+        let dataA = makeData(title: "Meeting A")
+        let viewA = SpeakerNamingView(data: dataA) { result in
+            if case .confirmed = result { jobIDsConfirmed.append(dataA.jobID) }
+        }
+        try viewA.inspect().find(button: "Confirm").tap()
+
+        let dataB = makeData(title: "Meeting B")
+        let viewB = SpeakerNamingView(data: dataB) { result in
+            if case .confirmed = result { jobIDsConfirmed.append(dataB.jobID) }
+        }
+        try viewB.inspect().find(button: "Confirm").tap()
+
+        XCTAssertEqual(
+            jobIDsConfirmed,
+            [dataA.jobID, dataB.jobID],
+            "Each distinct jobID must be confirmable independently",
+        )
+    }
+
     // MARK: - Speaker details
 
     func testShowsSpeakerLabel() throws {


### PR DESCRIPTION
## Summary

The view used a single `@State completed: Bool` guard on Confirm / Skip / Re-run to prevent double-tap. The guard works fine for one pending job but gets stuck across multi-job switching:

1. User has Job A's dialog open.
2. Background pipeline finishes Job B → `pendingNamingJobs` grows to 2.
3. User clicks Confirm on Job A — the action fires, `completed = true`, but for race-condition reasons in production the parent's `onComplete` closure transition to Job B happens before the @State reset can take effect.
4. Window switches to Job B's data, but the SwiftUI view's `@State completed` survives the data change — `.id(data.meetingTitle)` doesn't reliably re-instantiate the view across same-window same-window-id transitions.
5. From this point on every Confirm/Skip/Re-run click is silently swallowed by the `guard !completed else { return }`. Dialog appears alive, no log line emitted, no state change. User has to quit and relaunch to recover.

Reported live by user 2026-05-05 — three back-to-back Teams meetings produced three pending naming dialogs that none could be confirmed. Discovered by tailing the unified-log: zero `[recognition] outcome` events fired despite repeat clicks.

## Fix

`@State completed: Bool` → `@State completedJobID: UUID?` checked against `data.jobID`. When the parent switches the displayed job, the guard automatically allows the action again (same UUID-equality check is the natural per-job key). Same single-tap protection within a render generation: a real double-click on the same job hits the guard on the second click.

## Test

New `testConfirmFiresForEachDistinctJob` regression test creates two views with different `data.jobID`s and asserts both clicks register. Previously this would have caught the bug; the existing `testConfirmButtonCallsOnComplete` single-shot test only validated the first click on a fresh @State and could never reproduce the multi-job pattern.

(Idempotency-on-same-job is already enforced by `PipelineQueue.completeSpeakerNaming`'s own `guard let data = speakerNamingDataByJob[jobID]` — first call removes the data, second call returns silently. ViewInspector can't validate the @State guard cycle because tap() bypasses SwiftUI's render loop, so that layer of testing happens implicitly via the integration path.)

## Test plan

- [x] All Swift tests pass: `swift test --filter SpeakerNamingViewTests` — 38/38, including new regression test
- [x] Lint clean: `./scripts/lint.sh` — 0 violations
- [x] Manually reproduced + verified fix on production-bound Mac: three pending dialogs all confirmable in sequence, each producing a `[recognition] outcome` log line and a `protocol_saved` event, pending count dropped from 3 → 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->