### PR TITLE
fix(ci): install-developer-id prepends to keychain search list (don't drop mt-ci.keychain-db)

### DIFF
--- a/.github/actions/install-developer-id/action.yml
+++ b/.github/actions/install-developer-id/action.yml
@@ -72,6 +72,16 @@ runs:
         security set-key-partition-list -S "$PARTITION_LIST" \
           -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-        security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+        # `-s` REPLACES the user-domain search list (see `man security`),
+        # so a naive `-s "$KEYCHAIN_PATH" login.keychain-db` would drop any
+        # other keychains a parallel job depends on. On the self-hosted Mini
+        # both runners share an OS user, so quality-and-safety.yml's
+        # mt-ci.keychain-db has been observed to vanish from the search list
+        # mid-flight, silent-failing KeychainHelper tests. Prepend our
+        # keychain to whatever is already there instead, deduping on our
+        # own path so re-invocation in the same job is idempotent.
+        EXISTING=$(security list-keychains -d user | tr -d '"' | xargs)
+        FILTERED=$(printf '%s\n' $EXISTING | grep -vxF "$KEYCHAIN_PATH" | xargs || true)
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $FILTERED
 
         echo "keychain-path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- `security list-keychain -d user -s …` REPLACES the user-domain search list. The action set it to just two keychains, so on the self-hosted Mini (both runners share an OS user) `mt-ci.keychain-db` got dropped whenever e2e-app.yml ran install-developer-id, racing with quality-and-safety.yml's KeychainHelper tests.
- Fix: read the existing list, dedupe our own keychain, prepend it, then re-set. Idempotent under re-invocation in the same job.

## Honest caveat

This does NOT necessarily fix the codesign `no identity found` flake we hit on `bbdcd88` earlier — codesign's `--keychain` flag locates the identity inside the named keychain by SHA, which doesn't depend on the global search list. That flake likely has a different root cause (cert-import on stale default keychain, or temp-keychain leftover from a partially-failed prior run). The bug fixed here is real on its own merits — concurrent KeychainHelper test silent-fails on the Mini.

## Test plan

- [ ] PR CI green
- [ ] After merge: confirm next quality-and-safety run on Mini is green (no recurrence of KeychainHelperTests silent-fail in the race window)
- [ ] After merge: re-run e2e-app to confirm install-developer-id still produces a usable signing keychain