### PR TITLE
ci: declare stable-tag protection ruleset

### DIFF
--- a/.github/tag-ruleset.json
+++ b/.github/tag-ruleset.json
@@ -1,0 +1,30 @@
+{
+  "name": "Stable tag protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": ["refs/tags/*-*"]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "analyze" },
+          { "context": "test (homebrew)" },
+          { "context": "test (appstore)" },
+          { "context": "test (tsan)" },
+          { "context": "test (asan)" },
+          { "context": "quality-baseline" },
+          { "context": "e2e" },
+          { "context": "e2e-app" }
+        ]
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,15 @@ brew install --cask meeting-transcriber@beta
 builds the DMG on a macOS runner and creates a GitHub Release. Stable tags update the
 `meeting-transcriber` cask, pre-release tags (containing `-`) update `meeting-transcriber@beta`.
 
+**Stable tag gate:** A GitHub Tag Ruleset (`Stable tag protection`) rejects any
+`git push` of a tag matching `v*` *without* a `-` suffix unless the tagged SHA
+has green status checks for every context listed in
+`.github/tag-ruleset.json` (`required_status_checks`). Apply or update the
+ruleset via `./scripts/configure-tag-ruleset.sh` (idempotent, needs repo-admin
+`gh` auth). RC tags (`v*-rc*`) stay unrestricted. If the last commit before a
+stable tag was docs-only and didn't trigger `e2e-app`, fire it manually with
+`gh workflow run e2e-app.yml --ref main` before tagging.
+
 ## Git Workflow
 
 Use the `/git-workflow` skill. Commit proactively after every logical unit of work — don't wait for user permission.

--- a/scripts/configure-tag-ruleset.sh
+++ b/scripts/configure-tag-ruleset.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Apply (or update) the GitHub Tag Ruleset declared in
+# `.github/tag-ruleset.json`. Idempotent: creates the ruleset if missing,
+# updates it in place otherwise.
+#
+# Usage:
+#   ./scripts/configure-tag-ruleset.sh            # apply the ruleset
+#   ./scripts/configure-tag-ruleset.sh --dry-run  # show diff vs current
+#   ./scripts/configure-tag-ruleset.sh --delete   # remove the ruleset
+#
+# Why this exists: tag rulesets reject `git push` of a matching tag when
+# the named status checks aren't all green on the tagged SHA. Putting the
+# config in repo so the rule is version-controlled and reproducible
+# instead of living only in repo Settings → Rules.
+#
+# Requires: `gh` CLI authenticated as a repo admin.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REPO=${REPO:-pasrom/meeting-transcriber}
+CONFIG_FILE=.github/tag-ruleset.json
+
+DRY_RUN=0
+DELETE=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --delete) DELETE=1 ;;
+        -h|--help) sed -n '2,11p' "$0"; exit 0 ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not found in PATH" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq not found in PATH" >&2
+    exit 1
+fi
+
+RULESET_NAME=$(jq -r '.name' "$CONFIG_FILE")
+EXISTING_ID=$(gh api "repos/$REPO/rulesets" |
+    jq -r --arg name "$RULESET_NAME" '.[] | select(.name == $name) | .id')
+
+summarize() {
+    jq '{
+        name, target, enforcement,
+        conditions: .conditions.ref_name,
+        checks: [.rules[] | select(.type=="required_status_checks") |
+                 .parameters.required_status_checks[].context]
+    }' "$@"
+}
+
+if [[ "$DELETE" == "1" ]]; then
+    if [[ -z "$EXISTING_ID" ]]; then
+        echo "No ruleset named '$RULESET_NAME' found — nothing to delete."
+        exit 0
+    fi
+    if [[ "$DRY_RUN" == "1" ]]; then
+        echo "[dry-run] Would DELETE ruleset $EXISTING_ID ($RULESET_NAME)"
+        exit 0
+    fi
+    gh api -X DELETE "repos/$REPO/rulesets/$EXISTING_ID"
+    echo "Deleted ruleset $EXISTING_ID ($RULESET_NAME)"
+    exit 0
+fi
+
+if [[ -z "$EXISTING_ID" ]]; then
+    ACTION="CREATE"
+    METHOD=POST
+    ENDPOINT="repos/$REPO/rulesets"
+else
+    ACTION="UPDATE"
+    METHOD=PUT
+    ENDPOINT="repos/$REPO/rulesets/$EXISTING_ID"
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] Would $ACTION ruleset '$RULESET_NAME' at $ENDPOINT"
+    if [[ -n "$EXISTING_ID" ]]; then
+        echo "[dry-run] Current state:"
+        gh api "repos/$REPO/rulesets/$EXISTING_ID" | summarize
+    fi
+    echo "[dry-run] Desired state:"
+    summarize "$CONFIG_FILE"
+    exit 0
+fi
+
+RESULT=$(gh api -X "$METHOD" "$ENDPOINT" --input "$CONFIG_FILE")
+
+echo "$RESULT" | jq -r '"\(.name) — id=\(.id), enforcement=\(.enforcement), target=\(.target)"'
+echo "$ACTION ok"


### PR DESCRIPTION
## Summary

- Codify a GitHub Tag Ruleset (`Stable tag protection`) that rejects `git push` of any tag matching `v*` *without* a `-` suffix unless the tagged SHA already has green status checks for the full validation matrix.
- Ship as version-controlled config (`.github/tag-ruleset.json`) plus an idempotent installer (`scripts/configure-tag-ruleset.sh`) so the rule lives in the repo, not only in repo settings.
- Document in CLAUDE.md under Distribution.

## Required checks (matches what runs on a code-touching push to main today)

Source of truth: `.github/tag-ruleset.json` (`required_status_checks[].context`). Currently: `lint`, `analyze`, `test (homebrew)`, `test (appstore)`, `test (tsan)`, `test (asan)`, `quality-baseline`, `e2e`, `e2e-app`.

Intentionally **not** required: `build (homebrew)` and `build (appstore)` from `release.yml` — those *are* what the tag triggers, requiring them would be chicken-and-egg.

## Scope (ref patterns)

- `include: refs/tags/v*`
- `exclude: refs/tags/*-*`

Effect:
- `v0.5.1`, `v0.5.2`, `v1.0.0` → enforced
- `v0.5.1-rc12`, `v1.0.0-beta1` → unrestricted (fast RC iteration unchanged)

## Activation status

**Live as of 2026-05-11** — ruleset `id=16253707`, `enforcement=active`. Applied via `./scripts/configure-tag-ruleset.sh` against the repo. Verify with `gh api repos/pasrom/meeting-transcriber/rulesets`.

```bash
./scripts/configure-tag-ruleset.sh           # apply (idempotent — does CREATE or UPDATE)
./scripts/configure-tag-ruleset.sh --dry-run # preview against live state
./scripts/configure-tag-ruleset.sh --delete  # remove
```

## Test plan

- [x] `./scripts/configure-tag-ruleset.sh --dry-run` prints the desired state without API mutation. **Verified locally.**
- [x] After running `./scripts/configure-tag-ruleset.sh`: `gh api repos/pasrom/meeting-transcriber/rulesets` lists the new ruleset. **Verified — `id=16253707` returned with all 9 required contexts.**
- [ ] Try pushing a test tag `v0.5.99` on a SHA without all checks → push rejected. *To exercise next time a release candidate is staged on a fresh SHA.*
- [ ] Push the same test tag on a SHA with all checks green → push accepted. *Will be exercised by the next stable `v0.5.1` push.*
- [ ] Confirm pushing `v0.5.99-rc1` is unaffected (unrestricted RC path). *Will be exercised on the next `v*-rc*` push.*