### PR TITLE
fix(test): preserve fixture in ResamplingIntegrationTests pipeline tests

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -320,6 +320,22 @@ class PipelineQueue {
         triggerProcessing()
     }
 
+    /// Wait for the queue to drain: any in-flight processing finishes and no
+    /// jobs remain in `.waiting`. Used by tests that enqueue a job and need to
+    /// observe a terminal state without racing against the spawned process task
+    /// from `enqueue` → `triggerProcessing()`.
+    func awaitProcessing() async {
+        while isProcessing || !pendingJobs.isEmpty {
+            if let task = processTask {
+                await task.value
+            } else {
+                // processTask not yet assigned — yield so the spawning Task
+                // can run.
+                await Task.yield()
+            }
+        }
+    }
+
     func removeJob(id: UUID) {
         if let index = jobs.firstIndex(where: { $0.id == id }) {
             markProcessed(mixPath: jobs[index].mixPath)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -450,6 +450,25 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(pQueue.jobs.isEmpty)
     }
 
+    func testAwaitProcessingReturnsImmediatelyWhenIdle() async {
+        let pQueue = makeProcessingQueue()
+        await pQueue.awaitProcessing()
+        XCTAssertFalse(pQueue.isProcessing)
+        XCTAssertTrue(pQueue.pendingJobs.isEmpty)
+    }
+
+    func testAwaitProcessingDrainsSpawnedTask() async {
+        let pQueue = makeProcessingQueue()
+        let job = makeJob()
+        pQueue.enqueue(job)
+        // Spawned task is in flight (or about to be). Without awaitProcessing,
+        // observers race against the spawned Task.
+        await pQueue.awaitProcessing()
+        XCTAssertFalse(pQueue.isProcessing, "queue should be idle after awaitProcessing")
+        XCTAssertTrue(pQueue.pendingJobs.isEmpty, "no jobs should remain in waiting")
+        XCTAssertNotEqual(pQueue.jobs.first?.state, .waiting)
+    }
+
     func testIsProcessingFlag() {
         let pQueue = makeProcessingQueue()
         XCTAssertFalse(pQueue.isProcessing)

--- a/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
@@ -24,6 +24,16 @@ final class ResamplingIntegrationTests: XCTestCase {
             .appendingPathComponent(name)
     }
 
+    /// Copy a fixture into the test's tmpDir. Use for pipeline tests because
+    /// `PipelineQueue.copyAudioToOutput` moves the source file out of place —
+    /// passing the original Fixtures/ path would delete the shared asset.
+    private func copyFixtureIntoTmp(_ name: String) throws -> URL {
+        let src = fixtureURL(name)
+        let dst = tmpDir.appendingPathComponent("\(UUID().uuidString)_\(name)")
+        try FileManager.default.copyItem(at: src, to: dst)
+        return dst
+    }
+
     // MARK: - WAV resampling produces valid 16kHz output
 
     func testResampleWAVFixtureTo16kHz() async throws {
@@ -71,8 +81,9 @@ final class ResamplingIntegrationTests: XCTestCase {
 
     @MainActor
     func testResampledAudioFlowsThroughPipeline() async throws {
-        let fixture = fixtureURL("two_speakers_de.m4a")
-        try XCTSkipUnless(FileManager.default.fileExists(atPath: fixture.path), "Fixture not found")
+        let fixtureSrc = fixtureURL("two_speakers_de.m4a")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: fixtureSrc.path), "Fixture not found")
+        let fixture = try copyFixtureIntoTmp("two_speakers_de.m4a")
 
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -97,9 +108,10 @@ final class ResamplingIntegrationTests: XCTestCase {
             micDelay: 0,
         )
         queue.enqueue(job)
-        await queue.processNext()
+        await queue.awaitProcessing()
 
-        XCTAssertEqual(queue.jobs.first?.state, .done)
+        let result = queue.jobs.first
+        XCTAssertEqual(result?.state, .done, "pipeline error: \(result?.error ?? "nil")")
         XCTAssertEqual(engine.transcribeCallCount, 1)
         XCTAssertTrue(protocolGen.generateCalled)
         XCTAssertTrue(protocolGen.capturedTranscript?.contains("Resampled audio works") ?? false)
@@ -109,8 +121,14 @@ final class ResamplingIntegrationTests: XCTestCase {
 
     @MainActor
     func testDualSourceResamplingFlowsThroughPipeline() async throws {
-        let fixture = fixtureURL("two_speakers_de.m4a")
-        try XCTSkipUnless(FileManager.default.fileExists(atPath: fixture.path), "Fixture not found")
+        let fixtureSrc = fixtureURL("two_speakers_de.m4a")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: fixtureSrc.path), "Fixture not found")
+        // Each track needs its own copy because copyAudioToOutput moves the
+        // source file once per (mix/app/mic) path, even when several point at
+        // the same URL.
+        let mixPath = try copyFixtureIntoTmp("two_speakers_de.m4a")
+        let appPath = try copyFixtureIntoTmp("two_speakers_de.m4a")
+        let micPath = try copyFixtureIntoTmp("two_speakers_de.m4a")
 
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -129,15 +147,16 @@ final class ResamplingIntegrationTests: XCTestCase {
         let job = PipelineJob(
             meetingTitle: "Dual Resample",
             appName: "Test",
-            mixPath: fixture,
-            appPath: fixture,
-            micPath: fixture,
+            mixPath: mixPath,
+            appPath: appPath,
+            micPath: micPath,
             micDelay: 0,
         )
         queue.enqueue(job)
-        await queue.processNext()
+        await queue.awaitProcessing()
 
-        XCTAssertEqual(queue.jobs.first?.state, .done)
+        let result = queue.jobs.first
+        XCTAssertEqual(result?.state, .done, "pipeline error: \(result?.error ?? "nil")")
         XCTAssertEqual(engine.transcribeCallCount, 2)
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause of the `test (homebrew)` flake** seen on PRs #164/#168/#169/#170 (tracked as P3 in `docs/plans/.local/open/2026-05-06-side-effects-review.md`): `ResamplingIntegrationTests.test(Dual)?Resampling*FlowsThroughPipeline` passed the shared `Tests/Fixtures/two_speakers_de.m4a` URL directly into `PipelineQueue` as `mixPath`/`appPath`/`micPath`. `PipelineQueue.copyAudioToOutput` later does `moveItem(at: src, to: dst)` on each of those — i.e. it permanently moved the fixture out of the repo working tree. The next ResamplingIntegrationTests run (or a parallel sibling) saw `resampleFile`'s fast-path `copyItem` fail because the source file no longer existed → `state=.error, transcribeCallCount=0`. Locally it stays "green" because the failure made the test self-skip on subsequent runs once the fixture was gone (`XCTSkipUnless`); CI does a fresh checkout each run, so the destruction is invisible there but the flake reproduces.
- Fix: per-test copies of the fixture into `tmpDir`, one per (mix/app/mic) track since each path is moved independently. Diagnostic: include `result?.error` in the assertion message so any future regression surfaces the actual error.
- While here: add `PipelineQueue.awaitProcessing()` helper and switch the tests to it, so they stop double-triggering processing (`enqueue(job); await processNext()` races the spawned `triggerProcessing()` task through MainActor).

## Test plan

- [x] `swift test --parallel` (1227 / 1227 passed locally)
- [x] `./scripts/lint.sh` (0 violations)
- [x] Repeated `swift test --filter ResamplingIntegrationTests` 10× — fixture survives, all green
- [x] Two new `PipelineQueueTests` covering `awaitProcessing()` (idle queue + drain-after-enqueue)
- [ ] CI `test (homebrew)` no longer flakes on this suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->