### PR TITLE
ci(e2e): pin DEVELOPER_DIR for self-hosted Mac runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,21 @@ jobs:
     timeout-minutes: 30
     env:
       E2E_ENABLED: "1"
+      # Pin the toolchain to a full Xcode install. Without this the runner
+      # may default to the Command Line Tools, whose Swift toolchain ships
+      # without XCTest — `import XCTest` then fails when SwiftPM compiles
+      # test-only dependencies (swift-snapshot-testing, ViewInspector, …).
+      # GitHub-hosted runners point at Xcode out of the box; self-hosted
+      # runners need this hint until `xcode-select -s` is run on the host.
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Verify Xcode toolchain
+        run: |
+          xcode-select -p
+          swift --version
 
       - name: Resolve test filter
         id: filter


### PR DESCRIPTION
## Summary
- New self-hosted Mac mini runner picked up the E2E workflow but failed with `no such module 'XCTest'` while building `swift-snapshot-testing`
- Root cause: the runner's `swift` resolves to the Command Line Tools toolchain, which ships without XCTest. GitHub-hosted `macos-26` already points `xcode-select -p` at a full Xcode, so the same workflow worked there
- Fix: set `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` on the e2e job so the toolchain hint is part of the workflow, not the runner host setup
- Adds a `Verify Xcode toolchain` step that prints `xcode-select -p` and `swift --version` so the next failure mode (missing Xcode.app, wrong version) is visible in the log without SSH

## Test plan
- [ ] Workflow re-run on the self-hosted runner gets past `swift test` build phase (no more XCTest error)
- [ ] Verify-toolchain step prints a path under `/Applications/Xcode.app/...` and a Swift version with `Target: arm64-apple-macosx…`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->