### PR TITLE
fix(app): open security scope on bookmark URL, not record-only child

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -266,8 +266,8 @@ final class AppState {
                     micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
                     verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
                     recordOnly: { [settings] in settings.recordOnly },
-                    recordOnlyOutputDir: { [settings] in
-                        settings.effectiveOutputDir.appendingPathComponent("recordings")
+                    recordOnlyDestination: { [settings] in
+                        .production(parent: settings.effectiveOutputDir)
                     },
                     notifier: notifier,
                 )
@@ -324,8 +324,8 @@ final class AppState {
                 micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
                 verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
                 recordOnly: { [settings] in settings.recordOnly },
-                recordOnlyOutputDir: { [settings] in
-                    settings.effectiveOutputDir.appendingPathComponent("recordings")
+                recordOnlyDestination: { [settings] in
+                    .production(parent: settings.effectiveOutputDir)
                 },
                 notifier: notifier,
             )

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -55,11 +55,13 @@ class WatchLoop {
     /// Dynamic accessor — when true, skip the post-processing pipeline and
     /// instead write a `<basename>_meta.json` sidecar next to the recording.
     let recordOnly: () -> Bool
-    /// Dynamic accessor — destination directory for record-only output (WAVs +
-    /// sidecar JSON). Defaults to the app's transient `recordingsDir`; in
-    /// production wired to `<effectiveOutputDir>/recordings/` so users can
-    /// point Syncthing or similar at a visible folder.
-    let recordOnlyOutputDir: () -> URL
+    /// Dynamic accessor — destination for record-only output (WAVs + sidecar
+    /// JSON). Returns a `(scope, writeDir)` pair so we can call
+    /// `startAccessingSecurityScopedResource()` on the *bookmark-resolved
+    /// parent* (the URL the user actually picked) while writing into a
+    /// `recordings/` subfolder. Calling start-access on a child URL silently
+    /// fails inside the App Store sandbox — see `RecordOnlyDestination`.
+    let recordOnlyDestination: () -> RecordOnlyDestination
     /// Surface user-facing failures (e.g. sidecar write errors) that don't
     /// transition state to `.error`. Defaults to a silent no-op for tests.
     let notifier: any AppNotifying
@@ -80,7 +82,9 @@ class WatchLoop {
         micDeviceUID: String? = nil,
         verboseDiagnostics: @escaping () -> Bool = { false },
         recordOnly: @escaping () -> Bool = { false },
-        recordOnlyOutputDir: @escaping () -> URL = { AppPaths.recordingsDir },
+        recordOnlyDestination: @escaping () -> RecordOnlyDestination = {
+            .unscoped(AppPaths.recordingsDir)
+        },
         notifier: any AppNotifying = SilentNotifier(),
     ) {
         self.detector = detector
@@ -93,7 +97,7 @@ class WatchLoop {
         self.micDeviceUID = micDeviceUID
         self.verboseDiagnostics = verboseDiagnostics
         self.recordOnly = recordOnly
-        self.recordOnlyOutputDir = recordOnlyOutputDir
+        self.recordOnlyDestination = recordOnlyDestination
         self.notifier = notifier
     }
 
@@ -376,14 +380,16 @@ class WatchLoop {
         }
 
         do {
-            let destDir = recordOnlyOutputDir()
-            // The destination may be a user-chosen folder reached via a security-scoped
-            // bookmark (App Store sandboxed build, or any custom Output Folder pick).
-            // Without start/stopAccessingSecurityScopedResource the writes would silently
-            // fail. Other writers (ProtocolGenerator, PipelineQueue) follow the same pattern.
-            let accessing = destDir.startAccessingSecurityScopedResource()
-            defer { if accessing { destDir.stopAccessingSecurityScopedResource() } }
+            let destination = recordOnlyDestination()
+            // start/stopAccessingSecurityScopedResource MUST be called on the
+            // URL that resolved from the bookmark (App Store sandboxed build,
+            // or any custom Output Folder pick) — calling it on a child path
+            // silently fails. We then write into the `recordings/` subfolder
+            // beneath that scope.
+            let accessing = destination.scope.startAccessingSecurityScopedResource()
+            defer { if accessing { destination.scope.stopAccessingSecurityScopedResource() } }
 
+            let destDir = destination.writeDir
             try FileManager.default.createDirectory(
                 at: destDir, withIntermediateDirectories: true,
             )
@@ -451,5 +457,37 @@ class WatchLoop {
         case .recording: .recording
         case .error: .error
         }
+    }
+}
+
+/// Pair of URLs used by `WatchLoop` when persisting record-only output: the
+/// `scope` URL is what `startAccessingSecurityScopedResource()` is called on
+/// (the bookmark-resolved parent the user actually picked), and `writeDir` is
+/// the sub-path under that scope where the WAV + sidecar files land.
+///
+/// The split exists because Apple's security-scoped-bookmark API only grants
+/// access on the URL that resolved from the bookmark — calling start-access
+/// on a *child* path silently fails inside the App Store sandbox while
+/// appearing to work in the unsandboxed Homebrew build. The factory methods
+/// below make the two cases (real bookmark vs. transient app dir) explicit
+/// at every call site.
+struct RecordOnlyDestination: Equatable {
+    let scope: URL
+    let writeDir: URL
+
+    /// Production path: `parent` is the user-picked Output Folder (potentially
+    /// resolved from a security-scoped bookmark) and the WAVs land under
+    /// `parent/recordings/` so a Syncthing or rsync pair has a stable subtree.
+    static func production(parent: URL) -> Self {
+        Self(
+            scope: parent,
+            writeDir: parent.appendingPathComponent("recordings", isDirectory: true),
+        )
+    }
+
+    /// Test/default path: no security scope to manage — `scope == writeDir`,
+    /// so start-access is a harmless no-op and the writer hits `url` directly.
+    static func unscoped(_ url: URL) -> Self {
+        Self(scope: url, writeDir: url)
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -73,7 +73,7 @@ func makeTestWatchLoop(
         pollInterval: 0.05,
         endGracePeriod: 0.1,
         recordOnly: recordOnly,
-        recordOnlyOutputDir: recordOnlyOutputDir,
+        recordOnlyDestination: { .unscoped(recordOnlyOutputDir()) },
         notifier: notifier,
     )
     loop.permissionChecker = {

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -334,6 +334,26 @@ final class WatchLoopTests: XCTestCase {
         }
     }
 
+    // MARK: - RecordOnlyDestination
+
+    func test_production_destinationSplitsScopeAndWriteDir() {
+        let parent = URL(fileURLWithPath: "/tmp/picked")
+        let dest = RecordOnlyDestination.production(parent: parent)
+        // Scope is the bookmark-resolved parent — start-access target.
+        XCTAssertEqual(dest.scope, parent)
+        // Files land in the `recordings/` subfolder of that scope.
+        XCTAssertEqual(dest.writeDir.lastPathComponent, "recordings")
+        XCTAssertEqual(dest.writeDir.deletingLastPathComponent().path, parent.path)
+    }
+
+    func test_unscoped_destinationCollapsesScopeAndWriteDir() {
+        let url = URL(fileURLWithPath: "/tmp/local")
+        let dest = RecordOnlyDestination.unscoped(url)
+        // Identical so start-access on `scope` is harmless and writes hit `url`.
+        XCTAssertEqual(dest.scope, url)
+        XCTAssertEqual(dest.writeDir, url)
+    }
+
     // MARK: - Record-Only Mode
 
     /// Drives a complete `start → stop` manual recording cycle so the test


### PR DESCRIPTION
## Summary
- Record-only output silently failed in the App Store sandbox build because `WatchLoop` called `startAccessingSecurityScopedResource()` on `<effectiveOutputDir>/recordings/` — a *child* of the URL the user picked. Apple's API only grants access on the URL that *resolved from the bookmark*; calling it on a descendant returns true but opens no scope.
- The Homebrew build was unaffected (no sandbox), which is why the bug slipped past PR #144 review.

## Fix
Split the bookmark-resolved `scope` from the actual `writeDir` via a new `RecordOnlyDestination` value type. `WatchLoop` opens access on `scope` and writes into `writeDir`. Two static factories make the two cases explicit:
- `.production(parent:)` — wraps the user-picked Output Folder as `scope` and `parent/recordings/` as `writeDir`.
- `.unscoped(_:)` — collapses both to the same URL for tmp dirs and the in-app fallback `recordingsDir` so start-access is a harmless no-op.

The closure on `WatchLoop` is renamed `recordOnlyDestination` to surface the new return type. Both production wirings in `AppState` (auto-detect + manual-record) swap to `.production(parent:)`.

## Tests
- `test_production_destinationSplitsScopeAndWriteDir` — pure factory check that scope = parent and writeDir = parent/recordings.
- `test_unscoped_destinationCollapsesScopeAndWriteDir` — pure factory check that both URLs collapse for the no-bookmark case.
- Existing `test_recordOnly_writesSidecarAndDoesNotEnqueue` rewired through `makeTestWatchLoop` and still green.
- `swift build -c release` clean.