### PR TITLE
ci(workflows): split background QA into separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,10 @@ on:
     branches: [main, mac]
   pull_request:
     branches: [main]
-  # Nightly sanitizer sweep on main — TSan/ASan are too expensive to run on
-  # every PR, so we run them once a day instead. Catches regressions within
-  # ~24 h, which is acceptable for a solo project.
-  schedule:
-    - cron: "0 3 * * *"  # 03:00 UTC = 05:00 CEST
+  # Manual re-run knob (e.g. to re-trigger lint after a SwiftFormat config
+  # bump). Background-QA jobs (sanitizer, quality) live in
+  # `quality-and-safety.yml` with their own dispatch UI.
   workflow_dispatch:
-    inputs:
-      run-sanitizer:
-        description: "Run TSan/ASan matrix variants for this run"
-        type: boolean
-        default: false
-      run-quality:
-        description: "Run WER/DER quality regression suite for this run"
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -135,101 +124,6 @@ jobs:
           swift-flags: ${{ matrix.swift-flags }}
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}
-      - name: Cancel run on failure
-        if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  # Sanitizers are expensive (TSan ~10-15 min, ASan ~7-10 min on macos-26).
-  # Skip on PRs to keep review fast; cover via push to main, nightly cron,
-  # and explicit manual dispatch (`gh workflow run ci.yml -f run-sanitizer=true`).
-  # ASan + TSan can't run in the same process, so they live as separate legs.
-  test-sanitizer:
-    needs: changes
-    if: |
-      needs.changes.outputs.code == 'true' && (
-        github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer)
-      )
-    runs-on: macos-26
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      actions: write
-    strategy:
-      matrix:
-        variant: [tsan, asan]
-        include:
-          # ThreadSanitizer catches races the static @Sendable checker can't
-          # see — C-pointer shared state, GCD-callback closures over class
-          # properties.
-          - variant: tsan
-            sanitizer-flag: "--sanitize=thread"
-          # AddressSanitizer covers the Pointer-heavy code paths Swift's ARC
-          # can't help with — AudioTapLib's CATapDescription / IOProc, the
-          # `withUnsafePointer` slabs in audio mixing, and any C-imported
-          # framework boundary.
-          - variant: asan
-            sanitizer-flag: "--sanitize=address"
-    name: test (${{ matrix.variant }})
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-swift-test
-        with:
-          cache-key-suffix: ${{ matrix.variant }}
-      - name: Swift tests
-        run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
-      - name: Cancel run on failure
-        if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  # WER/DER quality regression suite. Runs the production WhisperKit
-  # variant against curated ground-truth fixtures and writes a JSON row
-  # per fixture/engine into the uploaded artifact, so future PRs can diff
-  # against the main-branch baseline. Skip-default on PRs (loads ~1 GB of
-  # model weights and runs real ASR); cover via push to main, nightly
-  # cron, and explicit manual dispatch (`gh workflow run ci.yml -f
-  # run-quality=true`).
-  quality-baseline:
-    needs: changes
-    if: |
-      needs.changes.outputs.code == 'true' && (
-        github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.run-quality)
-      )
-    runs-on: macos-26
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      actions: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-swift-test
-        with:
-          cache-key-suffix: quality
-      # Filter explicitly to engine-quality test classes — `--filter Quality`
-      # would also pull in `QualityResultsTests`, which exercises the writer
-      # via fake rows and would pollute the shared singleton's row buffer.
-      # When adding a new engine quality class, append it to the alternation.
-      - name: Run quality regression suite
-        env:
-          RUN_QUALITY_TESTS: "1"
-          QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
-        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests"
-      - name: Upload quality results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: quality-results
-          path: ${{ github.workspace }}/quality-results.json
-          if-no-files-found: warn
       - name: Cancel run on failure
         if: failure()
         continue-on-error: true

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -1,0 +1,115 @@
+name: Quality & Safety
+
+# Background QA workflow — runs the expensive Swift checks that don't
+# block PRs:
+#   - TSan/ASan sanitizer sweeps (catches races/UB the static checker
+#     can't see; ~10–15 min per leg).
+#   - WER/DER quality regression (downloads ~1 GB of model weights and
+#     runs real ASR; produces the baseline artifact future PRs diff
+#     against).
+#
+# Triggers: push to main, nightly cron, and explicit manual dispatch.
+# Never runs on pull requests — review iteration stays fast.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"  # 03:00 UTC = 05:00 CEST
+  workflow_dispatch:
+    inputs:
+      run-sanitizer:
+        description: "Run TSan/ASan matrix"
+        type: boolean
+        default: true
+      run-quality:
+        description: "Run WER/DER quality regression"
+        type: boolean
+        default: true
+
+# Main-branch and nightly runs produce baselines (sanitizer reports,
+# quality-results.json artifact). Cancelling them on a fresh push would
+# lose those baselines, so we don't cancel — let runs accumulate. Manual
+# back-to-back dispatches are rare enough that the wasted time isn't
+# worth a more complex carve-out.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-sanitizer:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer)
+    runs-on: macos-26
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write
+    strategy:
+      matrix:
+        variant: [tsan, asan]
+        include:
+          # ThreadSanitizer catches races the static @Sendable checker can't
+          # see — C-pointer shared state, GCD-callback closures over class
+          # properties.
+          - variant: tsan
+            sanitizer-flag: "--sanitize=thread"
+          # AddressSanitizer covers the Pointer-heavy code paths Swift's ARC
+          # can't help with — AudioTapLib's CATapDescription / IOProc, the
+          # `withUnsafePointer` slabs in audio mixing, and any C-imported
+          # framework boundary.
+          - variant: asan
+            sanitizer-flag: "--sanitize=address"
+    name: test (${{ matrix.variant }})
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-swift-test
+        with:
+          cache-key-suffix: ${{ matrix.variant }}
+      - name: Swift tests
+        run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
+      - name: Cancel run on failure
+        if: failure()
+        continue-on-error: true
+        run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  quality-baseline:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run-quality)
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-swift-test
+        with:
+          cache-key-suffix: quality
+      # Filter explicitly to engine-quality test classes — `--filter Quality`
+      # would also pull in `QualityResultsTests`, which exercises the writer
+      # via fake rows and would pollute the shared singleton's row buffer.
+      # When adding a new engine quality class, append it to the alternation.
+      - name: Run quality regression suite
+        env:
+          RUN_QUALITY_TESTS: "1"
+          QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
+        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests"
+      - name: Upload quality results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-results
+          path: ${{ github.workspace }}/quality-results.json
+          if-no-files-found: warn
+      - name: Cancel run on failure
+        if: failure()
+        continue-on-error: true
+        run: gh run cancel ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ cd app/MeetingTranscriber && swift test --parallel --sanitize=thread --skip Menu
 cd app/MeetingTranscriber && swift test --parallel --sanitize=address --skip MenuBarIconSnapshotTests
 
 # Trigger sanitizer matrix on a specific PR/branch via CI
-gh workflow run ci.yml -f run-sanitizer=true
+gh workflow run quality-and-safety.yml -f run-sanitizer=true -f run-quality=false
 
 # Lint & format check (dry-run, no changes)
 ./scripts/lint.sh


### PR DESCRIPTION
## Summary
- Moves `test-sanitizer` (TSan/ASan matrix) and `quality-baseline` (WER/DER regression) from `ci.yml` into a new `quality-and-safety.yml`. Same triggers (push to main, nightly cron, manual dispatch), same job definitions, but in their own file.
- The new workflow sets `cancel-in-progress: false` so a second push to main during a long sanitizer or quality run doesn't kill the first run's baseline. PR-blocking checks in `ci.yml` keep `cancel-in-progress: true`.
- `ci.yml` shrinks from 238 → 132 lines and is now exclusively PR-blocking checks.

## Live evidence this is needed
The post-merge run on main for the composite-action PR cancelled its TSan leg at 24m31s with `Canceling since a higher priority waiting request for CI-refs/heads/main exists` — exactly the behavior this PR fixes. With the split, TSan would have completed instead of being thrown away.

## Other small wins that fall out
- `needs: changes` removed from the moved jobs — the `changes` filter only matters for PR events, and the new workflow never runs on PRs. Saves the 1-minute serial dependency.
- `workflow_dispatch` inputs `run-sanitizer` / `run-quality` now default to `true` (file-level intent: "run the background QA"); explicit `false` opts out of an individual leg.
- `CLAUDE.md` `gh workflow run` example updated to point at the new workflow.

## Stacked on
PR #212 (composite action) — already merged, this PR rebases cleanly on the resulting main.

## Test plan
- [x] PR run only triggers `ci.yml` jobs (`changes`, `lint`, `analyze`, `test (homebrew/appstore)`); `quality-and-safety.yml` does not appear in the PR check list
- [x] After merge: push to main triggers BOTH workflows independently, sanitizer + quality run via composite action exactly as before — verified on merge SHA `cff5494`: ci.yml run completed (success), quality-and-safety.yml run dispatched in parallel with `quality-baseline` (3m14s) and `test (asan)` (6m43s) both via composite action
- [x] `gh workflow run quality-and-safety.yml -f run-sanitizer=true -f run-quality=false` runs only the sanitizer leg; the inverse runs only the quality leg — verified by inspection of on-main YAML `if: (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer)` / `inputs.run-quality` gating
- [x] Two consecutive pushes to main no longer cancel each other's sanitizer/quality runs — verified by on-main YAML `cancel-in-progress: false` plus live evidence: the post-merge `test (tsan)` leg ran past the point where the previous workflow's TSan was cancelled at 24m31s