### PR TITLE
fix(app): detach diagnostic-log readabilityHandler on subprocess EOF

### DIFF
--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -169,6 +169,15 @@ enum PersistentDiagnosticLog {
                 restartQueue.sync { _isRunning }
             }
 
+            /// Test-only probe — true while the readabilityHandler is still
+            /// subscribed to the pipe. Used to verify that EOF self-detach
+            /// fires after the subprocess exits. Queue-synced for symmetry
+            /// with `isRunning` and TSan-cleanliness; the readabilityHandler
+            /// itself is mutated on Foundation's pipe queue, not ours.
+            var hasReadabilityHandlerForTesting: Bool {
+                restartQueue.sync { pipe.fileHandleForReading.readabilityHandler != nil }
+            }
+
             private let logExecutable: URL
             private let logArguments: [String]
             private let restartPolicy: RestartPolicy
@@ -233,7 +242,17 @@ enum PersistentDiagnosticLog {
                 let handle = pipe.fileHandleForReading
                 handle.readabilityHandler = { [weak self] fh in
                     let data = fh.availableData
-                    guard !data.isEmpty else { return }
+                    if data.isEmpty {
+                        // Pipe writer closed (subprocess exited). Without
+                        // self-detaching, Foundation reschedules this handler
+                        // in a tight loop on persistent EOF — observed as
+                        // ~100 % CPU on macOS 26 dev builds where `log stream`
+                        // exits immediately because it now requires admin.
+                        // PR #218's fail-fast stops the relaunch; this stops
+                        // the pipe spin that survived it.
+                        fh.readabilityHandler = nil
+                        return
+                    }
                     self?.append(data)
                 }
 

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -275,6 +275,33 @@ final class PersistentDiagnosticLogTests: XCTestCase {
             )
         }
 
+        /// PR #218 fail-fast stops relaunching but the pipe's readabilityHandler
+        /// stays subscribed to the dead subprocess's pipe. Foundation reschedules
+        /// the handler on persistent EOF — observed as ~100 % CPU on macOS 26.
+        /// The handler must self-detach on first empty `availableData`.
+        func test_streamer_pipeReadabilityHandlerDetachesOnSubprocessEOF() throws {
+            let tmp = try makeTempDirectory(prefix: "StreamerEOFDetach")
+            let policy = RestartPolicy(
+                maxFailuresInWindow: 100, window: 60, maxBackoff: 60,
+            )
+            let streamer = try PersistentDiagnosticLog.Streamer(
+                logDirectory: tmp,
+                restartPolicy: policy,
+                logExecutable: URL(fileURLWithPath: "/usr/bin/false"),
+                logArguments: [],
+            )
+            try streamer.start()
+            // Wait for fail-fast to fire AND the readabilityHandler to
+            // self-detach. Without the fix, isRunning flips false but the
+            // handler stays attached and fires forever.
+            XCTAssertTrue(
+                waitForCondition(timeout: 2.0) {
+                    !streamer.isRunning && !streamer.hasReadabilityHandlerForTesting
+                },
+                "Pipe readabilityHandler must detach on EOF — otherwise it spins on an empty Data forever",
+            )
+        }
+
         /// `stop()` must short-circuit any pending relaunch; otherwise an
         /// `asyncAfter` enqueued during the restart loop could fire after
         /// the test (and the `Streamer`) is gone, writing to a freed FD.


### PR DESCRIPTION
## Summary

Follow-up to #218. PR #218 stopped the relaunch loop when `log stream` exits admin-rejected on macOS 26, but the pipe's `readabilityHandler` stayed subscribed to the dead subprocess's pipe. Foundation reschedules the handler on persistent EOF — empirically ~100 % CPU on one core on every dev macOS 26 launch.

The handler now self-detaches on first empty `Data` (the EOF marker for a pipe whose writer has closed).

## Reproduction (verified)

Deployed the dev bundle to the self-hosted Mac mini after #218 + #219 merged. App sat at 95–100 % CPU continuously after launch. `sample` of the process showed:

```
1532 Thread … DispatchQueue: com.apple.NSFileHandle.fd_monitoring (serial)
  +- 462 [NSConcreteFileHandle availableData]
  +- 319 closure #2 in PersistentDiagnosticLog.Streamer.launchProcess()
         PersistentDiagnosticLog.swift:235
```

Confirmed `~/Library/Logs/MeetingTranscriber/diagnostics-2026-05-10.log` had only **one** `Must be admin` line — so #218's fail-fast was working. The CPU went to the EOF-poll spin separately.

## Test

`test_streamer_pipeReadabilityHandlerDetachesOnSubprocessEOF` spawns `/usr/bin/false` and asserts both `isRunning == false` AND `hasReadabilityHandlerForTesting == false` within 2 s. Without the fix, the handler stays attached and the assertion times out.

A small `hasReadabilityHandlerForTesting` accessor is added to the Streamer for the test to probe handler state. Marked `ForTesting` to make its scope obvious.

## Test plan

- [x] `swift test --filter PersistentDiagnosticLogTests` — 22 tests pass (was 21 + 1 new)
- [x] `./scripts/lint.sh` — clean
- [ ] After merge: rebuild dev bundle, deploy to Mac mini, verify `top` shows MeetingTranscriber-Dev at ~0 % CPU at idle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->