### PR TITLE
fix(app): also reset stepper + names when naming dialog re-presents

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -165,20 +165,28 @@ struct SpeakerNamingView: View {
         .padding()
         .frame(minWidth: 400, maxHeight: 700)
         .id(data.meetingTitle)
-        .onAppear {
-            names = Self.computeInitialNames(speakers: speakers)
-            rerunCount = max(2, speakers.count + 1)
-        }
-        // After Re-run, the dialog is re-presented for the same jobID with
-        // fresh diarization data. Without resetting `completedJobID`, the
-        // per-job guard would still match and silently kill all three buttons.
-        .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
-            completedJobID = nil
+        .onAppear { resetForCurrentPresentation() }
+        // After Re-run, lateDiarization replaces `data.mapping` for the
+        // same jobID. Without resetting per-presentation @State here, the
+        // per-job guard kept Confirm/Skip/Re-run dead AND the stepper/names
+        // still reflected the previous diarization. `.onChange` fires after
+        // SwiftUI has propagated the new `data`, so `speakers` is current.
+        .onChange(of: data.mapping) { _, _ in
+            resetForCurrentPresentation()
         }
         // No onDisappear → .skipped: in the non-blocking architecture closing
         // the window (Cmd+Q, click X, app quit) leaves the job in
         // .speakerNamingPending so the user can re-open later. Explicit Skip
         // button still calls onComplete(.skipped).
+    }
+
+    /// Re-seed all per-presentation @State from the current `data`. Called
+    /// on first appearance and again whenever `data.mapping` changes (the
+    /// signal that lateDiarization replaced the speakers for this jobID).
+    private func resetForCurrentPresentation() {
+        completedJobID = nil
+        names = Self.computeInitialNames(speakers: speakers)
+        rerunCount = max(2, speakers.count + 1)
     }
 
     private func speakerRow(


### PR DESCRIPTION
## Summary

Follow-up to #162 (rc10). That fix only cleared `completedJobID` on `.showSpeakerNaming`, but the stepper and the per-speaker name fields stayed stale because `.onAppear` only fires once on first show.

After Re-run:
- ✅ Buttons respond again (rc10 fix)
- ❌ Stepper still proposes `oldSpeakers + 1` instead of `newSpeakers + 1`
- ❌ Textfields still hold prior auto-names

This PR switches to `.onChange(of: data.mapping)` and re-seeds **all** per-presentation @State (`completedJobID`, `names`, `rerunCount`) via a single helper. `.onChange` fires after SwiftUI has propagated the new `data`, so the recomputed values reflect the new diarization.

## Test plan

- [x] Lint clean
- [x] All `SpeakerNamingViewTests` pass
- [ ] Manual: trigger naming dialog → click Re-run → after re-diarization, stepper jumps to `newCount + 1` and name fields reflect new auto-matches

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->