### PR TITLE
chore(ci): drop redundant tags trigger from e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,9 +23,13 @@ on:
     # (~2-3 min, generic-label runner), so the few wasted runs on
     # docs-only commits are not worth the complexity of keeping the
     # filter in sync across workflows.
+    #
+    # No `tags: ["v*"]` here either: a tag push on the same SHA as a prior
+    # main push would NOT be cancelled by the concurrency group (different
+    # `github.ref` between `refs/heads/main` and `refs/tags/v…`), so it
+    # would fire a duplicate engine E2E run that the tag ruleset already
+    # has covered via the main-push check-run.
     branches: [main]
-    tags:
-      - "v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

After PR #240, every main push fires `e2e.yml` on the SHA via the push trigger. A second trigger on `tags: ["v*"]` would create a duplicate run on the same SHA: the concurrency group is keyed by `github.ref`, which differs between `refs/heads/main` and `refs/tags/v…`, so the two runs do NOT cancel each other.

The tag ruleset is already satisfied by the main-push check-run; the tag-push run is pure waste of Mini Runner #2 time.

## Test plan

- [ ] PR CI green
- [ ] After merge: next stable tag push to main shows only the prior main-push e2e run on the SHA, not a duplicate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->