### PR TITLE
fix(e2e): respect E2E_ENABLED flag so e2e.yml actually runs engine tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,10 @@ concurrency:
 jobs:
   e2e:
     runs-on: [self-hosted, macOS, ARM64]
-    timeout-minutes: 30
+    # 60 min headroom: cold runs download three multi-GB models
+    # (WhisperKit ~1 GB, Parakeet ~50 MB, Qwen3 ~1.75 GB). Subsequent
+    # runs hit the SPM cache + on-disk model cache and finish in <10 min.
+    timeout-minutes: 60
     env:
       E2E_ENABLED: "1"
       # Pin the toolchain to a full Xcode install. Without this the runner

--- a/app/MeetingTranscriber/Tests/E2EGateTests.swift
+++ b/app/MeetingTranscriber/Tests/E2EGateTests.swift
@@ -1,0 +1,29 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class E2EGateTests: XCTestCase {
+    func testLocalRunNeverSkips() {
+        XCTAssertFalse(shouldSkipForE2EGate(env: [:]))
+    }
+
+    func testCIWithoutOptInSkips() {
+        XCTAssertTrue(shouldSkipForE2EGate(env: ["CI": "true"]))
+    }
+
+    func testCIWithOptInRuns() {
+        XCTAssertFalse(shouldSkipForE2EGate(env: ["CI": "true", "E2E_ENABLED": "1"]))
+    }
+
+    func testCIWithOptInWrongValueSkips() {
+        XCTAssertTrue(shouldSkipForE2EGate(env: ["CI": "true", "E2E_ENABLED": "true"]))
+    }
+
+    func testOptInWithoutCIRuns() {
+        XCTAssertFalse(shouldSkipForE2EGate(env: ["E2E_ENABLED": "1"]))
+    }
+
+    func testCIEmptyStringSkips() {
+        // Some systems set `CI=""` instead of `CI=true`; gate is presence, not value.
+        XCTAssertTrue(shouldSkipForE2EGate(env: ["CI": ""]))
+    }
+}

--- a/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetE2ETests.swift
@@ -7,8 +7,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Model loading
 
     func testParakeetModelLoadsSuccessfully() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let engine = ParakeetEngine()
         await engine.loadModel()
@@ -18,8 +17,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Transcription with fixture
 
     func testTranscribeSegmentsWithFixture() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -51,8 +49,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscribeSegmentsProducesGermanContent() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -75,8 +72,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscribeSegmentsGroupsIntoSentences() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -103,8 +99,7 @@ final class ParakeetE2ETests: XCTestCase {
     // MARK: - Progress tracking
 
     func testDownloadProgressReachesOne() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let engine = ParakeetEngine()
         await engine.loadModel()
@@ -113,8 +108,7 @@ final class ParakeetE2ETests: XCTestCase {
     }
 
     func testTranscriptionProgressReachesOne() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Parakeet model download")
+        try skipIfCIWithoutE2EOptIn("requires Parakeet model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(

--- a/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3E2ETests.swift
@@ -10,8 +10,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try skipIfCIWithoutE2EOptIn("requires Qwen3-ASR model download (~1.75 GB)")
 
         let engine = Qwen3AsrEngine()
         await engine.loadModel()
@@ -24,8 +23,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try skipIfCIWithoutE2EOptIn("requires Qwen3-ASR model download (~1.75 GB)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -61,8 +59,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try skipIfCIWithoutE2EOptIn("requires Qwen3-ASR model download (~1.75 GB)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -90,8 +87,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try skipIfCIWithoutE2EOptIn("requires Qwen3-ASR model download (~1.75 GB)")
 
         let engine = Qwen3AsrEngine()
         await engine.loadModel()
@@ -103,8 +99,7 @@ final class Qwen3E2ETests: XCTestCase {
         guard #available(macOS 15, *) else {
             throw XCTSkip("Qwen3-ASR requires macOS 15+")
         }
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires Qwen3-ASR model download (~1.75 GB)")
+        try skipIfCIWithoutE2EOptIn("requires Qwen3-ASR model download (~1.75 GB)")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -67,6 +67,25 @@ extension XCTestCase {
     }
 }
 
+// MARK: - E2E Opt-In Gate
+
+/// Skip in CI unless the dedicated `e2e.yml` workflow opted in via `E2E_ENABLED=1`.
+/// Free function so the gate is unit-testable without an XCTestCase context.
+func shouldSkipForE2EGate(env: [String: String]) -> Bool {
+    let isCI = env["CI"] != nil
+    let optedIn = env["E2E_ENABLED"] == "1"
+    return isCI && !optedIn
+}
+
+extension XCTestCase {
+    func skipIfCIWithoutE2EOptIn(_ reason: String) throws {
+        try XCTSkipIf(
+            shouldSkipForE2EGate(env: ProcessInfo.processInfo.environment),
+            "Skipping in CI: \(reason)",
+        )
+    }
+}
+
 // MARK: - WatchLoop / AppState Helpers
 
 /// Returns a MeetingDetector with no patterns — never matches any window.

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -93,10 +93,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
     // MARK: - 1. Full Pipeline: detect → record → enqueue → transcribe → protocol
 
     func testFullPipelineDetectRecordTranscribeProtocol() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
-        )
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -150,10 +147,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
     // MARK: - 2. Dual Source Transcription Path
 
     func testDualSourceTranscriptionPath() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
-        )
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -245,10 +239,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
     // MARK: - 4. Diarization Skipped When Not Available
 
     func testDiarizationSkippedWhenNotAvailable() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
-        )
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -318,10 +309,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
     // MARK: - 6. Resample Path Produces 16kHz for WhisperKit
 
     func testResamplePathProduces16kHzForWhisperKit() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model download",
-        )
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -364,10 +352,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
     // MARK: - 7. Full Pipeline With Real Diarization (slow)
 
     func testFullPipelineWithRealDiarization() async throws {
-        try XCTSkipIf(
-            ProcessInfo.processInfo.environment["CI"] != nil,
-            "Skipping in CI: requires WhisperKit model + FluidAudio diarization",
-        )
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model + FluidAudio diarization")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -159,8 +159,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testTranscribeSegmentsWithFixture() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -205,8 +204,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testTranscribeSegmentsHallucinationFilter() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -234,8 +232,7 @@ final class WhisperKitE2ETests: XCTestCase {
 
     func testFullDualSourcePipeline() async throws {
         // This test downloads a WhisperKit model (~1GB) - skip in CI
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let fixture = fixtureURL()
         try XCTSkipUnless(
@@ -347,8 +344,7 @@ final class WhisperKitE2ETests: XCTestCase {
     }
 
     func testTranscribeMultiFormatContent() async throws {
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        try XCTSkipIf(isCI, "Skipping in CI: requires WhisperKit model download")
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
 
         let engine = WhisperKitEngine()
         engine.modelVariant = "openai_whisper-small"


### PR DESCRIPTION
## Summary

The `e2e.yml` workflow has been silently skipping all engine tests since it was created. The skip guard checked `ProcessInfo.processInfo.environment["CI"]` and unconditionally skipped — but GitHub Actions sets `CI=true` on every workflow run, including the dedicated E2E one. The job-level `E2E_ENABLED: "1"` env var in the YAML was the intended opt-in but no test ever consulted it.

## Symptom

Output of run #25625567339 on main (today's manual dispatch, before this PR):

```
Test Case '-[MeetingTranscriberTests.WhisperKitE2ETests testTranscribeSegmentsWithFixture]' skipped
  Skipping in CI: requires WhisperKit model download
…
Executed 40 tests, with 20 tests skipped and 0 failures
```

20 of 40 E2E tests skipped — i.e. every test that actually exercises a production model. The non-skipping ones only test data-structure helpers, not the engines themselves.

## Fix (3 atomic commits)

**1. `feat(test): add E2E gate helper respecting E2E_ENABLED env var`**

`shouldSkipForE2EGate(env:)` is a pure function: skip when in CI unless `E2E_ENABLED=1`. `XCTestCase.skipIfCIWithoutE2EOptIn(_:)` wraps it as an `XCTSkipIf` call. Six unit tests cover the gate logic (local / CI without opt-in / CI with opt-in / E2E_ENABLED set to wrong value / opt-in without CI / `CI=""` presence-not-value).

**2. `refactor(test): migrate 20 E2E test sites to skipIfCIWithoutE2EOptIn`**

20 call sites across 4 files (`WhisperKitE2ETests`:4, `ParakeetE2ETests`:6, `Qwen3E2ETests`:5, `WatchLoopE2ETests`:5). Mechanical pattern replacement.

Explicitly NOT touched:
- `MenuBarIconSnapshotTests` keeps its own `CI` skip — gates on machine-dependent rendering, not models. Should NOT be enabled by `E2E_ENABLED`.
- `ModelPreloadTests` was already gate-free; runs in the dedicated quality workflow.
- `XCTSkipUnless(fixtureExists)` lines are fixture-presence checks, not CI gates.

**3. `ci(e2e): bump e2e.yml timeout to 60 min for cold model downloads`**

Cold runs download ~3 GB of models (WhisperKit + Parakeet + Qwen3) on the first invocation. Subsequent runs hit cache and finish in <10 min.

## Test plan

- [x] Unit tests for `shouldSkipForE2EGate` — 6 cases, all pass
- [x] Local sanity: `CI=1 swift test --filter ParakeetE2ETests/testParakeetModelLoadsSuccessfully` correctly skips
- [x] Lint clean
- [x] No `ProcessInfo.processInfo.environment["CI"]` references remain in any `*E2ETests.swift` file
- [x] **Live validation on self-hosted Mac mini** (run #25632411615): `Executed 46 tests, with 0 failures` and **0 skipped** across `E2EGateTests` (6), `ParakeetE2ETests` (6), `Qwen3E2ETests` (5), `WatchLoopE2ETests` (8), `WhisperKitE2ETests` (21). Total wall time 2m40s thanks to warm model caches.

## What this does NOT do

- Doesn't change `ci.yml` — it never set `E2E_ENABLED`, so PR-blocking CI stays fast.
- Doesn't change the live-recording `e2e-app.yml` workflow, which uses a different mechanism (deployed app + RPC).