### PR TITLE
test(app): cover VoiceEnrollmentView (0%→92%) + extract pure logic

### DIFF
--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -13,11 +13,23 @@ struct VoiceEnrollmentView: View {
     let diarizerFactory: () -> any DiarizationProvider
     let onClose: () -> Void
 
-    @State private var stage: Stage = .pickFile
+    @State private var stage: Stage
     @State private var diarizeStart: Date?
     @State private var elapsed: TimeInterval = 0
     @State private var elapsedTimer: Task<Void, Never>?
     @State private var diarizationTask: Task<Void, Never>?
+
+    init(
+        matcher: SpeakerMatcher,
+        diarizerFactory: @escaping () -> any DiarizationProvider,
+        onClose: @escaping () -> Void,
+        initialStage: Stage = .pickFile,
+    ) {
+        self.matcher = matcher
+        self.diarizerFactory = diarizerFactory
+        self.onClose = onClose
+        _stage = State(initialValue: initialStage)
+    }
 
     enum Stage {
         case pickFile
@@ -108,7 +120,12 @@ struct VoiceEnrollmentView: View {
                 data: payload.namingData,
                 knownSpeakerNames: payload.knownNames,
             ) { result in
-                handleNamingResult(result, payload: payload)
+                switch VoiceEnrollmentLogic.handleNamingResult(
+                    result, payload: payload, matcher: matcher,
+                ) {
+                case let .stage(next): stage = next
+                case let .rerun(url, count): startDiarization(url: url, numSpeakers: count)
+                }
             }
             .frame(minHeight: 320)
         }
@@ -174,7 +191,9 @@ struct VoiceEnrollmentView: View {
                 if result.segments.isEmpty {
                     stage = .error("No speakers detected in this recording.")
                 } else {
-                    stage = .naming(buildNamingPayload(url: url, diarization: result))
+                    stage = .naming(VoiceEnrollmentLogic.buildNamingPayload(
+                        url: url, diarization: result, matcher: matcher,
+                    ))
                 }
             } catch is CancellationError {
                 // sheet dismissed mid-diarization; nothing to do
@@ -186,15 +205,50 @@ struct VoiceEnrollmentView: View {
         }
     }
 
-    private func handleNamingResult(
+    // MARK: - Elapsed timer
+
+    private func startElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(500))
+                if let start = diarizeStart {
+                    elapsed = Date().timeIntervalSince(start)
+                }
+            }
+        }
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = nil
+    }
+}
+
+// MARK: - Pure logic (testable without SwiftUI)
+
+/// Pure functions backing `VoiceEnrollmentView`. Separating them out keeps
+/// the view's mutating helpers `private` and lets tests assert on the
+/// computed outcome instead of poking at `@State`.
+enum VoiceEnrollmentLogic {
+    /// Outcome of consuming a `SpeakerNamingResult`: either a direct stage
+    /// transition, or a request to re-run diarization with N speakers.
+    /// The view turns the `.rerun` case into an async Task; the logic itself
+    /// stays synchronous and side-effect-free apart from `matcher.updateDB`.
+    enum Outcome {
+        case stage(VoiceEnrollmentView.Stage)
+        case rerun(url: URL, numSpeakers: Int)
+    }
+
+    static func handleNamingResult(
         _ result: PipelineQueue.SpeakerNamingResult,
-        payload: NamingPayload,
-    ) {
+        payload: VoiceEnrollmentView.NamingPayload,
+        matcher: SpeakerMatcher,
+    ) -> Outcome {
         switch result {
         case let .confirmed(mapping):
             guard let embeddings = payload.diarization.embeddings else {
-                stage = .error("Diarization produced no embeddings; cannot enroll.")
-                return
+                return .stage(.error("Diarization produced no embeddings; cannot enroll."))
             }
             matcher.updateDB(
                 mapping: mapping,
@@ -202,19 +256,21 @@ struct VoiceEnrollmentView: View {
                 speakingTimes: payload.diarization.speakingTimes,
             )
             let saved = Set(mapping.values.filter { !$0.isEmpty }).sorted()
-            stage = .done(savedNames: saved)
+            return .stage(.done(savedNames: saved))
 
         case .skipped:
-            stage = .done(savedNames: [])
+            return .stage(.done(savedNames: []))
 
         case let .rerun(count):
-            startDiarization(url: payload.url, numSpeakers: count)
+            return .rerun(url: payload.url, numSpeakers: count)
         }
     }
 
-    private func buildNamingPayload(
-        url: URL, diarization: DiarizationResult,
-    ) -> NamingPayload {
+    static func buildNamingPayload(
+        url: URL,
+        diarization: DiarizationResult,
+        matcher: SpeakerMatcher,
+    ) -> VoiceEnrollmentView.NamingPayload {
         let knownNames = matcher.allSpeakerNames()
         // Pre-fill auto-name suggestions by running a match against the
         // existing DB. Same flow as a real meeting.
@@ -238,31 +294,12 @@ struct VoiceEnrollmentView: View {
             isDualSource: false,
         )
         let speakerCount = Set(diarization.segments.map(\.speaker)).count
-        return NamingPayload(
+        return VoiceEnrollmentView.NamingPayload(
             url: url,
             diarization: diarization,
             namingData: data,
             knownNames: knownNames,
             speakerCount: speakerCount,
         )
-    }
-
-    // MARK: - Elapsed timer
-
-    private func startElapsedTimer() {
-        elapsedTimer?.cancel()
-        elapsedTimer = Task { @MainActor in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(500))
-                if let start = diarizeStart {
-                    elapsed = Date().timeIntervalSince(start)
-                }
-            }
-        }
-    }
-
-    private func stopElapsedTimer() {
-        elapsedTimer?.cancel()
-        elapsedTimer = nil
     }
 }

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -15,14 +15,300 @@ final class VoiceEnrollmentViewTests: XCTestCase { // swiftlint:disable:this bal
         dbPath = tmpDir.appendingPathComponent("speakers.json")
     }
 
-    func testRendersInPickFileStage() throws {
-        let view = VoiceEnrollmentView(
-            matcher: SpeakerMatcher(dbPath: dbPath),
+    // MARK: - Helpers
+
+    private func makeView(
+        matcher: SpeakerMatcher? = nil,
+        initialStage: VoiceEnrollmentView.Stage = .pickFile,
+        onClose: @escaping () -> Void = {},
+    ) -> VoiceEnrollmentView {
+        VoiceEnrollmentView(
+            matcher: matcher ?? SpeakerMatcher(dbPath: dbPath),
             diarizerFactory: { MockDiarization() },
-            onClose: {},
+            onClose: onClose,
+            initialStage: initialStage,
         )
+    }
+
+    private func makeNamingPayload(
+        url: URL = URL(fileURLWithPath: "/tmp/voice-enrollment-test.wav"),
+        diarization: DiarizationResult? = nil,
+        knownNames: [String] = [],
+    ) -> VoiceEnrollmentView.NamingPayload {
+        let diar = diarization ?? DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_00"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_01"),
+            ],
+            speakingTimes: ["SPEAKER_00": 5, "SPEAKER_01": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_00": [1, 0, 0], "SPEAKER_01": [0, 1, 0]],
+        )
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: url.lastPathComponent,
+            mapping: ["SPEAKER_00": "SPEAKER_00", "SPEAKER_01": "SPEAKER_01"],
+            speakingTimes: diar.speakingTimes,
+            embeddings: diar.embeddings ?? [:],
+            audioPath: url,
+            segments: diar.segments.map { seg in
+                PipelineQueue.SpeakerNamingData.Segment(
+                    start: seg.start, end: seg.end, speaker: seg.speaker,
+                )
+            },
+            participants: [],
+            isDualSource: false,
+        )
+        return VoiceEnrollmentView.NamingPayload(
+            url: url,
+            diarization: diar,
+            namingData: data,
+            knownNames: knownNames,
+            speakerCount: Set(diar.segments.map(\.speaker)).count,
+        )
+    }
+
+    // MARK: - Render: pickFile
+
+    func testRendersInPickFileStage() throws {
+        let view = makeView()
         XCTAssertNoThrow(try view.inspect())
     }
+
+    func testRendersPickFileBodyWithBothPickerButtons() throws {
+        let body = try makeView().inspect()
+        XCTAssertNoThrow(try body.find(button: "Choose File…"))
+        XCTAssertNoThrow(try body.find(button: "Browse Past Recordings…"))
+        XCTAssertNoThrow(try body.find(text: "Add Voice from Recording"))
+    }
+
+    // MARK: - Render: diarizing
+
+    func testRendersDiarizingBodyShowsFilename() throws {
+        let url = URL(fileURLWithPath: "/tmp/standup.wav")
+        let body = try makeView(initialStage: .diarizing(url)).inspect()
+        let texts = body.findAll(ViewType.Text.self)
+        let hasFilename = texts.contains { (try? $0.string())?.contains("standup.wav") == true }
+        XCTAssertTrue(hasFilename, "Diarizing body should mention the file name")
+    }
+
+    // MARK: - Render: naming
+
+    func testRendersNamingBodyShowsSpeakerCount() throws {
+        let payload = makeNamingPayload()
+        let body = try makeView(initialStage: .naming(payload)).inspect()
+        let texts = body.findAll(ViewType.Text.self)
+        let hasCount = texts.contains { (try? $0.string())?.contains("Found 2 speakers") == true }
+        XCTAssertTrue(hasCount, "Naming body should show speaker count")
+    }
+
+    // MARK: - Render: done
+
+    func testRendersDoneBodyWithMultipleSpeakers() throws {
+        let body = try makeView(initialStage: .done(savedNames: ["Alice", "Bob"])).inspect()
+        XCTAssertNoThrow(try body.find(text: "Enrolled 2 speakers"))
+        XCTAssertNoThrow(try body.find(text: "Alice, Bob"))
+        XCTAssertNoThrow(try body.find(button: "Done"))
+    }
+
+    func testRendersDoneBodySingularGrammar() throws {
+        let body = try makeView(initialStage: .done(savedNames: ["Alice"])).inspect()
+        XCTAssertNoThrow(try body.find(text: "Enrolled 1 speaker"))
+    }
+
+    func testRendersDoneBodyEmptySkipsNameList() throws {
+        let body = try makeView(initialStage: .done(savedNames: [])).inspect()
+        XCTAssertNoThrow(try body.find(text: "Enrolled 0 speakers"))
+        let texts = body.findAll(ViewType.Text.self)
+        let hasCommaList = texts.contains { (try? $0.string())?.contains(",") == true }
+        XCTAssertFalse(hasCommaList, "Empty enrollment should not render a comma-separated list")
+    }
+
+    // MARK: - Render: error
+
+    func testRendersErrorBodyShowsMessageAndButtons() throws {
+        let body = try makeView(initialStage: .error("disk full")).inspect()
+        XCTAssertNoThrow(try body.find(text: "Enrollment failed"))
+        XCTAssertNoThrow(try body.find(text: "disk full"))
+        XCTAssertNoThrow(try body.find(button: "Try Again"))
+        XCTAssertNoThrow(try body.find(button: "Close"))
+    }
+
+    // MARK: - Button taps
+
+    func testCancelButtonCallsOnClose() throws {
+        var closed = false
+        let body = try makeView { closed = true }.inspect()
+        try body.find(button: "Cancel").tap()
+        XCTAssertTrue(closed)
+    }
+
+    func testDoneButtonCallsOnClose() throws {
+        var closed = false
+        let body = try makeView(initialStage: .done(savedNames: ["Alice"])) { closed = true }
+            .inspect()
+        try body.find(button: "Done").tap()
+        XCTAssertTrue(closed)
+    }
+
+    func testErrorCloseButtonCallsOnClose() throws {
+        var closed = false
+        let body = try makeView(initialStage: .error("oops")) { closed = true }.inspect()
+        try body.find(button: "Close").tap()
+        XCTAssertTrue(closed)
+    }
+
+    // MARK: - Inlined namingBody closure (covers the call-site switch on Outcome)
+
+    func testNamingStageSkipButtonRunsInlinedClosure() throws {
+        // Tapping Skip on the embedded SpeakerNamingView fires
+        // VoiceEnrollmentView's inlined `onComplete` closure → executes the
+        // switch on `VoiceEnrollmentLogic.Outcome`. Coverage is the goal here;
+        // we can't observe the @State transition from outside the SwiftUI
+        // render context.
+        let view = makeView(initialStage: .naming(makeNamingPayload()))
+        let body = try view.inspect()
+        XCTAssertNoThrow(try body.find(button: "Skip").tap())
+    }
+
+    func testNamingStageRerunButtonRunsInlinedClosure() throws {
+        // Same idea for the .rerun branch of the inlined switch — taps the
+        // SpeakerNamingView's "Re-run" button which fires `onComplete(.rerun(N))`.
+        let view = makeView(initialStage: .naming(makeNamingPayload()))
+        let body = try view.inspect()
+        let rerun = try body.find(viewWithAccessibilityIdentifier: "rerun-button")
+        XCTAssertNoThrow(try rerun.button().tap())
+    }
+
+    // MARK: - VoiceEnrollmentLogic.handleNamingResult
+
+    func testHandleNamingResultConfirmedPersistsSpeakersAndReturnsDoneStage() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let outcome = VoiceEnrollmentLogic.handleNamingResult(
+            .confirmed(["SPEAKER_00": "Alice", "SPEAKER_01": "Bob"]),
+            payload: makeNamingPayload(),
+            matcher: matcher,
+        )
+        XCTAssertEqual(Set(matcher.allSpeakerNames()), ["Alice", "Bob"])
+        guard case let .stage(.done(savedNames)) = outcome else {
+            XCTFail("Expected .stage(.done), got something else")
+            return
+        }
+        XCTAssertEqual(savedNames, ["Alice", "Bob"])
+    }
+
+    func testHandleNamingResultConfirmedWithoutEmbeddingsReturnsErrorStage() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        // Without embeddings, updateDB has no per-label vector to attach;
+        // the logic surfaces this as an error stage rather than silently
+        // dropping the user's input.
+        let diar = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_00")],
+            speakingTimes: ["SPEAKER_00": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let outcome = VoiceEnrollmentLogic.handleNamingResult(
+            .confirmed(["SPEAKER_00": "Alice"]),
+            payload: makeNamingPayload(diarization: diar),
+            matcher: matcher,
+        )
+        XCTAssertTrue(matcher.allSpeakerNames().isEmpty)
+        guard case .stage(.error) = outcome else {
+            XCTFail("Expected .stage(.error), got something else")
+            return
+        }
+    }
+
+    func testHandleNamingResultSkippedReturnsDoneStageWithNoNames() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        let outcome = VoiceEnrollmentLogic.handleNamingResult(
+            .skipped, payload: makeNamingPayload(), matcher: matcher,
+        )
+        XCTAssertTrue(matcher.allSpeakerNames().isEmpty)
+        guard case let .stage(.done(savedNames)) = outcome else {
+            XCTFail("Expected .stage(.done), got something else")
+            return
+        }
+        XCTAssertTrue(savedNames.isEmpty)
+    }
+
+    func testHandleNamingResultRerunForwardsURLAndSpeakerCount() {
+        let url = URL(fileURLWithPath: "/tmp/rerun-target.wav")
+        let outcome = VoiceEnrollmentLogic.handleNamingResult(
+            .rerun(3),
+            payload: makeNamingPayload(url: url),
+            matcher: SpeakerMatcher(dbPath: dbPath),
+        )
+        guard case let .rerun(rerunURL, count) = outcome else {
+            XCTFail("Expected .rerun, got something else")
+            return
+        }
+        XCTAssertEqual(rerunURL, url)
+        XCTAssertEqual(count, 3)
+    }
+
+    // MARK: - VoiceEnrollmentLogic.buildNamingPayload
+
+    func testBuildNamingPayloadFallsBackToIdentityWhenMatcherEmpty() {
+        let matcher = SpeakerMatcher(dbPath: dbPath) // empty DB → no auto-names
+        let diar = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_00"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_01"),
+            ],
+            speakingTimes: ["SPEAKER_00": 5, "SPEAKER_01": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let payload = VoiceEnrollmentLogic.buildNamingPayload(
+            url: URL(fileURLWithPath: "/tmp/foo.wav"), diarization: diar, matcher: matcher,
+        )
+        XCTAssertEqual(payload.speakerCount, 2)
+        XCTAssertEqual(payload.namingData.mapping["SPEAKER_00"], "SPEAKER_00")
+        XCTAssertEqual(payload.namingData.mapping["SPEAKER_01"], "SPEAKER_01")
+        XCTAssertTrue(payload.knownNames.isEmpty)
+    }
+
+    func testBuildNamingPayloadIncludesKnownSpeakerNames() {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([
+            StoredSpeaker(name: "Alice", embeddings: [[1, 0, 0]]),
+            StoredSpeaker(name: "Bob", embeddings: [[0, 1, 0]]),
+        ])
+        let diar = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_00")],
+            speakingTimes: ["SPEAKER_00": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_00": [1, 0, 0]],
+        )
+        let payload = VoiceEnrollmentLogic.buildNamingPayload(
+            url: URL(fileURLWithPath: "/tmp/bar.wav"), diarization: diar, matcher: matcher,
+        )
+        XCTAssertEqual(Set(payload.knownNames), ["Alice", "Bob"])
+    }
+
+    func testBuildNamingPayloadDedupsSpeakerCountFromSegments() {
+        // Three segments but only two distinct speakers — speakerCount must be 2.
+        let diar = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_00"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_01"),
+                .init(start: 10, end: 15, speaker: "SPEAKER_00"),
+            ],
+            speakingTimes: ["SPEAKER_00": 10, "SPEAKER_01": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let payload = VoiceEnrollmentLogic.buildNamingPayload(
+            url: URL(fileURLWithPath: "/tmp/baz.wav"),
+            diarization: diar,
+            matcher: SpeakerMatcher(dbPath: dbPath),
+        )
+        XCTAssertEqual(payload.speakerCount, 2)
+    }
+
+    // MARK: - KnownVoicesView integration (this view is what hosts VoiceEnrollmentView)
 
     func testKnownVoicesViewShowsEnrollButtonWhenFactoryProvided() throws {
         let view = KnownVoicesView(


### PR DESCRIPTION
## Summary

- Adds 25 unit tests for \`VoiceEnrollmentView\`, lifting line coverage from **0% → 92.35%** (392 LOC, 30 missed).
- Extracts \`buildNamingPayload\` and \`handleNamingResult\` into a new \`enum VoiceEnrollmentLogic\` namespace as **pure static functions**. \`handleNamingResult\` returns an \`Outcome\` (\`.stage(Stage)\` or \`.rerun(url:numSpeakers:)\`) instead of mutating \`@State\`.
- The \`Outcome\` switch is inlined directly into the SpeakerNamingView \`onComplete\` callback in \`namingBody\` — no View-level wrapper functions, no \`private\` modifiers dropped.
- Two ViewInspector tap-tests drive SpeakerNamingView's Skip and Re-run buttons inside the .naming stage to cover the inlined switch end-to-end (closure construction, both Outcome branches, and the \`startDiarization\` call from .rerun).

## Why this shape

- Coverage is the user-visible goal; the refactor is the SOTA half. The view file used to need 3 \`private\` modifiers dropped just to make the logic testable. Extracting into a pure enum + inlining the switch at the call site achieves full coverage on the interesting branches *and* keeps the production surface tight.
- Logic is tested directly (synchronous, side-effect-free apart from \`matcher.updateDB\`); the inlined closure path is exercised via tap-tests so the switch + \`startDiarization\` rerun call show up as covered too.

## Test coverage

- All 5 stage renders (pickFile / diarizing / naming / done / error)
- Button callbacks: Cancel, Done, error-Close
- SpeakerNamingView tap-through (Skip + Re-run) drives the inlined \`Outcome\` switch
- \`VoiceEnrollmentLogic.handleNamingResult\`: confirmed-with-embeddings → done stage + DB writes, confirmed-without-embeddings → error stage + no DB writes, skipped → done stage with empty names, rerun → forwards URL + speaker count
- \`VoiceEnrollmentLogic.buildNamingPayload\`: identity fallback, known-names pre-fill, speaker-count dedup from segments

## Uncovered (~8%)

Reasonably untestable from xctest without major restructuring:

- \`pickFile()\` opens an \`NSOpenPanel\` modal
- \`startElapsedTimer()\` sleep loop
- Parts of the async error-catch path in \`startDiarization\`
- \`onDisappear\` cleanup

## Test plan

- [x] \`swift test --filter VoiceEnrollmentViewTests\` — 25/25 pass in 0.34 s
- [x] \`swift test --filter "VoiceEnrollmentViewTests|KnownVoicesViewTests"\` — 28/28 pass (host view unbroken)
- [x] \`./scripts/lint.sh\` — 0 violations
- [x] llvm-cov confirms 92.35% line coverage on \`VoiceEnrollmentView.swift\`