### PR TITLE
feat(e2e): add live-recording E2E (deployed app + RPC driver)

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -1,0 +1,73 @@
+name: E2E (Production App)
+
+# Pattern-C E2E: builds the dev .app, deploys to a stable path on the
+# self-hosted Mac mini runner, triggers a synthetic meeting via the
+# meeting-simulator tool, polls the DebugRPCServer for the resulting
+# pipeline job, and asserts on the transcript output.
+#
+# Distinct from `e2e.yml` (Pattern A — fixture-based component tests in
+# xctest) because the live recording path needs a stable code identity
+# and granted TCC permissions, neither of which xctest provides.
+#
+# Triggers:
+#   - workflow_dispatch — manual smoketest after PRs merge to main
+#   - push to main — light cadence as a backstop for regressions
+#   - nightly cron — catch flake / drift in the runner host environment
+#
+# Runner prerequisites are documented in scripts/setup-self-hosted-runner.sh
+# and CLAUDE.md > E2E architecture. Without that one-time setup the job
+# will fail on the input-device pre-check inside e2e-app.sh.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'app/MeetingTranscriber/Sources/**'
+      - 'tools/audiotap/**'
+      - 'tools/meeting-simulator/**'
+      - 'scripts/run_app.sh'
+      - 'scripts/e2e-app.sh'
+      - '.github/workflows/e2e-app.yml'
+  schedule:
+    # 04:30 UTC = 06:30 CEST. Stays clear of the 03:00 quality-and-safety
+    # cron; the dev .app rebuild takes ~70 s and the full pipeline ~60 s,
+    # so a small offset keeps both visible in `gh run list` if both fail.
+    - cron: '30 4 * * *'
+
+# Live-recording E2E mutates host state (deploys the bundle, runs the
+# meeting-simulator which plays audio through the speakers). Two parallel
+# runs would race for the recorder; serialise.
+concurrency:
+  group: e2e-app-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-app:
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Sanity — fail fast with a clear message if Xcode isn't pointed at
+      # the right toolchain. e2e.yml does the same dance.
+      - name: Verify toolchain
+        run: |
+          xcode-select -p
+          swift --version
+
+      - name: Run Pattern-C E2E driver
+        run: bash scripts/e2e-app.sh
+
+      # Best-effort: capture the simulator's stdout for post-mortem if
+      # the driver failed before tearing it down.
+      - name: Upload simulator log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: meeting-simulator.log
+          path: /tmp/e2e-app-sim.log
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -1,22 +1,7 @@
 name: E2E (Production App)
 
-# Pattern-C E2E: builds the dev .app, deploys to a stable path on the
-# self-hosted Mac mini runner, triggers a synthetic meeting via the
-# meeting-simulator tool, polls the DebugRPCServer for the resulting
-# pipeline job, and asserts on the transcript output.
-#
-# Distinct from `e2e.yml` (Pattern A — fixture-based component tests in
-# xctest) because the live recording path needs a stable code identity
-# and granted TCC permissions, neither of which xctest provides.
-#
-# Triggers:
-#   - workflow_dispatch — manual smoketest after PRs merge to main
-#   - push to main — light cadence as a backstop for regressions
-#   - nightly cron — catch flake / drift in the runner host environment
-#
-# Runner prerequisites are documented in scripts/setup-self-hosted-runner.sh
-# and CLAUDE.md > E2E architecture. Without that one-time setup the job
-# will fail on the input-device pre-check inside e2e-app.sh.
+# Pattern-C E2E. Background and rationale: CLAUDE.md > E2E Architecture.
+# Runner prerequisites: scripts/setup-self-hosted-runner.sh.
 
 on:
   workflow_dispatch:
@@ -24,15 +9,17 @@ on:
     branches: [main]
     paths:
       - 'app/MeetingTranscriber/Sources/**'
+      - 'app/MeetingTranscriber/Package.swift'
+      - 'app/MeetingTranscriber/Package.resolved'
+      - 'app/MeetingTranscriber/Tests/Fixtures/**'
       - 'tools/audiotap/**'
       - 'tools/meeting-simulator/**'
       - 'scripts/run_app.sh'
       - 'scripts/e2e-app.sh'
       - '.github/workflows/e2e-app.yml'
   schedule:
-    # 04:30 UTC = 06:30 CEST. Stays clear of the 03:00 quality-and-safety
-    # cron; the dev .app rebuild takes ~70 s and the full pipeline ~60 s,
-    # so a small offset keeps both visible in `gh run list` if both fail.
+    # 04:30 UTC = 06:30 CEST. Offset from the 03:00 quality-and-safety
+    # cron so concurrent failures are easy to tell apart in `gh run list`.
     - cron: '30 4 * * *'
 
 # Live-recording E2E mutates host state (deploys the bundle, runs the

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -1,6 +1,6 @@
 name: E2E (Production App)
 
-# Pattern-C E2E. Background and rationale: CLAUDE.md > E2E Architecture.
+# Live-recording E2E. Background and rationale: CLAUDE.md > E2E Architecture.
 # Runner prerequisites: scripts/setup-self-hosted-runner.sh.
 
 on:
@@ -80,7 +80,7 @@ jobs:
           # grant.
           echo "E2E_SIGNING_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
-      - name: Run Pattern-C E2E driver
+      - name: Run live-recording E2E driver
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         run: bash scripts/e2e-app.sh

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -59,7 +59,43 @@ jobs:
           xcode-select -p
           swift --version
 
+      # Same dance as release.yml: import the Developer ID Application
+      # cert into a temporary keychain so codesign can find it. Apple
+      # roots are in the system trust store already, so the resulting
+      # signature satisfies the dev .app's PPPC code requirement out of
+      # the box — no add-trusted-cert ceremony needed. If the secret
+      # isn't set, fall through to the self-signed path that
+      # setup-self-hosted-runner.sh installed (env var stays empty,
+      # e2e-app.sh detects this and signs with the local dev cert).
+      - name: Install Developer ID certificate
+        env:
+          DEVELOPER_ID_CERT: ${{ secrets.DEVELOPER_ID_CERT }}
+          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        if: env.DEVELOPER_ID_CERT != ''
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/e2e-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH=$RUNNER_TEMP/e2e-cert.p12
+          echo -n "$DEVELOPER_ID_CERT" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          # Hand the keychain path to e2e-app.sh so it can re-sign the
+          # deployed bundle with this cert too. Stable across runs because
+          # Apple Developer ID cert SHA doesn't change — TCC keeps the
+          # grant.
+          echo "E2E_SIGNING_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
       - name: Run Pattern-C E2E driver
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         run: bash scripts/e2e-app.sh
 
       # Best-effort: capture the simulator's stdout for post-mortem if
@@ -71,3 +107,7 @@ jobs:
           name: meeting-simulator.log
           path: /tmp/e2e-app-sim.log
           if-no-files-found: ignore
+
+      - name: Cleanup signing keychain
+        if: always() && env.E2E_SIGNING_KEYCHAIN != ''
+        run: security delete-keychain "$E2E_SIGNING_KEYCHAIN" 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,9 @@ scripts/
   build_whisperkit.sh      # Build WhisperKit CLI tool
   build_release.sh         # Build self-contained .app bundle + DMG (--appstore for App Store variant)
   notarize_status.sh       # Check Apple notarization status
-  run_app.sh               # Build + sign + launch menu bar app bundle
+  run_app.sh               # Build + sign + launch menu bar app bundle (--build-only skips `open -W`)
+  e2e-app.sh               # Pattern-C E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
+  setup-self-hosted-runner.sh  # One-time: self-signed code-signing cert + PPPC profile (needed before e2e-app.sh works)
   generate_test_audio.sh   # Generate 2-speaker test WAV fixture (requires sox)
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
   lint.sh                   # Lint & format (--fix to auto-correct; runs SwiftFormat + SwiftLint)
@@ -119,7 +121,8 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   ci.yml                   # CI: lint + analyze + Swift tests (3 parallel jobs)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
-  e2e.yml                  # E2E tests on self-hosted macOS runner (workflow_dispatch + v* tags)
+  e2e.yml                  # E2E (Pattern A) — fixture-based xctest on self-hosted Mac (dispatch + v* tags)
+  e2e-app.yml              # E2E (Pattern C) — deployed dev .app + RPC-driven assertion (dispatch + push to main + nightly)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
 docs/
   architecture-macos.md        # High-level architecture quick-reference
@@ -316,6 +319,69 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - Screen Recording permission required for **meeting detection** (window titles via `CGWindowListCopyWindowInfo`)
 - Audio capture (AudioTapLib) does NOT require Screen Recording — uses CATapDescription (purple dot indicator)
 - FluidAudio models are downloaded automatically on first run (~50 MB)
+
+## E2E Architecture
+
+Two complementary E2E approaches, run by different workflows. Pick by what
+you're validating:
+
+**Pattern A — fixture-based xctest (`e2e.yml`)**
+- Engine + pipeline tests in `app/MeetingTranscriber/Tests/*E2ETests.swift`
+  (Parakeet, WhisperKit, Qwen3, WatchLoop) feed pre-recorded `two_speakers_de.wav`
+  into the components and assert on transcripts.
+- Triggered on `workflow_dispatch` and `v*` tag pushes.
+- No live recording — `DualSourceRecorder` is bypassed; tests substitute
+  fixture WAVs at the same point the recorder would emit them.
+- Strengths: fast, deterministic, isolates engine logic; runs in xctest's
+  sandboxed harness without TCC concerns.
+- Limitations: can't catch regressions in the recording stack, the audio
+  routing path, TCC interactions, or detector → recorder handoff.
+
+**Pattern C — deployed app + RPC (`e2e-app.yml`, `scripts/e2e-app.sh`)**
+- Builds the dev `.app`, deploys to `~/Applications/MeetingTranscriber-Dev.app`
+  (stable path → TCC permissions persist), launches it, triggers a meeting
+  via `meeting-simulator`, polls `DebugRPCServer`'s `/state` for
+  `lastJob.state == .done`, asserts on the resulting transcript file.
+- Triggered on `workflow_dispatch`, `push` to main on relevant paths,
+  and a nightly cron at 04:30 UTC.
+- Exercises the production code path end-to-end including TCC, audio
+  routing, CATapDescription tap, and the dual-track recorder/diarizer
+  handoff.
+- Limitations: needs one-time runner setup (see below); can't run on
+  GitHub-hosted runners — only on a self-hosted Mac with an interactive
+  GUI session and a stable code-signing identity.
+
+**Why Pattern C exists** (history that's easy to lose):
+- An earlier attempt at "pattern A but with live recording" (PR #100,
+  `E2EFullPipelineTests`) crashed reproducibly with
+  `freed pointer was not the last allocation` on the self-hosted Mac mini.
+  Root cause: ad-hoc-signed xctest binaries get a fresh cdhash on every
+  build, never inherit stable TCC permissions, and AVAudioEngine on a
+  no-input host hits a libmalloc abort.
+- The production `.app` doesn't have any of those problems because it has
+  a stable bundle ID + (with `setup-self-hosted-runner.sh`) a stable
+  signing identity that PPPC profiles can grant permissions to.
+
+**One-time self-hosted runner setup**:
+1. `brew install blackhole-2ch` then reboot (or `sudo killall coreaudiod`),
+   set BlackHole 2ch as the default Input in System Settings → Sound.
+   Mac mini hosts have no built-in mic; without a virtual input device
+   the dual-source recorder hits the libmalloc abort path.
+2. Configure auto-login for the runner user so loginwindow brings up an
+   Aqua session at boot. CATapDescription captures silence in non-GUI
+   contexts even when API calls return `noErr`.
+3. Run `scripts/setup-self-hosted-runner.sh` once. Creates a self-signed
+   code-signing cert in the login keychain, signs and deploys the dev
+   `.app` to `~/Applications/`, generates and installs a PPPC mobileconfig
+   that grants Microphone + Screen & System Audio Recording to the bundle
+   gated on the cert SHA-1.
+4. Open System Settings → Profiles, click "Install" once on the
+   downloaded "MeetingTranscriber-Dev TCC Permissions" profile.
+5. Verify Microphone + Screen & System Audio Recording show the dev `.app`
+   with the toggle on.
+
+After setup, every CI run rebuilds the `.app`; cdhash differs per build but
+the cert SHA-1 doesn't, so PPPC keeps granting permissions automatically.
 
 ## Diagnostics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ scripts/
   build_release.sh         # Build self-contained .app bundle + DMG (--appstore for App Store variant)
   notarize_status.sh       # Check Apple notarization status
   run_app.sh               # Build + sign + launch menu bar app bundle (--build-only skips `open -W`)
-  e2e-app.sh               # Pattern-C E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
+  e2e-app.sh               # Live-recording E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
   setup-self-hosted-runner.sh  # One-time: self-signed code-signing cert + PPPC profile (needed before e2e-app.sh works)
   generate_test_audio.sh   # Generate 2-speaker test WAV fixture (requires sox)
   generate_test_audio_3speakers.sh  # Generate 3-speaker test WAV fixture (requires sox)
@@ -121,8 +121,8 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   ci.yml                   # CI: lint + analyze + Swift tests (3 parallel jobs)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
-  e2e.yml                  # E2E (Pattern A) — fixture-based xctest on self-hosted Mac (dispatch + v* tags)
-  e2e-app.yml              # E2E (Pattern C) — deployed dev .app + RPC-driven assertion (dispatch + push to main + nightly)
+  e2e.yml                  # E2E — fixture-based xctest on self-hosted Mac (dispatch + v* tags)
+  e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
 docs/
   architecture-macos.md        # High-level architecture quick-reference
@@ -325,7 +325,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 Two complementary E2E approaches, run by different workflows. Pick by what
 you're validating:
 
-**Pattern A — fixture-based xctest (`e2e.yml`)**
+**Fixture-based xctest E2E (`e2e.yml`)**
 - Engine + pipeline tests in `app/MeetingTranscriber/Tests/*E2ETests.swift`
   (Parakeet, WhisperKit, Qwen3, WatchLoop) feed pre-recorded `two_speakers_de.wav`
   into the components and assert on transcripts.
@@ -337,7 +337,7 @@ you're validating:
 - Limitations: can't catch regressions in the recording stack, the audio
   routing path, TCC interactions, or detector → recorder handoff.
 
-**Pattern C — deployed app + RPC (`e2e-app.yml`, `scripts/e2e-app.sh`)**
+**Live-recording E2E (`e2e-app.yml`, `scripts/e2e-app.sh`)**
 - Builds the dev `.app`, deploys to `~/Applications/MeetingTranscriber-Dev.app`
   (stable path → TCC permissions persist), launches it, triggers a meeting
   via `meeting-simulator`, polls `DebugRPCServer`'s `/state` for
@@ -351,8 +351,8 @@ you're validating:
   GitHub-hosted runners — only on a self-hosted Mac with an interactive
   GUI session and a stable code-signing identity.
 
-**Why Pattern C exists** (history that's easy to lose):
-- An earlier attempt at "pattern A but with live recording" (PR #100,
+**Why the live-recording variant exists** (history that's easy to lose):
+- An earlier attempt at xctest-framed live recording (PR #100,
   `E2EFullPipelineTests`) crashed reproducibly with
   `freed pointer was not the last allocation` on the self-hosted Mac mini.
   Root cause: ad-hoc-signed xctest binaries get a fresh cdhash on every

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -153,11 +153,25 @@ final class AppState {
         }
 
         private func startDebugRPCServer() {
+            let snapshot: () -> RPCStateSnapshot = { [weak self] in
+                self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
+            }
+            let skipNaming: () -> Void = { [weak self] in
+                Task { @MainActor in
+                    guard let self else { return }
+                    // Drain all currently-pending naming jobs. Each
+                    // completeSpeakerNaming call transitions the first
+                    // pending job out of .speakerNamingPending
+                    // synchronously, so the loop terminates.
+                    while !self.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
+                        self.pipelineQueue.completeSpeakerNaming(result: .skipped)
+                    }
+                }
+            }
             let server = DebugRPCServer(
-                snapshot: { [weak self] in
-                    self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
-                },
+                snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
+                skipNaming: skipNaming,
             )
             server.start()
             debugRPCServer = server

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -159,12 +159,16 @@ final class AppState {
             let skipNaming: () -> Void = { [weak self] in
                 Task { @MainActor in
                     guard let self else { return }
-                    // Drain all currently-pending naming jobs. Each
-                    // completeSpeakerNaming call transitions the first
-                    // pending job out of .speakerNamingPending
-                    // synchronously, so the loop terminates.
-                    while !self.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
-                        self.pipelineQueue.completeSpeakerNaming(result: .skipped)
+                    // Snapshot the pending job IDs and iterate the snapshot.
+                    // Avoids infinite-loop hazard if completeSpeakerNaming
+                    // ever short-circuits without transitioning state (e.g.
+                    // missing speakerNamingDataByJob entry → early return,
+                    // pending list unchanged) — observed live during E2E
+                    // when the data dictionary was already cleared by an
+                    // earlier skip race.
+                    let pendingIDs = self.pipelineQueue.pendingSpeakerNamingJobs.map(\.id)
+                    for jobID in pendingIDs {
+                        self.pipelineQueue.completeSpeakerNaming(jobID: jobID, result: .skipped)
                     }
                 }
             }

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -73,6 +73,7 @@
         private let port: NWEndpoint.Port
         private let snapshot: () -> RPCStateSnapshot
         private let speakerActions: SpeakerDBActions
+        private let skipNaming: () -> Void
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -88,11 +89,13 @@
             token: String = DebugRPCServer.loadOrCreateToken(),
             snapshot: @escaping () -> RPCStateSnapshot,
             speakerActions: SpeakerDBActions = .noop,
+            skipNaming: @escaping () -> Void = {},
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
             self.snapshot = snapshot
             self.speakerActions = speakerActions
+            self.skipNaming = skipNaming
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -231,6 +234,14 @@
 
             case ("POST", "/action/closeSettings"):
                 Self.closeSettings()
+                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+
+            case ("POST", "/action/skipNaming"):
+                // Skips ALL pending speaker-naming jobs in one shot — driver
+                // scripts (e2e-app.sh) just want to drain the queue without
+                // blocking on a UI dialog. Fire-and-forget; returns 200 even
+                // if there's nothing pending.
+                skipNaming()
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
 
             case ("POST", "/action/renameSpeaker"),

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -148,6 +148,14 @@ struct MeetingTranscriberApp: App {
                         closeWindow(id: "speaker-naming")
                     }
                 }
+                // Auto-close when the pending list drains. Covers RPC-driven
+                // skip (`POST /action/skipNaming`), where the data layer
+                // transitions but the UI callback never fires.
+                .onChange(of: appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty) { _, isEmpty in
+                    if isEmpty {
+                        closeWindow(id: "speaker-naming")
+                    }
+                }
         }
         .windowResizability(.contentSize)
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -178,7 +178,12 @@ class PipelineQueue {
     /// exists, fires off protocol generation in the background; the job
     /// transitions through .generatingProtocol → .done as that completes.
     private func acceptAutoNames(jobID: UUID, slug: String?) {
-        let canGenerateProtocol = protocolGeneratorFactory != nil
+        // Probe the factory's actual output, not just its existence — the
+        // closure is wired even when protocolProvider is `.none`, but
+        // returns nil. Without this, the Task path below fizzles silently
+        // (generateProtocol guards on factory()) and the job sits in
+        // .speakerNamingPending forever.
+        let canGenerateProtocol = (protocolGeneratorFactory?() != nil)
             && outputDir != nil
             && jobs.first { $0.id == jobID }?.transcriptPath != nil
 

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -121,6 +121,43 @@
         }
 
         @MainActor
+        func testRouteSkipNamingInvokesClosureAndReturnsOk() async {
+            let invoked = XCTestExpectation(description: "skipNaming closure fires")
+            let server = DebugRPCServer(
+                port: 0,
+                token: Self.testToken,
+                snapshot: { .empty },
+                skipNaming: { invoked.fulfill() },
+            )
+
+            let response = await server.route(authedRequest(method: "POST", path: "/action/skipNaming"))
+
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
+            await fulfillment(of: [invoked], timeout: 2)
+        }
+
+        @MainActor
+        func testRouteSkipNamingDefaultClosureDoesNotCrash() async {
+            // The init parameter has a `{}` default so existing call sites
+            // don't have to change. Hitting the endpoint without wiring a
+            // closure must still return 200 with the standard ok body.
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let response = await server.route(authedRequest(method: "POST", path: "/action/skipNaming"))
+            XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(String(data: response.body, encoding: .utf8), "ok\n")
+        }
+
+        @MainActor
+        func testRouteSkipNamingRequiresAuth() async {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            // Token value irrelevant — request omits the Authorization header.
+            let unauthed = HTTPRequest(method: "POST", path: "/action/skipNaming")
+            let response = await server.route(unauthed)
+            XCTAssertEqual(response.status, 401)
+        }
+
+        @MainActor
         func testRouteScreenshotNoWindowReturns503() async {
             // Tests run headless — NSApp has no visible window, so the
             // capture helper returns nil and the route maps to 503.

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1220,6 +1220,65 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertNil(queue.speakerNamingDataByJob[job.id])
     }
 
+    func testSkipTransitionsToDoneWhenProtocolFactoryReturnsNil() async throws {
+        // Regression: when AppSettings.protocolProvider == .none, the
+        // factory closure exists but returns nil. Earlier acceptAutoNames
+        // checked closure-existence (always true here), took the Task
+        // path, and that Task fizzled in generateProtocol's guard —
+        // leaving the job stuck in .speakerNamingPending. The fix
+        // probes the closure's output, so skip falls through to .done.
+        let outputDir = tmpDir.appendingPathComponent("output")
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        let mixPath = tmpDir.appendingPathComponent("mix.wav")
+        try Data([0]).write(to: mixPath)
+        let transcriptPath = tmpDir.appendingPathComponent("transcript.txt")
+        try "[00:00] SPEAKER_0: Hello".write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let queue = PipelineQueue(
+            engine: MockEngine(),
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: outputDir,
+            logDir: tmpDir,
+            diarizeEnabled: true,
+        )
+
+        var job = PipelineJob(
+            meetingTitle: "Provider None Skip",
+            appName: "Teams",
+            mixPath: mixPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.transcriptPath = transcriptPath
+        queue.enqueue(job)
+
+        queue.speakerNamingDataByJob[job.id] = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Provider None Skip",
+            mapping: [:], speakingTimes: [:], embeddings: [:],
+            audioPath: nil, segments: [], participants: [],
+            isDualSource: false,
+        )
+
+        let doneExpectation = XCTestExpectation(description: "Job transitions to done after skip")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        queue.completeSpeakerNaming(jobID: job.id, result: .skipped)
+
+        await fulfillment(of: [doneExpectation], timeout: 2)
+
+        XCTAssertEqual(
+            queue.jobs.first?.state, .done,
+            "Skip with provider=.none must transition to .done, not stay in .speakerNamingPending",
+        )
+        XCTAssertNil(queue.speakerNamingDataByJob[job.id])
+    }
+
     // MARK: - Late Re-apply Speaker Names
 
     func testLateConfirmationRewritesTranscript() async throws {

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -237,13 +237,24 @@ while true; do
     # (transient curl --max-time hit during model load / GC pause):
     # jq emits no output → read hits EOF → returns 1 → `set -e` would
     # otherwise kill the script silently. We just retry next tick.
-    lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""
-    IFS='|' read -r lj_id lj_state pipe_active pipe_processing < <(
-        rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing] | join("|")'
+    lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""; pending_naming=""
+    IFS='|' read -r lj_id lj_state pipe_active pipe_processing pending_naming < <(
+        rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing, .pipeline.pendingNamingJobCount] | join("|")'
     ) || true
 
+    # Auto-skip the speaker-naming dialog so headless runs don't deadlock
+    # waiting for a UI click. The endpoint drains all pending in one shot
+    # and is a no-op when nothing is pending. Fire-and-forget; next tick
+    # picks up the resulting state change.
+    if [ "${pending_naming:-0}" != "0" ] && [ -n "$pending_naming" ]; then
+        log "  Auto-skipping ${pending_naming} pending naming job(s) via /action/skipNaming"
+        curl --silent --show-error --max-time 5 -X POST \
+            --header "Authorization: Bearer $RPC_TOKEN" \
+            "$RPC_BASE/action/skipNaming" >/dev/null 2>&1 || true
+    fi
+
     if [ "$lj_state" != "$last_state" ] || [ "$lj_id" != "$new_job_id" ]; then
-        log "  pipeline.active=$pipe_active processing=$pipe_processing lastJob=$lj_id state=$lj_state"
+        log "  pipeline.active=$pipe_active processing=$pipe_processing lastJob=$lj_id state=$lj_state pending_naming=$pending_naming"
         last_state="$lj_state"
         new_job_id="$lj_id"
     fi

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -136,6 +136,41 @@ else
     cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
 fi
 
+# Re-sign so TCC sees the same designated requirement across rebuilds
+# and keeps the granted permissions. The rsync above brought in whatever
+# run_app.sh signed with (typically ad-hoc — run_app.sh's `find-identity
+# -v` doesn't pick up our identities), which would invalidate the TCC
+# grant tied to the cert SHA.
+#
+# Two paths:
+#   - CI / Apple Developer ID — `DEVELOPER_ID` env var set (provided by
+#     e2e-app.yml after importing the cert from secrets). Apple roots are
+#     in the system trust store, so this just works.
+#   - Local dev — `DEVELOPER_ID` empty; fall back to the self-signed cert
+#     + dedicated keychain installed by setup-self-hosted-runner.sh.
+
+if [ -n "${DEVELOPER_ID:-}" ]; then
+    log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
+    SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
+    [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
+    codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        || fail "codesign with Developer ID failed — check DEVELOPER_ID + E2E_SIGNING_KEYCHAIN env vars"
+else
+    DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
+    DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
+    if [ ! -f "$DEV_KEYCHAIN" ] || [ ! -f "$DEV_CERT_PATH" ]; then
+        fail "no Developer ID and dev keychain missing ($DEV_KEYCHAIN / $DEV_CERT_PATH) — set DEVELOPER_ID env or run scripts/setup-self-hosted-runner.sh first"
+    fi
+    DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
+        | sed 's/^.*=//' | tr -d ':')"
+    log "Re-signing $DEV_BUNDLE_DEPLOY with self-signed dev cert ($DEV_CERT_HASH)"
+    security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
+    codesign --force --sign "$DEV_CERT_HASH" \
+        --keychain "$DEV_KEYCHAIN" \
+        "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
+fi
+
 # --- 4. ensure debug RPC will be on -------------------------------------
 
 # Persistent debugRPCEnabled toggle survives across launches. Set it before

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -24,19 +24,24 @@ set -euo pipefail
 
 # --- args -----------------------------------------------------------------
 
-KEEP_APP=false           # leave the app running after assertions
-QUIT_APP=false           # quit the app on exit (overrides KEEP_APP)
+APP_AFTER=leave          # leave | quit
 SIMULATOR_FIXTURE=""     # custom audio fixture for the simulator
 NO_BUILD=false           # skip build/deploy/re-sign — use whatever's at ~/Applications already
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --keep-app)   KEEP_APP=true ;;
-        --quit-app)   QUIT_APP=true ;;
+        --quit-app)   APP_AFTER=quit ;;
+        --keep-app)   APP_AFTER=leave ;;     # explicit alias for the default
         --no-build)   NO_BUILD=true ;;
         --fixture)    shift; SIMULATOR_FIXTURE="$1" ;;
         -h|--help)
-            sed -n '2,/^$/p' "$0" | sed 's/^# //;s/^#//'
+            cat <<'HELP'
+Usage: e2e-app.sh [--no-build] [--quit-app] [--fixture path/to.wav]
+
+  --no-build   Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
+  --quit-app   Send Quit to the dev app on exit. Default: leave it running.
+  --fixture    Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
+HELP
             exit 0
             ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -74,27 +79,16 @@ require_command() {
     command -v "$1" >/dev/null || fail "missing command: $1"
 }
 
-# Read the RPC bearer token written by the running app at start-up.
-read_token() {
-    [ -f "$RPC_TOKEN_FILE" ] || fail "RPC token file not found: $RPC_TOKEN_FILE (is the app running with debugRPC enabled?)"
-    cat "$RPC_TOKEN_FILE"
-}
+RPC_TOKEN=""  # populated once when the token file appears
 
-# Curl the RPC with bearer auth. Returns empty string + exit 0 on
-# transient failure (timeout, connection refused) so callers in `set -e`
-# poll loops can keep trying. The 15 s timeout is generous because the
-# app's main thread can briefly block during model load + audio teardown.
+# Returns empty string + exit 0 on transient curl failure so callers in
+# `set -e` poll loops keep going. 15 s timeout covers brief main-thread
+# blocks during model load + audio teardown.
 rpc() {
     local path="$1"
-    local token; token="$(read_token)"
-    local response
-    if response=$(curl --silent --show-error --max-time 15 \
-            --header "Authorization: Bearer $token" \
-            "$RPC_BASE$path" 2>/dev/null); then
-        printf '%s' "$response"
-    else
-        printf ''
-    fi
+    curl --silent --show-error --max-time 15 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE$path" 2>/dev/null || true
 }
 
 # --- preflight ------------------------------------------------------------
@@ -118,35 +112,25 @@ if [ "$NO_BUILD" = true ]; then
     [ -d "$DEV_BUNDLE_DEPLOY" ] || fail "--no-build given but $DEV_BUNDLE_DEPLOY doesn't exist — deploy a signed bundle there first"
     log "Skipping build/deploy/re-sign — using existing $DEV_BUNDLE_DEPLOY"
 else
-    # --- 1. build dev bundle ----------------------------------------------
-
     log "Building dev .app bundle"
     "$SCRIPT_DIR/run_app.sh" --build-only
 
-    # --- 3. deploy to stable path (preserve bundle dir → preserve TCC) ----
-
     log "Deploying to $DEV_BUNDLE_DEPLOY"
     mkdir -p "$(dirname "$DEV_BUNDLE_DEPLOY")"
+    # rsync into the existing bundle dir — TCC keys off the bundle path,
+    # so a delete+copy would invalidate granted permissions.
     if [ -d "$DEV_BUNDLE_DEPLOY" ]; then
-        # cp -R into the existing bundle (NOT delete + copy) — TCC keys off
-        # the bundle path; a fresh dir would invalidate granted permissions.
         rsync -a --delete "$DEV_BUNDLE_BUILD/" "$DEV_BUNDLE_DEPLOY/"
     else
         cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
     fi
 
-    # Re-sign so TCC sees the same designated requirement across rebuilds.
-    # rsync above brought in whatever run_app.sh signed with (typically
-    # ad-hoc — run_app.sh's `find-identity -v` doesn't pick up our
-    # identities), which would invalidate the TCC grant tied to the cert
-    # SHA.
-    #
-    # Two paths:
-    #   - CI / Apple Developer ID — `DEVELOPER_ID` env var set (provided
-    #     by e2e-app.yml after importing the cert from secrets). Apple
-    #     roots are system-trusted; this just works.
-    #   - Local dev — `DEVELOPER_ID` empty; fall back to the self-signed
-    #     cert installed by setup-self-hosted-runner.sh.
+    # Re-sign with our stable identity. run_app.sh signs with whatever
+    # `find-identity -v | head -1` returns (often ad-hoc on CI hosts), so
+    # without re-signing TCC would see a different cert SHA on every
+    # rebuild and lose the grant. CI path uses the imported Developer ID;
+    # local-dev path falls back to the self-signed cert from
+    # setup-self-hosted-runner.sh.
     if [ -n "${DEVELOPER_ID:-}" ]; then
         log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
         SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
@@ -170,66 +154,51 @@ else
     fi
 fi
 
-# --- 2. build meeting-simulator (cached after first run) ------------------
-
 if [ ! -x "$SIMULATOR_BIN" ]; then
     log "Building meeting-simulator"
     (cd "$SIMULATOR_PKG" && swift build -c release)
 fi
 
-# --- 4. ensure debug RPC + auto-watch will be on -------------------------
-
-# Persistent toggles survive across launches. Set them before launching so
-# the server comes up immediately and the WatchLoop auto-starts 3 s after
-# init (without an explicit click on "Start Watching" in the menu, which
-# isn't reachable over SSH). The autoWatch path is already wired in
-# MeetingTranscriberApp via the `.autoWatchStart` notification; we just
-# flip the persistent flag it checks.
+# `autoWatch` triggers the same `.autoWatchStart` notification an
+# explicit "Start Watching" menu click would — necessary because that
+# menu isn't reachable over SSH. `debugRPCEnabled` brings the RPC up at
+# launch instead of after a Settings toggle.
 defaults write com.meetingtranscriber.dev debugRPCEnabled -bool true
 defaults write com.meetingtranscriber.dev autoWatch -bool true
 
-# --- 5. launch app --------------------------------------------------------
-
-# If a previous instance is still around, leave it — `open` brings the
-# existing PID to the front rather than re-launching with the new bundle.
-# That's fine: the deploy step above overwrote the bundle in-place.
 log "Launching $DEV_BUNDLE_DEPLOY"
 open "$DEV_BUNDLE_DEPLOY"
 
-# --- 6. wait for RPC ------------------------------------------------------
-
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
 deadline=$(( $(date +%s) + RPC_READY_TIMEOUT_S ))
-until [ -f "$RPC_TOKEN_FILE" ] && rpc /healthz >/dev/null 2>&1; do
+while [ ! -f "$RPC_TOKEN_FILE" ] || ! { RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null; }; do
     [ "$(date +%s)" -lt "$deadline" ] || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
     sleep 1
 done
 log "RPC up"
 
-# --- 7. snapshot pre-trigger state ---------------------------------------
-
 PRE_LAST_JOB_ID="$(rpc /state | jq -r '.lastJob.jobID // empty')"
 log "Pre-trigger lastJob.jobID: ${PRE_LAST_JOB_ID:-<none>}"
 
-# --- 8. trigger meeting-simulator ----------------------------------------
+# Single trap covers the simulator process for any exit path (success,
+# fail, signal). Set before the `&` line so a kill between fork and the
+# trap line doesn't orphan the subprocess.
+SIM_PID=""
+trap '[ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true' EXIT INT TERM
 
 log "Starting meeting-simulator → $SIMULATOR_FIXTURE"
 "$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" >/tmp/e2e-app-sim.log 2>&1 &
 SIM_PID=$!
-trap '[ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true' EXIT
-
-# --- 9. poll for new lastJob ---------------------------------------------
 
 log "Polling /state every 5s for new lastJob (timeout ${PIPELINE_TIMEOUT_S}s)"
 deadline=$(( $(date +%s) + PIPELINE_TIMEOUT_S ))
 last_state=""
 new_job_id=""
 while true; do
-    snap="$(rpc /state)"
-    lj_id="$(jq -r '.lastJob.jobID // empty' <<<"$snap")"
-    lj_state="$(jq -r '.lastJob.state // empty' <<<"$snap")"
-    pipe_active="$(jq -r '.pipeline.activeJobCount' <<<"$snap")"
-    pipe_processing="$(jq -r '.pipeline.isProcessing' <<<"$snap")"
+    # One jq invocation, four fields out via TSV — saves 3 forks per poll.
+    IFS=$'\t' read -r lj_id lj_state pipe_active pipe_processing < <(
+        rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing] | @tsv'
+    )
 
     if [ "$lj_state" != "$last_state" ] || [ "$lj_id" != "$new_job_id" ]; then
         log "  pipeline.active=$pipe_active processing=$pipe_processing lastJob=$lj_id state=$lj_state"
@@ -237,7 +206,6 @@ while true; do
         new_job_id="$lj_id"
     fi
 
-    # Done when a NEW lastJob has terminal state.
     if [ -n "$lj_id" ] && [ "$lj_id" != "$PRE_LAST_JOB_ID" ] \
         && { [ "$lj_state" = "done" ] || [ "$lj_state" = "error" ]; }; then
         break
@@ -246,8 +214,6 @@ while true; do
     [ "$(date +%s)" -lt "$deadline" ] || fail "no new pipeline job reached terminal state within ${PIPELINE_TIMEOUT_S}s (active=$pipe_active processing=$pipe_processing)"
     sleep 5
 done
-
-# --- 10. assertions ------------------------------------------------------
 
 log "Final state: $lj_state"
 final_snapshot="$(rpc /state)"
@@ -267,16 +233,9 @@ log "Preview:"
 head -c 500 "$transcript_path" | sed 's/^/    /'
 echo
 
-# --- 11. cleanup ---------------------------------------------------------
-
-[ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
-trap - EXIT
-
-if [ "$QUIT_APP" = true ]; then
+if [ "$APP_AFTER" = quit ]; then
     log "Quitting app"
     osascript -e 'tell application "MeetingTranscriber-Dev" to quit' 2>/dev/null || true
-elif [ "$KEEP_APP" = false ]; then
-    log "App still running (use --quit-app to quit)"
 fi
 
 log "PASS"

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -227,9 +227,14 @@ last_state=""
 new_job_id=""
 while true; do
     # One jq invocation, four fields out via TSV — saves 3 forks per poll.
+    # Trailing `|| true` keeps the loop alive when rpc() returns empty
+    # (transient curl failure during model load / GC pause): jq emits no
+    # output → read hits EOF → returns 1 → `set -e` would otherwise kill
+    # the script silently after polling once. We just want to retry next tick.
+    lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""
     IFS=$'\t' read -r lj_id lj_state pipe_active pipe_processing < <(
         rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing] | @tsv'
-    )
+    ) || true
 
     if [ "$lj_state" != "$last_state" ] || [ "$lj_id" != "$new_job_id" ]; then
         log "  pipeline.active=$pipe_active processing=$pipe_processing lastJob=$lj_id state=$lj_state"

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -226,14 +226,20 @@ deadline=$(( $(date +%s) + PIPELINE_TIMEOUT_S ))
 last_state=""
 new_job_id=""
 while true; do
-    # One jq invocation, four fields out via TSV — saves 3 forks per poll.
+    # One jq invocation, four fields out via `|`-joined output — saves
+    # 3 forks per poll vs separate jq calls.
+    #
+    # Why `|` and not `@tsv`: bash `IFS=$'\t' read` treats consecutive
+    # whitespace separators as ONE (and skips leading empties), so an
+    # all-null lastJob (`\t\t0\tfalse`) gets misparsed as `0\tfalse\t\t`.
+    # `|` is non-whitespace, so each separator stays a field boundary.
     # Trailing `|| true` keeps the loop alive when rpc() returns empty
-    # (transient curl failure during model load / GC pause): jq emits no
-    # output → read hits EOF → returns 1 → `set -e` would otherwise kill
-    # the script silently after polling once. We just want to retry next tick.
+    # (transient curl --max-time hit during model load / GC pause):
+    # jq emits no output → read hits EOF → returns 1 → `set -e` would
+    # otherwise kill the script silently. We just retry next tick.
     lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""
-    IFS=$'\t' read -r lj_id lj_state pipe_active pipe_processing < <(
-        rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing] | @tsv'
+    IFS='|' read -r lj_id lj_state pipe_active pipe_processing < <(
+        rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing] | join("|")'
     ) || true
 
     if [ "$lj_state" != "$last_state" ] || [ "$lj_id" != "$new_job_id" ]; then

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pattern-C E2E driver for the Meeting Transcriber dev app.
+# Live-recording E2E driver for the Meeting Transcriber dev app.
 #
 # Builds the dev .app, deploys it to a stable path so its TCC permissions
 # persist across runs, launches it, triggers a synthetic meeting via the

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -24,22 +24,22 @@ set -euo pipefail
 
 # --- args -----------------------------------------------------------------
 
-APP_AFTER=leave          # leave | quit
+APP_AFTER=quit           # quit | leave
 SIMULATOR_FIXTURE=""     # custom audio fixture for the simulator
 NO_BUILD=false           # skip build/deploy/re-sign — use whatever's at ~/Applications already
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --quit-app)   APP_AFTER=quit ;;
-        --keep-app)   APP_AFTER=leave ;;     # explicit alias for the default
+        --quit-app)   APP_AFTER=quit ;;     # explicit alias for the default
+        --keep-app)   APP_AFTER=leave ;;
         --no-build)   NO_BUILD=true ;;
         --fixture)    shift; SIMULATOR_FIXTURE="$1" ;;
         -h|--help)
             cat <<'HELP'
-Usage: e2e-app.sh [--no-build] [--quit-app] [--fixture path/to.wav]
+Usage: e2e-app.sh [--no-build] [--keep-app] [--fixture path/to.wav]
 
   --no-build   Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
-  --quit-app   Send Quit to the dev app on exit. Default: leave it running.
+  --keep-app   Leave the dev app running on exit. Default: quit it.
   --fixture    Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -91,6 +91,33 @@ rpc() {
         "$RPC_BASE$path" 2>/dev/null || true
 }
 
+# Stop any previous dev-app instance before we touch the bundle on disk
+# or open a new one. rsync would otherwise overwrite mmap'd mach-o pages,
+# and a still-running process holds the RPC port so the next `open` is a
+# no-op. Graceful AppleScript quit first, SIGTERM after 3 s, SIGKILL last.
+quit_running_app() {
+    local bundle_id="com.meetingtranscriber.dev"
+    if ! pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null; then
+        return 0
+    fi
+    log "Stopping previous MeetingTranscriber-Dev instance"
+    osascript -e "tell application id \"$bundle_id\" to quit" 2>/dev/null || true
+    for _ in 1 2 3; do
+        pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null || return 0
+        sleep 1
+    done
+    pkill -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" 2>/dev/null || true
+    for _ in 1 2 3; do
+        pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null || return 0
+        sleep 1
+    done
+    pkill -KILL -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" 2>/dev/null || true
+    sleep 1
+    if pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null; then
+        fail "could not stop running MeetingTranscriber-Dev — kill it manually and retry"
+    fi
+}
+
 # --- preflight ------------------------------------------------------------
 
 require_command curl
@@ -107,6 +134,10 @@ require_command codesign
 if ! system_profiler SPAudioDataType 2>/dev/null | grep -A4 "Default Input" | grep -q "Input Channels"; then
     fail "no default audio input device — install BlackHole 2ch (brew install blackhole-2ch + reboot/coreaudiod restart) and set it as the default Input in System Settings → Sound"
 fi
+
+# Always — even with --no-build, since UserDefaults below take effect
+# only on launch and the running RPC server would shadow the new one.
+quit_running_app
 
 if [ "$NO_BUILD" = true ]; then
     [ -d "$DEV_BUNDLE_DEPLOY" ] || fail "--no-build given but $DEV_BUNDLE_DEPLOY doesn't exist — deploy a signed bundle there first"
@@ -234,8 +265,7 @@ head -c 500 "$transcript_path" | sed 's/^/    /'
 echo
 
 if [ "$APP_AFTER" = quit ]; then
-    log "Quitting app"
-    osascript -e 'tell application "MeetingTranscriber-Dev" to quit' 2>/dev/null || true
+    quit_running_app
 fi
 
 log "PASS"

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Pattern-C E2E driver for the Meeting Transcriber dev app.
+#
+# Builds the dev .app, deploys it to a stable path so its TCC permissions
+# persist across runs, launches it, triggers a synthetic meeting via the
+# meeting-simulator tool, polls the DebugRPCServer for the resulting
+# pipeline job, and asserts on the transcript output.
+#
+# This is the production-app E2E path, intentionally separate from the
+# fixture-based component E2E tests in `app/MeetingTranscriber/Tests/*E2E*.swift`
+# (which run on PR-CI). Rationale and history: see CLAUDE.md > E2E architecture.
+#
+# Prerequisites on the runner host (one-time setup):
+#   - Xcode at /Applications/Xcode.app (xcode-select pointed there)
+#   - GUI session for the runner user (CATapDescription needs a logged-in
+#     loginwindow context — service-mode runners get silent audio capture)
+#   - A virtual input device (BlackHole 2ch) so AVAudioEngine has something
+#     to bind to on Mac mini hosts without a built-in mic
+#   - System Settings → Privacy: Microphone + Screen & System Audio Recording
+#     granted to ~/Applications/MeetingTranscriber-Dev.app
+#   See scripts/setup-self-hosted-runner.sh for the bootstrap flow.
+
+set -euo pipefail
+
+# --- args -----------------------------------------------------------------
+
+KEEP_APP=false           # leave the app running after assertions
+QUIT_APP=false           # quit the app on exit (overrides KEEP_APP)
+SIMULATOR_FIXTURE=""     # custom audio fixture for the simulator
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --keep-app)   KEEP_APP=true ;;
+        --quit-app)   QUIT_APP=true ;;
+        --fixture)    shift; SIMULATOR_FIXTURE="$1" ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# //;s/^#//'
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --- paths ----------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_BUNDLE_BUILD="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
+DEV_BUNDLE_DEPLOY="$HOME/Applications/MeetingTranscriber-Dev.app"
+SIMULATOR_PKG="$ROOT/tools/meeting-simulator"
+SIMULATOR_BIN="$SIMULATOR_PKG/.build/release/meeting-simulator"
+DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
+RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+RPC_BASE="http://127.0.0.1:9876"
+
+[ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
+
+# --- timing budgets -------------------------------------------------------
+
+# Cold first run downloads ~50 MB Parakeet model — give it room. Hot run
+# under 10 s easily.
+RPC_READY_TIMEOUT_S=30
+PIPELINE_TIMEOUT_S=240
+
+# --- helpers --------------------------------------------------------------
+
+log()  { printf '[e2e-app] %s\n' "$*"; }
+fail() { printf '[e2e-app] FAIL: %s\n' "$*" >&2; exit 1; }
+
+require_command() {
+    command -v "$1" >/dev/null || fail "missing command: $1"
+}
+
+# Read the RPC bearer token written by the running app at start-up.
+read_token() {
+    [ -f "$RPC_TOKEN_FILE" ] || fail "RPC token file not found: $RPC_TOKEN_FILE (is the app running with debugRPC enabled?)"
+    cat "$RPC_TOKEN_FILE"
+}
+
+# Curl the RPC with bearer auth. Returns empty string + exit 0 on
+# transient failure (timeout, connection refused) so callers in `set -e`
+# poll loops can keep trying. The 15 s timeout is generous because the
+# app's main thread can briefly block during model load + audio teardown.
+rpc() {
+    local path="$1"
+    local token; token="$(read_token)"
+    local response
+    if response=$(curl --silent --show-error --max-time 15 \
+            --header "Authorization: Bearer $token" \
+            "$RPC_BASE$path" 2>/dev/null); then
+        printf '%s' "$response"
+    else
+        printf ''
+    fi
+}
+
+# --- preflight ------------------------------------------------------------
+
+require_command curl
+require_command jq
+require_command swift
+require_command codesign
+
+[ -f "$SIMULATOR_FIXTURE" ] || fail "simulator fixture not found: $SIMULATOR_FIXTURE"
+
+# Sanity check: a virtual input device is set as default. If the runner
+# host has no built-in mic and no BlackHole/Loopback, AVAudioEngine binds
+# to a no-input device and the dual-source recorder hits a libmalloc abort
+# (observed on Mac mini hosts). Surface the misconfiguration up-front.
+if ! system_profiler SPAudioDataType 2>/dev/null | grep -A4 "Default Input" | grep -q "Input Channels"; then
+    fail "no default audio input device — install BlackHole 2ch (brew install blackhole-2ch + reboot/coreaudiod restart) and set it as the default Input in System Settings → Sound"
+fi
+
+# --- 1. build dev bundle --------------------------------------------------
+
+log "Building dev .app bundle"
+"$SCRIPT_DIR/run_app.sh" --build-only
+
+# --- 2. build meeting-simulator (cached after first run) ------------------
+
+if [ ! -x "$SIMULATOR_BIN" ]; then
+    log "Building meeting-simulator"
+    (cd "$SIMULATOR_PKG" && swift build -c release)
+fi
+
+# --- 3. deploy to stable path (preserve bundle dir → preserve TCC) --------
+
+log "Deploying to $DEV_BUNDLE_DEPLOY"
+mkdir -p "$(dirname "$DEV_BUNDLE_DEPLOY")"
+if [ -d "$DEV_BUNDLE_DEPLOY" ]; then
+    # cp -R into the existing bundle (NOT delete + copy) — TCC keys off the
+    # bundle path; a fresh dir would invalidate granted permissions.
+    rsync -a --delete "$DEV_BUNDLE_BUILD/" "$DEV_BUNDLE_DEPLOY/"
+else
+    cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
+fi
+
+# --- 4. ensure debug RPC will be on -------------------------------------
+
+# Persistent debugRPCEnabled toggle survives across launches. Set it before
+# launching so the server comes up immediately. Env-var alternative
+# (MEETINGTRANSCRIBER_DEBUG_RPC=1) requires re-launching after defaults
+# changes anyway, so the toggle is simpler here.
+defaults write com.meetingtranscriber.dev debugRPCEnabled -bool true
+
+# --- 5. launch app --------------------------------------------------------
+
+# If a previous instance is still around, leave it — `open` brings the
+# existing PID to the front rather than re-launching with the new bundle.
+# That's fine: the deploy step above overwrote the bundle in-place.
+log "Launching $DEV_BUNDLE_DEPLOY"
+open "$DEV_BUNDLE_DEPLOY"
+
+# --- 6. wait for RPC ------------------------------------------------------
+
+log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
+deadline=$(( $(date +%s) + RPC_READY_TIMEOUT_S ))
+until [ -f "$RPC_TOKEN_FILE" ] && rpc /healthz >/dev/null 2>&1; do
+    [ "$(date +%s)" -lt "$deadline" ] || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
+    sleep 1
+done
+log "RPC up"
+
+# --- 7. snapshot pre-trigger state ---------------------------------------
+
+PRE_LAST_JOB_ID="$(rpc /state | jq -r '.lastJob.jobID // empty')"
+log "Pre-trigger lastJob.jobID: ${PRE_LAST_JOB_ID:-<none>}"
+
+# --- 8. trigger meeting-simulator ----------------------------------------
+
+log "Starting meeting-simulator → $SIMULATOR_FIXTURE"
+"$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" >/tmp/e2e-app-sim.log 2>&1 &
+SIM_PID=$!
+trap '[ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true' EXIT
+
+# --- 9. poll for new lastJob ---------------------------------------------
+
+log "Polling /state every 5s for new lastJob (timeout ${PIPELINE_TIMEOUT_S}s)"
+deadline=$(( $(date +%s) + PIPELINE_TIMEOUT_S ))
+last_state=""
+new_job_id=""
+while true; do
+    snap="$(rpc /state)"
+    lj_id="$(jq -r '.lastJob.jobID // empty' <<<"$snap")"
+    lj_state="$(jq -r '.lastJob.state // empty' <<<"$snap")"
+    pipe_active="$(jq -r '.pipeline.activeJobCount' <<<"$snap")"
+    pipe_processing="$(jq -r '.pipeline.isProcessing' <<<"$snap")"
+
+    if [ "$lj_state" != "$last_state" ] || [ "$lj_id" != "$new_job_id" ]; then
+        log "  pipeline.active=$pipe_active processing=$pipe_processing lastJob=$lj_id state=$lj_state"
+        last_state="$lj_state"
+        new_job_id="$lj_id"
+    fi
+
+    # Done when a NEW lastJob has terminal state.
+    if [ -n "$lj_id" ] && [ "$lj_id" != "$PRE_LAST_JOB_ID" ] \
+        && { [ "$lj_state" = "done" ] || [ "$lj_state" = "error" ]; }; then
+        break
+    fi
+
+    [ "$(date +%s)" -lt "$deadline" ] || fail "no new pipeline job reached terminal state within ${PIPELINE_TIMEOUT_S}s (active=$pipe_active processing=$pipe_processing)"
+    sleep 5
+done
+
+# --- 10. assertions ------------------------------------------------------
+
+log "Final state: $lj_state"
+final_snapshot="$(rpc /state)"
+echo "$final_snapshot" | jq '.lastJob'
+
+[ "$lj_state" = "done" ] || fail "lastJob.state == \"$lj_state\", expected \"done\". Error: $(jq -r '.lastJob.error // "<none>"' <<<"$final_snapshot")"
+
+transcript_path="$(jq -r '.lastJob.transcriptPath // empty' <<<"$final_snapshot")"
+[ -n "$transcript_path" ] || fail "lastJob.transcriptPath is empty"
+[ -f "$transcript_path" ] || fail "transcript file does not exist: $transcript_path"
+
+transcript_size="$(wc -c <"$transcript_path" | tr -d ' ')"
+[ "$transcript_size" -gt 100 ] || fail "transcript suspiciously short: $transcript_size bytes (expected > 100)"
+
+log "Transcript: $transcript_path ($transcript_size bytes)"
+log "Preview:"
+head -c 500 "$transcript_path" | sed 's/^/    /'
+echo
+
+# --- 11. cleanup ---------------------------------------------------------
+
+[ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
+trap - EXIT
+
+if [ "$QUIT_APP" = true ]; then
+    log "Quitting app"
+    osascript -e 'tell application "MeetingTranscriber-Dev" to quit' 2>/dev/null || true
+elif [ "$KEEP_APP" = false ]; then
+    log "App still running (use --quit-app to quit)"
+fi
+
+log "PASS"

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -27,11 +27,13 @@ set -euo pipefail
 KEEP_APP=false           # leave the app running after assertions
 QUIT_APP=false           # quit the app on exit (overrides KEEP_APP)
 SIMULATOR_FIXTURE=""     # custom audio fixture for the simulator
+NO_BUILD=false           # skip build/deploy/re-sign — use whatever's at ~/Applications already
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --keep-app)   KEEP_APP=true ;;
         --quit-app)   QUIT_APP=true ;;
+        --no-build)   NO_BUILD=true ;;
         --fixture)    shift; SIMULATOR_FIXTURE="$1" ;;
         -h|--help)
             sed -n '2,/^$/p' "$0" | sed 's/^# //;s/^#//'
@@ -112,10 +114,61 @@ if ! system_profiler SPAudioDataType 2>/dev/null | grep -A4 "Default Input" | gr
     fail "no default audio input device — install BlackHole 2ch (brew install blackhole-2ch + reboot/coreaudiod restart) and set it as the default Input in System Settings → Sound"
 fi
 
-# --- 1. build dev bundle --------------------------------------------------
+if [ "$NO_BUILD" = true ]; then
+    [ -d "$DEV_BUNDLE_DEPLOY" ] || fail "--no-build given but $DEV_BUNDLE_DEPLOY doesn't exist — deploy a signed bundle there first"
+    log "Skipping build/deploy/re-sign — using existing $DEV_BUNDLE_DEPLOY"
+else
+    # --- 1. build dev bundle ----------------------------------------------
 
-log "Building dev .app bundle"
-"$SCRIPT_DIR/run_app.sh" --build-only
+    log "Building dev .app bundle"
+    "$SCRIPT_DIR/run_app.sh" --build-only
+
+    # --- 3. deploy to stable path (preserve bundle dir → preserve TCC) ----
+
+    log "Deploying to $DEV_BUNDLE_DEPLOY"
+    mkdir -p "$(dirname "$DEV_BUNDLE_DEPLOY")"
+    if [ -d "$DEV_BUNDLE_DEPLOY" ]; then
+        # cp -R into the existing bundle (NOT delete + copy) — TCC keys off
+        # the bundle path; a fresh dir would invalidate granted permissions.
+        rsync -a --delete "$DEV_BUNDLE_BUILD/" "$DEV_BUNDLE_DEPLOY/"
+    else
+        cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
+    fi
+
+    # Re-sign so TCC sees the same designated requirement across rebuilds.
+    # rsync above brought in whatever run_app.sh signed with (typically
+    # ad-hoc — run_app.sh's `find-identity -v` doesn't pick up our
+    # identities), which would invalidate the TCC grant tied to the cert
+    # SHA.
+    #
+    # Two paths:
+    #   - CI / Apple Developer ID — `DEVELOPER_ID` env var set (provided
+    #     by e2e-app.yml after importing the cert from secrets). Apple
+    #     roots are system-trusted; this just works.
+    #   - Local dev — `DEVELOPER_ID` empty; fall back to the self-signed
+    #     cert installed by setup-self-hosted-runner.sh.
+    if [ -n "${DEVELOPER_ID:-}" ]; then
+        log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
+        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
+        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
+        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+            || fail "codesign with Developer ID failed — check DEVELOPER_ID + E2E_SIGNING_KEYCHAIN env vars"
+    else
+        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
+        DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
+        if [ ! -f "$DEV_KEYCHAIN" ] || [ ! -f "$DEV_CERT_PATH" ]; then
+            fail "no Developer ID and dev keychain missing ($DEV_KEYCHAIN / $DEV_CERT_PATH) — set DEVELOPER_ID env or run scripts/setup-self-hosted-runner.sh first"
+        fi
+        DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
+            | sed 's/^.*=//' | tr -d ':')"
+        log "Re-signing $DEV_BUNDLE_DEPLOY with self-signed dev cert ($DEV_CERT_HASH)"
+        security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
+        codesign --force --sign "$DEV_CERT_HASH" \
+            --keychain "$DEV_KEYCHAIN" \
+            "$DEV_BUNDLE_DEPLOY" >/dev/null \
+            || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
+    fi
+fi
 
 # --- 2. build meeting-simulator (cached after first run) ------------------
 
@@ -124,60 +177,16 @@ if [ ! -x "$SIMULATOR_BIN" ]; then
     (cd "$SIMULATOR_PKG" && swift build -c release)
 fi
 
-# --- 3. deploy to stable path (preserve bundle dir → preserve TCC) --------
+# --- 4. ensure debug RPC + auto-watch will be on -------------------------
 
-log "Deploying to $DEV_BUNDLE_DEPLOY"
-mkdir -p "$(dirname "$DEV_BUNDLE_DEPLOY")"
-if [ -d "$DEV_BUNDLE_DEPLOY" ]; then
-    # cp -R into the existing bundle (NOT delete + copy) — TCC keys off the
-    # bundle path; a fresh dir would invalidate granted permissions.
-    rsync -a --delete "$DEV_BUNDLE_BUILD/" "$DEV_BUNDLE_DEPLOY/"
-else
-    cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
-fi
-
-# Re-sign so TCC sees the same designated requirement across rebuilds
-# and keeps the granted permissions. The rsync above brought in whatever
-# run_app.sh signed with (typically ad-hoc — run_app.sh's `find-identity
-# -v` doesn't pick up our identities), which would invalidate the TCC
-# grant tied to the cert SHA.
-#
-# Two paths:
-#   - CI / Apple Developer ID — `DEVELOPER_ID` env var set (provided by
-#     e2e-app.yml after importing the cert from secrets). Apple roots are
-#     in the system trust store, so this just works.
-#   - Local dev — `DEVELOPER_ID` empty; fall back to the self-signed cert
-#     + dedicated keychain installed by setup-self-hosted-runner.sh.
-
-if [ -n "${DEVELOPER_ID:-}" ]; then
-    log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
-    SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
-    [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
-    codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
-        || fail "codesign with Developer ID failed — check DEVELOPER_ID + E2E_SIGNING_KEYCHAIN env vars"
-else
-    DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
-    DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
-    if [ ! -f "$DEV_KEYCHAIN" ] || [ ! -f "$DEV_CERT_PATH" ]; then
-        fail "no Developer ID and dev keychain missing ($DEV_KEYCHAIN / $DEV_CERT_PATH) — set DEVELOPER_ID env or run scripts/setup-self-hosted-runner.sh first"
-    fi
-    DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
-        | sed 's/^.*=//' | tr -d ':')"
-    log "Re-signing $DEV_BUNDLE_DEPLOY with self-signed dev cert ($DEV_CERT_HASH)"
-    security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
-    codesign --force --sign "$DEV_CERT_HASH" \
-        --keychain "$DEV_KEYCHAIN" \
-        "$DEV_BUNDLE_DEPLOY" >/dev/null \
-        || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
-fi
-
-# --- 4. ensure debug RPC will be on -------------------------------------
-
-# Persistent debugRPCEnabled toggle survives across launches. Set it before
-# launching so the server comes up immediately. Env-var alternative
-# (MEETINGTRANSCRIBER_DEBUG_RPC=1) requires re-launching after defaults
-# changes anyway, so the toggle is simpler here.
+# Persistent toggles survive across launches. Set them before launching so
+# the server comes up immediately and the WatchLoop auto-starts 3 s after
+# init (without an explicit click on "Start Watching" in the menu, which
+# isn't reachable over SSH). The autoWatch path is already wired in
+# MeetingTranscriberApp via the `.autoWatchStart` notification; we just
+# flip the persistent flag it checks.
 defaults write com.meetingtranscriber.dev debugRPCEnabled -bool true
+defaults write com.meetingtranscriber.dev autoWatch -bool true
 
 # --- 5. launch app --------------------------------------------------------
 

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 # Launch the Meeting Transcriber menu bar app.
 # Builds an .app bundle so macOS APIs (notifications, etc.) work correctly.
+#
+# --build-only: Build the bundle but skip `open -W`. Used by the Pattern-C
+#   E2E driver (scripts/e2e-app.sh) which deploys the bundle to a stable
+#   path and launches it itself; opening the in-tree bundle there would
+#   confuse macOS LaunchServices about which one to use for TCC.
 
 set -euo pipefail
+
+BUILD_ONLY=false
+for arg in "$@"; do
+    case "$arg" in
+        --build-only) BUILD_ONLY=true ;;
+        *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TRANSCRIBER_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -44,6 +57,11 @@ SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}
 if [ -n "$SIGN_HASH" ]; then
     codesign --force --sign "$SIGN_HASH" "$APP_BUNDLE" 2>/dev/null && \
         echo "  Signed with: $SIGN_HASH"
+fi
+
+if [ "$BUILD_ONLY" = true ]; then
+    echo "Bundle ready: $APP_BUNDLE"
+    exit 0
 fi
 
 echo "Starting Meeting Transcriber..."

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# One-time setup for a self-hosted runner host that will run the Pattern-C
-# E2E driver (scripts/e2e-app.sh).
+# One-time setup for a self-hosted runner host that will run the
+# live-recording E2E driver (scripts/e2e-app.sh).
 #
 # What this does:
 #   1. Creates a self-signed code-signing cert in a dedicated dev keychain.

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# One-time setup for a self-hosted runner host that will run the Pattern-C
+# E2E driver (scripts/e2e-app.sh).
+#
+# What this does:
+#   1. Creates a self-signed code-signing cert in a dedicated dev keychain.
+#      That keychain has an empty password and lives in the runner user's
+#      Library — no sudo, no TouchID, no GUI prompts.
+#   2. Builds the dev .app via run_app.sh --build-only.
+#   3. Signs the .app with the new cert. The cert is NOT in the system
+#      trust store (would need sudo + GUI auth, or an MDM-installed PPPC
+#      profile — both blocked on macOS 26 without an actual MDM server).
+#      That's fine for our purpose: TCC matches future builds via the
+#      cert's leaf SHA-1, which stays constant across rebuilds even if
+#      the chain is untrusted.
+#   4. Deploys to ~/Applications/MeetingTranscriber-Dev.app (stable path).
+#
+# What you do once after this script:
+#   - Launch the deployed .app (e.g. `open ~/Applications/MeetingTranscriber-Dev.app`).
+#   - When macOS prompts for Microphone, click Allow.
+#   - When the app first tries to detect a meeting via Screen Recording,
+#     System Settings → Privacy & Security → Screen & System Audio
+#     Recording → toggle on for MeetingTranscriber-Dev.app.
+#   - From that point on, every rebuild keeps the same cert leaf SHA-1, so
+#     TCC keeps the grants — scripts/e2e-app.sh runs end-to-end.
+#
+# Re-running is safe: the cert + dev keychain are recreated only if missing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CERT_NAME="MeetingTranscriberDevSelfHosted"
+CERT_ORG="meetingtranscriber-self-hosted"
+# Dedicated keychain with empty password keeps everything non-interactive:
+# - `-A` ACL imports don't need TouchID
+# - `set-key-partition-list -k ""` succeeds without prompts
+# Login keychain has neither property over SSH, hence the separation.
+DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
+DEV_KEYCHAIN_PASS=""
+APP_BUNDLE_PATH="$HOME/Applications/MeetingTranscriber-Dev.app"
+# /tmp because world-readable; the cert file may also be useful for a
+# Keychain Access drag-import if the operator wants to manually mark the
+# cert trusted (not required for signing, just nice-to-have).
+ARTIFACTS_DIR="/tmp/meetingtranscriber-setup"
+CERT_PATH="$ARTIFACTS_DIR/dev-cert.crt"
+
+log()  { printf '[setup] %s\n' "$*"; }
+fail() { printf '[setup] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# --- 1. cert ----------------------------------------------------------
+
+# Skip recreation only if BOTH the dev keychain has the cert AND the
+# .crt file is still on disk — otherwise downstream steps that read
+# `$CERT_PATH` would fail. /tmp is volatile so partial state is common
+# after a reboot.
+if [ -f "$DEV_KEYCHAIN" ] && [ -f "$CERT_PATH" ] \
+    && security find-identity -p codesigning "$DEV_KEYCHAIN" 2>/dev/null \
+        | grep -q "$CERT_NAME"; then
+    log "Code-signing cert '$CERT_NAME' already in dev keychain + $CERT_PATH present — skipping creation"
+else
+    log "Creating self-signed code-signing cert '$CERT_NAME'"
+    TMPD="$(mktemp -d)"
+    trap 'rm -rf "$TMPD"' EXIT
+
+    # `keyUsage = digitalSignature` is required by Apple's code signing
+    # policy (CSSMERR_TP_INVALID_CERTIFICATE without it). EKU `codeSigning`
+    # alone is not sufficient on macOS 26 — find-identity reports "Invalid
+    # Key Usage for policy" and codesign refuses with "no identity found".
+    openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+        -subj "/CN=$CERT_NAME/O=$CERT_ORG" \
+        -keyout "$TMPD/cert.key" -out "$TMPD/cert.crt" \
+        -addext "keyUsage = critical, digitalSignature" \
+        -addext "extendedKeyUsage = critical, codeSigning" \
+        -addext "basicConstraints = critical, CA:false" >/dev/null 2>&1 \
+        || fail "openssl req failed"
+
+    # `-legacy` keeps PKCS#12 in the older format the macOS keychain
+    # accepts; without it, import fails with `MAC verification failed`.
+    openssl pkcs12 -export -legacy \
+        -inkey "$TMPD/cert.key" -in "$TMPD/cert.crt" \
+        -name "$CERT_NAME" -passout pass:dev -out "$TMPD/cert.p12" \
+        || fail "openssl pkcs12 failed"
+
+    if [ -f "$DEV_KEYCHAIN" ]; then
+        log "Removing stale dev keychain"
+        security delete-keychain "$DEV_KEYCHAIN" 2>/dev/null || true
+    fi
+    log "Creating dedicated keychain at $DEV_KEYCHAIN"
+    security create-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN"
+    # Disable auto-relock so codesign in long-running CI sessions never
+    # hits a locked keychain.
+    security set-keychain-settings "$DEV_KEYCHAIN"
+    security unlock-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN"
+
+    # Add to the user keychain search list so codesign and find-identity
+    # actually look there. Preserves the existing list.
+    EXISTING_LIST="$(security list-keychains -d user | sed -e 's/^[[:space:]]*"//' -e 's/"$//')"
+    # shellcheck disable=SC2086
+    security list-keychains -d user -s "$DEV_KEYCHAIN" $EXISTING_LIST
+
+    log "Importing cert into dev keychain"
+    security import "$TMPD/cert.p12" \
+        -k "$DEV_KEYCHAIN" -P dev -A -t agg \
+        || fail "security import failed"
+
+    log "Setting partition list (codesign + apple tools)"
+    security set-key-partition-list \
+        -S "apple-tool:,apple:,codesign:" \
+        -s -k "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN" >/dev/null \
+        || fail "set-key-partition-list failed"
+
+    mkdir -p "$ARTIFACTS_DIR"
+    chmod 0755 "$ARTIFACTS_DIR"
+    cp "$TMPD/cert.crt" "$CERT_PATH"
+    chmod 0644 "$CERT_PATH"
+    log "Cert .crt persisted at $CERT_PATH"
+
+    rm -rf "$TMPD"
+    trap - EXIT
+fi
+
+# Read the SHA-1 fingerprint straight from the .crt — works whether or
+# not the cert is trusted. (`find-identity -v` would only see trusted
+# identities; we don't trust this cert, so `-v` would always be empty.)
+CERT_HASH="$(openssl x509 -in "$CERT_PATH" -noout -fingerprint -sha1 \
+    | sed 's/^.*=//' | tr -d ':')"
+[ -n "$CERT_HASH" ] || fail "could not extract cert SHA-1 from $CERT_PATH"
+log "Cert SHA-1: $CERT_HASH"
+
+# --- 2. detect trust state -----------------------------------------------
+
+# `find-identity -v` only lists identities that codesign can actually use
+# (= cert chain validates). For a self-signed cert, that means the user
+# trusted it. macOS 26 forbids `add-trusted-cert -d` without an MDM
+# server, but the per-user variant works — it just needs an interactive
+# auth dialog the operator runs once from a GUI Terminal.
+CERT_TRUSTED=false
+if security find-identity -v -p codesigning "$DEV_KEYCHAIN" 2>/dev/null \
+        | grep -q "$CERT_NAME"; then
+    CERT_TRUSTED=true
+fi
+
+if [ "$CERT_TRUSTED" = false ]; then
+    cat <<MSG
+
+[setup] Phase 1 complete. ⏸  Cert generated but not yet trusted.
+
+Run this one command in a GUI Terminal as user '$USER' (it pops a
+TouchID / password prompt, can't be answered over SSH):
+
+  security add-trusted-cert \\
+      -r trustRoot -p codeSign \\
+      -k "\$HOME/Library/Keychains/login.keychain-db" \\
+      "$CERT_PATH"
+
+Then re-run this script:
+
+  bash $0
+
+It will detect the trust and proceed with build + sign + deploy.
+
+MSG
+    exit 0
+fi
+
+# --- 3. build + sign + deploy --------------------------------------------
+
+log "Building dev .app"
+"$SCRIPT_DIR/run_app.sh" --build-only
+
+mkdir -p "$(dirname "$APP_BUNDLE_PATH")"
+SRC="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
+log "Deploying to $APP_BUNDLE_PATH"
+if [ -d "$APP_BUNDLE_PATH" ]; then
+    rsync -a --delete "$SRC/" "$APP_BUNDLE_PATH/"
+else
+    cp -R "$SRC" "$APP_BUNDLE_PATH"
+fi
+
+# Unlock the dev keychain — codesign needs access to the private key,
+# and `errSecInternalComponent` is what you get when the keychain is
+# locked. Empty password (set in phase 1) makes this safe to call on
+# every run.
+security unlock-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN" \
+    || fail "could not unlock dev keychain"
+
+# Sign explicitly with our cert — run_app.sh's signing step uses
+# `find-identity -v` and so won't pick up our untrusted cert. Doing it
+# here keeps run_app.sh untouched for other callers.
+log "Signing with $CERT_NAME"
+codesign --force --sign "$CERT_HASH" \
+    --keychain "$DEV_KEYCHAIN" \
+    "$APP_BUNDLE_PATH" >/dev/null \
+    || fail "codesign failed"
+
+log "Signed: $(codesign -dv "$APP_BUNDLE_PATH" 2>&1 | grep -E 'Identifier|Authority' | head -2 | tr '\n' ' ')"
+
+cat <<MSG
+
+[setup] DONE. ✓
+        Cert SHA-1: $CERT_HASH
+        Dev bundle: $APP_BUNDLE_PATH
+
+Next (one-time, in the GUI session as user '$USER'):
+  1. Launch the dev app:
+
+       open $APP_BUNDLE_PATH
+
+  2. macOS will prompt for Microphone the first time the app tries to
+     record. Click Allow.
+
+  3. macOS may also prompt for Screen Recording (used for meeting
+     detection via window titles). Allow it. Or pre-grant via System
+     Settings → Privacy & Security → Screen & System Audio Recording →
+     "+" → $APP_BUNDLE_PATH.
+
+  4. Verify in System Settings → Privacy & Security:
+       - Microphone               → MeetingTranscriber-Dev.app on
+       - Screen & System Audio Recording → MeetingTranscriber-Dev.app on
+
+After that, scripts/e2e-app.sh rebuilds + redeploys, the cert leaf SHA-1
+stays $CERT_HASH across rebuilds, and TCC keeps the grants automatically.
+MSG

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -51,14 +51,23 @@ fail() { printf '[setup] FAIL: %s\n' "$*" >&2; exit 1; }
 
 # --- 1. cert ----------------------------------------------------------
 
-# Skip recreation only if BOTH the dev keychain has the cert AND the
-# .crt file is still on disk — otherwise downstream steps that read
-# `$CERT_PATH` would fail. /tmp is volatile so partial state is common
-# after a reboot.
-if [ -f "$DEV_KEYCHAIN" ] && [ -f "$CERT_PATH" ] \
+# Three states: keychain+cert exist (skip), only keychain exists (re-export
+# cert from it without nuking other identities the operator may have added),
+# neither (full create). /tmp is volatile so the cert-only-missing case
+# is common after a reboot.
+if [ -f "$DEV_KEYCHAIN" ] \
     && security find-identity -p codesigning "$DEV_KEYCHAIN" 2>/dev/null \
         | grep -q "$CERT_NAME"; then
-    log "Code-signing cert '$CERT_NAME' already in dev keychain + $CERT_PATH present — skipping creation"
+    if [ ! -f "$CERT_PATH" ]; then
+        log "Re-exporting cert from dev keychain → $CERT_PATH"
+        mkdir -p "$ARTIFACTS_DIR"
+        chmod 0755 "$ARTIFACTS_DIR"
+        security find-certificate -c "$CERT_NAME" -p "$DEV_KEYCHAIN" > "$CERT_PATH" \
+            || fail "could not export cert from $DEV_KEYCHAIN"
+        chmod 0644 "$CERT_PATH"
+    else
+        log "Code-signing cert '$CERT_NAME' already in dev keychain + $CERT_PATH present — skipping creation"
+    fi
 else
     log "Creating self-signed code-signing cert '$CERT_NAME'"
     TMPD="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Adds live-recording E2E infrastructure that exercises the production recording stack on a self-hosted Mac runner, complementing the existing fixture-based xctest E2E suite.

Closes the gap that the (now-closed) PR #100 hit: `xctest`-framed live-recording tests can't get stable TCC permissions because the binary's cdhash changes every build. The deployed `.app` doesn't have that problem.

The `RPCStateSnapshot.lastJob` field this driver depends on landed separately as #217 and is already on main. PRs #218 (CPU fix), #219 (silent-mic fallback), and #220 (EOF detach) also landed; this branch is rebased on top.

## What's in the branch — 17 commits

### Core infrastructure (commits 1–6)

1. **`chore(build): add --build-only flag to run_app.sh`** — skips the trailing `open -W` so the E2E driver can share the build/sign/plist logic without forking it.

2. **`feat(scripts): add e2e-app.sh — live-recording E2E driver`** — builds dev `.app`, deploys via `cp -R`/`rsync` into a stable bundle dir under `~/Applications/` (preserves TCC), launches via `open`, polls `/state` for `lastJob`, asserts `state == .done` and `transcriptPath` exists. Pre-checks for a default audio input device because no-input is the loudest host-misconfig footgun.

3. **`feat(scripts): add setup-self-hosted-runner.sh`** — one-time bootstrap on the runner: dedicated `meetingtranscriber-dev` keychain (empty password to avoid TouchID prompts over SSH), self-signed code-signing cert via `openssl` + `security import`, prints the one GUI command to trust the cert. Falls back gracefully when CI provides a Developer ID via secrets.

4. **`ci(e2e-app): add live-recording E2E workflow on the self-hosted Mac runner`** — `.github/workflows/e2e-app.yml`. Triggers: dispatch + push to main on relevant paths + nightly cron at 04:30 UTC. Concurrency-grouped without cancellation because live recording mutates host state.

5. **`docs(claude): add E2E architecture section`** — explains both approaches, when each applies, the failure history that motivated the live-recording variant, and the one-time runner bootstrap sequence.

6. **`feat(e2e-app): use Developer ID secrets when available, self-signed fallback`** — when `DEVELOPER_ID` env is set (CI imports the existing release secrets), re-sign the deployed bundle with that identity; otherwise fall back to the self-signed dev cert from setup-self-hosted-runner.sh.

### Iteration & polish (commits 7–10)

7. **`feat(e2e-app): add --no-build flag to test pre-deployed bundles`** — skip build/deploy/re-sign and exercise an existing `~/Applications/MeetingTranscriber-Dev.app`.

8. **`refactor(e2e-app): tighten scripts after /simplify review`** — single `jq` per poll (saves 3 forks per tick), token cached at startup, trap registered before the simulator fork.

9. **`fix(e2e-app): stop running dev app before deploy + quit by default`** — `quit_running_app` (graceful → SIGTERM → SIGKILL with bounded wait) runs before deploy and at end of test. Default `APP_AFTER` flipped from `leave` to `quit`; `--keep-app` preserves the inspect-after-run flow for local debugging.

10. **`chore(e2e): use descriptive labels for the two E2E variants`** — replaces internal nicknames with `fixture-based xctest` / `live-recording` labels in CLAUDE.md and the script/CI headers.

### Bugs surfaced + fixed during live validation (commits 11–15)

These five fixes were discovered while running the driver against the Mac mini and shipped in the same PR because the E2E run requires them to pass deterministically. Each is the smallest correct fix for the failure mode observed.

11. **`fix(e2e-app): keep poll loop alive on transient rpc() empty output`** — `set -e` + `read` + empty stdin = silent script death. `|| true` after the read.

12. **`fix(e2e-app): use non-whitespace separator for jq @tsv-style join`** — `IFS=$'\t' read` collapses leading empty fields because `\t` is whitespace IFS. Switched to `|`.

13. **`feat(rpc): POST /action/skipNaming + auto-skip in e2e-app.sh`** — new DebugRPCServer endpoint (token-auth, returns 200 even when nothing pending) to drain pending naming jobs for headless E2E. Driver auto-calls it when `pipeline.pendingNamingJobCount > 0`.

14. **`fix(rpc): snapshot pending IDs in skipNaming + auto-close window`** — first naive `while !pendingSpeakerNamingJobs.isEmpty` MainActor loop pegged main thread at 95 % CPU when `completeSpeakerNaming` short-circuited. Snapshot IDs once, iterate fixed. Also added `.onChange` on the speaker-naming Window to auto-close on RPC-driven skips (previously only the UI button path closed it).

15. **`fix(app): probe protocolGeneratorFactory output, not just existence`** — pre-existing production bug in `PipelineQueue.acceptAutoNames`. The factory closure is always wired; for `protocolProvider=.none` it returns nil. The guard checked closure-existence, not capability, so the Task path fizzled and jobs sat in `.speakerNamingPending` forever. **Affects every user with provider=none who hits the naming dialog and clicks Skip — the dialog stayed stuck.** The bug was masked until the E2E driver hit it via auto-skip.

### Regression coverage for the late-discovered bugs (commits 16–17)

16. **`test(app): regression test for acceptAutoNames factory-returns-nil`** — pins the fix from commit 15. Verified red→green: temporarily reverting the production fix to `protocolGeneratorFactory != nil` makes the new test fail with the exact symptom (state stays `.speakerNamingPending`).

17. **`test(rpc): /action/skipNaming endpoint coverage`** — three cases for the endpoint added in commit 13: closure invoked exactly once per POST, default-init (no closure provided) still returns 200, unauthed POST returns 401.

## Test plan

- [x] `bash -n scripts/e2e-app.sh` — clean
- [x] `./scripts/lint.sh` — clean
- [x] `swift test --parallel --filter "PipelineQueueTests|DebugRPCServerTests"` — 142 tests pass
- [x] Live end-to-end on the Mac mini — 4× PASS reproducibly (transcript ~622 bytes German, autoWatch + RPC + recording + transcription end-to-end). The diarization warning observed there is fixed via the merged PR #219.
- [ ] After this PR merges to main: trigger `e2e-app.yml` via `gh workflow run` and confirm green run end-to-end with the Developer ID secret signing path.

## What this does NOT do

- Doesn't change the existing `e2e.yml` or its xctest tests — they remain the fast PR-blocking signal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
