### PR TITLE
ci: tighten job timeouts + step-level limits for timed_out visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
-    timeout-minutes: 30
+    # 25 min job-timeout = 20 min setup (cold cache) + ~5 min margin. The
+    # `Swift tests` step below has its own 18 min step-timeout so a hang
+    # surfaces as `timed_out` (clearly distinguishable from cancellation),
+    # not the opaque `cancelled` a bare job-timeout produces. See
+    # docs/plans/.local/open/2026-05-11-job-timeout-visibility.md.
+    timeout-minutes: 25
     permissions:
       contents: read
       actions: write
@@ -113,14 +118,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # 20 min covers SPM + ML cache restore plus the cold-cache pre-warm
-      # download; well below the 30 min job timeout so a hung download
+      # download; well below the 25 min job timeout so a hung download
       # surfaces as a step failure, not a job-timeout.
       - uses: ./.github/actions/setup-swift-test
         timeout-minutes: 20
         with:
           cache-key-suffix: ${{ matrix.variant }}
           swift-flags: ${{ matrix.swift-flags }}
+      # 18 min step-timeout on the actual tests: typical hot-cache run is
+      # 5–7 min, so this is ~3× margin while still failing fast as
+      # `timed_out` (not `cancelled`) when a single test hangs.
       - name: Swift tests
+        timeout-minutes: 18
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.swift-flags }}
       - name: Cancel run on failure
         if: failure()

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -33,7 +33,12 @@ jobs:
     # racing for the audio stack — see runner labels via
     # `gh api /repos/{owner}/{repo}/actions/runners`.
     runs-on: [self-hosted, macOS, ARM64, audio]
-    timeout-minutes: 15
+    # Three lanes (transcript, record-only, reimport) at ~4–6 min each
+    # → ~14 min observed total. 20 min job budget gives honest margin;
+    # each lane has its own 10 min step-timeout below so a hang in lane
+    # N surfaces as `timed_out` on that step (not as an opaque job-level
+    # `cancelled`). See docs/plans/.local/open/2026-05-11-job-timeout-visibility.md.
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6
@@ -69,6 +74,7 @@ jobs:
       - name: Run live-recording E2E driver
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
         # `--two-meetings` always: meeting 1 covers fresh-state single-run,
         # meeting 2 covers cooldown + state reset. ~3 min total wall on Mini
         # vs ~1 min for single-meeting; signal latency is fine on nightly +
@@ -86,6 +92,7 @@ jobs:
       - name: Run live-recording E2E driver (record-only)
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
         run: bash scripts/e2e-app.sh --no-build --record-only
 
       # Re-import lane: chains a record-only meeting with a POST
@@ -101,6 +108,7 @@ jobs:
       - name: Run live-recording E2E driver (re-import recorded WAV)
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
         run: bash scripts/e2e-app.sh --no-build --reimport-recorded
 
       # Best-effort: capture the simulator's stdout for post-mortem if

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,10 +38,12 @@ concurrency:
 jobs:
   e2e:
     runs-on: [self-hosted, macOS, ARM64]
-    # 60 min headroom: cold runs download three multi-GB models
-    # (WhisperKit ~1 GB, Parakeet ~50 MB, Qwen3 ~1.75 GB). Subsequent
-    # runs hit the SPM cache + on-disk model cache and finish in <10 min.
-    timeout-minutes: 60
+    # Cold-cache runs download three multi-GB models (WhisperKit ~1 GB,
+    # Parakeet ~50 MB, Qwen3 ~1.75 GB); hot runs <10 min. 30 min job
+    # budget covers worst-case cold download. The `Run E2E tests` step
+    # below has a 25 min step-timeout so a hang surfaces as `timed_out`
+    # — see docs/plans/.local/open/2026-05-11-job-timeout-visibility.md.
+    timeout-minutes: 30
     env:
       E2E_ENABLED: "1"
 
@@ -69,6 +71,7 @@ jobs:
       # via HTTPS on hit and waste the multi-GB upload on miss — the
       # latter timed out the post-action on a real run (5.6 GB → GitHub).
       - name: Run E2E tests
+        timeout-minutes: 25
         run: |
           cd app/MeetingTranscriber
           swift test --filter '${{ steps.filter.outputs.filter }}'


### PR DESCRIPTION
## Summary

Three workflows had job-timeouts massively over their actual p50, and none paired the long-running steps with step-level timeouts. Result today: a hung test consumes the full budget AND surfaces as opaque \`cancelled\` (identical to user-cancel or concurrency-cancel) — needs API forensics to disambiguate.

This PR tightens job-timeouts to honest worst-case + 3× margin and adds step-level limits so hangs surface as \`timed_out\` on the actual hung step.

## Changes

| Workflow | Job | Before | After job | New step-timeout | Step covered |
|---|---|---|---|---|---|
| \`ci.yml\` | \`test\` | 30 min | **25 min** | 18 min | Swift tests |
| \`e2e.yml\` | \`e2e\` | 60 min | **30 min** | 25 min | Run E2E tests |
| \`e2e-app.yml\` | \`e2e-app\` | 15 min | **20 min** ↑ | 10 min × 3 | each live-recording lane |

## Why

- **\`ci.yml/test\`** observed p50 5–7 min, max ~15 min cold-cache. 18 min step-timeout = 3× margin. Old 30 min was 6× the actual budget — a hang ate 25 min of CI time before surfacing.
- **\`e2e.yml\`** observed p50 ~5 min. Old 60 min was defensive for 1.75 GB model downloads on cold cache, but the Mini's disk is persistent so cold cache is rare. 30 min covers worst-case fresh-download. 25 min step-timeout fails fast on hang.
- **\`e2e-app.yml\`** — 15 min was set when only one lane existed (~6 min wall). After #247 + #248 there are three lanes totaling ~14 min observed. Bumped to 20 min for honest margin; 10 min per lane lets us tell *which* lane hung.

Background: \`docs/plans/.local/open/2026-05-11-job-timeout-visibility.md\` documents the cancelled-vs-timed_out distinction from PR #231's incident.

## Test plan

- [x] All three YAMLs syntactically valid (\`python3 -c 'yaml.safe_load(open(…))'\`)
- [ ] PR-CI green on the new \`test\` budgets (this PR itself exercises them)
- [ ] After merge: future hangs in \`Swift tests\` / \`Run E2E tests\` / \`e2e-app\` lanes surface as \`timed_out\` on the step, not \`cancelled\` on the job

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->