### PR TITLE
chore(ci): align actions/upload-artifact on v7

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -79,7 +79,7 @@ jobs:
       # the driver failed before tearing it down.
       - name: Upload simulator log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: meeting-simulator.log
           path: /tmp/e2e-app-sim.log

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -115,7 +115,7 @@ jobs:
         run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests"
       - name: Upload quality results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quality-results
           path: ${{ github.workspace }}/quality-results.json


### PR DESCRIPTION
## Summary

- `release.yml` + `appstore.yml` were already pinned to `actions/upload-artifact@v7`.
- `e2e-app.yml` + `quality-and-safety.yml` lagged on `@v4`.
- All four now use `@v7` for consistency.

## Why safe

`v4 → v5` introduced artifact immutability (re-uploading to the same artifact name fails by default). None of our callers re-upload to the same name (`crash-reports`, `meeting-simulator.log`, `quality-results`, DMG-versioned names), so the behavior change doesn't affect us. `v5 → v6 → v7` are node-version bumps.

Latest tag confirmed via `gh api repos/actions/upload-artifact/releases/latest` → `v7.0.1`.

## Test plan

- [x] CI green on PR (lint, analyze, test).
- [ ] Manual sanity: trigger `quality-and-safety.yml` dispatch after merge → confirm `quality-results` artifact uploads.
- [ ] Manual sanity: trigger `e2e-app.yml` dispatch after merge → if `failure()` path triggers, confirm `meeting-simulator.log` uploads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->