### PR TITLE
ci: extract 4 composite actions + centralize paths-filter

### DIFF
--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -1,0 +1,22 @@
+name: "Cancel run on failure"
+description: >
+  Cancels sibling jobs in the current workflow run when the calling job
+  has failed. The workflow-level `concurrency` block only cancels
+  superseded runs of the same ref — it doesn't react to a single job
+  failing inside a run, so this composite fills the gap.
+
+  Caller must wrap the step in `if: failure()` so the cancellation is
+  scoped to actual failure (composite actions cannot have a top-level
+  step-level `if`). The inner step swallows errors via continue-on-error
+  so a transient gh CLI hiccup doesn't mask the original failure.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cancel current workflow run
+      shell: bash
+      continue-on-error: true
+      run: gh run cancel "$RUN_ID"
+      env:
+        RUN_ID: ${{ github.run_id }}
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/install-developer-id/action.yml
+++ b/.github/actions/install-developer-id/action.yml
@@ -1,0 +1,77 @@
+name: "Install Developer ID certificate"
+description: >
+  Imports a base64-encoded Developer ID Application (.p12) certificate into
+  a fresh per-job keychain so `codesign` can find it. Used by release.yml
+  for signing the distributable .app and by e2e-app.yml for re-signing the
+  deployed dev bundle. Caller is responsible for cleanup via
+  `security delete-keychain "$KEYCHAIN_PATH"` in an `if: always()` step.
+
+inputs:
+  cert:
+    description: "Base64-encoded .p12 certificate. If empty, the action is a no-op."
+    required: false
+    default: ""
+  cert-password:
+    description: "Password for the .p12 certificate."
+    required: false
+    default: ""
+  keychain-name:
+    description: >
+      Filename for the temporary keychain inside RUNNER_TEMP. Distinguish
+      callers when more than one keychain might co-exist on the runner
+      (relevant on self-hosted hosts).
+    required: false
+    default: "app-signing.keychain-db"
+  extra-partition-roles:
+    description: >
+      Extra partition-list roles appended to `apple-tool:,apple:`, joined
+      by a comma. Pass without leading or trailing commas (e.g.
+      `codesign:`). e2e-app needs `codesign:` because it shells out to
+      `codesign` directly; the release path doesn't because
+      xcodebuild/build_release.sh uses the `apple-tool:` role.
+    required: false
+    default: ""
+
+outputs:
+  keychain-path:
+    description: "Absolute path to the created keychain. Empty when cert input was empty."
+    value: ${{ steps.create.outputs.keychain-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: create
+      if: inputs.cert != ''
+      shell: bash
+      env:
+        DEVELOPER_ID_CERT: ${{ inputs.cert }}
+        DEVELOPER_ID_CERT_PASSWORD: ${{ inputs.cert-password }}
+        KEYCHAIN_NAME: ${{ inputs.keychain-name }}
+        EXTRA_PARTITION_ROLES: ${{ inputs.extra-partition-roles }}
+      run: |
+        set -euo pipefail
+        KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_NAME"
+        KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        CERT_PATH="$RUNNER_TEMP/${KEYCHAIN_NAME%.keychain-db}.p12"
+        echo -n "$DEVELOPER_ID_CERT" | base64 --decode -o "$CERT_PATH"
+        security import "$CERT_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
+          -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+
+        PARTITION_LIST="apple-tool:,apple:"
+        if [ -n "$EXTRA_PARTITION_ROLES" ]; then
+          # Strip stray leading/trailing commas so callers don't have to
+          # know the separator convention.
+          TRIMMED="${EXTRA_PARTITION_ROLES#,}"
+          TRIMMED="${TRIMMED%,}"
+          PARTITION_LIST="${PARTITION_LIST},${TRIMMED}"
+        fi
+        security set-key-partition-list -S "$PARTITION_LIST" \
+          -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+        echo "keychain-path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-swift-test/action.yml
+++ b/.github/actions/setup-swift-test/action.yml
@@ -21,6 +21,13 @@ inputs:
       sanitized builds are slower to warm.
     required: false
     default: ""
+  cache-models:
+    description: >
+      Cache the ML model directories and pre-warm them on cache miss.
+      Set to `false` for build-only jobs (release.yml) that don't load
+      models — skips both the cache restore and the prewarm step.
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -42,6 +49,7 @@ runs:
     # cache is populated and the preload step is skipped.
     - name: Cache ML models
       id: model-cache
+      if: inputs.cache-models == 'true'
       uses: actions/cache@v5
       with:
         path: |
@@ -55,6 +63,6 @@ runs:
     # outer `uses: ./.github/actions/setup-swift-test` step to bound the
     # cold-cache HuggingFace + FluidAudio download.
     - name: Pre-warm model cache (cache miss only)
-      if: steps.model-cache.outputs.cache-hit != 'true'
+      if: inputs.cache-models == 'true' && steps.model-cache.outputs.cache-hit != 'true'
       shell: bash
       run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ inputs.swift-flags }}

--- a/.github/actions/verify-xcode/action.yml
+++ b/.github/actions/verify-xcode/action.yml
@@ -1,0 +1,31 @@
+name: "Verify Xcode toolchain"
+description: >
+  Echoes the active developer dir + Swift version so failures from
+  pointing at the wrong toolchain (typically Command Line Tools instead
+  of a full Xcode install — XCTest then can't be imported) surface as a
+  clear early step rather than buried in a SwiftPM compile error half
+  the job later.
+
+  Also exports `DEVELOPER_DIR` to subsequent steps via $GITHUB_ENV so
+  callers don't have to repeat the job-level env block. Self-hosted
+  runners need the hint until `xcode-select -s` is run on the host;
+  GitHub-hosted runners point at Xcode out of the box but accept the
+  override harmlessly.
+
+inputs:
+  developer-dir:
+    description: "Value to export as DEVELOPER_DIR for subsequent steps."
+    required: false
+    default: "/Applications/Xcode.app/Contents/Developer"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify Xcode toolchain
+      shell: bash
+      env:
+        DEVELOPER_DIR: ${{ inputs.developer-dir }}
+      run: |
+        echo "DEVELOPER_DIR=$DEVELOPER_DIR" >> "$GITHUB_ENV"
+        xcode-select -p
+        swift --version

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,0 +1,13 @@
+# Shared dorny/paths-filter definitions. Referenced by ci.yml and release.yml
+# so docs-only PRs reliably skip both the test matrix and the DMG build.
+#
+# Use with `predicate-quantifier: every` — with the v4 default `some`, the
+# `**` catch-all alone marks every file as matched and the `!…` negations
+# never actually exclude anything.
+code:
+  - '**'
+  - '!*.md'
+  - '!**/*.md'
+  - '!docs/**'
+  - '!LICENSE'
+  - '!.gitignore'

--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -45,15 +45,10 @@ jobs:
   smoke:
     runs-on: macos-26
     timeout-minutes: 25
-    env:
-      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
     steps:
       - uses: actions/checkout@v6
 
-      - name: Verify toolchain
-        run: |
-          xcode-select -p
-          swift --version
+      - uses: ./.github/actions/verify-xcode
 
       # `--no-notarize` keeps the signing path on the ad-hoc fallback so we
       # don't need a Developer ID secret for a smoke run. `build_release.sh`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,9 @@ jobs:
         run: swiftlint lint --strict --reporter github-actions-logging
       - name: Build script regression tests
         run: bash scripts/tests/test_build_release_signing.sh
-      # Cancels sibling jobs in this run; the workflow-level `concurrency`
-      # block only cancels superseded runs of the same ref.
       - name: Cancel run on failure
         if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/cancel-on-failure
 
   analyze:
     needs: changes
@@ -93,10 +88,7 @@ jobs:
           swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging
       - name: Cancel run on failure
         if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/cancel-on-failure
 
   test:
     needs: changes
@@ -132,7 +124,4 @@ jobs:
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}
       - name: Cancel run on failure
         if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,23 +26,22 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code || 'true' }}
     steps:
+      # Needed so dorny/paths-filter can read .github/filters.yml from the
+      # workspace; the action otherwise hits the GitHub API for the file
+      # list but still needs the filter definition locally.
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
       - if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v4
         id: filter
         with:
-          # `every` is required for the exclusion-style filter below: with the
-          # v4 default `some`, the `**` catch-all alone marks every file as
-          # matched and the `!…` negations never actually exclude anything,
-          # so docs-only PRs still trigger the full build/test suite.
+          # `every` is required for the exclusion-style filter in
+          # .github/filters.yml: with the v4 default `some`, the `**`
+          # catch-all alone marks every file as matched and the `!…`
+          # negations never actually exclude anything, so docs-only PRs
+          # still trigger the full build/test suite.
           predicate-quantifier: every
-          filters: |
-            code:
-              - '**'
-              - '!*.md'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!LICENSE'
-              - '!.gitignore'
+          filters: .github/filters.yml
 
   lint:
     needs: changes

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -33,18 +33,11 @@ jobs:
   e2e-app:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v6
 
-      # Sanity — fail fast with a clear message if Xcode isn't pointed at
-      # the right toolchain. e2e.yml does the same dance.
-      - name: Verify toolchain
-        run: |
-          xcode-select -p
-          swift --version
+      - uses: ./.github/actions/verify-xcode
 
       # Import the Developer ID Application cert into a temporary keychain
       # so codesign can find it. Apple roots are in the system trust store

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -46,39 +46,31 @@ jobs:
           xcode-select -p
           swift --version
 
-      # Same dance as release.yml: import the Developer ID Application
-      # cert into a temporary keychain so codesign can find it. Apple
-      # roots are in the system trust store already, so the resulting
-      # signature satisfies the dev .app's PPPC code requirement out of
-      # the box — no add-trusted-cert ceremony needed. If the secret
-      # isn't set, fall through to the self-signed path that
-      # setup-self-hosted-runner.sh installed (env var stays empty,
-      # e2e-app.sh detects this and signs with the local dev cert).
+      # Import the Developer ID Application cert into a temporary keychain
+      # so codesign can find it. Apple roots are in the system trust store
+      # already, so the resulting signature satisfies the dev .app's PPPC
+      # code requirement out of the box — no add-trusted-cert ceremony
+      # needed. If the secret isn't set, the action becomes a no-op and
+      # e2e-app.sh falls back to the self-signed path that
+      # setup-self-hosted-runner.sh installed.
       - name: Install Developer ID certificate
-        env:
-          DEVELOPER_ID_CERT: ${{ secrets.DEVELOPER_ID_CERT }}
-          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
-        if: env.DEVELOPER_ID_CERT != ''
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/e2e-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        id: dev-id
+        uses: ./.github/actions/install-developer-id
+        with:
+          cert: ${{ secrets.DEVELOPER_ID_CERT }}
+          cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          keychain-name: e2e-signing.keychain-db
+          # e2e-app.sh shells out to `codesign` directly to re-sign the
+          # deployed bundle; release.yml builds via xcodebuild and doesn't
+          # need this extra role.
+          extra-partition-roles: "codesign:"
 
-          CERT_PATH=$RUNNER_TEMP/e2e-cert.p12
-          echo -n "$DEVELOPER_ID_CERT" | base64 --decode -o "$CERT_PATH"
-          security import "$CERT_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
-
-          # Hand the keychain path to e2e-app.sh so it can re-sign the
-          # deployed bundle with this cert too. Stable across runs because
-          # Apple Developer ID cert SHA doesn't change — TCC keeps the
-          # grant.
-          echo "E2E_SIGNING_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+      # Hand the keychain path to e2e-app.sh so it can re-sign the
+      # deployed bundle with this cert too. Stable across runs because
+      # Apple Developer ID cert SHA doesn't change — TCC keeps the grant.
+      - name: Export keychain path for e2e-app.sh
+        if: steps.dev-id.outputs.keychain-path != ''
+        run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
 
       - name: Run live-recording E2E driver
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,12 +59,13 @@ jobs:
           echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
           echo "Running E2E tests with filter: $FILTER"
 
-      - name: Cache SPM dependencies
-        uses: actions/cache@v5
+      # Pre-warm covers the SPM cache + ~2.8 GB of WhisperKit + Parakeet
+      # + Qwen3 weights that the engine E2E tests would otherwise
+      # sequentially download on a cold run.
+      - uses: ./.github/actions/setup-swift-test
+        timeout-minutes: 30
         with:
-          path: app/MeetingTranscriber/.build
-          key: spm-e2e-${{ runner.os }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
-          restore-keys: spm-e2e-${{ runner.os }}-
+          cache-key-suffix: e2e
 
       - name: Run E2E tests
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,21 +31,11 @@ jobs:
     timeout-minutes: 60
     env:
       E2E_ENABLED: "1"
-      # Pin the toolchain to a full Xcode install. Without this the runner
-      # may default to the Command Line Tools, whose Swift toolchain ships
-      # without XCTest — `import XCTest` then fails when SwiftPM compiles
-      # test-only dependencies (swift-snapshot-testing, ViewInspector, …).
-      # GitHub-hosted runners point at Xcode out of the box; self-hosted
-      # runners need this hint until `xcode-select -s` is run on the host.
-      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Verify Xcode toolchain
-        run: |
-          xcode-select -p
-          swift --version
+      - uses: ./.github/actions/verify-xcode
 
       - name: Resolve test filter
         id: filter

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,14 +49,12 @@ jobs:
           echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
           echo "Running E2E tests with filter: $FILTER"
 
-      # Pre-warm covers the SPM cache + ~2.8 GB of WhisperKit + Parakeet
-      # + Qwen3 weights that the engine E2E tests would otherwise
-      # sequentially download on a cold run.
-      - uses: ./.github/actions/setup-swift-test
-        timeout-minutes: 30
-        with:
-          cache-key-suffix: e2e
-
+      # No actions/cache here: the self-hosted Mini has persistent disk
+      # between runs, so the SPM `.build` directory and the on-disk model
+      # caches (~/Documents/huggingface, ~/Library/Application Support/
+      # FluidAudio) are already populated. actions/cache would re-download
+      # via HTTPS on hit and waste the multi-GB upload on miss — the
+      # latter timed out the post-action on a real run (5.6 GB → GitHub).
       - name: Run E2E tests
         run: |
           cd app/MeetingTranscriber

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -78,10 +78,7 @@ jobs:
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure
         if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/cancel-on-failure
 
   quality-baseline:
     if: |
@@ -125,7 +122,4 @@ jobs:
           if-no-files-found: warn
       - name: Cancel run on failure
         if: failure()
-        continue-on-error: true
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,13 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Cache SPM dependencies
-        uses: actions/cache@v5
+      # Same SPM cache key as ci.yml — release builds reuse the test
+      # matrix's resolved artifacts. ML models aren't loaded by
+      # build_release.sh, so skip the model cache + prewarm.
+      - uses: ./.github/actions/setup-swift-test
         with:
-          path: app/MeetingTranscriber/.build
-          key: spm-${{ runner.os }}-${{ matrix.variant }}-${{ hashFiles('app/MeetingTranscriber/Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-${{ matrix.variant }}-
+          cache-key-suffix: ${{ matrix.variant }}
+          cache-models: "false"
 
       - name: Install Developer ID certificate
         id: dev-id

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,19 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code || 'true' }}
     steps:
+      # Needed so dorny/paths-filter can read .github/filters.yml from the
+      # workspace; see ci.yml for the same dance.
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
       - if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v4
         id: filter
         with:
-          filters: |
-            code:
-              - '**'
-              - '!*.md'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!LICENSE'
-              - '!.gitignore'
+          # `every` is required for the exclusion-style filter — without it,
+          # the v4 default `some` makes `**` match every file and the `!…`
+          # negations never apply, silently building DMGs for docs-only PRs.
+          predicate-quantifier: every
+          filters: .github/filters.yml
 
   build:
     needs: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,28 +71,11 @@ jobs:
           restore-keys: spm-${{ runner.os }}-${{ matrix.variant }}-
 
       - name: Install Developer ID certificate
-        env:
-          DEVELOPER_ID_CERT: ${{ secrets.DEVELOPER_ID_CERT }}
-          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
-        if: env.DEVELOPER_ID_CERT != ''
-        run: |
-          # Create temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import certificate
-          CERT_PATH=$RUNNER_TEMP/certificate.p12
-          echo -n "$DEVELOPER_ID_CERT" | base64 --decode -o "$CERT_PATH"
-          security import "$CERT_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: \
-            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Add to search list
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+        id: dev-id
+        uses: ./.github/actions/install-developer-id
+        with:
+          cert: ${{ secrets.DEVELOPER_ID_CERT }}
+          cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
 
       - name: Build .app and DMG
         env:
@@ -239,7 +222,5 @@ jobs:
           git push
 
       - name: Cleanup keychain
-        if: always()
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+        if: always() && steps.dev-id.outputs.keychain-path != ''
+        run: security delete-keychain "${{ steps.dev-id.outputs.keychain-path }}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Workflow-Review (alle 9 `.github/workflows/*.yml`) hat klare Wiederverwendungs-Patterns gezeigt. Diese PR extrahiert 4 Composite Actions und eine zentrale Filter-Datei und fixt im Vorbeigehen einen Bug in `release.yml`.

**Vorher:** ~200 Zeilen kopierte Boilerplate, ein silent-Bug, mehrere Drift-Risiken.
**Nachher:** 5 Single-Sources-of-Truth, jeder mit Rationale-Docstring.

## Changes (5 Commits, atomar)

1. **`ci: centralize paths-filter definition + fix release.yml docs-only bug`**
   - Neue `.github/filters.yml` als gemeinsamer Filter für `ci.yml` und `release.yml`.
   - **Bugfix:** `release.yml` hatte `predicate-quantifier: every` nicht gesetzt — mit dem v4-Default `some` matchte `**` immer und `!docs/**` / `!*.md` etc. griffen nie. Docs-only PRs lösten den vollen DMG-Build aus.

2. **`ci: extract Developer ID keychain setup into composite action`**
   - Neue `.github/actions/install-developer-id` mit Inputs (`cert`, `cert-password`, `keychain-name`, `extra-partition-roles`) und Output `keychain-path`.
   - Migration in `release.yml` und `e2e-app.yml` — eliminiert ~20 Zeilen identische `security`-Boilerplate × 2.
   - No-op wenn `cert` leer (preserviert Fallback auf self-signed Identität auf Hosts ohne Developer ID Secret).

3. **`ci: extract cancel-on-failure step into composite action`**
   - Neue `.github/actions/cancel-on-failure`.
   - Migration in 5 Stellen: `ci.yml` (3 Jobs) + `quality-and-safety.yml` (2 Jobs).

4. **`ci: adopt setup-swift-test in e2e.yml and release.yml`**
   - `e2e.yml` hatte vorher kein ML-Cache → Cold Runs luden ~2.8 GB sequenziell.
   - `release.yml` nutzt das SPM-Cache mit gleichem Key wie `ci.yml` → Test-Matrix und Release-Build teilen Artefakte.
   - `setup-swift-test` neuer Input `cache-models: false` für Build-only Jobs (skipt sowohl Cache als auch Pre-Warm).

5. **`ci: extract verify-xcode toolchain check into composite action`**
   - Neue `.github/actions/verify-xcode` mit optionalem `developer-dir` Input (default `/Applications/Xcode.app/Contents/Developer`) der via `\$GITHUB_ENV` an folgende Steps weitergegeben wird.
   - Migration in `e2e.yml`, `e2e-app.yml`, `appstore.yml` — eliminiert auch die 3× duplizierte Job-Level `DEVELOPER_DIR: …` env Block.

## Test plan

- [x] CI (`ci.yml`) grün auf diesem PR — bestätigt dass `filters.yml` + `cancel-on-failure` + `setup-swift-test` Migration funktionieren
- [ ] Release-Build-Job (`release.yml`) grün auf push to main — bestätigt `install-developer-id` + `setup-swift-test cache-models: false`
- [x] E2E (`e2e-app.yml`) grün post-merge — bestätigt `install-developer-id` mit `extra-partition-roles: codesign:`, `verify-xcode` Migration, Keychain-Path Output-Wiring
- [x] App Store Smoke (`appstore.yml`) grün post-merge — bestätigt `verify-xcode` mit `DEVELOPER_DIR` Export
- [x] Quality & Safety (`quality-and-safety.yml`) grün auf push-to-main / nightly — bestätigt `cancel-on-failure` Migration in beiden Sanitizer + Quality Jobs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

---

**Update 2026-05-10 evening:** Self-hosted Mini run revealed cache-action timeout on Post-step (5.6 GB upload to GitHub cache from persistent-disk runner). Test step itself was green. Added commit `dabbeaa` to drop `actions/cache` from `e2e.yml` — Mini's persistent disk makes the cache useless on hit (overwrite via HTTPS) and harmful on miss (multi-GB upload). `setup-swift-test` stays in ci.yml + release.yml (macos-26, ephemeral) where caching is genuinely useful.