### PR TITLE
perf(app): cache subview sizes in ChipFlowLayout

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -498,42 +498,65 @@ struct SpeakerNamingView: View {
 struct ChipFlowLayout: Layout {
     var spacing: CGFloat = 4
 
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+    /// Subview intrinsic sizes are cached so `sizeThatFits` and
+    /// `placeSubviews` don't each re-query every child per layout pass.
+    typealias Cache = [CGSize]
+
+    func makeCache(subviews: Subviews) -> Cache {
+        subviews.map { $0.sizeThatFits(.unspecified) }
+    }
+
+    func updateCache(_ cache: inout Cache, subviews: Subviews) {
+        cache = subviews.map { $0.sizeThatFits(.unspecified) }
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews _: Subviews, cache: inout Cache) -> CGSize {
         let containerWidth = proposal.width ?? .infinity
+        return Self.computeLayout(
+            sizes: cache, containerWidth: containerWidth, spacing: spacing,
+        ).totalSize
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache: inout Cache) {
+        let result = Self.computeLayout(
+            sizes: cache, containerWidth: bounds.width, spacing: spacing,
+        )
+        for (index, sv) in subviews.enumerated() {
+            let pos = result.positions[index]
+            sv.place(
+                at: CGPoint(x: bounds.minX + pos.x, y: bounds.minY + pos.y),
+                proposal: ProposedViewSize(cache[index]),
+            )
+        }
+    }
+
+    /// Pure layout calculation — extracted so the wrapping logic can be
+    /// covered by unit tests without a SwiftUI host.
+    static func computeLayout(
+        sizes: [CGSize], containerWidth: CGFloat, spacing: CGFloat,
+    ) -> (totalSize: CGSize, positions: [CGPoint]) {
         var x: CGFloat = 0
         var y: CGFloat = 0
         var rowHeight: CGFloat = 0
         var maxWidth: CGFloat = 0
-        for sv in subviews {
-            let size = sv.sizeThatFits(.unspecified)
+        var positions: [CGPoint] = []
+        positions.reserveCapacity(sizes.count)
+
+        for size in sizes {
             if x > 0, x + size.width > containerWidth {
                 y += rowHeight + spacing
                 x = 0
                 rowHeight = 0
             }
+            positions.append(CGPoint(x: x, y: y))
             x += size.width + spacing
             rowHeight = max(rowHeight, size.height)
             maxWidth = max(maxWidth, x - spacing)
         }
         // Report the actual content width (capped at the container) so unconstrained
         // parents (proposal == .infinity) don't get an infinite frame.
-        return CGSize(width: min(maxWidth, containerWidth), height: y + rowHeight)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var rowHeight: CGFloat = 0
-        for sv in subviews {
-            let size = sv.sizeThatFits(.unspecified)
-            if x > bounds.minX, x + size.width > bounds.maxX {
-                y += rowHeight + spacing
-                x = bounds.minX
-                rowHeight = 0
-            }
-            sv.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
+        let width = sizes.isEmpty ? 0 : min(maxWidth, containerWidth)
+        let height = sizes.isEmpty ? 0 : y + rowHeight
+        return (totalSize: CGSize(width: width, height: height), positions: positions)
     }
 }

--- a/app/MeetingTranscriber/Tests/ChipFlowLayoutTests.swift
+++ b/app/MeetingTranscriber/Tests/ChipFlowLayoutTests.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+@testable import MeetingTranscriber
+import XCTest
+
+final class ChipFlowLayoutTests: XCTestCase {
+    func testEmptyInputReturnsZero() {
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [], containerWidth: 200, spacing: 4,
+        )
+        XCTAssertEqual(result.totalSize, .zero)
+        XCTAssertEqual(result.positions, [])
+    }
+
+    func testSingleChipPlacedAtOrigin() {
+        let chip = CGSize(width: 60, height: 24)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [chip], containerWidth: 200, spacing: 4,
+        )
+        XCTAssertEqual(result.positions, [.zero])
+        XCTAssertEqual(result.totalSize.width, 60)
+        XCTAssertEqual(result.totalSize.height, 24)
+    }
+
+    func testTwoChipsShareRowWithSpacing() {
+        let a = CGSize(width: 60, height: 24)
+        let b = CGSize(width: 80, height: 24)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [a, b], containerWidth: 200, spacing: 4,
+        )
+        XCTAssertEqual(result.positions, [
+            .zero,
+            CGPoint(x: 64, y: 0),
+        ])
+        XCTAssertEqual(result.totalSize.width, 144)
+        XCTAssertEqual(result.totalSize.height, 24)
+    }
+
+    func testThirdChipWrapsToSecondRow() {
+        let chip = CGSize(width: 80, height: 24)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [chip, chip, chip], containerWidth: 200, spacing: 4,
+        )
+        // First two share row; third wraps because 80+4+80+4+80 = 248 > 200.
+        XCTAssertEqual(result.positions, [
+            .zero,
+            CGPoint(x: 84, y: 0),
+            CGPoint(x: 0, y: 28),
+        ])
+        XCTAssertEqual(result.totalSize.height, 52)
+    }
+
+    func testWidthCappedAtContainerWhenChipsOverflow() {
+        // Single chip wider than container — placed anyway, but reported
+        // width is capped so unconstrained parents don't get an infinite frame.
+        let wide = CGSize(width: 500, height: 24)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [wide], containerWidth: 200, spacing: 4,
+        )
+        XCTAssertEqual(result.positions, [.zero])
+        XCTAssertEqual(result.totalSize.width, 200)
+        XCTAssertEqual(result.totalSize.height, 24)
+    }
+
+    func testRowHeightFollowsTallestChipInRow() {
+        let short = CGSize(width: 40, height: 20)
+        let tall = CGSize(width: 40, height: 40)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [short, tall, short], containerWidth: 200, spacing: 4,
+        )
+        // All three fit one row; row height = max(20, 40, 20) = 40.
+        XCTAssertEqual(result.totalSize.height, 40)
+        // Positions all on y=0.
+        for pos in result.positions {
+            XCTAssertEqual(pos.y, 0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adopt the SwiftUI \`Layout\` protocol's cache mechanism in \`ChipFlowLayout\`. The previous implementation called \`sv.sizeThatFits(.unspecified)\` for every subview in **both** \`sizeThatFits\` and \`placeSubviews\` — doubling the work per layout pass. Cost grew linearly with the speaker DB (chip count == known voices count) and amplified re-render storms.

Also extracts the wrapping math into a static \`computeLayout\` helper so the row logic is unit-testable without a SwiftUI host.

## Why

Discovered while investigating a long-running \`MeetingTranscriber-Dev\` instance pinned at ~15 % CPU. A profiler sample showed the main thread spinning in \`NSDisplayCycleObserverInvoke\` → \`NSHostingView.SizeConstraints.update\` → \`ViewGraph.sizeThatFits\` recursion. \`ChipFlowLayout\` was flagged as a re-render-storm amplifier alongside the matcher init issue addressed in #167.

This is a secondary perf fix in the same chain.

## Test plan

- [x] \`ChipFlowLayoutTests\` — 6 tests covering empty input, single chip at origin, two chips sharing a row with spacing, third-chip wrap, oversize-chip width capping, tallest-chip row height
- [x] Existing \`SpeakerNamingViewTests\` (40 tests) still green — no behavior regression
- [x] \`./scripts/lint.sh\` — 0 violations