### PR TITLE
fix(app): propagate runtime AppSettings changes to engine instances

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -79,6 +79,13 @@ final class AppState {
         self.notifier = notifier
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
+
+        // Bring engines in line with the current settings up front so the
+        // first transcription doesn't run against stale defaults, then
+        // start observing for runtime changes.
+        syncLanguageSettings()
+        observeEngineSettings()
+
         #if !APPSTORE
             // Env var force-enables at launch only — preserves back-compat with
             // scripts/test_rpc.sh and CI. After init, settings.debugRPCEnabled
@@ -421,22 +428,49 @@ final class AppState {
 
     // MARK: - Pipeline
 
-    /// Apply language settings to the active engine before creating a pipeline.
+    /// Push current language/vocabulary settings into the active engine.
+    /// Idempotent — each branch only writes when the value actually differs,
+    /// so unchanged settings don't churn the engine's `@Observable` watchers.
     private func syncLanguageSettings() {
-        if settings.transcriptionEngine == .whisperKit {
-            whisperKit.language = settings.whisperLanguageOrNil
+        switch settings.transcriptionEngine {
+        case .whisperKit:
+            let next = settings.whisperLanguageOrNil
+            if whisperKit.language != next { whisperKit.language = next }
+
+        case .parakeet:
+            let next = settings.customVocabularyPath
+            if parakeetEngine.customVocabularyPath != next {
+                parakeetEngine.customVocabularyPath = next
+            }
+
+        case .qwen3:
+            if #available(macOS 15, *) {
+                let next = settings.qwen3LanguageOrNil
+                if qwen3Engine.language != next { qwen3Engine.language = next }
+            }
         }
-        if settings.transcriptionEngine == .parakeet {
-            parakeetEngine.customVocabularyPath = settings.customVocabularyPath
-        }
-        if #available(macOS 15, *), settings.transcriptionEngine == .qwen3 {
-            qwen3Engine.language = settings.qwen3LanguageOrNil
+    }
+
+    /// `withObservationTracking` is one-shot — re-arm after each fire so the
+    /// AppState reacts to every settings change, not just the first one.
+    /// Mirrors the `observeDebugRPCSetting` pattern.
+    private func observeEngineSettings() {
+        withObservationTracking {
+            _ = settings.transcriptionEngine
+            _ = settings.whisperLanguage
+            _ = settings.customVocabularyPath
+            _ = settings.qwen3Language
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.syncLanguageSettings()
+                self.observeEngineSettings()
+            }
         }
     }
 
     func ensurePipelineQueue() {
         guard pipelineQueue.engine == nil else { return }
-        syncLanguageSettings()
         pipelineQueue = makePipelineQueue()
         configurePipelineCallbacks()
     }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -6,20 +6,6 @@ import XCTest
 final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_length
     // MARK: - Helpers
 
-    /// Yields repeatedly until `condition()` is true or the timeout elapses.
-    /// Needed for tests that await toggleWatching()/startManualRecording() which
-    /// internally spawn a Task containing AVCaptureDevice.requestAccess — a real
-    /// async suspension point that requires more than one yield to resolve.
-    private func waitFor(
-        _ condition: @autoclosure () -> Bool,
-        timeout: Duration = .milliseconds(500),
-    ) async {
-        let deadline = ContinuousClock.now + timeout
-        while !condition(), ContinuousClock.now < deadline {
-            await Task.yield()
-        }
-    }
-
     private func makeState() -> (AppState, RecordingNotifier) {
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)

--- a/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
+++ b/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
@@ -1,0 +1,138 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Verifies that `AppSettings` changes propagate to the engine instances at
+/// runtime, not just on app restart. The settings ↔ engine sync used to run
+/// only once when the pipeline queue was first built; later UI changes
+/// silently dropped on the floor until the next launch.
+@MainActor
+final class EngineSettingsRuntimeSyncTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var defaults: UserDefaults!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var settings: AppSettings!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var testSuiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testSuiteName = "EngineSettingsRuntimeSyncTests-\(getpid())-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: testSuiteName) else {
+            XCTFail("Could not create test UserDefaults suite")
+            return
+        }
+        defaults = suite
+        settings = AppSettings(defaults: defaults)
+    }
+
+    override func tearDown() async throws {
+        settings = nil
+        defaults.removePersistentDomain(forName: testSuiteName)
+        defaults = nil
+        testSuiteName = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Initial sync at AppState init
+
+    func test_initialSync_propagatesWhisperLanguageToEngine() {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperLanguage = "de"
+        let state = AppState(settings: settings)
+        XCTAssertEqual(state.whisperKit.language, "de")
+    }
+
+    func test_initialSync_propagatesCustomVocabularyPathToParakeet() {
+        settings.transcriptionEngine = .parakeet
+        settings.customVocabularyPath = "/tmp/init-vocab.txt"
+        let state = AppState(settings: settings)
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
+    }
+
+    // MARK: - Runtime propagation
+
+    func test_runtimeChange_whisperLanguage_propagatesToEngine() async {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperLanguage = "de"
+        let state = AppState(settings: settings)
+        XCTAssertEqual(state.whisperKit.language, "de")
+
+        settings.whisperLanguage = "en"
+
+        await waitFor(state.whisperKit.language == "en")
+        XCTAssertEqual(state.whisperKit.language, "en")
+    }
+
+    func test_runtimeChange_customVocabularyPath_propagatesToParakeet() async {
+        settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "")
+
+        settings.customVocabularyPath = "/tmp/runtime-vocab.txt"
+
+        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/runtime-vocab.txt")
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/runtime-vocab.txt")
+    }
+
+    func test_runtimeChange_qwen3Language_propagatesToEngine() async throws {
+        guard #available(macOS 15, *) else {
+            throw XCTSkip("Qwen3 requires macOS 15+")
+        }
+        settings.transcriptionEngine = .qwen3
+        settings.qwen3Language = "de"
+        let state = AppState(settings: settings)
+        XCTAssertEqual(state.qwen3Engine.language, "de")
+
+        settings.qwen3Language = "en"
+
+        await waitFor(state.qwen3Engine.language == "en")
+        XCTAssertEqual(state.qwen3Engine.language, "en")
+    }
+
+    // MARK: - Re-arming
+
+    /// `withObservationTracking` is one-shot per registration; the re-arm in
+    /// `onChange` is what makes consecutive changes fire. Without it, only
+    /// the first change would propagate and subsequent ones silently no-op.
+    func test_observation_rearmsForMultipleChanges() async {
+        settings.transcriptionEngine = .parakeet
+        let state = AppState(settings: settings)
+
+        settings.customVocabularyPath = "/tmp/v1.txt"
+        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v1.txt")
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v1.txt")
+
+        settings.customVocabularyPath = "/tmp/v2.txt"
+        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v2.txt")
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v2.txt")
+
+        settings.customVocabularyPath = "/tmp/v3.txt"
+        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v3.txt")
+        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v3.txt")
+    }
+
+    // MARK: - Engine switch
+
+    /// Switching `transcriptionEngine` must re-sync the now-active engine
+    /// with the existing settings — otherwise the user gets a stale engine
+    /// state until they touch any other setting.
+    func test_engineSwitch_syncsNewlyActiveEngine() async {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperLanguage = "de"
+        settings.customVocabularyPath = "/tmp/parakeet-vocab.txt"
+        let state = AppState(settings: settings)
+
+        XCTAssertEqual(state.whisperKit.language, "de")
+        XCTAssertEqual(
+            state.parakeetEngine.customVocabularyPath, "",
+            "Parakeet inactive at init — no sync expected",
+        )
+
+        settings.transcriptionEngine = .parakeet
+
+        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/parakeet-vocab.txt")
+        XCTAssertEqual(
+            state.parakeetEngine.customVocabularyPath, "/tmp/parakeet-vocab.txt",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -94,6 +94,31 @@
             XCTAssertNil(snapshot.engines.whisperKit.language)
         }
 
+        // MARK: - Live propagation through the snapshot
+
+        /// End-to-end smoketest: the snapshot is the supported way to observe
+        /// runtime settings → engine propagation from outside the process.
+        /// Same flow `mt-cli state | jq .engines` exercises against the live app.
+        func test_snapshot_reflectsRuntimeSettingChange() async {
+            settings.transcriptionEngine = .parakeet
+            let state = AppState(settings: settings)
+
+            XCTAssertEqual(
+                state.rpcStateSnapshot().engines.parakeet.customVocabularyPath, "",
+            )
+
+            settings.customVocabularyPath = "/tmp/runtime.txt"
+            await waitFor(
+                state.rpcStateSnapshot().engines.parakeet.customVocabularyPath
+                    == "/tmp/runtime.txt",
+            )
+
+            XCTAssertEqual(
+                state.rpcStateSnapshot().engines.parakeet.customVocabularyPath,
+                "/tmp/runtime.txt",
+            )
+        }
+
         // MARK: - JSON shape
 
         func test_snapshot_jsonContainsEnginesBlock() throws {

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -33,6 +33,26 @@ extension XCTestCase {
     }
 }
 
+// MARK: - Async Polling Helper
+
+extension XCTestCase {
+    /// Yields repeatedly until `condition()` is true or `timeout` elapses.
+    /// Needed for tests that await operations spawning a `Task { @MainActor in … }`
+    /// (e.g. AppState's `withObservationTracking` re-arm, AVCaptureDevice
+    /// permission prompts) — a single `Task.yield()` isn't always enough to
+    /// drain the runloop before the assertion fires.
+    @MainActor
+    func waitFor(
+        _ condition: @autoclosure () -> Bool,
+        timeout: Duration = .milliseconds(500),
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+    }
+}
+
 // MARK: - Fixture URL Helper
 
 extension XCTestCase {

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -80,9 +80,16 @@ step "mt-cli roundtrips"
 "$MT_CLI_BIN" healthz | grep -q "^ok$" || fail "healthz output unexpected"
 ok "healthz"
 
-"$MT_CLI_BIN" state | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'pipeline' in d and 'speakerDB' in d" \
-    || fail "state JSON malformed"
-ok "state JSON parses"
+"$MT_CLI_BIN" state | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'pipeline' in d and 'speakerDB' in d
+e = d['engines']
+assert e['active'] in ('whisperKit', 'parakeet', 'qwen3'), f'bad active: {e[\"active\"]!r}'
+assert 'modelVariant' in e['whisperKit']
+assert 'customVocabularyPath' in e['parakeet']
+" || fail "state JSON malformed"
+ok "state JSON parses (incl. engines block)"
 
 step "Action + screenshot loop"
 "$MT_CLI_BIN" close-settings >/dev/null  # ensure clean idle


### PR DESCRIPTION
## Summary
- `AppState.syncLanguageSettings()` was only invoked from `ensurePipelineQueue` (guarded `guard pipelineQueue.engine == nil`), so settings UI changes after the first transcription went nowhere — the engine kept its launch-time values until the next app start. Affected fields: WhisperKit's `language`, ParakeetEngine's `customVocabularyPath`, Qwen3AsrEngine's `language`.
- Symptom: user picks a new vocab file or changes language in Settings → next transcription still uses the old value with no indication anything is off.

## Fix
Mirror the existing `observeDebugRPCSetting` pattern with a re-arming `withObservationTracking` that watches `transcriptionEngine`, `whisperLanguage`, `customVocabularyPath` and `qwen3Language`. On any change, `syncLanguageSettings()` runs and the observer re-arms for the next one. AppState init now also calls `syncLanguageSettings()` once upfront so engines start aligned with settings instead of waiting for the first transcription to lazily sync via `ensurePipelineQueue`.

`ensurePipelineQueue`'s `syncLanguageSettings()` call stays as belt-and-suspenders — at this point it's a no-op since both init and the observer cover the cases, but keeping it documents the "engine must be in sync before the queue is created" contract.

## Tests
`EngineSettingsRuntimeSyncTests` covers:
- **Initial sync at init** — `whisperLanguage` and `customVocabularyPath` are set on the engines before the first transcription.
- **Runtime propagation** for each engine field (whisperKit / parakeet / qwen3).
- **Multi-change re-arming** — three consecutive writes each propagate, catching a missing re-arm.
- **Engine switch** — flipping `transcriptionEngine` syncs the newly-active engine with the existing settings.

`RPCEngineStateTests.test_snapshot_reflectsRuntimeSettingChange` adds an end-to-end smoketest combining this fix with the RPC observability shipped in #207: change a setting at runtime → hit `rpcStateSnapshot()` → see the new value reflected in the `engines` block. Same flow `mt-cli state | jq .engines` exercises against the live app.

Without the fix all eight assertions fail; with it all eight pass. Full suite green, lint clean, `swift build -c release` clean.