### PR TITLE
fix(ci): restore keychain search list + dedup e2e runs by SHA

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,10 @@ on:
       - "v*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Key by SHA, not ref: merge-to-main + the `v*` tag push share one
+  # commit but differ in `github.ref`, so ref-keyed grouping would rerun
+  # the suite on identical code.
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -75,13 +75,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/verify-xcode
-      # No actions/cache: Mini has persistent disk (see e2e.yml).
-      # `mt-ci.keychain-db` is provisioned by scripts/setup-self-hosted-runner.sh
-      # and set as the runner user's default keychain so
-      # `KeychainHelper`-touching tests don't hit the locked login.keychain.
-      # Defensive re-unlock in case it auto-locked between runs.
-      - name: Ensure CI keychain unlocked
-        run: security unlock-keychain -p "" ~/Library/Keychains/mt-ci.keychain-db
+      # `mt-ci.keychain-db` is pre-staged by setup-self-hosted-runner.sh, but
+      # macOS occasionally drops it from the per-user search list (seen after
+      # a second runner's `config.sh` ran as the same OS user). When that
+      # happens `SecItemAdd` writes to the default keychain while
+      # `SecItemCopyMatching` searches login.keychain only — KeychainHelper
+      # tests silent-fail. Re-assert per job; safe under matrix parallelism
+      # because every job writes the same value.
+      - name: Ensure CI keychain is default + in search list + unlocked
+        run: |
+          security default-keychain -s ~/Library/Keychains/mt-ci.keychain-db
+          security list-keychains -d user -s \
+            ~/Library/Keychains/mt-ci.keychain-db \
+            ~/Library/Keychains/login.keychain-db
+          security unlock-keychain -p "" ~/Library/Keychains/mt-ci.keychain-db
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure


### PR DESCRIPTION
## Summary

Two small CI fixes:

1. **`fix(ci): assert keychain default + search list per job`** — restores red main from `a2a4373`. The Mini's per-user keychain search list drifted (mt-ci dropped out of `security list-keychains -d user`) when Runner #2 was added today. Re-asserting default + search list + unlock on every job, race-free under matrix parallelism because all jobs write the *same* value.

2. **`ci(e2e): dedup main+tag push runs on identical SHA via concurrency group`** — drop-down from the simplify review of #236. Switch `concurrency.group` from `github.ref` to `github.sha` so a merge-to-main + immediate `v*` tag against that commit no longer re-runs the engine E2E suite end-to-end. Cancel-in-progress remains on, the second trigger supersedes the first if they overlap, otherwise the older run satisfies the gate and the newer is skipped.

## Why now

Today's red on main (`Quality & Safety / test (asan)` cancelled the matrix; failures in `KeychainHelperTests` + `AppSettingsTests.testKeychainRoundTrip` + `testOpenAIAPIKeyViaKeychainHelper`) is the immediate trigger. Live host state confirmed the search-list drift:

```
$ security default-keychain
    "/Users/runner/Library/Keychains/mt-ci.keychain-db"
$ security list-keychains -d user
    "/Users/runner/Library/Keychains/login.keychain-db"
```

Default points at mt-ci ✓ — but mt-ci isn't in the search list, so `SecItemAdd` writes there while `SecItemCopyMatching` searches login.keychain only and finds nothing.

## Test plan

- [x] Merge → `Quality & Safety` on main runs against the new step and goes green. **Verified:** post-merge runs on `40a04f8` and `8a0741d` both `completed/success` (TSan 6:14, ASan 1:34, quality-baseline 6:25). Keychain tests passed.
- [x] Subsequent main pushes confirm idempotency. **Verified:** parallel matrix jobs (TSan + ASan) ran concurrently and both green; no clobber.
- [ ] ~~Next `v*-rc*` tag push reuses the main-push e2e run instead of starting fresh.~~ **Superseded:** the sha-based concurrency group is being reverted in #239 — observation today (40a04f8 and 8a0741d e2e runs in parallel, neither cancelled) showed sha-grouping broke back-to-back-main-push cancellation, with no real win for the merge+tag case (completed runs aren't subject to concurrency dedup).