### PR TITLE
feat(app): RPC routes for speaker DB testing

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -1,0 +1,61 @@
+#if !APPSTORE
+    import Foundation
+
+    extension AppState {
+        /// Build a snapshot of state for the debug RPC. Read-only.
+        func rpcStateSnapshot() -> RPCStateSnapshot {
+            let stored = SpeakerMatcher().loadDB()
+            let recentNames = SpeakerMatcher.rankByRecency(speakers: stored)
+                .prefix(10).map(\.name)
+            let pendingJobs = pipelineQueue.pendingSpeakerNamingJobs.map { job in
+                let data = pipelineQueue.speakerNamingDataByJob[job.id]
+                return RPCStateSnapshot.PendingNaming(
+                    jobID: job.id.uuidString,
+                    meetingTitle: job.meetingTitle,
+                    speakerCount: data?.mapping.count ?? 0,
+                    namingSlug: job.namingSlug,
+                )
+            }
+            return RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: pipelineQueue.isProcessing,
+                    activeJobCount: pipelineQueue.activeJobs.count,
+                    waitingJobCount: pipelineQueue.pendingJobs.count,
+                    pendingNamingJobCount: pendingJobs.count,
+                ),
+                speakerDB: .init(count: stored.count, recentNames: recentNames),
+                pendingNamingJobs: pendingJobs,
+            )
+        }
+
+        /// Closures the RPC server invokes for `/action/{rename,delete,merge}Speaker`.
+        /// Same wiring as `KnownVoicesView.onMutate`: mutate the DB, then refresh
+        /// the cached `knownSpeakerNames` only when the mutation actually changed
+        /// state — `.notFound` paths skip the redundant disk read.
+        func makeSpeakerDBActions() -> SpeakerDBActions {
+            SpeakerDBActions(
+                rename: { [weak self] from, to in
+                    let result = SpeakerMatcher().renameSpeaker(from: from, to: to)
+                    let outcome: SpeakerActionOutcome = switch result {
+                    case .renamed: .ok
+                    case .merged: .merged
+                    case .noop: .noop
+                    case .notFound: .notFound
+                    }
+                    if outcome != .notFound { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    return outcome
+                },
+                delete: { [weak self] name in
+                    let removed = SpeakerMatcher().deleteSpeaker(name: name)
+                    if removed { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    return removed ? .ok : .notFound
+                },
+                merge: { [weak self] from, into in
+                    let merged = SpeakerMatcher().mergeSpeakers(from: from, into: into)
+                    if merged { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    return merged ? .ok : .notFound
+                },
+            )
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -59,7 +59,29 @@
                     if merged { self?.pipelineQueue.refreshKnownSpeakerNames() }
                     return merged ? .ok : .notFound
                 },
+                seed: { [weak self] name in
+                    let matcher = SpeakerMatcher()
+                    var stored = matcher.loadDB()
+                    let embedding = (0 ..< Self.seedEmbeddingDimension).map { _ in
+                        Float.random(in: -1 ... 1)
+                    }
+                    stored.append(StoredSpeaker(
+                        name: name,
+                        embeddings: [embedding],
+                        centroid: embedding,
+                        centroidSampleCount: 1,
+                        lastUsed: Date(),
+                        useCount: 1,
+                    ))
+                    matcher.saveDB(stored)
+                    self?.pipelineQueue.refreshKnownSpeakerNames()
+                    return .ok
+                },
             )
         }
+
+        /// FluidAudio's diarizer emits 192-dim embeddings; seeded speakers use
+        /// the same shape so they round-trip through `SpeakerMatcher` cleanly.
+        private static let seedEmbeddingDimension = 192
     }
 #endif

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -23,7 +23,11 @@
                     waitingJobCount: pipelineQueue.pendingJobs.count,
                     pendingNamingJobCount: pendingJobs.count,
                 ),
-                speakerDB: .init(count: stored.count, recentNames: recentNames),
+                speakerDB: .init(
+                    count: stored.count,
+                    recentNames: recentNames,
+                    knownSpeakerNames: pipelineQueue.knownSpeakerNames,
+                ),
                 pendingNamingJobs: pendingJobs,
             )
         }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -138,9 +138,12 @@ final class AppState {
         }
 
         private func startDebugRPCServer() {
-            let server = DebugRPCServer { [weak self] in
-                self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
-            }
+            let server = DebugRPCServer(
+                snapshot: { [weak self] in
+                    self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
+                },
+                speakerActions: makeSpeakerDBActions(),
+            )
             server.start()
             debugRPCServer = server
         }
@@ -158,34 +161,6 @@ final class AppState {
                     self.observeDebugRPCSetting()
                 }
             }
-        }
-    #endif
-
-    #if !APPSTORE
-        /// Build a snapshot of state for the debug RPC. Read-only.
-        func rpcStateSnapshot() -> RPCStateSnapshot {
-            let stored = SpeakerMatcher().loadDB()
-            let recentNames = SpeakerMatcher.rankByRecency(speakers: stored)
-                .prefix(10).map(\.name)
-            let pendingJobs = pipelineQueue.pendingSpeakerNamingJobs.map { job in
-                let data = pipelineQueue.speakerNamingDataByJob[job.id]
-                return RPCStateSnapshot.PendingNaming(
-                    jobID: job.id.uuidString,
-                    meetingTitle: job.meetingTitle,
-                    speakerCount: data?.mapping.count ?? 0,
-                    namingSlug: job.namingSlug,
-                )
-            }
-            return RPCStateSnapshot(
-                pipeline: .init(
-                    isProcessing: pipelineQueue.isProcessing,
-                    activeJobCount: pipelineQueue.activeJobs.count,
-                    waitingJobCount: pipelineQueue.pendingJobs.count,
-                    pendingNamingJobCount: pendingJobs.count,
-                ),
-                speakerDB: .init(count: stored.count, recentNames: recentNames),
-                pendingNamingJobs: pendingJobs,
-            )
         }
     #endif
 

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -179,23 +179,11 @@
                 Self.closeSettings()
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
 
-            case ("POST", "/action/renameSpeaker"):
-                guard let payload = try? JSONDecoder().decode(RenamePayload.self, from: request.body),
-                      !payload.from.isEmpty, !payload.to.isEmpty
-                else { return HTTPResponse.badRequest() }
-                return Self.respond(to: speakerActions.rename(payload.from, payload.to))
-
-            case ("POST", "/action/deleteSpeaker"):
-                guard let payload = try? JSONDecoder().decode(DeletePayload.self, from: request.body),
-                      !payload.name.isEmpty
-                else { return HTTPResponse.badRequest() }
-                return Self.respond(to: speakerActions.delete(payload.name))
-
-            case ("POST", "/action/mergeSpeakers"):
-                guard let payload = try? JSONDecoder().decode(MergePayload.self, from: request.body),
-                      !payload.from.isEmpty, !payload.into.isEmpty
-                else { return HTTPResponse.badRequest() }
-                return Self.respond(to: speakerActions.merge(payload.from, payload.into))
+            case ("POST", "/action/renameSpeaker"),
+                 ("POST", "/action/deleteSpeaker"),
+                 ("POST", "/action/mergeSpeakers"),
+                 ("POST", "/action/seedSpeaker"):
+                return routeSpeakerAction(path: request.path, body: request.body)
 
             case ("GET", "/screenshot"):
                 if let png = Self.captureFrontmostWindowPNG() {
@@ -213,6 +201,40 @@
 
         // MARK: - Speaker DB action helpers
 
+        /// Decode the request body for one of the four speaker-DB action paths,
+        /// run the matching closure on `speakerActions`, and return the mapped
+        /// HTTP response. 400 on missing/empty fields or undecodable JSON.
+        private func routeSpeakerAction(path: String, body: Data) -> HTTPResponse {
+            switch path {
+            case "/action/renameSpeaker":
+                guard let p = try? JSONDecoder().decode(RenamePayload.self, from: body),
+                      !p.from.isEmpty, !p.to.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.rename(p.from, p.to))
+
+            case "/action/deleteSpeaker":
+                guard let p = try? JSONDecoder().decode(DeletePayload.self, from: body),
+                      !p.name.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.delete(p.name))
+
+            case "/action/mergeSpeakers":
+                guard let p = try? JSONDecoder().decode(MergePayload.self, from: body),
+                      !p.from.isEmpty, !p.into.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.merge(p.from, p.into))
+
+            case "/action/seedSpeaker":
+                guard let p = try? JSONDecoder().decode(SeedPayload.self, from: body),
+                      !p.name.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.seed(p.name))
+
+            default:
+                return HTTPResponse.notFound()
+            }
+        }
+
         private struct RenamePayload: Decodable {
             let from: String
             let to: String
@@ -225,6 +247,10 @@
         private struct MergePayload: Decodable {
             let from: String
             let into: String
+        }
+
+        private struct SeedPayload: Decodable {
+            let name: String
         }
 
         /// Map the action outcome to an HTTP response. `notFound` → 404,
@@ -387,11 +413,15 @@
         var rename: (String, String) -> SpeakerActionOutcome
         var delete: (String) -> SpeakerActionOutcome
         var merge: (String, String) -> SpeakerActionOutcome
+        /// Insert a synthetic speaker with a random embedding. Test-only path
+        /// — production never calls this.
+        var seed: (String) -> SpeakerActionOutcome
 
         static let noop = Self(
             rename: { _, _ in .invalid },
             delete: { _ in .invalid },
             merge: { _, _ in .invalid },
+            seed: { _ in .invalid },
         )
     }
 

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -33,6 +33,7 @@
 
         private let port: NWEndpoint.Port
         private let snapshot: () -> RPCStateSnapshot
+        private let speakerActions: SpeakerDBActions
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -47,10 +48,12 @@
             port: UInt16 = DebugRPCServer.defaultPort,
             token: String = DebugRPCServer.loadOrCreateToken(),
             snapshot: @escaping () -> RPCStateSnapshot,
+            speakerActions: SpeakerDBActions = .noop,
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
             self.snapshot = snapshot
+            self.speakerActions = speakerActions
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -176,6 +179,24 @@
                 Self.closeSettings()
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
 
+            case ("POST", "/action/renameSpeaker"):
+                guard let payload = try? JSONDecoder().decode(RenamePayload.self, from: request.body),
+                      !payload.from.isEmpty, !payload.to.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.rename(payload.from, payload.to))
+
+            case ("POST", "/action/deleteSpeaker"):
+                guard let payload = try? JSONDecoder().decode(DeletePayload.self, from: request.body),
+                      !payload.name.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.delete(payload.name))
+
+            case ("POST", "/action/mergeSpeakers"):
+                guard let payload = try? JSONDecoder().decode(MergePayload.self, from: request.body),
+                      !payload.from.isEmpty, !payload.into.isEmpty
+                else { return HTTPResponse.badRequest() }
+                return Self.respond(to: speakerActions.merge(payload.from, payload.into))
+
             case ("GET", "/screenshot"):
                 if let png = Self.captureFrontmostWindowPNG() {
                     return HTTPResponse.ok(body: png, contentType: "image/png")
@@ -187,6 +208,38 @@
 
             default:
                 return HTTPResponse.notFound()
+            }
+        }
+
+        // MARK: - Speaker DB action helpers
+
+        private struct RenamePayload: Decodable {
+            let from: String
+            let to: String
+        }
+
+        private struct DeletePayload: Decodable {
+            let name: String
+        }
+
+        private struct MergePayload: Decodable {
+            let from: String
+            let into: String
+        }
+
+        /// Map the action outcome to an HTTP response. `notFound` → 404,
+        /// `invalid` → 400, everything else → 200 with the outcome string in the body.
+        private static func respond(to outcome: SpeakerActionOutcome) -> HTTPResponse {
+            switch outcome {
+            case .notFound:
+                return HTTPResponse.notFound()
+
+            case .invalid:
+                return HTTPResponse.badRequest()
+
+            case .ok, .noop, .merged:
+                let body = Data(#"{"outcome":"\#(outcome.rawValue)"}"#.utf8)
+                return HTTPResponse.ok(body: body, contentType: "application/json")
             }
         }
 
@@ -302,6 +355,10 @@
             Self(status: 403, reason: "Forbidden", body: Data(), contentType: "text/plain")
         }
 
+        static func badRequest() -> Self {
+            Self(status: 400, reason: "Bad Request", body: Data(), contentType: "text/plain")
+        }
+
         func serialize() -> Data {
             var response = "HTTP/1.1 \(status) \(reason)\r\n"
             response += "Content-Type: \(contentType)\r\n"
@@ -312,6 +369,30 @@
             out.append(body)
             return out
         }
+    }
+
+    // MARK: - Speaker DB action types
+
+    enum SpeakerActionOutcome: String {
+        case ok
+        case noop
+        case merged
+        case notFound
+        case invalid
+    }
+
+    /// Default `.noop` rejects every request so tests and dry-launches can't
+    /// accidentally mutate state — wire real closures explicitly when starting.
+    struct SpeakerDBActions {
+        var rename: (String, String) -> SpeakerActionOutcome
+        var delete: (String) -> SpeakerActionOutcome
+        var merge: (String, String) -> SpeakerActionOutcome
+
+        static let noop = Self(
+            rename: { _, _ in .invalid },
+            delete: { _ in .invalid },
+            merge: { _, _ in .invalid },
+        )
     }
 
     // MARK: - State snapshot

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -413,7 +413,13 @@
 
         struct SpeakerDB: Codable {
             let count: Int
+            /// Top-10 names ranked by recency, read fresh from the matcher on
+            /// every snapshot — independent of any cache.
             let recentNames: [String]
+            /// `PipelineQueue.knownSpeakerNames` — the cache the next naming
+            /// dialog reads. Surfaced separately so smoketests can verify the
+            /// invalidation flow (#155 → #158 → #159).
+            let knownSpeakerNames: [String]
         }
 
         struct PendingNaming: Codable {
@@ -434,7 +440,7 @@
                 isProcessing: false, activeJobCount: 0,
                 waitingJobCount: 0, pendingNamingJobCount: 0,
             ),
-            speakerDB: .init(count: 0, recentNames: []),
+            speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
             pendingNamingJobs: [],
         )
     }

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -86,7 +86,7 @@
         func testStateReturnsValidJSON() async throws {
             let snapshot = RPCStateSnapshot(
                 pipeline: .init(isProcessing: true, activeJobCount: 2, waitingJobCount: 0, pendingNamingJobCount: 1),
-                speakerDB: .init(count: 7, recentNames: ["Alice"]),
+                speakerDB: .init(count: 7, recentNames: ["Alice"], knownSpeakerNames: ["Alice"]),
                 pendingNamingJobs: [],
             )
             let base = try await startServer(snapshot: snapshot)

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -82,7 +82,7 @@
         func testRouteState() {
             let snapshot = RPCStateSnapshot(
                 pipeline: .init(isProcessing: false, activeJobCount: 1, waitingJobCount: 0, pendingNamingJobCount: 0),
-                speakerDB: .init(count: 5, recentNames: ["Speaker A"]),
+                speakerDB: .init(count: 5, recentNames: ["Speaker A"], knownSpeakerNames: ["Speaker A"]),
                 pendingNamingJobs: [],
             )
             let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
@@ -339,6 +339,19 @@
             let body = Data(#"{"from":"X","into":"Y"}"#.utf8)
             let response = server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
             XCTAssertEqual(response.status, 404)
+        }
+
+        @MainActor
+        func testRouteStateExposesKnownSpeakerNames() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(isProcessing: false, activeJobCount: 0, waitingJobCount: 0, pendingNamingJobCount: 0),
+                speakerDB: .init(count: 2, recentNames: ["Alice", "Bob"], knownSpeakerNames: ["Alice", "Bob"]),
+                pendingNamingJobs: [],
+            )
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
+            let response = server.route(authedRequest(method: "GET", path: "/state"))
+            let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: response.body)
+            XCTAssertEqual(decoded.speakerDB.knownSpeakerNames, ["Alice", "Bob"])
         }
 
         @MainActor

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -214,6 +214,148 @@
             XCTAssertEqual(perms, 0o600)
         }
 
+        // MARK: - Speaker DB action routes
+
+        @MainActor
+        func testRouteRenameSpeakerCallsActionAndReturnsOK() throws {
+            let stub = StubSpeakerActions()
+            stub.renameOutcome = .ok
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"Old","to":"New"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(stub.renameCalls.count, 1)
+            XCTAssertEqual(stub.renameCalls.first?.0, "Old")
+            XCTAssertEqual(stub.renameCalls.first?.1, "New")
+            let decoded = try JSONSerialization.jsonObject(with: response.body) as? [String: String]
+            XCTAssertEqual(decoded?["outcome"], "ok")
+        }
+
+        @MainActor
+        func testRouteRenameSpeakerNotFoundReturns404() {
+            let stub = StubSpeakerActions()
+            stub.renameOutcome = .notFound
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"Missing","to":"Whatever"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            XCTAssertEqual(response.status, 404)
+        }
+
+        @MainActor
+        func testRouteRenameSpeakerCollisionReturnsMerged() throws {
+            let stub = StubSpeakerActions()
+            stub.renameOutcome = .merged
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"A","to":"B"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            XCTAssertEqual(response.status, 200)
+            let decoded = try JSONSerialization.jsonObject(with: response.body) as? [String: String]
+            XCTAssertEqual(decoded?["outcome"], "merged")
+        }
+
+        @MainActor
+        func testRouteRenameSpeakerInvalidJSONReturns400() {
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+            )
+            let body = Data("{not json".utf8)
+            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            XCTAssertEqual(response.status, 400)
+        }
+
+        @MainActor
+        func testRouteRenameSpeakerMissingFieldReturns400() {
+            let stub = StubSpeakerActions()
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"OnlyThis"}"#.utf8) // missing "to"
+            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            XCTAssertEqual(response.status, 400)
+            XCTAssertTrue(stub.renameCalls.isEmpty)
+        }
+
+        @MainActor
+        func testRouteDeleteSpeakerCallsActionAndReturnsOK() {
+            let stub = StubSpeakerActions()
+            stub.deleteOutcome = .ok
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"name":"Doomed"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(stub.deleteCalls, ["Doomed"])
+        }
+
+        @MainActor
+        func testRouteDeleteSpeakerNotFoundReturns404() {
+            let stub = StubSpeakerActions()
+            stub.deleteOutcome = .notFound
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"name":"Ghost"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
+            XCTAssertEqual(response.status, 404)
+        }
+
+        @MainActor
+        func testRouteMergeSpeakersCallsActionAndReturnsOK() {
+            let stub = StubSpeakerActions()
+            stub.mergeOutcome = .ok
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"A","into":"B"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(stub.mergeCalls.first?.0, "A")
+            XCTAssertEqual(stub.mergeCalls.first?.1, "B")
+        }
+
+        @MainActor
+        func testRouteMergeSpeakersNotFoundReturns404() {
+            let stub = StubSpeakerActions()
+            stub.mergeOutcome = .notFound
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"from":"X","into":"Y"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
+            XCTAssertEqual(response.status, 404)
+        }
+
+        @MainActor
+        func testRouteSpeakerActionsRejectMissingAuth() {
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+            )
+            let body = Data(#"{"from":"A","to":"B"}"#.utf8)
+            // Missing Authorization header.
+            let request = HTTPRequest(
+                method: "POST", path: "/action/renameSpeaker",
+                headers: ["content-type": "application/json"], body: body,
+            )
+            XCTAssertEqual(server.route(request).status, 401)
+        }
+
         // MARK: - Snapshot JSON
 
         func testSnapshotEncodesPretty() throws {
@@ -230,6 +372,40 @@
 
         private func authedRequest(method: String, path: String, body: Data = Data()) -> HTTPRequest {
             HTTPRequest(method: method, path: path, headers: Self.authHeaders, body: body)
+        }
+
+        private func authedJSONRequest(path: String, body: Data) -> HTTPRequest {
+            var headers = Self.authHeaders
+            headers["content-type"] = "application/json"
+            return HTTPRequest(method: "POST", path: path, headers: headers, body: body)
+        }
+    }
+
+    /// Stub that records calls and returns canned outcomes per action.
+    /// Used by routing tests to verify the request → closure → response wiring.
+    final class StubSpeakerActions {
+        private(set) var renameCalls: [(String, String)] = []
+        private(set) var deleteCalls: [String] = []
+        private(set) var mergeCalls: [(String, String)] = []
+        var renameOutcome: SpeakerActionOutcome = .ok
+        var deleteOutcome: SpeakerActionOutcome = .ok
+        var mergeOutcome: SpeakerActionOutcome = .ok
+
+        func actions() -> SpeakerDBActions {
+            SpeakerDBActions(
+                rename: { [weak self] from, to in
+                    self?.renameCalls.append((from, to))
+                    return self?.renameOutcome ?? .invalid
+                },
+                delete: { [weak self] name in
+                    self?.deleteCalls.append(name)
+                    return self?.deleteOutcome ?? .invalid
+                },
+                merge: { [weak self] from, into in
+                    self?.mergeCalls.append((from, into))
+                    return self?.mergeOutcome ?? .invalid
+                },
+            )
         }
     }
 #endif

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -342,6 +342,31 @@
         }
 
         @MainActor
+        func testRouteSeedSpeakerCallsActionAndReturnsOK() {
+            let stub = StubSpeakerActions()
+            stub.seedOutcome = .ok
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: stub.actions(),
+            )
+            let body = Data(#"{"name":"NewSeed"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(stub.seedCalls, ["NewSeed"])
+        }
+
+        @MainActor
+        func testRouteSeedSpeakerInvalidJSONReturns400() {
+            let server = DebugRPCServer(
+                port: 0, token: Self.testToken,
+                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+            )
+            let body = Data(#"{"wrong":"shape"}"#.utf8)
+            let response = server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
+            XCTAssertEqual(response.status, 400)
+        }
+
+        @MainActor
         func testRouteStateExposesKnownSpeakerNames() throws {
             let snapshot = RPCStateSnapshot(
                 pipeline: .init(isProcessing: false, activeJobCount: 0, waitingJobCount: 0, pendingNamingJobCount: 0),
@@ -400,9 +425,11 @@
         private(set) var renameCalls: [(String, String)] = []
         private(set) var deleteCalls: [String] = []
         private(set) var mergeCalls: [(String, String)] = []
+        private(set) var seedCalls: [String] = []
         var renameOutcome: SpeakerActionOutcome = .ok
         var deleteOutcome: SpeakerActionOutcome = .ok
         var mergeOutcome: SpeakerActionOutcome = .ok
+        var seedOutcome: SpeakerActionOutcome = .ok
 
         func actions() -> SpeakerDBActions {
             SpeakerDBActions(
@@ -417,6 +444,10 @@
                 merge: { [weak self] from, into in
                     self?.mergeCalls.append((from, into))
                     return self?.mergeOutcome ?? .invalid
+                },
+                seed: { [weak self] name in
+                    self?.seedCalls.append(name)
+                    return self?.seedOutcome ?? .invalid
                 },
             )
         }

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -109,4 +109,31 @@ out=$("$MT_CLI_BIN" screenshot /tmp/rpc-smoke-after-close.png 2>&1 || true)
 echo "$out" | grep -q "503" || fail "after-close: expected 503, got: $out"
 ok "close → 503 again"
 
+step "Speaker DB mutation routes"
+
+probe_name="rpc-smoketest-$$"
+followup_name="rpc-smoketest-$$-renamed"
+
+# rename of a non-existent speaker → 404 (mt-cli exits non-zero).
+out=$("$MT_CLI_BIN" rename-speaker "$probe_name" "$followup_name" 2>&1 || true)
+echo "$out" | grep -q "404" || fail "rename of missing speaker: expected 404, got: $out"
+ok "rename missing → 404"
+
+# delete of a non-existent speaker → 404.
+out=$("$MT_CLI_BIN" delete-speaker "$probe_name" 2>&1 || true)
+echo "$out" | grep -q "404" || fail "delete of missing speaker: expected 404, got: $out"
+ok "delete missing → 404"
+
+# merge with non-existent source → 404.
+out=$("$MT_CLI_BIN" merge-speakers "$probe_name" "$followup_name" 2>&1 || true)
+echo "$out" | grep -q "404" || fail "merge missing → expected 404, got: $out"
+ok "merge missing → 404"
+
+# Malformed payload → 400.
+code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d 'not-json' "http://127.0.0.1:9876/action/renameSpeaker")
+[ "$code" = "400" ] || fail "bad JSON: expected 400 got $code"
+ok "bad JSON → 400"
+
 step "All checks passed"

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -136,4 +136,36 @@ code=$(curl -s -o /dev/null -w "%{http_code}" \
 [ "$code" = "400" ] || fail "bad JSON: expected 400 got $code"
 ok "bad JSON → 400"
 
+step "Cache invalidation roundtrip (seed → rename → delete via knownSpeakerNames)"
+
+seed_name="rpc-smoketest-$$-seed"
+rename_target="rpc-smoketest-$$-renamed"
+
+"$MT_CLI_BIN" seed-speaker "$seed_name" >/dev/null
+"$MT_CLI_BIN" state | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+names = d['speakerDB']['knownSpeakerNames']
+assert '$seed_name' in names, f'seed missing from cache: {names}'
+" || fail "seed not reflected in knownSpeakerNames"
+ok "seed → cache updated"
+
+"$MT_CLI_BIN" rename-speaker "$seed_name" "$rename_target" >/dev/null
+"$MT_CLI_BIN" state | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+names = d['speakerDB']['knownSpeakerNames']
+assert '$rename_target' in names and '$seed_name' not in names, f'rename not in cache: {names}'
+" || fail "rename not reflected in knownSpeakerNames"
+ok "rename → cache updated"
+
+"$MT_CLI_BIN" delete-speaker "$rename_target" >/dev/null
+"$MT_CLI_BIN" state | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+names = d['speakerDB']['knownSpeakerNames']
+assert '$rename_target' not in names, f'delete not reflected: {names}'
+" || fail "delete not reflected in knownSpeakerNames"
+ok "delete → cache updated"
+
 step "All checks passed"

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -9,7 +9,7 @@ struct MTCLI: AsyncParsableCommand {
         subcommands: [
             State.self, Healthz.self, Screenshot.self,
             OpenSettings.self, CloseSettings.self,
-            RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
+            SeedSpeaker.self, RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
         ],
     )
 }
@@ -73,6 +73,20 @@ private func postAction(_ path: String, _ payload: [String: String]) async throw
     let data = try await client.post(path, json: payload)
     FileHandle.standardOutput.write(data)
     FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+struct SeedSpeaker: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "seed-speaker",
+        abstract: "Insert a synthetic speaker with a random embedding (testing only).",
+    )
+
+    @Argument(help: "Name of the speaker to seed.")
+    var name: String
+
+    func run() async throws {
+        try await postAction("/action/seedSpeaker", ["name": name])
+    }
 }
 
 struct RenameSpeaker: AsyncParsableCommand {

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -6,7 +6,11 @@ struct MTCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mt-cli",
         abstract: "Thin client for the Meeting Transcriber debug RPC server.",
-        subcommands: [State.self, Healthz.self, Screenshot.self, OpenSettings.self, CloseSettings.self],
+        subcommands: [
+            State.self, Healthz.self, Screenshot.self,
+            OpenSettings.self, CloseSettings.self,
+            RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
+        ],
     )
 }
 
@@ -58,6 +62,64 @@ struct CloseSettings: AsyncParsableCommand {
         let client = try RPCClient.loadDefault()
         let data = try await client.post("/action/closeSettings", json: [:])
         FileHandle.standardOutput.write(data)
+    }
+}
+
+/// POST a JSON action to the RPC server and write the response body + newline
+/// to stdout. Shared by every action subcommand that returns the server's
+/// outcome JSON unchanged.
+private func postAction(_ path: String, _ payload: [String: String]) async throws {
+    let client = try RPCClient.loadDefault()
+    let data = try await client.post(path, json: payload)
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+struct RenameSpeaker: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rename-speaker",
+        abstract: "Rename a speaker in the persisted DB. Merges if the target name exists.",
+    )
+
+    @Argument(help: "Current name of the speaker.")
+    var from: String
+
+    @Argument(help: "New name. If a speaker already has this name, the two are merged.")
+    var to: String
+
+    func run() async throws {
+        try await postAction("/action/renameSpeaker", ["from": from, "to": to])
+    }
+}
+
+struct DeleteSpeaker: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete-speaker",
+        abstract: "Remove a speaker from the persisted DB.",
+    )
+
+    @Argument(help: "Name of the speaker to delete.")
+    var name: String
+
+    func run() async throws {
+        try await postAction("/action/deleteSpeaker", ["name": name])
+    }
+}
+
+struct MergeSpeakers: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "merge-speakers",
+        abstract: "Merge one speaker into another. Embeddings, centroid and counts are combined.",
+    )
+
+    @Argument(help: "Source speaker — its data is merged into the target and the source is removed.")
+    var from: String
+
+    @Argument(help: "Target speaker — receives the source's embeddings and centroid.")
+    var into: String
+
+    func run() async throws {
+        try await postAction("/action/mergeSpeakers", ["from": from, "into": into])
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the debug RPC server with four POST routes + one new `/state` field, so shell-driven smoketests can drive the full cache-invalidation flow without clicking through the Known Voices sheet:

**Mutators:**
- ``POST /action/renameSpeaker``  — body ``{\"from\": \"...\", \"to\": \"...\"}``
- ``POST /action/deleteSpeaker``  — body ``{\"name\": \"...\"}``
- ``POST /action/mergeSpeakers``  — body ``{\"from\": \"...\", \"into\": \"...\"}``
- ``POST /action/seedSpeaker``    — body ``{\"name\": \"...\"}`` (testing only — synthetic 192-dim embedding)

**Cache observability:**
- ``GET /state`` now exposes ``speakerDB.knownSpeakerNames`` separately from ``speakerDB.recentNames`` — the former is the cached list the next naming dialog reads (the one that went stale in #155 → #158 → #159), the latter is read fresh from the matcher on every snapshot.

Each mutator returns:
- **200** with ``{\"outcome\": \"ok|noop|merged\"}`` on success
- **404** when the source speaker doesn't exist
- **400** on malformed JSON or empty fields
- **401/403** for the existing auth/origin guards

The action closures wired in ``AppState`` mutate the DB via ``SpeakerMatcher`` and refresh ``PipelineQueue.knownSpeakerNames`` *only* when the mutation actually changed state — ``.notFound`` paths skip the redundant ``loadDB()`` (#160's hot-path rule).

``mt-cli`` gains ``seed-speaker`` / ``rename-speaker`` / ``delete-speaker`` / ``merge-speakers`` subcommands sharing a private ``postAction`` helper. ``scripts/test_rpc.sh`` asserts the full seed → rename → delete cache-invalidation loop end-to-end.

``rpcStateSnapshot()`` and the new ``makeSpeakerDBActions()`` move to a new ``AppState+RPC.swift`` extension file so ``AppState`` stays within ``type_body_length``. Speaker-DB action routing extracted into ``routeSpeakerAction(path:body:)`` to keep ``route()`` under ``cyclomatic_complexity`` 15.

## Test plan
- [x] 47 ``DebugRPC*Tests`` pass (14 new — rename/delete/merge/seed × outcome paths + auth + state)
- [x] Full ``./scripts/lint.sh`` clean
- [x] ``mt-cli --help`` lists all four new subcommands
- [ ] Live smoketest: ``MEETINGTRANSCRIBER_DEBUG_RPC=1 ./scripts/run_app.sh`` then ``./scripts/test_rpc.sh`` (manual; CI doesn't launch a real app)

## Why

PR #159 fixed the cache-invalidation gap that PR #158 left open. To prevent regressions and let future cache audits be scripted, this PR exposes the cache via ``/state`` *and* gives shell scripts the mutators they need to drive every path. The end-to-end smoketest now does:

```
seed-speaker X → state.knownSpeakerNames contains X
rename-speaker X Y → state.knownSpeakerNames contains Y, not X
delete-speaker Y → state.knownSpeakerNames does not contain Y
```

— catches any future PR that breaks the cache-refresh wiring.