### PR TITLE
fix(app): preserve fractional precision in speaker-snippet sample range

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -365,11 +365,14 @@ struct SpeakerNamingView: View {
         Task.detached { [audioPath, longest] in
             do {
                 let (samples, sampleRate) = try await AudioMixer.loadAudioAsFloat32(url: audioPath)
-                let startSample = max(0, Int(longest.start) * sampleRate)
-                let endSample = min(samples.count, Int(longest.end) * sampleRate)
-                guard startSample < endSample else { return }
+                guard let range = Self.sampleRange(
+                    start: longest.start,
+                    end: longest.end,
+                    sampleRate: sampleRate,
+                    totalSamples: samples.count,
+                ) else { return }
 
-                let snippet = Array(samples[startSample ..< endSample])
+                let snippet = Array(samples[range])
                 let tmpPath = FileManager.default.temporaryDirectory
                     .appendingPathComponent("speaker_\(label).wav")
                 try AudioMixer.saveWAV(samples: snippet, sampleRate: sampleRate, url: tmpPath)
@@ -404,6 +407,24 @@ struct SpeakerNamingView: View {
     }
 
     // MARK: - Pure Functions (testable without UI)
+
+    /// Maps a [start, end] time range (seconds) to a clamped half-open sample range,
+    /// rounding down to whole samples. Returns `nil` when the resulting range is
+    /// empty (start >= end after clamping/conversion). Multiplies before truncation
+    /// so fractional starts (e.g. 1.7s) preserve precision; the previous inline code
+    /// did `Int(start) * sampleRate`, which discarded the sub-second offset and shifted
+    /// playback by up to ~1s into a different speaker.
+    static func sampleRange(
+        start: TimeInterval,
+        end: TimeInterval,
+        sampleRate: Int,
+        totalSamples: Int,
+    ) -> Range<Int>? {
+        let startSample = max(0, Int(start * Double(sampleRate)))
+        let endSample = min(totalSamples, Int(end * Double(sampleRate)))
+        guard startSample < endSample else { return nil }
+        return startSample ..< endSample
+    }
 
     /// Computes initial text field names from speaker auto-name mappings.
     static func computeInitialNames(

--- a/app/MeetingTranscriber/Tests/SampleRangeTests.swift
+++ b/app/MeetingTranscriber/Tests/SampleRangeTests.swift
@@ -1,0 +1,52 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Tests for the pure helper that maps a (start, end) seconds range to a
+/// clamped half-open sample range. Lives in its own file to keep
+/// `SpeakerNamingViewTests` under SwiftLint's `type_body_length` cap.
+final class SampleRangeTests: XCTestCase {
+    func testSampleRangeIntegerBoundaries() {
+        let result = SpeakerNamingView.sampleRange(
+            start: 1.0, end: 3.0, sampleRate: 16000, totalSamples: 100_000,
+        )
+        XCTAssertEqual(result, 16000 ..< 48000)
+    }
+
+    func testSampleRangeFractionalBoundariesPreservePrecision() {
+        // start = 1.7s at 16kHz must yield 27200, NOT 16000 (which is what
+        // `Int(1.7) * 16000 = 1 * 16000` would produce).
+        let result = SpeakerNamingView.sampleRange(
+            start: 1.7, end: 3.7, sampleRate: 16000, totalSamples: 100_000,
+        )
+        XCTAssertEqual(result, 27200 ..< 59200)
+    }
+
+    func testSampleRangeClampsEndToTotalSamples() {
+        let result = SpeakerNamingView.sampleRange(
+            start: 0.0, end: 100.0, sampleRate: 16000, totalSamples: 50000,
+        )
+        XCTAssertEqual(result, 0 ..< 50000)
+    }
+
+    func testSampleRangeClampsNegativeStartToZero() {
+        let result = SpeakerNamingView.sampleRange(
+            start: -0.5, end: 2.0, sampleRate: 16000, totalSamples: 100_000,
+        )
+        XCTAssertEqual(result?.lowerBound, 0)
+        XCTAssertEqual(result?.upperBound, 32000)
+    }
+
+    func testSampleRangeReturnsNilForZeroDuration() {
+        let result = SpeakerNamingView.sampleRange(
+            start: 1.0, end: 1.0, sampleRate: 16000, totalSamples: 100_000,
+        )
+        XCTAssertNil(result)
+    }
+
+    func testSampleRangeReturnsNilWhenStartAfterEnd() {
+        let result = SpeakerNamingView.sampleRange(
+            start: 5.0, end: 3.0, sampleRate: 16000, totalSamples: 100_000,
+        )
+        XCTAssertNil(result)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix a long-standing truncation bug in `SpeakerNamingView.playSpeakerSnippet`: `Int(start) * sampleRate` discarded the sub-second offset, shifting playback by up to ~1s and often into a different speaker entirely.
- Extract a pure `sampleRange(start:end:sampleRate:totalSamples:)` helper that multiplies before converting, then clamps to `[0, totalSamples]`.
- Independent of #166 — bug exists on `main` regardless of segment selection.

## Test plan
- [x] 6 new unit tests in `SampleRangeTests.swift` cover integer, fractional, end clamping, negative-start clamping, zero-duration, reversed-range cases.
- [x] TDD red→green confirmed: extracting the original buggy `Int(start) * sampleRate` produces `Range(16000..<48000)` for a (1.7, 3.7)s input at 16kHz; the fixed version produces `Range(27200..<59200)` — test 2 fails on the buggy version, passes on the fix.
- [x] `swift test --filter SampleRangeTests` green.
- [x] `./scripts/lint.sh` clean (0 violations / 140 files).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->