### PR TITLE
docs(claude): forbid referencing .local/ content in shared artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
   - `docs/plans/` (committed) — RFCs and reference docs for future features that should be visible to anyone reading the repo
   - `docs/plans/.local/` (gitignored) — personal scratch; optional subfolders `open/`, `research/`, `done/`, `future/`, `deferred/`
   - Default to `.local/` for ad-hoc notes, diagnostic dumps, and active finding-trackers; promote to committed `docs/plans/` only when the plan is shared reference material
+  - **Never reference `.local/` content in shared artifacts** (PR descriptions, commit messages, code comments, in-app UI, GitHub issues): no file paths under `.local/`, no internal task identifiers like P4/P6/B22/H1/L6, no internal PR-internal nicknames. Reviewers don't see those. Inline the relevant content instead, or describe in plain language. The same applies to chat replies framed as PR/commit-ready text.
 
 ## Architecture Notes
 


### PR DESCRIPTION
## Summary
- Adds explicit rule to CLAUDE.md: never reference gitignored personal-scratch content (paths, internal task IDs) in PR descriptions, commit messages, code comments, in-app UI, or GitHub issues.
- The existing convention covered *where* to put plan files but not *how to talk about them* in shared artifacts. Reviewers without access to local notes see opaque identifiers; this codifies the inline-the-content rule.

## Test plan
- [x] No code changed — docs only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->