### PR TITLE
test(app): cover ClaudeCLIProtocolGenerator parsing + path resolution

### DIFF
--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -1,0 +1,118 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    final class ClaudeCLIProtocolGeneratorTests: XCTestCase {
+        // MARK: - parseStreamJSONLine
+
+        func testParseStreamJSONLineExtractsContentBlockDeltaText() {
+            let line = #"{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}"#
+            XCTAssertEqual(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line), "Hello")
+        }
+
+        func testParseStreamJSONLineExtractsAssistantText() {
+            let line = #"""
+            {"type":"assistant","message":{"content":[{"type":"text","text":"Final"}]}}
+            """#
+            XCTAssertEqual(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line), "Final")
+        }
+
+        func testParseStreamJSONLineAssistantSkipsNonTextBlocks() {
+            // First block is non-text (e.g. tool_use); the loop must continue and
+            // pick up the next text block.
+            let line = #"""
+            {"type":"assistant","message":{"content":[{"type":"tool_use","id":"x"},{"type":"text","text":"After"}]}}
+            """#
+            XCTAssertEqual(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line), "After")
+        }
+
+        func testParseStreamJSONLineAssistantWithoutTextBlockReturnsNil() {
+            let line = #"""
+            {"type":"assistant","message":{"content":[{"type":"tool_use","id":"x"}]}}
+            """#
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line))
+        }
+
+        func testParseStreamJSONLineContentBlockDeltaWrongDeltaTypeReturnsNil() {
+            // Anthropic stream-json carries `input_json_delta` for tool inputs;
+            // those must not be confused with text content.
+            let line = #"{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{"}}"#
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line))
+        }
+
+        func testParseStreamJSONLineContentBlockDeltaMissingDeltaReturnsNil() {
+            let line = #"{"type":"content_block_delta"}"#
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line))
+        }
+
+        func testParseStreamJSONLineUnknownTypeReturnsNil() {
+            let line = #"{"type":"message_stop"}"#
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line))
+        }
+
+        func testParseStreamJSONLineInvalidJSONReturnsNil() {
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine("not json"))
+        }
+
+        func testParseStreamJSONLineNonObjectJSONReturnsNil() {
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine("[1,2,3]"))
+        }
+
+        func testParseStreamJSONLineAssistantMissingContentReturnsNil() {
+            let line = #"{"type":"assistant","message":{}}"#
+            XCTAssertNil(ClaudeCLIProtocolGenerator.parseStreamJSONLine(line))
+        }
+
+        // MARK: - resolveClaudePath
+
+        func testResolveClaudePathAbsolutePathReturnsAsIs() {
+            // Absolute paths are trusted verbatim — even if the file doesn't
+            // exist, that's the caller's problem; the resolver doesn't probe.
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.resolveClaudePath("/totally/fake/claude"),
+                "/totally/fake/claude",
+            )
+        }
+
+        func testResolveClaudePathFallsBackToEnvForUnknownBareName() {
+            // A bare name not present in any search path falls through to the
+            // /usr/bin/env shim so the production code can still attempt the
+            // launch (which will fail loudly with a known error path).
+            let unique = "claude-does-not-exist-\(UUID().uuidString)"
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.resolveClaudePath(unique),
+                "/usr/bin/env",
+            )
+        }
+
+        // MARK: - availableClaudeBinaries
+
+        func testAvailableClaudeBinariesAlwaysIncludesClaudeFallback() {
+            // "claude" is unconditionally inserted so the picker UI always has
+            // at least one option even on hosts where no claude* binary is
+            // installed in any of the standard search paths.
+            let names = ClaudeCLIProtocolGenerator.availableClaudeBinaries()
+            XCTAssertTrue(names.contains("claude"))
+        }
+
+        func testAvailableClaudeBinariesAreSortedAndDeduped() {
+            let names = ClaudeCLIProtocolGenerator.availableClaudeBinaries()
+            XCTAssertEqual(names, names.sorted(), "Result must be sorted")
+            XCTAssertEqual(Set(names).count, names.count, "Result must be deduped")
+        }
+
+        // MARK: - searchPaths
+
+        func testSearchPathsContainExpectedDirectories() {
+            // Lock in the search-path list; changing it (e.g. adding a new
+            // location) is intentional and should be reviewed alongside the
+            // test update.
+            let paths = ClaudeCLIProtocolGenerator.searchPaths
+            XCTAssertEqual(paths.count, 4)
+            XCTAssertTrue(paths.contains("/usr/local/bin"))
+            XCTAssertTrue(paths.contains("/opt/homebrew/bin"))
+            XCTAssertTrue(paths.contains("\(NSHomeDirectory())/.local/bin"))
+            XCTAssertTrue(paths.contains("\(NSHomeDirectory())/.npm-global/bin"))
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- Adds 15 unit tests for the static, deterministic surface of `ClaudeCLIProtocolGenerator`:
  - `parseStreamJSONLine` — 10 tests covering content_block_delta with text_delta, assistant message blocks (incl. mixed tool_use+text), wrong delta types, missing fields, invalid/non-object JSON, unknown types
  - `resolveClaudePath` — absolute-path passthrough, missing-bare-name fallback to `/usr/bin/env`
  - `availableClaudeBinaries` — always-includes-`claude` fallback, sorted-and-deduped invariant
  - `searchPaths` — locked-in list of 4 expected install locations
- Coverage on `ClaudeCLIProtocolGenerator.swift`: **~0% → 24.57%** (line, 232 LOC).

## Why

Step 2 of the path toward 80% project coverage. Stream-json parsing is the part of this file that's actually risky to change (Anthropic's stream-json shape evolves; new event types appear), so locking it down is high-value.

## Out of scope

The remaining ~75 % is `generate()` + `readStreamJSON()` — both spawn a real `Process()` and read from real `Pipe`s. Testing those needs either a `Process` mocking layer (none exists) or a real `claude` binary on the test host. Both are larger refactors.

## Test plan

- [x] `swift test --filter ClaudeCLIProtocolGeneratorTests` — 15/15 pass in 0.07 s
- [x] `./scripts/lint.sh` — 0 violations
- [x] llvm-cov confirms 24.57 % line coverage on `ClaudeCLIProtocolGenerator.swift`
- [x] `#if !APPSTORE` gate matches the source file's gate (App Store variant excludes both)