### PR TITLE
test(e2e): expand multi-format ingestion to all 7 fixture formats

### DIFF
--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -352,15 +352,22 @@ final class WhisperKitE2ETests: XCTestCase {
         await engine.loadModel()
         XCTAssertEqual(engine.modelState, .loaded)
 
-        let wavTranscript = try await transcribeFixture("two_speakers_de.wav", engine: engine)
-        let mp3Transcript = try await transcribeFixture("two_speakers_de.mp3", engine: engine)
-        let m4aTranscript = try await transcribeFixture("two_speakers_de.m4a", engine: engine)
-        let mp4Transcript = try await transcribeFixture("two_speakers_de.mp4", engine: engine)
+        // Each entry covers one ingestion path:
+        //   - WAV/MP3/M4A/MP4 ride the AVAudioFile/AVAsset tier of `AudioMixer`
+        //   - MKV/WebM/OGG only decode through the FFmpegHelper fallback,
+        //     so they're skipped on hosts without ffmpeg installed.
+        let stem = "two_speakers_de"
+        let formats: [(ext: String, label: String)] = [
+            ("wav", "WAV"), ("mp3", "MP3"), ("m4a", "M4A"), ("mp4", "MP4"),
+            ("mkv", "MKV"), ("webm", "WebM"), ("ogg", "OGG"),
+        ]
 
-        // Verify each format produces the expected German content
-        assertTranscriptContent(wavTranscript, format: "WAV")
-        assertTranscriptContent(mp3Transcript, format: "MP3")
-        assertTranscriptContent(m4aTranscript, format: "M4A")
-        assertTranscriptContent(mp4Transcript, format: "MP4")
+        for entry in formats {
+            if FFmpegHelper.ffmpegOnlyExtensions.contains(entry.ext), !FFmpegHelper.isAvailable {
+                continue
+            }
+            let transcript = try await transcribeFixture("\(stem).\(entry.ext)", engine: engine)
+            assertTranscriptContent(transcript, format: entry.label)
+        }
     }
 }


### PR DESCRIPTION
## Summary

`testTranscribeMultiFormatContent` was hard-coded to test only WAV/MP3/M4A/MP4 even though the repo already shipped `Tests/Fixtures/two_speakers_de.{mkv,webm,ogg}` from earlier multi-format work — those three fixtures were dead bytes. This PR turns the test into a loop over all seven extensions and skips the FFmpegHelper-only formats on hosts without ffmpeg.

## Why this matters

The pre-change test only exercised the **AVAudioFile/AVAsset** tier of `AudioMixer.loadAudioAsFloat32()`. The third tier — `FFmpegHelper` fallback for MKV/WebM/OGG — had **no end-to-end coverage**. A regression that broke `FFmpegHelper.ffmpegPath` detection, the CLI argument shape, or temp-file handling would have shipped silently. Now any such regression fails the test on every CI host with ffmpeg installed (Mac mini self-hosted runner has it via brew install ffmpeg).

## Skip behavior

`FFmpegHelper.ffmpegOnlyExtensions` (`{mkv, webm, ogg}`) drives the skip — same set the production app picker uses. Hosts without ffmpeg silently skip those three; the four native formats always run.

## Local validation

- `swift test --filter "WhisperKitE2ETests/testTranscribeMultiFormatContent"` → 18 s, all 7 formats transcribed (M3 Max, ffmpeg installed)
- Full `WhisperKitE2ETests` regression: 21/21 pass, 35 s
- `./scripts/lint.sh` clean

## Mini impact

~+7 s wall on Mini's existing `e2e.yml` WhisperKit suite (was ~21 tests, now adds 3 transcribes in the matrix test).

## Test plan

- [x] Local: all 7 formats transcribe non-empty German content
- [x] Local: lint clean
- [x] Local: regression sanity on full WhisperKitE2ETests class
- [ ] Mini `e2e.yml`: all 7 formats green