### PR TITLE
ci(e2e-app): drop paths-filter so push-event check-runs land on every main SHA

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -6,17 +6,13 @@ name: E2E (Production App)
 on:
   workflow_dispatch:
   push:
+    # No paths-filter. Stable-tag ruleset requires a *push*-event check-run
+    # on the SHA; `workflow_dispatch`-created check-runs don't satisfy the
+    # gate (GitHub quirk — same name + success, still not counted). So
+    # every main push fires e2e-app to guarantee the check exists on every
+    # SHA a stable tag might point at. Mini Runner #1 is dedicated and
+    # otherwise idle — extra runs on docs-only commits are essentially free.
     branches: [main]
-    paths:
-      - 'app/MeetingTranscriber/Sources/**'
-      - 'app/MeetingTranscriber/Package.swift'
-      - 'app/MeetingTranscriber/Package.resolved'
-      - 'app/MeetingTranscriber/Tests/Fixtures/**'
-      - 'tools/audiotap/**'
-      - 'tools/meeting-simulator/**'
-      - 'scripts/run_app.sh'
-      - 'scripts/e2e-app.sh'
-      - '.github/workflows/e2e-app.yml'
   schedule:
     # 04:30 UTC = 06:30 CEST. Offset from the 03:00 quality-and-safety
     # cron so concurrent failures are easy to tell apart in `gh run list`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,9 +221,10 @@ builds the DMG on a macOS runner and creates a GitHub Release. Stable tags updat
 has green status checks for every context listed in
 `.github/tag-ruleset.json` (`required_status_checks`). Apply or update the
 ruleset via `./scripts/configure-tag-ruleset.sh` (idempotent, needs repo-admin
-`gh` auth). RC tags (`v*-rc*`) stay unrestricted. If the last commit before a
-stable tag was docs-only and didn't trigger `e2e-app`, fire it manually with
-`gh workflow run e2e-app.yml --ref main` before tagging.
+`gh` auth). RC tags (`v*-rc*`) stay unrestricted. `e2e.yml` and `e2e-app.yml`
+both fire on every main push (no paths-filter) so every SHA a stable tag might
+point at already has the required check-runs — no manual `gh workflow run`
+ceremony before tagging.
 
 ## Git Workflow
 
@@ -351,8 +352,9 @@ you're validating:
   (stable path → TCC permissions persist), launches it, triggers a meeting
   via `meeting-simulator`, polls `DebugRPCServer`'s `/state` for
   `lastJob.state == .done`, asserts on the resulting transcript file.
-- Triggered on `workflow_dispatch`, `push` to main on relevant paths,
-  and a nightly cron at 04:30 UTC.
+- Triggered on `workflow_dispatch`, every `push` to main (no paths-filter
+  — so the stable-tag ruleset always has a push-event check-run on the
+  SHA), and a nightly cron at 04:30 UTC.
 - Exercises the production code path end-to-end including TCC, audio
   routing, CATapDescription tap, and the dual-track recorder/diarizer
   handoff.


### PR DESCRIPTION
## Summary

- The stable-tag ruleset (id `16253707`) requires a push-event check-run on the tagged SHA. `workflow_dispatch`-created check-runs don't satisfy it, even when the run is green and visible in `gh api .../check-runs`.
- Verified yesterday by pushing throwaway tag `v0.99.99` on `74596ea` — both before *and* after firing `gh workflow run e2e-app.yml --ref main` (which completed green), the push was rejected with the identical `Required status check "e2e-app" is expected.` message.
- Fix: drop the paths-filter from `e2e-app.yml` so every main push triggers a real push-event `e2e-app` check-run on that SHA. Mini Runner #1 is dedicated to audio E2E and otherwise idle, so the extra ~10 min wall-clock on docs-only commits is essentially free.
- Also cleans up the now-broken workaround line in `CLAUDE.md`.

## Evidence

```
$ gh api repos/pasrom/meeting-transcriber/rulesets/rule-suites/2749171202
"details":"Required status check \"e2e-app\" is expected."
```

The `e2e-app` check-run was `success` on the same SHA at that moment — just attached to a `workflow_dispatch` run instead of a `push` run.

## Test plan

- [ ] PR CI green (lint + analyze + test (homebrew/appstore/tsan/asan) + quality-baseline + e2e + e2e-app)
- [ ] After merge: confirm push-to-main of merge commit triggers `e2e-app` automatically
- [ ] Re-test the Accept-path by pushing throwaway `v0.99.99` once `e2e-app` is green on new main HEAD — expected to be accepted
- [ ] Delete throwaway tag + auto-created Release post-test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->