### PR TITLE
fix(app): split statRow to bring type-checking under 300ms threshold

### DIFF
--- a/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
@@ -69,16 +69,22 @@ struct RecognitionStatsView: View {
         statRow(.dismissed, count: agg.counts[.dismissed] ?? 0, total: agg.total)
     }
 
-    @ViewBuilder
     private func statRow(_ action: RecognitionAction, count: Int, total: Int) -> some View {
-        let pct = Int((Double(count) / Double(total) * 100).rounded())
         LabeledContent(action.rawValue.capitalized) {
-            HStack(spacing: 8) {
-                Text("\(count)")
-                Text("(\(pct)%)").foregroundStyle(.secondary).font(.caption)
-                ProgressView(value: Double(count), total: Double(total))
-                    .frame(width: 80)
-            }
+            statRowDetail(count: count, total: total)
+        }
+    }
+
+    @ViewBuilder
+    private func statRowDetail(count: Int, total: Int) -> some View {
+        let pct = Int((Double(count) / Double(total) * 100).rounded())
+        HStack(spacing: 8) {
+            Text("\(count)")
+            Text("(\(pct)%)")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            ProgressView(value: Double(count), total: Double(total))
+                .frame(width: 80)
         }
     }
 


### PR DESCRIPTION
## Summary

`RecognitionStatsView.statRow(_:count:total:)` has been hovering right at the 300ms type-check limit locally and intermittently breaking CI (observed 322ms in #196 and #197) since PR #193 tightened `-warn-long-expression-type-checking=300`.

Fix: split the inner `HStack` into a dedicated `statRowDetail(count:total:)`. The type-checker now has two smaller bodies instead of one ViewBuilder closure that combined four child views with an `Int <- (Double / Double * 100).rounded()` expression. No behavior change.

## Test plan

- [x] `swift test --parallel --filter RecognitionStatsView` — passes locally
- [x] `./scripts/lint.sh` — clean (`statRow` no longer needs `@ViewBuilder` since it returns a single `LabeledContent`)
- [x] `./scripts/pre-push.sh` — release-mode build passes
- [x] CI green here (the actual goal)

## Why this PR exists

This is a hotfix-style mechanical refactor blocking #196 and #197. Once CI is green here and this merges, both follow-up PRs need a quick rebase to pick the fix up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->