### PR TITLE
build(ci): pre-push release-parity check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ scripts/
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
   test_rpc.sh               # Live smoketest for DebugRPCServer (build + launch + drive via mt-cli + assert)
+  pre-push.sh               # Pre-push parity check: swift build -c release (catches Sendable diagnostics that debug-mode builds tolerate)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
   tests/
     test_build_release_signing.sh  # Regression test for build_release.sh codesign-identity detection
@@ -160,6 +161,10 @@ cd app/MeetingTranscriber && swift test --parallel
 
 # Lint & format auto-fix (SwiftFormat + SwiftLint --fix)
 ./scripts/lint.sh --fix
+
+# Pre-push parity check (release build — catches Sendable diagnostics
+# that debug-mode tolerates; flags App Store variant when --with-appstore)
+./scripts/pre-push.sh
 
 # Build self-contained .app + DMG for distribution (Homebrew)
 ./scripts/build_release.sh

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Pre-push parity check. Runs the strictest local builds that surface issues
+# CI's release pipeline would otherwise catch first.
+#
+# Usage:
+#   ./scripts/pre-push.sh                     # release build of the app
+#   ./scripts/pre-push.sh --with-tests        # also build the test target
+#   ./scripts/pre-push.sh --with-appstore     # also build the App Store variant
+#   ./scripts/pre-push.sh --all               # everything
+#
+# Why this exists: `swift build` (debug) and `swift build -c release` use
+# different Sendable-inference rules. Release mode enables WMO which can
+# surface concurrency diagnostics that incremental debug builds tolerate
+# (see PR #191 for the canonical example: ScreenCaptureKit Sendable hop
+# only failed under -c release on CI). Running release locally before
+# `git push` keeps that round-trip out of CI.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+WITH_TESTS=0
+WITH_APPSTORE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --with-tests) WITH_TESTS=1 ;;
+        --with-appstore) WITH_APPSTORE=1 ;;
+        --all) WITH_TESTS=1; WITH_APPSTORE=1 ;;
+        -h|--help)
+            sed -n '2,11p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "unknown flag: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd app/MeetingTranscriber
+
+echo "==> swift build -c release (Homebrew variant)"
+swift build -c release
+
+if [[ "$WITH_APPSTORE" == 1 ]]; then
+    echo "==> swift build -c release -DAPPSTORE (App Store variant)"
+    swift build -c release -Xswiftc -DAPPSTORE
+fi
+
+if [[ "$WITH_TESTS" == 1 ]]; then
+    echo "==> swift build --target MeetingTranscriberTests"
+    swift build --target MeetingTranscriberTests
+fi
+
+echo
+echo "OK — pre-push parity check passed."


### PR DESCRIPTION
## Summary

Adds `scripts/pre-push.sh` so devs can run the strictest local builds before pushing.

`swift build` (debug) and `swift build -c release` apply different Sendable-inference rules — release mode enables Whole-Module-Optimization which surfaces concurrency diagnostics that incremental debug builds tolerate. PR #191 was the canonical example: a `ScreenCaptureKit` Sendable hop in `DebugRPCServer` compiled cleanly under local debug, then failed under CI's release build. One round-trip we shouldn't pay again.

## Usage

```bash
./scripts/pre-push.sh                  # release build of the Homebrew variant
./scripts/pre-push.sh --with-tests     # also build the test target
./scripts/pre-push.sh --with-appstore  # also build the App Store variant (-DAPPSTORE)
./scripts/pre-push.sh --all            # everything
```

Not wired as a Git hook on purpose — opt-in usage keeps the fast feedback loop intact. Devs run it explicitly before pushing concurrency-sensitive changes (Sendable, MainActor, async/await edits). For everyday iteration, `swift build` debug stays the right call.

CLAUDE.md updated with a one-line entry next to `lint.sh`.

## Verification

- `./scripts/pre-push.sh` runs end-to-end: 88 s release build, exits 0
- `./scripts/pre-push.sh --help` prints the usage block

## Test plan

- [ ] CI: lint, analyze, and Swift tests pass (script itself isn't invoked in CI)
- [ ] Local: `./scripts/pre-push.sh --all` from a clean checkout