### PR TITLE
test(app): expand SpeakerNamingView coverage from 56% to 75%

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 // `@preconcurrency`: AVFoundation types lack Sendable annotations —
 // same gap as AudioMixer.swift; preemptively guarded.
 @preconcurrency import AVFoundation
@@ -79,6 +80,14 @@ struct SpeakerNamingView: View {
         self.data = data
         self.knownSpeakerNames = knownSpeakerNames
         self.onComplete = onComplete
+        // Seed `names` and `rerunCount` synchronously so the view renders
+        // its chip rows on first body evaluation (the chips depend on
+        // `index < names.count`). `.onAppear` re-runs the same logic for
+        // belt-and-braces, but this lets ViewInspector tests + tests that
+        // never trigger SwiftUI lifecycle still see the correct surface.
+        let speakerList = Self.computeSpeakers(from: data)
+        _names = State(initialValue: Self.computeInitialNames(speakers: speakerList))
+        _rerunCount = State(initialValue: max(2, speakerList.count + 1))
     }
 
     @State private var names: [String] = []
@@ -98,6 +107,12 @@ struct SpeakerNamingView: View {
     private static let knownChipsCollapsedLimit = 8
 
     private var speakers: [(label: String, autoName: String?, speakingTime: Double)] {
+        Self.computeSpeakers(from: data)
+    }
+
+    static func computeSpeakers(
+        from data: PipelineQueue.SpeakerNamingData,
+    ) -> [(label: String, autoName: String?, speakingTime: Double)] {
         data.mapping.keys.sorted().map { label in
             let autoName = data.mapping[label]
             let isAutoNamed = autoName != nil && autoName != label

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -1,9 +1,12 @@
+// swiftlint:disable file_length
+import AppKit
 @testable import MeetingTranscriber
+import SwiftUI
 import ViewInspector
 import XCTest
 
 @MainActor
-final class SpeakerNamingViewTests: XCTestCase {
+final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_body_length
     // MARK: - Helpers
 
     private func makeData(
@@ -439,5 +442,192 @@ final class SpeakerNamingViewTests: XCTestCase {
         let images = body.findAll(ViewType.Image.self)
         let hasPlayIcon = images.contains { (try? $0.actualImage().name()) == "play.circle.fill" }
         XCTAssertTrue(hasPlayIcon, "Play button should be shown when audioPath is present")
+    }
+
+    // MARK: - knownChips render branch (requires non-empty knownSpeakerNames)
+
+    func testRendersKnownLabelWhenKnownSpeakerNamesProvided() throws {
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            knownSpeakerNames: ["Alice", "Bob"],
+        ) { _ in }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Known:"))
+    }
+
+    func testRendersKnownChipForEachKnownSpeakerName() throws {
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            knownSpeakerNames: ["Alice", "Bob", "Charlie"],
+        ) { _ in }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(button: "Alice"))
+        XCTAssertNoThrow(try body.find(button: "Bob"))
+        XCTAssertNoThrow(try body.find(button: "Charlie"))
+    }
+
+    func testKnownChipTapInvokesActionClosureAndConfirmFires() throws {
+        // Tap the known chip (covers the chipButton action closure inside
+        // `knownChips`), then Confirm. We don't assert on the mapping content
+        // because @State assignment from a ViewInspector tap doesn't
+        // reliably propagate to subsequent .inspect() calls; the goal here
+        // is exercising the chip's action path.
+        var result: PipelineQueue.SpeakerNamingResult?
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            knownSpeakerNames: ["Alice"],
+        ) { result = $0 }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(button: "Alice").tap())
+        try body.find(button: "Confirm").tap()
+        if case .confirmed = result {} else {
+            XCTFail("Expected .confirmed, got \(String(describing: result))")
+        }
+    }
+
+    // MARK: - More button (collapsed → expanded chip list)
+
+    func testMoreChipAppearsWhenKnownNamesExceedCollapsedLimit() throws {
+        // Limit is 8; provide 10 to force a "More (2)…" chip to render.
+        let manyNames = (0 ..< 10).map { "Speaker\($0)" }
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            knownSpeakerNames: manyNames,
+        ) { _ in }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(button: "More (2)…"))
+    }
+
+    func testMoreChipHiddenWhenKnownNamesAtOrBelowCollapsedLimit() throws {
+        let eightNames = (0 ..< 8).map { "Speaker\($0)" }
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            knownSpeakerNames: eightNames,
+        ) { _ in }
+        let body = try sut.inspect()
+        // Any chip whose label starts with "More" would indicate the
+        // collapse/expand control is showing — there shouldn't be one.
+        let buttons = body.findAll(ViewType.Button.self)
+        let hasMore = buttons.contains { btn in
+            (try? btn.labelView().text().string().hasPrefix("More")) == true
+        }
+        XCTAssertFalse(hasMore)
+    }
+
+    // MARK: - Participant chips
+
+    func testRendersParticipantChipsWhenParticipantsProvided() throws {
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: "Standup",
+            mapping: ["SPEAKER_00": "SPEAKER_00"],
+            speakingTimes: ["SPEAKER_00": 60],
+            embeddings: ["SPEAKER_00": [0.1, 0.2, 0.3]],
+            audioPath: nil,
+            segments: [],
+            participants: ["Dave", "Eve"],
+            isDualSource: false,
+        )
+        let sut = SpeakerNamingView(data: data) { _ in }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(button: "Dave"))
+        XCTAssertNoThrow(try body.find(button: "Eve"))
+    }
+
+    func testParticipantChipTapInvokesActionClosureAndConfirmFires() throws {
+        // Same coverage goal as the known-chip test — tap the participant
+        // chip to exercise the chipButton action closure inside
+        // `participantChips`, then Confirm. State propagation through
+        // ViewInspector taps is unreliable, so we don't assert mapping content.
+        var result: PipelineQueue.SpeakerNamingResult?
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: "Standup",
+            mapping: ["SPEAKER_00": "SPEAKER_00"],
+            speakingTimes: ["SPEAKER_00": 60],
+            embeddings: ["SPEAKER_00": [0.1, 0.2, 0.3]],
+            audioPath: nil,
+            segments: [],
+            participants: ["Dave"],
+            isDualSource: false,
+        )
+        let sut = SpeakerNamingView(data: data) { result = $0 }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(button: "Dave").tap())
+        try body.find(button: "Confirm").tap()
+        if case .confirmed = result {} else {
+            XCTFail("Expected .confirmed, got \(String(describing: result))")
+        }
+    }
+
+    // MARK: - Known speakers also in participants are de-duplicated
+
+    func testKnownNameAlreadyInParticipantsIsNotShownTwice() throws {
+        // "Dave" is both a participant AND a known speaker. The Known: row
+        // must skip him — chipping the same name twice would let the user
+        // tap the "wrong" one and surfaces no extra information.
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: UUID(),
+            meetingTitle: "Standup",
+            mapping: ["SPEAKER_00": "SPEAKER_00"],
+            speakingTimes: ["SPEAKER_00": 60],
+            embeddings: ["SPEAKER_00": [0.1, 0.2, 0.3]],
+            audioPath: nil,
+            segments: [],
+            participants: ["Dave"],
+            isDualSource: false,
+        )
+        let sut = SpeakerNamingView(
+            data: data,
+            knownSpeakerNames: ["Dave", "Eve"],
+        ) { _ in }
+        let body = try sut.inspect()
+        // "Eve" should still show up under Known:
+        XCTAssertNoThrow(try body.find(button: "Eve"))
+        // "Dave" only shows once (participant chip), not in Known: row.
+        let daveButtons = body.findAll(ViewType.Button.self).filter { btn in
+            (try? btn.labelView().text().string()) == "Dave"
+        }
+        XCTAssertEqual(daveButtons.count, 1)
+    }
+
+    // MARK: - AccessibleTextField NSViewRepresentable bridge
+
+    func testAccessibleTextFieldCoordinatorWritesBackToBinding() {
+        var current = ""
+        let binding = Binding<String>(get: { current }, set: { current = $0 })
+        let coord = AccessibleTextField.Coordinator(text: binding)
+        let field = NSTextField()
+        field.stringValue = "Frank"
+        let notif = Notification(name: NSControl.textDidChangeNotification, object: field)
+        coord.controlTextDidChange(notif)
+        XCTAssertEqual(current, "Frank")
+    }
+
+    func testAccessibleTextFieldCoordinatorIgnoresNonTextFieldNotification() {
+        var current = "unchanged"
+        let binding = Binding<String>(get: { current }, set: { current = $0 })
+        let coord = AccessibleTextField.Coordinator(text: binding)
+        // Notification.object is not an NSTextField → guard fires, binding stays.
+        let notif = Notification(name: NSControl.textDidChangeNotification, object: NSObject())
+        coord.controlTextDidChange(notif)
+        XCTAssertEqual(current, "unchanged")
+    }
+
+    func testAccessibleTextFieldMakeCoordinatorReturnsCoordinatorBoundToText() {
+        var captured = ""
+        let field = AccessibleTextField(
+            text: Binding(get: { captured }, set: { captured = $0 }),
+            placeholder: "Name",
+            identifier: "speaker-name-test",
+        )
+        let coord = field.makeCoordinator()
+        // Drive the coordinator to verify the binding is wired through.
+        let nsField = NSTextField()
+        nsField.stringValue = "Grace"
+        coord.controlTextDidChange(
+            Notification(name: NSControl.textDidChangeNotification, object: nsField),
+        )
+        XCTAssertEqual(captured, "Grace")
     }
 }


### PR DESCRIPTION
## Summary

- Adds 11 unit tests for \`SpeakerNamingView\`, lifting line coverage from **55.9% → 75.4%** (+19.5pp on 825 LOC).
- Targets the previously uncovered render branches: \`knownChips\` body, \`participantChips\` body, the collapsed-vs-expanded chip-list cutoff (More button at >8 names), de-duplication of names that appear in both participants and known speakers.
- Covers the chip-tap action closures inside \`knownChips\` and \`participantChips\` end-to-end (chip → Confirm) — the assertion is on the .confirmed case, not the mapping content (ViewInspector taps don't reliably propagate \`@State\` mutations to subsequent inspect calls).
- Adds three direct unit tests for the \`AccessibleTextField\` NSViewRepresentable bridge: \`Coordinator.controlTextDidChange\` writes back to the binding, the non-NSTextField notification path is guarded, \`makeCoordinator\` wires through to the same binding.

## Production changes (minimal, behaviour-preserving)

- **Seed \`names\` and \`rerunCount\` synchronously in \`init\`** from the data, instead of waiting for \`.onAppear → resetForCurrentPresentation\`. The chip rows are gated on \`index < names.count\`, which was always false on first body evaluation in tests that don't drive SwiftUI lifecycle. \`.onAppear\` still re-runs the same logic for in-place data swaps (lateDiarization revision).
- **Extract the \`speakers\` computation into \`static func computeSpeakers(from:)\`** so the init can call it before the instance is fully formed. The \`private var speakers\` getter now delegates to it.

## Uncovered (~25%)

- \`playSpeakerSnippet\` — AVAudioPlayer + AudioMixer file I/O wrapped in \`Task.detached\` (no DI, hardware-bound)
- \`AutomationTextField.setAccessibilityValue\` — file-private NSTextField subclass, not reachable from tests
- Larger AccessibleTextField NSViewRepresentable surfaces (\`makeNSView\`, \`updateNSView\`) — need a hosting context to fire
- \`.onChange/.onAppear\` lifecycle handlers

## Test plan

- [x] \`swift test --filter SpeakerNamingViewTests\` — 51/51 pass in 0.43 s
- [x] \`./scripts/lint.sh\` — 0 violations (added \`file_length\` disable on the source + tests, \`type_body_length\` on the tests class — file is now 600+ lines)
- [x] llvm-cov confirms 75.39% line coverage on \`SpeakerNamingView.swift\`