### PR TITLE
test(quality): add Qwen3-ASR WER coverage

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -136,7 +136,7 @@ jobs:
           RUN_QUALITY_TESTS: "1"
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
           WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
-        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests|Qwen3AsrEngineQualityTests"
+        run: cd app/MeetingTranscriber && swift test --filter "Qwen3AsrEngineQualityTests"
       - name: Upload quality results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -136,7 +136,7 @@ jobs:
           RUN_QUALITY_TESTS: "1"
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
           WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
-        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests"
+        run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests|Qwen3AsrEngineQualityTests"
       - name: Upload quality results
         if: always()
         uses: actions/upload-artifact@v7

--- a/app/MeetingTranscriber/Tests/Quality/Qwen3AsrEngineQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/Qwen3AsrEngineQualityTests.swift
@@ -1,0 +1,53 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Production-model Qwen3-ASR quality tests. Skipped by default — gated by
+/// `RUN_QUALITY_TESTS=1` so a normal `swift test` run on a dev machine
+/// doesn't pull the ~1.75 GB CoreML f32 bundle. CI's quality job sets the
+/// env var.
+///
+/// Computes WER per fixture and appends rows to `QualityResultsWriter`.
+/// Pairs with `WhisperKitQualityTests` (Whisper) and `ParakeetQualityTests`
+/// so a single quality artifact contains baselines across all three ASR
+/// engines plus the diarizer DER rows.
+///
+/// Class-level `@available(macOS 15, *)` mirrors `Qwen3AsrEngine`'s gate
+/// (CoreML stateful models require macOS 15). The annotation is runtime-only
+/// — the file compiles fine against the package's macOS 14 deployment
+/// target; XCTest just skips the methods on macOS 14 hosts at discovery
+/// time.
+@available(macOS 15, *)
+@MainActor
+final class Qwen3AsrEngineQualityTests: XCTestCase {
+    func test_qwen3_twoSpeakers_de_wer() async throws {
+        try skipUnlessQualityRun()
+        try await runFixture(named: "two_speakers_de")
+    }
+
+    func test_qwen3_threeSpeakers_de_wer() async throws {
+        try skipUnlessQualityRun()
+        try await runFixture(named: "three_speakers_de")
+    }
+
+    // Threshold 0.6 sits ~10 % above the current baselines (two ≈ 0.32,
+    // three ≈ 0.51 as of 2026-05-10) — wide enough to absorb run-to-run
+    // variance, tight enough to flag catastrophic breakage. Qwen3 does
+    // accept an explicit `language="de"` hint (unlike Parakeet's
+    // auto-detect-only contract), but the model still misrecognises proper
+    // nouns + tech jargon on the three-speaker fixture, lifting WER above
+    // WhisperKit's level.
+    private func runFixture(named name: String) async throws {
+        let engine = Qwen3AsrEngine()
+        engine.language = "de"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Qwen3-ASR model failed to load")
+
+        try await runWERAgainstFixture(
+            named: name,
+            engine: engine,
+            engineLabel: "qwen3",
+            modelVariant: nil,
+            threshold: 0.6,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/Quality/Qwen3AsrEngineQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/Qwen3AsrEngineQualityTests.swift
@@ -36,7 +36,31 @@ final class Qwen3AsrEngineQualityTests: XCTestCase {
     // auto-detect-only contract), but the model still misrecognises proper
     // nouns + tech jargon on the three-speaker fixture, lifting WER above
     // WhisperKit's level.
+    //
+    // Round-trips the fixture through `AudioMixer.loadAudioFileAsFloat32`
+    // → `AudioMixer.saveWAV` before transcription. Without this, the Mini
+    // CI run produced garbage tokens (single Cyrillic chars / punctuation)
+    // even though the fixture is already 16 kHz mono PCM. The same
+    // round-trip is what `Qwen3E2ETests` does, and that test runs green
+    // on Mini against the top-level fixture. Cause not yet root-caused,
+    // but mirroring the working test's ingestion path normalises whatever
+    // Qwen3's loader is choking on.
     private func runFixture(named name: String) async throws {
+        let truth = try GroundTruth.load(named: name)
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: truth.audioURL.path),
+            "Audio fixture missing: \(truth.audioURL.path)",
+        )
+
+        let tmpDir = try makeTempDirectory(prefix: "qwen3_quality")
+        let resampled16k = tmpDir.appendingPathComponent("resampled_16k.wav")
+        let samples = try AudioMixer.loadAudioFileAsFloat32(url: truth.audioURL)
+        try AudioMixer.saveWAV(
+            samples: samples,
+            sampleRate: AudioConstants.targetSampleRate,
+            url: resampled16k,
+        )
+
         let engine = Qwen3AsrEngine()
         engine.language = "de"
         await engine.loadModel()
@@ -48,6 +72,7 @@ final class Qwen3AsrEngineQualityTests: XCTestCase {
             engineLabel: "qwen3",
             modelVariant: nil,
             threshold: 0.6,
+            audioPathOverride: resampled16k,
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -123,6 +123,7 @@ extension XCTestCase {
         engineLabel: String,
         modelVariant: String?,
         threshold: Double,
+        audioPathOverride: URL? = nil,
     ) async throws {
         let truth = try GroundTruth.load(named: fixture)
         try XCTSkipUnless(
@@ -130,8 +131,9 @@ extension XCTestCase {
             "Audio fixture missing: \(truth.audioURL.path)",
         )
 
+        let audioPath = audioPathOverride ?? truth.audioURL
         let started = Date()
-        let segments = try await engine.transcribeSegments(audioPath: truth.audioURL)
+        let segments = try await engine.transcribeSegments(audioPath: audioPath)
         let hypothesis = segments.map(\.text).joined(separator: " ")
         let breakdown = WERCalculator.werBreakdown(
             reference: truth.text,


### PR DESCRIPTION
## Summary

Closes the last gap in the WER quality matrix. Qwen3-ASR (FluidAudio Qwen3 0.6B) was the only production engine without regression coverage. A FluidAudio bump or a Qwen3 model swap could shift the baseline silently.

## What's new

- `Qwen3AsrEngineQualityTests` — 2 tests against `two_speakers_de` and `three_speakers_de`, feeding through the shared `runWERAgainstFixture` helper (same one Parakeet + WhisperKit use). Engine pins `language = "de"`.
- 1-line append to the `--filter` alternation in `quality-and-safety.yml`.
- `runWERAgainstFixture` gains an optional `audioPathOverride: URL?` parameter; defaults to nil so WhisperKit + Parakeet behaviour is unchanged.

## The Mini-bug round-trip workaround

Initial Mini live-run returned garbage tokens — single Cyrillic `б` on the two-speaker fixture, two punctuation chars on the three-speaker — even though local M3 Max gave reasonable German (WER 0.214 / 0.509) against the same code, same fixture, same language hint.

`Qwen3E2ETests.testTranscribeSegmentsProducesGermanContent` runs green on the same Mini. The only material difference between the working E2E call and the failing quality call was that the E2E test round-trips the fixture through `AudioMixer.loadAudioFileAsFloat32` → `AudioMixer.saveWAV` to a temp WAV before handing the path to the engine. Both files report identical ffprobe metadata (16 kHz mono PCM s16le); the round-trip rewrites bytes to Float32 PCM but reports the same shape — yet Qwen3's loader cares about something the round-trip normalises.

The Qwen3 quality test now mirrors that round-trip inline, then passes the temp path through the new `audioPathOverride`. Inline (vs sharing the resample helper) so the Mini-bug workaround is visible at the point of use; if a future investigation roots out the loader issue and removes the need for the round-trip, the delete is local to one file.

## Local baselines (M3 Max, 2026-05-10)

| Engine | Fixture | WER |
|---|---|---|
| `qwen3` | two_speakers_de | 0.214 |
| `qwen3` | three_speakers_de | 0.509 |

Soft threshold 0.6 sits ~10 % above the higher baseline. Wide enough to absorb run-to-run variance, tight enough to flag catastrophic breakage (model corrupted, language hint ignored, audio not loaded).

For comparison after this PR lands, `quality-results.json` carries:

| Engine | two_speakers_de | three_speakers_de |
|---|---|---|
| `whisperKit` (large-v3-turbo, language=de) | 0.286 | 0.226 |
| `parakeet` (auto-detect) | 0.464 | 0.453 |
| `qwen3` (language=de) | 0.214 | 0.509 |

Qwen3 actually beats WhisperKit on the two-speaker fixture (0.21 vs 0.29) but trails on the three-speaker one (0.51 vs 0.23). Proper-noun + tech-jargon substitutions in the longer audio drive the gap.

## macOS gate

Class-level `@available(macOS 15, *)` mirrors `Qwen3AsrEngine`'s gate — CoreML stateful models need macOS 15+. The annotation is runtime-only; the file compiles fine against the package's macOS 14 deployment target, XCTest just skips the methods at discovery time on older hosts.

## Test plan

- [x] `RUN_QUALITY_TESTS=1 swift test --filter "WhisperKitQualityTests|ParakeetQualityTests|Qwen3AsrEngineQualityTests|FluidDiarizerQualityTests"` → all pass locally
- [x] Lint clean
- [x] Verified all four engine rows land in `quality-results.json`
- [ ] Mini quality job green with the round-trip workaround (initial run without it failed; resume run pending)