### PR TITLE
fix(app): refresh PipelineQueue cache on speakers DB mutations

### DIFF
--- a/app/MeetingTranscriber/Sources/KnownVoicesView.swift
+++ b/app/MeetingTranscriber/Sources/KnownVoicesView.swift
@@ -27,16 +27,24 @@ struct KnownVoicesView: View {
         return f
     }()
 
+    /// Fires after every successful rename / delete / merge mutation so the
+    /// caller can invalidate caches that mirror the speakers DB. Without this,
+    /// `PipelineQueue.knownSpeakerNames` (issue #155) goes stale until the
+    /// next pipeline event.
+    private let onMutate: (() -> Void)?
+
     init(
         matcher: SpeakerMatcher,
         diarizerFactory: (() -> DiarizationProvider)? = nil,
         namingDialogActive: Bool = false,
         pipelineBusy: Bool = false,
+        onMutate: (() -> Void)? = nil,
     ) {
         self.matcher = matcher
         self.diarizerFactory = diarizerFactory
         self.namingDialogActive = namingDialogActive
         self.pipelineBusy = pipelineBusy
+        self.onMutate = onMutate
     }
 
     enum ActiveModal: Identifiable {
@@ -244,9 +252,14 @@ struct KnownVoicesView: View {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         modal = nil
         guard !trimmed.isEmpty else { return }
-        matcher.renameSpeaker(from: from, to: trimmed)
+        performRename(from: from, to: trimmed)
         selection = trimmed
+    }
+
+    func performRename(from: String, to: String) {
+        matcher.renameSpeaker(from: from, to: to)
         reload()
+        onMutate?()
     }
 
     private func startMerge() {
@@ -257,17 +270,27 @@ struct KnownVoicesView: View {
     private func applyMerge() {
         guard case let .merge(from, dst) = modal, !dst.isEmpty else { return }
         modal = nil
-        matcher.mergeSpeakers(from: from, into: dst)
+        performMerge(from: from, into: dst)
         selection = dst
+    }
+
+    func performMerge(from: String, into: String) {
+        matcher.mergeSpeakers(from: from, into: into)
         reload()
+        onMutate?()
     }
 
     private func applyDelete() {
         guard case let .delete(name) = modal else { return }
         modal = nil
-        matcher.deleteSpeaker(name: name)
+        performDelete(name: name)
         if selection == name { selection = nil }
+    }
+
+    func performDelete(name: String) {
+        matcher.deleteSpeaker(name: name)
         reload()
+        onMutate?()
     }
 
     private static func lastUsedLabel(_ date: Date?) -> String {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -144,6 +144,7 @@ struct MeetingTranscriberApp: App {
                 enrollmentDiarizerFactory: { FluidDiarizer(mode: appState.settings.diarizerMode) },
                 namingDialogActive: appState.pipelineQueue.pendingSpeakerNaming != nil,
                 pipelineBusy: appState.pipelineQueue.isProcessing,
+                onSpeakerMutate: appState.pipelineQueue.refreshKnownSpeakerNames,
             )
         }
         .windowResizability(.contentSize)

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -6,6 +6,12 @@ struct SpeakersSettingsView: View {
     var enrollmentDiarizerFactory: (() -> DiarizationProvider)?
     var namingDialogActive: Bool
     var pipelineBusy: Bool
+    /// Called whenever the user mutates the speakers DB from the Known
+    /// Voices sheet (rename / delete / merge). Used to refresh
+    /// `PipelineQueue.knownSpeakerNames` so the next naming dialog sees
+    /// up-to-date chips. Optional — tests and the parent that doesn't
+    /// own a PipelineQueue can omit.
+    var onSpeakerMutate: (() -> Void)?
 
     @State private var showKnownVoices = false
 
@@ -78,6 +84,7 @@ struct SpeakersSettingsView: View {
                 diarizerFactory: enrollmentDiarizerFactory,
                 namingDialogActive: namingDialogActive,
                 pipelineBusy: pipelineBusy,
+                onMutate: onSpeakerMutate,
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     var namingDialogActive: Bool = false
     /// True when the pipeline is processing a job — soft hint only.
     var pipelineBusy: Bool = false
+    var onSpeakerMutate: (() -> Void)?
 
     @State private var selection: SettingsTab = .general
 
@@ -71,6 +72,7 @@ struct SettingsView: View {
                 enrollmentDiarizerFactory: enrollmentDiarizerFactory,
                 namingDialogActive: namingDialogActive,
                 pipelineBusy: pipelineBusy,
+                onSpeakerMutate: onSpeakerMutate,
             )
 
         case .output:

--- a/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
+++ b/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
@@ -35,4 +35,61 @@ final class KnownVoicesViewTests: XCTestCase {
         let view = KnownVoicesView(matcher: matcher)
         XCTAssertNoThrow(try view.inspect())
     }
+
+    // MARK: - onMutate callback (cache invalidation gap, follow-up to #155)
+
+    //
+    // KnownVoicesView mutates the SpeakerMatcher's on-disk DB directly via
+    // rename / delete / merge. Without notifying anyone, the PipelineQueue's
+    // cached `knownSpeakerNames` (#155) goes stale — the next naming dialog
+    // shows obsolete chips. The view now fires `onMutate` after every
+    // successful mutation so the caller (SpeakersSettingsView wires it to
+    // `pipelineQueue.refreshKnownSpeakerNames()`) can keep the cache fresh.
+
+    func testRenameInvokesOnMutate() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([StoredSpeaker(name: "Old", embeddings: [[1, 0, 0]])])
+
+        var calls = 0
+        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+
+        view.performRename(from: "Old", to: "New")
+
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testDeleteInvokesOnMutate() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([StoredSpeaker(name: "Doomed", embeddings: [[1, 0, 0]])])
+
+        var calls = 0
+        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+
+        view.performDelete(name: "Doomed")
+
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testMergeInvokesOnMutate() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([
+            StoredSpeaker(name: "From", embeddings: [[1, 0, 0]]),
+            StoredSpeaker(name: "Into", embeddings: [[0, 1, 0]]),
+        ])
+
+        var calls = 0
+        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+
+        view.performMerge(from: "From", into: "Into")
+
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testMissingOnMutateIsHandledGracefully() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([StoredSpeaker(name: "X", embeddings: [[1, 0, 0]])])
+        let view = KnownVoicesView(matcher: matcher) // onMutate omitted
+        // Mutations without a callback must not crash.
+        view.performRename(from: "X", to: "Y")
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on top of #158. Fixes the cache-invalidation gap that #158's review surfaced: the Known Voices sheet (rename / delete / merge) mutates the speakers DB directly and never notified anyone, so `PipelineQueue.knownSpeakerNames` went stale until the next pipeline event and the next naming dialog showed obsolete chips.

- `KnownVoicesView` gains an `onMutate` callback that fires after every successful rename / delete / merge.
- `SpeakersSettingsView` and `SettingsView` thread the callback through.
- The `@main` scene wires it to `pipelineQueue.refreshKnownSpeakerNames` (method-reference form, no inline closure).
- Modal-driven mutators now delegate to `performRename` / `performMerge` / `performDelete`, which tests call directly instead of having to drive the SwiftUI modal flow.

Follow-up to #155.

## Test plan
- [x] 6 / 6 `KnownVoicesViewTests` pass (3 mutation-callback tests + 1 missing-callback safety test + 2 pre-existing render tests)
- [x] Full Swift test suite passes (1203 tests)
- [x] `./scripts/lint.sh` clean (no SwiftFormat / SwiftLint suppressions added)
- [ ] Manual: rename a speaker in the Known Voices sheet, then trigger a new naming dialog — chips reflect the rename

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->