### PR TITLE
test(app): add makeTempFile + fixtureURL helpers, sweep ~30 sites

### DIFF
--- a/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerDelayTests.swift
@@ -9,16 +9,9 @@ final class AudioMixerDelayTests: XCTestCase {
         _ micDelay: TimeInterval,
         trackSeconds: Int = 1,
     ) throws -> [Float] {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let id = UUID().uuidString
-        let appURL = tmpDir.appendingPathComponent("delay_app_\(id).wav")
-        let micURL = tmpDir.appendingPathComponent("delay_mic_\(id).wav")
-        let outURL = tmpDir.appendingPathComponent("delay_out_\(id).wav")
-        defer {
-            try? FileManager.default.removeItem(at: appURL)
-            try? FileManager.default.removeItem(at: micURL)
-            try? FileManager.default.removeItem(at: outURL)
-        }
+        let appURL = makeTempFile(suffix: ".wav")
+        let micURL = makeTempFile(suffix: ".wav")
+        let outURL = makeTempFile(suffix: ".wav")
 
         let count = sampleRate * trackSeconds
         try AudioMixer.saveWAV(

--- a/app/MeetingTranscriber/Tests/AudioMixerTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerTests.swift
@@ -124,9 +124,7 @@ final class AudioMixerTests: XCTestCase {
     // MARK: - WAV Round-trip
 
     func testWAVRoundTrip() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let wavURL = tmpDir.appendingPathComponent("test_roundtrip_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let wavURL = makeTempFile(suffix: ".wav")
 
         let original: [Float] = [0.0, 0.5, -0.5, 0.25, -0.25]
         let sampleRate = 16000
@@ -142,9 +140,7 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testSaveWAVCreatesFile() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let wavURL = tmpDir.appendingPathComponent("test_create_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let wavURL = makeTempFile(suffix: ".wav")
 
         let samples = [Float](repeating: 0, count: 48000) // 1 second silence
         try AudioMixer.saveWAV(samples: samples, sampleRate: 48000, url: wavURL)
@@ -156,9 +152,7 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testSaveWAVSetsOwnerOnlyPermissions() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let wavURL = tmpDir.appendingPathComponent("test_perms_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let wavURL = makeTempFile(suffix: ".wav")
 
         try AudioMixer.saveWAV(samples: [0.0, 0.5, -0.5], sampleRate: 16000, url: wavURL)
 
@@ -170,9 +164,7 @@ final class AudioMixerTests: XCTestCase {
     // MARK: - Multi-format Loading
 
     func testLoadAudioAsFloat32WAV() async throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let wavURL = tmpDir.appendingPathComponent("test_multiformat_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let wavURL = makeTempFile(suffix: ".wav")
 
         let original: [Float] = [0.0, 0.5, -0.5, 0.25, -0.25]
         try AudioMixer.saveWAV(samples: original, sampleRate: 16000, url: wavURL)
@@ -186,9 +178,7 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testLoadAudioAsFloat32RoundTrip() async throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let wavURL = tmpDir.appendingPathComponent("test_async_roundtrip_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let wavURL = makeTempFile(suffix: ".wav")
 
         let original: [Float] = [0.1, -0.1, 0.3, -0.3, 0.0]
         try AudioMixer.saveWAV(samples: original, sampleRate: 44100, url: wavURL)
@@ -202,8 +192,7 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testLoadAudioAsFloat32NonexistentFile() async {
-        let bogus = FileManager.default.temporaryDirectory
-            .appendingPathComponent("nonexistent_\(UUID().uuidString).wav")
+        let bogus = makeTempFile(suffix: ".wav")
         do {
             _ = try await AudioMixer.loadAudioAsFloat32(url: bogus)
             XCTFail("Expected error for nonexistent file")
@@ -213,13 +202,8 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testResampleFileAsyncRoundTrip() async throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let src = tmpDir.appendingPathComponent("test_resample_src_\(UUID().uuidString).wav")
-        let dst = tmpDir.appendingPathComponent("test_resample_dst_\(UUID().uuidString).wav")
-        defer {
-            try? FileManager.default.removeItem(at: src)
-            try? FileManager.default.removeItem(at: dst)
-        }
+        let src = makeTempFile(suffix: ".wav")
+        let dst = makeTempFile(suffix: ".wav")
 
         // Create a 48kHz source (480 samples = 10ms)
         let samples48k = [Float](repeating: 0.5, count: 480)
@@ -234,13 +218,6 @@ final class AudioMixerTests: XCTestCase {
     }
 
     // MARK: - Multi-format Fixtures
-
-    private func fixtureURL(_ name: String) -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
 
     // -- Loading (AVAudioFile fast path) --
 
@@ -303,9 +280,7 @@ final class AudioMixerTests: XCTestCase {
 
     func testResampleFileM4A44kTo16k() async throws {
         let src = fixtureURL("sine_440hz_44k.m4a")
-        let dst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_resample_m4a_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: dst) }
+        let dst = makeTempFile(suffix: ".wav")
 
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
@@ -319,9 +294,7 @@ final class AudioMixerTests: XCTestCase {
 
     func testResampleFileMP3_44kTo16k() async throws {
         let src = fixtureURL("sine_440hz_44k.mp3")
-        let dst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_resample_mp3_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: dst) }
+        let dst = makeTempFile(suffix: ".wav")
 
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
@@ -336,9 +309,7 @@ final class AudioMixerTests: XCTestCase {
 
     func testResampleFileDurationPreserved() async throws {
         let src = fixtureURL("sine_440hz_44k.m4a")
-        let dst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_duration_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: dst) }
+        let dst = makeTempFile(suffix: ".wav")
 
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
@@ -351,9 +322,7 @@ final class AudioMixerTests: XCTestCase {
 
     func testResampleFileAudioHasEnergy() async throws {
         let src = fixtureURL("sine_440hz_44k.m4a")
-        let dst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_energy_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: dst) }
+        let dst = makeTempFile(suffix: ".wav")
 
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
@@ -422,13 +391,8 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testResampleFilePreservesFrequency() async throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let src = tmpDir.appendingPathComponent("test_freq_src_\(UUID().uuidString).wav")
-        let dst = tmpDir.appendingPathComponent("test_freq_dst_\(UUID().uuidString).wav")
-        defer {
-            try? FileManager.default.removeItem(at: src)
-            try? FileManager.default.removeItem(at: dst)
-        }
+        let src = makeTempFile(suffix: ".wav")
+        let dst = makeTempFile(suffix: ".wav")
 
         // 440Hz sine at 48kHz, save to WAV, resample file to 16kHz
         let input = Self.generateSine(frequency: 440, sampleRate: 48000, duration: 1.0)
@@ -443,11 +407,8 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func testSaveWAVHeaderSampleRateCorrect() throws {
-        let tmpDir = FileManager.default.temporaryDirectory
-
         for rate in [48000, 16000, 44100] {
-            let url = tmpDir.appendingPathComponent("test_header_\(rate)_\(UUID().uuidString).wav")
-            defer { try? FileManager.default.removeItem(at: url) }
+            let url = makeTempFile(suffix: ".wav")
 
             let samples = [Float](repeating: 0, count: rate) // 1s silence
             try AudioMixer.saveWAV(samples: samples, sampleRate: rate, url: url)
@@ -462,9 +423,7 @@ final class AudioMixerTests: XCTestCase {
 
     func testResampleFileFromM4APreservesFrequency() async throws {
         let src = fixtureURL("sine_440hz_44k.m4a")
-        let dst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_freq_m4a_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: dst) }
+        let dst = makeTempFile(suffix: ".wav")
 
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
@@ -493,9 +452,7 @@ final class AudioMixerTests: XCTestCase {
     }
 
     func test_rmsDecibels_forFileAt_silentWAV() throws {
-        let tmpURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("rms_silent_\(UUID().uuidString).wav")
-        defer { try? FileManager.default.removeItem(at: tmpURL) }
+        let tmpURL = makeTempFile(suffix: ".wav")
 
         let silent = [Float](repeating: 0, count: 16000)
         try AudioMixer.saveWAV(samples: silent, sampleRate: 16000, url: tmpURL)

--- a/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
+++ b/app/MeetingTranscriber/Tests/DiagnosticExporterTests.swift
@@ -108,14 +108,8 @@ final class DiagnosticExporterTests: XCTestCase {
     // MARK: - exportFromFile
 
     func test_exportFromFile_writesHeaderPlusBody_withinWindow() throws {
-        let tmpSrc = FileManager.default.temporaryDirectory
-            .appendingPathComponent("src-\(UUID().uuidString).log")
-        let tmpDst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("dst-\(UUID().uuidString).log")
-        defer {
-            try? FileManager.default.removeItem(at: tmpSrc)
-            try? FileManager.default.removeItem(at: tmpDst)
-        }
+        let tmpSrc = makeTempFile(suffix: ".log")
+        let tmpDst = makeTempFile(suffix: ".log")
         let now = Date()
         let fmt = DateFormatter()
         fmt.dateFormat = "MMM d HH:mm:ss"
@@ -140,14 +134,8 @@ final class DiagnosticExporterTests: XCTestCase {
     }
 
     func test_exportFromFile_filtersOutEntriesOlderThanWindow() throws {
-        let tmpSrc = FileManager.default.temporaryDirectory
-            .appendingPathComponent("src-\(UUID().uuidString).log")
-        let tmpDst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("dst-\(UUID().uuidString).log")
-        defer {
-            try? FileManager.default.removeItem(at: tmpSrc)
-            try? FileManager.default.removeItem(at: tmpDst)
-        }
+        let tmpSrc = makeTempFile(suffix: ".log")
+        let tmpDst = makeTempFile(suffix: ".log")
         let fmt = DateFormatter()
         fmt.dateFormat = "MMM d HH:mm:ss"
         fmt.locale = Locale(identifier: "en_US_POSIX")
@@ -177,11 +165,8 @@ final class DiagnosticExporterTests: XCTestCase {
     }
 
     func test_exportFromFile_missingSource_writesHeaderOnly() throws {
-        let bogusSrc = FileManager.default.temporaryDirectory
-            .appendingPathComponent("missing-\(UUID().uuidString).log")
-        let tmpDst = FileManager.default.temporaryDirectory
-            .appendingPathComponent("dst-\(UUID().uuidString).log")
-        defer { try? FileManager.default.removeItem(at: tmpDst) }
+        let bogusSrc = makeTempFile(suffix: ".log")
+        let tmpDst = makeTempFile(suffix: ".log")
 
         let info = DiagnosticExporter.HeaderInfo(
             appVersion: "1.0", commit: "abc", macOSVersion: "14.5", settings: [:],

--- a/app/MeetingTranscriber/Tests/FFmpegHelperTests.swift
+++ b/app/MeetingTranscriber/Tests/FFmpegHelperTests.swift
@@ -30,13 +30,6 @@ final class FFmpegHelperTests: XCTestCase {
 
     // MARK: - Audio Loading from Fixtures (requires ffmpeg)
 
-    private func fixtureURL(_ name: String) -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
-
     func testLoadAudioFromMKV() async throws {
         try XCTSkipUnless(FFmpegHelper.isAvailable, "ffmpeg not installed")
 

--- a/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
@@ -156,13 +156,6 @@ final class ParakeetE2ETests: XCTestCase {
         )
     }
 
-    private func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests/
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
-
     /// Resample the 48kHz fixture to a 16kHz temp WAV file for Parakeet.
     private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
         let tmpDir = try makeTempDirectory(prefix: "parakeet_e2e")

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -41,10 +41,7 @@ final class PersistentDiagnosticLogTests: XCTestCase {
     // MARK: - cleanup
 
     func test_cleanup_removesExpiredFiles_keepsRecentOnes_doesNotTouchOthers() throws {
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("PersistentDiagnosticLogTests-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = try makeTempDirectory(prefix: "PersistentDiagnosticLogTests")
 
         let expiredFile = tmp.appendingPathComponent("diagnostics-2026-04-01.log")
         let recentFile = tmp.appendingPathComponent("diagnostics-2026-05-01.log")
@@ -74,10 +71,7 @@ final class PersistentDiagnosticLogTests: XCTestCase {
     }
 
     func test_cleanup_emptyDirectory_doesNotCrash() throws {
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("PersistentDiagnosticLogTests-empty-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = try makeTempDirectory(prefix: "PersistentDiagnosticLogTests-empty")
         PersistentDiagnosticLog.cleanup(in: tmp, retentionDays: 30)
     }
 
@@ -91,10 +85,7 @@ final class PersistentDiagnosticLogTests: XCTestCase {
 
     #if !APPSTORE
         func test_streamer_rotatesToNewFileWhenDayChanges() throws {
-            let tmp = FileManager.default.temporaryDirectory
-                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
-            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-            defer { try? FileManager.default.removeItem(at: tmp) }
+            let tmp = try makeTempDirectory(prefix: "StreamerRotation")
 
             var clock = try XCTUnwrap(
                 ISO8601DateFormatter().date(from: "2026-05-04T23:59:50Z"),
@@ -116,10 +107,7 @@ final class PersistentDiagnosticLogTests: XCTestCase {
         }
 
         func test_streamer_keepsSameFileWhenDayUnchanged() throws {
-            let tmp = FileManager.default.temporaryDirectory
-                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
-            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-            defer { try? FileManager.default.removeItem(at: tmp) }
+            let tmp = try makeTempDirectory(prefix: "StreamerRotation")
 
             var clock = try XCTUnwrap(
                 ISO8601DateFormatter().date(from: "2026-05-04T08:00:00Z"),
@@ -144,15 +132,13 @@ final class PersistentDiagnosticLogTests: XCTestCase {
         /// fails, every subsequent `append` would write to a closed FD and
         /// silently drop entries.
         func test_streamer_keepsWritingToOldFileWhenRotationOpenFails() throws {
-            let tmp = FileManager.default.temporaryDirectory
-                .appendingPathComponent("StreamerRotation-\(UUID().uuidString)")
-            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-            defer {
-                // Make the directory writable again so cleanup can remove it.
+            let tmp = try makeTempDirectory(prefix: "StreamerRotation")
+            // Restore writable perms BEFORE makeTempDirectory's removal teardown
+            // runs. addTeardownBlock is LIFO, so this fires first.
+            addTeardownBlock {
                 try? FileManager.default.setAttributes(
                     [.posixPermissions: 0o755], ofItemAtPath: tmp.path,
                 )
-                try? FileManager.default.removeItem(at: tmp)
             }
 
             var clock = try XCTUnwrap(

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -254,22 +254,14 @@ final class ProtocolGeneratorTests: XCTestCase {
 
     // MARK: - Custom Prompt Loading
 
-    /// Unique-per-test prompt file path. Avoids racing on the shared
-    /// `AppPaths.customPromptFile` location under `swift test --parallel`.
-    private func makeTempPromptFile() -> URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("test-prompt-\(UUID().uuidString).md")
-    }
-
     func testLoadPromptReturnsDefaultWhenNoFile() {
-        let url = makeTempPromptFile()
+        let url = makeTempFile(suffix: ".md")
         // File doesn't exist → loadPrompt falls back to the built-in default.
         XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)
     }
 
     func testLoadPromptReadsCustomFile() throws {
-        let url = makeTempPromptFile()
-        defer { try? FileManager.default.removeItem(at: url) }
+        let url = makeTempFile(suffix: ".md")
         let custom = "Custom prompt for testing"
         try custom.write(to: url, atomically: true, encoding: .utf8)
 
@@ -277,16 +269,14 @@ final class ProtocolGeneratorTests: XCTestCase {
     }
 
     func testLoadPromptIgnoresEmptyFile() throws {
-        let url = makeTempPromptFile()
-        defer { try? FileManager.default.removeItem(at: url) }
+        let url = makeTempFile(suffix: ".md")
         try "".write(to: url, atomically: true, encoding: .utf8)
 
         XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)
     }
 
     func testLoadPromptIgnoresWhitespaceOnlyFile() throws {
-        let url = makeTempPromptFile()
-        defer { try? FileManager.default.removeItem(at: url) }
+        let url = makeTempFile(suffix: ".md")
         try "   \n  \n  ".write(to: url, atomically: true, encoding: .utf8)
 
         XCTAssertEqual(ProtocolGenerator.loadPrompt(from: url), ProtocolGenerator.protocolPrompt)

--- a/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
@@ -146,13 +146,6 @@ final class Qwen3E2ETests: XCTestCase {
         )
     }
 
-    private func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests/
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
-
     /// Resample the 48kHz fixture to a 16kHz temp WAV file for Qwen3.
     private func resampleFixtureToTemp(_ fixture: URL) throws -> URL {
         let tmpDir = try makeTempDirectory(prefix: "qwen3_e2e")

--- a/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/RecognitionStatsTests.swift
@@ -79,7 +79,7 @@ final class RecognitionStatsTests: XCTestCase {
     // MARK: - JSONL round-trip via RecognitionStatsLog
 
     func testAppendAndLoadRoundTrip() async {
-        let tmp = uniqueTempPath()
+        let tmp = makeTempFile(suffix: ".jsonl")
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
         let events: [RecognitionEvent] = [
@@ -91,12 +91,10 @@ final class RecognitionStatsTests: XCTestCase {
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 2)
         XCTAssertEqual(loaded.map(\.userName).sorted { ($0 ?? "") < ($1 ?? "") }, ["Speaker A", "Speaker B"])
-
-        try? FileManager.default.removeItem(at: tmp)
     }
 
     func testAppendMultipleBatches() async {
-        let tmp = uniqueTempPath()
+        let tmp = makeTempFile(suffix: ".jsonl")
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
         await log.append([event(name: "A", action: .accepted, ts: now)])
@@ -104,12 +102,10 @@ final class RecognitionStatsTests: XCTestCase {
 
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 2)
-
-        try? FileManager.default.removeItem(at: tmp)
     }
 
     func testLoadRecentSkipsCorruptLines() async throws {
-        let tmp = uniqueTempPath()
+        let tmp = makeTempFile(suffix: ".jsonl")
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
         await log.append([event(name: "Speaker A", action: .accepted, ts: now)])
@@ -123,12 +119,10 @@ final class RecognitionStatsTests: XCTestCase {
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 1)
         XCTAssertEqual(loaded.first?.userName, "Speaker A")
-
-        try? FileManager.default.removeItem(at: tmp)
     }
 
     func testLoadRecentFiltersByCutoff() async {
-        let tmp = uniqueTempPath()
+        let tmp = makeTempFile(suffix: ".jsonl")
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()
         await log.append([
@@ -139,8 +133,6 @@ final class RecognitionStatsTests: XCTestCase {
         let loaded = await log.loadRecent(within: 60, now: now)
         XCTAssertEqual(loaded.count, 1)
         XCTAssertEqual(loaded.first?.userName, "new")
-
-        try? FileManager.default.removeItem(at: tmp)
     }
 
     // MARK: - buildEvents
@@ -222,10 +214,5 @@ final class RecognitionStatsTests: XCTestCase {
         XCTAssertEqual(events.first?.topCandidates?.first?.name, "Speaker A")
         let lastCentroid: Float? = events.first?.topCandidates?.last?.centroid
         XCTAssertNil(lastCentroid)
-    }
-
-    private func uniqueTempPath() -> URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
     }
 }

--- a/app/MeetingTranscriber/Tests/RecognitionStatsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/RecognitionStatsViewTests.swift
@@ -5,18 +5,14 @@ import XCTest
 @MainActor
 final class RecognitionStatsViewTests: XCTestCase {
     func testViewRendersEmpty() throws {
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = makeTempFile(suffix: ".jsonl")
 
         let view = RecognitionStatsView(log: RecognitionStatsLog(path: tmp))
         XCTAssertNoThrow(try view.inspect())
     }
 
     func testViewLoadsAggregateFromLog() async {
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("recognition_log_\(UUID().uuidString).jsonl")
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = makeTempFile(suffix: ".jsonl")
 
         let log = RecognitionStatsLog(path: tmp)
         let now = Date()

--- a/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
+++ b/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
@@ -63,10 +63,7 @@ final class RecordingSidecarTests: XCTestCase {
     }
 
     func test_write_createsFileNextToBasename() throws {
-        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("rs-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: dir) }
+        let dir = try makeTempDirectory(prefix: "rs")
 
         let basename = "20260503_083000"
         let sidecar = makeFullSidecar()

--- a/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ResamplingIntegrationTests.swift
@@ -11,13 +11,6 @@ final class ResamplingIntegrationTests: XCTestCase { // swiftlint:disable:this b
         tmpDir = try makeTempDirectory(prefix: "resample_integ")
     }
 
-    private func fixtureURL(_ name: String) -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
-
     /// Copy a fixture into the test's tmpDir. Use for pipeline tests because
     /// `PipelineQueue.copyAudioToOutput` moves the source file out of place —
     /// passing the original Fixtures/ path would delete the shared asset.

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -3,7 +3,7 @@ import Foundation
 import WhisperKit
 import XCTest
 
-// MARK: - Temp-Directory Helper
+// MARK: - Temp-Directory / Temp-File Helpers
 
 extension XCTestCase {
     /// Create a unique temp directory under `FileManager.default.temporaryDirectory`
@@ -17,6 +17,33 @@ extension XCTestCase {
             try? FileManager.default.removeItem(at: url)
         }
         return url
+    }
+
+    /// Reserve a unique temp file URL under `FileManager.default.temporaryDirectory`
+    /// and register an automatic cleanup with `addTeardownBlock`. The file is
+    /// NOT pre-created — only the URL is reserved.
+    /// `suffix` typically includes the extension, e.g. `".wav"`.
+    func makeTempFile(suffix: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)\(suffix)")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}
+
+// MARK: - Fixture URL Helper
+
+extension XCTestCase {
+    /// Resolve a fixture file in `Tests/Fixtures/` relative to TestHelpers.swift.
+    /// All callers share the same Fixtures dir. The default `two_speakers_de.wav`
+    /// is the canonical German two-speaker fixture used by ASR-engine E2E tests.
+    func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent(name)
     }
 }
 

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -22,13 +22,6 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
     // MARK: - Helpers
 
-    private func fixtureURL() -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests/
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent("two_speakers_de.wav")
-    }
-
     /// Upsample the fixture to 48kHz to simulate DualSourceRecorder output, save to tmpDir.
     private func prepare48kHzFixture(name: String = "mix.wav") throws -> URL {
         let fixture = fixtureURL()

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -365,10 +365,7 @@ final class WatchLoopTests: XCTestCase {
 
     func test_recordOnly_writesSidecarAndDoesNotEnqueue() async throws {
         let queue = PipelineQueue()
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("recordOnly_\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = try makeTempDirectory(prefix: "recordOnly")
 
         let mixURL = tmp.appendingPathComponent("20260503_120000_mix.wav")
         let appURL = tmp.appendingPathComponent("20260503_120000_app.wav")
@@ -423,10 +420,8 @@ final class WatchLoopTests: XCTestCase {
         // `/dev/null` is not a directory — createDirectory(at:) will throw,
         // exercising the failure path.
         let unwritable = URL(fileURLWithPath: "/dev/null/cannot-write")
-        let mixURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(UUID().uuidString)_mix.wav")
+        let mixURL = makeTempFile(suffix: "_mix.wav")
         try Data().write(to: mixURL)
-        defer { try? FileManager.default.removeItem(at: mixURL) }
         let notifier = RecordingNotifier()
 
         let queue = PipelineQueue()
@@ -445,10 +440,7 @@ final class WatchLoopTests: XCTestCase {
 
     func test_normalMode_enqueuesAndWritesNoSidecar() async throws {
         let queue = PipelineQueue()
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("normalMode_\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tmp) }
+        let tmp = try makeTempDirectory(prefix: "normalMode")
 
         let mixURL = tmp.appendingPathComponent("20260503_120000_mix.wav")
         try Data().write(to: mixURL)

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -367,13 +367,4 @@ final class WhisperKitE2ETests: XCTestCase {
         assertTranscriptContent(m4aTranscript, format: "M4A")
         assertTranscriptContent(mp4Transcript, format: "MP4")
     }
-
-    // MARK: - Helpers
-
-    private func fixtureURL(_ name: String = "two_speakers_de.wav") -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests/
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent(name)
-    }
 }

--- a/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
@@ -31,10 +31,7 @@ final class WhisperKitEngineTests: XCTestCase {
 
     /// Integration test: downloads whisper-small model and transcribes a German audio fixture.
     func testTranscribeGermanAudio() async throws {
-        let fixture = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests/
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent("two_speakers_de.wav")
+        let fixture = fixtureURL()
 
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: fixture.path),


### PR DESCRIPTION
## Summary

Follow-up to PR #195. Adds two `XCTestCase` extensions in `TestHelpers.swift`:

- **`makeTempFile(suffix:) -> URL`** — reserves a unique temp file URL with automatic cleanup via `addTeardownBlock`. Companion to the existing `makeTempDirectory(prefix:)`.
- **`fixtureURL(_ name:) -> URL`** — resolves `Tests/Fixtures/<name>` relative to `TestHelpers.swift`. Folds **7 private duplicates** (Parakeet/Qwen3/WhisperKitE2E + AudioMixer/Resampling/FFmpeg/WatchLoopE2E tests) that all repeated the same `#filePath -> deletingLastPathComponent -> Fixtures` pattern.

Sweeps **~30 sites across 14 test files** that previously open-coded `FileManager.default.temporaryDirectory.appendingPathComponent(...)` + `defer try? removeItem`. Where a temp directory was needed, sites now use the existing `makeTempDirectory` helper.

**Net diff:** -130 lines, no behavior change.

## Test plan

- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — 1264 tests pass
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/pre-push.sh` — release-mode parity OK
- [x] /simplify reviewers (reuse + quality + efficiency) reviewed; quality-reviewer suggestion folded (clarified docstring on `fixtureURL` default), reuse-reviewer found 2 missed sites which were swept in too (RecordingSidecarTests, WhisperKitEngineTests)

## Notes

- `PersistentDiagnosticLogTests.test_streamer_keepsWritingToOldFileWhenRotationOpenFails` adds an explicit `addTeardownBlock` for permission-restore on top of `makeTempDirectory`. LIFO ordering ensures perm-restore fires before dir-removal — comment documents this.
- Two intentionally-non-existent paths (`testLoadAudioAsFloat32NonexistentFile`, `test_cleanup_missingDirectory_doesNotCrash`) still use the helper / kept hand-coded — `try?` cleanup is no-op on missing files.