### PR TITLE
Revert: ci(e2e) concurrency group back to github.ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,10 +28,7 @@ on:
       - "v*"
 
 concurrency:
-  # Key by SHA, not ref: merge-to-main + the `v*` tag push share one
-  # commit but differ in `github.ref`, so ref-keyed grouping would rerun
-  # the suite on identical code.
-  group: ${{ github.workflow }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Why

Reverts the concurrency-group switch from commit `40a04f8` (part of the merged PR #238). Observed today on commits `40a04f8` + `8a0741d` (21 seconds apart): both e2e runs ran in parallel instead of the newer push cancelling the older, wasting ~3 min of Mini time.

The sha-based grouping was meant to dedup merge-to-main + `v*` tag pushes on the same SHA. But:
- Once the main-push e2e run completes, its concurrency-group entry expires. A subsequent tag push starts a fresh run regardless of grouping style — sha-grouping doesn't help.
- With the tag ruleset from #237 active, the tag push *must* wait for green checks on the SHA, so the main-push run is always done before the tag push fires — eliminating the only window where sha-grouping would have made a difference.

Meanwhile, sha-grouping actively breaks the common case (back-to-back main pushes), since each new SHA forms its own group → no cancellation possible.

## Test plan

- [ ] Merge → next two back-to-back main pushes should show the older `e2e` run going to `cancelled` when the newer one starts, instead of both running to completion.

## Trade-offs

Quality & Safety stays with `cancel-in-progress: false` by design (the comment in `quality-and-safety.yml` explains the baseline-preservation rationale). Not touching it here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->