### PR TITLE
build: zero compiler warnings + warnings-as-errors gate

### DIFF
--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -24,7 +24,14 @@ let package = Package(
             // Assets.xcassets is compiled by `actool` in scripts/build_release.sh,
             // not by SPM. Excluding silences "unhandled file" warnings without
             // changing the runtime bundle.
-            exclude: ["Info.plist", "Assets.xcassets"]
+            exclude: ["Info.plist", "Assets.xcassets"],
+            // Treat any new compiler warning as a build failure so deprecations
+            // and concurrency hints are caught at PR time, not on a future
+            // dependency bump. Scoped to our targets only — does not propagate
+            // to WhisperKit/FluidAudio. `unsafeFlags` instead of the cleaner
+            // `treatAllWarnings(as:)` because the latter needs
+            // swift-tools-version 6.0; we still target 5.10 for SPM compat.
+            swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
         ),
         .testTarget(
             name: "MeetingTranscriberTests",
@@ -37,7 +44,8 @@ let package = Package(
             // __Snapshots__ is the SnapshotTesting reference-image directory.
             // Tests load these via filesystem path at runtime, not via the
             // bundle, so SPM doesn't need to package them as resources.
-            exclude: ["Fixtures", "__Snapshots__"]
+            exclude: ["Fixtures", "__Snapshots__"],
+            swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
         ),
     ]
 )

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -31,7 +31,10 @@ let package = Package(
             // to WhisperKit/FluidAudio. `unsafeFlags` instead of the cleaner
             // `treatAllWarnings(as:)` because the latter needs
             // swift-tools-version 6.0; we still target 5.10 for SPM compat.
-            swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"]),
+                .enableUpcomingFeature("ExistentialAny"),
+            ]
         ),
         .testTarget(
             name: "MeetingTranscriberTests",
@@ -45,7 +48,10 @@ let package = Package(
             // Tests load these via filesystem path at runtime, not via the
             // bundle, so SPM doesn't need to package them as resources.
             exclude: ["Fixtures", "__Snapshots__"],
-            swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"]),
+                .enableUpcomingFeature("ExistentialAny"),
+            ]
         ),
     ]
 )

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
                 .product(name: "AudioTapLib", package: "audiotap"),
             ],
             path: "Sources",
-            exclude: ["Info.plist"]
+            // Assets.xcassets is compiled by `actool` in scripts/build_release.sh,
+            // not by SPM. Excluding silences "unhandled file" warnings without
+            // changing the runtime bundle.
+            exclude: ["Info.plist", "Assets.xcassets"]
         ),
         .testTarget(
             name: "MeetingTranscriberTests",
@@ -31,7 +34,10 @@ let package = Package(
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             path: "Tests",
-            exclude: ["Fixtures"]
+            // __Snapshots__ is the SnapshotTesting reference-image directory.
+            // Tests load these via filesystem path at runtime, not via the
+            // bundle, so SPM doesn't need to package them as resources.
+            exclude: ["Fixtures", "__Snapshots__"]
         ),
     ]
 )

--- a/app/MeetingTranscriber/Sources/AppPickerView.swift
+++ b/app/MeetingTranscriber/Sources/AppPickerView.swift
@@ -37,7 +37,7 @@ struct SystemRunningAppsProvider: RunningAppsProvider {
 /// View that lets the user pick a running app and start recording it.
 @MainActor
 struct AppPickerView: View {
-    let appsProvider: RunningAppsProvider
+    let appsProvider: any RunningAppsProvider
     let onStartRecording: (pid_t, String, String) -> Void
     let onCancel: () -> Void
 
@@ -46,7 +46,7 @@ struct AppPickerView: View {
     @State private var meetingTitle: String = ""
 
     init(
-        appsProvider: RunningAppsProvider = SystemRunningAppsProvider(),
+        appsProvider: any RunningAppsProvider = SystemRunningAppsProvider(),
         onStartRecording: @escaping (pid_t, String, String) -> Void,
         onCancel: @escaping () -> Void,
     ) {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -255,7 +255,7 @@ final class AppState {
                 syncLanguageSettings()
                 pipelineQueue = makePipelineQueue()
 
-                let detector: MeetingDetecting = PowerAssertionDetector()
+                let detector: any MeetingDetecting = PowerAssertionDetector()
 
                 let loop = WatchLoop(
                     detector: detector,
@@ -452,7 +452,7 @@ final class AppState {
         return queue
     }
 
-    func makeProtocolGenerator() -> ProtocolGenerating? {
+    func makeProtocolGenerator() -> (any ProtocolGenerating)? {
         switch settings.protocolProvider {
         #if !APPSTORE
             case .claudeCLI:

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -3,6 +3,7 @@
     import Foundation
     import Network
     import os.log
+    import ScreenCaptureKit
 
     private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "DebugRPCServer")
 
@@ -176,7 +177,7 @@
                         return
                     }
                     if let request = HTTPRequest.parse(buffer) {
-                        let response = self.route(request)
+                        let response = await self.route(request)
                         connection.send(content: response.serialize(), completion: .contentProcessed { _ in
                             connection.cancel()
                         })
@@ -191,7 +192,7 @@
 
         // MARK: - Routing
 
-        func route(_ request: HTTPRequest) -> HTTPResponse {
+        func route(_ request: HTTPRequest) async -> HTTPResponse {
             if let origin = request.headers["origin"], !origin.isEmpty, origin != "null" {
                 return HTTPResponse.forbidden()
             }
@@ -227,7 +228,7 @@
                 return routeSpeakerAction(path: request.path, body: request.body)
 
             case ("GET", "/screenshot"):
-                if let png = Self.captureFrontmostWindowPNG() {
+                if let png = await Self.captureFrontmostWindowPNG() {
                     return HTTPResponse.ok(body: png, contentType: "image/png")
                 }
                 return HTTPResponse(
@@ -329,9 +330,13 @@
         // MARK: - Screenshot
 
         /// PNG of the largest visible content window, or nil when none qualifies.
-        /// The app captures itself, so no Screen Recording permission is needed.
+        /// Uses ScreenCaptureKit (`SCScreenshotManager.captureImage`) — the
+        /// non-deprecated successor to `CGWindowListCreateImage`. Unlike the old
+        /// API, SCK requires Screen Recording permission even for self-capture;
+        /// the first request triggers the standard TCC prompt. Acceptable for
+        /// this debug-only path (whole file is `#if !APPSTORE`, RPC is opt-in).
         @MainActor
-        static func captureFrontmostWindowPNG() -> Data? {
+        static func captureFrontmostWindowPNG() async -> Data? {
             let app = NSApplication.shared
             let area: (NSWindow) -> CGFloat = { window in
                 let b = window.contentView?.bounds ?? .zero
@@ -341,17 +346,27 @@
                 .filter { $0.isVisible && $0.contentView != nil }
                 .max { area($0) < area($1) }
             guard let window = candidate, area(window) >= minWindowAreaPx else { return nil }
-            // CGWindowListCreateImage composites real SwiftUI/Metal content;
-            // NSView.cacheDisplay produces blank PNGs for layer-backed views.
             let windowID = CGWindowID(window.windowNumber)
-            guard let cgImage = CGWindowListCreateImage(
-                .null,
-                .optionIncludingWindow,
-                windowID,
-                [.bestResolution, .boundsIgnoreFraming],
-            ) else { return nil }
-            let rep = NSBitmapImageRep(cgImage: cgImage)
-            return rep.representation(using: .png, properties: [:])
+            do {
+                let content = try await SCShareableContent.current
+                guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+                    return nil
+                }
+                let filter = SCContentFilter(desktopIndependentWindow: scWindow)
+                let config = SCStreamConfiguration()
+                let scale = window.backingScaleFactor
+                config.width = max(Int(scWindow.frame.width * scale), 1)
+                config.height = max(Int(scWindow.frame.height * scale), 1)
+                config.showsCursor = false
+                let cgImage = try await SCScreenshotManager.captureImage(
+                    contentFilter: filter, configuration: config,
+                )
+                let rep = NSBitmapImageRep(cgImage: cgImage)
+                return rep.representation(using: .png, properties: [:])
+            } catch {
+                logger.warning("Screenshot capture failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
         }
     }
 

--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -12,7 +12,7 @@ protocol OfflineDiarizationProcessing {
 /// CoreML-based speaker diarization using FluidAudio (on-device, no HuggingFace token needed).
 class FluidDiarizer: DiarizationProvider {
     let mode: DiarizerMode
-    private var offlineProcessor: OfflineDiarizationProcessing
+    private var offlineProcessor: any OfflineDiarizationProcessing
 
     private var sortformerDiarizer: SortformerDiarizer?
 
@@ -20,7 +20,7 @@ class FluidDiarizer: DiarizationProvider {
         true
     }
 
-    init(mode: DiarizerMode = .offline, offlineProcessor: OfflineDiarizationProcessing? = nil) {
+    init(mode: DiarizerMode = .offline, offlineProcessor: (any OfflineDiarizationProcessing)? = nil) {
         self.mode = mode
         self.offlineProcessor = offlineProcessor ?? FluidOfflineProcessor()
     }

--- a/app/MeetingTranscriber/Sources/KnownVoicesView.swift
+++ b/app/MeetingTranscriber/Sources/KnownVoicesView.swift
@@ -10,7 +10,7 @@ struct KnownVoicesView: View {
     @State private var showingEnrollment = false
 
     private let matcher: SpeakerMatcher
-    private let diarizerFactory: (() -> DiarizationProvider)?
+    private let diarizerFactory: (() -> any DiarizationProvider)?
     /// Set by the parent when a meeting is currently waiting on a naming
     /// dialog — we then disable the enroll button to avoid two
     /// SpeakerNamingViews fighting for the user's attention.
@@ -35,7 +35,7 @@ struct KnownVoicesView: View {
 
     init(
         matcher: SpeakerMatcher,
-        diarizerFactory: (() -> DiarizationProvider)? = nil,
+        diarizerFactory: (() -> any DiarizationProvider)? = nil,
         namingDialogActive: Bool = false,
         pipelineBusy: Bool = false,
         onMutate: (() -> Void)? = nil,

--- a/app/MeetingTranscriber/Sources/MicRecorder.swift
+++ b/app/MeetingTranscriber/Sources/MicRecorder.swift
@@ -1,5 +1,6 @@
 // MicRecorder is currently unused (DualSourceRecorder uses AudioTapLib directly).
 // Kept for potential future standalone mic recording feature.
+import AudioTapLib
 import AVFoundation
 import CoreAudio
 import Foundation
@@ -146,27 +147,9 @@ class MicRecorder {
             }
             guard inputChannels > 0 else { continue }
 
-            // Get UID
-            var uidAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyDeviceUID,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain,
-            )
-            var uid: CFString = "" as CFString
-            var uidSize = UInt32(MemoryLayout<CFString>.size)
-            guard AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, &uid) == noErr else { continue }
-
-            // Get name
-            var nameAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioObjectPropertyName,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain,
-            )
-            var name: CFString = "" as CFString
-            var nameSize = UInt32(MemoryLayout<CFString>.size)
-            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name) == noErr else { continue }
-
-            results.append((uid: uid as String, name: name as String, channels: inputChannels))
+            guard let uidValue = readCFStringAudioProperty(deviceID, kAudioDevicePropertyDeviceUID),
+                  let nameValue = readCFStringAudioProperty(deviceID, kAudioObjectPropertyName) else { continue }
+            results.append((uid: uidValue, name: nameValue, channels: inputChannels))
         }
         return results
     }

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -124,7 +124,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
 
     /// Test connection to the API by querying available models.
     /// Returns model names on success.
-    static func testConnection(endpoint: String, model _: String, apiKey: String?, session: URLSession = .shared) async -> Result<[String], Error> {
+    static func testConnection(endpoint: String, model _: String, apiKey: String?, session: URLSession = .shared) async -> Result<[String], any Error> {
         // Derive models endpoint from chat completions endpoint
         guard let chatURL = URL(string: endpoint) else {
             return .failure(ProtocolError.connectionFailed("Invalid endpoint URL"))

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -176,7 +176,7 @@ enum PersistentDiagnosticLog {
                 // fails (disk full, permissions), keep writing to the old
                 // file rather than silently dropping every subsequent entry.
                 guard let newHandle = try? FileHandle(forWritingTo: newURL) else { return }
-                try? newHandle.seekToEnd()
+                _ = try? newHandle.seekToEnd()
                 try? logFileHandle.close()
                 logFileHandle = newHandle
                 openedDateString = today

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -13,8 +13,8 @@ class PipelineQueue {
 
     // Dependencies for processing
     let engine: (any TranscribingEngine)?
-    let diarizationFactory: (() -> DiarizationProvider)?
-    let protocolGeneratorFactory: (() -> ProtocolGenerating?)?
+    let diarizationFactory: (() -> any DiarizationProvider)?
+    let protocolGeneratorFactory: (() -> (any ProtocolGenerating)?)?
     let outputDir: URL?
     let diarizeEnabled: Bool
     let numSpeakers: Int
@@ -287,8 +287,8 @@ class PipelineQueue {
     /// Full init with all processing dependencies.
     init(
         engine: any TranscribingEngine,
-        diarizationFactory: @escaping () -> DiarizationProvider,
-        protocolGeneratorFactory: @escaping () -> ProtocolGenerating?,
+        diarizationFactory: @escaping () -> any DiarizationProvider,
+        protocolGeneratorFactory: @escaping () -> (any ProtocolGenerating)?,
         outputDir: URL,
         logDir: URL? = nil,
         diarizeEnabled: Bool = false,

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SpeakersSettingsView: View {
     @Bindable var settings: AppSettings
     var recognitionStatsLog: RecognitionStatsLog
-    var enrollmentDiarizerFactory: (() -> DiarizationProvider)?
+    var enrollmentDiarizerFactory: (() -> any DiarizationProvider)?
     var namingDialogActive: Bool
     var pipelineBusy: Bool
     /// Called whenever the user mutates the speakers DB from the Known

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
     var updateChecker: UpdateChecker?
     var recognitionStatsLog: RecognitionStatsLog = .init()
     /// Factory for the voice-enrollment diarizer. nil → enroll button hidden.
-    var enrollmentDiarizerFactory: (() -> DiarizationProvider)?
+    var enrollmentDiarizerFactory: (() -> any DiarizationProvider)?
     /// True when a meeting is currently waiting on a naming dialog. We gate
     /// the enroll button to avoid two `SpeakerNamingView` instances.
     var namingDialogActive: Bool = false

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -417,7 +417,7 @@ struct SpeakerNamingView: View {
     /// so fractional starts (e.g. 1.7s) preserve precision; the previous inline code
     /// did `Int(start) * sampleRate`, which discarded the sub-second offset and shifted
     /// playback by up to ~1s into a different speaker.
-    static func sampleRange(
+    nonisolated static func sampleRange(
         start: TimeInterval,
         end: TimeInterval,
         sampleRate: Int,

--- a/app/MeetingTranscriber/Sources/StoredSpeaker.swift
+++ b/app/MeetingTranscriber/Sources/StoredSpeaker.swift
@@ -39,7 +39,7 @@ struct StoredSpeaker: Codable, Identifiable {
     // Migrate old single-embedding format automatically (legacy `embedding`
     // key); default lastUsed/useCount for entries before recency tracking;
     // default centroid/centroidSampleCount for entries before v3 schema.
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         if let multi = try? container.decode([[Float]].self, forKey: .embeddings) {
@@ -79,7 +79,7 @@ struct StoredSpeaker: Codable, Identifiable {
              lastUsed, useCount, isSynthetic
     }
 
-    func encode(to encoder: Encoder) throws {
+    func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(embeddings, forKey: .embeddings)

--- a/app/MeetingTranscriber/Sources/UpdateChecker.swift
+++ b/app/MeetingTranscriber/Sources/UpdateChecker.swift
@@ -111,12 +111,12 @@ final class UpdateChecker {
     var lastCheckDate: Date?
     var lastError: String?
 
-    private let provider: UpdateProviding
+    private let provider: any UpdateProviding
     private let currentVersion: (Int, Int, Int)
     private var checkTask: Task<Void, Never>?
     private var periodicTask: Task<Void, Never>?
 
-    init(provider: UpdateProviding = GitHubReleaseProvider()) {
+    init(provider: any UpdateProviding = GitHubReleaseProvider()) {
         self.provider = provider
         let version =
             Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"

--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 /// diarization side.
 struct VoiceEnrollmentView: View {
     let matcher: SpeakerMatcher
-    let diarizerFactory: () -> DiarizationProvider
+    let diarizerFactory: () -> any DiarizationProvider
     let onClose: () -> Void
 
     @State private var stage: Stage = .pickFile

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -30,7 +30,7 @@ class WatchLoop {
 
     // Manual recording
     private(set) var manualRecordingInfo: ManualRecordingInfo?
-    private var activeRecorder: RecordingProvider?
+    private var activeRecorder: (any RecordingProvider)?
     private var manualRecordingTask: Task<Void, Never>?
 
     var isManualRecording: Bool {
@@ -38,8 +38,8 @@ class WatchLoop {
     }
 
     // Dependencies
-    let detector: MeetingDetecting
-    let recorderFactory: @MainActor () -> RecordingProvider
+    let detector: any MeetingDetecting
+    let recorderFactory: @MainActor () -> any RecordingProvider
     var pipelineQueue: PipelineQueue?
     var permissionChecker: () async -> HealthCheckResult = { await PermissionHealthCheck.runLive() }
 
@@ -70,8 +70,8 @@ class WatchLoop {
     var onStateChange: ((State, State) -> Void)?
 
     init(
-        detector: MeetingDetecting = WatchLoop.defaultDetector(),
-        recorderFactory: @MainActor @escaping () -> RecordingProvider = { DualSourceRecorder() },
+        detector: any MeetingDetecting = WatchLoop.defaultDetector(),
+        recorderFactory: @MainActor @escaping () -> any RecordingProvider = { DualSourceRecorder() },
         pipelineQueue: PipelineQueue? = nil,
         pollInterval: TimeInterval = 3.0,
         endGracePeriod: TimeInterval = 15.0,
@@ -101,7 +101,7 @@ class WatchLoop {
         AppPaths.downloadsProtocolsDir
     }
 
-    nonisolated static func defaultDetector() -> MeetingDetecting {
+    nonisolated static func defaultDetector() -> any MeetingDetecting {
         PowerAssertionDetector()
     }
 

--- a/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
@@ -37,7 +37,7 @@ final class AppPickerViewTests: XCTestCase {
         )
         let body = try sut.inspect()
         let button = try body.find(button: "Start Recording")
-        XCTAssertTrue(try button.isDisabled())
+        XCTAssertTrue(button.isDisabled())
     }
 
     func testCancelButtonExists() throws {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -264,9 +264,10 @@
 
         @MainActor
         func testRouteRenameSpeakerInvalidJSONReturns400() {
+            let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
-                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+                snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data("{not json".utf8)
             let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
@@ -357,9 +358,10 @@
 
         @MainActor
         func testRouteSeedSpeakerInvalidJSONReturns400() {
+            let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
-                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+                snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"wrong":"shape"}"#.utf8)
             let response = server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
@@ -381,9 +383,10 @@
 
         @MainActor
         func testRouteSpeakerActionsRejectMissingAuth() {
+            let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
-                snapshot: { .empty }, speakerActions: StubSpeakerActions().actions(),
+                snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"A","to":"B"}"#.utf8)
             // Missing Authorization header.

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -79,14 +79,14 @@
         // MARK: - Routing
 
         @MainActor
-        func testRouteState() {
+        func testRouteState() async {
             let snapshot = RPCStateSnapshot(
                 pipeline: .init(isProcessing: false, activeJobCount: 1, waitingJobCount: 0, pendingNamingJobCount: 0),
                 speakerDB: .init(count: 5, recentNames: ["Speaker A"], knownSpeakerNames: ["Speaker A"]),
                 pendingNamingJobs: [],
             )
             let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
-            let response = server.route(authedRequest(method: "GET", path: "/state"))
+            let response = await server.route(authedRequest(method: "GET", path: "/state"))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(response.contentType, "application/json")
             let decoded = try? JSONDecoder().decode(RPCStateSnapshot.self, from: response.body)
@@ -95,59 +95,59 @@
         }
 
         @MainActor
-        func testRouteHealthz() {
+        func testRouteHealthz() async {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(authedRequest(method: "GET", path: "/healthz"))
+            let response = await server.route(authedRequest(method: "GET", path: "/healthz"))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
         }
 
         @MainActor
-        func testRouteOpenSettingsReturnsOk() {
+        func testRouteOpenSettingsReturnsOk() async {
             // The actual AppKit selector is a no-op in the test harness (no
             // Settings scene declared); we only verify the route plumbs through.
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(authedRequest(method: "POST", path: "/action/openSettings"))
+            let response = await server.route(authedRequest(method: "POST", path: "/action/openSettings"))
             XCTAssertEqual(response.status, 200)
         }
 
         @MainActor
-        func testRouteCloseSettingsReturnsOk() {
+        func testRouteCloseSettingsReturnsOk() async {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(authedRequest(method: "POST", path: "/action/closeSettings"))
+            let response = await server.route(authedRequest(method: "POST", path: "/action/closeSettings"))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
         }
 
         @MainActor
-        func testRouteScreenshotNoWindowReturns503() {
+        func testRouteScreenshotNoWindowReturns503() async {
             // Tests run headless — NSApp has no visible window, so the
             // capture helper returns nil and the route maps to 503.
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(authedRequest(method: "GET", path: "/screenshot"))
+            let response = await server.route(authedRequest(method: "GET", path: "/screenshot"))
             XCTAssertEqual(response.status, 503)
         }
 
         @MainActor
-        func testRouteUnknown() {
+        func testRouteUnknown() async {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(authedRequest(method: "GET", path: "/nope"))
+            let response = await server.route(authedRequest(method: "GET", path: "/nope"))
             XCTAssertEqual(response.status, 404)
         }
 
         // MARK: - Security
 
         @MainActor
-        func testRouteRejectsMissingAuth() {
+        func testRouteRejectsMissingAuth() async {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(HTTPRequest(method: "GET", path: "/state"))
+            let response = await server.route(HTTPRequest(method: "GET", path: "/state"))
             XCTAssertEqual(response.status, 401)
         }
 
         @MainActor
-        func testRouteRejectsWrongToken() {
+        func testRouteRejectsWrongToken() async {
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
-            let response = server.route(HTTPRequest(
+            let response = await server.route(HTTPRequest(
                 method: "GET", path: "/state",
                 headers: ["authorization": "Bearer nope"],
             ))
@@ -155,23 +155,23 @@
         }
 
         @MainActor
-        func testRouteRejectsNonEmptyOrigin() {
+        func testRouteRejectsNonEmptyOrigin() async {
             // Browser CSRF: page on https://evil.example sends Origin.
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
             var headers = Self.authHeaders
             headers["origin"] = "http://evil.example"
-            let response = server.route(HTTPRequest(method: "GET", path: "/state", headers: headers))
+            let response = await server.route(HTTPRequest(method: "GET", path: "/state", headers: headers))
             XCTAssertEqual(response.status, 403)
         }
 
         @MainActor
-        func testRouteAcceptsNullOrigin() {
+        func testRouteAcceptsNullOrigin() async {
             // Some user agents send literal "null" for sandboxed/file:// contexts —
             // treat as absent so curl/native tools always work.
             let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
             var headers = Self.authHeaders
             headers["origin"] = "null"
-            let response = server.route(HTTPRequest(method: "GET", path: "/healthz", headers: headers))
+            let response = await server.route(HTTPRequest(method: "GET", path: "/healthz", headers: headers))
             XCTAssertEqual(response.status, 200)
         }
 
@@ -217,7 +217,7 @@
         // MARK: - Speaker DB action routes
 
         @MainActor
-        func testRouteRenameSpeakerCallsActionAndReturnsOK() throws {
+        func testRouteRenameSpeakerCallsActionAndReturnsOK() async throws {
             let stub = StubSpeakerActions()
             stub.renameOutcome = .ok
             let server = DebugRPCServer(
@@ -225,7 +225,7 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"Old","to":"New"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(stub.renameCalls.count, 1)
             XCTAssertEqual(stub.renameCalls.first?.0, "Old")
@@ -235,7 +235,7 @@
         }
 
         @MainActor
-        func testRouteRenameSpeakerNotFoundReturns404() {
+        func testRouteRenameSpeakerNotFoundReturns404() async {
             let stub = StubSpeakerActions()
             stub.renameOutcome = .notFound
             let server = DebugRPCServer(
@@ -243,12 +243,12 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"Missing","to":"Whatever"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
             XCTAssertEqual(response.status, 404)
         }
 
         @MainActor
-        func testRouteRenameSpeakerCollisionReturnsMerged() throws {
+        func testRouteRenameSpeakerCollisionReturnsMerged() async throws {
             let stub = StubSpeakerActions()
             stub.renameOutcome = .merged
             let server = DebugRPCServer(
@@ -256,39 +256,39 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"A","to":"B"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
             XCTAssertEqual(response.status, 200)
             let decoded = try JSONSerialization.jsonObject(with: response.body) as? [String: String]
             XCTAssertEqual(decoded?["outcome"], "merged")
         }
 
         @MainActor
-        func testRouteRenameSpeakerInvalidJSONReturns400() {
+        func testRouteRenameSpeakerInvalidJSONReturns400() async {
             let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data("{not json".utf8)
-            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
             XCTAssertEqual(response.status, 400)
         }
 
         @MainActor
-        func testRouteRenameSpeakerMissingFieldReturns400() {
+        func testRouteRenameSpeakerMissingFieldReturns400() async {
             let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"OnlyThis"}"#.utf8) // missing "to"
-            let response = server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/renameSpeaker", body: body))
             XCTAssertEqual(response.status, 400)
             XCTAssertTrue(stub.renameCalls.isEmpty)
         }
 
         @MainActor
-        func testRouteDeleteSpeakerCallsActionAndReturnsOK() {
+        func testRouteDeleteSpeakerCallsActionAndReturnsOK() async {
             let stub = StubSpeakerActions()
             stub.deleteOutcome = .ok
             let server = DebugRPCServer(
@@ -296,13 +296,13 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"name":"Doomed"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(stub.deleteCalls, ["Doomed"])
         }
 
         @MainActor
-        func testRouteDeleteSpeakerNotFoundReturns404() {
+        func testRouteDeleteSpeakerNotFoundReturns404() async {
             let stub = StubSpeakerActions()
             stub.deleteOutcome = .notFound
             let server = DebugRPCServer(
@@ -310,12 +310,12 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"name":"Ghost"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/deleteSpeaker", body: body))
             XCTAssertEqual(response.status, 404)
         }
 
         @MainActor
-        func testRouteMergeSpeakersCallsActionAndReturnsOK() {
+        func testRouteMergeSpeakersCallsActionAndReturnsOK() async {
             let stub = StubSpeakerActions()
             stub.mergeOutcome = .ok
             let server = DebugRPCServer(
@@ -323,14 +323,14 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"A","into":"B"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(stub.mergeCalls.first?.0, "A")
             XCTAssertEqual(stub.mergeCalls.first?.1, "B")
         }
 
         @MainActor
-        func testRouteMergeSpeakersNotFoundReturns404() {
+        func testRouteMergeSpeakersNotFoundReturns404() async {
             let stub = StubSpeakerActions()
             stub.mergeOutcome = .notFound
             let server = DebugRPCServer(
@@ -338,12 +338,12 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"from":"X","into":"Y"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/mergeSpeakers", body: body))
             XCTAssertEqual(response.status, 404)
         }
 
         @MainActor
-        func testRouteSeedSpeakerCallsActionAndReturnsOK() {
+        func testRouteSeedSpeakerCallsActionAndReturnsOK() async {
             let stub = StubSpeakerActions()
             stub.seedOutcome = .ok
             let server = DebugRPCServer(
@@ -351,38 +351,38 @@
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"name":"NewSeed"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
             XCTAssertEqual(response.status, 200)
             XCTAssertEqual(stub.seedCalls, ["NewSeed"])
         }
 
         @MainActor
-        func testRouteSeedSpeakerInvalidJSONReturns400() {
+        func testRouteSeedSpeakerInvalidJSONReturns400() async {
             let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
                 snapshot: { .empty }, speakerActions: stub.actions(),
             )
             let body = Data(#"{"wrong":"shape"}"#.utf8)
-            let response = server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
+            let response = await server.route(authedJSONRequest(path: "/action/seedSpeaker", body: body))
             XCTAssertEqual(response.status, 400)
         }
 
         @MainActor
-        func testRouteStateExposesKnownSpeakerNames() throws {
+        func testRouteStateExposesKnownSpeakerNames() async throws {
             let snapshot = RPCStateSnapshot(
                 pipeline: .init(isProcessing: false, activeJobCount: 0, waitingJobCount: 0, pendingNamingJobCount: 0),
                 speakerDB: .init(count: 2, recentNames: ["Alice", "Bob"], knownSpeakerNames: ["Alice", "Bob"]),
                 pendingNamingJobs: [],
             )
             let server = DebugRPCServer(port: 0, token: Self.testToken) { snapshot }
-            let response = server.route(authedRequest(method: "GET", path: "/state"))
+            let response = await server.route(authedRequest(method: "GET", path: "/state"))
             let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: response.body)
             XCTAssertEqual(decoded.speakerDB.knownSpeakerNames, ["Alice", "Bob"])
         }
 
         @MainActor
-        func testRouteSpeakerActionsRejectMissingAuth() {
+        func testRouteSpeakerActionsRejectMissingAuth() async {
             let stub = StubSpeakerActions()
             let server = DebugRPCServer(
                 port: 0, token: Self.testToken,
@@ -394,7 +394,8 @@
                 method: "POST", path: "/action/renameSpeaker",
                 headers: ["content-type": "application/json"], body: body,
             )
-            XCTAssertEqual(server.route(request).status, 401)
+            let response = await server.route(request)
+            XCTAssertEqual(response.status, 401)
         }
 
         // MARK: - Snapshot JSON

--- a/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
+++ b/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
@@ -51,7 +51,7 @@ final class KnownVoicesViewTests: XCTestCase {
         matcher.saveDB([StoredSpeaker(name: "Old", embeddings: [[1, 0, 0]])])
 
         var calls = 0
-        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+        let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performRename(from: "Old", to: "New")
 
@@ -63,7 +63,7 @@ final class KnownVoicesViewTests: XCTestCase {
         matcher.saveDB([StoredSpeaker(name: "Doomed", embeddings: [[1, 0, 0]])])
 
         var calls = 0
-        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+        let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performDelete(name: "Doomed")
 
@@ -78,7 +78,7 @@ final class KnownVoicesViewTests: XCTestCase {
         ])
 
         var calls = 0
-        let view = KnownVoicesView(matcher: matcher) { calls += 1 }
+        let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performMerge(from: "From", into: "Into")
 

--- a/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
+++ b/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
@@ -51,6 +51,10 @@ final class KnownVoicesViewTests: XCTestCase {
         matcher.saveDB([StoredSpeaker(name: "Old", embeddings: [[1, 0, 0]])])
 
         var calls = 0
+        // Swift's trailing-closure disambiguation forces an explicit `onMutate:`
+        // label here (KnownVoicesView has multiple closure params); SwiftLint's
+        // trailing_closure rule disagrees but the compiler wins.
+        // swiftlint:disable:next trailing_closure
         let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performRename(from: "Old", to: "New")
@@ -63,6 +67,10 @@ final class KnownVoicesViewTests: XCTestCase {
         matcher.saveDB([StoredSpeaker(name: "Doomed", embeddings: [[1, 0, 0]])])
 
         var calls = 0
+        // Swift's trailing-closure disambiguation forces an explicit `onMutate:`
+        // label here (KnownVoicesView has multiple closure params); SwiftLint's
+        // trailing_closure rule disagrees but the compiler wins.
+        // swiftlint:disable:next trailing_closure
         let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performDelete(name: "Doomed")
@@ -78,6 +86,10 @@ final class KnownVoicesViewTests: XCTestCase {
         ])
 
         var calls = 0
+        // Swift's trailing-closure disambiguation forces an explicit `onMutate:`
+        // label here (KnownVoicesView has multiple closure params); SwiftLint's
+        // trailing_closure rule disagrees but the compiler wins.
+        // swiftlint:disable:next trailing_closure
         let view = KnownVoicesView(matcher: matcher, onMutate: { calls += 1 })
 
         view.performMerge(from: "From", into: "Into")

--- a/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
@@ -26,13 +26,13 @@ final class ParakeetEngineTests: XCTestCase {
     func testConformsToTranscribingEngine() {
         let engine = ParakeetEngine()
         // Assign to protocol type to verify conformance at compile time
-        let proto: TranscribingEngine = engine
+        let proto: any TranscribingEngine = engine
         XCTAssertNotNil(proto)
     }
 
     func testIsReferenceType() {
         let engine = ParakeetEngine()
-        let ref: TranscribingEngine = engine
+        let ref: any TranscribingEngine = engine
         // Mutating the reference should be visible via the original variable
         XCTAssertIdentical(engine, ref, "ParakeetEngine should be a reference type (class)")
     }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -501,7 +501,7 @@ final class PipelineQueueTests: XCTestCase {
 
     private func makeMockProcessingQueue(
         engine: MockEngine? = nil,
-        diarizationFactory: @escaping () -> DiarizationProvider = { MockDiarization() },
+        diarizationFactory: @escaping () -> any DiarizationProvider = { MockDiarization() },
         diarizeEnabled: Bool = false,
         numSpeakers: Int = 0,
     ) -> (PipelineQueue, MockEngine) {

--- a/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
@@ -30,14 +30,14 @@ final class Qwen3AsrEngineTests: XCTestCase {
         guard #available(macOS 15, *) else { return }
         let engine = Qwen3AsrEngine()
         // Assign to protocol type to verify conformance at compile time
-        let proto: TranscribingEngine = engine
+        let proto: any TranscribingEngine = engine
         XCTAssertNotNil(proto)
     }
 
     func testIsReferenceType() {
         guard #available(macOS 15, *) else { return }
         let engine = Qwen3AsrEngine()
-        let ref: TranscribingEngine = engine
+        let ref: any TranscribingEngine = engine
         // Mutating the reference should be visible via the original variable
         XCTAssertIdentical(engine, ref, "Qwen3AsrEngine should be a reference type (class)")
     }

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -385,7 +385,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.clearCustomOutputDir()
         let body = try makeOutput(settings: settings).inspect()
         let button = try body.find(button: "Reset")
-        XCTAssertTrue(try button.isDisabled())
+        XCTAssertTrue(button.isDisabled())
     }
 
     func testEditPromptButtonExists() throws {
@@ -483,7 +483,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.recordOnly = true
         let body = try makeTranscription(settings: settings).inspect()
         let section = try body.find(viewWithAccessibilityIdentifier: "transcriptionSection")
-        XCTAssertTrue(try section.isDisabled())
+        XCTAssertTrue(section.isDisabled())
     }
 
     func testRecordOnlyDisablesProtocolSection() throws {
@@ -491,7 +491,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.recordOnly = true
         let body = try makeOutput(settings: settings).inspect()
         let section = try body.find(viewWithAccessibilityIdentifier: "protocolSection")
-        XCTAssertTrue(try section.isDisabled())
+        XCTAssertTrue(section.isDisabled())
     }
 
     func testRecordOnlyDoesNotDisableOutputFolderSection() throws {
@@ -501,7 +501,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.recordOnly = true
         let body = try makeOutput(settings: settings).inspect()
         let section = try body.find(viewWithAccessibilityIdentifier: "outputFolderSection")
-        XCTAssertFalse(try section.isDisabled())
+        XCTAssertFalse(section.isDisabled())
     }
 
     func testRecordOnlyDisablesDiarizationSection() throws {
@@ -509,7 +509,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.recordOnly = true
         let body = try makeSpeakers(settings: settings).inspect()
         let section = try body.find(viewWithAccessibilityIdentifier: "diarizationSection")
-        XCTAssertTrue(try section.isDisabled())
+        XCTAssertTrue(section.isDisabled())
     }
 
     func testRecordOnlyDisablesVadSection() throws {
@@ -517,6 +517,6 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.recordOnly = true
         let body = try makeAudio(settings: settings).inspect()
         let section = try body.find(viewWithAccessibilityIdentifier: "vadSection")
-        XCTAssertTrue(try section.isDisabled())
+        XCTAssertTrue(section.isDisabled())
     }
 }

--- a/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
+++ b/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
@@ -4,8 +4,8 @@ import XCTest
 // MARK: - Mock Provider
 
 final class MockUpdateProvider: UpdateProviding, @unchecked Sendable {
-    var latestReleaseResult: Result<ReleaseInfo, Error> = .failure(UpdateCheckerError.networkError("not configured"))
-    var allReleasesResult: Result<[ReleaseInfo], Error> = .failure(UpdateCheckerError.networkError("not configured"))
+    var latestReleaseResult: Result<ReleaseInfo, any Error> = .failure(UpdateCheckerError.networkError("not configured"))
+    var allReleasesResult: Result<[ReleaseInfo], any Error> = .failure(UpdateCheckerError.networkError("not configured"))
     var latestReleaseCalled = false
     var allReleasesCalled = false
     var delay: Duration?

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -52,7 +52,7 @@ final class VoiceEnrollmentViewTests: XCTestCase {
         )
         let inspected = try view.inspect()
         let button = try inspected.find(button: "Add from Recording…")
-        XCTAssertTrue(try button.isDisabled())
+        XCTAssertTrue(button.isDisabled())
     }
 
     func testKnownVoicesViewShowsBusyHintWhenPipelineBusy() throws {

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -32,7 +32,7 @@ final class VoiceEnrollmentViewTests: XCTestCase {
     func testKnownVoicesViewShowsEnrollButtonWhenFactoryProvided() throws {
         let view = KnownVoicesView(
             matcher: SpeakerMatcher(dbPath: dbPath),
-            diarizerFactory: { MockDiarization() } as (() -> DiarizationProvider),
+            diarizerFactory: { MockDiarization() } as (() -> any DiarizationProvider),
         )
         let inspected = try view.inspect()
         XCTAssertNoThrow(try inspected.find(button: "Add from Recording…"))

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -26,13 +26,16 @@ else
 fi
 
 # --- SwiftLint (linter) ---
+# `--strict` promotes warning-level rules to errors so any new violation
+# fails CI rather than slowly accumulating. Pair with the swiftSettings'
+# `-warnings-as-errors` for full zero-warning enforcement.
 if command -v swiftlint &>/dev/null; then
     if [[ "${1:-}" == "--fix" ]]; then
         echo "Running swiftlint --fix..."
-        swiftlint lint --fix
+        swiftlint lint --fix --strict
     else
-        echo "Running swiftlint..."
-        swiftlint lint "$@"
+        echo "Running swiftlint --strict..."
+        swiftlint lint --strict "$@"
     fi
 else
     echo "Error: swiftlint not found. Install with: brew install swiftlint"

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -67,7 +67,7 @@ func getDefaultOutputDeviceUID() -> String? {
 }
 
 /// Read a CFString-valued audio property. Returns nil if the property is unavailable.
-func readCFStringAudioProperty(
+public func readCFStringAudioProperty(
     _ id: AudioObjectID,
     _ selector: AudioObjectPropertySelector,
     scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,


### PR DESCRIPTION
## Summary

- Fix every Swift compiler warning the CI build emitted across Sources, Tests, and the SPM manifest.
- Migrate the deprecated `CGWindowListCreateImage` to `SCScreenshotManager` (ScreenCaptureKit, macOS 14+).
- Lock the gate going forward: `-warnings-as-errors` on both SPM targets, `swiftlint --strict` in `scripts/lint.sh`, `ExistentialAny` upcoming feature, and lint coverage extended to mt-cli + audiotap-Tests (previously silently skipped).

## Commits (atomic, 13)

| | What |
|---|---|
| `fix(app)` | unused `try?` in PersistentDiagnosticLog |
| `test(app)` | drop `try` on ViewInspector `isDisabled()` (8 sites) |
| `test(app)` | label trailing closure `onMutate:` |
| `test(app)` | keep `StubSpeakerActions` alive in routing tests |
| `fix(app)` | `sampleRange` nonisolated |
| `fix(app)` | bridge CoreAudio CFString reads via `AudioTapLib.readCFStringAudioProperty` (helper promoted to public) |
| `build(app)` | exclude `Assets.xcassets` + `__Snapshots__` from SPM |
| `refactor(app)` | migrate `/screenshot` to ScreenCaptureKit |
| `build(app)` | treat Swift warnings as errors (`-warnings-as-errors` on both targets) |
| `test(app)` | exempt `KnownVoicesView` callers from `trailing_closure` rule (compiler-vs-lint conflict) |
| `ci(lint)` | pass `--strict` to swiftlint |
| `build(app)` | require explicit `any` for protocol existentials (`ExistentialAny` upcoming feature) — 26 sites across 13 source + 5 test files |
| `ci(lint)` | close lint-coverage gap on mt-cli + audiotap tests — `.swiftlint.yml` was missing 3 paths, mt-cli source bypassed strict lint entirely; refactor `lint.sh` as single source of truth via new `--format-only` / `--lint-only` flags |

## Behavioural deltas worth flagging

- **`/screenshot` debug RPC endpoint now requires Screen Recording permission.** SCK does not have CGWindowList's self-capture TCC exemption — first call triggers a TCC prompt. Acceptable: whole `DebugRPCServer.swift` is `#if !APPSTORE`, the server itself is opt-in (env var or Settings toggle).
- `route(_:)` is now `async`. 23 test sites + their methods get `await` / `async`. Behaviour-equivalent for sync branches.
- `swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]` rather than `.treatAllWarnings(as: .error)` because the latter needs swift-tools-version 6.0; we still target 5.10. Scoped to our targets only — does not propagate to WhisperKit/FluidAudio.
- `ExistentialAny` is an opt-in via `.enableUpcomingFeature` — no language-mode bump, no transitive effect on dependencies.
- Lint coverage grew from 141 → 151 files (added: tools/audiotap/Tests, tools/mt-cli/Sources, tools/mt-cli/Tests). RPCClient.swift had 5 latent violations (force-unwrapping, vertical-whitespace-between-cases, prefer-Self) that are now fixed.

## Test plan

- [x] `swift build` (Homebrew) — clean, 0 warnings
- [x] `swift build -Xswiftc -DAPPSTORE` — clean, 0 warnings
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — 1253 tests, 0 failures (snapshot drift is pre-existing on `main`, not in scope)
- [x] `cd tools/audiotap && swift test` — 56/56 passing
- [x] `cd tools/mt-cli && swift test` — 6/6 passing
- [x] `./scripts/lint.sh` — 0 violations, 0 serious in 151 files
- [ ] CI matrix green