### PR TITLE
test(app): regression tests for Skip and Re-run multi-job switching

### DIFF
--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -117,6 +117,55 @@ final class SpeakerNamingViewTests: XCTestCase {
         )
     }
 
+    /// Skip shares the same per-job guard as Confirm. If a future refactor
+    /// reverts Skip's guard to a global Bool, the multi-job stuck-state
+    /// would resurface for users who hit Skip on back-to-back meetings.
+    func testSkipFiresForEachDistinctJob() throws {
+        var jobIDsSkipped: [UUID] = []
+
+        let dataA = makeData(title: "Meeting A")
+        let viewA = SpeakerNamingView(data: dataA) { result in
+            if case .skipped = result { jobIDsSkipped.append(dataA.jobID) }
+        }
+        try viewA.inspect().find(button: "Skip").tap()
+
+        let dataB = makeData(title: "Meeting B")
+        let viewB = SpeakerNamingView(data: dataB) { result in
+            if case .skipped = result { jobIDsSkipped.append(dataB.jobID) }
+        }
+        try viewB.inspect().find(button: "Skip").tap()
+
+        XCTAssertEqual(
+            jobIDsSkipped,
+            [dataA.jobID, dataB.jobID],
+            "Each distinct jobID must be skippable independently",
+        )
+    }
+
+    /// Re-run shares the same per-job guard as Confirm and Skip — same
+    /// regression risk if the guard ever reverts to a global Bool.
+    func testRerunFiresForEachDistinctJob() throws {
+        var jobIDsRerun: [UUID] = []
+
+        let dataA = makeData(title: "Meeting A")
+        let viewA = SpeakerNamingView(data: dataA) { result in
+            if case .rerun = result { jobIDsRerun.append(dataA.jobID) }
+        }
+        try viewA.inspect().find(button: "Re-run").tap()
+
+        let dataB = makeData(title: "Meeting B")
+        let viewB = SpeakerNamingView(data: dataB) { result in
+            if case .rerun = result { jobIDsRerun.append(dataB.jobID) }
+        }
+        try viewB.inspect().find(button: "Re-run").tap()
+
+        XCTAssertEqual(
+            jobIDsRerun,
+            [dataA.jobID, dataB.jobID],
+            "Each distinct jobID must be re-runnable independently",
+        )
+    }
+
     // MARK: - Speaker details
 
     func testShowsSpeakerLabel() throws {


### PR DESCRIPTION
## Summary

PR #156 fixed the multi-job stuck-state bug by replacing `@State completed: Bool` with `@State completedJobID: UUID?` and added `testConfirmFiresForEachDistinctJob` as the regression test.

Skip and Re-run share the same per-job guard pattern but only Confirm has the regression test. If a future refactor reverts any of the three guards to a global Bool, only the Confirm break would be caught. Adding the parallel tests so all three buttons are covered.

## Changes

- `testSkipFiresForEachDistinctJob` — same shape as the Confirm test, taps Skip on two distinct-jobID views
- `testRerunFiresForEachDistinctJob` — same for Re-run

40 tests in `SpeakerNamingViewTests` total, +2 from this PR. All pass.

## Test plan

- [x] `swift test --filter SpeakerNamingViewTests` → 40/40 pass
- [x] `./scripts/lint.sh` → 0 violations

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->