### PR TITLE
fix(app): split statRow further to bring type-checking under 300ms

### DIFF
--- a/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStatsView.swift
@@ -70,22 +70,25 @@ struct RecognitionStatsView: View {
     }
 
     private func statRow(_ action: RecognitionAction, count: Int, total: Int) -> some View {
-        LabeledContent(action.rawValue.capitalized) {
-            statRowDetail(count: count, total: total)
+        let pct = Int((Double(count) / Double(total) * 100).rounded())
+        return LabeledContent(action.rawValue.capitalized) {
+            HStack(spacing: 8) {
+                Text("\(count)")
+                pctLabel(pct)
+                progressBar(count: count, total: total)
+            }
         }
     }
 
-    @ViewBuilder
-    private func statRowDetail(count: Int, total: Int) -> some View {
-        let pct = Int((Double(count) / Double(total) * 100).rounded())
-        HStack(spacing: 8) {
-            Text("\(count)")
-            Text("(\(pct)%)")
-                .foregroundStyle(.secondary)
-                .font(.caption)
-            ProgressView(value: Double(count), total: Double(total))
-                .frame(width: 80)
-        }
+    private func pctLabel(_ pct: Int) -> some View {
+        Text("(\(pct)%)")
+            .foregroundStyle(.secondary)
+            .font(.caption)
+    }
+
+    private func progressBar(count: Int, total: Int) -> some View {
+        ProgressView(value: Double(count), total: Double(total))
+            .frame(width: 80)
     }
 
     private func reload() async {


### PR DESCRIPTION
## Summary

PR #198 split the inner `HStack` out of `statRow` into `statRowDetail`, but the type-checker just moved to the new function (**342ms** observed in CI on #199, threshold 300ms). The HStack with `ProgressView` + `Double` conversions, plus the inner `Text` with multiple modifiers, was still the heavy hitter.

This PR:
- Hoists the `pct` computation out of any `@ViewBuilder` body into the outer `statRow`.
- Extracts the per-cent `Text` (`pctLabel(_:)`) and the `ProgressView` (`progressBar(count:total:)`) into their own private helpers.

Result: four small ViewBuilder bodies instead of two medium ones. Each closure has at most one non-trivial expression. No behavior change.

## Test plan

- [x] `swift build` — clean
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/pre-push.sh` — release-mode build OK
- [ ] CI green here (the actual goal). Once merged, #199 needs a quick rebase.

## Why this PR exists

Hotfix-style mechanical refactor blocking #199. PR #198 partly addressed the symptom; this finishes the job.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->