### PR TITLE
ci(e2e-app): pin live-recording job to audio-labeled runner

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -31,7 +31,12 @@ concurrency:
 
 jobs:
   e2e-app:
-    runs-on: [self-hosted, macOS, ARM64]
+    # `audio` label pins the job to the runner that has exclusive access
+    # to the BlackHole virtual input device. A second runner on the same
+    # Mini handles other self-hosted workloads in parallel without
+    # racing for the audio stack — see runner labels via
+    # `gh api /repos/{owner}/{repo}/actions/runners`.
+    runs-on: [self-hosted, macOS, ARM64, audio]
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary

A second self-hosted runner (`mac-mini-runner-2`) now lives on the same Mac mini as the existing `mac-mini-runner`. Both pull from the shared runner pool for generic workloads (\`self-hosted, macOS, ARM64\`), so e2e fixture tests, quality-and-safety jobs, and any future sanitizer-on-Mini work can run in parallel.

The live-recording E2E in this workflow needs **exclusive** access to the BlackHole virtual input device — two parallel jobs would race for the audio stack and corrupt each other's recordings. Adds the \`audio\` label to \`runs-on\` so this workflow always picks the runner that owns the audio hardware.

## Runner layout post-PR

| Runner | Labels | Picks |
|---|---|---|
| \`mac-mini-runner\` (#1) | self-hosted, macOS, ARM64, ml-cache, **audio** | e2e-app exclusive + general |
| \`mac-mini-runner-2\` (#2) | self-hosted, macOS, ARM64 | General only (no audio) |

## Why now

- M4 Pro + 24 GB is overprovisioned for one runner — measured during a TSan run, swap stayed at 0 MB with 12 GB headroom.
- Nightly batches stack e2e (~10 min) + e2e-app (~14 min) + future Mini-sanitizer (~7 min) serially; with two runners the wall-clock drops to ~max(jobs).
- Parallel CPU jobs on Runner #2 can't disturb audio capture on Runner #1 because they don't touch \`coreaudiod\`'s exclusive client list.

## Test plan

- [x] Both runners online + correct labels (\`gh api /actions/runners\`).
- [ ] After merge: trigger \`e2e-app.yml\` dispatch — confirm it lands on \`mac-mini-runner\` only (\`runner_name\` in run logs).
- [ ] Trigger \`e2e.yml\` simultaneously — confirm it can land on either runner without blocking the audio job.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->