### PR TITLE
ci(appstore): smoke-launch the App Store variant on push + nightly

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -1,0 +1,99 @@
+name: App Store Smoke
+
+# Builds the App Store variant of the .app (sandbox + restricted entitlements,
+# `#if APPSTORE` source branches active) and verifies the resulting bundle
+# launches without crashing within the first 5 s.
+#
+# Why this exists: the `--appstore` build path has zero automated coverage
+# beyond compilation. Sandbox-rejected operations, `#if APPSTORE` regressions
+# in record-only output paths, broken dynamic linking, or wrong deployment
+# target all surface only at launch — and previously only when a human
+# happened to test the App Store variant. This workflow catches that class
+# of breakage on every push to main and nightly.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # Self-validate any PR that touches this workflow or the build script.
+    # Other PRs are NOT burdened — keeps the macos-26 runner budget for the
+    # cases where it actually matters.
+    paths:
+      - '.github/workflows/appstore.yml'
+      - 'scripts/build_release.sh'
+  push:
+    branches: [main]
+    paths:
+      - 'app/MeetingTranscriber/Sources/**'
+      - 'app/MeetingTranscriber/Package.swift'
+      - 'app/MeetingTranscriber/Package.resolved'
+      - 'app/MeetingTranscriber/Entitlements/AppStore.entitlements'
+      - 'app/MeetingTranscriber/Sources/Info.plist'
+      - 'tools/audiotap/**'
+      - 'scripts/build_release.sh'
+      - '.github/workflows/appstore.yml'
+  schedule:
+    # 03:30 UTC sits between quality-and-safety (03:00) and e2e-app (04:30) so
+    # concurrent failures are easy to disambiguate in `gh run list`.
+    - cron: '30 3 * * *'
+
+# Two parallel runs would race on the build dir and the launched app process.
+concurrency:
+  group: appstore-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: macos-26
+    timeout-minutes: 25
+    env:
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify toolchain
+        run: |
+          xcode-select -p
+          swift --version
+
+      # `--no-notarize` keeps the signing path on the ad-hoc fallback so we
+      # don't need a Developer ID secret for a smoke run. `build_release.sh`
+      # detects an empty DEVELOPER_ID and falls back automatically.
+      - name: Build App Store variant
+        run: ./scripts/build_release.sh --appstore --no-notarize
+
+      # Launch the bundle non-modally and verify it survives 5 s. A regression
+      # that breaks `#if APPSTORE`, sandbox entitlements, or dynamic linking
+      # crashes within the first second; the 5 s window gives enough margin
+      # without being so long that a stuck-on-startup launch loops forever.
+      - name: Smoke-launch the .app
+        run: |
+          set -euo pipefail
+          # `open` requires an absolute path (or a bundle ID / registered
+          # name); a relative path resolves to "Unable to find application".
+          APP="$GITHUB_WORKSPACE/.build/release/MeetingTranscriber.app"
+          if [ ! -d "$APP" ]; then
+            echo "Build artifact missing at $APP. Contents of .build/release/:"
+            ls -la "$GITHUB_WORKSPACE/.build/release/" || true
+            exit 1
+          fi
+          # `open -na` launches a fresh instance even if a stale one happens
+          # to be running. The runner is fresh per job, but cheap insurance.
+          open -na "$APP"
+          sleep 5
+          if ! pgrep -x MeetingTranscriber >/dev/null; then
+            echo "MeetingTranscriber died within 5 s of launch."
+            echo "--- Recent crash report (if any): ---"
+            ls -t ~/Library/Logs/DiagnosticReports/MeetingTranscriber-*.ips 2>/dev/null \
+              | head -1 | xargs cat 2>/dev/null || echo "no crash report found"
+            exit 1
+          fi
+          pkill -x MeetingTranscriber || true
+          echo "App Store smoke: bundle launched and survived 5 s"
+
+      - name: Upload crash reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-reports
+          path: ~/Library/Logs/DiagnosticReports/MeetingTranscriber-*.ips
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds `.github/workflows/appstore.yml` to give the App Store variant the automated coverage it currently lacks. Today the only signal that `--appstore` still works is "someone built it locally" — which means sandbox-rejected operations, regressions in `#if APPSTORE` source branches, broken dynamic linking, or wrong deployment targets can sit on main for days before anyone notices.

## What this catches

The 5-second smoke launch is enough to surface every regression that fires in the first second of process startup:

- a sandbox entitlement that no longer permits a startup operation
- a `#if APPSTORE` branch that compiles but immediately crashes (e.g. a static let initializer that hits a sandbox-rejected path)
- a Swift Package or dynamic library that doesn't ship in the sandboxed bundle
- a wrong `MACOSX_DEPLOYMENT_TARGET` that builds but won't load on macOS 14
- ad-hoc signing rejecting an entitlement combination

Anything that requires user interaction (mic permission prompt, model download) is out of scope — it would need a real run, which `e2e-app.yml` already covers for the Homebrew variant.

## Workflow shape

- **Runner:** `macos-26` GitHub-hosted (not the self-hosted Mini — decoupled from the Mini queue, doesn't mutate Mini's TCC state)
- **Build:** `./scripts/build_release.sh --appstore --no-notarize` — falls back to ad-hoc signing when no Developer ID is available, so no secrets needed
- **Smoke:** `open -na .build/release/MeetingTranscriber.app` → 5 s sleep → `pgrep -x MeetingTranscriber`. Fails the job if the process is gone, dumping the most recent crash report from `~/Library/Logs/DiagnosticReports/`
- **Triggers:** push to main on relevant paths (Sources, Entitlements, Info.plist, AudioTapLib, build_release.sh, this YAML), manual dispatch, nightly cron at 03:30 UTC
- **Concurrency:** group per ref + cancel-in-progress so main pushes don't queue up behind the cron

## Cron slot

03:30 UTC sits between `quality-and-safety` (03:00) and `e2e-app` (04:30) so concurrent failures stay easy to disambiguate in `gh run list`.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Lint clean
- [x] First CI run on the PR branch comes back green
- [ ] Nightly cron fires once main is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->