### PR TITLE
chore: gitignore docs/plans/.local for personal scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ tools/audiotap/.build/
 __pycache__/
 *.pyc
 .coverage
+
+# Local-only plans (open findings, research dumps, deferred work, history).
+# docs/plans/ stays committed for future-feature RFCs and reference docs.
+docs/plans/.local/


### PR DESCRIPTION
## Summary

Establishes a convention for plan files:

- \`docs/plans/\` — committed RFCs and reference docs (future features, architecture decisions visible to anyone reading the repo)
- \`docs/plans/.local/\` — gitignored personal scratch with optional subfolders:
  - \`open/\` active findings
  - \`research/\` diagnostic dumps, samples
  - \`done/\` completed plans (history)
  - \`future/\` drafts not yet promoted to committed RFC
  - \`deferred/\` pushed back

## Why

\`docs/plans/\` had collected a mix of committed and 14+ untracked files, making \`git status\` permanently noisy. Personal notes (real names, internal diagnostic dumps) risked leaking into the repo if accidentally committed.

## Test plan

- [x] \`git status\` no longer lists files inside \`docs/plans/.local/\`
- [x] Tracked files in \`docs/plans/\` (5 existing reference docs) untouched
- [ ] Convention documented in CLAUDE.md follow-up if useful for future maintainers — open question

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->