### PR TITLE
ci(e2e): trigger on push to main so tag gate has data

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,15 @@ on:
           - Qwen3
           - WatchLoop
   push:
+    # Trigger on every main push so the engine E2E run produces a status
+    # check on the same SHA that a future `v*` tag will point at. Tag
+    # rulesets can then gate on this check without falling into the
+    # chicken-and-egg of "tag fires e2e.yml, tag rejected because e2e.yml
+    # hasn't run yet." No paths-filter: the test is cheap on the Mini
+    # (~2-3 min, generic-label runner), so the few wasted runs on
+    # docs-only commits are not worth the complexity of keeping the
+    # filter in sync across workflows.
+    branches: [main]
     tags:
       - "v*"
 


### PR DESCRIPTION
## Summary

- Add `branches: [main]` to `e2e.yml`'s push trigger so the fixture E2E runs on every main commit, not only on `workflow_dispatch` and `v*` tag pushes.
- Prerequisite for a future tag ruleset on `v*.*.*` that requires `e2e` as a status check on the tagged SHA.

## Why

The chicken-and-egg today: a tag ruleset requiring `e2e` would block the tag push, because the workflow hadn't run on that SHA yet — the tag push *itself* is what currently triggers it. Producing the status check ahead of the tag (via every main push) closes that gap.

No paths filter: the workflow takes ~2-3 min on the spare self-hosted Mini and runs on the no-label generic runner, so the marginal cost on docs-only commits is bounded. Keeping a paths filter in sync between e2e.yml, e2e-app.yml, ci.yml, and any future tag ruleset is more brittle than running the test unconditionally.

## Test plan

- [ ] After merge to main: confirm `e2e.yml` fires automatically on the merge push and produces a `success` status on the SHA.
- [ ] Confirm the existing `v*` tag trigger still works (next RC tag should still kick off `e2e.yml`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->