### PR TITLE
fix(app): lazy SpeakerMatcher init in Known Voices sheet

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -12,8 +12,12 @@ struct SpeakersSettingsView: View {
     /// up-to-date chips. Optional — tests and the parent that doesn't
     /// own a PipelineQueue can omit.
     var onSpeakerMutate: (() -> Void)?
+    var matcherFactory: () -> SpeakerMatcher = { SpeakerMatcher() }
 
     @State private var showKnownVoices = false
+    /// SpeakerMatcher.init reads + decodes speakers.json — must not run
+    /// per body re-evaluation, so the matcher is created lazily on tap.
+    @State private var sheetMatcher: SpeakerMatcher?
 
     var body: some View {
         // swiftlint:disable:next closure_body_length
@@ -69,7 +73,10 @@ struct SpeakersSettingsView: View {
             }
 
             Section("Known Voices") {
-                Button("Manage\u{2026}") { showKnownVoices = true }
+                Button("Manage\u{2026}") {
+                    sheetMatcher = matcherFactory()
+                    showKnownVoices = true
+                }
                 Text("Rename, delete, or merge entries in your speaker DB.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -79,13 +86,15 @@ struct SpeakersSettingsView: View {
         }
         .formStyle(.grouped)
         .sheet(isPresented: $showKnownVoices) {
-            KnownVoicesView(
-                matcher: SpeakerMatcher(),
-                diarizerFactory: enrollmentDiarizerFactory,
-                namingDialogActive: namingDialogActive,
-                pipelineBusy: pipelineBusy,
-                onMutate: onSpeakerMutate,
-            )
+            if let matcher = sheetMatcher {
+                KnownVoicesView(
+                    matcher: matcher,
+                    diarizerFactory: enrollmentDiarizerFactory,
+                    namingDialogActive: namingDialogActive,
+                    pipelineBusy: pipelineBusy,
+                    onMutate: onSpeakerMutate,
+                )
+            }
         }
     }
 }

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -77,13 +77,17 @@ final class SettingsViewTests: XCTestCase {
         )
     }
 
-    private func makeSpeakers(settings: AppSettings? = nil) -> SpeakersSettingsView {
+    private func makeSpeakers(
+        settings: AppSettings? = nil,
+        matcherFactory: @escaping () -> SpeakerMatcher = { SpeakerMatcher() },
+    ) -> SpeakersSettingsView {
         SpeakersSettingsView(
             settings: settings ?? makeSettings(),
             recognitionStatsLog: RecognitionStatsLog(),
             enrollmentDiarizerFactory: nil,
             namingDialogActive: false,
             pipelineBusy: false,
+            matcherFactory: matcherFactory,
         )
     }
 
@@ -293,6 +297,31 @@ final class SettingsViewTests: XCTestCase {
         XCTAssertThrowsError(try body.find(
             text: "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
         ))
+    }
+
+    // SpeakerMatcher.init reads + decodes speakers.json. It must run only
+    // when the user opens the Known Voices sheet, never as a side effect
+    // of body evaluation.
+    func testKnownVoicesMatcherNotCreatedOnBodyEval() throws {
+        var matcherInits = 0
+        let view = makeSpeakers {
+            matcherInits += 1
+            return SpeakerMatcher()
+        }
+        _ = try view.inspect()
+        XCTAssertEqual(matcherInits, 0)
+    }
+
+    // Companion: tapping "Manage…" invokes the factory exactly once.
+    func testKnownVoicesMatcherCreatedOnManageTap() throws {
+        var matcherInits = 0
+        let view = makeSpeakers {
+            matcherInits += 1
+            return SpeakerMatcher()
+        }
+        let button = try view.inspect().find(button: "Manage\u{2026}")
+        try button.tap()
+        XCTAssertEqual(matcherInits, 1)
     }
 
     // MARK: - Output tab

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -3,7 +3,7 @@ import ViewInspector
 import XCTest
 
 @MainActor
-final class SettingsViewTests: XCTestCase {
+final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_length
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var defaults: UserDefaults!
     // swiftlint:disable:next implicitly_unwrapped_optional


### PR DESCRIPTION
## Summary

Move \`SpeakerMatcher\` creation out of the \`.sheet\` content closure and into the \"Manage…\" Button's action, stored in \`@State\`. The previous inline \`KnownVoicesView(matcher: SpeakerMatcher(), ...)\` ran the matcher's init (which reads + decodes \`speakers.json\`) every time SwiftUI re-evaluated the parent body while the sheet was presented — same hot-path-disk-I/O class as #155 → #158 → #159.

Adds \`matcherFactory\` injection so tests can count invocations.

## Why

Identified as **H2** in the side-effects review of the features shipped in weeks 17–19 (\`docs/plans/2026-05-06-side-effects-review.md\`). SwiftUI evaluates a presented sheet's content closure on every parent re-render — window resize, color-scheme change, environment changes — re-instantiating \`SpeakerMatcher()\` and re-reading \`speakers.json\` from disk each time.

## Test plan

- [x] Unit: \`SettingsViewTests/testKnownVoicesMatcherNotCreatedOnBodyEval\` passes
- [x] Unit: \`SettingsViewTests/testKnownVoicesMatcherCreatedOnManageTap\` passes — and confirmed to fail against the pre-fix code (matcher in \`.sheet\` closure is never reached via tap in unit tests)
- [x] Manual: \`fs_usage\` trace on the dev app with the fix shows 2 reads per \"Manage…\" tap (matcher init + \`KnownVoicesView.onAppear\` loadDB), zero reads during 18 s of window resizing while sheet open. Without the fix, every resize event would have triggered an additional read.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->