### PR TITLE
docs(readme): add Testing & CI section highlighting on-device E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ The toggle persists in `UserDefaults` and takes effect on the next recording wit
 
 ---
 
+## Testing & CI
+
+Pull requests run unit tests, lint, and analyzer in [`ci.yml`](.github/workflows/ci.yml). Two complementary E2E layers run on a self-hosted Apple Silicon Mac mini against the real production models (no mocks): [`e2e.yml`](.github/workflows/e2e.yml) feeds fixture audio through each ASR engine + the WatchLoop pipeline, and [`e2e-app.yml`](.github/workflows/e2e-app.yml) builds and signs the actual `.app`, drives a simulated meeting via [`tools/meeting-simulator`](tools/meeting-simulator), and asserts on the resulting transcript over the embedded debug RPC server.
+
+---
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

Adds a short "Testing & CI" section between Troubleshooting and License so first-time visitors can see at a glance that this repo isn't unit-tests-only:

- `ci.yml` — PR-blocking unit tests + lint + analyzer
- `e2e.yml` — fixture-based engine + WatchLoop E2E on a self-hosted Apple Silicon Mac mini, against the real production models (no mocks)
- `e2e-app.yml` — built + signed `.app` driven by a meeting simulator and asserted via the embedded debug RPC server

3 lines of prose, 3 markdown links into existing files. No content change anywhere else.

## Test plan

- [x] Markdown renders correctly on github.com
- [x] All 5 linked paths exist (`ci.yml`, `e2e.yml`, `e2e-app.yml`, `tools/meeting-simulator`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->