### PR TITLE
fix: RPC quick-wins — constant-time auth, Host allowlist, mt-cli timeouts

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -23,6 +23,42 @@
         nonisolated static let defaultPort: UInt16 = 9876
         nonisolated static let tokenFileURL = AppPaths.dataDir.appendingPathComponent(".rpc-token")
 
+        /// Constant-time byte-wise equality. Used to compare incoming bearer
+        /// tokens against the expected value so an attacker on a shared Mac
+        /// can't infer a token by measuring early-mismatch latency. Iterates
+        /// the longer of the two strings unconditionally; length differences
+        /// still return false but only after walking both fully.
+        nonisolated static func constantTimeEquals(_ provided: String, _ expected: String) -> Bool {
+            let a = Array(provided.utf8)
+            let b = Array(expected.utf8)
+            let len = max(a.count, b.count)
+            var diff: UInt8 = a.count == b.count ? 0 : 1
+            for i in 0 ..< len {
+                let av: UInt8 = i < a.count ? a[i] : 0
+                let bv: UInt8 = i < b.count ? b[i] : 0
+                diff |= (av ^ bv)
+            }
+            return diff == 0
+        }
+
+        /// Validate the request's `Host` header against `127.0.0.1` /
+        /// `localhost` (with or without our bound port). Empty Host is
+        /// accepted because old HTTP/1.0 clients and our own loopback
+        /// probes don't always set one; the bind + bearer check still
+        /// gates them. Defense-in-depth against DNS-rebinding payloads
+        /// where an attacker's site resolves a hostname to 127.0.0.1
+        /// and the browser dutifully sends `Host: evil.example`.
+        nonisolated static func isHostAllowed(_ host: String, port: UInt16) -> Bool {
+            if host.isEmpty { return true }
+            let allowedNoPort: Set = ["127.0.0.1", "localhost"]
+            if allowedNoPort.contains(host) { return true }
+            let allowedWithPort: Set = [
+                "127.0.0.1:\(port)",
+                "localhost:\(port)",
+            ]
+            return allowedWithPort.contains(host)
+        }
+
         /// Cap accumulated bytes per connection so a misbehaving client
         /// streaming bytes without `\r\n\r\n` can't OOM the app.
         private static let maxRequestBytes = 64 * 1024
@@ -159,7 +195,12 @@
             if let origin = request.headers["origin"], !origin.isEmpty, origin != "null" {
                 return HTTPResponse.forbidden()
             }
-            guard request.headers["authorization"] == expectedAuth else {
+            let hostPort = boundPort ?? port.rawValue
+            guard Self.isHostAllowed(request.headers["host"] ?? "", port: hostPort) else {
+                return HTTPResponse.forbidden()
+            }
+            let provided = request.headers["authorization"] ?? ""
+            guard Self.constantTimeEquals(provided, expectedAuth) else {
                 return HTTPResponse.unauthorized()
             }
 

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -452,4 +452,95 @@
             )
         }
     }
+
+    // MARK: - M1: constant-time auth compare
+
+    extension DebugRPCServerTests {
+        /// Equal strings compare equal. Boring sanity baseline.
+        func testConstantTimeEqualsAcceptsExactMatch() {
+            XCTAssertTrue(
+                DebugRPCServer.constantTimeEquals(
+                    "Bearer abcdef1234567890",
+                    "Bearer abcdef1234567890",
+                ),
+            )
+        }
+
+        /// First-byte mismatch must still walk the full string — that's the
+        /// whole point. Correctness check: non-equal returns false regardless
+        /// of which byte differs.
+        func testConstantTimeEqualsRejectsFirstByteMismatch() {
+            XCTAssertFalse(
+                DebugRPCServer.constantTimeEquals(
+                    "X" + "earer abcdef1234567890",
+                    "Bearer abcdef1234567890",
+                ),
+            )
+        }
+
+        func testConstantTimeEqualsRejectsLastByteMismatch() {
+            XCTAssertFalse(
+                DebugRPCServer.constantTimeEquals(
+                    "Bearer abcdef123456789X",
+                    "Bearer abcdef1234567890",
+                ),
+            )
+        }
+
+        /// Different lengths are unconditionally not-equal — but the
+        /// implementation must not short-circuit at the length check (which
+        /// would reveal length via timing). We can't assert the timing
+        /// directly, only the correctness.
+        func testConstantTimeEqualsRejectsLengthMismatch() {
+            XCTAssertFalse(
+                DebugRPCServer.constantTimeEquals("Bearer abc", "Bearer abcdef"),
+            )
+            XCTAssertFalse(
+                DebugRPCServer.constantTimeEquals("Bearer abcdef", "Bearer abc"),
+            )
+        }
+
+        func testConstantTimeEqualsHandlesEmptyStrings() {
+            XCTAssertTrue(DebugRPCServer.constantTimeEquals("", ""))
+            XCTAssertFalse(DebugRPCServer.constantTimeEquals("", "a"))
+        }
+    }
+
+    // MARK: - M6: Host header allowlist
+
+    extension DebugRPCServerTests {
+        func testIsHostAllowedAcceptsLoopback() {
+            XCTAssertTrue(DebugRPCServer.isHostAllowed("127.0.0.1:9876", port: 9876))
+            XCTAssertTrue(DebugRPCServer.isHostAllowed("localhost:9876", port: 9876))
+        }
+
+        /// Missing Host header passes — old HTTP/1.0 clients and our own
+        /// server's startup probes don't always set one. Defense-in-depth on
+        /// top of the loopback bind + bearer check, not a primary gate.
+        func testIsHostAllowedAcceptsEmpty() {
+            XCTAssertTrue(DebugRPCServer.isHostAllowed("", port: 9876))
+        }
+
+        /// DNS-rebinding payload: attacker's site resolves a hostname they
+        /// control to 127.0.0.1, then the browser sends `Host: evil.example`.
+        /// Loopback bind doesn't catch this; the Host header does.
+        func testIsHostAllowedRejectsForeignHostname() {
+            XCTAssertFalse(DebugRPCServer.isHostAllowed("evil.example:9876", port: 9876))
+            XCTAssertFalse(DebugRPCServer.isHostAllowed("rebind.attacker.com", port: 9876))
+        }
+
+        /// Wrong-port spoof — the bearer is the real defense, but reject
+        /// anyway so a misconfigured proxy can't accidentally talk to us.
+        func testIsHostAllowedRejectsWrongPort() {
+            XCTAssertFalse(DebugRPCServer.isHostAllowed("127.0.0.1:8080", port: 9876))
+        }
+
+        func testIsHostAllowedAcceptsHostWithoutPort() {
+            // RFC 7230: Host MAY omit port when it's the default. Our default
+            // is 9876, never 80/443, so a bare "127.0.0.1" without port is
+            // ambiguous — accept it as loopback rather than fail-closed.
+            XCTAssertTrue(DebugRPCServer.isHostAllowed("127.0.0.1", port: 9876))
+            XCTAssertTrue(DebugRPCServer.isHostAllowed("localhost", port: 9876))
+        }
+    }
 #endif

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -147,7 +147,7 @@ struct Screenshot: AsyncParsableCommand {
 
     func run() async throws {
         let client = try RPCClient.loadDefault()
-        let data = try await client.get("/screenshot")
+        let data = try await client.get("/screenshot", timeout: RPCClient.screenshotTimeoutSeconds)
         try data.write(to: URL(fileURLWithPath: path))
         print("wrote \(data.count) bytes to \(path)")
     }

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -39,6 +39,16 @@ struct RPCClient {
 
     static let defaultBaseURL = URL(string: "http://127.0.0.1:9876")!
 
+    /// Per-request timeout. Without this the CLI hangs forever against a
+    /// wedged server (paused process, lost connection mid-stream). Short
+    /// enough that a human notices, generous enough that a slow `/state`
+    /// snapshot off a heavily loaded app doesn't trip it.
+    static let requestTimeoutSeconds: TimeInterval = 5
+
+    /// `/screenshot` renders a window image and is allowed a longer budget;
+    /// the rest of the API is fast.
+    static let screenshotTimeoutSeconds: TimeInterval = 15
+
     static func loadDefault() throws -> RPCClient {
         let url = defaultTokenURL
         guard let data = try? Data(contentsOf: url),
@@ -51,18 +61,23 @@ struct RPCClient {
         return RPCClient(baseURL: defaultBaseURL, token: token)
     }
 
-    func get(_ path: String) async throws -> Data {
-        try await request("GET", path: path, body: nil)
+    func get(_ path: String, timeout: TimeInterval = requestTimeoutSeconds) async throws -> Data {
+        try await request("GET", path: path, body: nil, timeout: timeout)
     }
 
-    func post(_ path: String, json: [String: Any]) async throws -> Data {
+    func post(
+        _ path: String, json: [String: Any], timeout: TimeInterval = requestTimeoutSeconds,
+    ) async throws -> Data {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await request("POST", path: path, body: body)
+        return try await request("POST", path: path, body: body, timeout: timeout)
     }
 
-    private func request(_ method: String, path: String, body: Data?) async throws -> Data {
+    private func request(
+        _ method: String, path: String, body: Data?, timeout: TimeInterval,
+    ) async throws -> Data {
         var req = URLRequest(url: baseURL.appendingPathComponent(path))
         req.httpMethod = method
+        req.timeoutInterval = timeout
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         if let body {
             req.httpBody = body

--- a/tools/mt-cli/Tests/RPCClientTests.swift
+++ b/tools/mt-cli/Tests/RPCClientTests.swift
@@ -22,4 +22,24 @@ final class RPCClientTests: XCTestCase {
         let err = RPCClient.RPCError.appNotRunning(RPCClient.defaultBaseURL)
         XCTAssertTrue(err.description.contains("127.0.0.1:9876"))
     }
+
+    // MARK: - M7: HTTP timeouts
+
+    /// A wedged server must not hang the CLI forever. The default per-request
+    /// timeout has to be short enough for a human to notice, long enough that
+    /// a slow `/state` snapshot doesn't false-positive.
+    func testRequestTimeoutIsBounded() {
+        XCTAssertLessThanOrEqual(RPCClient.requestTimeoutSeconds, 10)
+        XCTAssertGreaterThan(RPCClient.requestTimeoutSeconds, 0)
+    }
+
+    /// `/screenshot` renders a window image and can legitimately take longer
+    /// than `/state`; it gets its own bound, also bounded.
+    func testScreenshotTimeoutIsBounded() {
+        XCTAssertLessThanOrEqual(RPCClient.screenshotTimeoutSeconds, 30)
+        XCTAssertGreaterThanOrEqual(
+            RPCClient.screenshotTimeoutSeconds, RPCClient.requestTimeoutSeconds,
+            "screenshot must allow at least the default per-request budget",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Three small defense-in-depth additions to the debug RPC server / CLI, bundled because they all touch the same code path and follow the same shape (small static helper + unit tests). Two atomic commits.

### Commit 1 — RPC server hardening (M1 + M6)

**Constant-time bearer compare (M1).** The old `==` compare on `request.headers["authorization"]` short-circuits at the first mismatched byte, leaking token-prefix length via timing on a shared Mac. New `constantTimeEquals(_:_:)` accumulates `XOR | OR` over the longer of the two byte arrays — equal-length strings always walk the full length, length-mismatched strings still walk both fully.

**Host header allowlist (M6).** Loopback bind + bearer check don't catch DNS-rebinding payloads where an attacker's site resolves a hostname they control to `127.0.0.1` and the browser sends `Host: evil.example`. New `isHostAllowed(_:port:)` accepts only `127.0.0.1` / `localhost` (with or without our bound port) and an empty Host. Foreign hosts return 403.

Both helpers are pure static functions, unit-tested with 5 cases each (mismatch positions, length mismatch, port mismatch, foreign hostname, edge cases).

### Commit 2 — mt-cli HTTP timeouts (M7)

Without `URLRequest.timeoutInterval`, `URLSession.data(for:)` waits forever when the app is paused or has a stuck listener — the CLI hangs with no output, no exit. Two static lets: `requestTimeoutSeconds = 5` (default), `screenshotTimeoutSeconds = 15` (PNG rendering). `get` / `post` take an explicit `timeout:` parameter; the `screenshot` subcommand threads the longer one through. Avoids a string-based `path.contains("screenshot")` sniff that would silently inherit the longer budget for any future path with that substring.

Two contract tests assert the bounds (timeouts > 0, default ≤ 10s, screenshot ≥ default).

## Bonus
M5 (knownSpeakerNames cache consistency window) was verified closed by H4's `mutateDB` lock and marked done in the side-effects-review plan.

## Test plan
- [x] `swift test --parallel --filter DebugRPCServerTests` — 46 tests, including 10 new (5 M1, 5 M6).
- [x] `swift test --parallel --filter DebugRPCServerIntegrationTests` — 7 tests, all green (Host check doesn't break URLSession-default `Host: 127.0.0.1:port`).
- [x] `(cd tools/mt-cli && swift test)` — 6 tests, including 2 new for the timeout consts.
- [x] `swift build -Xswiftc -DAPPSTORE` — App Store variant compiles (DebugRPC is `#if !APPSTORE`).
- [x] `./scripts/lint.sh` — clean.
- [x] Manual: `mt-cli state` (+ healthz + open-settings) against the running app, verify it still works (sanity check that the new Host check doesn't break URLSession's default Host header).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->