### PR TITLE
ci(qa): move TSan + ASan matrix to self-hosted Mac mini

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -41,8 +41,15 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer)
-    runs-on: macos-26
-    timeout-minutes: 60
+    # Self-hosted Mini absorbs sanitizer instrumentation 4× better than
+    # macos-26 GH-hosted (TSan ~6:41 vs ~25 min) and avoids the CoreML
+    # model-load assertion race that flaked WhisperKitEngineTests on
+    # macos-26. Sanitizer doesn't need the `audio` label, so either Mini
+    # runner picks up.
+    runs-on: [self-hosted, macOS, ARM64]
+    # ~7 min wall-clock observed; 20 min leaves room for cold-build
+    # variance while still surfacing runaways before they cost an hour.
+    timeout-minutes: 20
     permissions:
       contents: read
       actions: write
@@ -67,13 +74,14 @@ jobs:
     name: test (${{ matrix.variant }})
     steps:
       - uses: actions/checkout@v6
-      # 20 min covers SPM + ML cache restore plus the cold-cache pre-warm
-      # download; well below the 60 min job timeout so a hung download
-      # surfaces as a step failure, not a job-timeout.
-      - uses: ./.github/actions/setup-swift-test
-        timeout-minutes: 20
-        with:
-          cache-key-suffix: ${{ matrix.variant }}
+      - uses: ./.github/actions/verify-xcode
+      # No actions/cache: Mini has persistent disk (see e2e.yml).
+      # `mt-ci.keychain-db` is provisioned by scripts/setup-self-hosted-runner.sh
+      # and set as the runner user's default keychain so
+      # `KeychainHelper`-touching tests don't hit the locked login.keychain.
+      # Defensive re-unlock in case it auto-locked between runs.
+      - name: Ensure CI keychain unlocked
+        run: security unlock-keychain -p "" ~/Library/Keychains/mt-ci.keychain-db
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -206,6 +206,26 @@ codesign --force --sign "$CERT_HASH" \
 
 log "Signed: $(codesign -dv "$APP_BUNDLE_PATH" 2>&1 | grep -E 'Identifier|Authority' | head -2 | tr '\n' ' ')"
 
+# CI keychain for Security.framework-touching tests (KeychainHelper et al.)
+# under the runner's user-level launchd context. The runner spawns xctest
+# in a non-interactive context where the login.keychain returns
+# errSecInteractionNotAllowed even when auto-login + Aqua session are
+# active. A pre-staged unlocked keychain set as the user default sidesteps
+# both the lock state and per-user search-list mutation races between
+# parallel matrix jobs.
+CI_KEYCHAIN="$HOME/Library/Keychains/mt-ci.keychain-db"
+LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+if [[ -f "$CI_KEYCHAIN" ]]; then
+    log "CI keychain already at $CI_KEYCHAIN — re-unlocking + asserting default"
+    security unlock-keychain -p "" "$CI_KEYCHAIN"
+else
+    log "Creating CI keychain at $CI_KEYCHAIN (empty password, default)"
+    security create-keychain -p "" "$CI_KEYCHAIN"
+    security unlock-keychain -p "" "$CI_KEYCHAIN"
+fi
+security list-keychains -d user -s "$CI_KEYCHAIN" "$LOGIN_KEYCHAIN"
+security default-keychain -s "$CI_KEYCHAIN"
+
 cat <<MSG
 
 [setup] DONE. ✓


### PR DESCRIPTION
## Summary

Moves the sanitizer matrix (TSan + ASan) from `macos-26` GitHub-hosted to the self-hosted Mac mini. Driven by both speed and reliability:

- **Speed:** Mini (M4 Pro / 24 GB) runs TSan in **6:41**, macos-26 averaged **25-29 min** across 7 recent runs. ~4× wall-clock improvement.
- **Reliability:** macos-26 + TSan flakes on CoreML model-load assertions. Concrete instance: PR #233 post-merge push run failed on `WhisperKitEngineTests.testTranscribeGermanAudio` after 87 s with `modelState=Unloaded`. Sanitizer-slowed CoreML loses the race with `XCTAssertEqual(.loaded)` immediately after `await loadModel()`. The same test passes green on Mini.

`quality-baseline` stays on `macos-26` — only ~5 min, and keeping it on a different runner pool means a single Mini outage doesn't block all nightly QA.

## What this PR changes

`.github/workflows/quality-and-safety.yml`, `test-sanitizer` job:

1. `runs-on: [self-hosted, macOS, ARM64]` (was `macos-26`). Either Mini runner picks up — sanitizer doesn't need the `audio` label.
2. Drops `setup-swift-test` composite (= `actions/cache` wrapper). Persistent disk on Mini already keeps SPM `.build` and ML model caches. `actions/cache` save was timing out the post-step at multi-GB on sanitizer-mode `.build`. Same fix already applied in `e2e.yml`.
3. Adopts the in-tree `verify-xcode` composite action (same one `e2e.yml` and `e2e-app.yml` use) instead of an inline `env: DEVELOPER_DIR`. Earlier-failing toolchain check + one fewer drift point.
4. Single `Ensure CI keychain unlocked` step before `swift test`. Defensive `security unlock-keychain` on the shared CI keychain.
5. `timeout-minutes` tightened from 60 → 20. Observed wall-clock ~7 min, leaves room for cold-build variance.

`scripts/setup-self-hosted-runner.sh`: adds provisioning for a per-Mini `~/Library/Keychains/mt-ci.keychain-db` (empty password, set as the runner user's default keychain). Re-running the script is idempotent.

## Why a shared CI keychain instead of per-job

xctest spawned by the runner's user-level launchd service gets a non-interactive context where `SecItemAdd` / `SecItemUpdate` on the persistent login.keychain returns `errSecInteractionNotAllowed`. An earlier attempt to create + tear down an ephemeral test keychain per job hit a real race:

- Both Mini runners share the same `runner` OS user.
- `security default-keychain -s` and `security list-keychains -d user -s` mutate per-user state.
- When TSan and ASan ran in parallel, ASan's `Tear down test keychain` restored the default to login.keychain mid-TSan, and TSan's later Keychain operations silent-failed.
- Pinning the matrix to `max-parallel: 1` fixed it but doubled wall-clock.

Pre-staging one shared keychain once on the Mini removes the race entirely: jobs never mutate per-user state, parallel matrix works, no `max-parallel` restriction needed.

## Test plan

- [x] Pre-merge dispatch on Mini ran TSan + ASan in parallel, both green (run `25682991091`).
- [x] Local `swift build`, `./scripts/lint.sh` clean.
- [ ] Setup script extension verified by re-running on the Mini (idempotent — existing keychain re-unlocked, no recreate).
- [ ] After merge: nightly cron at 03:00 UTC and next push to main confirm Mini placement + the audio-labeled Runner #1 stays free for `e2e-app` when both workflows fire.