### PR TITLE
feat(app): apply custom vocabulary as Whisper decoding prompt

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -425,6 +425,7 @@ final class AppState {
     private func syncLanguageSettings() {
         if settings.transcriptionEngine == .whisperKit {
             whisperKit.language = settings.whisperLanguageOrNil
+            whisperKit.customVocabularyPath = settings.customVocabularyPath
         }
         if settings.transcriptionEngine == .parakeet {
             parakeetEngine.customVocabularyPath = settings.customVocabularyPath

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -55,7 +55,7 @@ final class WhisperKitEngine: TranscribingEngine {
     /// Cached prompt tokens for `DecodingOptions.promptTokens`. Refreshed
     /// when `customVocabularyPath` changes since last transcription. Empty
     /// means "no biasing" — translated to `nil` at the `DecodingOptions` call.
-    private var cachedPromptTokens: [Int] = []
+    private(set) var cachedPromptTokens: [Int] = []
     private var lastTokenizedVocabularyPath: String = ""
 
     /// Whisper's prompt context is bounded; 224 leaves headroom under the

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -42,12 +42,25 @@ extension TimestampedSegment {
 final class WhisperKitEngine: TranscribingEngine {
     var modelVariant = "openai_whisper-large-v3-v20240930_turbo"
     var language: String?
+    /// Path to a newline-separated vocabulary file. Empty disables biasing.
+    /// Read in `transcribeSegments` to build `DecodingOptions.promptTokens`.
+    var customVocabularyPath: String = ""
     private(set) var modelState: ModelState = .unloaded
     private(set) var downloadProgress: Double = 0
     /// Transcription progress (0.0–1.0) based on WhisperKit's 30s window processing.
     private(set) var transcriptionProgress: Double = 0
     private var pipe: WhisperKit?
     private var loadingTask: Task<Void, Never>?
+
+    /// Cached prompt tokens for `DecodingOptions.promptTokens`. Refreshed
+    /// when `customVocabularyPath` changes since last transcription. Empty
+    /// means "no biasing" — translated to `nil` at the `DecodingOptions` call.
+    private var cachedPromptTokens: [Int] = []
+    private var lastTokenizedVocabularyPath: String = ""
+
+    /// Whisper's prompt context is bounded; 224 leaves headroom under the
+    /// 448-token total context for prefix + audio. Matches OpenAI guidance.
+    static let maxPromptTokens = 224
 
     func loadModel() async {
         // Deduplicate concurrent loads
@@ -120,9 +133,12 @@ final class WhisperKitEngine: TranscribingEngine {
         // Estimate total 30s windows from audio duration
         let totalWindows = max(1, Self.estimateWindowCount(audioPath: audioPath))
 
+        refreshVocabularyTokensIfNeeded(tokenizer: pipe.tokenizer)
+
         let options = DecodingOptions(
             language: language,
             wordTimestamps: false,
+            promptTokens: cachedPromptTokens.isEmpty ? nil : cachedPromptTokens,
         )
 
         let results = await pipe.transcribe(
@@ -170,6 +186,52 @@ final class WhisperKitEngine: TranscribingEngine {
     /// Remove Whisper special tokens like <|startoftranscript|>, <|en|>, <|0.00|>, etc.
     static func stripWhisperTokens(_ text: String) -> String {
         text.replacingOccurrences(of: #"<\|[^|]*\|>"#, with: "", options: .regularExpression)
+    }
+
+    /// Read a newline-separated vocabulary file into trimmed, non-empty terms.
+    /// Returns `[]` for empty/missing paths (no biasing — silently skipped).
+    nonisolated static func parseVocabulary(from path: String) -> [String] {
+        guard !path.isEmpty,
+              let content = try? String(contentsOfFile: path, encoding: .utf8)
+        else { return [] }
+        return content.split(separator: "\n", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Compose a Whisper prompt phrase from `terms`. Whisper uses the prompt
+    /// as transcript-style context, so framing it as "Glossary: …" gives the
+    /// decoder a stable hint without hijacking the output language.
+    nonisolated static func makeVocabularyPrompt(terms: [String]) -> String? {
+        guard !terms.isEmpty else { return nil }
+        return "Glossary: " + terms.joined(separator: ", ")
+    }
+
+    /// Truncate `tokens` to `maxLength`, keeping the head. Whisper's prompt
+    /// context is bounded; if the vocab tokenises past the cap we drop the
+    /// tail rather than refusing to set any prompt at all.
+    nonisolated static func clampTokens(_ tokens: [Int], maxLength: Int) -> [Int] {
+        guard tokens.count > maxLength else { return tokens }
+        return Array(tokens.prefix(maxLength))
+    }
+
+    private func refreshVocabularyTokensIfNeeded(tokenizer: (any WhisperTokenizer)?) {
+        guard customVocabularyPath != lastTokenizedVocabularyPath else { return }
+        lastTokenizedVocabularyPath = customVocabularyPath
+
+        let terms = Self.parseVocabulary(from: customVocabularyPath)
+        guard let prompt = Self.makeVocabularyPrompt(terms: terms),
+              let tokenizer
+        else {
+            cachedPromptTokens = []
+            return
+        }
+        // Leading space matches Whisper's BPE expectations for prompt text.
+        let raw = tokenizer.encode(text: " " + prompt)
+        cachedPromptTokens = Self.clampTokens(raw, maxLength: Self.maxPromptTokens)
+        logger.info(
+            "WhisperKit: vocabulary loaded terms=\(terms.count, privacy: .public) tokens=\(self.cachedPromptTokens.count, privacy: .public)",
+        )
     }
 }
 

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -80,4 +80,62 @@ final class CustomVocabularyTests: XCTestCase {
         // Should not throw for missing file — just logs a warning
         try await engine.configureVocabulary(from: "/nonexistent/vocab.txt")
     }
+
+    // MARK: - WhisperKitEngine vocabulary parsing
+
+    @MainActor
+    func testWhisperKitEngineHasCustomVocabularyPath() {
+        let engine = WhisperKitEngine()
+        XCTAssertEqual(engine.customVocabularyPath, "")
+    }
+
+    func testParseVocabulary_returnsEmptyForEmptyPath() {
+        XCTAssertEqual(WhisperKitEngine.parseVocabulary(from: ""), [])
+    }
+
+    func testParseVocabulary_returnsEmptyForMissingFile() {
+        XCTAssertEqual(
+            WhisperKitEngine.parseVocabulary(from: "/nonexistent/vocab.txt"),
+            [],
+        )
+    }
+
+    func testParseVocabulary_splitsLinesAndTrimsWhitespace() throws {
+        let url = makeTempFile(suffix: ".txt")
+        try "  Klaus-Dieter\n CATapDescription \n\n  pasrom \n".write(
+            to: url, atomically: true, encoding: .utf8,
+        )
+        XCTAssertEqual(
+            WhisperKitEngine.parseVocabulary(from: url.path),
+            ["Klaus-Dieter", "CATapDescription", "pasrom"],
+        )
+    }
+
+    func testMakeVocabularyPrompt_isNilForEmptyTerms() {
+        XCTAssertNil(WhisperKitEngine.makeVocabularyPrompt(terms: []))
+    }
+
+    func testMakeVocabularyPrompt_joinsTermsWithCommaPrefix() {
+        XCTAssertEqual(
+            WhisperKitEngine.makeVocabularyPrompt(
+                terms: ["Klaus-Dieter", "CATapDescription"],
+            ),
+            "Glossary: Klaus-Dieter, CATapDescription",
+        )
+    }
+
+    func testClampTokens_returnsArrayUnchangedWhenUnderLimit() {
+        XCTAssertEqual(
+            WhisperKitEngine.clampTokens([1, 2, 3], maxLength: 224),
+            [1, 2, 3],
+        )
+    }
+
+    func testClampTokens_truncatesToMaxLength() {
+        let tokens = Array(0 ..< 300)
+        let clamped = WhisperKitEngine.clampTokens(tokens, maxLength: 224)
+        XCTAssertEqual(clamped.count, 224)
+        XCTAssertEqual(clamped.first, 0)
+        XCTAssertEqual(clamped.last, 223)
+    }
 }

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -203,6 +203,60 @@ final class WhisperKitE2ETests: XCTestCase {
         }
     }
 
+    /// End-to-end wiring check: when `customVocabularyPath` points at a real
+    /// file, `transcribeSegments` must populate `cachedPromptTokens` from the
+    /// loaded model's tokenizer before invoking `pipe.transcribe`. The model
+    /// download is shared with the fixture test above, so this is cheap on
+    /// any machine that already ran the suite once.
+    func testTranscribeSegmentsAppliesCustomVocabularyAsPrompt() async throws {
+        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+
+        let fixture = fixtureURL()
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Test fixture not found at \(fixture.path)",
+        )
+
+        let vocabFile = makeTempFile(suffix: ".txt")
+        try """
+        Klaus-Dieter
+        CATapDescription
+        Sortformer
+        FluidAudio
+        WhisperKit
+        pasrom
+        """.write(to: vocabFile, atomically: true, encoding: .utf8)
+
+        let engine = WhisperKitEngine()
+        engine.modelVariant = "openai_whisper-small"
+        engine.language = "de"
+        engine.customVocabularyPath = vocabFile.path
+
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        // Prompt tokens are populated lazily inside transcribeSegments — empty
+        // until the first transcribe call wires them up.
+        XCTAssertTrue(engine.cachedPromptTokens.isEmpty, "Should be empty before transcribe")
+
+        _ = try await engine.transcribeSegments(audioPath: fixture)
+
+        XCTAssertFalse(
+            engine.cachedPromptTokens.isEmpty,
+            "Vocabulary should have been tokenised and cached",
+        )
+        XCTAssertLessThanOrEqual(
+            engine.cachedPromptTokens.count, WhisperKitEngine.maxPromptTokens,
+            "Tokens must respect the prompt budget",
+        )
+        // A six-term glossary tokenises to a small handful — well under cap.
+        XCTAssertGreaterThan(
+            engine.cachedPromptTokens.count, 5,
+            "6 terms should produce more than 5 tokens",
+        )
+    }
+
     func testTranscribeSegmentsHallucinationFilter() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
         let isCI = ProcessInfo.processInfo.environment["CI"] != nil


### PR DESCRIPTION
## Summary
- Until now the custom-vocabulary file at `AppSettings.customVocabularyPath` was only consumed by `ParakeetEngine` (CTC boosting). When transcribing with WhisperKit, those terms had no effect — domain-specific names like "Klaus-Dieter" or "CATapDescription" were free to be misheard as generic words even though the user had configured them as project vocabulary.
- `WhisperKitEngine` now reads the same newline-separated file, joins non-empty terms into a `"Glossary: t1, t2, …"` prompt phrase, tokenises it via the loaded model's `WhisperTokenizer`, and feeds the result into `DecodingOptions.promptTokens`.
- No settings UI change — existing users with a configured vocab path get biasing automatically the next time they transcribe with WhisperKit.

## Implementation
- Three pure helpers on `WhisperKitEngine` (all `nonisolated static`): `parseVocabulary(from:)` (file → trimmed, non-empty terms), `makeVocabularyPrompt(terms:)` (terms → `"Glossary: …"`), `clampTokens(_:maxLength:)` (head-truncate to fit the 224-token budget).
- `refreshVocabularyTokensIfNeeded(tokenizer:)` runs once per `customVocabularyPath` change — caches the encoded tokens so repeated transcriptions don't re-tokenise.
- `cachedPromptTokens.isEmpty ? nil : cachedPromptTokens` is passed to `DecodingOptions.promptTokens`, preserving the `nil = no prompt` semantics WhisperKit expects.
- `AppState.syncLanguageSettings` propagates the path to the WhisperKit engine in addition to Parakeet.
- Token cap is 224, well under WhisperKit's `Constants.maxTokenContext = 448`, leaving room for the prefill prompt + audio.

## Tests
- **Unit (7):** `parseVocabulary` covers empty path / missing file / multi-line file with whitespace + blanks; `makeVocabularyPrompt` covers empty-terms → nil and terms → `"Glossary: <comma-joined>"`; `clampTokens` covers under-limit pass-through and over-limit head-truncation. Plus a smoke test that `WhisperKitEngine.customVocabularyPath` defaults to `""`.
- **End-to-end (1, skipped on CI):** `testTranscribeSegmentsAppliesCustomVocabularyAsPrompt` loads `openai_whisper-small`, sets a six-term vocab path, transcribes the German fixture, asserts `cachedPromptTokens` is non-empty, ≤ `maxPromptTokens`, and > 5 (six terms tokenise to a handful). Runs in ~6 s locally when the model is cached. `cachedPromptTokens` is `private(set)` to make this assertable.
- Full suite green, `swift build -c release` clean.

## Manual verification
Performed locally on `openai_whisper-small`: vocabulary file is parsed, tokenised through the live model, and the resulting prompt-token array stays under the budget after a real transcription run. Token count for the six-term glossary above lands well below the 224-token cap.