### PR TITLE
fix(app): rotate persistent diagnostic log across day boundaries

### DIFF
--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -40,6 +40,11 @@ enum PersistentDiagnosticLog {
         "diagnostics-\(fileNameFormatter.string(from: date)).log"
     }
 
+    /// UTC date stamp used to detect day boundaries — same formatter as filenames.
+    static func dateString(for date: Date) -> String {
+        fileNameFormatter.string(from: date)
+    }
+
     /// True when the file's mtime is older than `retentionDays` ago.
     static func isExpired(modifiedAt date: Date, retentionDays: Int) -> Bool {
         let cutoff = Date().addingTimeInterval(-Double(retentionDays) * 86400)
@@ -58,8 +63,7 @@ enum PersistentDiagnosticLog {
         /// running streamer so the caller can stop it on app shutdown.
         @discardableResult
         static func startForToday() throws -> Streamer {
-            let target = logDirectory.appendingPathComponent(logFileName(for: Date()))
-            let streamer = try Streamer(targetURL: target)
+            let streamer = try Streamer()
             try streamer.start()
             return streamer
         }
@@ -92,25 +96,37 @@ enum PersistentDiagnosticLog {
     #if !APPSTORE
         /// Wraps a running `log stream` subprocess that mirrors our subsystems
         /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
-        /// `init(targetURL:)` opens the file, `start()` launches the subprocess
-        /// and pipes its stdout into the file, `stop()` terminates the process
-        /// and closes the file handle.
+        /// `init(logDirectory:now:)` opens today's file, `start()` launches the
+        /// subprocess and pipes its stdout into the file, `stop()` terminates
+        /// the process and closes the file handle. The file rotates lazily
+        /// when `append(_:)` first sees a new UTC day.
         ///
         /// Gated `#if !APPSTORE` because `Process` is forbidden under sandbox.
         /// The App Store variant falls back to `OSLogStore` in `DiagnosticExporter`.
         final class Streamer {
             private let process = Process()
-            private let logFileHandle: FileHandle
             private let pipe = Pipe()
+            private let logDirectory: URL
+            private let now: () -> Date
+            private var logFileHandle: FileHandle
+            private var openedDateString: String
             private var isRunning = false
 
-            init(targetURL: URL) throws {
+            init(
+                logDirectory: URL = PersistentDiagnosticLog.logDirectory,
+                now: @escaping () -> Date = { Date() },
+            ) throws {
+                self.logDirectory = logDirectory
+                self.now = now
+                let date = now()
+                let target = logDirectory.appendingPathComponent(logFileName(for: date))
                 let fm = FileManager.default
-                if !fm.fileExists(atPath: targetURL.path) {
-                    fm.createFile(atPath: targetURL.path, contents: nil)
+                if !fm.fileExists(atPath: target.path) {
+                    fm.createFile(atPath: target.path, contents: nil)
                 }
-                self.logFileHandle = try FileHandle(forWritingTo: targetURL)
+                self.logFileHandle = try FileHandle(forWritingTo: target)
                 try self.logFileHandle.seekToEnd()
+                self.openedDateString = PersistentDiagnosticLog.dateString(for: date)
             }
 
             func start() throws {
@@ -129,7 +145,7 @@ enum PersistentDiagnosticLog {
                 handle.readabilityHandler = { [weak self] fh in
                     let data = fh.availableData
                     guard !data.isEmpty else { return }
-                    try? self?.logFileHandle.write(contentsOf: data)
+                    self?.append(data)
                 }
 
                 try process.run()
@@ -139,9 +155,41 @@ enum PersistentDiagnosticLog {
                 )
             }
 
+            /// Append `data` to the current day's file, rotating to the new
+            /// day's file first if the UTC date has changed since the handle
+            /// was opened. Test seam: also called by the readability handler.
+            func append(_ data: Data) {
+                rotateIfNeeded()
+                try? logFileHandle.write(contentsOf: data)
+            }
+
+            private func rotateIfNeeded() {
+                let date = now()
+                let today = PersistentDiagnosticLog.dateString(for: date)
+                guard today != openedDateString else { return }
+                let newURL = logDirectory.appendingPathComponent(logFileName(for: date))
+                let fm = FileManager.default
+                if !fm.fileExists(atPath: newURL.path) {
+                    fm.createFile(atPath: newURL.path, contents: nil)
+                }
+                // Open the new handle before closing the old one — if open
+                // fails (disk full, permissions), keep writing to the old
+                // file rather than silently dropping every subsequent entry.
+                guard let newHandle = try? FileHandle(forWritingTo: newURL) else { return }
+                try? newHandle.seekToEnd()
+                try? logFileHandle.close()
+                logFileHandle = newHandle
+                openedDateString = today
+                logger.info("persistent_log_streamer_rotated date=\(today, privacy: .public)")
+            }
+
             func stop() {
                 guard isRunning else { return }
                 process.terminate()
+                // Detach the readability callback before closing the file
+                // handle — otherwise a late callback could write to a
+                // recycled FD.
+                pipe.fileHandleForReading.readabilityHandler = nil
                 try? logFileHandle.close()
                 isRunning = false
                 logger.info("persistent_log_streamer_stopped")
@@ -150,6 +198,7 @@ enum PersistentDiagnosticLog {
             deinit {
                 if isRunning {
                     process.terminate()
+                    pipe.fileHandleForReading.readabilityHandler = nil
                     try? logFileHandle.close()
                 }
             }

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -86,4 +86,94 @@ final class PersistentDiagnosticLogTests: XCTestCase {
             .appendingPathComponent("PersistentDiagnosticLogTests-missing-\(UUID().uuidString)")
         PersistentDiagnosticLog.cleanup(in: bogus, retentionDays: 30)
     }
+
+    // MARK: - Streamer day-rotation
+
+    #if !APPSTORE
+        func test_streamer_rotatesToNewFileWhenDayChanges() throws {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmp) }
+
+            var clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-04T23:59:50Z"),
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(logDirectory: tmp) { clock }
+
+            streamer.append(Data("before-midnight\n".utf8))
+
+            clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-05T00:00:10Z"),
+            )
+            streamer.append(Data("after-midnight\n".utf8))
+
+            let day1 = tmp.appendingPathComponent("diagnostics-2026-05-04.log")
+            let day2 = tmp.appendingPathComponent("diagnostics-2026-05-05.log")
+
+            XCTAssertEqual(try String(contentsOf: day1), "before-midnight\n")
+            XCTAssertEqual(try String(contentsOf: day2), "after-midnight\n")
+        }
+
+        func test_streamer_keepsSameFileWhenDayUnchanged() throws {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmp) }
+
+            var clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-04T08:00:00Z"),
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(logDirectory: tmp) { clock }
+
+            streamer.append(Data("a\n".utf8))
+            clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-04T20:00:00Z"),
+            )
+            streamer.append(Data("b\n".utf8))
+
+            let day1 = tmp.appendingPathComponent("diagnostics-2026-05-04.log")
+            XCTAssertEqual(try String(contentsOf: day1), "a\nb\n")
+            // No second file should appear.
+            let entries = try FileManager.default.contentsOfDirectory(atPath: tmp.path)
+            XCTAssertEqual(entries.sorted(), ["diagnostics-2026-05-04.log"])
+        }
+
+        /// Regression guard: rotation must open the new handle BEFORE closing
+        /// the old one. If the old handle is closed eagerly and the new open
+        /// fails, every subsequent `append` would write to a closed FD and
+        /// silently drop entries.
+        func test_streamer_keepsWritingToOldFileWhenRotationOpenFails() throws {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            defer {
+                // Make the directory writable again so cleanup can remove it.
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755], ofItemAtPath: tmp.path,
+                )
+                try? FileManager.default.removeItem(at: tmp)
+            }
+
+            var clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-04T23:59:50Z"),
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(logDirectory: tmp) { clock }
+            streamer.append(Data("before\n".utf8))
+
+            // Make the directory read-only so creating tomorrow's file fails.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o555], ofItemAtPath: tmp.path,
+            )
+
+            clock = try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-05-05T00:00:10Z"),
+            )
+            streamer.append(Data("after\n".utf8))
+
+            // Old file kept being writable — entry landed there, not dropped.
+            let day1 = tmp.appendingPathComponent("diagnostics-2026-05-04.log")
+            XCTAssertEqual(try String(contentsOf: day1), "before\nafter\n")
+        }
+    #endif
 }


### PR DESCRIPTION
## Summary

The on-disk diagnostic log streamer (`PersistentDiagnosticLog.Streamer`) is started once at app launch and pinned to that day's `diagnostics-YYYY-MM-DD.log`. Long-running sessions keep writing to yesterday's file indefinitely, and `DiagnosticExporter` — which looks up *today's* filename via `Date()` — silently falls back to the OSLogStore 1h window once midnight passes, losing access to the disk-mirrored history of the current day.

### What changed
- `Streamer` now tracks the UTC date its handle was opened for. Each `append(_:)` re-opens against the new filename if the day has rolled over. Rotation is driven by the incoming log stream rather than a wall-clock timer — no Dispatch source or main-thread firing to manage.
- `Streamer.init` takes `(logDirectory:now:)` instead of a fixed `targetURL` — the URL is derived from the directory + injected clock, which makes day-rotation testable without launching `/usr/bin/log stream`.
- `startForToday()` collapses to `Streamer()` + `start()`.
- **Rotation atomicity:** the new file handle is opened *before* the old one is closed. If the new open fails (disk full, permissions), the old handle stays live and writes continue against yesterday's file rather than being silently dropped.
- **Bonus:** `stop()` and `deinit` now nil out `pipe.fileHandleForReading.readabilityHandler` before closing the file handle, removing a theoretical race where a late callback could write to a recycled FD.

### Out of scope
Process-termination handling (`process.terminationHandler`) and auto-restart on `log stream` crash were called out as adjacent issues but are tracked separately — they involve retry/backoff policy that deserves its own discussion.

## Test plan
- [x] New `test_streamer_rotatesToNewFileWhenDayChanges` — injects a clock, writes once at 23:59:50 UTC, advances to 00:00:10 UTC, writes again, asserts both date-stamped files exist with the correct content
- [x] New `test_streamer_keepsSameFileWhenDayUnchanged` — two writes 12 h apart on the same day, asserts a single file contains both
- [x] New `test_streamer_keepsWritingToOldFileWhenRotationOpenFails` — sets the directory to read-only, advances clock past midnight, asserts the entry still lands in yesterday's file (not dropped)
- [x] `swift test --parallel --skip ModelPreloadTests --skip MenuBarIconSnapshotTests` — 0 failures
- [x] `./scripts/lint.sh` clean