### PR TITLE
ci: cancel run when any job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
       - name: Install tools
@@ -58,12 +61,23 @@ jobs:
         run: swiftlint lint --strict --reporter github-actions-logging
       - name: Build script regression tests
         run: bash scripts/tests/test_build_release_signing.sh
+      # Cancels sibling jobs in this run; the workflow-level `concurrency`
+      # block only cancels superseded runs of the same ref.
+      - name: Cancel run on failure
+        if: failure()
+        continue-on-error: true
+        run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   analyze:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
       - name: Install SwiftLint
@@ -74,12 +88,21 @@ jobs:
           xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' build-for-testing 2>&1 | tee /tmp/xcodebuild.log
           cd "$GITHUB_WORKSPACE"
           swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging
+      - name: Cancel run on failure
+        if: failure()
+        continue-on-error: true
+        run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   test:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         variant: [homebrew, appstore]
@@ -116,3 +139,9 @@ jobs:
         run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ matrix.swift-flags }}
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}
+      - name: Cancel run on failure
+        if: failure()
+        continue-on-error: true
+        run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- When `lint`, `analyze`, or `test` fails, cancel the rest of the run via `gh run cancel` instead of letting siblings burn ~85 runner-minutes on a doomed run.
- Complements the existing workflow-level `concurrency` block, which only cancels superseded runs of the same ref — this handles intra-run failure.
- `actions: write` is scoped to the three jobs that need it; the `changes` job stays read-only.
- `continue-on-error: true` on the cancel step prevents a transient `gh` API hiccup from flipping a green job to failed.

## Test plan

- [ ] Open a follow-up PR that intentionally breaks lint and confirm `analyze` + both `test` matrix jobs flip to `cancelled` shortly after.
- [ ] Confirm a fully-green run is unaffected (cancel step is `if: failure()`, skipped on success).
- [ ] Confirm branch protection still blocks merge of failed/cancelled runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->