### PR TITLE
concurrency(app): preemptively guard remaining AV/AX imports

### DIFF
--- a/app/MeetingTranscriber/Sources/AXHelper.swift
+++ b/app/MeetingTranscriber/Sources/AXHelper.swift
@@ -1,4 +1,6 @@
-import ApplicationServices
+// `@preconcurrency`: ApplicationServices AX globals lack Sendable
+// annotations — same gap as Permissions.swift; preemptively guarded.
+@preconcurrency import ApplicationServices
 import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AXHelper")

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -1,5 +1,8 @@
 import AudioTapLib
-import AVFoundation
+
+// `@preconcurrency`: AVFoundation types lack Sendable annotations —
+// same gap as AudioMixer.swift; preemptively guarded.
+@preconcurrency import AVFoundation
 import Foundation
 import os.log
 

--- a/app/MeetingTranscriber/Sources/MicRecorder.swift
+++ b/app/MeetingTranscriber/Sources/MicRecorder.swift
@@ -1,7 +1,10 @@
 // MicRecorder is currently unused (DualSourceRecorder uses AudioTapLib directly).
 // Kept for potential future standalone mic recording feature.
 import AudioTapLib
-import AVFoundation
+
+// `@preconcurrency`: AVFoundation types lack Sendable annotations —
+// same gap as AudioMixer.swift; preemptively guarded.
+@preconcurrency import AVFoundation
 import CoreAudio
 import Foundation
 import os.log

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -1,5 +1,8 @@
-import ApplicationServices
-import AVFoundation
+// `@preconcurrency`: ApplicationServices AX globals + AVFoundation
+// types lack Sendable annotations — same gaps as Permissions.swift /
+// AudioMixer.swift; preemptively guarded.
+@preconcurrency import ApplicationServices
+@preconcurrency import AVFoundation
 import CoreGraphics
 import os.log
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -1,4 +1,6 @@
-import AVFoundation
+// `@preconcurrency`: AVFoundation types lack Sendable annotations —
+// same gap as AudioMixer.swift; preemptively guarded.
+@preconcurrency import AVFoundation
 import SwiftUI
 
 /// NSTextField subclass that forwards accessibility `set value` (AppleScript)

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -1,4 +1,6 @@
-import AVFoundation
+// `@preconcurrency`: AVFoundation types lack Sendable annotations —
+// same gap as AudioMixer.swift; preemptively guarded.
+@preconcurrency import AVFoundation
 import Foundation
 import os.log
 import WhisperKit


### PR DESCRIPTION
## Summary

When PR #191 turned on Swift 6 mode, Sendable diagnostics surfaced for `AVFoundation` and `ApplicationServices` in the files that happened to use the relevant APIs. Those got `@preconcurrency` (`AudioMixer.swift`, `Permissions.swift`, etc.).

Six other source files import the same SDK modules **without** `@preconcurrency`. They're currently clean because they don't use the offending types yet — but the next time someone touches an `AVAudioPCMBuffer` capture or an AX global in one of these files, the same diagnostic would re-fire mid-PR. This change guards them up-front.

**Files patched:**
- `AXHelper.swift` — `ApplicationServices`
- `PermissionHealthCheck.swift` — `ApplicationServices` + `AVFoundation`
- `DualSourceRecorder.swift` — `AVFoundation`
- `MicRecorder.swift` — `AVFoundation`
- `WhisperKitEngine.swift` — `AVFoundation`
- `SpeakerNamingView.swift` — `AVFoundation`

Same comment convention as `AudioMixer.swift` / `Permissions.swift`: short trailing rationale above the import.

## Test plan

- [x] `swift build` — clean
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/pre-push.sh` — release-mode parity OK (Sendable inference)

## Why this PR exists

`@preconcurrency` is a downgrade-only annotation: it relaxes Sendable diagnostics for the imported module without changing runtime behavior. Adding it preemptively to imports that share the same SDK gap is purely defensive — no functional change, no perf impact, and it shrinks the surface on which a future PR can stumble.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->