### PR TITLE
fix(app): hygiene batch — dead branch, lazy disk reads, migration cleanup, ID helper

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -373,6 +373,12 @@ final class AppSettings {
         } else {
             verboseDiagnostics = false
         }
+        // Drop legacy key once the new key is populated, so a future second
+        // migration pass can't resurrect a stale value.
+        if defaults.object(forKey: "audioDebugLogging") != nil,
+           defaults.object(forKey: "verboseDiagnostics") != nil {
+            defaults.removeObject(forKey: "audioDebugLogging")
+        }
         #if !APPSTORE
             debugRPCEnabled = defaults.object(forKey: "debugRPCEnabled") as? Bool ?? false
         #endif

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -32,6 +32,11 @@ struct PipelineJob: Identifiable, Codable {
     /// correlate diagnostic lines across the transcribe → diarize → protocol
     /// stages of the same job.
     var shortID: String {
+        Self.shortID(for: id)
+    }
+
+    /// Same format, callable when only the UUID is in scope.
+    static func shortID(for id: UUID) -> String {
         String(id.uuidString.prefix(8).lowercased())
     }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -843,7 +843,7 @@ class PipelineQueue {
         guard let protocolGeneratorFactory, let generator = protocolGeneratorFactory() else {
             return
         }
-        let shortID = String(jobID.uuidString.prefix(8).lowercased())
+        let shortID = PipelineJob.shortID(for: jobID)
         do {
             updateJobState(id: jobID, to: .generatingProtocol)
             startElapsedTimer()

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -13,7 +13,7 @@ struct OutputSettingsView: View {
     @State private var availableModels: [String] = []
     @State private var didAttemptConnectionTest = false
     @State private var showResetPromptConfirmation = false
-    @State private var hasCustomPrompt = FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path)
+    @State private var hasCustomPrompt = false
 
     enum ConnectionTestResult {
         case success(String)
@@ -75,6 +75,7 @@ struct OutputSettingsView: View {
             #if !APPSTORE
                 claudeBinaries = ClaudeCLIProtocolGenerator.availableClaudeBinaries()
             #endif
+            refreshCustomPromptState()
         }
     }
 

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -19,14 +19,9 @@ struct SettingsView: View {
     @State private var selection: SettingsTab = .general
 
     var body: some View {
-        if #available(macOS 13, *) {
-            splitView
-        } else {
-            tabContent
-        }
+        splitView
     }
 
-    @available(macOS 13, *)
     private var splitView: some View {
         NavigationSplitView {
             List(SettingsTab.allCases, selection: $selection) { tab in
@@ -81,24 +76,6 @@ struct SettingsView: View {
         case .advanced:
             AdvancedSettingsView(settings: settings)
         }
-    }
-
-    private var tabContent: some View {
-        TabView(selection: $selection) {
-            ForEach(SettingsTab.allCases) { tab in
-                detailView(for: tab)
-                    .tabItem { Label(tab.label, systemImage: tab.systemImage) }
-                    .tag(tab)
-            }
-        }
-        .frame(
-            minWidth: 760,
-            idealWidth: 860,
-            maxWidth: 1000,
-            minHeight: 520,
-            idealHeight: 640,
-            maxHeight: .infinity,
-        )
     }
 }
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -187,6 +187,9 @@ struct SpeakerNamingView: View {
         completedJobID = nil
         names = Self.computeInitialNames(speakers: speakers)
         rerunCount = max(2, speakers.count + 1)
+        // Indices are speaker-position based; a different speaker count would
+        // leave stale entries pointing at no-longer-rendered rows.
+        knownExpanded.removeAll()
     }
 
     private func speakerRow(

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -288,6 +288,25 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(migrated.verboseDiagnostics)
     }
 
+    func test_verboseDiagnostics_migrationRemovesLegacyKey() {
+        let suiteName = "AppSettingsTests-cleanup-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        suite.set(true, forKey: "audioDebugLogging")
+
+        _ = AppSettings(defaults: suite)
+
+        XCTAssertNil(
+            suite.object(forKey: "audioDebugLogging"),
+            "Legacy audioDebugLogging key should be removed once migrated to verboseDiagnostics",
+        )
+        XCTAssertTrue(suite.bool(forKey: "verboseDiagnostics"))
+    }
+
     // MARK: - Keychain
 
     func testKeychainRoundTrip() {

--- a/app/MeetingTranscriber/Tests/PipelineJobTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineJobTests.swift
@@ -119,6 +119,18 @@ final class PipelineJobTests: XCTestCase {
         XCTAssertNotEqual(a.shortID, b.shortID)
     }
 
+    func test_shortID_staticHelperMatchesInstanceProperty() {
+        let job = PipelineJob(
+            meetingTitle: "Standup",
+            appName: "Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        XCTAssertEqual(PipelineJob.shortID(for: job.id), job.shortID)
+    }
+
     func testJobStateRawValues() {
         XCTAssertEqual(JobState.waiting.rawValue, "waiting")
         XCTAssertEqual(JobState.transcribing.rawValue, "transcribing")


### PR DESCRIPTION
## Summary

Five small hygiene fixes from the 2026-05-06 side-effects review (findings L1, L2, L3, L7, M8). Independently safe; bundled because each is too small to justify its own PR.

- **L1** `b804964` — drop dead `if #available(macOS 13, *)` branch in `SettingsView` (deployment target is macOS 14)
- **L2** `d714356` — defer `hasCustomPrompt` disk check to `.onAppear`; previously ran on every parent re-render (#155-class footgun)
- **L3** `5d08eb5` — drop legacy `audioDebugLogging` UserDefaults key after migration to `verboseDiagnostics`, so a second migration pass can't resurrect a stale value
- **L7** `dbb8a04` — extract `PipelineJob.shortID(for:)` static helper; `PipelineQueue` no longer duplicates the `prefix(8).lowercased()` formatting
- **M8** `379e29f` — reset `knownExpanded` set between speaker-naming jobs; row indices are speaker-position based and would otherwise point at no-longer-rendered rows

## Test plan
- [x] `swift test --parallel --skip ModelPreloadTests` — only failures are pre-existing `MenuBarIconSnapshotTests` environment drift (verified to fail on `main` head identically)
- [x] `./scripts/lint.sh` clean
- [x] L3 covered by new `test_verboseDiagnostics_migrationRemovesLegacyKey`
- [x] L7 covered by new `test_shortID_staticHelperMatchesInstanceProperty`
- [ ] L1, L2, M8 not unit-tested — L1 is dead-code removal; L2 reads a global path (no easy injection seam); M8 is private `@State` not reachable via ViewInspector

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->