### PR TITLE
test(app): factor out tmpDir setUp/tearDown into helper

### DIFF
--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -391,10 +391,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     // MARK: - configurePipelineCallbacks
 
     func testConfigurePipelineCallbacksDoneFiresNotification() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
         state.configurePipelineCallbacks()
@@ -409,10 +406,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     }
 
     func testConfigurePipelineCallbacksErrorFiresNotification() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
         state.configurePipelineCallbacks()
@@ -436,10 +430,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     }
 
     func testConfigurePipelineCallbacksTranscribingNoNotification() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("appstate_callbacks_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
         state.configurePipelineCallbacks()

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -13,10 +13,7 @@ final class DualSourceRecorderTests: XCTestCase {
     // MARK: - Cleanup Temp Files
 
     func testCleanupRemovesTmpButNotWav() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cleanup_test_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "cleanup_test")
 
         let tmpFile = tmpDir.appendingPathComponent("20260311_100000_app_raw.tmp")
         let wavFile = tmpDir.appendingPathComponent("20260311_100000_mix.wav")
@@ -151,9 +148,7 @@ final class DualSourceRecorderTests: XCTestCase {
     // MARK: - Cleanup Edge Cases
 
     func testCleanupMultipleTmpFiles() throws {
-        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("cleanup_multi_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "cleanup_multi")
 
         let tmp1 = tmpDir.appendingPathComponent("20260311_100000_app_raw.tmp")
         let tmp2 = tmpDir.appendingPathComponent("20260311_110000_app_raw.tmp")
@@ -175,9 +170,7 @@ final class DualSourceRecorderTests: XCTestCase {
     }
 
     func testCleanupEmptyDirectory() throws {
-        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("cleanup_empty_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "cleanup_empty")
         DualSourceRecorder.cleanupTempFiles(recordingsDir: tmpDir)
     }
 
@@ -187,10 +180,7 @@ final class DualSourceRecorderTests: XCTestCase {
     /// instead of raw device-rate samples. Regression test for the bug where 48kHz samples
     /// were saved with a 16kHz header, producing a file 3× too long.
     func testMixFallbackWithoutMicUsesResampledSamples() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("mix_fallback_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "mix_fallback")
 
         // Simulate 1 second of 48kHz mono app audio (captured by CATapDescription)
         let deviceRate = 48000

--- a/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
+++ b/app/MeetingTranscriber/Tests/KnownVoicesViewTests.swift
@@ -3,7 +3,7 @@ import ViewInspector
 import XCTest
 
 @MainActor
-final class KnownVoicesViewTests: XCTestCase {
+final class KnownVoicesViewTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
     // swiftlint:disable implicitly_unwrapped_optional
     private var tmpDir: URL!
     private var dbPath: URL!
@@ -11,15 +11,8 @@ final class KnownVoicesViewTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("KnownVoicesViewTests-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        tmpDir = try makeTempDirectory(prefix: "KnownVoicesViewTests")
         dbPath = tmpDir.appendingPathComponent("speakers.json")
-    }
-
-    override func tearDown() async throws {
-        try? FileManager.default.removeItem(at: tmpDir)
-        try await super.tearDown()
     }
 
     func testViewRendersWithEmptyDB() throws {

--- a/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
@@ -33,7 +33,6 @@ final class ParakeetE2ETests: XCTestCase {
 
         // Resample 48kHz fixture to 16kHz for Parakeet
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         let segments = try await engine.transcribeSegments(audioPath: resampled16k)
 
@@ -67,7 +66,6 @@ final class ParakeetE2ETests: XCTestCase {
 
         // Resample 48kHz fixture to 16kHz for Parakeet
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         let segments = try await engine.transcribeSegments(audioPath: resampled16k)
         XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
@@ -92,7 +90,6 @@ final class ParakeetE2ETests: XCTestCase {
 
         // Resample 48kHz fixture to 16kHz for Parakeet
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         let segments = try await engine.transcribeSegments(audioPath: resampled16k)
 
@@ -131,7 +128,6 @@ final class ParakeetE2ETests: XCTestCase {
 
         // Resample 48kHz fixture to 16kHz for Parakeet
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         _ = try await engine.transcribeSegments(audioPath: resampled16k)
         XCTAssertEqual(
@@ -169,10 +165,7 @@ final class ParakeetE2ETests: XCTestCase {
 
     /// Resample the 48kHz fixture to a 16kHz temp WAV file for Parakeet.
     private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("parakeet_e2e_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-
+        let tmpDir = try makeTempDirectory(prefix: "parakeet_e2e")
         let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")
 
         let samples = try AudioMixer.loadAudioFileAsFloat32(url: fixture)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 
 @MainActor
-// swiftlint:disable:next attributes type_body_length
+// swiftlint:disable:next attributes type_body_length balanced_xctest_lifecycle
 final class PipelineQueueTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var tmpDir: URL!
@@ -11,15 +11,9 @@ final class PipelineQueueTests: XCTestCase {
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUp() async throws {
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("pipeline_queue_test_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "pipeline_queue_test")
         queue = PipelineQueue(logDir: tmpDir)
-    }
-
-    override func tearDown() async throws {
-        try? FileManager.default.removeItem(at: tmpDir)
-        try await super.tearDown()
     }
 
     private func makeJob(title: String = "Test Meeting") -> PipelineJob {

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -175,9 +175,7 @@ final class ProtocolGeneratorTests: XCTestCase {
     // MARK: - File Save Operations
 
     func testSaveTranscript() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("proto_test_\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "proto_test")
 
         let text = "[00:00] Hello\n[00:05] World"
         let url = try ProtocolGenerator.saveTranscript(text, title: "Test", dir: tmpDir)
@@ -190,9 +188,7 @@ final class ProtocolGeneratorTests: XCTestCase {
     }
 
     func testSaveProtocol() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("proto_test_\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "proto_test")
 
         let markdown = "# Meeting Protocol\n\n## Summary\nTest meeting."
         let url = try ProtocolGenerator.saveProtocol(markdown, title: "Standup", dir: tmpDir)
@@ -205,14 +201,8 @@ final class ProtocolGeneratorTests: XCTestCase {
     }
 
     func testSaveCreatesDirectory() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("proto_test_\(UUID().uuidString)")
-            .appendingPathComponent("nested")
-        defer {
-            try? FileManager.default.removeItem(
-                at: tmpDir.deletingLastPathComponent(),
-            )
-        }
+        let parent = try makeTempDirectory(prefix: "proto_test")
+        let tmpDir = parent.appendingPathComponent("nested")
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: tmpDir.path))
 

--- a/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
@@ -39,7 +39,6 @@ final class Qwen3E2ETests: XCTestCase {
         XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
 
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         let segments = try await engine.transcribeSegments(audioPath: resampled16k)
 
@@ -77,7 +76,6 @@ final class Qwen3E2ETests: XCTestCase {
         XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
 
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         let segments = try await engine.transcribeSegments(audioPath: resampled16k)
         XCTAssertFalse(segments.isEmpty, "Should produce at least one segment")
@@ -120,7 +118,6 @@ final class Qwen3E2ETests: XCTestCase {
         XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
 
         let resampled16k = try resampleFixtureToTemp(fixture)
-        defer { try? FileManager.default.removeItem(at: resampled16k.deletingLastPathComponent()) }
 
         _ = try await engine.transcribeSegments(audioPath: resampled16k)
         XCTAssertEqual(
@@ -158,10 +155,7 @@ final class Qwen3E2ETests: XCTestCase {
 
     /// Resample the 48kHz fixture to a 16kHz temp WAV file for Qwen3.
     private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("qwen3_e2e_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-
+        let tmpDir = try makeTempDirectory(prefix: "qwen3_e2e")
         let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")
 
         let samples = try AudioMixer.loadAudioFileAsFloat32(url: fixture)

--- a/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
@@ -2,19 +2,13 @@ import AVFoundation
 @testable import MeetingTranscriber
 import XCTest
 
-final class ResamplingIntegrationTests: XCTestCase {
+final class ResamplingIntegrationTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var tmpDir: URL!
 
     override func setUp() async throws {
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("resample_integ_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-    }
-
-    // swiftlint:disable:next unneeded_throws_rethrows
-    override func tearDown() async throws {
-        try? FileManager.default.removeItem(at: tmpDir)
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "resample_integ")
     }
 
     private func fixtureURL(_ name: String) -> URL {

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -2,7 +2,7 @@
 @testable import MeetingTranscriber
 import XCTest
 
-// swiftlint:disable:next type_body_length
+// swiftlint:disable:next type_body_length balanced_xctest_lifecycle
 final class SpeakerMatcherTests: XCTestCase {
     /// Fixed reference timestamp used by recency-tracking tests so assertions
     /// don't depend on wall-clock time.
@@ -13,15 +13,9 @@ final class SpeakerMatcherTests: XCTestCase {
     private var dbPath: URL!
     // swiftlint:enable implicitly_unwrapped_optional
 
-    override func setUp() {
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("SpeakerMatcherTests-\(UUID().uuidString)")
-        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true) // swiftlint:disable:this force_try
+    override func setUpWithError() throws {
+        tmpDir = try makeTempDirectory(prefix: "SpeakerMatcherTests")
         dbPath = tmpDir.appendingPathComponent("speakers.json")
-    }
-
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: tmpDir)
     }
 
     // MARK: - Cosine distance

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -1,6 +1,24 @@
 import Foundation
 @testable import MeetingTranscriber
 import WhisperKit
+import XCTest
+
+// MARK: - Temp-Directory Helper
+
+extension XCTestCase {
+    /// Create a unique temp directory under `FileManager.default.temporaryDirectory`
+    /// and register an automatic cleanup with `addTeardownBlock`. The dir is
+    /// removed regardless of whether tearDown is async, sync, or absent.
+    func makeTempDirectory(prefix: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}
 
 // MARK: - WatchLoop / AppState Helpers
 

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -3,7 +3,7 @@ import ViewInspector
 import XCTest
 
 @MainActor
-final class VoiceEnrollmentViewTests: XCTestCase {
+final class VoiceEnrollmentViewTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
     // swiftlint:disable implicitly_unwrapped_optional
     private var tmpDir: URL!
     private var dbPath: URL!
@@ -11,15 +11,8 @@ final class VoiceEnrollmentViewTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("VoiceEnrollmentViewTests-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        tmpDir = try makeTempDirectory(prefix: "VoiceEnrollmentViewTests")
         dbPath = tmpDir.appendingPathComponent("speakers.json")
-    }
-
-    override func tearDown() async throws {
-        try? FileManager.default.removeItem(at: tmpDir)
-        try await super.tearDown()
     }
 
     func testRendersInPickFileStage() throws {

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -5,28 +5,19 @@ import XCTest
 // MARK: - Tests
 
 @MainActor
-final class WatchLoopE2ETests: XCTestCase {
+final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var tmpDir: URL!
 
     override func setUp() async throws {
         try await super.setUp()
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("watchloop_e2e_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        tmpDir = try makeTempDirectory(prefix: "watchloop_e2e")
 
         // Ensure recordingsDir exists (handleMeeting writes intermediate 16kHz files there)
         try FileManager.default.createDirectory(
             at: DualSourceRecorder.recordingsDir,
             withIntermediateDirectories: true,
         )
-    }
-
-    override func tearDown() async throws {
-        if let tmpDir, FileManager.default.fileExists(atPath: tmpDir.path) {
-            try? FileManager.default.removeItem(at: tmpDir)
-        }
-        try await super.tearDown()
     }
 
     // MARK: - Helpers

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -262,10 +262,7 @@ final class WhisperKitE2ETests: XCTestCase {
         }
 
         // Save resampled audio to temp file
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("whisperkit_e2e_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "whisperkit_e2e")
 
         let tmpWAV = tmpDir.appendingPathComponent("resampled_16k.wav")
         try AudioMixer.saveWAV(samples: resampled, sampleRate: targetRate, url: tmpWAV)
@@ -309,10 +306,7 @@ final class WhisperKitE2ETests: XCTestCase {
             "Fixture \(filename) not found",
         )
 
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("multiformat_e2e_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let tmpDir = try makeTempDirectory(prefix: "multiformat_e2e")
 
         // resampleFile uses loadAudioAsFloat32 → AVAudioFile or AVAsset fallback
         let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -2,19 +2,13 @@
 import XCTest
 
 @MainActor
-final class WorkflowIntegrationTests: XCTestCase {
+final class WorkflowIntegrationTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var tmpDir: URL!
 
     override func setUp() async throws {
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("workflow_test_\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-    }
-
-    // swiftlint:disable:next unneeded_throws_rethrows
-    override func tearDown() async throws {
-        try? FileManager.default.removeItem(at: tmpDir)
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "workflow_test")
     }
 
     // MARK: - Harness


### PR DESCRIPTION
## Summary

Closes the `TempDirectoryTestCase` follow-up flagged by `/simplify` reviewers on #192. Adds one tiny extension on `XCTestCase` and migrates 13 test files to use it. ~67 lines of boilerplate gone.

## Helper

```swift
extension XCTestCase {
    func makeTempDirectory(prefix: String) throws -> URL {
        let url = FileManager.default.temporaryDirectory
            .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
        addTeardownBlock {
            try? FileManager.default.removeItem(at: url)
        }
        return url
    }
}
```

`addTeardownBlock` runs regardless of whether the test class uses sync `tearDown`, async `tearDown`, or no override at all — so test classes whose only cleanup duty was the temp dir can drop their `tearDown` override entirely. 7 of the 13 migrated files did exactly that, which trips the `balanced_xctest_lifecycle` lint rule; suppressed per-class to preserve the rule's signal elsewhere.

## Migration shape

```swift
// Before (typical IUO pattern, 8 lines)
override func setUp() async throws {
    try await super.setUp()
    tmpDir = FileManager.default.temporaryDirectory
        .appendingPathComponent("FooTests-\(UUID().uuidString)")
    try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
}
override func tearDown() async throws {
    try? FileManager.default.removeItem(at: tmpDir)
    try await super.tearDown()
}

// After (3 lines, no tearDown)
override func setUp() async throws {
    try await super.setUp()
    tmpDir = try makeTempDirectory(prefix: "FooTests")
}
```

## Files migrated

- IUO + setUp + tearDown pattern: `KnownVoicesViewTests`, `VoiceEnrollmentViewTests`, `PipelineQueueTests`, `SpeakerMatcherTests`, `ResamplingIntegrationTests`, `WorkflowIntegrationTests`, `WatchLoopE2ETests`
- Per-test inline pattern: `AppStateTests` (3 sites), `DualSourceRecorderTests` (3), `WhisperKitE2ETests` (2), `ProtocolGeneratorTests` (3), `ParakeetE2ETests` (1 helper, 4 callers cleaned of `defer`), `Qwen3E2ETests` (1 helper, 3 callers cleaned of `defer`)

Side benefit on the E2E ones: cleanup now runs even when an `XCTUnwrap` aborts the test before the caller's `defer` would fire.

## Verification

- `swift test --parallel --skip MenuBarIconSnapshotTests` — 1264 tests passing
- `./scripts/lint.sh` — 0 violations across 152 files
- `swift build -c release` — clean (B19 release-parity check applied)

## Out of scope

`/simplify` flagged ~40 more occurrences across `AudioMixerTests`, `WatchLoopTests`, `DiagnosticExporterTests`, `PersistentDiagnosticLogTests`, `RecognitionStatsViewTests`, `RecognitionStatsTests`, `AudioMixerDelayTests` that use the same idiom but at file-level paths (not dir-level). Most don't fit the helper cleanly (file path with `defer { removeItem(at: file) }`, not dir creation). Worth a separate sweep that adds a `makeTempFile(suffix:)` companion helper.

## Test plan

- [ ] CI: lint, analyze, and `swift test --parallel` jobs pass
- [ ] CI: release build clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->