### PR TITLE
ci: repo-meta polish — PR template, SECURITY.md, dependency-review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- 1-3 bullets: what changes, why now. Drop the why if obvious from the title. -->
+
+-
+
+## Behavioural deltas worth flagging
+
+<!-- New TCC prompts, breaking config changes, performance regressions, anything a user/reviewer
+     should know that isn't obvious from the diff. Delete this section if there are none. -->
+
+-
+
+## Test plan
+
+<!-- Tick off what was actually run locally before pushing. CI matrix is the catch-all last item. -->
+
+- [ ] `swift build` (Homebrew variant) — clean
+- [ ] `swift build -Xswiftc -DAPPSTORE` — clean
+- [ ] `swift test --parallel --skip MenuBarIconSnapshotTests`
+- [ ] `./scripts/lint.sh` — 0 violations
+- [ ] CI matrix green

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+# `dependency-review-action` only inspects the diff between PR HEAD and the
+# base branch — no work to do on push/tag/dispatch. Cancel superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Audit added dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          # Block GPL / AGPL / SSPL / proprietary; the project's own dependency
+          # tree is currently MIT/BSD/Apache-2.0 — keep it that way so users
+          # can ship the binary under any of those terms.
+          allow-licenses: >-
+            MIT, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC, MPL-2.0,
+            Unlicense, CC0-1.0, Zlib, 0BSD, BlueOak-1.0.0
+          # Surface high/critical CVEs on touched dependencies as PR comments.
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable release on the `main` branch receives security patches. Pre-release builds from the `meeting-transcriber@beta` cask are best-effort.
+
+| Channel | Branch | Cask | Security fixes |
+|---------|--------|------|----------------|
+| Stable  | `main`, latest tag | `pasrom/meeting-transcriber/meeting-transcriber` | Yes |
+| Beta (RC) | `main`, RC tags | `pasrom/meeting-transcriber/meeting-transcriber@beta` | Best-effort |
+| App Store | TBD | TBD | Yes (when published) |
+
+## Reporting a Vulnerability
+
+**Please do not file public issues for security problems.** Use one of the private channels below:
+
+- **Preferred:** GitHub's private vulnerability reporting — open a draft advisory at <https://github.com/pasrom/meeting-transcriber/security/advisories/new>. This is encrypted, only visible to maintainers, and lets us coordinate a fix and release before disclosure.
+- **Email:** if GitHub is not available to you, contact the maintainer directly via the email associated with the GitHub account.
+
+When reporting, please include:
+
+1. The affected version (`Settings → Advanced → About` shows version + commit hash).
+2. A minimal reproduction or proof-of-concept.
+3. The impact you observed and any mitigating factors.
+
+## Disclosure Timeline
+
+- **Within 5 business days**: acknowledgement and triage.
+- **Within 30 days**: a fix or a clear timeline for one, depending on severity.
+- **At release**: credit in the release notes (you can opt out).
+
+## Scope
+
+- The macOS menu-bar app and its bundled libraries (AudioTapLib, mt-cli, whisperkit-cli) are in scope.
+- The Debug RPC server (`#if !APPSTORE`, off by default) is in scope when enabled.
+- Vulnerabilities in upstream dependencies (WhisperKit, FluidAudio, swift-snapshot-testing, ViewInspector) should be reported to those projects directly; we will track and bump as fixes land.
+
+## Out of Scope
+
+- Issues that require the attacker to already have full filesystem access on the same Mac (the app is designed for personal use, not multi-tenant).
+- Theoretical issues without a working reproduction.


### PR DESCRIPTION
## Summary

Three small build-pipeline-SOTA quick-wins from the local roadmap (`B12`+`B13`+`B16`), bundled because each is a single config file:

- **PR template** at `.github/PULL_REQUEST_TEMPLATE.md` — codifies the Summary / behavioural-deltas / test-plan shape we already use in practice.
- **SECURITY.md** with private-disclosure policy (GitHub Security Advisories preferred), 5-day-ack / 30-day-fix timeline, explicit scope.
- **Dependency-review workflow** running `actions/dependency-review-action@v4` on every PR — license allowlist (MIT/BSD/Apache-2.0/etc.) blocks GPL/AGPL/SSPL/proprietary deps, and high/critical CVEs on added dependencies fail the gate.

## Behavioural deltas worth flagging

- New required check on PRs: `Dependency Review / review`. It runs on `pull_request` against main only — push/tag events are unaffected, and dependency-clean PRs stay silent (no comments).
- Existing dependency tree is well within the license allowlist (WhisperKit MIT, FluidAudio BSD, ViewInspector MIT, swift-snapshot-testing MIT). No churn for any current PR.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations, 0 serious in 152 files
- [x] YAML workflow files validated visually (no `act` available locally)
- [ ] CI matrix green (including the new `Dependency Review` job)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->