### PR TITLE
fix(ci): release.yml stops swallowing Homebrew tap update failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,11 @@ jobs:
             ${{ steps.sha.outputs.sha256 }}
             ```
 
+      # Gate stays loud: tap-update failure must fail the release —
+      # otherwise `brew upgrade` silently keeps users on the prior version.
       - name: Update Homebrew tap with new version and SHA256
+        id: tap-update
         if: matrix.variant == 'homebrew' && startsWith(github.ref, 'refs/tags/v')
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.TAP_REPO_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- The "Update Homebrew tap" step in `release.yml` had `continue-on-error: true` with no follow-up failure handler. Failures (TAP_REPO_TOKEN scope/expiry, git push rejected, BSD `sed -i ''` regex error, missing Cask file) left the GitHub Release looking green while the Cask in `pasrom/homebrew-meeting-transcriber` kept pointing at the old version.
- Symptom: users running `brew upgrade` silently stay behind without anyone noticing until next install attempt.
- Fix: drop the flag, let the job fail loudly. The DMG artifact is uploaded by the prior step, so a second attempt is just `gh workflow run release.yml --ref <tag>` after fixing the cause.
- Also add `id: tap-update` so a future PR can layer in a nuanced failure handler (e.g. issue creator) without first having to add the id.

## Test plan

- [ ] PR CI green
- [ ] Verified by next stable tag push (or rc tag) that release.yml's Cask-update step still works on the green path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->