### PR TITLE
test(quality): add diarization DER regression suite

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -115,7 +115,7 @@ jobs:
           RUN_QUALITY_TESTS: "1"
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
           WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
-        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests"
+        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests"
       - name: Upload quality results
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/MeetingTranscriber/Tests/Quality/FluidDiarizerQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/FluidDiarizerQualityTests.swift
@@ -1,0 +1,100 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Production-model FluidAudio diarization quality tests. Skipped by default
+/// — gated by `RUN_QUALITY_TESTS=1` so a normal `swift test` run on a dev
+/// machine doesn't pull the diarization models. CI's quality job sets the
+/// env var.
+///
+/// Computes DER per fixture × mode and appends rows to `QualityResultsWriter`.
+/// Pairs with `WhisperKitQualityTests` (WER); the writer aggregates both.
+@MainActor
+final class FluidDiarizerQualityTests: XCTestCase {
+    func test_offline_twoSpeakers_de_der() async throws {
+        try skipUnlessQualityRun()
+        try await runDERFixture(named: "two_speakers_de", mode: .offline)
+    }
+
+    func test_offline_threeSpeakers_de_der() async throws {
+        try skipUnlessQualityRun()
+        try await runDERFixture(named: "three_speakers_de", mode: .offline)
+    }
+
+    func test_sortformer_twoSpeakers_de_der() async throws {
+        try skipUnlessQualityRun()
+        try await runDERFixture(named: "two_speakers_de", mode: .sortformer)
+    }
+
+    func test_sortformer_threeSpeakers_de_der() async throws {
+        try skipUnlessQualityRun()
+        try await runDERFixture(named: "three_speakers_de", mode: .sortformer)
+    }
+
+    // MARK: - Helpers
+
+    /// Per-mode soft sanity bound. Set well above current observed baselines so
+    /// the test catches catastrophic regressions (model corrupted, audio not
+    /// loaded, segments=0) without flapping on small variance.
+    ///
+    /// Offline mode systematically under-clusters short fixtures (≤30 s) — both
+    /// `two_speakers_de` and `three_speakers_de` collapse to 1 speaker, producing
+    /// DER ≈0.53 and ≈0.68 respectively as of 2026-05-10. The offline threshold
+    /// is set high enough to accept that baseline; it would still trip if the
+    /// diarizer regressed to "no segments at all" (DER=1.0). Sortformer is
+    /// overlap-aware end-to-end and handles short fixtures fine.
+    private static let derThreshold: [DiarizerMode: Double] = [
+        .offline: 0.85,
+        .sortformer: 0.50,
+    ]
+
+    private func runDERFixture(named name: String, mode: DiarizerMode) async throws {
+        let truth = try GroundTruth.load(named: name)
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: truth.audioURL.path),
+            "Audio fixture missing: \(truth.audioURL.path)",
+        )
+
+        let diarizer = FluidDiarizer(mode: mode)
+
+        let started = Date()
+        let result = try await diarizer.run(
+            audioPath: truth.audioURL,
+            numSpeakers: nil,
+            meetingTitle: name,
+        )
+        let elapsed = Date().timeIntervalSince(started)
+
+        let hypothesis = result.segments.map { seg in
+            DERCalculator.Turn(speaker: seg.speaker, start: seg.start, end: seg.end)
+        }
+        let breakdown = DERCalculator.derBreakdown(
+            reference: truth.diarizationTurns,
+            hypothesis: hypothesis,
+        )
+
+        QualityResultsWriter.shared.append(
+            QualityResult(
+                engine: "fluidDiarizer.\(mode.rawValue)",
+                fixture: name,
+                modelVariant: nil,
+                wer: nil,
+                der: breakdown.der,
+                werBreakdown: nil,
+                derBreakdown: .init(breakdown),
+                appVersion: qualityAppVersion,
+                timestamp: ISO8601DateFormatter().string(from: started),
+                durationSeconds: elapsed,
+            ),
+        )
+        _ = try? QualityResultsWriter.shared.flush()
+
+        let threshold = Self.derThreshold[mode, default: 0.5]
+        XCTAssertLessThan(
+            breakdown.der,
+            threshold,
+            "DER too high (\(breakdown.der)) for \(name) in \(mode.rawValue) mode — "
+                + "hypothesis had \(hypothesis.count) segments across "
+                + "\(Set(hypothesis.map(\.speaker)).count) speakers",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
@@ -15,12 +15,12 @@ final class WhisperKitQualityTests: XCTestCase {
     }
 
     func test_whisperKit_twoSpeakers_de_wer() async throws {
-        try requireQualityRun()
+        try skipUnlessQualityRun()
         try await runWERFixture(named: "two_speakers_de")
     }
 
     func test_whisperKit_threeSpeakers_de_wer() async throws {
-        try requireQualityRun()
+        try skipUnlessQualityRun()
         try await runWERFixture(named: "three_speakers_de")
     }
 
@@ -58,7 +58,7 @@ final class WhisperKitQualityTests: XCTestCase {
                 der: nil,
                 werBreakdown: .init(breakdown),
                 derBreakdown: nil,
-                appVersion: appVersion,
+                appVersion: qualityAppVersion,
                 timestamp: ISO8601DateFormatter().string(from: started),
                 durationSeconds: elapsed,
             ),
@@ -77,17 +77,5 @@ final class WhisperKitQualityTests: XCTestCase {
 
         // Flush eagerly so even a later test crash doesn't lose this row.
         _ = try? QualityResultsWriter.shared.flush()
-    }
-
-    private func requireQualityRun() throws {
-        try XCTSkipUnless(
-            ProcessInfo.processInfo.environment["RUN_QUALITY_TESTS"] == "1",
-            "Set RUN_QUALITY_TESTS=1 to run quality regression tests",
-        )
-    }
-
-    private var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "dev"
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -86,6 +86,28 @@ extension XCTestCase {
     }
 }
 
+// MARK: - Quality-Suite Helpers
+
+extension XCTestCase {
+    /// Skip unless the dedicated quality job opted in via `RUN_QUALITY_TESTS=1`.
+    /// Quality tests pull production-size models (~1 GB) and are gated so a
+    /// normal `swift test` on a dev machine doesn't pay that cost.
+    func skipUnlessQualityRun() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_QUALITY_TESTS"] == "1",
+            "Set RUN_QUALITY_TESTS=1 to run quality regression tests",
+        )
+    }
+
+    /// App version recorded in `QualityResult` rows. Bundle's
+    /// `CFBundleShortVersionString` when hosted in the app, "dev" under raw
+    /// `swift test`.
+    var qualityAppVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "dev"
+    }
+}
+
 // MARK: - WatchLoop / AppState Helpers
 
 /// Returns a MeetingDetector with no patterns — never matches any window.


### PR DESCRIPTION
## Summary

Adds `FluidDiarizerQualityTests` — the diarization arm of the existing quality regression suite. Until now we had WER coverage (`WhisperKitQualityTests`) but **no DER coverage**, so any diarization regression — Sortformer model swap, OfflineDiarizer config change, FluidAudio version bump — would silently shift baselines without surfacing in CI.

## What's new

- 4 new tests in `FluidDiarizerQualityTests`: 2 fixtures × 2 modes (offline + sortformer)
- Each test loads the shared `GroundTruth.load(named:)`, runs the diarizer end-to-end on the production CoreML models, computes DER vs the reference turns, and appends a `QualityResult` row to the same `QualityResultsWriter` singleton the WER suite uses
- Shared helper `skipUnlessQualityRun()` + `qualityAppVersion` extracted to `TestHelpers.swift`, dedup'd in WhisperKitQualityTests
- One-line filter bump in `quality-and-safety.yml` so the new class actually runs

## Local baselines (M3 Max, 2026-05-10)

| Engine | Fixture | DER |
|---|---|---|
| `fluidDiarizer.sortformer` | two_speakers_de | 0.0597 |
| `fluidDiarizer.sortformer` | three_speakers_de | 0.0898 |
| `fluidDiarizer.offline` | two_speakers_de | 0.5325 |
| `fluidDiarizer.offline` | three_speakers_de | 0.6811 |

Sortformer is overlap-aware end-to-end and handles the short fixtures (17 s and 31 s) cleanly. **Offline mode systematically under-clusters short audio**, collapsing both fixtures to a single speaker — that's a known limitation of embedding-based clustering on <30 s of speech, not a bug introduced by this PR. Documented inline on the threshold dictionary.

## Soft thresholds

Per-mode bounds set well above the observed baselines so the tests catch catastrophic regressions (model corrupted, audio not loaded, segments=0, DER → 1.0) without flapping on small variance:

- `offline`: 0.85
- `sortformer`: 0.50

A future "fix offline mode for short fixtures" PR would tighten the offline threshold once it's earned.

## Why not parametrize the 4 tests into one?

Same reason the WER class has 2 explicit methods instead of a loop — `--filter test_offline_twoSpeakers_de_der` granularity for triaging single regressions.

## Test plan

- [x] `RUN_QUALITY_TESTS=1 swift test --filter "FluidDiarizerQualityTests|WhisperKitQualityTests"` locally — 6 tests, 0 failures, ~24 s wall
- [x] `./scripts/lint.sh` — clean
- [x] Verified `quality-results.json` contains all 4 new DER rows + 2 WER rows
- [x] Regression check on `FluidDiarizerTests | FluidDiarizerSortformerTests | DERCalculatorTests | GroundTruthTests | QualityResultsTests` — 33 tests, 0 failures
- [x] Mac mini: 6/6 green, 124 s wall