### PR TITLE
ci(setup-swift-test): pre-warm fails fast on rename or swift-test crash

### DIFF
--- a/.github/actions/setup-swift-test/action.yml
+++ b/.github/actions/setup-swift-test/action.yml
@@ -62,7 +62,22 @@ runs:
     # don't support it. Callers should set `timeout-minutes` on the
     # outer `uses: ./.github/actions/setup-swift-test` step to bound the
     # cold-cache HuggingFace + FluidAudio download.
+    #
+    # `pipefail` ensures a crashing `swift test` propagates through `tee`
+    # (otherwise the step would report success and the grep below would
+    # match the partial start-of-suite output). Log file is per-job under
+    # $RUNNER_TEMP so parallel self-hosted jobs don't race on /tmp. The
+    # grep is a belt-and-braces detector for the silent no-op that occurs
+    # if `ModelPreloadTests` is ever renamed/removed.
     - name: Pre-warm model cache (cache miss only)
       if: inputs.cache-models == 'true' && steps.model-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: cd app/MeetingTranscriber && swift test --filter ModelPreloadTests ${{ inputs.swift-flags }}
+      run: |
+        set -euo pipefail
+        cd app/MeetingTranscriber
+        LOG="$RUNNER_TEMP/prewarm.log"
+        swift test --filter ModelPreloadTests ${{ inputs.swift-flags }} 2>&1 | tee "$LOG"
+        if ! grep -q "Test Suite 'ModelPreloadTests' started" "$LOG"; then
+          echo "::error::Pre-warm filter matched zero tests — has ModelPreloadTests been renamed or removed?"
+          exit 1
+        fi


### PR DESCRIPTION
## Summary

Two problems with the previous one-line pre-warm command:

1. **Missing `pipefail`** — `swift test ... 2>&1 | tee` exits with `tee`'s 0 status. A crashing `swift test` mid-suite would still report success, and the next `swift test` in the calling job pays the cold model download.
2. **Silent no-op on rename** — if `ModelPreloadTests` is ever renamed/removed, `--filter` matches zero tests, swift test exits 0, pre-warm reports success, cold download happens later.

Fix:
- `set -euo pipefail` so swift-test failures propagate
- Grep on the suite-start banner — belt-and-braces detector for the rename case
- Log path moved from `/tmp/prewarm.log` to `$RUNNER_TEMP/prewarm.log` so parallel self-hosted jobs don't race on the file

## Test plan

- [ ] PR CI green
- [ ] After merge: confirm next cold-cache CI run (any non-trivial Package.resolved change) sees the prewarm grep pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->