### PR TITLE
fix(app): auto-restart persistent log streamer on unexpected exit

### DIFF
--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -5,6 +5,43 @@ private let logger = Logger(
     subsystem: AppPaths.logSubsystem, category: "PersistentDiagnosticLog",
 )
 
+/// Sliding-window restart policy for the `log stream` subprocess. Pure value
+/// type so it can be exhaustively unit-tested without spawning processes.
+/// `Streamer` keeps a list of recent failure timestamps and asks the policy
+/// after each unexpected exit whether to relaunch (and how long to wait).
+struct RestartPolicy: Equatable {
+    /// Maximum failures allowed within `window` before `decide` returns `.giveUp`.
+    let maxFailuresInWindow: Int
+    /// Sliding window over which failures are counted, in seconds.
+    let window: TimeInterval
+    /// Cap on the exponential backoff (`2^count` seconds) between restarts.
+    let maxBackoff: TimeInterval
+
+    static let `default` = Self(
+        maxFailuresInWindow: 5,
+        window: 60,
+        maxBackoff: 30,
+    )
+
+    enum Decision: Equatable {
+        case restart(after: TimeInterval)
+        case giveUp
+    }
+
+    /// Filters `recentFailures` to entries newer than `now - window`, then
+    /// returns `.giveUp` if too many remain or `.restart` with exponential
+    /// backoff (1 s, 2 s, 4 s, …, clamped to `maxBackoff`).
+    func decide(now: Date, recentFailures: [Date]) -> Decision {
+        let cutoff = now.addingTimeInterval(-window)
+        let inWindow = recentFailures.filter { $0 >= cutoff }
+        if inWindow.count >= maxFailuresInWindow {
+            return .giveUp
+        }
+        let delay = min(pow(2.0, Double(inWindow.count)), maxBackoff)
+        return .restart(after: delay)
+    }
+}
+
 /// Manages a rolling on-disk mirror of `os.Logger` output for the
 /// `com.meetingtranscriber*` subsystems. Files are written by a background
 /// `log stream` subprocess (see `Streamer`) and rotated daily.
@@ -96,36 +133,60 @@ enum PersistentDiagnosticLog {
     #if !APPSTORE
         /// Wraps a running `log stream` subprocess that mirrors our subsystems
         /// to a local file. Lifetime is owned by `AppState`. Lifecycle:
-        /// `init(logDirectory:now:)` opens today's file, `start()` launches the
-        /// subprocess and pipes its stdout into the file, `stop()` terminates
-        /// the process and closes the file handle. The file rotates lazily
-        /// when `append(_:)` first sees a new UTC day.
+        /// `init(...)` opens today's file, `start()` launches the subprocess
+        /// and pipes its stdout into the file, `stop()` terminates the process
+        /// and closes the file handle. The file rotates lazily when
+        /// `append(_:)` first sees a new UTC day. If the subprocess exits
+        /// unexpectedly, the streamer relaunches it according to
+        /// `restartPolicy`; once the policy gives up, `isRunning` flips to
+        /// false and no further data is collected until the next `start()`.
         ///
         /// Gated `#if !APPSTORE` because `Process` is forbidden under sandbox.
         /// The App Store variant falls back to `OSLogStore` in `DiagnosticExporter`.
         ///
-        /// `@unchecked Sendable` because `Pipe.readabilityHandler` is invoked on
-        /// an arbitrary background queue and Swift 6 requires the captured
-        /// `[weak self]` to be Sendable. Internal mutable state (`logFileHandle`,
-        /// `openedDateString`, `isRunning`) is touched only by `start()` and
-        /// the readability handler, which the OS serialises by way of issuing
-        /// callbacks one-at-a-time per pipe — the class is externally
-        /// single-threaded by contract.
+        /// `@unchecked Sendable` because `Pipe.readabilityHandler` is invoked
+        /// on an arbitrary background queue and the `terminationHandler`
+        /// fires on Foundation's private Process queue. All state mutations
+        /// (`isRunning`, `recentFailures`, `process`, `pipe`) go through
+        /// `restartQueue` to serialise start, stop, unexpected-exit, and the
+        /// delayed relaunch with respect to each other. `append`'s file-handle
+        /// writes stay outside the queue — the OS serialises readability
+        /// callbacks per pipe and the day-rotation tests exercise that path
+        /// directly without spawning a real subprocess.
         final class Streamer: @unchecked Sendable {
-            private let process = Process()
-            private let pipe = Pipe()
+            private var process = Process()
+            private var pipe = Pipe()
             private let logDirectory: URL
             private let now: () -> Date
             private var logFileHandle: FileHandle
             private var openedDateString: String
-            private var isRunning = false
+            private(set) var isRunning = false
+
+            private let logExecutable: URL
+            private let logArguments: [String]
+            private let restartPolicy: RestartPolicy
+            private var recentFailures: [Date] = []
+            private let restartQueue = DispatchQueue(
+                label: "com.meetingtranscriber.persistent-log-streamer.restart",
+            )
 
             init(
                 logDirectory: URL = PersistentDiagnosticLog.logDirectory,
                 now: @escaping () -> Date = { Date() },
+                restartPolicy: RestartPolicy = .default,
+                logExecutable: URL = URL(fileURLWithPath: "/usr/bin/log"),
+                logArguments: [String] = [
+                    "stream",
+                    "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
+                    "--style", "syslog",
+                    "--info",
+                ],
             ) throws {
                 self.logDirectory = logDirectory
                 self.now = now
+                self.restartPolicy = restartPolicy
+                self.logExecutable = logExecutable
+                self.logArguments = logArguments
                 let date = now()
                 let target = logDirectory.appendingPathComponent(logFileName(for: date))
                 let fm = FileManager.default
@@ -138,16 +199,29 @@ enum PersistentDiagnosticLog {
             }
 
             func start() throws {
-                guard !isRunning else { return }
-                process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
-                process.arguments = [
-                    "stream",
-                    "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
-                    "--style", "syslog",
-                    "--info",
-                ]
+                try restartQueue.sync {
+                    guard !isRunning else { return }
+                    recentFailures.removeAll()
+                    try launchProcess()
+                    isRunning = true
+                }
+            }
+
+            /// Must be called on `restartQueue`. Recreates `process`/`pipe`
+            /// (Process is single-shot — once exited, can't be relaunched).
+            private func launchProcess() throws {
+                process = Process()
+                pipe = Pipe()
+                process.executableURL = logExecutable
+                process.arguments = logArguments
                 process.standardOutput = pipe
                 process.standardError = pipe
+                process.terminationHandler = { [weak self] proc in
+                    self?.handleProcessExit(
+                        reason: proc.terminationReason,
+                        status: proc.terminationStatus,
+                    )
+                }
 
                 let handle = pipe.fileHandleForReading
                 handle.readabilityHandler = { [weak self] fh in
@@ -157,10 +231,52 @@ enum PersistentDiagnosticLog {
                 }
 
                 try process.run()
-                isRunning = true
                 logger.info(
                     "persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)",
                 )
+            }
+
+            private func handleProcessExit(
+                reason: Process.TerminationReason, status: Int32,
+            ) {
+                restartQueue.async { [weak self] in
+                    guard let self else { return }
+                    // User-initiated stop already flipped `isRunning` and
+                    // detached the handler, so any straggling callback is a
+                    // no-op.
+                    guard self.isRunning else { return }
+
+                    let now = self.now()
+                    let cutoff = now.addingTimeInterval(-self.restartPolicy.window)
+                    self.recentFailures = self.recentFailures.filter { $0 >= cutoff }
+
+                    switch self.restartPolicy.decide(
+                        now: now, recentFailures: self.recentFailures,
+                    ) {
+                    case .giveUp:
+                        logger.error(
+                            "persistent_log_streamer_gave_up failures=\(self.recentFailures.count, privacy: .public)",
+                        )
+                        self.isRunning = false
+
+                    case let .restart(delay):
+                        logger.warning(
+                            "persistent_log_streamer_restarting reason=\(reason.rawValue, privacy: .public) status=\(status, privacy: .public) delay=\(delay, privacy: .public)",
+                        )
+                        self.recentFailures.append(now)
+                        self.restartQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                            guard let self, self.isRunning else { return }
+                            do {
+                                try self.launchProcess()
+                            } catch {
+                                logger.error(
+                                    "persistent_log_streamer_relaunch_failed error=\(error.localizedDescription, privacy: .public)",
+                                )
+                                self.isRunning = false
+                            }
+                        }
+                    }
+                }
             }
 
             /// Append `data` to the current day's file, rotating to the new
@@ -192,19 +308,27 @@ enum PersistentDiagnosticLog {
             }
 
             func stop() {
-                guard isRunning else { return }
-                process.terminate()
-                // Detach the readability callback before closing the file
-                // handle — otherwise a late callback could write to a
-                // recycled FD.
-                pipe.fileHandleForReading.readabilityHandler = nil
-                try? logFileHandle.close()
-                isRunning = false
-                logger.info("persistent_log_streamer_stopped")
+                restartQueue.sync {
+                    guard isRunning else { return }
+                    isRunning = false
+                    // Drop the termination handler before terminate so the
+                    // resulting exit isn't mistaken for an unexpected crash —
+                    // belt-and-suspenders alongside the `isRunning` check in
+                    // `handleProcessExit`.
+                    process.terminationHandler = nil
+                    process.terminate()
+                    // Detach the readability callback before closing the file
+                    // handle — otherwise a late callback could write to a
+                    // recycled FD.
+                    pipe.fileHandleForReading.readabilityHandler = nil
+                    try? logFileHandle.close()
+                    logger.info("persistent_log_streamer_stopped")
+                }
             }
 
             deinit {
                 if isRunning {
+                    process.terminationHandler = nil
                     process.terminate()
                     pipe.fileHandleForReading.readabilityHandler = nil
                     try? logFileHandle.close()

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -2,6 +2,51 @@
 import XCTest
 
 final class PersistentDiagnosticLogTests: XCTestCase {
+    // MARK: - RestartPolicy
+
+    func test_restartPolicy_emptyHistory_restartsImmediately() {
+        let policy = RestartPolicy(maxFailuresInWindow: 5, window: 60, maxBackoff: 30)
+        let now = Date()
+        XCTAssertEqual(policy.decide(now: now, recentFailures: []), .restart(after: 1))
+    }
+
+    func test_restartPolicy_oneRecentFailure_doublesBackoff() {
+        let policy = RestartPolicy(maxFailuresInWindow: 5, window: 60, maxBackoff: 30)
+        let now = Date()
+        let recent = [now.addingTimeInterval(-5)]
+        XCTAssertEqual(policy.decide(now: now, recentFailures: recent), .restart(after: 2))
+    }
+
+    func test_restartPolicy_fourFailures_uses16sBackoff() {
+        let policy = RestartPolicy(maxFailuresInWindow: 5, window: 60, maxBackoff: 30)
+        let now = Date()
+        let recent = (1 ... 4).map { now.addingTimeInterval(-Double($0)) }
+        XCTAssertEqual(policy.decide(now: now, recentFailures: recent), .restart(after: 16))
+    }
+
+    func test_restartPolicy_atMaxFailures_givesUp() {
+        let policy = RestartPolicy(maxFailuresInWindow: 5, window: 60, maxBackoff: 30)
+        let now = Date()
+        let recent = (1 ... 5).map { now.addingTimeInterval(-Double($0)) }
+        XCTAssertEqual(policy.decide(now: now, recentFailures: recent), .giveUp)
+    }
+
+    func test_restartPolicy_failuresOutsideWindow_areIgnored() {
+        let policy = RestartPolicy(maxFailuresInWindow: 5, window: 60, maxBackoff: 30)
+        let now = Date()
+        let stale = (1 ... 10).map { now.addingTimeInterval(-Double($0) - 60) }
+        XCTAssertEqual(policy.decide(now: now, recentFailures: stale), .restart(after: 1))
+    }
+
+    func test_restartPolicy_backoffCappedAtMaxBackoff() {
+        let policy = RestartPolicy(maxFailuresInWindow: 100, window: 60, maxBackoff: 5)
+        let now = Date()
+        let recent = (1 ... 10).map { now.addingTimeInterval(-Double($0)) }
+        XCTAssertEqual(policy.decide(now: now, recentFailures: recent), .restart(after: 5))
+    }
+
+    // MARK: - Static helpers
+
     func test_logFileName_isYYYYMMDD() {
         let date = ISO8601DateFormatter().date(from: "2026-05-04T12:00:00Z") ?? Date()
         XCTAssertEqual(
@@ -160,6 +205,73 @@ final class PersistentDiagnosticLogTests: XCTestCase {
             // Old file kept being writable — entry landed there, not dropped.
             let day1 = tmp.appendingPathComponent("diagnostics-2026-05-04.log")
             XCTAssertEqual(try String(contentsOf: day1), "before\nafter\n")
+        }
+
+        // MARK: - Streamer auto-restart
+
+        /// Wait for `condition` to become true, polling every 20 ms, up to
+        /// `timeout` seconds. Returns the final value. Used instead of a
+        /// fixed `Thread.sleep` so the test exits as soon as the streamer's
+        /// state settles instead of always paying the worst-case wait.
+        private func waitForCondition(
+            timeout: TimeInterval,
+            _ condition: () -> Bool,
+        ) -> Bool {
+            let deadline = Date().addingTimeInterval(timeout)
+            while Date() < deadline {
+                if condition() { return true }
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+            return condition()
+        }
+
+        /// `/usr/bin/false` exits immediately with status 1 — a reliable
+        /// crash-stub for the auto-restart path that doesn't need a real
+        /// `log` daemon. Combined with `maxBackoff = 0.01` the whole loop
+        /// completes in well under a second.
+        func test_streamer_givesUpAfterRepeatedUnexpectedExits() throws {
+            let tmp = try makeTempDirectory(prefix: "StreamerRestart")
+            let policy = RestartPolicy(
+                maxFailuresInWindow: 3, window: 60, maxBackoff: 0.01,
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(
+                logDirectory: tmp,
+                restartPolicy: policy,
+                logExecutable: URL(fileURLWithPath: "/usr/bin/false"),
+                logArguments: [],
+            )
+            try streamer.start()
+            XCTAssertTrue(streamer.isRunning)
+
+            XCTAssertTrue(
+                waitForCondition(timeout: 2.0) { !streamer.isRunning },
+                "Streamer should have given up after 3 failures",
+            )
+        }
+
+        /// `stop()` must short-circuit any pending relaunch; otherwise an
+        /// `asyncAfter` enqueued during the restart loop could fire after
+        /// the test (and the `Streamer`) is gone, writing to a freed FD.
+        func test_streamer_stopDuringRestartLoopIsCleanlyTerminated() throws {
+            let tmp = try makeTempDirectory(prefix: "StreamerStopMidRestart")
+            let policy = RestartPolicy(
+                maxFailuresInWindow: 100, window: 60, maxBackoff: 0.05,
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(
+                logDirectory: tmp,
+                restartPolicy: policy,
+                logExecutable: URL(fileURLWithPath: "/usr/bin/false"),
+                logArguments: [],
+            )
+            try streamer.start()
+            // Let the restart loop iterate at least once before pulling the rug.
+            Thread.sleep(forTimeInterval: 0.1)
+            streamer.stop()
+            XCTAssertFalse(streamer.isRunning)
+            // Give any in-flight `asyncAfter` a chance to fire — it must
+            // observe `isRunning == false` and bail.
+            Thread.sleep(forTimeInterval: 0.2)
+            XCTAssertFalse(streamer.isRunning)
         }
     #endif
 }


### PR DESCRIPTION
## Summary
- The persistent diagnostic log streamer wraps `/usr/bin/log stream` to mirror our subsystems into `~/Library/Logs/MeetingTranscriber/diagnostics-*.log`. Until now, if the subprocess died mid-session — SIGPIPE on a forced restart of the unified log daemon, kernel sandbox eviction, or someone manually killing the helper — no `terminationHandler` was wired, so the readability callback simply stopped receiving bytes and `isRunning` stayed `true` forever. Subsequent diagnostics were silently dropped until the next app launch.
- New `RestartPolicy` (pure value type) decides on every unexpected exit whether to relaunch with exponential backoff or give up after too many failures in a sliding window. Defaults: 5 failures in 60 s, backoff cap 30 s.

## Implementation
- `process.terminationHandler` is now set on each (re)launch. On exit, `handleProcessExit` runs on a private serial `restartQueue` and consults the policy.
- `launchProcess()` recreates `process` and `pipe` on every (re)start because Foundation's `Process` is single-shot.
- All bookkeeping (`isRunning`, `recentFailures`, `process`, `pipe`) goes through `restartQueue` so the start, stop, unexpected-exit, and delayed-relaunch paths can't race each other.
- User-initiated `stop()` flips `isRunning` and detaches the handler **before** `process.terminate()`, so the resulting SIGTERM exit isn't mistaken for a crash.
- `init` adds `restartPolicy`, `logExecutable`, and `logArguments` parameters — all defaulted, so existing callers (`AppState`, day-rotation tests) keep working unchanged.

## Tests
- Six pure-policy unit tests covering the decision matrix: empty history, doubling backoff, four-failures, give-up at max, window filter, backoff cap.
- Two integration tests using `/usr/bin/false` as a crash-stub (exits status 1 immediately):
  - `test_streamer_givesUpAfterRepeatedUnexpectedExits` — asserts `isRunning` flips to false after the configured failure count (~50 ms).
  - `test_streamer_stopDuringRestartLoopIsCleanlyTerminated` — verifies `stop()` mid-loop terminates without late `asyncAfter` callbacks firing into a freed receiver.
- Existing day-rotation tests still exercise `append()` directly without spawning a real subprocess.
- `swift build -c release` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->