### PR TITLE
fix(app): fall back to app-only diarization when mic track has no speakers

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -133,6 +133,16 @@ enum DiarizationProcess {
         )
     }
 
+    /// Strip a track prefix (e.g. `"R_"` or `"M_"`) from a `[speakerID: name]`
+    /// dictionary, dropping entries whose key doesn't carry the prefix.
+    /// Inverse of the prefixing done in `mergeDualTrackDiarization`.
+    static func unprefixNames(_ autoNames: [String: String], prefix: String) -> [String: String] {
+        autoNames.reduce(into: [:]) { acc, kv in
+            guard kv.key.hasPrefix(prefix) else { return }
+            acc[String(kv.key.dropFirst(prefix.count))] = kv.value
+        }
+    }
+
     /// Maximum silence gap (seconds) before breaking a same-speaker block.
     /// Pauses longer than this start a new paragraph even for the same speaker.
     static let mergeGapThreshold: TimeInterval = 2.0

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -606,7 +606,10 @@ class PipelineQueue {
 
                         diarizationLoop: while true {
                             if useDualTrack {
-                                // Diarize app and mic tracks separately
+                                // Diarize app and mic tracks separately. Mic
+                                // failures (silent track on Mac mini hosts
+                                // without a real input device, etc.) are
+                                // tolerated — fall back to app-only.
                                 let app16k = workDir.appendingPathComponent("app_16k.wav")
                                 let mic16k = workDir.appendingPathComponent("mic_16k.wav")
 
@@ -615,19 +618,36 @@ class PipelineQueue {
                                     numSpeakers: speakerCount,
                                     meetingTitle: title,
                                 )
-                                micDiarization = try await diarizeProcess.run(
-                                    audioPath: mic16k,
-                                    numSpeakers: nil, // auto-detect local speakers
-                                    meetingTitle: title,
-                                )
+                                do {
+                                    micDiarization = try await diarizeProcess.run(
+                                        audioPath: mic16k,
+                                        numSpeakers: nil, // auto-detect local speakers
+                                        meetingTitle: title,
+                                    )
+                                } catch {
+                                    logger.warning(
+                                        "[\(shortID, privacy: .public)] mic_diarization_failed error=\(error.localizedDescription, privacy: .public) — falling back to app-only diarization",
+                                    )
+                                    addWarning(id: jobID, "Mic track diarization failed — speaker labels reflect remote audio only")
+                                    micDiarization = nil
+                                }
 
-                                // Merge for speaker naming (prefixed IDs: R_, M_)
-                                // swiftlint:disable force_unwrapping
-                                diarization = DiarizationProcess.mergeDualTrackDiarization(
-                                    appDiarization: appDiarization!,
-                                    micDiarization: micDiarization!,
-                                    // swiftlint:enable force_unwrapping
-                                )
+                                if let micDiar = micDiarization {
+                                    // Merge for speaker naming (prefixed IDs: R_, M_)
+                                    // swiftlint:disable force_unwrapping
+                                    diarization = DiarizationProcess.mergeDualTrackDiarization(
+                                        appDiarization: appDiarization!,
+                                        micDiarization: micDiar,
+                                        // swiftlint:enable force_unwrapping
+                                    )
+                                } else {
+                                    // App-only fallback. Feeds the speaker-naming
+                                    // loop below; the dual-track-app-only branch in
+                                    // the assignment block then keeps mic segments
+                                    // with their raw `micLabel` instead of forcing
+                                    // them through speaker matching.
+                                    diarization = appDiarization
+                                }
                             } else {
                                 diarization = try await diarizeProcess.run(
                                     audioPath: mix16k,
@@ -746,15 +766,13 @@ class PipelineQueue {
                             let namedAppDiar = DiarizationResult(
                                 segments: appDiar.segments,
                                 speakingTimes: appDiar.speakingTimes,
-                                autoNames: autoNames.filter { $0.key.hasPrefix("R_") }
-                                    .reduce(into: [:]) { $0[String($1.key.dropFirst(2))] = $1.value },
+                                autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "R_"),
                                 embeddings: appDiar.embeddings,
                             )
                             let namedMicDiar = DiarizationResult(
                                 segments: micDiar.segments,
                                 speakingTimes: micDiar.speakingTimes,
-                                autoNames: autoNames.filter { $0.key.hasPrefix("M_") }
-                                    .reduce(into: [:]) { $0[String($1.key.dropFirst(2))] = $1.value },
+                                autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "M_"),
                                 embeddings: micDiar.embeddings,
                             )
 
@@ -767,6 +785,28 @@ class PipelineQueue {
                                 micDiarization: namedMicDiar,
                             )
                             let merged = DiarizationProcess.mergeConsecutiveSpeakers(labeled)
+                            finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
+                        } else if useDualTrack, let appDiar = appDiarization, let cached = cachedSegments {
+                            // Mic diarization failed (silent track / no input
+                            // device). Diarize the app track normally and keep
+                            // the mic transcript with its raw `micLabel` —
+                            // better than emitting "speakers not identified"
+                            // on a recording that has perfectly good remote
+                            // audio.
+                            let namedAppDiar = DiarizationResult(
+                                segments: appDiar.segments,
+                                speakingTimes: appDiar.speakingTimes,
+                                autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "R_"),
+                                embeddings: appDiar.embeddings,
+                            )
+                            let appSegs = cached.filter { $0.speaker == "Remote" }
+                            let micSegs = cached.filter { $0.speaker == micLabel }
+                            let labeledApp = DiarizationProcess.assignSpeakers(
+                                transcript: appSegs, diarization: namedAppDiar,
+                            )
+                            // micSegs keep their original micLabel speaker tag.
+                            let combined = (labeledApp + micSegs).sorted { $0.start < $1.start }
+                            let merged = DiarizationProcess.mergeConsecutiveSpeakers(combined)
                             finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
                         } else if let currentDiarization = diarization {
                             // Single-source: standard assignment

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -143,21 +143,24 @@ class MockRecorder: RecordingProvider {
     }
 }
 
-/// Mock diarization that returns pre-set segments.
-/// `@unchecked Sendable` because tests configure mutable state (`runCount`,
-/// `shouldThrow`, etc.) before exercising the diarizer; XCTest serialises
-/// test execution per class, and mocks aren't shared across tests.
+/// Mock diarization that returns pre-set segments. Set `throwOnPathSuffix`
+/// to simulate per-track failure (e.g. silent mic on a Mac mini host) —
+/// the run() call throws when the audio path ends with that string.
+/// `@unchecked Sendable` because tests configure mutable state before
+/// exercising the diarizer; XCTest serialises per class.
 final class MockDiarization: DiarizationProvider, @unchecked Sendable {
     var isAvailable: Bool = true
     var runCount = 0
-    var shouldThrow = false
+    var throwOnPathSuffix: String?
     var resultToReturn: DiarizationResult?
 
-    func run(audioPath _: URL, numSpeakers _: Int?, meetingTitle _: String) -> DiarizationResult {
+    func run(audioPath: URL, numSpeakers _: Int?, meetingTitle _: String) throws -> DiarizationResult {
         runCount += 1
-        if shouldThrow {
-            // Return empty result to simulate failure path
-            return DiarizationResult(segments: [], speakingTimes: [:], autoNames: [:], embeddings: nil)
+        if let suffix = throwOnPathSuffix, audioPath.lastPathComponent.hasSuffix(suffix) {
+            throw NSError(
+                domain: "MockDiarization", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "mock diarizer threw on \(audioPath.lastPathComponent)"],
+            )
         }
         if let result = resultToReturn {
             return result

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -247,6 +247,37 @@ final class WorkflowIntegrationTests: XCTestCase { // swiftlint:disable:this bal
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
     }
 
+    /// Regression: dual-source recording where the mic track produces no
+    /// detectable speakers (silent BlackHole input on a mic-less Mac mini,
+    /// noisy office without anyone speaking close to the mic, etc.).
+    /// The mic-track diarizer throws; the pipeline must fall back to
+    /// app-only diarization, complete with `.done`, save the transcript,
+    /// and warn with the new "Mic track diarization failed" message —
+    /// not the old all-or-nothing "speakers not identified".
+    func testWorkflowDualSourceMicDiarizationFailsFallsBackToAppOnly() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true)
+        h.diarization.throwOnPathSuffix = "mic_16k.wav"
+        h.queue.speakerNamingHandler = { _ in .skipped }
+
+        let job = try makeDualSourceJob(audioPath: h.audioPath)
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        let finalJob = try XCTUnwrap(h.queue.jobs.first)
+        XCTAssertEqual(finalJob.state, .done, "Pipeline must complete when only mic diarization fails")
+        XCTAssertNotNil(finalJob.transcriptPath)
+
+        let warnings = finalJob.warnings.joined(separator: " | ")
+        XCTAssertTrue(
+            warnings.contains("Mic track diarization failed"),
+            "Expected the new fallback warning, got: \(warnings)",
+        )
+        XCTAssertFalse(
+            warnings.contains("speakers not identified"),
+            "The old all-or-nothing warning should not fire for the mic-only fallback path",
+        )
+    }
+
     func testWorkflowDiarizationNoEmbeddingsFallsBack() async throws {
         let (h, _) = try makeHarness(diarizeEnabled: true)
         h.diarization.resultToReturn = DiarizationResult(


### PR DESCRIPTION
## Symptom

Dual-source recordings on hosts where the mic track is silent (Mac mini without a built-in mic, BlackHole loopback with nothing routed to it, sealed enclosure, etc.) emit:

> Diarization failed — speakers not identified

as a job warning. The remote-audio app track contained perfectly recognisable speakers; their labels are lost.

## Root cause

In `PipelineQueue` the dual-track diarization runs both `diarizeProcess.run(...)` calls inside a single `try/catch`. When mic diarization throws (FluidAudio can't extract embeddings from silence), the catch fires and the all-or-nothing warning is appended. The app track's diarization result — already computed and valid — is thrown away.

## Fix

1. Wrap the mic-track `diarizeProcess.run(...)` call in its own do/catch. On failure: log + add a more useful warning (`"Mic track diarization failed — speaker labels reflect remote audio only"`) + continue with `micDiarization = nil`.
2. In the assignment block, add a third branch for `useDualTrack && appDiarization && !micDiarization`:
   - Assign speakers to the Remote-tagged segments using the app diarization.
   - Keep the mic-tagged segments with their raw `micLabel` speaker.
   - Sort + merge.

Real users now get a transcript with proper `R_S0`/`R_S1`/… labels for the remote audio plus the existing `"Me"` label for whatever the mic captured (typically nothing in the failure case).

## Mock change

Existing `MockDiarization.shouldThrow` was misleading — it returned an empty success, not a real throw — and was unused by any test. Renamed/replaced with `throwOnPathSuffix: String?`: `run()` throws when the audio path's last component ends with that suffix. Lets a single test simulate per-track failure (app succeeds, mic throws) without scaffolding a dedicated mock.

## Test plan

- [x] New `testWorkflowDualSourceMicDiarizationFailsFallsBackToAppOnly` in `WorkflowIntegrationTests`. Sets `throwOnPathSuffix = "mic_16k.wav"`, runs the dual-source pipeline, asserts:
  - Job ends `.done` (was `.error` before this commit).
  - `transcriptPath` is set.
  - Warnings include the new `"Mic track diarization failed"`.
  - Warnings do NOT include the old `"speakers not identified"`.
- [x] All 16 `WorkflowIntegrationTests` still pass.
- [x] `./scripts/lint.sh` clean.

## What this does NOT do

- Doesn't fix the upstream cause (BlackHole loopback being empty on the self-hosted Mac mini runner). That's a runner-config issue, not an app-side bug — the app should still produce a useful transcript when mic input is silent for any reason.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->