### PR TITLE
ci(quality): disable mt-ci keychain auto-lock during sanitizer runs

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -82,13 +82,23 @@ jobs:
       # `SecItemCopyMatching` searches login.keychain only — KeychainHelper
       # tests silent-fail. Re-assert per job; safe under matrix parallelism
       # because every job writes the same value.
-      - name: Ensure CI keychain is default + in search list + unlocked
+      #
+      # `set-keychain-settings -lut 36000` raises the auto-lock-on-idle
+      # timeout to 10 h. The default ~5 min fired mid-run on the Mini
+      # (sanitizer compile ~4 min + slower tests pushed read calls past
+      # the threshold), causing `SecItemCopyMatching` to silent-fail with
+      # `errSecAuthFailed` between two consecutive reads in
+      # `testOpenAIAPIKeyViaKeychainHelper`. Without `-l` the keychain
+      # also doesn't lock on system sleep — irrelevant inside a CI job
+      # but defensive.
+      - name: Ensure CI keychain is default + in search list + unlocked + no-autolock
         run: |
           security default-keychain -s ~/Library/Keychains/mt-ci.keychain-db
           security list-keychains -d user -s \
             ~/Library/Keychains/mt-ci.keychain-db \
             ~/Library/Keychains/login.keychain-db
           security unlock-keychain -p "" ~/Library/Keychains/mt-ci.keychain-db
+          security set-keychain-settings -lut 36000 ~/Library/Keychains/mt-ci.keychain-db
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure


### PR DESCRIPTION
## Symptom

`testOpenAIAPIKeyViaKeychainHelper` silent-failed on the Mini's `test (asan)` (2026-05-13) and `test (tsan)` (2026-05-15) legs of `quality-and-safety.yml`:

```
AppSettingsTests.swift:198  KeychainHelper.read → "sk-test-key"  ✓
AppSettingsTests.swift:199  settings.openAIAPIKey  → ""           ✗
```

Two consecutive reads of the same Keychain item, ~1 ms apart, with divergent results.

## Cause

`mt-ci.keychain-db` is pre-staged by `scripts/setup-self-hosted-runner.sh` without an explicit `security set-keychain-settings`, so it inherits macOS' default **~5 min idle auto-lock**. Sanitizer compile takes ~4 min and the test suite runs another 2–3 min, so reads after the threshold get `errSecAuthFailed` — which `KeychainHelper.read` returns as `nil` and the getter coerces to `""`. Plain `ci.yml` is fast enough to stay under the threshold; the sanitizer matrix isn't.

## Fix

One line added to the per-job pre-flight step in `quality-and-safety.yml`:

```yaml
security set-keychain-settings -lut 36000 ~/Library/Keychains/mt-ci.keychain-db
```

- `-lut 36000` raises the lock-on-idle timeout to 10 h
- Without `-l`: doesn't lock on system sleep (defensive — irrelevant inside a CI job, but correct semantically for a CI keychain)

Renamed the step accordingly: `Ensure CI keychain is default + in search list + unlocked + no-autolock`.

## Why patched in workflow not setup script

| | this PR (workflow) | setup script |
|---|---|---|
| Self-deploying | ✓ next push | ✗ needs SSH + manual re-run |
| Idempotent across job runs | ✓ every job re-asserts | once |
| Resilient to mid-day Mini drift | ✓ | ✗ |
| Permanent baseline | ✗ | ✓ |

Mirroring into `setup-self-hosted-runner.sh:223` is a sensible follow-up PR — included as a TODO in the commit message but deliberately deferred.

## Test plan

- [x] `actionlint .github/workflows/quality-and-safety.yml` — clean
- [ ] `quality-and-safety.yml` runs on this PR's `push` to `ci/keychain-no-autolock` is grey-not-running (workflow only fires on main, nightly, dispatch). After merge, push to main triggers it.
- [ ] First post-merge `quality-and-safety.yml` run on main goes green on Mini-Runner-2 (`testOpenAIAPIKeyViaKeychainHelper` no longer silent-fails)