### PR TITLE
ci(codecov): tighten ignores + upload audiotap as separate flag

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -38,7 +38,7 @@ comment:
   layout: "reach, diff, flags, files"
   # `once`: post a single comment per PR and edit it in place on re-runs.
   # `default` would post a new comment on every push and force-push, which
-  # is noisy with a 2-leg matrix (two uploads per push → two comments).
+  # is noisy with a 3-upload fan-in (one comment per upload otherwise).
   behavior: once
   require_changes: true   # only comment when coverage actually moved
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,9 +7,9 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    # Wait for both matrix legs before commenting on a PR. Avoids flapping
-    # status while the second leg is still uploading.
-    after_n_builds: 2
+    # Wait for all uploads (homebrew + appstore + audiotap) before
+    # commenting on a PR. Avoids flapping status while uploads stagger.
+    after_n_builds: 3
 
 coverage:
   precision: 1
@@ -46,7 +46,6 @@ flags:
   homebrew:
     paths:
       - app/MeetingTranscriber/Sources/
-      - tools/audiotap/Sources/
     # `carryforward: true` keeps the last known coverage for a flag when
     # one matrix leg fails to upload — prevents a transient upload error
     # from showing as a 100 % coverage drop.
@@ -54,6 +53,14 @@ flags:
   appstore:
     paths:
       - app/MeetingTranscriber/Sources/
+    carryforward: true
+  # AudioTapLib SPM library uploaded by the audiotap CI step. Lives in
+  # its own flag because the test suite is in `tools/audiotap/Tests/`,
+  # not the app's xctest bundle. Same library binary regardless of the
+  # homebrew/appstore variant, so we upload it once (homebrew leg only)
+  # and rely on `carryforward` for non-CI events.
+  audiotap:
+    paths:
       - tools/audiotap/Sources/
     carryforward: true
 
@@ -63,11 +70,17 @@ ignore:
   - "app/MeetingTranscriber/Tests/**/*"
   - "app/MeetingTranscriber/Sources/Info.plist"
   - "app/MeetingTranscriber/Sources/Assets.xcassets/**/*"
-  # Live-only audio capture path — exercised by e2e-app.yml, not xctest.
+  # @main SwiftUI scene shell — NSOpenPanel / NSWorkspace bindings, no
+  # mock-point, exercised end-to-end by e2e-app.yml (live recording).
+  - "app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift"
+  # Pure AVAudioEngine wrapper — hardware-bound, exercised by e2e-app.yml.
+  - "app/MeetingTranscriber/Sources/MicRecorder.swift"
+  # AudioTapLib hardware-bound paths — exercised by e2e-app.yml (live
+  # recording with BlackHole), not by xctest. The rest of `tools/audiotap/`
+  # is covered by its own test suite and uploaded under the `audiotap` flag.
   - "tools/audiotap/Sources/AppAudioCapture.swift"
   - "tools/audiotap/Sources/MicCaptureHandler.swift"
   - "tools/audiotap/Sources/AudioCaptureSession.swift"
-  - "tools/audiotap/Sources/OutputDeviceChangeCoordinator.swift"
   # CLI-only / tools targets — separate test suites, not part of the app.
   - "tools/whisperkit-cli/**/*"
   - "tools/meeting-simulator/**/*"

--- a/.github/actions/export-lcov/action.yml
+++ b/.github/actions/export-lcov/action.yml
@@ -1,0 +1,51 @@
+name: "Export LCOV + upload to Codecov"
+description: >
+  Locates the most recently built `.xctest` bundle and `default.profdata`
+  in the given SPM package, exports an LCOV report via `xcrun llvm-cov
+  export`, then uploads it to codecov under the given flag. Caller must
+  have already run `swift test --enable-code-coverage` in `package-dir`.
+
+  Two callers today: the homebrew/appstore matrix legs of the `test`
+  job (app sources) and the standalone `audiotap-coverage` job. The
+  composite collapses ~30 lines of byte-identical shell per call site
+  to a single `uses:` block.
+
+inputs:
+  package-dir:
+    description: SPM package directory containing the test build output (relative to repo root).
+    required: true
+  flag:
+    description: codecov flag to upload under (e.g. homebrew, appstore, audiotap).
+    required: true
+  codecov-token:
+    description: codecov upload token.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Export LCOV
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "${{ inputs.package-dir }}"
+        BIN_PATH=$(swift build --show-bin-path)
+        PROFDATA="$BIN_PATH/codecov/default.profdata"
+        XCTEST_DIR=$(find "$BIN_PATH" -name '*.xctest' -type d | head -n1)
+        [[ -n "$XCTEST_DIR" ]] || { echo "::error::no .xctest bundle in $BIN_PATH"; exit 1; }
+        XCTEST_BIN="$XCTEST_DIR/Contents/MacOS/$(basename "$XCTEST_DIR" .xctest)"
+        xcrun llvm-cov export \
+          -format=lcov \
+          -instr-profile="$PROFDATA" \
+          -ignore-filename-regex='\.build/|Tests/|/usr/' \
+          "$XCTEST_BIN" \
+          > "$GITHUB_WORKSPACE/coverage-${{ inputs.flag }}.lcov"
+        wc -l "$GITHUB_WORKSPACE/coverage-${{ inputs.flag }}.lcov"
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: coverage-${{ inputs.flag }}.lcov
+        flags: ${{ inputs.flag }}
+        fail_ci_if_error: false
+        verbose: true

--- a/.github/actions/export-lcov/action.yml
+++ b/.github/actions/export-lcov/action.yml
@@ -1,14 +1,9 @@
 name: "Export LCOV + upload to Codecov"
 description: >
-  Locates the most recently built `.xctest` bundle and `default.profdata`
-  in the given SPM package, exports an LCOV report via `xcrun llvm-cov
-  export`, then uploads it to codecov under the given flag. Caller must
-  have already run `swift test --enable-code-coverage` in `package-dir`.
-
-  Two callers today: the homebrew/appstore matrix legs of the `test`
-  job (app sources) and the standalone `audiotap-coverage` job. The
-  composite collapses ~30 lines of byte-identical shell per call site
-  to a single `uses:` block.
+  Runs `scripts/export-lcov.sh` to convert the given SPM package's
+  `default.profdata` into an LCOV file, then uploads it to codecov
+  under the given flag. Caller must have already run
+  `swift test --enable-code-coverage` in `package-dir`.
 
 inputs:
   package-dir:
@@ -24,23 +19,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Inputs are surfaced as env vars rather than substituted directly
+    # into the bash body — keeps the shell side template-free and
+    # avoids the GH-Actions-templating-in-bash injection footgun.
     - name: Export LCOV
       shell: bash
-      run: |
-        set -euo pipefail
-        cd "${{ inputs.package-dir }}"
-        BIN_PATH=$(swift build --show-bin-path)
-        PROFDATA="$BIN_PATH/codecov/default.profdata"
-        XCTEST_DIR=$(find "$BIN_PATH" -name '*.xctest' -type d | head -n1)
-        [[ -n "$XCTEST_DIR" ]] || { echo "::error::no .xctest bundle in $BIN_PATH"; exit 1; }
-        XCTEST_BIN="$XCTEST_DIR/Contents/MacOS/$(basename "$XCTEST_DIR" .xctest)"
-        xcrun llvm-cov export \
-          -format=lcov \
-          -instr-profile="$PROFDATA" \
-          -ignore-filename-regex='\.build/|Tests/|/usr/' \
-          "$XCTEST_BIN" \
-          > "$GITHUB_WORKSPACE/coverage-${{ inputs.flag }}.lcov"
-        wc -l "$GITHUB_WORKSPACE/coverage-${{ inputs.flag }}.lcov"
+      env:
+        PACKAGE_DIR: ${{ inputs.package-dir }}
+        OUTPUT_PATH: ${{ github.workspace }}/coverage-${{ inputs.flag }}.lcov
+      run: ./scripts/export-lcov.sh "$PACKAGE_DIR" "$OUTPUT_PATH"
     - name: Upload to Codecov
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,78 +133,50 @@ jobs:
       - name: Swift tests
         timeout-minutes: 18
         run: cd app/MeetingTranscriber && swift test --parallel --enable-code-coverage --skip ModelPreloadTests ${{ matrix.swift-flags }}
-      # Export LCOV from `default.profdata` for codecov upload. `swift
-      # build --show-bin-path` is a no-op query (no recompile) that
-      # returns the directory holding both the xctest bundle and the
-      # `codecov/default.profdata` SPM emits. Skipping the step on test
-      # failure is intentional — we never want a stale coverage snapshot
-      # uploaded as if it were green.
-      - name: Export LCOV
+      # Skipping on test failure is intentional — we never want a stale
+      # coverage snapshot uploaded as if it were green.
+      - uses: ./.github/actions/export-lcov
         if: success()
-        run: |
-          set -euo pipefail
-          cd app/MeetingTranscriber
-          BIN_PATH=$(swift build --show-bin-path)
-          PROFDATA="$BIN_PATH/codecov/default.profdata"
-          XCTEST_DIR=$(find "$BIN_PATH" -name '*.xctest' -type d | head -n1)
-          [[ -n "$XCTEST_DIR" ]] || { echo "::error::no .xctest bundle in $BIN_PATH"; exit 1; }
-          XCTEST_BIN="$XCTEST_DIR/Contents/MacOS/$(basename "$XCTEST_DIR" .xctest)"
-          xcrun llvm-cov export \
-            -format=lcov \
-            -instr-profile="$PROFDATA" \
-            -ignore-filename-regex='\.build/|Tests/|/usr/' \
-            "$XCTEST_BIN" \
-            > "$GITHUB_WORKSPACE/coverage-${{ matrix.variant }}.lcov"
-          wc -l "$GITHUB_WORKSPACE/coverage-${{ matrix.variant }}.lcov"
-      - name: Upload coverage to Codecov
-        if: success()
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
-          # Token-based upload (vs. tokenless OIDC) — more reliable and
-          # avoids the tokenless-upload rate limit. The token is safe to
-          # treat as a normal Actions secret; Codecov docs explicitly
-          # state public-repo upload tokens are not sensitive.
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage-${{ matrix.variant }}.lcov
-          flags: ${{ matrix.variant }}
-          fail_ci_if_error: false
-          verbose: true
-      # AudioTapLib SPM library has its own test suite in
-      # `tools/audiotap/Tests/`. Run + upload its coverage only from the
-      # homebrew leg — the library is variant-agnostic (no -DAPPSTORE
-      # path), so the appstore leg would just produce an identical second
-      # copy. Single upload + `carryforward` in `.codecov.yml` keeps the
-      # number stable on non-CI events.
-      - name: Audiotap tests with coverage
-        if: success() && matrix.variant == 'homebrew'
+          package-dir: app/MeetingTranscriber
+          flag: ${{ matrix.variant }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Cancel run on failure
+        if: failure()
+        uses: ./.github/actions/cancel-on-failure
+
+  # AudioTapLib SPM library lives in `tools/audiotap/` and has its own
+  # test suite (`tools/audiotap/Tests/`). Runs as its own top-level job
+  # in parallel with `test` so wall-clock isn't gated by the app suite.
+  # No matrix — the library is variant-agnostic (no -DAPPSTORE path),
+  # so a single upload + `carryforward` in `.codecov.yml` is sufficient.
+  audiotap-coverage:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: macos-26
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+      # No ML model dependencies — a plain SPM cache keyed off the
+      # manifest is enough to drop cold-compile cost on repeat runs.
+      - uses: actions/cache@v5
+        with:
+          path: tools/audiotap/.build
+          key: audiotap-spm-${{ runner.os }}-${{ hashFiles('tools/audiotap/Package.swift') }}
+          restore-keys: |
+            audiotap-spm-${{ runner.os }}-
+      - name: Swift tests
         timeout-minutes: 5
         run: cd tools/audiotap && swift test --parallel --enable-code-coverage
-      - name: Export audiotap LCOV
-        if: success() && matrix.variant == 'homebrew'
-        run: |
-          set -euo pipefail
-          cd tools/audiotap
-          BIN_PATH=$(swift build --show-bin-path)
-          PROFDATA="$BIN_PATH/codecov/default.profdata"
-          XCTEST_DIR=$(find "$BIN_PATH" -name '*.xctest' -type d | head -n1)
-          [[ -n "$XCTEST_DIR" ]] || { echo "::error::no audiotap .xctest bundle in $BIN_PATH"; exit 1; }
-          XCTEST_BIN="$XCTEST_DIR/Contents/MacOS/$(basename "$XCTEST_DIR" .xctest)"
-          xcrun llvm-cov export \
-            -format=lcov \
-            -instr-profile="$PROFDATA" \
-            -ignore-filename-regex='\.build/|Tests/|/usr/' \
-            "$XCTEST_BIN" \
-            > "$GITHUB_WORKSPACE/coverage-audiotap.lcov"
-          wc -l "$GITHUB_WORKSPACE/coverage-audiotap.lcov"
-      - name: Upload audiotap coverage to Codecov
-        if: success() && matrix.variant == 'homebrew'
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+      - uses: ./.github/actions/export-lcov
+        if: success()
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage-audiotap.lcov
-          flags: audiotap
-          fail_ci_if_error: false
-          verbose: true
+          package-dir: tools/audiotap
+          flag: audiotap
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,42 @@ jobs:
           flags: ${{ matrix.variant }}
           fail_ci_if_error: false
           verbose: true
+      # AudioTapLib SPM library has its own test suite in
+      # `tools/audiotap/Tests/`. Run + upload its coverage only from the
+      # homebrew leg — the library is variant-agnostic (no -DAPPSTORE
+      # path), so the appstore leg would just produce an identical second
+      # copy. Single upload + `carryforward` in `.codecov.yml` keeps the
+      # number stable on non-CI events.
+      - name: Audiotap tests with coverage
+        if: success() && matrix.variant == 'homebrew'
+        timeout-minutes: 5
+        run: cd tools/audiotap && swift test --parallel --enable-code-coverage
+      - name: Export audiotap LCOV
+        if: success() && matrix.variant == 'homebrew'
+        run: |
+          set -euo pipefail
+          cd tools/audiotap
+          BIN_PATH=$(swift build --show-bin-path)
+          PROFDATA="$BIN_PATH/codecov/default.profdata"
+          XCTEST_DIR=$(find "$BIN_PATH" -name '*.xctest' -type d | head -n1)
+          [[ -n "$XCTEST_DIR" ]] || { echo "::error::no audiotap .xctest bundle in $BIN_PATH"; exit 1; }
+          XCTEST_BIN="$XCTEST_DIR/Contents/MacOS/$(basename "$XCTEST_DIR" .xctest)"
+          xcrun llvm-cov export \
+            -format=lcov \
+            -instr-profile="$PROFDATA" \
+            -ignore-filename-regex='\.build/|Tests/|/usr/' \
+            "$XCTEST_BIN" \
+            > "$GITHUB_WORKSPACE/coverage-audiotap.lcov"
+          wc -l "$GITHUB_WORKSPACE/coverage-audiotap.lcov"
+      - name: Upload audiotap coverage to Codecov
+        if: success() && matrix.variant == 'homebrew'
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage-audiotap.lcov
+          flags: audiotap
+          fail_ci_if_error: false
+          verbose: true
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure

--- a/scripts/export-lcov.sh
+++ b/scripts/export-lcov.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Export LCOV coverage for an SPM package's xctest bundle.
+#
+# Usage: scripts/export-lcov.sh <package-dir> <output-path>
+#
+# Locates the most recently built `.xctest` bundle and `default.profdata`
+# in <package-dir>, exports an LCOV report via `xcrun llvm-cov export`,
+# writes to <output-path>. Caller must have already run
+# `swift test --enable-code-coverage` in <package-dir>.
+
+set -euo pipefail
+
+package_dir=${1:?package-dir required (e.g. app/MeetingTranscriber)}
+output_path=${2:?output-path required (e.g. coverage-homebrew.lcov)}
+
+cd "$package_dir"
+bin_path=$(swift build --show-bin-path)
+profdata="$bin_path/codecov/default.profdata"
+xctest_dir=$(find "$bin_path" -name '*.xctest' -type d | head -n1)
+[[ -n "$xctest_dir" ]] || { echo "::error::no .xctest bundle in $bin_path" >&2; exit 1; }
+xctest_bin="$xctest_dir/Contents/MacOS/$(basename "$xctest_dir" .xctest)"
+
+xcrun llvm-cov export \
+  -format=lcov \
+  -instr-profile="$profdata" \
+  -ignore-filename-regex='\.build/|Tests/|/usr/' \
+  "$xctest_bin" \
+  > "$output_path"
+wc -l "$output_path"


### PR DESCRIPTION
## Summary

Three related commits that together align the codecov signal with what's actually tested:

### Commit 1 — tighten ignore list

Two files were dragging the headline number down despite not being unit-testable in xctest:

- **`MeetingTranscriberApp.swift`** — `@main` SwiftUI scene shell, NSOpenPanel/NSWorkspace bindings. Exercised by `e2e-app.yml`. Was 1.3 % covered.
- **`MicRecorder.swift`** — pure AVAudioEngine wrapper, hardware-bound. Was 4.8 % covered.

Both added to the ignore list. End-to-end coverage stays via `e2e-app.yml`.

### Commit 2 — upload audiotap with its own flag

AudioTapLib has a real test suite in `tools/audiotap/Tests/` that the previous CI never uploaded. This commit ran the tests + uploaded LCOV with a new `audiotap` flag, replaced the blanket `tools/audiotap/Sources/**/*` ignore with targeted entries for the 3 hardware-bound files exercised by `e2e-app.yml`, and bumped `after_n_builds` 2 → 3.

### Commit 3 — refactor (driven by /simplify review)

- Extracted the LCOV-export + codecov-upload shell block into a composite action `.github/actions/export-lcov/`. Both call sites (app coverage + audiotap) collapse to a 5-line `uses:` block. Single point to fix if the export incantation ever needs to change.
- Split audiotap out of the homebrew matrix leg into its own top-level job `audiotap-coverage`. Runs in parallel with the `test` matrix instead of serially after the 5–7 min app suite.
- Added `actions/cache@v5` for `tools/audiotap/.build`. AudioTapLib has no external dependencies, so cold-compile cost drops on repeat runs.
- Fixed stale comment in `.codecov.yml` ("2-leg matrix" → "3-upload fan-in").

Net: workflow shrunk by 28 lines, no behavior loss.

## Effect

App-side line coverage (measured locally):

|              | Before | After   |
|--------------|--------|---------|
| LOC measured | 15151  | 13039   |
| Missed       | 5385   | 3396    |
| **Coverage** | **64.5 %** | **74.0 %** |

The new `audiotap` flag contributes another ~200 LOC of high-coverage code (`MicRestartPolicy` 100 %, `SampleRateQuery` 97.7 %, `OutputDeviceChangeCoordinator` 100 %) to the project total.

## Test plan

- [x] `curl --data-binary @.codecov.yml https://codecov.io/validate` returns `Valid!`
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `./scripts/lint.sh` — 0 violations
- [x] Local LCOV export from audiotap profdata produces 8 source files
- [ ] CI sees 3 flagged uploads (homebrew, appstore, audiotap) on this PR
- [ ] `audiotap-coverage` job runs in parallel with `test (homebrew/appstore)` legs, not after them