### PR TITLE
docs(claude): document docs/plans/.local convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,10 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 - All code and UI text in English
 - Protocol output language configurable via `AppSettings.protocolLanguage` (default: German)
+- **Plan files:**
+  - `docs/plans/` (committed) — RFCs and reference docs for future features that should be visible to anyone reading the repo
+  - `docs/plans/.local/` (gitignored) — personal scratch; optional subfolders `open/`, `research/`, `done/`, `future/`, `deferred/`
+  - Default to `.local/` for ad-hoc notes, diagnostic dumps, and active finding-trackers; promote to committed `docs/plans/` only when the plan is shared reference material
 
 ## Architecture Notes
 


### PR DESCRIPTION
Follow-up to #173: documents the plan-file layout under \`## Conventions\` in CLAUDE.md so future maintainers (and Claude in fresh sessions) discover it without having to re-derive from \`.gitignore\`.

Should have shipped with #173 but the merge landed before the second commit reached the PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->