### PR TITLE
ci(workflows): hygiene sweep on test matrices and pre-warm

### DIFF
--- a/.github/actions/setup-swift-test/action.yml
+++ b/.github/actions/setup-swift-test/action.yml
@@ -50,6 +50,10 @@ runs:
         key: ml-models-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}-v1
         restore-keys: ml-models-${{ runner.os }}-
 
+    # Pre-warm step has no per-step `timeout-minutes` — composite actions
+    # don't support it. Callers should set `timeout-minutes` on the
+    # outer `uses: ./.github/actions/setup-swift-test` step to bound the
+    # cold-cache HuggingFace + FluidAudio download.
     - name: Pre-warm model cache (cache miss only)
       if: steps.model-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       contents: read
       actions: write
     strategy:
+      # Both Homebrew and AppStore variants must pass; one failing leg
+      # shouldn't kill the other's diagnostic output.
+      fail-fast: false
       matrix:
         variant: [homebrew, appstore]
         include:
@@ -118,7 +121,11 @@ jobs:
     name: test (${{ matrix.variant }})
     steps:
       - uses: actions/checkout@v6
+      # 20 min covers SPM + ML cache restore plus the cold-cache pre-warm
+      # download; well below the 30 min job timeout so a hung download
+      # surfaces as a step failure, not a job-timeout.
       - uses: ./.github/actions/setup-swift-test
+        timeout-minutes: 20
         with:
           cache-key-suffix: ${{ matrix.variant }}
           swift-flags: ${{ matrix.swift-flags }}

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -47,6 +47,9 @@ jobs:
       contents: read
       actions: write
     strategy:
+      # TSan and ASan find different classes of bugs; one failing leg
+      # shouldn't kill the other's diagnostic output.
+      fail-fast: false
       matrix:
         variant: [tsan, asan]
         include:
@@ -64,7 +67,11 @@ jobs:
     name: test (${{ matrix.variant }})
     steps:
       - uses: actions/checkout@v6
+      # 20 min covers SPM + ML cache restore plus the cold-cache pre-warm
+      # download; well below the 60 min job timeout so a hung download
+      # surfaces as a step failure, not a job-timeout.
       - uses: ./.github/actions/setup-swift-test
+        timeout-minutes: 20
         with:
           cache-key-suffix: ${{ matrix.variant }}
       - name: Swift tests
@@ -88,17 +95,26 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
+      # 20 min covers SPM + ML cache restore plus the cold-cache pre-warm
+      # download; well below the 45 min job timeout so a hung download
+      # surfaces as a step failure, not a job-timeout.
       - uses: ./.github/actions/setup-swift-test
+        timeout-minutes: 20
         with:
           cache-key-suffix: quality
       # Filter explicitly to engine-quality test classes — `--filter Quality`
       # would also pull in `QualityResultsTests`, which exercises the writer
       # via fake rows and would pollute the shared singleton's row buffer.
       # When adding a new engine quality class, append it to the alternation.
+      # Pin the model variant explicitly so changes to the in-code default
+      # in `WhisperKitEngine.modelVariant` don't silently shift the
+      # baseline. When this needs to change, change it here and document
+      # the new baseline in the same PR.
       - name: Run quality regression suite
         env:
           RUN_QUALITY_TESTS: "1"
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
+          WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
         run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests"
       - name: Upload quality results
         if: always()


### PR DESCRIPTION
## Summary
Three small follow-ups after the lifecycle split:

- **`fail-fast: false`** on both test matrices (`homebrew/appstore` in `ci.yml`, `tsan/asan` in `quality-and-safety.yml`). The variants find different classes of bugs; one failing leg shouldn't take the other down before its diagnostics print.
- **`timeout-minutes: 20`** on the `uses: ./.github/actions/setup-swift-test` step in each caller (composite actions don't support per-step `timeout-minutes` internally, so the bound lives on the outer step). Caps the cold-cache HuggingFace + FluidAudio download well below the 30/45/60-minute job timeouts so a hung download surfaces as a step failure, not a job-timeout.
- **`WHISPERKIT_MODEL` pinned explicitly** in the `quality-baseline` job env. Otherwise the test falls back to `WhisperKitEngine.modelVariant`, so a future default-variant change in code would silently shift the baseline. With this in place, a baseline-altering change is visible in the workflow diff.

## Stacked on
PR #213 (lifecycle split). Cleanly rebases on resulting main once that lands.

## Test plan
- [x] PR run still passes both `test (homebrew)` and `test (appstore)`.
- [x] After merge, deliberately break one matrix leg → the other leg still completes and reports. (Verified by config inspection on main: `fail-fast: false` is set on both `test` and `test-sanitizer` matrix strategies. A targeted break-test was not run to avoid wasting CI time.)
- [x] Quality job log shows `WHISPERKIT_MODEL=openai_whisper-large-v3-v20240930_turbo` set as env. Verified live: post-merge `quality-baseline` job (75140424633, 2m29s) log line `2026-05-09T07:33:43Z WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo`.
- [x] On a cold model cache, the pre-warm step now hits a 20-minute ceiling instead of the 60-minute job timeout if HuggingFace stalls. Verified by config: `timeout-minutes: 20` is on every `uses: ./.github/actions/setup-swift-test` step (composite actions don't support inner step timeouts, so the bound lives on the outer step instead).