### PR TITLE
ci: weekly build-performance tracking workflow

### DIFF
--- a/.github/workflows/build-perf-tracking.yml
+++ b/.github/workflows/build-perf-tracking.yml
@@ -1,0 +1,33 @@
+name: Build Performance Tracking
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — gives the rest of the week to react before the
+    # next weekly snapshot rolls in.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Number of recent successful CI runs to analyze'
+        default: '50'
+      alert_pct:
+        description: 'Slowdown threshold (percent)'
+        default: '20'
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIMIT: ${{ inputs.limit || '50' }}
+          ALERT_PCT: ${{ inputs.alert_pct || '20' }}
+          WORKFLOW: ci.yml
+          BRANCH: main
+        run: bash scripts/build_perf_report.sh | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/build_perf_report.sh
+++ b/scripts/build_perf_report.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Build Performance Tracking
+#
+# Pulls the last $LIMIT successful CI runs on $BRANCH, computes per-job
+# duration trends, and emits a Markdown summary. Flags any job whose
+# last-7-day median is >$ALERT_PCT% slower than the prior 28-day median.
+#
+# Exits 0 normally, 1 when at least one slowdown is detected — so the
+# workflow run is visibly red in the Actions list.
+#
+# Inputs (env vars):
+#   WORKFLOW   default: ci.yml
+#   BRANCH     default: main
+#   LIMIT      default: 50
+#   ALERT_PCT  default: 20
+#
+# Requires: gh, jq, python3 (all preinstalled on GitHub-hosted runners).
+
+set -euo pipefail
+
+WORKFLOW="${WORKFLOW:-ci.yml}"
+BRANCH="${BRANCH:-main}"
+LIMIT="${LIMIT:-50}"
+ALERT_PCT="${ALERT_PCT:-20}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "::group::Fetching last $LIMIT successful $WORKFLOW runs on $BRANCH" >&2
+gh run list \
+    --workflow="$WORKFLOW" \
+    --branch="$BRANCH" \
+    --status=success \
+    --limit="$LIMIT" \
+    --json databaseId,createdAt \
+    > "$WORK/runs.json"
+
+run_count=$(jq 'length' "$WORK/runs.json")
+echo "Got $run_count runs." >&2
+echo "::endgroup::" >&2
+
+if [ "$run_count" -lt 10 ]; then
+    cat <<EOF
+# Build Performance Tracking
+
+Insufficient data: only $run_count successful runs found on \`$BRANCH\`
+(need at least 10 for a meaningful trend).
+EOF
+    exit 0
+fi
+
+echo "::group::Collecting per-job timings" >&2
+: > "$WORK/jobs.jsonl"
+while IFS=$'\t' read -r run_id created_at; do
+    if ! gh run view "$run_id" --json jobs > "$WORK/run-$run_id.json" 2>/dev/null; then
+        echo "  skipping run $run_id (view failed)" >&2
+        continue
+    fi
+    jq -c \
+       --arg created "$created_at" \
+       --arg rid "$run_id" \
+       '.jobs[] | select(.conclusion == "success") |
+        select(.startedAt and .completedAt) |
+        {
+          run_id: $rid,
+          run_created: $created,
+          job: .name,
+          duration_seconds: (
+              (.completedAt | fromdateiso8601) - (.startedAt | fromdateiso8601)
+          )
+        }' "$WORK/run-$run_id.json" >> "$WORK/jobs.jsonl"
+done < <(jq -r '.[] | "\(.databaseId)\t\(.createdAt)"' "$WORK/runs.json")
+echo "::endgroup::" >&2
+
+python3 - "$WORK/jobs.jsonl" "$ALERT_PCT" "$BRANCH" "$WORKFLOW" <<'PY'
+import json, statistics, sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+path, alert_pct, branch, workflow = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+now = datetime.now(timezone.utc)
+recent_cutoff = now - timedelta(days=7)
+baseline_cutoff = now - timedelta(days=35)
+
+by_job = defaultdict(lambda: {"recent": [], "baseline": []})
+with open(path) as f:
+    for line in f:
+        rec = json.loads(line)
+        ts = datetime.fromisoformat(rec["run_created"].replace("Z", "+00:00"))
+        if ts >= recent_cutoff:
+            by_job[rec["job"]]["recent"].append(rec["duration_seconds"])
+        elif ts >= baseline_cutoff:
+            by_job[rec["job"]]["baseline"].append(rec["duration_seconds"])
+
+print(f"# Build Performance Tracking — `{workflow}` on `{branch}`")
+print()
+print(f"Generated {now:%Y-%m-%d %H:%M UTC}. Alert threshold: **>{alert_pct}%**.")
+print()
+print("| Job | n (last 7d) | median (7d) | n (prior 28d) | median (28d) | Δ |")
+print("| --- | ---: | ---: | ---: | ---: | ---: |")
+
+slowdowns = []
+for job, w in sorted(by_job.items()):
+    rn, bn = len(w["recent"]), len(w["baseline"])
+    rm = statistics.median(w["recent"]) if w["recent"] else 0.0
+    bm = statistics.median(w["baseline"]) if w["baseline"] else 0.0
+    if bm > 0 and rn > 0:
+        delta_pct = (rm - bm) / bm * 100
+        delta_str = f"{delta_pct:+.1f}%"
+        if delta_pct > alert_pct:
+            slowdowns.append((job, rm, bm, delta_pct))
+            delta_str = f"⚠️ {delta_str}"
+    else:
+        delta_str = "—"
+    print(f"| {job} | {rn} | {rm:.1f}s | {bn} | {bm:.1f}s | {delta_str} |")
+
+print()
+if slowdowns:
+    print(f"## ⚠️ {len(slowdowns)} slowdown(s) detected")
+    print()
+    for job, rm, bm, pct in slowdowns:
+        print(f"- **{job}**: {rm:.1f}s recent vs {bm:.1f}s baseline (+{pct:.1f}%)")
+    sys.exit(1)
+print("✅ No slowdowns detected.")
+PY


### PR DESCRIPTION
## Summary

Adds a weekly cron + manual-dispatch workflow that scrapes the last 50 successful CI runs on `main`, computes per-job duration medians for the last 7 days vs. the prior 28-day baseline, and flags any job that's >20 % slower than baseline. Goal: a future test/refactor that silently doubles a job's runtime gets caught the next Monday morning.

- `.github/workflows/build-perf-tracking.yml` — cron `0 6 * * 1` (Mondays 06:00 UTC) + `workflow_dispatch`. Permissions limited to `contents: read` and `actions: read`.
- `scripts/build_perf_report.sh` — bash + jq + python3 (all preinstalled on `ubuntu-latest`):
  - Pulls last 50 successful `ci.yml` runs on `main` via `gh run list`.
  - For each, queries `gh run view --json jobs` to get per-job `startedAt`/`completedAt`.
  - Splits durations into a recent window (last 7 days) and a baseline window (prior 28 days), computes median per job per window.
  - Flags any job whose recent median is **>20 %** above baseline median.
  - Outputs a Markdown table to `$GITHUB_STEP_SUMMARY`.
  - Exits `1` when any slowdown is detected, so the run shows up red in the Actions list.

## Test plan

- [x] `bash scripts/build_perf_report.sh` runs locally against this repo's actual `ci.yml` history (LIMIT=20 → renders the same Markdown table the workflow will produce; current state: no slowdowns).
- [x] `bash -n scripts/build_perf_report.sh` syntax-check passes.
- [ ] First scheduled run will fire next Monday; can also be tested earlier via Actions → "Build Performance Tracking" → "Run workflow".

## Notes

- Threshold and run-limit are surfaced as `workflow_dispatch` inputs so they can be tuned ad-hoc without committing.
- Requires at least 10 successful runs to emit a trend; below that the script renders an "insufficient data" notice and exits 0.