### PR TITLE
test: integration coverage for RPC Host allowlist, slug uniqueness, mt-cli timeout

### DIFF
--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -1,5 +1,6 @@
 #if !APPSTORE
     @testable import MeetingTranscriber
+    import Network
     import XCTest
 
     /// Real socket roundtrips: build a server, hit it via URLSession on the
@@ -126,6 +127,135 @@
                 for: request("GET", base.appendingPathComponent("screenshot"), headers: authHeader),
             )
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 503)
+        }
+
+        // MARK: - M6: Host header allowlist (raw-socket)
+
+        /// `URLRequest.setValue(_:forHTTPHeaderField: "Host")` is silently
+        /// ignored by URLSession — Host is reserved. To exercise the
+        /// server's Host check we have to write the request bytes ourselves
+        /// over a TCP socket.
+        ///
+        /// This test sends a syntactically valid HTTP/1.1 request with
+        /// `Host: evil.example` and a valid bearer; expects a 403 from the
+        /// route guard (not a 401 — auth would pass, Host comes first).
+        func testRawSocketForeignHostReturns403() async throws {
+            let base = try await startServer()
+            guard let port = base.port else { XCTFail("no port"); return }
+
+            let raw =
+                "GET /healthz HTTP/1.1\r\n" +
+                "Host: evil.example\r\n" +
+                "Authorization: Bearer \(Self.testToken)\r\n" +
+                "\r\n"
+
+            let response = try await sendRawHTTP(toPort: UInt16(port), bytes: Data(raw.utf8))
+            let firstLine = response.split(separator: "\n").first ?? ""
+            XCTAssertTrue(
+                firstLine.contains("403"),
+                "Expected 403 for foreign Host, got: \(firstLine)",
+            )
+        }
+
+        /// Same shape, but the Host is loopback — must pass the allowlist
+        /// and reach 200. Confirms we didn't accidentally close the door
+        /// on legitimate clients.
+        func testRawSocketLoopbackHostReturns200() async throws {
+            let base = try await startServer()
+            guard let port = base.port else { XCTFail("no port"); return }
+
+            let raw =
+                "GET /healthz HTTP/1.1\r\n" +
+                "Host: 127.0.0.1:\(port)\r\n" +
+                "Authorization: Bearer \(Self.testToken)\r\n" +
+                "\r\n"
+
+            let response = try await sendRawHTTP(toPort: UInt16(port), bytes: Data(raw.utf8))
+            let firstLine = response.split(separator: "\n").first ?? ""
+            XCTAssertTrue(
+                firstLine.contains("200"),
+                "Expected 200 for loopback Host, got: \(firstLine)",
+            )
+        }
+
+        /// Open a TCP connection to `port`, write `bytes`, read response,
+        /// return as String. Used by the raw-socket Host tests because
+        /// URLSession reserves the `Host` header.
+        private func sendRawHTTP(toPort port: UInt16, bytes: Data) async throws -> String {
+            let connection = NWConnection(
+                host: "127.0.0.1",
+                port: NWEndpoint.Port(rawValue: port) ?? .any,
+                using: .tcp,
+            )
+            return try await withCheckedThrowingContinuation { continuation in
+                let resumer = OneShotResumer(continuation, connection: connection)
+                connection.stateUpdateHandler = { state in
+                    if case let .failed(error) = state {
+                        resumer.fail(error)
+                    }
+                }
+                connection.start(queue: .global())
+                connection.send(content: bytes, completion: .contentProcessed { error in
+                    if let error {
+                        resumer.fail(error)
+                        return
+                    }
+                    receiveUntilHeadersComplete(connection: connection, resumer: resumer)
+                })
+            }
+        }
+    }
+
+    /// Read repeatedly until the server's status line + headers are in,
+    /// then resume with the accumulated bytes as a UTF-8 string. The
+    /// debug RPC keeps the connection open after responding, so we use
+    /// `\r\n\r\n` as the "headers ended" marker rather than waiting for
+    /// `isComplete`. File-scope (non-isolated) so it can be called from
+    /// the Network.framework callbacks that run off the main actor.
+    private func receiveUntilHeadersComplete(
+        connection: NWConnection, resumer: OneShotResumer, accumulated: Data = Data(),
+    ) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, isComplete, _ in
+            var buffer = accumulated
+            if let data { buffer.append(data) }
+            let body = String(data: buffer, encoding: .utf8) ?? ""
+            if isComplete || body.contains("\r\n\r\n") {
+                resumer.succeed(body)
+                return
+            }
+            receiveUntilHeadersComplete(connection: connection, resumer: resumer, accumulated: buffer)
+        }
+    }
+
+    /// Resumes a `CheckedContinuation` exactly once and cancels the underlying
+    /// connection. Multiple callbacks (state-failed, send-error, receive-error
+    /// or receive-success) can race; without this the second resume would
+    /// trip the runtime check.
+    private final class OneShotResumer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var done = false
+        private let continuation: CheckedContinuation<String, any Error>
+        private let connection: NWConnection
+
+        init(_ continuation: CheckedContinuation<String, any Error>, connection: NWConnection) {
+            self.continuation = continuation
+            self.connection = connection
+        }
+
+        func succeed(_ body: String) {
+            lock.lock(); defer { lock.unlock() }
+            guard !done else { return }
+            done = true
+            continuation.resume(returning: body)
+            connection.cancel()
+        }
+
+        func fail(_ error: any Error) {
+            lock.lock(); defer { lock.unlock() }
+            guard !done else { return }
+            done = true
+            continuation.resume(throwing: error)
+            connection.cancel()
         }
     }
 #endif

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1754,4 +1754,62 @@ final class PipelineQueueTests: XCTestCase {
             "Slug should still encode the title for human-readable filenames",
         )
     }
+
+    /// End-to-end: two same-title jobs save naming data to disk via the
+    /// real `saveNamingData(_:slug:)` path and produce distinct files. The
+    /// pure-function slug tests above prove the helper is collision-free;
+    /// this test proves the helper is actually wired into the persistence
+    /// path (catches a future refactor that bypasses `namingSlug`).
+    func test_sameTitleJobsWriteDistinctNamingFiles() throws {
+        let outputDir = try XCTUnwrap(tmpDir)
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+
+        let mockEngine = MockEngine()
+        let queueWithOutput = PipelineQueue(
+            engine: mockEngine,
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: outputDir,
+            logDir: tmpDir,
+            diarizeEnabled: false,
+        )
+
+        let title = "Daily Standup"
+        let job1ID = UUID()
+        let job2ID = UUID()
+        let slug1 = PipelineQueue.namingSlug(title: title, jobID: job1ID)
+        let slug2 = PipelineQueue.namingSlug(title: title, jobID: job2ID)
+
+        let data1 = PipelineQueue.SpeakerNamingData(
+            jobID: job1ID, meetingTitle: title,
+            mapping: ["SPEAKER_0": "Alice"], speakingTimes: [:], embeddings: [:],
+            audioPath: nil, segments: [], participants: [], isDualSource: false,
+        )
+        let data2 = PipelineQueue.SpeakerNamingData(
+            jobID: job2ID, meetingTitle: title,
+            mapping: ["SPEAKER_0": "Bob"], speakingTimes: [:], embeddings: [:],
+            audioPath: nil, segments: [], participants: [], isDualSource: false,
+        )
+
+        queueWithOutput.saveNamingData(data1, slug: slug1)
+        queueWithOutput.saveNamingData(data2, slug: slug2)
+
+        let path1 = recordingsDir.appendingPathComponent("\(slug1)_naming.json")
+        let path2 = recordingsDir.appendingPathComponent("\(slug2)_naming.json")
+
+        XCTAssertNotEqual(
+            path1.lastPathComponent, path2.lastPathComponent,
+            "Same-title jobs must produce distinct on-disk filenames",
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path1.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path2.path))
+
+        // Each file resolves back to its own job's mapping — survivor's
+        // data isn't shadowing the other.
+        let loaded1 = queueWithOutput.loadNamingData(slug: slug1)
+        let loaded2 = queueWithOutput.loadNamingData(slug: slug2)
+        XCTAssertEqual(loaded1?.mapping["SPEAKER_0"], "Alice")
+        XCTAssertEqual(loaded2?.mapping["SPEAKER_0"], "Bob")
+    }
 }

--- a/tools/mt-cli/Tests/RPCClientTests.swift
+++ b/tools/mt-cli/Tests/RPCClientTests.swift
@@ -1,4 +1,5 @@
 @testable import mt_cli
+import Network
 import XCTest
 
 final class RPCClientTests: XCTestCase {
@@ -41,5 +42,94 @@ final class RPCClientTests: XCTestCase {
             RPCClient.screenshotTimeoutSeconds, RPCClient.requestTimeoutSeconds,
             "screenshot must allow at least the default per-request budget",
         )
+    }
+
+    /// Behaviour-level: against a server that accepts the connection but
+    /// never sends bytes back, `client.get` must time out instead of
+    /// hanging. Catches a wiring regression that the contract test above
+    /// can't see (e.g. `URLRequest.timeoutInterval` removed, custom
+    /// `URLSessionConfiguration` overriding the per-request value, etc.).
+    func testGetTimesOutAgainstSilentServer() async throws {
+        let listener = try NWListener(using: .tcp, on: .any)
+        // Holds incoming connections without writing — keeps a strong ref so
+        // the connection isn't torn down before URLSession's timeout fires.
+        let held = SilentConnectionHolder()
+        listener.newConnectionHandler = { connection in
+            held.add(connection)
+            connection.start(queue: .global())
+            // Don't read or write; the client is waiting for our response.
+        }
+
+        // The listener's `.port` is the requested port (.any → 0) until the
+        // `.ready` state fires with the OS-assigned port. Wait for that.
+        let portReady = XCTestExpectation(description: "listener bound")
+        let assignedPort = OSPortBox()
+        listener.stateUpdateHandler = { state in
+            if case .ready = state, let port = listener.port?.rawValue {
+                assignedPort.set(port)
+                portReady.fulfill()
+            }
+        }
+        listener.start(queue: .global())
+        defer { listener.cancel() }
+
+        await fulfillment(of: [portReady], timeout: 2)
+        let port = try XCTUnwrap(assignedPort.value)
+        guard let baseURL = URL(string: "http://127.0.0.1:\(port)") else {
+            XCTFail("could not build URL")
+            return
+        }
+        let client = RPCClient(baseURL: baseURL, token: "test-token")
+
+        let start = Date()
+        let timeout: TimeInterval = 1
+        do {
+            _ = try await client.get("/healthz", timeout: timeout)
+            XCTFail("expected request to time out, got data")
+        } catch {
+            let elapsed = Date().timeIntervalSince(start)
+            // The request must have actually taken roughly the configured
+            // timeout — a quick bail-out (e.g. connection refused, missing
+            // wiring of `req.timeoutInterval`) finishes in milliseconds and
+            // means the timeout knob isn't being honoured.
+            XCTAssertGreaterThanOrEqual(
+                elapsed, timeout * 0.7,
+                "Client gave up too fast (elapsed=\(elapsed)s, timeout=\(timeout)s)" +
+                    " — connection probably failed before timeout could fire." +
+                    " Error was: \(error)",
+            )
+            XCTAssertLessThan(
+                elapsed, timeout * 4,
+                "Client did not honour timeout: elapsed=\(elapsed)s, timeout=\(timeout)s",
+            )
+        }
+    }
+}
+
+/// Thread-safe single-shot box for the OS-assigned listener port — written
+/// from the listener's stateUpdateHandler queue, read from the test actor.
+private final class OSPortBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: UInt16?
+    var value: UInt16? {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
+
+    func set(_ port: UInt16) {
+        lock.lock(); defer { lock.unlock() }
+        stored = port
+    }
+}
+
+/// Thread-safe holder that keeps `NWConnection` instances alive for the
+/// duration of a test. Without strong references the system tears the
+/// connection down before URLSession's timeout has a chance to fire.
+private final class SilentConnectionHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var connections: [NWConnection] = []
+    func add(_ connection: NWConnection) {
+        lock.lock(); defer { lock.unlock() }
+        connections.append(connection)
     }
 }


### PR DESCRIPTION
## Summary

Integration tests on top of the helpers landed in #184 and #185.

The unit tests added in #184 + #185 prove the new helpers are correct in isolation. These integration tests prove the helpers are actually **wired into** the production code paths — catching a future refactor that bypasses the helper or silently disables the new check.

### Commit 1 — raw-socket Host allowlist

URLSession's `setValue(_:forHTTPHeaderField: "Host")` is silently ignored. Two tests in `DebugRPCServerIntegrationTests` write raw HTTP bytes onto a TCP socket: foreign Host → 403, loopback Host → 200. Adds an `OneShotResumer` helper so the racing Network-framework callbacks don't double-resume the continuation.

### Commit 2 — slug uniqueness end-to-end

Builds two `SpeakerNamingData` instances for jobs with identical titles + different IDs, runs them through the real `saveNamingData(_:slug:)` path, asserts distinct on-disk filenames + correct round-trip via `loadNamingData(slug:)`. Catches a future regression where someone reverts to deriving filenames from `title` alone.

### Commit 3 — mt-cli timeout behavior

`NWListener` that accepts TCP but never responds. Real `client.get(_:timeout:)` with 1-second timeout. Asserts BOTH bounds: `elapsed >= 0.7s` (didn't fail fast — timeout actually fired) and `elapsed < 4s` (didn't hang). The lower bound is the regression-catching half — without it a broken `req.timeoutInterval = ...` line would pass. Adds thread-safe `OSPortBox` + `SilentConnectionHolder` Sendable helpers so the listener's `.ready` port and held-connection refs survive the NWListener queue handoff.

## Test plan
- [x] `swift test --parallel --filter DebugRPCServerIntegrationTests` — 9 tests pass, 2 new (raw-socket).
- [x] `swift test --parallel --filter PipelineQueueTests/test_sameTitleJobs` — green, 1 new.
- [x] `(cd tools/mt-cli && swift test)` — 7 tests, 1 new behavioural timeout test (~1s real wallclock).
- [x] `swift build -Xswiftc -DAPPSTORE` — App Store variant compiles (DebugRPC tests are `#if !APPSTORE`).
- [x] `./scripts/lint.sh` — clean.

## Why these three (and not all five)

- **Screenshot window allowlist**: integration would need a real SwiftUI scene + visible NSWindow — XCTest harness doesn't have full app context. Predicate is fully covered by unit tests; manual sanity check stays.
- **Diagnostics export off-main**: "main thread isn't blocked" is intrinsic UI behaviour, hard to assert without flaky timing tests. Manual sanity check stays.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->