### PR TITLE
docs(readme): add status badges for E2E + quality + App Store workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Meeting Transcriber
 
 [![CI](https://github.com/pasrom/meeting-transcriber/actions/workflows/ci.yml/badge.svg)](https://github.com/pasrom/meeting-transcriber/actions/workflows/ci.yml)
+[![E2E](https://github.com/pasrom/meeting-transcriber/actions/workflows/e2e.yml/badge.svg)](https://github.com/pasrom/meeting-transcriber/actions/workflows/e2e.yml)
+[![E2E (App)](https://github.com/pasrom/meeting-transcriber/actions/workflows/e2e-app.yml/badge.svg)](https://github.com/pasrom/meeting-transcriber/actions/workflows/e2e-app.yml)
+[![Quality & Safety](https://github.com/pasrom/meeting-transcriber/actions/workflows/quality-and-safety.yml/badge.svg)](https://github.com/pasrom/meeting-transcriber/actions/workflows/quality-and-safety.yml)
+[![App Store Smoke](https://github.com/pasrom/meeting-transcriber/actions/workflows/appstore.yml/badge.svg)](https://github.com/pasrom/meeting-transcriber/actions/workflows/appstore.yml)
 
 A native macOS menu bar app that automatically detects, records, transcribes, and summarizes your meetings — fully on-device, no cloud transcription.
 


### PR DESCRIPTION
## Summary

Adds four status badges next to the existing CI badge so the README surfaces the actual main-branch state of every meaningful workflow:

- E2E (fixture-based engine tests)
- E2E (App) (live-recording on the Mini)
- Quality & Safety (TSan + WER/DER nightly)
- App Store Smoke (sandbox-variant launch check)

Skipped: \`release.yml\` (only fires on v-tag push — bad continuous indicator), \`pr-labels.yml\`, \`dependabot-auto-merge.yml\` (no test signal).

## Test plan

- [x] Render correct on github.com/pasrom/meeting-transcriber once merged — badges resolve to `?branch=` default (= main)
- [x] No formatting damage to the rest of the README (only 4 lines added)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pasrom/codesmith/meeting-transcriber/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->