### PR TITLE
concurrency(test): migrate test target to Swift 6

### DIFF
--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -65,18 +65,8 @@ let package = Package(
                     "-Xfrontend", "-warn-long-expression-type-checking=500",
                 ]),
                 .enableUpcomingFeature("ExistentialAny"),
-                // Tests stay in Swift 5 mode for now: 200+ XCTest setup
-                // patterns (`tmpDir!` mutated from setUp, MainActor
-                // properties touched from sync test bodies) would surface
-                // as concurrency errors, none of which are real races —
-                // XCTest serialises test execution per class. Migrating
-                // tests is its own dedicated effort.
-                .swiftLanguageMode(.v5),
             ]
         ),
     ],
-    // Sources run under Swift 6 strict concurrency. The test target opts
-    // back to v5 via per-target `swiftLanguageMode` — see the test
-    // swiftSettings above for the rationale.
     swiftLanguageModes: [.v6]
 )

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -425,6 +425,7 @@
 
     /// Stub that records calls and returns canned outcomes per action.
     /// Used by routing tests to verify the request → closure → response wiring.
+    @MainActor
     final class StubSpeakerActions {
         private(set) var renameCalls: [(String, String)] = []
         private(set) var deleteCalls: [String] = []

--- a/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
+++ b/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
@@ -9,15 +9,17 @@ final class KnownVoicesViewTests: XCTestCase {
     private var dbPath: URL!
     // swiftlint:enable implicitly_unwrapped_optional
 
-    override func setUp() {
+    override func setUp() async throws {
+        try await super.setUp()
         tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("KnownVoicesViewTests-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         dbPath = tmpDir.appendingPathComponent("speakers.json")
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         try? FileManager.default.removeItem(at: tmpDir)
+        try await super.tearDown()
     }
 
     func testViewRendersWithEmptyDB() throws {

--- a/app/MeetingTranscriber/Tests/MeetingTranscriberAppTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingTranscriberAppTests.swift
@@ -1,6 +1,7 @@
 @testable import MeetingTranscriber
 import XCTest
 
+@MainActor
 final class MeetingTranscriberAppTests: XCTestCase {
     // MARK: - shouldAutoWatch
 

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -377,14 +377,16 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
 
 // MARK: - MockURLProtocol
 
-private class MockURLProtocol: URLProtocol {
-    static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+private final class MockURLProtocol: URLProtocol {
+    // URLSession serialises protocol callbacks per task; the handler is set
+    // before the request is started and cleared in tearDown. No real race.
+    nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
 
-    override class func canInit(with _: URLRequest) -> Bool {
+    override static func canInit(with _: URLRequest) -> Bool {
         true
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
         request
     }
 

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -13,8 +13,8 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
     /// Avoids `swift test --parallel` plist races AND prevents test pollution
     /// from leaking into the dev app's `.standard` plist when a test process
     /// is killed before tearDown runs.
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         testSuiteName = "SettingsViewTests-\(getpid())-\(UUID().uuidString)"
         guard let suite = UserDefaults(suiteName: testSuiteName) else {
             XCTFail("Could not create test UserDefaults suite")
@@ -23,11 +23,11 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         defaults = suite
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         defaults?.removePersistentDomain(forName: testSuiteName)
         defaults = nil
         testSuiteName = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Helpers

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -2,6 +2,7 @@
 import ViewInspector
 import XCTest
 
+@MainActor
 final class SpeakerNamingViewTests: XCTestCase {
     // MARK: - Helpers
 

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -9,15 +9,17 @@ final class VoiceEnrollmentViewTests: XCTestCase {
     private var dbPath: URL!
     // swiftlint:enable implicitly_unwrapped_optional
 
-    override func setUp() {
+    override func setUp() async throws {
+        try await super.setUp()
         tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("VoiceEnrollmentViewTests-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         dbPath = tmpDir.appendingPathComponent("speakers.json")
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         try? FileManager.default.removeItem(at: tmpDir)
+        try await super.tearDown()
     }
 
     func testRendersInPickFileStage() throws {


### PR DESCRIPTION
## Summary

Closes Stufe 5 (Tests) of the strict-warnings escalation roadmap. The test target now compiles under Swift 6 strict concurrency (package-wide `swiftLanguageModes: [.v6]`) — the per-target `.swiftLanguageMode(.v5)` pin introduced in #191 is gone.

8 atomic commits, all mechanical adaptations:
- 3 `setUp`/`tearDown` overrides → `async throws` so the `@MainActor` class isolation propagates into the body (`KnownVoicesViewTests`, `VoiceEnrollmentViewTests`, `SettingsViewTests`)
- 2 test classes annotated `@MainActor` because their bodies invoke main-actor-isolated initialisers/static methods (`SpeakerNamingViewTests`, `MeetingTranscriberAppTests`)
- 1 nested helper `@MainActor` because its closures land in `SpeakerDBActions` which is itself main-actor-isolated (`StubSpeakerActions` in `DebugRPCServerTests`)
- 1 `MockURLProtocol.handler` marked `nonisolated(unsafe)` — URLSession serialises protocol callbacks per task and the handler is set before the request and cleared in tearDown, so no real race. `class` → `final class` and `override class func` → `override static func` to satisfy SwiftLint after `final`.
- `Package.swift`: drop the `.v5` pin and the now-stale rationale comments

## Verification

- `swift test --parallel --skip MenuBarIconSnapshotTests` → 1264 tests passing
- `swift build -c release` → clean (B19 release-mode parity check applied locally)
- `./scripts/lint.sh` → 0 violations across 152 files

`MenuBarIconSnapshotTests` (6 tests) is skipped locally — same pre-existing render drift seen against `main` HEAD, unrelated to this migration. CI re-records or matches its own renders.

## Follow-up

Three reviewers (`/simplify`) flagged a pre-existing duplication: `tmpDir` setUp/tearDown is byte-identical across 15+ test files (only the prefix string differs). This migration just made it more visible because of the new `async throws` ceremony. A `TempDirectoryTestCase` base class would dedupe ~15 lines but is out of scope for this mechanical Swift 6 sweep — tracked separately.

## Test plan

- [ ] CI: lint, analyze, and `swift test --parallel` jobs pass
- [ ] CI: release-mode workflow (if triggered) builds the `.app` cleanly
- [ ] Local: dev app (`./scripts/run_app.sh`) launches and the menu-bar icon, settings tabs, and speaker naming dialog still work — i.e. nothing about the migration silently broke `@MainActor`-touching UI paths the tests cover

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->