### PR TITLE
fix(app): re-arm Re-run button after each late diarization cycle

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -53,6 +53,19 @@ class PipelineQueue {
         let segments: [Segment] // for extracting speaker snippets
         let participants: [String] // Teams participant names as suggestions
         let isDualSource: Bool
+        /// Per-instance identity for SwiftUI `.onChange` change-detection.
+        /// Late re-diarization can produce a `mapping`/`speakingTimes` set
+        /// that compares byte-equal to the previous run (same speaker count,
+        /// same matcher output) — without a fresh marker, the naming view's
+        /// per-presentation reset never fires and consecutive Re-run clicks
+        /// are silently swallowed by the `completedJobID` guard. Excluded
+        /// from CodingKeys so disk reloads regenerate it.
+        var revision: UUID = .init()
+
+        private enum CodingKeys: String, CodingKey {
+            case jobID, meetingTitle, mapping, speakingTimes, embeddings,
+                 audioPath, segments, participants, isDualSource
+        }
 
         struct Segment: Codable {
             let start: TimeInterval

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -166,12 +166,12 @@ struct SpeakerNamingView: View {
         .frame(minWidth: 400, maxHeight: 700)
         .id(data.meetingTitle)
         .onAppear { resetForCurrentPresentation() }
-        // After Re-run, lateDiarization replaces `data.mapping` for the
-        // same jobID. Without resetting per-presentation @State here, the
-        // per-job guard kept Confirm/Skip/Re-run dead AND the stepper/names
-        // still reflected the previous diarization. `.onChange` fires after
-        // SwiftUI has propagated the new `data`, so `speakers` is current.
-        .onChange(of: data.mapping) { _, _ in
+        // After Re-run, lateDiarization replaces the SpeakerNamingData for
+        // the same jobID. Watching `data.revision` (a fresh UUID per
+        // instance) fires reliably even when the new mapping happens to be
+        // byte-identical to the previous one — otherwise the per-job
+        // `completedJobID` guard kept Confirm/Skip/Re-run dead.
+        .onChange(of: data.revision) { _, _ in
             resetForCurrentPresentation()
         }
         // No onDisappear → .skipped: in the non-blocking architecture closing

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1012,6 +1012,55 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(decoded.segments.count, 2)
     }
 
+    /// Regression: each `SpeakerNamingData` instance must carry a unique
+    /// `revision` so that SwiftUI `.onChange(of: data.revision)` fires on
+    /// every late-diarization re-render — even when the resulting mapping
+    /// happens to be byte-identical to the previous run. Without this,
+    /// the SpeakerNamingView's per-presentation `@State` reset never runs
+    /// and consecutive Re-run clicks are silently swallowed.
+    func test_speakerNamingData_revisionDiffersBetweenInstancesWithIdenticalContent() {
+        let jobID = UUID()
+        let mapping = ["SPEAKER_0": "Alice"]
+        let speakingTimes: [String: TimeInterval] = ["SPEAKER_0": 60]
+        let embeddings: [String: [Float]] = ["SPEAKER_0": [0.1, 0.2]]
+
+        let first = PipelineQueue.SpeakerNamingData(
+            jobID: jobID, meetingTitle: "Standup",
+            mapping: mapping, speakingTimes: speakingTimes,
+            embeddings: embeddings, audioPath: nil,
+            segments: [], participants: [], isDualSource: false,
+        )
+        let second = PipelineQueue.SpeakerNamingData(
+            jobID: jobID, meetingTitle: "Standup",
+            mapping: mapping, speakingTimes: speakingTimes,
+            embeddings: embeddings, audioPath: nil,
+            segments: [], participants: [], isDualSource: false,
+        )
+
+        XCTAssertNotEqual(first.revision, second.revision)
+    }
+
+    /// `revision` is a presentation-only marker and must not survive the
+    /// JSON sidecar round-trip — encoding leaves it out, decoding regenerates
+    /// it. Otherwise reloading the sidecar from disk would freeze the
+    /// revision and re-introduce the stuck-button bug after app restart.
+    func test_speakerNamingData_revisionRegeneratesOnJSONRoundTrip() throws {
+        let original = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(), meetingTitle: "Standup",
+            mapping: ["S": "Alice"], speakingTimes: ["S": 60],
+            embeddings: ["S": [0.1]], audioPath: nil,
+            segments: [], participants: [], isDualSource: false,
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PipelineQueue.SpeakerNamingData.self, from: encoded)
+
+        XCTAssertNotEqual(original.revision, decoded.revision)
+        // JSON payload must not contain the field name.
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertFalse(json.contains("revision"))
+    }
+
     func testPendingSpeakerNamingJobsReturnsNamingPendingJobs() {
         let queue = PipelineQueue(logDir: tmpDir)
         XCTAssertTrue(queue.pendingSpeakerNamingJobs.isEmpty)


### PR DESCRIPTION
## Symptom

User reports: in the speaker-naming dialog the Re-run button works the **first** time, but a **second** Re-run click immediately after silently does nothing. Closing the dialog and re-opening it via the menu makes the button responsive again — until the next pair of clicks reproduces the bug.

## Root cause

`SpeakerNamingView` carries a per-presentation `@State` guard `completedJobID: UUID?` that's set on click and cleared by `resetForCurrentPresentation()`. The reset has two triggers:

- `.onAppear { resetForCurrentPresentation() }` — fires on initial dialog show
- `.onChange(of: data.mapping) { _ in resetForCurrentPresentation() }` — fires when `lateDiarization` writes a new `SpeakerNamingData` into `speakerNamingDataByJob[jobID]` and the view re-renders

The second trigger is unreliable. `data.mapping` is a `[String: String]` whose contents can compare byte-equal between two diarization runs of the same audio (same speaker count → same labels; matcher fallback → same auto-names). When that happens, SwiftUI sees no value change, `.onChange` skips its closure, `completedJobID` stays equal to `data.jobID`, and the next Re-run / Confirm / Skip click hits `guard completedJobID != data.jobID else { return }` and is dropped.

The user's close+reopen workaround works because closing the window tears down the view's @State; the next presentation hits `.onAppear` instead of `.onChange`.

## Fix

Add a presentation-only `revision: UUID` field to `SpeakerNamingData`, freshly minted in each instance, excluded from `CodingKeys` so disk reloads regenerate it. Switch the view's reset watcher to `.onChange(of: data.revision)`. Each `buildNamingData(...)` call returns a new `SpeakerNamingData` with a new revision, so the watcher fires on every late re-diarization regardless of whether the resulting mapping content happens to be byte-identical.

## Test plan
- [x] New `test_speakerNamingData_revisionDiffersBetweenInstancesWithIdenticalContent` — proves the fresh-revision contract at the data layer
- [x] New `test_speakerNamingData_revisionRegeneratesOnJSONRoundTrip` — proves the field is excluded from the JSON sidecar so reload doesn't freeze the revision
- [x] All existing `PipelineQueueTests` and `SpeakerNamingViewTests` still pass (Codable round-trip, multi-job tap regressions, per-job guard tests)
- [x] Full suite: `swift test --parallel --skip ModelPreloadTests --skip MenuBarIconSnapshotTests` — 0 failures
- [x] `./scripts/lint.sh` clean
- [x] Manual: rebuild dev bundle, trigger speaker naming, click Re-run twice in a row, verify the second click triggers a fresh diarization

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->