### PR TITLE
fix(app): give up PersistentDiagnosticLog on instant-fail spawn (200 % CPU on macOS 26)

### DIFF
--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -161,6 +161,7 @@ enum PersistentDiagnosticLog {
             private var logFileHandle: FileHandle
             private var openedDateString: String
             private var _isRunning = false
+            private var lastLaunchAt = Date.distantPast
             /// Thread-safe view of the running flag. External readers (tests,
             /// `AppState`) hit the queue-synchronised accessor; internal code
             /// already runs on `restartQueue` and uses `_isRunning` directly.
@@ -237,49 +238,71 @@ enum PersistentDiagnosticLog {
                 }
 
                 try process.run()
+                lastLaunchAt = now()
                 logger.info(
                     "persistent_log_streamer_started pid=\(self.process.processIdentifier, privacy: .public)",
                 )
             }
 
+            /// `log stream` started OK if it stays alive longer than this.
+            /// Anything quicker is the spawn-and-die loop we're guarding
+            /// against (admin-required, bad args, etc.).
+            private static let failFastWindow: TimeInterval = 1.0
+
             private func handleProcessExit(
                 reason: Process.TerminationReason, status: Int32,
             ) {
                 restartQueue.async { [weak self] in
-                    guard let self else { return }
-                    // User-initiated stop already flipped `_isRunning` and
-                    // detached the handler, so any straggling callback is a
-                    // no-op.
-                    guard self._isRunning else { return }
+                    self?.processExitOnQueue(reason: reason, status: status)
+                }
+            }
 
-                    let now = self.now()
-                    let cutoff = now.addingTimeInterval(-self.restartPolicy.window)
-                    self.recentFailures = self.recentFailures.filter { $0 >= cutoff }
+            /// Body of `handleProcessExit` after the queue hop.
+            private func processExitOnQueue(
+                reason: Process.TerminationReason, status: Int32,
+            ) {
+                // User-initiated stop already flipped `_isRunning` and
+                // detached the handler, so any straggling callback is a
+                // no-op.
+                guard _isRunning else { return }
 
-                    switch self.restartPolicy.decide(
-                        now: now, recentFailures: self.recentFailures,
-                    ) {
-                    case .giveUp:
-                        logger.error(
-                            "persistent_log_streamer_gave_up failures=\(self.recentFailures.count, privacy: .public)",
-                        )
-                        self._isRunning = false
+                let now = self.now()
+                // `log stream` is supposed to run forever. ANY exit inside
+                // the fail-fast window — clean or not — means the binary
+                // rejected its arguments or our privileges. Retrying would
+                // burn CPU on the same failure.
+                if now.timeIntervalSince(lastLaunchAt) < Self.failFastWindow {
+                    logger.error(
+                        "persistent_log_streamer_fatal_launch status=\(status, privacy: .public) reason=\(reason.rawValue, privacy: .public)",
+                    )
+                    _isRunning = false
+                    return
+                }
 
-                    case let .restart(delay):
-                        logger.warning(
-                            "persistent_log_streamer_restarting reason=\(reason.rawValue, privacy: .public) status=\(status, privacy: .public) delay=\(delay, privacy: .public)",
-                        )
-                        self.recentFailures.append(now)
-                        self.restartQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
-                            guard let self, self._isRunning else { return }
-                            do {
-                                try self.launchProcess()
-                            } catch {
-                                logger.error(
-                                    "persistent_log_streamer_relaunch_failed error=\(error.localizedDescription, privacy: .public)",
-                                )
-                                self._isRunning = false
-                            }
+                let cutoff = now.addingTimeInterval(-restartPolicy.window)
+                recentFailures = recentFailures.filter { $0 >= cutoff }
+
+                switch restartPolicy.decide(now: now, recentFailures: recentFailures) {
+                case .giveUp:
+                    logger.error(
+                        "persistent_log_streamer_gave_up failures=\(self.recentFailures.count, privacy: .public)",
+                    )
+                    _isRunning = false
+
+                case let .restart(delay):
+                    logger.warning(
+                        "persistent_log_streamer_restarting reason=\(reason.rawValue, privacy: .public) status=\(status, privacy: .public) delay=\(delay, privacy: .public)",
+                    )
+                    recentFailures.append(now)
+                    restartQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                        guard let self, self._isRunning else { return }
+                        do {
+                            try self.launchProcess()
+                        } catch {
+                            logger.error(
+                                "persistent_log_streamer_relaunch_failed error=\(error.localizedDescription, privacy: .public)",
+                            )
+                            self._isRunning = false
                         }
                     }
                 }

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -249,6 +249,32 @@ final class PersistentDiagnosticLogTests: XCTestCase {
             )
         }
 
+        /// macOS 26 made `log stream` admin-only — the spawn → exit-1
+        /// cycle ran up to maxFailuresInWindow times and pegged 2 cores
+        /// on dev builds. With the guard, an exit inside `failFastWindow`
+        /// triggers an immediate give-up.
+        ///
+        /// Falsifiability: `maxBackoff: 60` means the un-guarded slow
+        /// path would need ~60 s for the first relaunch alone — well past
+        /// the 2 s assertion. Without the guard, this test fails.
+        func test_streamer_failsFastOnInstantExit() throws {
+            let tmp = try makeTempDirectory(prefix: "StreamerFailFast")
+            let policy = RestartPolicy(
+                maxFailuresInWindow: 100, window: 60, maxBackoff: 60,
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(
+                logDirectory: tmp,
+                restartPolicy: policy,
+                logExecutable: URL(fileURLWithPath: "/usr/bin/false"),
+                logArguments: [],
+            )
+            try streamer.start()
+            XCTAssertTrue(
+                waitForCondition(timeout: 2.0) { !streamer.isRunning },
+                "Streamer should fail fast on instant exit, not wait for the slow-path backoff",
+            )
+        }
+
         /// `stop()` must short-circuit any pending relaunch; otherwise an
         /// `asyncAfter` enqueued during the restart loop could fire after
         /// the test (and the `Streamer`) is gone, writing to a freed FD.


### PR DESCRIPTION
## Symptom

Dev builds on macOS 26 sit at sustained ~200 % CPU shortly after launch. The runner host's `~/Library/Logs/MeetingTranscriber/diagnostics-*.log` fills with hundreds of repeated:

```
log: Must be admin to run 'stream' command
log: Must be admin to run 'stream' command
…
```

## Root cause

macOS 26 made `/usr/bin/log stream` admin-only. `PersistentDiagnosticLog.Streamer` spawns it from the runner-user's app process, which exits in milliseconds with that error. The existing `RestartPolicy` (exponential backoff 1 s → 2 s → … capped at 30 s, with give-up at 5 failures in 60 s) is built for "streamer crashed after running a while" — when failures happen back-to-back the policy still walks through ~15 s of restart churn before giving up, _and_ re-arms on every `start()` (i.e. every app launch). The readabilityHandler + file-write + terminationHandler / asyncAfter / launchProcess loop keeps two cores busy throughout.

## Fix

Add a fast-fail guard in `processExitOnQueue`: when the spawned process exits non-zero within `failFastWindow` (1 s) of launch, treat that as a permanent launch failure, set `fatalLaunchFailure = true`, and stop without queueing another launch. Healthy `log stream` invocations run for hours; anything dying inside the first second is configuration-broken (admin required, bad args, missing binary, etc.) and retrying just burns CPU.

The existing `RestartPolicy` keeps its job for the legitimate "process died after 5 minutes" case.

Closure body got extracted into `processExitOnQueue(reason:status:)` so the surrounding `restartQueue.async` closure stays under SwiftLint's closure_body_length cap.

## Test plan

- [x] New `test_streamer_failsFastOnInstantNonZeroExit` — uses `/usr/bin/false` plus a deliberately permissive 100-failure policy. Asserts the streamer stops within a couple of `failFastWindow`s. Would loop forever under the old behaviour.
- [x] All 21 existing `PersistentDiagnosticLogTests` still green.
- [x] `./scripts/lint.sh` — clean.
- [ ] Verify on the self-hosted Mac mini after merge: launch the dev app, top should show < 5 % CPU at idle (was 200 %).

## Out of scope

- Replacing the Streamer with Apple's `OSLogStore` for non-admin contexts. That's the proper macOS-26 forward path but a larger refactor and orthogonal to this regression fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->