### PR TITLE
ci: set predicate-quantifier=every for paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         uses: dorny/paths-filter@v4
         id: filter
         with:
+          # `every` is required for the exclusion-style filter below: with the
+          # v4 default `some`, the `**` catch-all alone marks every file as
+          # matched and the `!…` negations never actually exclude anything,
+          # so docs-only PRs still trigger the full build/test suite.
+          predicate-quantifier: every
           filters: |
             code:
               - '**'


### PR DESCRIPTION
## Summary

Pin \`predicate-quantifier: every\` on the \`dorny/paths-filter@v4\` step in the \`changes\` job. Without it, the exclusion-style filter (\`**\` plus a list of \`!…\` negations) silently degrades into a catch-all that always returns \`code = true\`.

## Why

\`dorny/paths-filter@v4\` changed the default \`predicate-quantifier\` from \`every\` (v3) to \`some\`. With \`some\`, only one rule has to consider a file matched for the filter to fire — and \`**\` always matches, so the \`!*.md\` / \`!docs/**\` / \`!.gitignore\` / \`!LICENSE\` rules never act as a veto. The negations become "rules that don't add a positive match" rather than "rules that exclude".

Concrete evidence — the \`changes\` job log on #174 (single file changed: \`CLAUDE.md\`):

\`\`\`
Detected 1 changed files
Filter code = true
Matching files:
CLAUDE.md [modified]
\`\`\`

This silently re-enabled the full lint/analyze/build/test matrix for every docs-only PR (#173, #174 both ran the macOS jobs).

\`every\` restores the v3 semantics the filter was originally written against: a file matches only if **all** rules agree — i.e. \`**\` matches AND no \`!…\` negation excludes it.

## Test plan

- [x] Local YAML diff trivial; no test infrastructure to run
- [ ] After merge: open a tiny docs-only PR (or rebase #174-style changes) and confirm \`changes.outputs.code\` evaluates to \`'false'\` and lint / analyze / build / test are skipped (status "skipped" in CI checks)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->