### PR TITLE
ci(e2e-app): fail fast with actionable error on Fast User Switching

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -255,6 +255,18 @@ else
     defaults delete com.meetingtranscriber.dev recordOnly 2>/dev/null || true
 fi
 
+# LaunchServices' `open` routes to the WindowServer of the *foreground* Aqua
+# session, not just any session with our UID loaded. If a second user is
+# signed in via Fast User Switching and currently has the foreground, our
+# LaunchAgent's `open` lands in an inactive session and LaunchServices
+# returns the misleading `procNotFound (-600)`. Catch this before the call
+# so the failure is actionable instead of cryptic.
+fg_user=$(stat -f "%Su" /dev/console)
+my_user=$(id -un)
+if [ "$fg_user" != "$my_user" ]; then
+    fail "Aqua foreground user is '$fg_user', not '$my_user' — Fast User Switching is active. On the Mac mini, log '$fg_user' out completely (Apple menu → Log Out '$fg_user'…), then re-trigger this workflow."
+fi
+
 log "Launching $DEV_BUNDLE_DEPLOY"
 open "$DEV_BUNDLE_DEPLOY"
 


### PR DESCRIPTION
## Summary

When LaunchServices' `open` from the CI LaunchAgent fails because another user is in the Aqua foreground (Fast User Switching), the surface error is the cryptic `_LSOpenURLsWithCompletionHandler() failed with error -600`. Build, codesign, deploy all succeed — only the launch fails, and the symptom mimics Gatekeeper, quarantine, or missing-executable issues.

This PR adds a pre-flight check before `open` that compares `/dev/console` owner against `id -un`. If they differ, we abort with a remediation message pointing at the actual root cause.

## Why this happens

LaunchServices routes `open` to the WindowServer of the *foreground* Aqua session, not any session with the caller's UID loaded. A LaunchAgent for a backgrounded user lands in an inactive session, and LaunchServices returns the misleading `procNotFound (-600)`.

`CGSession` (Apple's old programmatic switch tool) is no longer shipped on recent macOS, so the only sensible recovery is to ask the host operator to log the other user out completely on the Mac mini.

## What changed

- `scripts/e2e-app.sh:258` — 12 lines added immediately before the existing `open` call
- No behavior change when only one user is logged in on the host

## Test plan

- [x] `bash -n scripts/e2e-app.sh` passes
- [x] `./scripts/lint.sh` passes (no Swift files touched, but ran for parity)
- [ ] After merge, the e2e-app workflow fires on push-to-main and the new check passes silently (no false-positive when host is in the normal one-user state)

The e2e-app workflow doesn't fire on PRs, so the production behavior is verified post-merge by the next main-push trigger.