### PR TITLE
feat(app): expose lastJob in RPC state snapshot

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -30,6 +30,30 @@
                 ),
                 pendingNamingJobs: pendingJobs,
                 engines: enginesSnapshot(),
+                lastJob: lastFinishedJobSnapshot(),
+            )
+        }
+
+        /// Most recent `.done`-or-`.error` job from the queue, mapped to the
+        /// snapshot shape. Used by E2E driver scripts to assert on outcome
+        /// after triggering a meeting.
+        private func lastFinishedJobSnapshot() -> RPCStateSnapshot.LastJob? {
+            guard let job = pipelineQueue.jobs.last(where: { job in
+                job.state == .done || job.state == .error
+            }) else {
+                return nil
+            }
+            return RPCStateSnapshot.LastJob(
+                jobID: job.id.uuidString,
+                state: job.state,
+                meetingTitle: job.meetingTitle,
+                appName: job.appName,
+                durationSec: Date().timeIntervalSince(job.enqueuedAt),
+                transcriptPath: job.transcriptPath?.path,
+                protocolPath: job.protocolPath?.path,
+                error: job.error,
+                warnings: job.warnings,
+                participants: job.participants,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -345,6 +345,14 @@ class PipelineQueue {
         triggerProcessing()
     }
 
+    /// Test-only: insert a fully-formed job at any state, bypassing
+    /// `enqueue()` and the processing trigger. Lets snapshot/observer tests
+    /// exercise terminal states (`.done`, `.error`) without spinning real
+    /// engines. Production code MUST go through `enqueue()`.
+    func insertJobForTesting(_ job: PipelineJob) {
+        jobs.append(job)
+    }
+
     /// Wait for the queue to drain: any in-flight processing finishes and no
     /// jobs remain in `.waiting`. Used by tests that enqueue a job and need to
     /// observe a terminal state without racing against the spawned process task

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -8,6 +8,11 @@
         let speakerDB: SpeakerDB
         let pendingNamingJobs: [PendingNaming]
         let engines: Engines
+        /// The most recent pipeline job that finished — `.done` or `.error`.
+        /// Surfaced so a driver script can poll `/state` (or hit `/jobs/last`)
+        /// and assert on the outcome of a triggered meeting without needing
+        /// to scrape disk paths from logs.
+        let lastJob: LastJob?
 
         struct Pipeline: Codable {
             let isProcessing: Bool
@@ -32,6 +37,20 @@
             let meetingTitle: String
             let speakerCount: Int
             let namingSlug: String?
+        }
+
+        struct LastJob: Codable {
+            let jobID: String
+            let state: JobState
+            let meetingTitle: String
+            let appName: String
+            /// Wall-clock seconds from `enqueuedAt` to snapshot time.
+            let durationSec: Double
+            let transcriptPath: String?
+            let protocolPath: String?
+            let error: String?
+            let warnings: [String]
+            let participants: [String]
         }
 
         struct Engines: Codable {
@@ -68,11 +87,13 @@
             speakerDB: SpeakerDB,
             pendingNamingJobs: [PendingNaming],
             engines: Engines = .empty,
+            lastJob: LastJob? = nil,
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
             self.pendingNamingJobs = pendingNamingJobs
             self.engines = engines
+            self.lastJob = lastJob
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -133,5 +133,80 @@
             XCTAssertTrue(s.contains("\"whisperKit\""))
             XCTAssertTrue(s.contains("\"parakeet\""))
         }
+
+        // MARK: - LastJob
+
+        func test_snapshot_lastJob_isNilWhenQueueEmpty() {
+            let state = AppState(settings: settings)
+            XCTAssertNil(state.rpcStateSnapshot().lastJob)
+        }
+
+        func test_snapshot_lastJob_skipsWaitingAndInFlightJobs() {
+            let state = AppState(settings: settings)
+            let waiting = makeJob(title: "in-flight")
+            state.pipelineQueue.insertJobForTesting(waiting)
+            // .waiting is the default state on init; not finished yet.
+            XCTAssertNil(state.rpcStateSnapshot().lastJob)
+        }
+
+        func test_snapshot_lastJob_returnsMostRecentFinishedJob() throws {
+            let state = AppState(settings: settings)
+            var done = makeJob(title: "earlier-done")
+            done.state = .done
+            done.transcriptPath = URL(fileURLWithPath: "/tmp/transcript-earlier.md")
+            var errored = makeJob(title: "later-error")
+            errored.state = .error
+            errored.error = "Empty transcript"
+            errored.warnings = ["mic silent"]
+            // Order in the array determines "last" — `last(where:)` walks
+            // back-to-front. Append done first, then errored, so the latter
+            // is returned.
+            state.pipelineQueue.insertJobForTesting(done)
+            state.pipelineQueue.insertJobForTesting(errored)
+
+            let snapshot = state.rpcStateSnapshot()
+            let last = try XCTUnwrap(snapshot.lastJob)
+            XCTAssertEqual(last.meetingTitle, "later-error")
+            XCTAssertEqual(last.state, .error)
+            XCTAssertEqual(last.error, "Empty transcript")
+            XCTAssertEqual(last.warnings, ["mic silent"])
+            XCTAssertNil(last.transcriptPath)
+            XCTAssertGreaterThanOrEqual(last.durationSec, 0)
+        }
+
+        func test_snapshot_lastJob_jsonRoundtripsAllFields() throws {
+            let state = AppState(settings: settings)
+            var done = makeJob(title: "Acme · Standup", participants: ["Alice", "Bob"])
+            done.state = .done
+            done.transcriptPath = URL(fileURLWithPath: "/tmp/transcript.md")
+            done.protocolPath = URL(fileURLWithPath: "/tmp/protocol.md")
+            done.warnings = ["diarization fell back to single track"]
+            state.pipelineQueue.insertJobForTesting(done)
+
+            let json = try state.rpcStateSnapshot().jsonData()
+            let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: json)
+            let last = try XCTUnwrap(decoded.lastJob)
+
+            XCTAssertEqual(last.meetingTitle, "Acme · Standup")
+            XCTAssertEqual(last.state, .done)
+            XCTAssertEqual(last.transcriptPath, "/tmp/transcript.md")
+            XCTAssertEqual(last.protocolPath, "/tmp/protocol.md")
+            XCTAssertEqual(last.participants, ["Alice", "Bob"])
+            XCTAssertEqual(last.warnings, ["diarization fell back to single track"])
+        }
+
+        // MARK: - Helpers
+
+        private func makeJob(title: String, participants: [String] = []) -> PipelineJob {
+            PipelineJob(
+                meetingTitle: title,
+                appName: "MeetingSimulator",
+                mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+                appPath: nil,
+                micPath: nil,
+                micDelay: 0,
+                participants: participants,
+            )
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

Adds `RPCStateSnapshot.LastJob` and surfaces it under `/state`'s `lastJob` key. Carries `jobID`, terminal state (`.done`/`.error`), titles, paths, error, warnings, participants, and wall-clock duration since enqueue.

## Why

Carved out from PR #216 (the Pattern-C E2E driver) so it can land independently. The driver script polls `/state` for the most recent finished pipeline job to know when a triggered meeting completed and where the transcript landed — without it the driver would have to scrape the app's log files. Useful in its own right for any external tool (mt-cli, future telemetry) that wants the same visibility.

## What's in the commit

- `RPCStateSnapshot.LastJob` struct + `lastJob: LastJob?` snapshot field.
- `AppState.rpcStateSnapshot()` populates it from `pipelineQueue.jobs.last(where: .done || .error)`.
- `PipelineQueue.insertJobForTesting` (well-named to discourage production use) so snapshot tests can compose terminal-state jobs without spinning real engines.
- 4 new `RPCEngineStateTests` cases covering nil-when-empty, skipping in-flight, picking the most recent finished, and JSON roundtrip of all fields. Suite goes 6 → 10 tests, all passing.

## Test plan

- [x] `swift test --filter RPCEngineStateTests` — 10 tests pass
- [x] `./scripts/lint.sh` — clean (verified locally before extracting the commit)
- [x] Build sanity: `swift build` clean

## What this does NOT do

- No driver/workflow/script changes — those stay in PR #216 and depend on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->