### PR TITLE
fix(app): roll back partial record-only finalize

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -49,6 +49,8 @@ class DualSourceRecorder: RecordingProvider {
     /// Suffix on the merged-output WAV file, used by downstream code (the
     /// record-only sidecar writer) to recover the recording basename.
     static let mixFilenameSuffix = "_mix.wav"
+    static let appFilenameSuffix = "_app.wav"
+    static let micFilenameSuffix = "_mic.wav"
 
     /// Remove leftover `*_app_raw.tmp` files from a previous crash.
     static func cleanupTempFiles(recordingsDir: URL = AppPaths.recordingsDir) {
@@ -84,7 +86,7 @@ class DualSourceRecorder: RecordingProvider {
 
         // ── AudioTapLib capture session ──
         let appTempURL = recDir.appendingPathComponent("\(ts)_app_raw.tmp")
-        let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)_mic.wav")
+        let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)\(Self.micFilenameSuffix)")
 
         let session = AudioCaptureSession(
             pid: appPID,
@@ -188,7 +190,7 @@ class DualSourceRecorder: RecordingProvider {
 
             // Resample to 16kHz and save app track
             appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: targetRate)
-            let appFile = recDir.appendingPathComponent("\(ts)_app.wav")
+            let appFile = recDir.appendingPathComponent("\(ts)\(Self.appFilenameSuffix)")
             try AudioMixer.saveWAV(samples: appSamples16k, sampleRate: targetRate, url: appFile)
             appPath = appFile
             logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate)→\(self.targetRate) Hz)")

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -375,6 +375,11 @@ class WatchLoop {
             recording.mixPath.deletingPathExtension().lastPathComponent
         }
 
+        // Track every destination URL we materialise so a mid-finalize error
+        // can roll back partial state instead of leaving orphan WAVs in the
+        // user's output dir. The sidecar is written last; without it,
+        // anything we already moved is provisional.
+        var moved: [URL] = []
         do {
             let destDir = recordOnlyOutputDir()
             // The destination may be a user-chosen folder reached via a security-scoped
@@ -388,8 +393,17 @@ class WatchLoop {
                 at: destDir, withIntermediateDirectories: true,
             )
             let movedMix = try Self.move(recording.mixPath, into: destDir)
-            let movedApp = try recording.appPath.map { try Self.move($0, into: destDir) }
-            let movedMic = try recording.micPath.map { try Self.move($0, into: destDir) }
+            moved.append(movedMix)
+            let movedApp = try recording.appPath.map { source -> URL in
+                let url = try Self.move(source, into: destDir)
+                moved.append(url)
+                return url
+            }
+            let movedMic = try recording.micPath.map { source -> URL in
+                let url = try Self.move(source, into: destDir)
+                moved.append(url)
+                return url
+            }
 
             let sidecar = RecordingSidecar(
                 title: title,
@@ -405,6 +419,12 @@ class WatchLoop {
             try sidecar.write(toDirectory: destDir, basename: basename)
             logger.info("Record-only: wrote sidecar + WAVs to \(destDir.path) for \(title)")
         } catch {
+            // Roll back any audio we moved before the failure point — without
+            // a sidecar they're indistinguishable from a successful recording
+            // to downstream consumers.
+            for url in moved {
+                try? FileManager.default.removeItem(at: url)
+            }
             logger.error("Record-only: \(error.localizedDescription)")
             lastError = "Record-only output failed: \(error.localizedDescription)"
             // Record-only skips state transitions, so `lastError` alone is

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -478,4 +478,53 @@ final class WatchLoopTests: XCTestCase {
         try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
         XCTAssertTrue(recorder.startCalled)
     }
+
+    // MARK: - H7: record-only finalize atomicity
+
+    /// When one of the audio moves fails mid-finalize (e.g. the mic source has
+    /// vanished between recorder stop and our move), already-moved files must
+    /// not be left in the destination as orphans. Without rollback, the
+    /// previous behaviour silently dropped a partially-finalized recording in
+    /// the user's output dir and required manual cleanup.
+    func test_recordOnly_partialMoveFailure_rollsBackOrphanedFiles() async throws {
+        let queue = PipelineQueue()
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("recordOnlyRollback_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let destDir = tmp.appendingPathComponent("dest", isDirectory: true)
+        let mixURL = tmp.appendingPathComponent("20260507_100000_mix.wav")
+        let appURL = tmp.appendingPathComponent("20260507_100000_app.wav")
+        // mic path is set on the recorder but the file is missing on disk —
+        // the mix + app moves succeed, the mic move throws.
+        let micURL = tmp.appendingPathComponent("20260507_100000_mic.wav")
+        try Data().write(to: mixURL)
+        try Data().write(to: appURL)
+        // intentionally do NOT create micURL
+
+        _ = try await runManualRecordOnlyRecording(
+            recorderMix: mixURL,
+            outputDir: destDir,
+            queue: queue,
+            recorderApp: appURL,
+            recorderMic: micURL,
+        )
+
+        let movedMix = destDir.appendingPathComponent("20260507_100000_mix.wav")
+        let movedApp = destDir.appendingPathComponent("20260507_100000_app.wav")
+        let sidecar = destDir.appendingPathComponent("20260507_100000_meta.json")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: movedMix.path),
+            "mix WAV must not survive a failed finalize — it would be an orphan",
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: movedApp.path),
+            "app WAV must not survive a failed finalize — it would be an orphan",
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: sidecar.path),
+            "no sidecar should be written when finalize fails partway",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Record-only mode finalises a recording by moving the mix/app/mic WAVs into the user's output dir and writing a `_meta.json` sidecar. When a move mid-flow throws (e.g. mic source vanished between recorder stop and our move), the already-moved WAVs were left in the output dir as orphans. The `do/catch` only logged. To a downstream consumer (e.g. Linux GPU pipeline reading the dir over Syncthing) those orphan WAVs were indistinguishable from a complete recording missing only its sidecar.

## Approach

Track every URL we materialise during finalize in a `[URL]`. On any thrown error in `do/catch`, roll them back. The sidecar is written last and atomically; without it, anything we already moved is provisional.

While here: `_app.wav` / `_mic.wav` literals get joined to the existing `mixFilenameSuffix` constant on `DualSourceRecorder` to avoid hardcoded copies of the same string.

## Why no startup orphan sweep

Initially this PR included a `cleanupOrphanedRecordOnlyOutputs` sweep at `WatchLoop.start()` that would delete `*_(mix|app|mic).wav` files without a matching `_meta.json` sidecar — to recover from app crashes mid-finalize. **Rejected after live testing exposed a destructive bug:** the `recordings/` directory is shared with normal (non-record-only) pipeline output, which `PipelineQueue.copyAudioToOutput` writes via `moveItem` to the same location. Normal pipeline recordings **never** write a sidecar (only record-only does). The sweep would therefore delete every legitimate non-record-only recording on the next launch, and conflict with `PipelineQueue.recoverOrphanedRecordings` which already treats orphan `_mix.wav` files as candidates for re-queuing.

The H7 finding's stated impact ("manual cleanup needed after crash mid-finalize") is acceptable. A proper crash-recovery design would require either a record-only-only subdir layout (breaks the consumer protocol) or a `.partial` rename pattern at finalize — both out of scope for this fix.

## Test plan
- [x] `swift test --parallel --filter WatchLoopTests` — 32 tests pass, including `test_recordOnly_partialMoveFailure_rollsBackOrphanedFiles`.
- [x] `swift test --parallel` — only pre-existing `MenuBarIconSnapshotTests` flake on local machine, unrelated.
- [x] `swift build -Xswiftc -DAPPSTORE` — App Store variant compiles.
- [x] `./scripts/lint.sh` — clean.