### PR TITLE
fix(app): make speakers.json mutations race-free and gate RPC seeds

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -60,20 +60,19 @@
                     return merged ? .ok : .notFound
                 },
                 seed: { [weak self] name in
-                    let matcher = SpeakerMatcher()
-                    var stored = matcher.loadDB()
                     let embedding = (0 ..< Self.seedEmbeddingDimension).map { _ in
                         Float.random(in: -1 ... 1)
                     }
-                    stored.append(StoredSpeaker(
-                        name: name,
-                        embeddings: [embedding],
-                        centroid: embedding,
-                        centroidSampleCount: 1,
-                        lastUsed: Date(),
-                        useCount: 1,
-                    ))
-                    matcher.saveDB(stored)
+                    SpeakerMatcher().mutateDB { stored in
+                        stored.append(StoredSpeaker(
+                            name: name,
+                            embeddings: [embedding],
+                            centroid: embedding,
+                            centroidSampleCount: 1,
+                            lastUsed: Date(),
+                            useCount: 1,
+                        ))
+                    }
                     self?.pipelineQueue.refreshKnownSpeakerNames()
                     return .ok
                 },

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -71,6 +71,10 @@
                             centroidSampleCount: 1,
                             lastUsed: Date(),
                             useCount: 1,
+                            // Random vector — must never participate in
+                            // auto-naming a real speaker. Filtered out by
+                            // `SpeakerMatcher.matchVerbose`.
+                            isSynthetic: true,
                         ))
                     }
                     self?.pipelineQueue.refreshKnownSpeakerNames()

--- a/app/MeetingTranscriber/Sources/KnownVoicesView.swift
+++ b/app/MeetingTranscriber/Sources/KnownVoicesView.swift
@@ -71,13 +71,8 @@ struct KnownVoicesView: View {
             TextField("Filter…", text: $filter)
                 .textFieldStyle(.roundedBorder)
 
-            Table(filteredSpeakers, selection: $selection) {
-                TableColumn("Name", value: \.name)
-                TableColumn("Last used") { Text(Self.lastUsedLabel($0.lastUsed)) }
-                TableColumn("Uses") { Text("\($0.useCount)") }
-                TableColumn("Samples") { Text("\($0.embeddings.count)") }
-            }
-            .frame(minHeight: 280)
+            speakerTable
+                .frame(minHeight: 280)
 
             actionButtonsRow
             if pipelineBusy, diarizerFactory != nil {
@@ -197,6 +192,35 @@ struct KnownVoicesView: View {
         }
         .padding(20)
         .frame(minWidth: 360)
+    }
+
+    private var speakerTable: some View {
+        Table(filteredSpeakers, selection: $selection) {
+            TableColumn("Name") { speaker in
+                HStack(spacing: 6) {
+                    Text(speaker.name)
+                    if speaker.isSynthetic {
+                        syntheticTag
+                    }
+                }
+            }
+            TableColumn("Last used") { Text(Self.lastUsedLabel($0.lastUsed)) }
+            TableColumn("Uses") { Text("\($0.useCount)") }
+            TableColumn("Samples") { Text("\($0.embeddings.count)") }
+        }
+    }
+
+    private var syntheticTag: some View {
+        Text("synthetic")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .overlay(Capsule().stroke(.secondary.opacity(0.5), lineWidth: 1))
+            .help(
+                "Seeded via debug RPC with a random embedding."
+                    + " Excluded from auto-naming. Delete to remove.",
+            )
     }
 
     // MARK: - Derived

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -7,88 +7,6 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "SpeakerMatcher")
 
-struct StoredSpeaker: Codable, Identifiable {
-    var id: String {
-        name
-    }
-
-    let name: String
-    /// Recent quality samples (FIFO, max `SpeakerMatcher.maxRecentSamples`).
-    /// Used as a fallback when the centroid match is borderline, and as the
-    /// seed for `centroid` on first confirmation after the v3 schema upgrade.
-    let embeddings: [[Float]]
-    /// Running mean of all quality-filtered embeddings ever confirmed for this
-    /// speaker. The primary match anchor in v3+. nil for legacy entries; the
-    /// matcher computes `meanEmbedding(embeddings)` lazily until the next
-    /// confirmation persists a real centroid.
-    let centroid: [Float]?
-    /// Number of embeddings folded into `centroid` so far. Drives the running-
-    /// average update math and tells us whether we trust the centroid.
-    let centroidSampleCount: Int
-    /// Wall-clock time when this speaker was last confirmed by the user via
-    /// `updateDB`. Used to rank suggestion chips by recency. nil for entries
-    /// migrated from older DB versions that didn't track usage.
-    let lastUsed: Date?
-    /// Number of times this speaker has been confirmed by the user across
-    /// recordings. Defaults to 0 for entries that pre-date usage tracking.
-    let useCount: Int
-
-    // Migrate old single-embedding format automatically (legacy `embedding`
-    // key); default lastUsed/useCount for entries before recency tracking;
-    // default centroid/centroidSampleCount for entries before v3 schema.
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try container.decode(String.self, forKey: .name)
-        if let multi = try? container.decode([[Float]].self, forKey: .embeddings) {
-            embeddings = multi
-        } else if let single = try? container.decode([Float].self, forKey: .embedding) {
-            embeddings = [single]
-        } else {
-            embeddings = []
-        }
-        centroid = try container.decodeIfPresent([Float].self, forKey: .centroid)
-        centroidSampleCount = try container.decodeIfPresent(Int.self, forKey: .centroidSampleCount) ?? 0
-        lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
-        useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
-    }
-
-    init(
-        name: String,
-        embeddings: [[Float]],
-        centroid: [Float]? = nil,
-        centroidSampleCount: Int = 0,
-        lastUsed: Date? = nil,
-        useCount: Int = 0,
-    ) {
-        self.name = name
-        self.embeddings = embeddings
-        self.centroid = centroid
-        self.centroidSampleCount = centroidSampleCount
-        self.lastUsed = lastUsed
-        self.useCount = useCount
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name, embeddings, embedding, centroid, centroidSampleCount, lastUsed, useCount
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
-        try container.encode(embeddings, forKey: .embeddings)
-        try container.encodeIfPresent(centroid, forKey: .centroid)
-        if centroidSampleCount > 0 {
-            try container.encode(centroidSampleCount, forKey: .centroidSampleCount)
-        }
-        try container.encodeIfPresent(lastUsed, forKey: .lastUsed)
-        // Skip when 0 so entries that pre-date recency tracking round-trip
-        // byte-identical (no spurious useCount=0 field added on first save).
-        if useCount > 0 {
-            try container.encode(useCount, forKey: .useCount)
-        }
-    }
-}
-
 class SpeakerMatcher {
     private let dbPath: URL
     private let threshold: Float
@@ -100,12 +18,33 @@ class SpeakerMatcher {
     /// into the centroid. Short snippets are still kept as fallback samples
     /// but don't pollute the running average.
     static let minSpeakingTimeForCentroid: TimeInterval = 3.0
+    /// Process-wide lock for read-modify-write sequences against
+    /// `speakers.json`. The RPC handlers, the pipeline-job confirmation
+    /// path, the KnownVoices UI, and voice enrollment can all mutate the
+    /// DB concurrently — without serialization, two writers can both load
+    /// the same snapshot and the second `saveDB` silently overwrites the
+    /// first. Reads stay unlocked: every code path reloads after a
+    /// mutation anyway, and `replaceItemAt` already gives atomic file
+    /// replacement at the FS level.
+    private static let dbLock = NSLock()
 
     init(dbPath: URL? = nil, threshold: Float = 0.40, confidenceMargin: Float = 0.10) {
         self.dbPath = dbPath ?? AppPaths.speakersDB
         self.threshold = threshold
         self.confidenceMargin = confidenceMargin
         Self.migrateIfNeeded(dbPath: self.dbPath)
+    }
+
+    /// Atomic read-modify-write against `speakers.json`. Holds the
+    /// process-wide DB lock for the duration of the closure so concurrent
+    /// callers can't lose updates. Use this for every mutating operation;
+    /// raw `loadDB` + `saveDB` paired by hand reintroduces the race.
+    func mutateDB(_ block: (inout [StoredSpeaker]) -> Void) {
+        Self.dbLock.lock()
+        defer { Self.dbLock.unlock() }
+        var stored = loadDB()
+        block(&stored)
+        saveDB(stored)
     }
 
     /// Reset old pyannote-format speakers.json (incompatible embeddings).
@@ -257,27 +196,25 @@ class SpeakerMatcher {
         speakingTimes: [String: TimeInterval] = [:],
         now: Date = Date(),
     ) {
-        var stored = loadDB()
+        mutateDB { stored in
+            for (label, name) in mapping {
+                guard name != label, let embedding = embeddings[label] else { continue }
+                let duration = speakingTimes[label] ?? 0
 
-        for (label, name) in mapping {
-            guard name != label, let embedding = embeddings[label] else { continue }
-            let duration = speakingTimes[label] ?? 0
-
-            if let idx = stored.firstIndex(where: { $0.name == name }) {
-                stored[idx] = Self.applyConfirmation(
-                    to: stored[idx],
-                    embedding: embedding,
-                    duration: duration,
-                    now: now,
-                )
-            } else {
-                stored.append(Self.newSpeaker(
-                    name: name, embedding: embedding, duration: duration, now: now,
-                ))
+                if let idx = stored.firstIndex(where: { $0.name == name }) {
+                    stored[idx] = Self.applyConfirmation(
+                        to: stored[idx],
+                        embedding: embedding,
+                        duration: duration,
+                        now: now,
+                    )
+                } else {
+                    stored.append(Self.newSpeaker(
+                        name: name, embedding: embedding, duration: duration, now: now,
+                    ))
+                }
             }
         }
-
-        saveDB(stored)
     }
 
     /// Pure helper: fold a confirmed embedding into an existing `StoredSpeaker`.
@@ -351,37 +288,42 @@ class SpeakerMatcher {
     @discardableResult
     func renameSpeaker(from: String, to: String) -> RenameResult {
         guard from != to else { return .noop }
-        var stored = loadDB()
-        guard let srcIdx = stored.firstIndex(where: { $0.name == from }) else {
-            return .notFound
+        var outcome: RenameResult = .notFound
+        mutateDB { stored in
+            guard let srcIdx = stored.firstIndex(where: { $0.name == from }) else {
+                outcome = .notFound
+                return
+            }
+            if let dstIdx = stored.firstIndex(where: { $0.name == to }) {
+                stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
+                stored.remove(at: srcIdx)
+                outcome = .merged
+                return
+            }
+            let src = stored[srcIdx]
+            stored[srcIdx] = StoredSpeaker(
+                name: to,
+                embeddings: src.embeddings,
+                centroid: src.centroid,
+                centroidSampleCount: src.centroidSampleCount,
+                lastUsed: src.lastUsed,
+                useCount: src.useCount,
+            )
+            outcome = .renamed
         }
-        if let dstIdx = stored.firstIndex(where: { $0.name == to }) {
-            stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
-            stored.remove(at: srcIdx)
-            saveDB(stored)
-            return .merged
-        }
-        let src = stored[srcIdx]
-        stored[srcIdx] = StoredSpeaker(
-            name: to,
-            embeddings: src.embeddings,
-            centroid: src.centroid,
-            centroidSampleCount: src.centroidSampleCount,
-            lastUsed: src.lastUsed,
-            useCount: src.useCount,
-        )
-        saveDB(stored)
-        return .renamed
+        return outcome
     }
 
     /// Remove a speaker. Returns `false` if no speaker with that name was found.
     @discardableResult
     func deleteSpeaker(name: String) -> Bool {
-        var stored = loadDB()
-        guard let idx = stored.firstIndex(where: { $0.name == name }) else { return false }
-        stored.remove(at: idx)
-        saveDB(stored)
-        return true
+        var removed = false
+        mutateDB { stored in
+            guard let idx = stored.firstIndex(where: { $0.name == name }) else { return }
+            stored.remove(at: idx)
+            removed = true
+        }
+        return removed
     }
 
     /// Merge `from` into `into`. Embeddings concatenated and FIFO-trimmed,
@@ -390,15 +332,17 @@ class SpeakerMatcher {
     @discardableResult
     func mergeSpeakers(from: String, into: String) -> Bool {
         guard from != into else { return false }
-        var stored = loadDB()
-        guard let srcIdx = stored.firstIndex(where: { $0.name == from }),
-              let dstIdx = stored.firstIndex(where: { $0.name == into }) else {
-            return false
+        var ok = false
+        mutateDB { stored in
+            guard let srcIdx = stored.firstIndex(where: { $0.name == from }),
+                  let dstIdx = stored.firstIndex(where: { $0.name == into }) else {
+                return
+            }
+            stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
+            stored.removeAll { $0.name == from }
+            ok = true
         }
-        stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
-        stored.removeAll { $0.name == from }
-        saveDB(stored)
-        return true
+        return ok
     }
 
     /// Pure helper: combine `src` into `dst`. Used by both rename-collision

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -39,12 +39,14 @@ class SpeakerMatcher {
     /// process-wide DB lock for the duration of the closure so concurrent
     /// callers can't lose updates. Use this for every mutating operation;
     /// raw `loadDB` + `saveDB` paired by hand reintroduces the race.
-    func mutateDB(_ block: (inout [StoredSpeaker]) -> Void) {
+    @discardableResult
+    func mutateDB<R>(_ block: (inout [StoredSpeaker]) -> R) -> R {
         Self.dbLock.lock()
         defer { Self.dbLock.unlock() }
         var stored = loadDB()
-        block(&stored)
+        let result = block(&stored)
         saveDB(stored)
+        return result
     }
 
     /// Reset old pyannote-format speakers.json (incompatible embeddings).
@@ -87,7 +89,10 @@ class SpeakerMatcher {
     /// with their per-anchor distances.
     func matchVerbose(embeddings: [String: [Float]], topK: Int = 3)
         -> [String: VerboseMatch] {
-        let stored = loadDB()
+        // Synthetic entries (RPC `seedSpeaker`) carry random embeddings —
+        // letting them participate in matching would let any caller with
+        // RPC access poison auto-naming. Drop them before scoring.
+        let stored = loadDB().filter { !$0.isSynthetic }
         var result: [String: VerboseMatch] = [:]
         var usedNames: Set<String> = []
 
@@ -288,42 +293,28 @@ class SpeakerMatcher {
     @discardableResult
     func renameSpeaker(from: String, to: String) -> RenameResult {
         guard from != to else { return .noop }
-        var outcome: RenameResult = .notFound
-        mutateDB { stored in
+        return mutateDB { stored in
             guard let srcIdx = stored.firstIndex(where: { $0.name == from }) else {
-                outcome = .notFound
-                return
+                return .notFound
             }
             if let dstIdx = stored.firstIndex(where: { $0.name == to }) {
                 stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
                 stored.remove(at: srcIdx)
-                outcome = .merged
-                return
+                return .merged
             }
-            let src = stored[srcIdx]
-            stored[srcIdx] = StoredSpeaker(
-                name: to,
-                embeddings: src.embeddings,
-                centroid: src.centroid,
-                centroidSampleCount: src.centroidSampleCount,
-                lastUsed: src.lastUsed,
-                useCount: src.useCount,
-            )
-            outcome = .renamed
+            stored[srcIdx] = stored[srcIdx].renamed(to: to)
+            return .renamed
         }
-        return outcome
     }
 
     /// Remove a speaker. Returns `false` if no speaker with that name was found.
     @discardableResult
     func deleteSpeaker(name: String) -> Bool {
-        var removed = false
         mutateDB { stored in
-            guard let idx = stored.firstIndex(where: { $0.name == name }) else { return }
+            guard let idx = stored.firstIndex(where: { $0.name == name }) else { return false }
             stored.remove(at: idx)
-            removed = true
+            return true
         }
-        return removed
     }
 
     /// Merge `from` into `into`. Embeddings concatenated and FIFO-trimmed,
@@ -332,17 +323,15 @@ class SpeakerMatcher {
     @discardableResult
     func mergeSpeakers(from: String, into: String) -> Bool {
         guard from != into else { return false }
-        var ok = false
-        mutateDB { stored in
+        return mutateDB { stored in
             guard let srcIdx = stored.firstIndex(where: { $0.name == from }),
                   let dstIdx = stored.firstIndex(where: { $0.name == into }) else {
-                return
+                return false
             }
             stored[dstIdx] = Self.merged(into: stored[dstIdx], from: stored[srcIdx])
             stored.removeAll { $0.name == from }
-            ok = true
+            return true
         }
-        return ok
     }
 
     /// Pure helper: combine `src` into `dst`. Used by both rename-collision
@@ -370,6 +359,9 @@ class SpeakerMatcher {
             centroidSampleCount: combined.count,
             lastUsed: lastUsed,
             useCount: dst.useCount + src.useCount,
+            // Stay synthetic only when both sides are synthetic. Merging a
+            // real entry in promotes the result back to real.
+            isSynthetic: dst.isSynthetic && src.isSynthetic,
         )
     }
 

--- a/app/MeetingTranscriber/Sources/StoredSpeaker.swift
+++ b/app/MeetingTranscriber/Sources/StoredSpeaker.swift
@@ -1,0 +1,89 @@
+// swiftlint:disable discouraged_optional_collection
+// Optional `[Float]?` is intentional: nil signals "no centroid yet" (legacy
+// entries / dim-mismatch / empty input), which is semantically distinct from
+// an empty embedding vector.
+import Foundation
+
+struct StoredSpeaker: Codable, Identifiable {
+    var id: String {
+        name
+    }
+
+    let name: String
+    /// Recent quality samples (FIFO, max `SpeakerMatcher.maxRecentSamples`).
+    /// Used as a fallback when the centroid match is borderline, and as the
+    /// seed for `centroid` on first confirmation after the v3 schema upgrade.
+    let embeddings: [[Float]]
+    /// Running mean of all quality-filtered embeddings ever confirmed for this
+    /// speaker. The primary match anchor in v3+. nil for legacy entries; the
+    /// matcher computes `meanEmbedding(embeddings)` lazily until the next
+    /// confirmation persists a real centroid.
+    let centroid: [Float]?
+    /// Number of embeddings folded into `centroid` so far. Drives the running-
+    /// average update math and tells us whether we trust the centroid.
+    let centroidSampleCount: Int
+    /// Wall-clock time when this speaker was last confirmed by the user via
+    /// `updateDB`. Used to rank suggestion chips by recency. nil for entries
+    /// migrated from older DB versions that didn't track usage.
+    let lastUsed: Date?
+    /// Number of times this speaker has been confirmed by the user across
+    /// recordings. Defaults to 0 for entries that pre-date usage tracking.
+    let useCount: Int
+
+    // Migrate old single-embedding format automatically (legacy `embedding`
+    // key); default lastUsed/useCount for entries before recency tracking;
+    // default centroid/centroidSampleCount for entries before v3 schema.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        if let multi = try? container.decode([[Float]].self, forKey: .embeddings) {
+            embeddings = multi
+        } else if let single = try? container.decode([Float].self, forKey: .embedding) {
+            embeddings = [single]
+        } else {
+            embeddings = []
+        }
+        centroid = try container.decodeIfPresent([Float].self, forKey: .centroid)
+        centroidSampleCount = try container.decodeIfPresent(Int.self, forKey: .centroidSampleCount) ?? 0
+        lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
+        useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
+    }
+
+    init(
+        name: String,
+        embeddings: [[Float]],
+        centroid: [Float]? = nil,
+        centroidSampleCount: Int = 0,
+        lastUsed: Date? = nil,
+        useCount: Int = 0,
+    ) {
+        self.name = name
+        self.embeddings = embeddings
+        self.centroid = centroid
+        self.centroidSampleCount = centroidSampleCount
+        self.lastUsed = lastUsed
+        self.useCount = useCount
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, embeddings, embedding, centroid, centroidSampleCount, lastUsed, useCount
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(embeddings, forKey: .embeddings)
+        try container.encodeIfPresent(centroid, forKey: .centroid)
+        if centroidSampleCount > 0 {
+            try container.encode(centroidSampleCount, forKey: .centroidSampleCount)
+        }
+        try container.encodeIfPresent(lastUsed, forKey: .lastUsed)
+        // Skip when 0 so entries that pre-date recency tracking round-trip
+        // byte-identical (no spurious useCount=0 field added on first save).
+        if useCount > 0 {
+            try container.encode(useCount, forKey: .useCount)
+        }
+    }
+}
+
+// swiftlint:enable discouraged_optional_collection

--- a/app/MeetingTranscriber/Sources/StoredSpeaker.swift
+++ b/app/MeetingTranscriber/Sources/StoredSpeaker.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable discouraged_optional_collection
-// Optional `[Float]?` is intentional: nil signals "no centroid yet" (legacy
-// entries / dim-mismatch / empty input), which is semantically distinct from
-// an empty embedding vector.
+// `centroid: [Float]?` and `lastUsed: Date?` use nil to signal a distinct
+// "absent" state (no centroid yet / never confirmed), which an empty
+// collection cannot express.
 import Foundation
 
 struct StoredSpeaker: Codable, Identifiable {
@@ -29,6 +29,12 @@ struct StoredSpeaker: Codable, Identifiable {
     /// Number of times this speaker has been confirmed by the user across
     /// recordings. Defaults to 0 for entries that pre-date usage tracking.
     let useCount: Int
+    /// True for entries seeded by the debug RPC `seedSpeaker` action, which
+    /// writes random embeddings for testing. Synthetic entries are skipped
+    /// in `match()`/`matchVerbose()` so a poisoned random vector can never
+    /// auto-name a real speaker. Defaults to false for legacy entries and
+    /// for every user-confirmed speaker.
+    let isSynthetic: Bool
 
     // Migrate old single-embedding format automatically (legacy `embedding`
     // key); default lastUsed/useCount for entries before recency tracking;
@@ -47,6 +53,7 @@ struct StoredSpeaker: Codable, Identifiable {
         centroidSampleCount = try container.decodeIfPresent(Int.self, forKey: .centroidSampleCount) ?? 0
         lastUsed = try container.decodeIfPresent(Date.self, forKey: .lastUsed)
         useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
+        isSynthetic = try container.decodeIfPresent(Bool.self, forKey: .isSynthetic) ?? false
     }
 
     init(
@@ -56,6 +63,7 @@ struct StoredSpeaker: Codable, Identifiable {
         centroidSampleCount: Int = 0,
         lastUsed: Date? = nil,
         useCount: Int = 0,
+        isSynthetic: Bool = false,
     ) {
         self.name = name
         self.embeddings = embeddings
@@ -63,10 +71,12 @@ struct StoredSpeaker: Codable, Identifiable {
         self.centroidSampleCount = centroidSampleCount
         self.lastUsed = lastUsed
         self.useCount = useCount
+        self.isSynthetic = isSynthetic
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, embeddings, embedding, centroid, centroidSampleCount, lastUsed, useCount
+        case name, embeddings, embedding, centroid, centroidSampleCount,
+             lastUsed, useCount, isSynthetic
     }
 
     func encode(to encoder: Encoder) throws {
@@ -83,6 +93,25 @@ struct StoredSpeaker: Codable, Identifiable {
         if useCount > 0 {
             try container.encode(useCount, forKey: .useCount)
         }
+        // Same byte-identity rule for legacy entries.
+        if isSynthetic {
+            try container.encode(isSynthetic, forKey: .isSynthetic)
+        }
+    }
+
+    /// Copy of this speaker with a new `name`, preserving all other fields.
+    /// Used by `SpeakerMatcher.renameSpeaker`; centralises the field list so
+    /// future additions don't have to be threaded through the rename site.
+    func renamed(to newName: String) -> Self {
+        Self(
+            name: newName,
+            embeddings: embeddings,
+            centroid: centroid,
+            centroidSampleCount: centroidSampleCount,
+            lastUsed: lastUsed,
+            useCount: useCount,
+            isSynthetic: isSynthetic,
+        )
     }
 }
 

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -963,4 +963,65 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result.centroid?[1] ?? 0, 0.25, accuracy: 0.001)
         XCTAssertEqual(result.count, 4)
     }
+
+    // MARK: - Concurrent write serialization
+
+    /// Read-modify-write across concurrent callers must not lose updates.
+    /// Each task appends a uniquely-named entry; with proper locking the
+    /// final count equals the number of mutations. Without locking, two
+    /// tasks can read the same snapshot and one save overwrites the other.
+    func testMutateDBSerializesConcurrentReadModifyWrites() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([StoredSpeaker(name: "seed", embeddings: [[1]])])
+
+        let iterations = 100
+        let group = DispatchGroup()
+        for i in 0 ..< iterations {
+            group.enter()
+            DispatchQueue.global().async { [dbPath] in
+                let m = SpeakerMatcher(dbPath: dbPath)
+                m.mutateDB { stored in
+                    stored.append(StoredSpeaker(name: "x\(i)", embeddings: [[1]]))
+                }
+                group.leave()
+            }
+        }
+        group.wait()
+
+        let final = matcher.loadDB()
+        XCTAssertEqual(
+            final.count, iterations + 1,
+            "Lost updates from unsynchronized RMW: expected \(iterations + 1), got \(final.count)",
+        )
+    }
+
+    /// High-level public API must also be race-free — RPC `renameSpeaker`
+    /// can fire concurrently with a pipeline-job confirmation, both calling
+    /// the same matcher methods. Each thread renames a distinct entry; all
+    /// renames must survive.
+    func testRenameSpeakerConcurrentDoesNotLoseUpdates() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let count = 50
+        let initial = (0 ..< count).map { idx in
+            StoredSpeaker(name: "S\(idx)", embeddings: [[Float(idx)]])
+        }
+        matcher.saveDB(initial)
+
+        let group = DispatchGroup()
+        for i in 0 ..< count {
+            group.enter()
+            DispatchQueue.global().async { [dbPath] in
+                let m = SpeakerMatcher(dbPath: dbPath)
+                m.renameSpeaker(from: "S\(i)", to: "P\(i)")
+                group.leave()
+            }
+        }
+        group.wait()
+
+        let names = Set(matcher.loadDB().map(\.name))
+        for i in 0 ..< count {
+            XCTAssertTrue(names.contains("P\(i)"), "Lost rename for P\(i)")
+        }
+        XCTAssertEqual(names.count, count, "Final DB has wrong entry count")
+    }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -964,6 +964,60 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result.count, 4)
     }
 
+    // MARK: - Synthetic speaker marker
+
+    /// Legacy entries written before the `isSynthetic` field existed must
+    /// decode as `false` so a database upgrade doesn't turn real speakers
+    /// invisible.
+    func testStoredSpeakerDecodesLegacyEntryWithIsSyntheticFalse() throws {
+        let json = Data(#"[{"name":"A","embeddings":[[1,0,0]]}]"#.utf8)
+        let decoded = try JSONDecoder().decode([StoredSpeaker].self, from: json)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertFalse(decoded[0].isSynthetic)
+    }
+
+    func testStoredSpeakerCodableRoundTripPreservesIsSynthetic() throws {
+        let original = StoredSpeaker(
+            name: "X", embeddings: [[1, 0, 0]], isSynthetic: true,
+        )
+        let data = try JSONEncoder().encode([original])
+        let decoded = try JSONDecoder().decode([StoredSpeaker].self, from: data)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertTrue(decoded[0].isSynthetic)
+    }
+
+    /// `seedSpeaker` (RPC) writes random embeddings. Without a synthetic
+    /// marker, these poison every future match — even the closest query
+    /// would be auto-named after the random vector. The match path must
+    /// skip synthetic anchors.
+    func testMatchExcludesSyntheticSpeakers() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let stored = [
+            StoredSpeaker(name: "Synth", embeddings: [[1, 0, 0]], isSynthetic: true),
+        ]
+        matcher.saveDB(stored)
+
+        // Query practically identical to "Synth" — without filter, "Synth" wins.
+        let result = matcher.match(embeddings: ["SPEAKER_0": [0.99, 0.01, 0]])
+        XCTAssertEqual(
+            result["SPEAKER_0"], "SPEAKER_0",
+            "Synthetic speaker leaked into match() output",
+        )
+    }
+
+    func testMatchVerboseExcludesSyntheticFromTopCandidates() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([
+            StoredSpeaker(name: "Real", embeddings: [[0, 1, 0]]),
+            StoredSpeaker(name: "Synth", embeddings: [[1, 0, 0]], isSynthetic: true),
+        ])
+        let verbose = matcher.matchVerbose(
+            embeddings: ["SPEAKER_0": [0.99, 0.01, 0]],
+        )
+        let names = verbose["SPEAKER_0"]?.topCandidates.map(\.name) ?? []
+        XCTAssertFalse(names.contains("Synth"), "Synthetic anchor in topCandidates")
+    }
+
     // MARK: - Concurrent write serialization
 
     /// Read-modify-write across concurrent callers must not lose updates.


### PR DESCRIPTION
## Summary

Two related side-effect fixes to the persisted speaker DB. Both touch the same code paths (every mutation site goes through `SpeakerMatcher`), so they ship together as separate commits.

### Commit 1 — Concurrent write lost-update

Every write site (RPC `/action/{rename,delete,merge,seed}Speaker`, pipeline-job confirmation, `KnownVoicesView`, `VoiceEnrollmentView`) constructs a fresh `SpeakerMatcher()` and runs a load-mutate-save sequence. There's no lock between `loadDB()` and `saveDB(stored)`, so two writers can both load the same snapshot and the second `saveDB` silently overwrites the first — a classic lost-update race for `speakers.json`.

Fix: process-wide `NSLock` + new `mutateDB(_:)` helper that wraps `load → block → save` under the lock. All four mutating methods (`renameSpeaker`, `deleteSpeaker`, `mergeSpeakers`, `updateDB`) and the RPC `seedSpeaker` handler now go through it. Reads stay unlocked because every code path reloads after a mutation anyway and `replaceItemAt` is already atomic at the FS level. `StoredSpeaker` extracted into its own file to satisfy the file-length lint budget — matches the codebase's one-type-per-file pattern.

Tests: a direct `mutateDB` stress test (100 concurrent appends → must end with 101 entries) and a high-level `renameSpeaker` stress test (50 concurrent renames of distinct entries → all 50 must survive). Both fail deterministically on the unsynchronized RMW.

### Commit 2 — Synthetic-marker for RPC seed

The `/action/seedSpeaker` RPC writes a 192-dim random `Float[-1, 1]` vector into `speakers.json` with the same shape as a user-confirmed entry. Cosine distance to a random vector is uniformly distributed in `[0, 2]` — small distances aren't unusual — so a seeded entry can win auto-naming against a real diarization embedding, indistinguishably. With RPC auth compromised (or simply a forgotten test cleanup), poisoned entries persist forever and corrupt naming.

Fix: add `isSynthetic: Bool = false` to `StoredSpeaker` (Codable, encoded only when `true` so legacy entries round-trip byte-identical). `seedSpeaker` sets it `true`. `SpeakerMatcher.matchVerbose` filters synthetic entries out of the candidate pool, so they can never be auto-named onto a real speaker. Rename preserves the flag; merge keeps the result synthetic only when both sides are. `KnownVoicesView` shows a `synthetic` pill with a tooltip so users can spot and delete poisoned rows.

## Test plan
- [x] `swift test --parallel --filter SpeakerMatcherTests` — 81 tests pass, including 6 new (4 synthetic, 2 concurrency).
- [x] `swift test --parallel` — all suites pass except `MenuBarIconSnapshotTests` (known pre-existing local-only flake on main, unrelated).
- [x] `swift build -Xswiftc -DAPPSTORE` — App Store variant compiles cleanly (`isSynthetic`/`mutateDB` are universal, only the RPC seed path is `#if !APPSTORE`).
- [x] `./scripts/lint.sh` — clean.
- [ ] Manual: seed a speaker via mt-cli, confirm it shows the `synthetic` pill in Known Voices, confirm a real diarization run doesn't auto-name onto it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->