### PR TITLE
fix(app): rotate RPC bearer token on settings toggle off → on

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -128,8 +128,16 @@ final class AppState {
 
     #if !APPSTORE
         /// Reconcile the debug RPC server with the current setting.
+        ///
+        /// Called only from the settings-driven `observeDebugRPCSetting` path
+        /// (init has its own gate). On a toggle off → on we rotate the bearer
+        /// token before starting the listener: that way any token an attacker
+        /// scraped while the server was previously running is invalidated by
+        /// the act of turning it off and on again — the same gesture a user
+        /// already performs to "reset" the feature.
         func applyDebugRPCSetting() {
             if settings.debugRPCEnabled, debugRPCServer == nil {
+                DebugRPCServer.rotateToken()
                 startDebugRPCServer()
             } else if !settings.debugRPCEnabled, let server = debugRPCServer {
                 server.stop()

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -105,6 +105,15 @@
                !existing.isEmpty {
                 return existing
             }
+            return rotateToken(at: url)
+        }
+
+        /// Unconditionally write a fresh 32-byte hex token to `url`. Used by the
+        /// settings toggle so that flipping the server off → on invalidates any
+        /// previously-leaked token. Mode 0600 is set at create time to avoid
+        /// the brief 0644 window a write-then-chmod sequence would have.
+        @discardableResult
+        nonisolated static func rotateToken(at url: URL = tokenFileURL) -> String {
             var bytes = [UInt8](repeating: 0, count: 32)
             // SecRandomCopyBytes returning non-zero means the buffer is
             // unmodified (all zeros) — refuse to write that as a token.
@@ -116,8 +125,9 @@
             try? FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(), withIntermediateDirectories: true,
             )
-            // createFile with .posixPermissions sets mode at creation time —
-            // avoids the brief 0644 window that a write-then-chmod sequence has.
+            // Remove any prior file so createFile re-applies the 0600 attribute
+            // even if the existing inode had drifted to a looser mode.
+            try? FileManager.default.removeItem(at: url)
             FileManager.default.createFile(
                 atPath: url.path,
                 contents: Data(token.utf8),

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -1,4 +1,5 @@
 #if !APPSTORE
+    // swiftlint:disable file_length
     @testable import MeetingTranscriber
     import XCTest
 
@@ -212,6 +213,38 @@
             let attrs = try FileManager.default.attributesOfItem(atPath: DebugRPCServer.tokenFileURL.path)
             let perms = (attrs[.posixPermissions] as? Int) ?? -1
             XCTAssertEqual(perms, 0o600)
+        }
+
+        func testRotateTokenGeneratesNewValueAndPersistsAtomically() throws {
+            let url = makeTempFile(suffix: "-rpc-token")
+            // Seed an existing token to ensure rotate doesn't reuse it.
+            let seed = "seed-token-1234"
+            FileManager.default.createFile(
+                atPath: url.path, contents: Data(seed.utf8),
+                attributes: [.posixPermissions: 0o600],
+            )
+
+            let rotated = DebugRPCServer.rotateToken(at: url)
+            XCTAssertNotEqual(rotated, seed)
+            XCTAssertEqual(rotated.count, 64)
+            XCTAssertTrue(rotated.allSatisfy(\.isHexDigit))
+
+            // File now contains the rotated value.
+            let onDisk = try String(contentsOf: url, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            XCTAssertEqual(onDisk, rotated)
+
+            // Mode preserved at 0600 across the rewrite.
+            let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+            let perms = (attrs[.posixPermissions] as? Int) ?? -1
+            XCTAssertEqual(perms, 0o600)
+        }
+
+        func testRotateTokenProducesDistinctValuesAcrossCalls() {
+            let url = makeTempFile(suffix: "-rpc-token")
+            let a = DebugRPCServer.rotateToken(at: url)
+            let b = DebugRPCServer.rotateToken(at: url)
+            XCTAssertNotEqual(a, b, "Two consecutive rotations must yield different tokens")
         }
 
         // MARK: - Speaker DB action routes


### PR DESCRIPTION
## Summary
- Toggling Debug RPC Server off and on in Settings now rotates the bearer token, so a token scraped while the server was running can't be reused after the user resets the feature.
- Init-time start (env var force-enable, or persisted-ON across relaunches) keeps calling `loadOrCreateToken()` and reuses the existing token — `mt-cli` sessions and `scripts/test_rpc.sh` continue to work across launches.
- Only the Settings-driven toggle path rotates (the same gesture users already perform to "reset" the feature).

## Implementation
- New `DebugRPCServer.rotateToken(at:)` always writes a fresh 32-byte hex value with mode 0600 (added a `removeItem` before `createFile` so the attribute is re-applied even if a prior file had drifted to a looser mode).
- `loadOrCreateToken` now delegates the write half to `rotateToken`, eliminating the duplicated SecRandomCopyBytes / 0600 / createFile path.
- `AppState.applyDebugRPCSetting()` calls `rotateToken()` before `startDebugRPCServer()` on the off → on transition.

## Tests
- `testRotateTokenGeneratesNewValueAndPersistsAtomically` — seeds a tmp file, asserts the new value differs, contents match, mode is 0600.
- `testRotateTokenProducesDistinctValuesAcrossCalls` — two consecutive rotations yield different tokens.
- Full `DebugRPCServerTests` suite still green (53 tests).
- `swift build -c release` clean (Sendable/strict-concurrency parity).