### PR TITLE
ci(workflows): extract Swift-test setup into composite action

### DIFF
--- a/.github/actions/setup-swift-test/action.yml
+++ b/.github/actions/setup-swift-test/action.yml
@@ -1,0 +1,56 @@
+name: "Setup Swift test environment"
+description: >
+  Checks out the repo, restores SPM and ML-model caches keyed off
+  `Package.resolved`, and pre-warms the ML model cache on a cache miss.
+  Used by every job that runs `swift test` against engines that load
+  WhisperKit / FluidAudio / Qwen3 weights, so the boilerplate lives in
+  one place instead of being copy-pasted per job.
+
+inputs:
+  cache-key-suffix:
+    description: >
+      Distinguishes parallel SPM caches by compile-flag set. Pick a stable
+      string like `homebrew`, `appstore`, `tsan`, `asan`, or `quality`.
+      Different suffixes get independent caches; same suffix can share.
+    required: true
+  swift-flags:
+    description: >
+      Extra arguments forwarded to the pre-warm `swift test` invocation
+      (e.g. `-Xswiftc -DAPPSTORE`). Sanitizer flags are intentionally NOT
+      applied to the pre-warm — the model loader doesn't need them, and
+      sanitized builds are slower to warm.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # Caller is responsible for `actions/checkout` before invoking this
+    # action — GitHub loads `./.github/actions/...` from the workspace, so
+    # the repo must already be present.
+    - name: Cache SPM dependencies
+      uses: actions/cache@v5
+      with:
+        path: app/MeetingTranscriber/.build
+        key: spm-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
+        restore-keys: spm-${{ runner.os }}-${{ inputs.cache-key-suffix }}-
+
+    # Cache the WhisperKit (HuggingFace) + FluidAudio model files. The
+    # HuggingFace download client races on cold-cache concurrent loads of
+    # the same variant; pre-warming sequentially populates the cache so
+    # the parallel run can hit it. After the first successful CI run the
+    # cache is populated and the preload step is skipped.
+    - name: Cache ML models
+      id: model-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/Documents/huggingface
+          ~/Library/Application Support/FluidAudio
+        key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
+        restore-keys: ml-models-${{ runner.os }}-
+
+    - name: Pre-warm model cache (cache miss only)
+      if: steps.model-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ inputs.swift-flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,29 +129,10 @@ jobs:
     name: test (${{ matrix.variant }})
     steps:
       - uses: actions/checkout@v6
-      - name: Cache SPM dependencies
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-swift-test
         with:
-          path: app/MeetingTranscriber/.build
-          key: spm-${{ runner.os }}-${{ matrix.variant }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-${{ matrix.variant }}-
-      # Cache the WhisperKit (HuggingFace) + FluidAudio model files. The
-      # HuggingFace download client races on cold-cache concurrent loads of
-      # the same variant; pre-warming sequentially populates the cache so
-      # the parallel run can hit it. After the first successful CI run the
-      # cache is populated and the preload step is skipped.
-      - name: Cache ML models
-        id: model-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/Documents/huggingface
-            ~/Library/Application Support/FluidAudio
-          key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
-          restore-keys: ml-models-${{ runner.os }}-
-      - name: Pre-warm model cache (cache miss only)
-        if: steps.model-cache.outputs.cache-hit != 'true'
-        run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ matrix.swift-flags }}
+          cache-key-suffix: ${{ matrix.variant }}
+          swift-flags: ${{ matrix.swift-flags }}
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}
       - name: Cancel run on failure
@@ -196,24 +177,9 @@ jobs:
     name: test (${{ matrix.variant }})
     steps:
       - uses: actions/checkout@v6
-      - name: Cache SPM dependencies
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-swift-test
         with:
-          path: app/MeetingTranscriber/.build
-          key: spm-${{ runner.os }}-${{ matrix.variant }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-${{ matrix.variant }}-
-      - name: Cache ML models
-        id: model-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/Documents/huggingface
-            ~/Library/Application Support/FluidAudio
-          key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
-          restore-keys: ml-models-${{ runner.os }}-
-      - name: Pre-warm model cache (cache miss only)
-        if: steps.model-cache.outputs.cache-hit != 'true'
-        run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests
+          cache-key-suffix: ${{ matrix.variant }}
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure
@@ -245,24 +211,9 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - name: Cache SPM dependencies
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-swift-test
         with:
-          path: app/MeetingTranscriber/.build
-          key: spm-${{ runner.os }}-quality-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-quality-
-      - name: Cache ML models
-        id: model-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/Documents/huggingface
-            ~/Library/Application Support/FluidAudio
-          key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
-          restore-keys: ml-models-${{ runner.os }}-
-      - name: Pre-warm model cache (cache miss only)
-        if: steps.model-cache.outputs.cache-hit != 'true'
-        run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests
+          cache-key-suffix: quality
       # Filter explicitly to engine-quality test classes — `--filter Quality`
       # would also pull in `QualityResultsTests`, which exercises the writer
       # via fake rows and would pollute the shared singleton's row buffer.


### PR DESCRIPTION
## Summary
- Three jobs (`test`, `test-sanitizer`, `quality-baseline`) had identical 20-line blocks for SPM cache + ML model cache + pre-warm-on-cache-miss. Extracts that boilerplate into a new local composite action `.github/actions/setup-swift-test`.
- Each job now invokes the action with a single `uses:` step plus its own `actions/checkout@v6`. Inputs are `cache-key-suffix` (required, distinguishes parallel SPM caches by compile-flag set) and `swift-flags` (optional, forwarded to the pre-warm `swift test`).
- Net `ci.yml`: -49 lines. Adding new engine-quality jobs (Parakeet, Qwen3, DER, …) now costs four lines of setup instead of twenty-five.

## Why this PR exists
Last week the `quality-baseline` job duplicated the same 20-line setup block that already existed in `test` and `test-sanitizer`. The next planned jobs (Parakeet quality, Qwen3 quality, possibly coverage) would have made it 5–6 copies. Extracting now is cheaper than later.

## Behavior changes
- None expected. Cache keys, paths, and pre-warm semantics are identical to what the inline blocks did. The composite action keeps the existing `cache-hit` short-circuit on the pre-warm step.

## Test plan
- [x] `test (homebrew)` and `test (appstore)` still run on this PR via the existing `pull_request` trigger and pass.
- [x] Cache keys are bit-identical to before (verifiable from the run log: `spm-macOS-homebrew-<hash>`, `spm-macOS-appstore-<hash>`, ML cache key unchanged).
- [x] After merge: next push to main exercises `test-sanitizer` and `quality-baseline` through the composite action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->