### PR TITLE
fix(app): share RecognitionStatsLog actor between pipeline and SettingsView

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -163,6 +163,10 @@ struct MeetingTranscriberApp: App {
                     return nil
                 }(),
                 updateChecker: appState.updateChecker,
+                // Share the pipeline's actor instance so both writers serialise on
+                // the same `recognition_log.jsonl` file. Fallback only fires in the
+                // test-only PipelineQueue init that intentionally leaves it nil.
+                recognitionStatsLog: appState.pipelineQueue.recognitionStatsLog ?? RecognitionStatsLog(),
                 enrollmentDiarizerFactory: { FluidDiarizer(mode: appState.settings.diarizerMode) },
                 namingDialogActive: appState.pipelineQueue.pendingSpeakerNaming != nil,
                 pipelineBusy: appState.pipelineQueue.isProcessing,

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -6,7 +6,9 @@ struct SettingsView: View {
     var parakeetEngine: ParakeetEngine
     var qwen3Engine: (any TranscribingEngine)? // nil on macOS < 15
     var updateChecker: UpdateChecker?
-    var recognitionStatsLog: RecognitionStatsLog = .init()
+    /// Required: the same actor instance the pipeline writes to, so the Stats
+    /// tab and the pipeline don't race two writers on `recognition_log.jsonl`.
+    var recognitionStatsLog: RecognitionStatsLog
     /// Factory for the voice-enrollment diarizer. nil → enroll button hidden.
     var enrollmentDiarizerFactory: (() -> any DiarizationProvider)?
     /// True when a meeting is currently waiting on a naming dialog. We gate

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -50,6 +50,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
             parakeetEngine: ParakeetEngine(),
             qwen3Engine: qwen3,
             updateChecker: updateChecker,
+            recognitionStatsLog: RecognitionStatsLog(),
         )
     }
 


### PR DESCRIPTION
## Summary

`SettingsView.recognitionStatsLog` had a default value `= .init()` and `MeetingTranscriberApp` never passed one explicitly, so the Stats tab and the pipeline used **two distinct actor instances**. Both wrote to the same `recognition_log.jsonl` file. Two actors do not serialise across each other → concurrent appends could interleave at the file level (Stats-tab reload running while a pipeline job's per-batch append fires).

## Changes

- `SettingsView.swift` — drop default, make `recognitionStatsLog` a required init param. Comment explains why.
- `MeetingTranscriberApp.swift` — pass `appState.pipelineQueue.recognitionStatsLog ?? RecognitionStatsLog()`. The fallback only triggers if `PipelineQueue` was built via its test-only init that intentionally leaves the log nil; in production AppState always injects a real instance.
- `Tests/SettingsViewTests.swift` — pass `RecognitionStatsLog()` explicitly in the test helper.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --parallel --filter "SettingsView|MeetingTranscriberApp"` — passes
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/pre-push.sh` — release-mode build OK

## Risk

Trivial-refactor. No behavior change in production (one fewer actor instance pointing at the same file). The Stats tab continues to read its own snapshot via the actor's `loadRecent`; sharing the instance just means appends are now properly serialised.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->