### PR TITLE
test(quality): add Parakeet WER coverage + hoist shared fixture helper

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -115,7 +115,7 @@ jobs:
           RUN_QUALITY_TESTS: "1"
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
           WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
-        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests"
+        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests"
       - name: Upload quality results
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/MeetingTranscriber/Tests/Quality/ParakeetQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/ParakeetQualityTests.swift
@@ -1,0 +1,48 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Production-model Parakeet quality tests. Skipped by default — gated by
+/// `RUN_QUALITY_TESTS=1` so a normal `swift test` run on a dev machine
+/// doesn't pull the ~50 MB FluidAudio model bundle. CI's quality job sets
+/// the env var.
+///
+/// Computes WER per fixture and appends rows to `QualityResultsWriter`.
+/// Pairs with `WhisperKitQualityTests` (Whisper) and the future Qwen3
+/// quality class so a single quality artifact contains baselines across
+/// all three ASR engines plus the diarizer DER rows.
+///
+/// Parakeet auto-detects language — there's no `engine.language = "de"`
+/// equivalent. As of 2026-05-10, WER on the German fixtures runs ~0.45-0.46
+/// vs WhisperKit's ~0.23-0.29 with explicit `language="de"`. Auto-detect on
+/// short (<30 s) German audio is the likely cause; the numbers are still
+/// useful as a regression baseline, just don't read them as quality parity.
+@MainActor
+final class ParakeetQualityTests: XCTestCase {
+    func test_parakeet_twoSpeakers_de_wer() async throws {
+        try skipUnlessQualityRun()
+        try await runFixture(named: "two_speakers_de")
+    }
+
+    func test_parakeet_threeSpeakers_de_wer() async throws {
+        try skipUnlessQualityRun()
+        try await runFixture(named: "three_speakers_de")
+    }
+
+    // Threshold 0.6 sits ~12-15 % above the current baseline (~0.45-0.46) so
+    // the test catches catastrophic breakage (model corrupted, language
+    // auto-detect misfiring, audio not loaded) without flapping on minor
+    // variance.
+    private func runFixture(named name: String) async throws {
+        let engine = ParakeetEngine()
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Parakeet model failed to load")
+
+        try await runWERAgainstFixture(
+            named: name,
+            engine: engine,
+            engineLabel: "parakeet",
+            modelVariant: nil,
+            threshold: 0.6,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
@@ -16,66 +16,30 @@ final class WhisperKitQualityTests: XCTestCase {
 
     func test_whisperKit_twoSpeakers_de_wer() async throws {
         try skipUnlessQualityRun()
-        try await runWERFixture(named: "two_speakers_de")
+        try await runFixture(named: "two_speakers_de")
     }
 
     func test_whisperKit_threeSpeakers_de_wer() async throws {
         try skipUnlessQualityRun()
-        try await runWERFixture(named: "three_speakers_de")
+        try await runFixture(named: "three_speakers_de")
     }
 
-    // MARK: - Helpers
-
-    private func runWERFixture(named name: String) async throws {
-        let truth = try GroundTruth.load(named: name)
-        try XCTSkipUnless(
-            FileManager.default.fileExists(atPath: truth.audioURL.path),
-            "Audio fixture missing: \(truth.audioURL.path)",
-        )
-
+    // Soft threshold of 0.5 catches catastrophic breakage (corrupted model,
+    // audio not loaded, biasing prompt destroying decoding) but stays well
+    // above the production baseline (~0.23-0.29 with explicit `language=de`).
+    private func runFixture(named name: String) async throws {
         let engine = WhisperKitEngine()
         engine.modelVariant = modelVariant
         engine.language = "de"
-
-        let started = Date()
         await engine.loadModel()
         XCTAssertEqual(engine.modelState, .loaded, "WhisperKit model failed to load")
 
-        let segments = try await engine.transcribeSegments(audioPath: truth.audioURL)
-        let hypothesis = segments.map(\.text).joined(separator: " ")
-        let breakdown = WERCalculator.werBreakdown(
-            reference: truth.text,
-            hypothesis: hypothesis,
+        try await runWERAgainstFixture(
+            named: name,
+            engine: engine,
+            engineLabel: "whisperKit",
+            modelVariant: modelVariant,
+            threshold: 0.5,
         )
-
-        let elapsed = Date().timeIntervalSince(started)
-        QualityResultsWriter.shared.append(
-            QualityResult(
-                engine: "whisperKit",
-                fixture: name,
-                modelVariant: modelVariant,
-                wer: breakdown.wer,
-                der: nil,
-                werBreakdown: .init(breakdown),
-                derBreakdown: nil,
-                appVersion: qualityAppVersion,
-                timestamp: ISO8601DateFormatter().string(from: started),
-                durationSeconds: elapsed,
-            ),
-        )
-
-        // Soft sanity bound — the production model on clean German audio
-        // should be well under 30 % WER on these fixtures. This is not a
-        // strict pass/fail threshold, just an early warning that something
-        // is catastrophically broken (e.g. model download corrupted, audio
-        // not loaded, biasing prompt destroying decoding).
-        XCTAssertLessThan(
-            breakdown.wer,
-            0.5,
-            "WER too high: \(breakdown.wer) — hypothesis was: \(hypothesis)",
-        )
-
-        // Flush eagerly so even a later test crash doesn't lose this row.
-        _ = try? QualityResultsWriter.shared.flush()
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -106,6 +106,61 @@ extension XCTestCase {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
             ?? "dev"
     }
+
+    /// Standard WER quality flow against a ground-truth fixture using an
+    /// already-loaded engine. Computes WER, appends a `QualityResult` row to
+    /// the shared writer, flushes eagerly so a later test crash doesn't lose
+    /// data, then soft-asserts the WER is below `threshold`.
+    ///
+    /// Engine instantiation, model load, and `modelState` verification stay
+    /// in the calling test method because each engine has different load
+    /// semantics and configuration knobs (WhisperKit needs `modelVariant +
+    /// language`; Parakeet auto-detects; Qwen3 is `@available(macOS 15+)`).
+    @MainActor
+    func runWERAgainstFixture(
+        named fixture: String,
+        engine: any TranscribingEngine,
+        engineLabel: String,
+        modelVariant: String?,
+        threshold: Double,
+    ) async throws {
+        let truth = try GroundTruth.load(named: fixture)
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: truth.audioURL.path),
+            "Audio fixture missing: \(truth.audioURL.path)",
+        )
+
+        let started = Date()
+        let segments = try await engine.transcribeSegments(audioPath: truth.audioURL)
+        let hypothesis = segments.map(\.text).joined(separator: " ")
+        let breakdown = WERCalculator.werBreakdown(
+            reference: truth.text,
+            hypothesis: hypothesis,
+        )
+
+        let elapsed = Date().timeIntervalSince(started)
+        QualityResultsWriter.shared.append(
+            QualityResult(
+                engine: engineLabel,
+                fixture: fixture,
+                modelVariant: modelVariant,
+                wer: breakdown.wer,
+                der: nil,
+                werBreakdown: .init(breakdown),
+                derBreakdown: nil,
+                appVersion: qualityAppVersion,
+                timestamp: ISO8601DateFormatter().string(from: started),
+                durationSeconds: elapsed,
+            ),
+        )
+        _ = try? QualityResultsWriter.shared.flush()
+
+        XCTAssertLessThan(
+            breakdown.wer,
+            threshold,
+            "\(engineLabel) WER too high: \(breakdown.wer) — hypothesis was: \(hypothesis)",
+        )
+    }
 }
 
 // MARK: - WatchLoop / AppState Helpers


### PR DESCRIPTION
## Summary

Parakeet (FluidAudio Parakeet TDT v3) had no automated WER coverage. A FluidAudio bump, a Parakeet model swap, or a regression in the auto-language-detection path could shift the baseline silently. This PR fills the gap and refactors the per-engine boilerplate into a shared helper so the upcoming Qwen3 quality class lands zero-copy.

## What's new

**Refactor (commit 1):** `XCTestCase.runWERAgainstFixture(...)` in `TestHelpers.swift` owns the post-load pipeline — load ground truth, transcribe, compute WER, append a `QualityResult` row, flush, soft-assert under threshold. Engine instantiation + model load + `modelState` verification stay in the calling test method because each engine has different load semantics (WhisperKit needs `modelVariant + language`; Parakeet auto-detects; Qwen3 is `@available(macOS 15+)`).

`WhisperKitQualityTests` migrates as the proof-of-life — class shrinks from 81 to 44 lines with byte-equivalent test behaviour.

**New tests (commit 2):** `ParakeetQualityTests` runs the same German fixtures (`two_speakers_de`, `three_speakers_de`) through the shared helper.

**CI wiring (commit 3):** one-line append to the `--filter` alternation in `quality-and-safety.yml`.

## Local baselines (M3 Max, 2026-05-10)

| Engine | Fixture | WER |
|---|---|---|
| `parakeet` | two_speakers_de | 0.464 |
| `parakeet` | three_speakers_de | 0.453 |

Soft threshold 0.6 sits ~12-15 % above today's baselines — wide enough to absorb run-to-run variance, tight enough to flag catastrophic breakage (model corrupted, language auto-detect picking the wrong language, audio not loaded).

**Heads-up:** Parakeet's WER is materially worse than WhisperKit's (~0.45 vs ~0.23-0.29 with explicit `language="de"`). This is auto-detect on <30 s of speech being an unfair contest, not a regression introduced here. Documented inline in the class comment so future readers don't mis-read the numbers as quality parity.

## Test plan

- [x] `RUN_QUALITY_TESTS=1 swift test --filter "ParakeetQualityTests|WhisperKitQualityTests|FluidDiarizerQualityTests"` — 8/8 pass, ~25 s wall locally
- [x] Lint clean
- [x] Verified `quality-results.json` contains the new Parakeet rows
- [ ] Mini quality job green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->