### PR TITLE
ci(lint): close lint-coverage gap on mt-cli + audiotap tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,11 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install tools
         run: brew install swiftformat swiftlint
+      # SwiftFormat path list lives in scripts/lint.sh; calling it keeps CI and
+      # local lint runs aligned. SwiftLint stays an explicit step to use the
+      # github-actions-logging reporter (annotations in the PR diff).
       - name: SwiftFormat
-        run: |
-          swiftformat --dryrun --lint \
-            app/MeetingTranscriber/Sources \
-            app/MeetingTranscriber/Tests \
-            tools/audiotap/Sources \
-            tools/meeting-simulator/Sources \
-            tools/mt-cli/Sources \
-            tools/mt-cli/Tests \
-            scripts/generate_menu_bar_gifs.swift
+        run: bash scripts/lint.sh --format-only
       - name: SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging
       - name: Build script regression tests

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,10 @@ included:
   - app/MeetingTranscriber/Sources
   - app/MeetingTranscriber/Tests
   - tools/audiotap/Sources
+  - tools/audiotap/Tests
   - tools/meeting-simulator/Sources
+  - tools/mt-cli/Sources
+  - tools/mt-cli/Tests
   - scripts/generate_menu_bar_gifs.swift
 
 excluded:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ included:
   - tools/meeting-simulator/Sources
   - tools/mt-cli/Sources
   - tools/mt-cli/Tests
+  - tools/whisperkit-cli/Sources
   - scripts/generate_menu_bar_gifs.swift
 
 excluded:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# Lint orchestrator. Single source of truth for the Swift directories that get
+# formatted and linted across local dev and CI.
+#
+# Usage:
+#   ./scripts/lint.sh                # check both (dry-run)
+#   ./scripts/lint.sh --fix          # auto-correct both
+#   ./scripts/lint.sh --format-only  # only SwiftFormat
+#   ./scripts/lint.sh --lint-only    # only SwiftLint
+
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -6,38 +15,51 @@ SWIFT_DIRS=(
     app/MeetingTranscriber/Sources
     app/MeetingTranscriber/Tests
     tools/audiotap/Sources
+    tools/audiotap/Tests
     tools/meeting-simulator/Sources
     tools/mt-cli/Sources
     tools/mt-cli/Tests
     scripts/generate_menu_bar_gifs.swift
 )
 
+MODE="${1:-}"
+RUN_FORMAT=true
+RUN_LINT=true
+case "$MODE" in
+    --format-only) RUN_LINT=false ;;
+    --lint-only)   RUN_FORMAT=false ;;
+esac
+
 # --- SwiftFormat (formatter) ---
-if command -v swiftformat &>/dev/null; then
-    if [[ "${1:-}" == "--fix" ]]; then
-        echo "Running swiftformat..."
-        swiftformat "${SWIFT_DIRS[@]}"
+if [[ "$RUN_FORMAT" == "true" ]]; then
+    if command -v swiftformat &>/dev/null; then
+        if [[ "$MODE" == "--fix" ]]; then
+            echo "Running swiftformat..."
+            swiftformat "${SWIFT_DIRS[@]}"
+        else
+            echo "Checking swiftformat..."
+            swiftformat --dryrun --lint "${SWIFT_DIRS[@]}"
+        fi
     else
-        echo "Checking swiftformat..."
-        swiftformat --dryrun --lint "${SWIFT_DIRS[@]}"
+        echo "Warning: swiftformat not found. Install with: brew install swiftformat"
     fi
-else
-    echo "Warning: swiftformat not found. Install with: brew install swiftformat"
 fi
 
 # --- SwiftLint (linter) ---
 # `--strict` promotes warning-level rules to errors so any new violation
 # fails CI rather than slowly accumulating. Pair with the swiftSettings'
 # `-warnings-as-errors` for full zero-warning enforcement.
-if command -v swiftlint &>/dev/null; then
-    if [[ "${1:-}" == "--fix" ]]; then
-        echo "Running swiftlint --fix..."
-        swiftlint lint --fix --strict
+if [[ "$RUN_LINT" == "true" ]]; then
+    if command -v swiftlint &>/dev/null; then
+        if [[ "$MODE" == "--fix" ]]; then
+            echo "Running swiftlint --fix..."
+            swiftlint lint --fix --strict
+        else
+            echo "Running swiftlint --strict..."
+            swiftlint lint --strict
+        fi
     else
-        echo "Running swiftlint --strict..."
-        swiftlint lint --strict "$@"
+        echo "Error: swiftlint not found. Install with: brew install swiftlint"
+        exit 1
     fi
-else
-    echo "Error: swiftlint not found. Install with: brew install swiftlint"
-    exit 1
 fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,6 +19,7 @@ SWIFT_DIRS=(
     tools/meeting-simulator/Sources
     tools/mt-cli/Sources
     tools/mt-cli/Tests
+    tools/whisperkit-cli/Sources
     scripts/generate_menu_bar_gifs.swift
 )
 

--- a/tools/audiotap/Tests/AppAudioCaptureStatusTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureStatusTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @available(macOS 14.2, *)
 final class AppAudioCaptureStatusTests: XCTestCase {
     func test_describeTapError_permissionDenied_mentionsPermission() {
-        let msg = AppAudioCapture.describeTapError(-12_988)
+        let msg = AppAudioCapture.describeTapError(-12988)
         XCTAssertTrue(
             msg.lowercased().contains("permission") || msg.contains("Privacy"),
             "Expected hint about permissions/Privacy, got: \(msg)",
@@ -12,7 +12,7 @@ final class AppAudioCaptureStatusTests: XCTestCase {
     }
 
     func test_describeTapError_invalidProperty_mentionsTargetExited() {
-        let msg = AppAudioCapture.describeTapError(-10_851)
+        let msg = AppAudioCapture.describeTapError(-10851)
         XCTAssertTrue(msg.contains("exited") || msg.contains("Invalid"))
     }
 
@@ -22,7 +22,7 @@ final class AppAudioCaptureStatusTests: XCTestCase {
     }
 
     func test_describeTapError_unknown_includesNumericCode() {
-        let msg = AppAudioCapture.describeTapError(-99_999)
+        let msg = AppAudioCapture.describeTapError(-99999)
         XCTAssertTrue(msg.contains("-99999"))
     }
 }

--- a/tools/audiotap/Tests/AudioCaptureResultTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureResultTests.swift
@@ -1,7 +1,6 @@
+@testable import AudioTapLib
 import Foundation
 import XCTest
-
-@testable import AudioTapLib
 
 final class AudioCaptureResultTests: XCTestCase {
     func testFieldsStored() {
@@ -12,7 +11,7 @@ final class AudioCaptureResultTests: XCTestCase {
             micAudioFileURL: micURL,
             actualSampleRate: 48000,
             actualChannels: 2,
-            micDelay: 0.123
+            micDelay: 0.123,
         )
 
         XCTAssertEqual(result.appAudioFileURL, appURL)
@@ -28,7 +27,7 @@ final class AudioCaptureResultTests: XCTestCase {
             micAudioFileURL: nil,
             actualSampleRate: 16000,
             actualChannels: 2,
-            micDelay: 0
+            micDelay: 0,
         )
 
         XCTAssertNil(result.micAudioFileURL)
@@ -41,7 +40,7 @@ final class AudioCaptureResultTests: XCTestCase {
             micAudioFileURL: nil,
             actualSampleRate: 16000,
             actualChannels: 1,
-            micDelay: 0
+            micDelay: 0,
         )
 
         XCTAssertEqual(result.actualChannels, 1)

--- a/tools/audiotap/Tests/MicCaptureErrorTests.swift
+++ b/tools/audiotap/Tests/MicCaptureErrorTests.swift
@@ -1,7 +1,6 @@
+@testable import AudioTapLib
 import Foundation
 import XCTest
-
-@testable import AudioTapLib
 
 final class MicCaptureErrorTests: XCTestCase {
     func testNoInputDeviceDescription() {

--- a/tools/audiotap/Tests/SampleRateQueryTests.swift
+++ b/tools/audiotap/Tests/SampleRateQueryTests.swift
@@ -7,7 +7,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testValidRatePassesThrough() {
         let result = SampleRateQuery.validateSampleRate(
             queriedRate: 48000,
-            requestedRate: 48000
+            requestedRate: 48000,
         )
         XCTAssertEqual(result.rate, 48000)
         XCTAssertEqual(result.source, .queriedMatchesRequested)
@@ -16,7 +16,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testValidRateDiffersFromRequested() {
         let result = SampleRateQuery.validateSampleRate(
             queriedRate: 44100,
-            requestedRate: 48000
+            requestedRate: 48000,
         )
         XCTAssertEqual(result.rate, 44100)
         XCTAssertEqual(result.source, .queriedDiffersFromRequested)
@@ -25,7 +25,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testZeroRateFallsBackToRequested() {
         let result = SampleRateQuery.validateSampleRate(
             queriedRate: 0,
-            requestedRate: 48000
+            requestedRate: 48000,
         )
         XCTAssertEqual(result.rate, 48000)
         XCTAssertEqual(result.source, .fallbackToRequested)
@@ -34,7 +34,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testNegativeRateFallsBackToRequested() {
         let result = SampleRateQuery.validateSampleRate(
             queriedRate: -1,
-            requestedRate: 48000
+            requestedRate: 48000,
         )
         XCTAssertEqual(result.rate, 48000)
         XCTAssertEqual(result.source, .fallbackToRequested)
@@ -44,7 +44,7 @@ final class SampleRateQueryTests: XCTestCase {
         for rate in [8000, 16000, 22050, 32000, 44100, 48000, 88200, 96000] {
             let result = SampleRateQuery.validateSampleRate(
                 queriedRate: rate,
-                requestedRate: 48000
+                requestedRate: 48000,
             )
             XCTAssertEqual(result.rate, rate, "Rate \(rate) should be accepted")
             XCTAssertNotEqual(result.source, .fallbackToRequested)
@@ -54,7 +54,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testUnreasonablyHighRateFallsBack() {
         let result = SampleRateQuery.validateSampleRate(
             queriedRate: 1_000_000,
-            requestedRate: 48000
+            requestedRate: 48000,
         )
         XCTAssertEqual(result.rate, 48000)
         XCTAssertEqual(result.source, .fallbackToRequested)
@@ -65,7 +65,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testCrossValidationMatchingRates() {
         let result = SampleRateQuery.crossValidateRate(
             nominalRate: 48000,
-            streamRate: 48000
+            streamRate: 48000,
         )
         XCTAssertEqual(result, .consistent(rate: 48000))
     }
@@ -73,7 +73,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testCrossValidationMismatch() {
         let result = SampleRateQuery.crossValidateRate(
             nominalRate: 48000,
-            streamRate: 44100
+            streamRate: 44100,
         )
         XCTAssertEqual(result, .mismatch(nominal: 48000, stream: 44100))
     }
@@ -81,7 +81,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testCrossValidationOnlyNominal() {
         let result = SampleRateQuery.crossValidateRate(
             nominalRate: 48000,
-            streamRate: 0
+            streamRate: 0,
         )
         XCTAssertEqual(result, .onlyNominal(rate: 48000))
     }
@@ -89,7 +89,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testCrossValidationOnlyStream() {
         let result = SampleRateQuery.crossValidateRate(
             nominalRate: 0,
-            streamRate: 44100
+            streamRate: 44100,
         )
         XCTAssertEqual(result, .onlyStream(rate: 44100))
     }
@@ -97,7 +97,7 @@ final class SampleRateQueryTests: XCTestCase {
     func testCrossValidationBothZero() {
         let result = SampleRateQuery.crossValidateRate(
             nominalRate: 0,
-            streamRate: 0
+            streamRate: 0,
         )
         XCTAssertEqual(result, .neitherAvailable)
     }
@@ -135,42 +135,42 @@ final class SampleRateQueryTests: XCTestCase {
 
     func testInferRate48kStereo60s() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 23_040_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+            rawBytes: 23_040_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0,
         )
         XCTAssertEqual(result, 48000)
     }
 
     func testInferRate44100Stereo60s() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 21_168_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+            rawBytes: 21_168_000, bytesPerSample: 4, channels: 2, durationSeconds: 60.0,
         )
         XCTAssertEqual(result, 44100)
     }
 
     func testInferRate24kMono30s() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 30 * 24000 * 1 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 30.0
+            rawBytes: 30 * 24000 * 1 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 30.0,
         )
         XCTAssertEqual(result, 24000)
     }
 
     func testInferRateZeroBytesReturnsNil() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 0, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+            rawBytes: 0, bytesPerSample: 4, channels: 2, durationSeconds: 60.0,
         )
         XCTAssertNil(result)
     }
 
     func testInferRateTooShortReturnsNil() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 48000 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 0.5
+            rawBytes: 48000 * 4, bytesPerSample: 4, channels: 1, durationSeconds: 0.5,
         )
         XCTAssertNil(result)
     }
 
     func testInferRateImplausibleHighReturnsNil() {
         let result = SampleRateQuery.inferRateFromDuration(
-            rawBytes: 500_000 * 4 * 2 * 60, bytesPerSample: 4, channels: 2, durationSeconds: 60.0
+            rawBytes: 500_000 * 4 * 2 * 60, bytesPerSample: 4, channels: 2, durationSeconds: 60.0,
         )
         XCTAssertNil(result)
     }

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -16,8 +16,10 @@ struct RPCClient {
             case let .appNotRunning(url):
                 "Meeting Transcriber app is not running on \(url.absoluteString) " +
                     "(or MEETINGTRANSCRIBER_DEBUG_RPC=1 was not set when it launched)"
+
             case let .http(status, body):
                 "RPC returned HTTP \(status): \(body)"
+
             case let .missingToken(url):
                 "RPC token not found at \(url.path) — start the app with " +
                     "MEETINGTRANSCRIBER_DEBUG_RPC=1 first"
@@ -37,6 +39,8 @@ struct RPCClient {
             .appendingPathComponent(".rpc-token")
     }()
 
+    // Hardcoded literal — URL(string:) cannot fail on a constant valid URL.
+    // swiftlint:disable:next force_unwrapping
     static let defaultBaseURL = URL(string: "http://127.0.0.1:9876")!
 
     /// Per-request timeout. Without this the CLI hangs forever against a
@@ -49,7 +53,7 @@ struct RPCClient {
     /// the rest of the API is fast.
     static let screenshotTimeoutSeconds: TimeInterval = 15
 
-    static func loadDefault() throws -> RPCClient {
+    static func loadDefault() throws -> Self {
         let url = defaultTokenURL
         guard let data = try? Data(contentsOf: url),
               let token = String(data: data, encoding: .utf8)?
@@ -58,7 +62,7 @@ struct RPCClient {
         else {
             throw RPCError.missingToken(url)
         }
-        return RPCClient(baseURL: defaultBaseURL, token: token)
+        return Self(baseURL: defaultBaseURL, token: token)
     }
 
     func get(_ path: String, timeout: TimeInterval = requestTimeoutSeconds) async throws -> Data {

--- a/tools/whisperkit-cli/Sources/main.swift
+++ b/tools/whisperkit-cli/Sources/main.swift
@@ -6,7 +6,7 @@ import WhisperKit
 struct WhisperKitTranscribe: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "whisperkit-transcribe",
-        abstract: "Transcribe audio files using WhisperKit (CoreML/ANE)"
+        abstract: "Transcribe audio files using WhisperKit (CoreML/ANE)",
     )
 
     @Argument(help: "Path to audio file (WAV, M4A, etc.)")
@@ -25,15 +25,14 @@ struct WhisperKitTranscribe: AsyncParsableCommand {
         }
 
         // Resolve model: use specified or device-recommended
-        let resolvedModel: String
-        if let model {
-            resolvedModel = model
+        let resolvedModel: String = if let model {
+            model
         } else {
-            resolvedModel = WhisperKit.recommendedModels().default
+            WhisperKit.recommendedModels().default
         }
 
         FileHandle.standardError.write(
-            Data("Loading model: \(resolvedModel)\n".utf8)
+            Data("Loading model: \(resolvedModel)\n".utf8),
         )
 
         // Download + load model
@@ -44,15 +43,15 @@ struct WhisperKitTranscribe: AsyncParsableCommand {
         let options = DecodingOptions(
             language: language,
             skipSpecialTokens: true,
-            wordTimestamps: false
+            wordTimestamps: false,
         )
         let results: [TranscriptionResult] = try await pipe.transcribe(
             audioPath: audioURL.path(),
-            decodeOptions: options
+            decodeOptions: options,
         )
 
         // Output in [MM:SS] format
-        for segment in results.flatMap({ $0.segments }) {
+        for segment in results.flatMap(\.segments) {
             let total = Int(segment.start)
             let h = total / 3600
             let m = (total % 3600) / 60


### PR DESCRIPTION
## Summary

- `.swiftlint.yml`'s `included:` list was missing `tools/audiotap/Tests`, `tools/mt-cli/Sources`, `tools/mt-cli/Tests`, **and `tools/whisperkit-cli/Sources`**, so `swiftlint --strict` silently skipped them — entire mt-cli and whisperkit-cli code bases bypassed the lint gate.
- `lint.sh`'s `SWIFT_DIRS` was missing `tools/audiotap/Tests` and `tools/whisperkit-cli/Sources`, so SwiftFormat skipped them too.
- `ci.yml` duplicated the SwiftFormat path list; it now calls `bash scripts/lint.sh --format-only` so paths live in exactly one file.

## Behavioural deltas

- Lint coverage grew from 141 → **152** files.
- `RPCClient.swift` had 5 latent SwiftLint violations (force-unwrapping with rationale, vertical-whitespace-between-cases, prefer-Self) — all fixed.
- `tools/audiotap/Tests/*.swift` had 4 latent SwiftFormat trailing-comma findings, auto-corrected.
- `tools/whisperkit-cli/Sources/main.swift` had 2 latent SwiftFormat findings (trailing-comma, preferKeyPath collapse `{ $0.text }` → `\.text`), auto-corrected.
- New `--format-only` / `--lint-only` flags on `lint.sh` let CI keep the explicit SwiftLint step (with `github-actions-logging` reporter for PR annotations) without duplicating SwiftFormat invocation.
- Package.swift manifests stay out — they live at repo roots outside any `included:` path; lint rules add marginal value for declarative target lists.

## Why now

PR #187 just locked `swiftlint --strict` + compiler `-warnings-as-errors` as the zero-warnings gate. Closing this coverage gap means the gate actually applies to all our Swift code, not just the app target.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations, 0 serious in 152 files
- [x] `swift build` (app + tools/whisperkit-cli) — clean
- [x] `cd tools/audiotap && swift test` — 56/56 passing
- [x] `cd tools/mt-cli && swift test` — 6/6 passing
- [ ] CI matrix green