### PR TITLE
build(app): compile-perf threshold 500ms → 300ms

### DIFF
--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -32,16 +32,14 @@ let package = Package(
             swiftSettings: [
                 .treatAllWarnings(as: .error),
                 // Surface accidental compile-time blowups. Type-checking a
-                // function body or expression beyond 500 ms is almost always
+                // function body or expression beyond 300 ms is almost always
                 // a sign of pathological generic-overload search or deeply
-                // nested SwiftUI builders. Apple recommends 100 ms; 500 ms
-                // gives headroom for cold CI runners and the extra
-                // concurrency-analysis overhead Swift 6 mode adds (which
-                // otherwise pushes existing SwiftUI bodies over a 300 ms
-                // threshold intermittently).
+                // nested SwiftUI builders. Apple recommends 100 ms; 300 ms
+                // is the historical pre-Swift-6 setting that turned out to
+                // be sustainable once strict-concurrency analysis settled.
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-long-function-bodies=500",
-                    "-Xfrontend", "-warn-long-expression-type-checking=500",
+                    "-Xfrontend", "-warn-long-function-bodies=300",
+                    "-Xfrontend", "-warn-long-expression-type-checking=300",
                 ]),
                 .enableUpcomingFeature("ExistentialAny"),
             ]
@@ -61,8 +59,8 @@ let package = Package(
             swiftSettings: [
                 .treatAllWarnings(as: .error),
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-long-function-bodies=500",
-                    "-Xfrontend", "-warn-long-expression-type-checking=500",
+                    "-Xfrontend", "-warn-long-function-bodies=300",
+                    "-Xfrontend", "-warn-long-expression-type-checking=300",
                 ]),
                 .enableUpcomingFeature("ExistentialAny"),
             ]


### PR DESCRIPTION
## Summary

Returns the `-warn-long-function-bodies` / `-warn-long-expression-type-checking` ceiling to the historical pre-Swift-6 setting.

The 500 ms cushion was added in #191 to absorb the extra concurrency-analysis pass that Swift 6 strict mode runs alongside type-checking. With the migration of both Sources (#191) and Tests (#192) settled and no intermittent overruns observed since, 300 ms is sustainable again — closer to Apple's recommended 100 ms and tight enough to flag accidental SwiftUI builder blowups before they ship.

## Verification

Local, all clean (zero `took … ms` warnings):

- `swift build` (debug) — 29 s
- `swift build -c release` — 78 s
- `swift build --target MeetingTranscriberTests` — 14 s

If CI surfaces a sustained spurious overrun on a cold runner, the rollback is one digit (300 → 500). The comment was updated to reflect the new rationale rather than the historical Swift 6 ramp-up.

## Test plan

- [ ] CI: lint, analyze, and `swift test --parallel` jobs pass
- [ ] CI release-build (if triggered) clean — proves threshold survives WMO + cold-runner timing