### PR TITLE
fix: small RPC + Settings hardening (PII-safe screenshots, off-main diagnostics, unique meeting slugs)

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -329,12 +329,29 @@
 
         // MARK: - Screenshot
 
-        /// PNG of the largest visible content window, or nil when none qualifies.
-        /// Uses ScreenCaptureKit (`SCScreenshotManager.captureImage`) — the
-        /// non-deprecated successor to `CGWindowListCreateImage`. Unlike the old
-        /// API, SCK requires Screen Recording permission even for self-capture;
-        /// the first request triggers the standard TCC prompt. Acceptable for
-        /// this debug-only path (whole file is `#if !APPSTORE`, RPC is opt-in).
+        /// SwiftUI scene identifiers we expose to `/screenshot`. SpeakerNamingView
+        /// (`speaker-naming`) is deliberately excluded because it surfaces real
+        /// participant names and meeting titles — capturing it would let any
+        /// local process with the RPC token read PII off-screen. Record-app
+        /// picker (`record-app`) is excluded by default for the same reason
+        /// (it lists the user's running apps); add to the set if a screenshot
+        /// of it becomes useful for debugging. System file pickers, AppKit
+        /// alerts, and similar transients carry no SwiftUI identifier and are
+        /// rejected by the nil/empty case.
+        nonisolated static let screenshotAllowedWindowIDs: Set<String> = ["settings"]
+
+        nonisolated static func isWindowAllowedForScreenshot(identifier: String?) -> Bool {
+            guard let identifier, !identifier.isEmpty else { return false }
+            return screenshotAllowedWindowIDs.contains(identifier)
+        }
+
+        /// PNG of the largest visible content window from the screenshot
+        /// allowlist, or nil when none qualifies. Uses ScreenCaptureKit
+        /// (`SCScreenshotManager.captureImage`) — the non-deprecated successor
+        /// to `CGWindowListCreateImage`. Unlike the old API, SCK requires
+        /// Screen Recording permission even for self-capture; the first
+        /// request triggers the standard TCC prompt. Acceptable for this
+        /// debug-only path (whole file is `#if !APPSTORE`, RPC is opt-in).
         @MainActor
         static func captureFrontmostWindowPNG() async -> Data? {
             let app = NSApplication.shared
@@ -343,7 +360,11 @@
                 return b.width * b.height
             }
             let candidate = app.windows
-                .filter { $0.isVisible && $0.contentView != nil }
+                .filter { window in
+                    isWindowAllowedForScreenshot(identifier: window.identifier?.rawValue)
+                        && window.isVisible
+                        && window.contentView != nil
+                }
                 .max { area($0) < area($1) }
             guard let window = candidate, area(window) >= minWindowAreaPx else { return nil }
             let windowID = CGWindowID(window.windowNumber)

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -99,6 +99,18 @@ class PipelineQueue {
         return speakerNamingDataByJob[firstPendingJob.id]
     }
 
+    /// Filesystem slug for a job's persisted artefacts (`<slug>_naming.json`,
+    /// `<slug>_16k.wav`, `<slug>_segments.json`, mix/app/mic WAVs). Embedding
+    /// the job's short-id keeps two back-to-back same-title meetings (e.g. a
+    /// recurring "Daily Standup") from clobbering each other on disk and
+    /// confusing snapshot rebuild — without it both jobs would resolve to the
+    /// same `<title>_naming.json` and the second save would overwrite the
+    /// first, then both UUIDs would map to the survivor.
+    static func namingSlug(title: String, jobID: UUID) -> String {
+        let titleSlug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
+        return "\(titleSlug)_\(PipelineJob.shortID(for: jobID))"
+    }
+
     /// Returns naming data for a specific job ID, or the first pending job as fallback.
     func speakerNamingData(forJobID jobID: UUID?) -> SpeakerNamingData? {
         if let jobID, let data = speakerNamingDataByJob[jobID] { return data }
@@ -480,7 +492,7 @@ class PipelineQueue {
             defer { try? FileManager.default.removeItem(at: workDir) }
 
             // Compute slug early so it's available for persisted file names
-            let slug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
+            let slug = Self.namingSlug(title: title, jobID: jobID)
 
             let transcript: String
             // Segments cached for potential diarization reuse (avoids double transcription)

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -24,6 +24,10 @@ struct AdvancedSettingsView: View {
     @State private var accessibilityOK = false
     @State private var lastExportFile: String?
     @State private var lastExportError: String?
+    /// True while a `DiagnosticExporter.export` call is running off-main.
+    /// Used to dim the button and surface a spinner so a 50-200 MB persistent
+    /// log doesn't look like the app froze.
+    @State private var isExportingDiagnostics = false
 
     var body: some View {
         // swiftlint:disable:next closure_body_length
@@ -74,7 +78,14 @@ struct AdvancedSettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                Button("Export Diagnostics…") { exportDiagnostics() }
+                HStack {
+                    Button("Export Diagnostics…") { exportDiagnostics() }
+                        .disabled(isExportingDiagnostics)
+                    if isExportingDiagnostics {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
                 if let file = lastExportFile {
                     Text("Exported to: \(file)")
                         .font(.caption)
@@ -163,36 +174,51 @@ struct AdvancedSettingsView: View {
     }
 
     private func exportDiagnostics() {
+        guard !isExportingDiagnostics else { return }
         let stamp = Int(Date().timeIntervalSince1970)
         let outURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingTranscriber-diagnostics-\(stamp).log")
-        do {
-            let info = DiagnosticExporter.HeaderInfo(
-                appVersion: Bundle.main.appVersion,
-                commit: Bundle.main.gitCommitHash,
-                macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
-                settings: [
-                    "verboseDiagnostics": "\(settings.verboseDiagnostics)",
-                    "diarize": "\(settings.diarize)",
-                    "vadEnabled": "\(settings.vadEnabled)",
-                    "transcriptionEngine": settings.transcriptionEngine.rawValue,
-                    "protocolProvider": settings.protocolProvider.rawValue,
-                    "recordOnly": "\(settings.recordOnly)",
-                ],
-            )
-            let count = try DiagnosticExporter.export(to: outURL, info: info)
-            lastExportFile = outURL.lastPathComponent
-            lastExportError = nil
-            NSWorkspace.shared.activateFileViewerSelecting([outURL])
-            logger.info(
-                "diagnostics_exported lines=\(count, privacy: .public) file=\(outURL.lastPathComponent, privacy: .public)",
-            )
-        } catch {
-            lastExportFile = nil
-            lastExportError = error.localizedDescription
-            logger.error(
-                "diagnostics_export_failed error=\(error.localizedDescription, privacy: .public)",
-            )
+        let info = DiagnosticExporter.HeaderInfo(
+            appVersion: Bundle.main.appVersion,
+            commit: Bundle.main.gitCommitHash,
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            settings: [
+                "verboseDiagnostics": "\(settings.verboseDiagnostics)",
+                "diarize": "\(settings.diarize)",
+                "vadEnabled": "\(settings.vadEnabled)",
+                "transcriptionEngine": settings.transcriptionEngine.rawValue,
+                "protocolProvider": settings.protocolProvider.rawValue,
+                "recordOnly": "\(settings.recordOnly)",
+            ],
+        )
+
+        isExportingDiagnostics = true
+        // The persistent-log file source can be 50-200 MB and reads via
+        // `String(contentsOf:)` + `split(separator:)` — and the OSLogStore
+        // fallback's `getEntries` is famously slow on the main actor. Detach
+        // so the Settings UI stays responsive while the export runs.
+        Task.detached(priority: .userInitiated) {
+            let result = Result { try DiagnosticExporter.export(to: outURL, info: info) }
+            await MainActor.run {
+                isExportingDiagnostics = false
+                switch result {
+                case let .success(count):
+                    lastExportFile = outURL.lastPathComponent
+                    lastExportError = nil
+                    NSWorkspace.shared.activateFileViewerSelecting([outURL])
+                    let exportedFile = outURL.lastPathComponent
+                    logger.info(
+                        "diagnostics_exported lines=\(count, privacy: .public) file=\(exportedFile, privacy: .public)",
+                    )
+
+                case let .failure(error):
+                    lastExportFile = nil
+                    lastExportError = error.localizedDescription
+                    logger.error(
+                        "diagnostics_export_failed error=\(error.localizedDescription, privacy: .public)",
+                    )
+                }
+            }
         }
     }
 }

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -547,4 +547,41 @@
             XCTAssertTrue(DebugRPCServer.isHostAllowed("localhost", port: 9876))
         }
     }
+
+    // MARK: - Screenshot window allowlist
+
+    extension DebugRPCServerTests {
+        /// Settings is the explicitly-supported screenshot target — debug
+        /// inspection of the app's configuration UI.
+        func testIsWindowAllowedForScreenshotAcceptsSettings() {
+            XCTAssertTrue(DebugRPCServer.isWindowAllowedForScreenshot(identifier: "settings"))
+        }
+
+        /// SpeakerNamingView surfaces real participant names and meeting
+        /// titles. /screenshot must not capture it — local processes with
+        /// the RPC token would otherwise read PII off-screen.
+        func testIsWindowAllowedForScreenshotRejectsSpeakerNaming() {
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForScreenshot(identifier: "speaker-naming"))
+        }
+
+        /// Record-app picker shows the user's running-app list — sensitive
+        /// enough to keep off the wire by default. Add to the allowlist if
+        /// a screenshot becomes useful for debugging.
+        func testIsWindowAllowedForScreenshotRejectsRecordApp() {
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForScreenshot(identifier: "record-app"))
+        }
+
+        /// Anonymous windows (no identifier set) are rejected — system file
+        /// pickers, AppKit alerts, and similar transients shouldn't be
+        /// targetable.
+        func testIsWindowAllowedForScreenshotRejectsAnonymous() {
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForScreenshot(identifier: nil))
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForScreenshot(identifier: ""))
+        }
+
+        /// Future scenes default to closed unless explicitly allowed.
+        func testIsWindowAllowedForScreenshotRejectsUnknown() {
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForScreenshot(identifier: "future-debug-window"))
+        }
+    }
 #endif

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1713,4 +1713,45 @@ final class PipelineQueueTests: XCTestCase {
             "Reading knownSpeakerNames must not invoke speakerMatcherFactory",
         )
     }
+
+    // MARK: - M3: slug uniqueness
+
+    /// Two back-to-back meetings with identical titles (e.g. recurring
+    /// "Daily Standup") would otherwise share the same on-disk slug — the
+    /// second job's `_naming.json` / `_16k.wav` overwrites the first's, and
+    /// snapshot rebuild then maps the survivor's data onto both UUIDs.
+    /// Embedding the job's short-id keeps each on-disk artefact distinct.
+    func test_namingSlug_differsForSameTitleDifferentJobs() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let slug1 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id1)
+        let slug2 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id2)
+        XCTAssertNotEqual(
+            slug1, slug2,
+            "Identical titles must produce distinct slugs when job IDs differ",
+        )
+    }
+
+    /// Determinism: same input → same slug. Snapshot rebuild relies on this
+    /// to find a job's persisted `_naming.json` after a relaunch.
+    func test_namingSlug_isDeterministicForSameJob() {
+        let id = UUID()
+        let first = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
+        let second = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
+        XCTAssertEqual(first, second)
+    }
+
+    func test_namingSlug_embedsTitleAndShortID() {
+        let id = UUID()
+        let slug = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
+        XCTAssertTrue(
+            slug.contains(PipelineJob.shortID(for: id)),
+            "Slug must include the job short-ID for uniqueness across same-title runs",
+        )
+        // Title-derived part should still be present (filesystem-friendly form).
+        XCTAssertTrue(
+            slug.lowercased().contains("daily") && slug.lowercased().contains("standup"),
+            "Slug should still encode the title for human-readable filenames",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Three small independent hardening fixes, each on its own commit. All low-risk, well-tested.

### Commit 1 — `/screenshot` Settings-only allowlist

**Problem:** `/screenshot` (debug RPC) previously captured the largest visible app window. If `SpeakerNamingView` (window id `speaker-naming`) was open with real participant names + meeting title, those went out over the wire to anyone with the RPC token. Same risk for the record-app picker (`record-app`) which lists the user's running apps.

**Fix:** New `screenshotAllowedWindowIDs = ["settings"]` set + static `isWindowAllowedForScreenshot(identifier:)` predicate; capture path filters by `NSWindow.identifier?.rawValue`. SwiftUI `Window(_, id:)` propagates the id directly to NSWindow.identifier, so the match is reliable. System file pickers / AppKit alerts have no identifier and are rejected by the nil/empty case.

5 unit tests cover the predicate (settings allowed; speaker-naming/record-app/anonymous/unknown all rejected).

### Commit 2 — DiagnosticExporter off main thread

**Problem:** `DiagnosticExporter.export(...)` reads the persistent diagnostic-log file via `String(contentsOf:)` + `split(separator:)` — that's potentially 50–200 MB into RAM on the main thread. The OSLogStore fallback's `getEntries(at:matching:)` is also famously slow on the main actor. On heavily-loaded systems pressing "Export Diagnostics…" froze the Settings window for several seconds with no feedback.

**Fix:** Wrap the call in `Task.detached(priority: .userInitiated)`. New `@State isExportingDiagnostics` gates the button and shows a small `ProgressView().controlSize(.small)` next to it (matches the spinner pattern other Settings sub-views use). Completion hops back to MainActor to update result state.

No automated test: requires a SwiftUI scene + clock control. The behaviour change is intrinsic — main thread is no longer blocked — and not asserted-on by existing tests.

### Commit 3 — Slug uniqueness for same-title meetings

**Problem:** Two back-to-back recordings with identical meeting titles (e.g. a recurring "Daily Standup") resolved to the same on-disk slug. The second job's `<title>_naming.json` / `<title>_16k.wav` overwrote the first's; snapshot rebuild then mapped the survivor's data onto both UUIDs — the first job's late-confirm dialog popped up showing the second job's speakers.

**Fix:** New `PipelineQueue.namingSlug(title:jobID:)` static helper appends the 8-hex `PipelineJob.shortID(for:)` to the title-derived slug. Each job's persisted artefacts are now distinct on disk: `Daily Standup_a1b2c3d4_naming.json` vs `Daily Standup_e5f6g7h8_…`.

Snapshot rebuild keeps working because `loadSnapshot` reads `job.namingSlug` directly from the persisted PipelineJob model — old snapshots with old-format slugs still find their files; new jobs use the new format. No migration step needed.

3 unit tests: uniqueness across same-title jobs, determinism for the same job, slug embeds title + shortID.

## Test plan
- [x] `swift test --parallel --filter PipelineQueueTests` — all green, includes 3 new (`test_namingSlug_*`).
- [x] `swift test --parallel --filter DebugRPCServerTests` — all green, includes 5 new (`testIsWindowAllowedForScreenshot_*`).
- [x] `swift test --parallel --filter DebugRPCServerIntegrationTests` — all green (allowlist doesn't change route plumbing).
- [x] `swift build -Xswiftc -DAPPSTORE` — App Store variant compiles.
- [x] `./scripts/lint.sh` — clean.
- [ ] Manual screenshot allowlist: open SpeakerNamingView, run `mt-cli screenshot` → expect 503 (no allowed window visible). Open Settings → screenshot → expect Settings window PNG.
- [ ] Manual export off-main: enable verbose diagnostics, accumulate ~30 min of logs, click "Export Diagnostics…" → spinner appears, button disables, UI stays responsive while drag-resizing the window.
- [ ] Manual slug uniqueness: run two back-to-back manual recordings of the same app/title → both naming dialogs queue up and don't show each other's speakers.