### PR TITLE
ci(security): wipe imported .p12 + SHA-pin ncipollo/release-action

### DIFF
--- a/.github/actions/install-developer-id/action.yml
+++ b/.github/actions/install-developer-id/action.yml
@@ -60,6 +60,11 @@ runs:
         echo -n "$DEVELOPER_ID_CERT" | base64 --decode -o "$CERT_PATH"
         security import "$CERT_PATH" -P "$DEVELOPER_ID_CERT_PASSWORD" \
           -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+        # Wipe the .p12 immediately — it's already absorbed into the
+        # keychain. On self-hosted Mini $RUNNER_TEMP persists across runs;
+        # leaving the .p12 (encrypted, but still cert+key on disk) is an
+        # unnecessary attack surface.
+        rm -f "$CERT_PATH"
 
         PARTITION_LIST="apple-tool:,apple:"
         if [ -n "$EXTRA_PARTITION_ROLES" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,12 @@ jobs:
 
       - name: Create GitHub Release
         if: matrix.variant == 'homebrew' && startsWith(github.ref, 'refs/tags/v')
-        uses: ncipollo/release-action@v1
+        # SHA-pinned: this is the highest-privilege third-party action in
+        # release.yml — runs with DEVELOPER_ID_CERT, APP_PASSWORD,
+        # TAP_REPO_TOKEN, APPLE_ID. SHA pin (vs tag pin) means a hijacked
+        # v1 tag cannot retarget us to a malicious commit. Dependabot
+        # bumps the SHA + comment in lockstep.
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: .build/release/${{ matrix.dmg-prefix }}-${{ steps.version.outputs.version }}.dmg
           generateReleaseNotes: true


### PR DESCRIPTION
## Summary

Two low-effort hardening tweaks surfaced by an independent security audit. No critical findings underlying these — defense-in-depth only.

**L2 — install-developer-id wipes the .p12 after `security import`.** On self-hosted Mini, `\$RUNNER_TEMP` persists across runs, so the .p12 (encrypted, but still cert+key on disk) was sticking around for no reason. `set -euo pipefail` already aborts on import failure, leaving the .p12 in place for debugging when that actually matters — so the cleanup only runs on the success path. release.yml's call site benefits for free.

**M3 — release.yml SHA-pins ncipollo/release-action.** This is the highest-privilege third-party action in the repo (runs with `DEVELOPER_ID_CERT`, `APP_PASSWORD`, `TAP_REPO_TOKEN`, `APPLE_ID`). SHA-pin (vs tag-pin) means a hijacked `v1` tag cannot retarget us. Trailing `# v1.21.0` comment is Dependabot's documented format — it bumps the SHA + comment together on future releases.

## Out of scope (could follow up if you want)

- `dorny/paths-filter@v4` and `dependabot/fetch-metadata@v3` don't hold high-value secrets at their call sites, so they stay tag-pinned for now. Pin if you want full supply-chain hygiene.

## Test plan

- [x] PR CI green
- [ ] After merge: next tag push exercises `ncipollo/release-action` at the SHA-pinned ref and creates the GitHub Release as before

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->