### PR TITLE
fix(app): pick temporally-pure sample for speaker-naming dialog (#165 phase 4)

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -400,7 +400,7 @@ struct SpeakerNamingView: View {
             .accessibilityIdentifier(identifier)
     }
 
-    /// Play the longest segment of a speaker from the audio file.
+    /// Play the longest temporally-pure segment of a speaker from the audio file.
     private func playSpeakerSnippet(label: String) {
         // Stop if already playing this speaker
         if playingLabel == label {
@@ -412,15 +412,16 @@ struct SpeakerNamingView: View {
 
         guard let audioPath = data.audioPath else { return }
 
-        guard let longest = Self.longestSegment(forSpeaker: label, in: data.segments) else { return }
+        // Pick the longest pure segment to avoid cross-voice contamination.
+        guard let chosen = Self.selectSampleSegment(for: label, in: data.segments) else { return }
 
         // Perform file I/O off the main thread
-        Task.detached { [audioPath, longest] in
+        Task.detached { [audioPath, chosen] in
             do {
                 let (samples, sampleRate) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
                 guard let range = Self.sampleRange(
-                    start: longest.start,
-                    end: longest.end,
+                    start: chosen.start,
+                    end: chosen.end,
                     sampleRate: sampleRate,
                     totalSamples: samples.count,
                 ) else { return }
@@ -490,6 +491,29 @@ struct SpeakerNamingView: View {
         let endSample = min(totalSamples, Int(end * Double(sampleRate)))
         guard startSample < endSample else { return nil }
         return startSample ..< endSample
+    }
+
+    /// Picks the longest temporally-pure segment for `label`, falling back to
+    /// `longestSegment` when no pure segment ≥ `minDuration` exists. A segment is
+    /// "pure" when no other speaker has any segment overlapping the window
+    /// `[c.start - purityWindow, c.end + purityWindow]`. Used to avoid
+    /// cross-voice contamination in the speaker-naming dialog playback.
+    static func selectSampleSegment(
+        for label: String,
+        in segments: [PipelineQueue.SpeakerNamingData.Segment],
+        minDuration: TimeInterval = 1.5,
+        purityWindow: TimeInterval = 0.5,
+    ) -> PipelineQueue.SpeakerNamingData.Segment? {
+        let own = segments.filter { $0.speaker == label }
+        guard !own.isEmpty else { return nil }
+        let others = segments.filter { $0.speaker != label }
+        let pure = own
+            .filter { c in
+                (c.end - c.start) >= minDuration
+                    && !others.contains { $0.start < c.end + purityWindow && c.start - purityWindow < $0.end }
+            }
+            .max { ($0.end - $0.start) < ($1.end - $1.start) }
+        return pure ?? longestSegment(forSpeaker: label, in: segments)
     }
 
     /// Computes initial text field names from speaker auto-name mappings.

--- a/app/MeetingTranscriber/Tests/SelectSampleSegmentTests.swift
+++ b/app/MeetingTranscriber/Tests/SelectSampleSegmentTests.swift
@@ -1,0 +1,104 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Tests for the pure helper that picks a temporally-pure sample segment
+/// for the speaker-naming dialog playback. Lives in its own file so the
+/// main `SpeakerNamingViewTests` body stays under SwiftLint's 400-line cap.
+@MainActor
+final class SelectSampleSegmentTests: XCTestCase {
+    private typealias Seg = PipelineQueue.SpeakerNamingData.Segment
+
+    func testSelectSampleSegmentReturnsLoneIsolatedSegment() {
+        // SPEAKER_0 has a single isolated segment, no other speakers nearby.
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 4.0, speaker: "SPEAKER_0"),
+            Seg(start: 20.0, end: 25.0, speaker: "SPEAKER_1"),
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertEqual(result?.start, 0.0)
+        XCTAssertEqual(result?.end, 4.0)
+    }
+
+    func testSelectSampleSegmentPrefersShorterPureOverLongerContaminated() {
+        // The 10s segment is contaminated (SPEAKER_1 cuts in within ±0.5s).
+        // The shorter 2s segment is pure and ≥ minDuration → must win.
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 10.0, speaker: "SPEAKER_0"), // contaminated
+            Seg(start: 9.8, end: 12.0, speaker: "SPEAKER_1"), // overlaps the long one
+            Seg(start: 30.0, end: 32.0, speaker: "SPEAKER_0"), // pure, 2s
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertEqual(result?.start, 30.0)
+        XCTAssertEqual(result?.end, 32.0)
+    }
+
+    func testSelectSampleSegmentFallsBackToLongestWhenAllContaminated() {
+        // Every SPEAKER_0 segment has another speaker within ±0.5s.
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 4.0, speaker: "SPEAKER_0"),
+            Seg(start: 4.2, end: 6.0, speaker: "SPEAKER_1"), // contaminates [0,4]
+            Seg(start: 10.0, end: 18.0, speaker: "SPEAKER_0"), // longest
+            Seg(start: 17.5, end: 20.0, speaker: "SPEAKER_1"), // contaminates [10,18]
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertEqual(result?.start, 10.0)
+        XCTAssertEqual(result?.end, 18.0)
+    }
+
+    func testSelectSampleSegmentFallsBackWhenPureSegmentBelowMinDuration() {
+        // The pure SPEAKER_0 segment is only 0.5s — below the 1.5s minDuration.
+        // Must fall back to the longest overall (the contaminated 8s one).
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 8.0, speaker: "SPEAKER_0"), // contaminated, longest
+            Seg(start: 7.8, end: 10.0, speaker: "SPEAKER_1"),
+            Seg(start: 30.0, end: 30.5, speaker: "SPEAKER_0"), // pure but too short
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertEqual(result?.start, 0.0)
+        XCTAssertEqual(result?.end, 8.0)
+    }
+
+    func testSelectSampleSegmentReturnsNilWhenSpeakerHasNoSegments() {
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 5.0, speaker: "SPEAKER_1"),
+            Seg(start: 5.0, end: 10.0, speaker: "SPEAKER_2"),
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertNil(result)
+    }
+
+    func testSelectSampleSegmentZeroGapCountsAsContamination() {
+        // SPEAKER_1 starts exactly at SPEAKER_0.end → zero gap.
+        // Zero gap < purityWindow (0.5) → counts as overlap → contaminated.
+        // Should fall back to longest overall.
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 5.0, speaker: "SPEAKER_0"),
+            Seg(start: 5.0, end: 8.0, speaker: "SPEAKER_1"),
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        // Only one SPEAKER_0 segment, contaminated → fallback returns it anyway.
+        XCTAssertEqual(result?.start, 0.0)
+        XCTAssertEqual(result?.end, 5.0)
+
+        // Add a shorter pure segment ≥ minDuration; the contaminated one must lose now.
+        let withPure: [Seg] = segments + [
+            Seg(start: 30.0, end: 32.0, speaker: "SPEAKER_0"),
+        ]
+        let r2 = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: withPure)
+        XCTAssertEqual(r2?.start, 30.0)
+        XCTAssertEqual(r2?.end, 32.0)
+    }
+
+    func testSelectSampleSegmentExactBoundaryNotContaminated() {
+        // SPEAKER_1 starts at SPEAKER_0.end + purityWindow (exactly 0.5s gap).
+        // Overlap test is strict (a < d && c < b); a window edge that just
+        // touches another segment does NOT overlap → segment stays pure.
+        let segments: [Seg] = [
+            Seg(start: 0.0, end: 5.0, speaker: "SPEAKER_0"),
+            Seg(start: 5.5, end: 8.0, speaker: "SPEAKER_1"), // exactly at boundary
+        ]
+        let result = SpeakerNamingView.selectSampleSegment(for: "SPEAKER_0", in: segments)
+        XCTAssertEqual(result?.start, 0.0)
+        XCTAssertEqual(result?.end, 5.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace longest-segment selection in `SpeakerNamingView.playSample` with longest *temporally-pure* segment (no other speaker within ±0.5s of boundaries).
- Fall back to longest overall when no pure segment ≥ 1.5s exists, so playback never breaks.
- Pure helper `selectSampleSegment(for:in:minDuration:purityWindow:)` is unit-tested in isolation.

Implements phase 4 of #165.

## Test plan
- [x] Unit tests cover: isolated segment, contamination + pure fallback, all-contaminated fallback, too-short pure fallback, no-segments → nil, zero-gap counted as contamination, exact-boundary not contaminated.
- [x] `swift test --parallel` green.
- [x] `./scripts/lint.sh` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->