### PR TITLE
test(app): extract longestSegment helper + cover infinite-container layout

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -377,9 +377,7 @@ struct SpeakerNamingView: View {
 
         guard let audioPath = data.audioPath else { return }
 
-        // Find the longest segment for this speaker
-        let speakerSegments = data.segments.filter { $0.speaker == label }
-        guard let longest = speakerSegments.max(by: { ($0.end - $0.start) < ($1.end - $1.start) }) else { return }
+        guard let longest = Self.longestSegment(forSpeaker: label, in: data.segments) else { return }
 
         // Perform file I/O off the main thread
         Task.detached { [audioPath, longest] in
@@ -418,6 +416,19 @@ struct SpeakerNamingView: View {
                 // Silently fail — playback is best-effort
             }
         }
+    }
+
+    /// Picks the longest-duration segment attributed to `label` so the
+    /// playback snippet is the speaker's most representative sample.
+    /// Returns nil when the speaker has no segments. Pure for testability —
+    /// `playSpeakerSnippet`'s detached I/O path stays unchanged.
+    static func longestSegment(
+        forSpeaker label: String,
+        in segments: [PipelineQueue.SpeakerNamingData.Segment],
+    ) -> PipelineQueue.SpeakerNamingData.Segment? {
+        segments
+            .filter { $0.speaker == label }
+            .max { ($0.end - $0.start) < ($1.end - $1.start) }
     }
 
     private func confirm() {

--- a/app/MeetingTranscriber/Tests/ChipFlowLayoutTests.swift
+++ b/app/MeetingTranscriber/Tests/ChipFlowLayoutTests.swift
@@ -74,4 +74,17 @@ final class ChipFlowLayoutTests: XCTestCase {
             XCTAssertEqual(pos.y, 0)
         }
     }
+
+    func testInfiniteContainerKeepsContentWidthFinite() {
+        // SwiftUI proposal.width == nil propagates as .infinity upstream. The
+        // layout must still report a finite content width — an infinite frame
+        // would break unconstrained parents (e.g. ScrollView, VStack).
+        let chip = CGSize(width: 40, height: 20)
+        let result = ChipFlowLayout.computeLayout(
+            sizes: [chip, chip], containerWidth: .infinity, spacing: 4,
+        )
+        XCTAssertFalse(result.totalSize.width.isInfinite)
+        // Both 40-wide chips with 4 spacing → exactly 84.
+        XCTAssertEqual(result.totalSize.width, 84)
+    }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -630,4 +630,35 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         )
         XCTAssertEqual(captured, "Grace")
     }
+
+    // MARK: - longestSegment (pure)
+
+    /// `playSpeakerSnippet` plays the longest segment per speaker so the
+    /// preview is the speaker's most representative utterance. Extracted as
+    /// a static helper; the detached audio-load path is integration-only.
+    private func segment(speaker: String, start: Double, end: Double)
+        -> PipelineQueue.SpeakerNamingData.Segment {
+        PipelineQueue.SpeakerNamingData.Segment(start: start, end: end, speaker: speaker)
+    }
+
+    func testLongestSegmentPicksLongestForLabel() throws {
+        let segs = [
+            segment(speaker: "A", start: 0, end: 1),
+            segment(speaker: "A", start: 5, end: 10), // 5s — longest A
+            segment(speaker: "A", start: 12, end: 13),
+            segment(speaker: "B", start: 0, end: 100), // huge B, must be ignored
+        ]
+        let picked = try XCTUnwrap(SpeakerNamingView.longestSegment(forSpeaker: "A", in: segs))
+        XCTAssertEqual(picked.start, 5)
+        XCTAssertEqual(picked.end, 10)
+    }
+
+    func testLongestSegmentReturnsNilForUnknownSpeaker() {
+        let segs = [segment(speaker: "A", start: 0, end: 1)]
+        XCTAssertNil(SpeakerNamingView.longestSegment(forSpeaker: "C", in: segs))
+    }
+
+    func testLongestSegmentReturnsNilForEmptyInput() {
+        XCTAssertNil(SpeakerNamingView.longestSegment(forSpeaker: "A", in: []))
+    }
 }


### PR DESCRIPTION
## Why

`SpeakerNamingView.swift` was at **74.6%** line coverage on Codecov. The largest uncovered block was `playSpeakerSnippet`'s detached audio-loading `Task` (~50 LOC) — hard to test without an integration harness. The leading two inline lines (filter segments by speaker, pick longest-by-duration) are extractable to a pure helper, which lets us cover that intent without the async I/O.

Separately, `ChipFlowLayout.computeLayout` already had its own dedicated test file (`ChipFlowLayoutTests.swift`, 6 tests), but no coverage for the `containerWidth: .infinity` branch — relevant when SwiftUI proposes nil width (e.g. inside an unconstrained ScrollView).

## What

- **`SpeakerNamingView.swift`** — extracts the 2-line `data.segments.filter { ... }.max { ... }` from `playSpeakerSnippet` into a `static func longestSegment(forSpeaker:in:)`. Identical complexity, identical behaviour; the `Task.detached` audio path stays untouched.
- **`SpeakerNamingViewTests.swift`** — 3 unit tests for the new helper:
  - `testLongestSegmentPicksLongestForLabel` — confirms it picks the longest segment for the requested speaker even when a different speaker has a longer overall segment.
  - `testLongestSegmentReturnsNilForUnknownSpeaker`
  - `testLongestSegmentReturnsNilForEmptyInput`
- **`ChipFlowLayoutTests.swift`** — adds `testInfiniteContainerKeepsContentWidthFinite` asserting the layout returns finite width (exactly 84 for two 40-wide chips with 4 spacing) under `.infinity` container width.

## Test plan

- [x] `swift test --filter MeetingTranscriberTests.SpeakerNamingViewTests` — 54/54 green
- [x] `swift test --filter MeetingTranscriberTests.ChipFlowLayoutTests` — 7/7 green
- [x] `scripts/lint.sh` — 0 violations (173 files)
- [ ] PR-CI green
- [ ] Codecov delta: `SpeakerNamingView.swift` 74.6% → ~76% (small, +3-4 lines covered); `ChipFlowLayout.swift` already 100% — the new test exercises an unhit path inside `computeLayout` that was logically reachable via the `.infinity` branch.

## /simplify outcome

Three parallel agents found:
- **One real duplication** (Agent 1): 5 of my initial 6 ChipFlowLayout tests duplicated cases already in `ChipFlowLayoutTests.swift`. Dropped the dupes; moved the genuinely-new `.infinity` test to that file.
- **One assertion tightening** (Agent 2): the `.infinity` test was using `>= 80`, allowed silent regressions. Tightened to exact `== 84`.
- Efficiency clean.