### PR TITLE
ci(quality): bump SPM cache-key to invalidate corrupted cache

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: ./.github/actions/setup-swift-test
         timeout-minutes: 20
         with:
-          cache-key-suffix: quality
+          cache-key-suffix: quality-v2
       # Filter explicitly to engine-quality test classes — `--filter Quality`
       # would also pull in `QualityResultsTests`, which exercises the writer
       # via fake rows and would pollute the shared singleton's row buffer.


### PR DESCRIPTION
## Why

`quality-baseline` started failing on push to main ([run 25903504974](https://github.com/pasrom/meeting-transcriber/actions/runs/25903504974)) with 62× the same compile error against cached WhisperKit modules:

```
module 'ArgmaxCore' is in package 'whisperkit' but was built from a
non-package interface; modules of the same package can only be loaded
if built from source or package interface:
.../debug/Modules/ArgmaxCore.private.swiftinterface
```

The failing SHA (`a1fcbb9`) only adds unit tests for `ClaudeCLIProtocolGenerator` — no `Package.resolved` / `Package.swift` change, so the cache key matched the previous green run exactly and the corrupted `.swiftinterface` was restored verbatim. A manual re-run reproduced the same error, ruling out actions/cache transient flake.

Root cause is a known Swift toolchain fragility: actions/cache's compression+restore roundtrip can lose the metadata swiftc uses to decide whether a cached `.swiftinterface` was emitted in a package vs non-package build context. Once that signal is lost, WhisperKit's internal `package`-access imports of `ArgmaxCore` are rejected on every subsequent restore until the cache entry is invalidated.

## What

Bumps `cache-key-suffix: quality` → `quality-v2` in the `quality-baseline` job's call to `setup-swift-test`. Forces a one-time cold build (~5 min added to the next run only), after which incremental builds resume normally.

`tsan` and `asan` jobs use different suffixes and are unaffected — left alone.

## Test plan

- [x] Merge → next push-to-main triggers `quality-and-safety.yml` ([run 25906173002](https://github.com/pasrom/meeting-transcriber/actions/runs/25906173002))
- [x] `quality-baseline` step "Run quality regression suite" completes successfully (cold-build observed ~5 min, total job 07:31:55 → 07:36:49)
- [x] Cache populated under new key `spm-macOS-quality-v2-6bc43832...` (log confirms "Cache not found for input keys: spm-macOS-quality-v2-..." → cold build → save under new key)
- [ ] Subsequent run hits warm cache and finishes in expected time — pending next main-push or nightly cron (04:30 UTC)

## Follow-up (not in this PR)

The `restore-keys` fallback in `setup-swift-test/action.yml:43` can restore stale `.build/` across `Package.resolved` changes, which could reproduce the same class of failure after the next Dependabot bump. Tracked separately — non-trivial CI cost trade-off (~25 min wall-time per dep bump if we remove the fallback) deserves its own discussion.