### PR TITLE
ci(install-developer-id): fail fast on keychain with no valid signing identity

### DIFF
--- a/.github/actions/install-developer-id/action.yml
+++ b/.github/actions/install-developer-id/action.yml
@@ -84,4 +84,15 @@ runs:
         FILTERED=$(printf '%s\n' $EXISTING | grep -vxF "$KEYCHAIN_PATH" | xargs || true)
         security list-keychains -d user -s "$KEYCHAIN_PATH" $FILTERED
 
+        # Fail fast on cert/key import mismatch or missing trust chain.
+        # Callers (release.yml + e2e-app.yml) otherwise burn a multi-minute
+        # build before codesign reports `no identity found`; this surfaces
+        # the same condition in <1 s right at the install boundary.
+        IDENTITY_LIST=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH")
+        echo "$IDENTITY_LIST"
+        if echo "$IDENTITY_LIST" | grep -q "0 valid identities found"; then
+          echo "::error::install-developer-id imported cert/key but no valid codesigning identity in $KEYCHAIN_PATH. Check cert/key match or trust chain."
+          exit 1
+        fi
+
         echo "keychain-path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The action currently imports cert + key + sets partition-list + updates search list, then exits. Callers (`release.yml` + `e2e-app.yml`) compile the full `.app` before codesign discovers `no identity found` at the very end — wasting 1m20s+ per failed run.
- Add a `security find-identity -v -p codesigning` probe at the end of the action. If the keychain has zero valid identities, abort with a `::error::` annotation pointing at the likely root cause (cert/key mismatch or missing trust chain).
- /simplify pass relocated this from `e2e-app.yml` (where it was originally proposed) into the composite action so both callers benefit without per-caller boilerplate.

## Test plan

- [ ] PR CI green
- [ ] After merge: next `e2e-app` run on main shows the new probe step pass + identity list in the log

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->