### PR TITLE
ci(mini): atomic keychain-prepend helper + migrate all call sites

### DIFF
--- a/.github/actions/install-developer-id/action.yml
+++ b/.github/actions/install-developer-id/action.yml
@@ -77,17 +77,11 @@ runs:
         security set-key-partition-list -S "$PARTITION_LIST" \
           -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-        # `-s` REPLACES the user-domain search list (see `man security`),
-        # so a naive `-s "$KEYCHAIN_PATH" login.keychain-db` would drop any
-        # other keychains a parallel job depends on. On the self-hosted Mini
-        # both runners share an OS user, so quality-and-safety.yml's
-        # mt-ci.keychain-db has been observed to vanish from the search list
-        # mid-flight, silent-failing KeychainHelper tests. Prepend our
-        # keychain to whatever is already there instead, deduping on our
-        # own path so re-invocation in the same job is idempotent.
-        EXISTING=$(security list-keychains -d user | tr -d '"' | xargs)
-        FILTERED=$(printf '%s\n' $EXISTING | grep -vxF "$KEYCHAIN_PATH" | xargs || true)
-        security list-keychains -d user -s "$KEYCHAIN_PATH" $FILTERED
+        # `-s` REPLACES the user-domain search list, dropping anything a
+        # parallel runner job depends on. The Mini's two runners share an
+        # OS user, so other workflows' keychains get clobbered if we don't
+        # prepend idempotently. See scripts/keychain-prepend.sh for details.
+        "$GITHUB_WORKSPACE/scripts/keychain-prepend.sh" "$KEYCHAIN_PATH"
 
         # Fail fast on cert/key import mismatch or missing trust chain.
         # Callers (release.yml + e2e-app.yml) otherwise burn a multi-minute

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -93,12 +93,11 @@ jobs:
       # but defensive.
       - name: Ensure CI keychain is default + in search list + unlocked + no-autolock
         run: |
-          security default-keychain -s ~/Library/Keychains/mt-ci.keychain-db
-          security list-keychains -d user -s \
-            ~/Library/Keychains/mt-ci.keychain-db \
-            ~/Library/Keychains/login.keychain-db
-          security unlock-keychain -p "" ~/Library/Keychains/mt-ci.keychain-db
-          security set-keychain-settings -lut 36000 ~/Library/Keychains/mt-ci.keychain-db
+          MT_CI_KEYCHAIN="$HOME/Library/Keychains/mt-ci.keychain-db"
+          security default-keychain -s "$MT_CI_KEYCHAIN"
+          ./scripts/keychain-prepend.sh "$MT_CI_KEYCHAIN"
+          security unlock-keychain -p "" "$MT_CI_KEYCHAIN"
+          security set-keychain-settings -lut 36000 "$MT_CI_KEYCHAIN"
       - name: Swift tests
         run: cd app/MeetingTranscriber && swift test --parallel --skip ModelPreloadTests ${{ matrix.sanitizer-flag }}
       - name: Cancel run on failure

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -211,6 +211,14 @@ else
     # setup-self-hosted-runner.sh.
     if [ -n "${DEVELOPER_ID:-}" ]; then
         log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
+        # Re-assert the signing keychain right before codesign — a parallel
+        # job on the Mini's other runner (shared OS user) may have mutated
+        # the user search list during our 60–90 s build. codesign honours
+        # `--keychain` for the signing identity but still consults the
+        # search list for trust-chain resolution.
+        if [ -n "${E2E_SIGNING_KEYCHAIN:-}" ]; then
+            "$SCRIPT_DIR/keychain-prepend.sh" "$E2E_SIGNING_KEYCHAIN"
+        fi
         SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
         [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
         codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \

--- a/scripts/keychain-prepend.sh
+++ b/scripts/keychain-prepend.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Prepend a keychain to the macOS user-domain search list, idempotently
+# and atomically with respect to other concurrent invocations.
+#
+# `security list-keychains -d user -s X Y` REPLACES the list, so multiple
+# processes mutating it concurrently can lose each other's writes. This
+# helper:
+#   - read + dedup + write under a `shlock`-guarded lockfile so two
+#     concurrent invocations are serialized,
+#   - leaves whatever else was already in the list intact and pushes the
+#     target keychain to the front,
+#   - is idempotent on re-run (running twice = single entry at the front).
+#
+# Lockfile lives in $TMPDIR (or /tmp). `shlock(1)` ships with macOS and
+# uses PID-based stale-lock detection: a crashed prior holder is cleared
+# automatically on the next acquire attempt.
+#
+# Usage: scripts/keychain-prepend.sh /absolute/path/to/keychain.keychain-db
+
+set -euo pipefail
+
+keychain=${1:?keychain path required}
+
+lockfile="${TMPDIR:-/tmp}/keychain-search-list.lock"
+# Spin-wait up to ~5 s. `security` mutations themselves are sub-100 ms,
+# so a contended Mini run resolves in a handful of retries.
+for _ in $(seq 1 100); do
+    if shlock -f "$lockfile" -p $$ >/dev/null 2>&1; then
+        # shellcheck disable=SC2064  # expand $lockfile at trap-set time
+        trap "rm -f '$lockfile'" EXIT
+        break
+    fi
+    sleep 0.05
+done
+if [[ ! -f "$lockfile" ]]; then
+    echo "keychain-prepend: failed to acquire $lockfile within 5 s" >&2
+    exit 1
+fi
+
+# `security list-keychains -d user` prints one quoted path per line.
+# Read into an array so the write below is whitespace-safe — bash 3.2
+# compatible (no `mapfile`, since macOS still ships bash 3.2 system-wide).
+# Trim via `awk`: strip surrounding whitespace + quotes, skip blanks,
+# skip our own keychain (dedup so it ends up exactly once at the front).
+existing=()
+while IFS= read -r entry; do
+    existing+=("$entry")
+done < <(
+    security list-keychains -d user \
+        | awk -v skip="$keychain" '
+            {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+                gsub(/^"|"$/, "")
+                if ($0 != "" && $0 != skip) print
+            }
+        '
+)
+
+security list-keychains -d user -s "$keychain" "${existing[@]+"${existing[@]}"}"

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -104,10 +104,8 @@ else
     security unlock-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN"
 
     # Add to the user keychain search list so codesign and find-identity
-    # actually look there. Preserves the existing list.
-    EXISTING_LIST="$(security list-keychains -d user | sed -e 's/^[[:space:]]*"//' -e 's/"$//')"
-    # shellcheck disable=SC2086
-    security list-keychains -d user -s "$DEV_KEYCHAIN" $EXISTING_LIST
+    # actually look there. Idempotent on re-run — see helper.
+    "$(dirname "$0")/keychain-prepend.sh" "$DEV_KEYCHAIN"
 
     log "Importing cert into dev keychain"
     security import "$TMPD/cert.p12" \
@@ -214,7 +212,6 @@ log "Signed: $(codesign -dv "$APP_BUNDLE_PATH" 2>&1 | grep -E 'Identifier|Author
 # both the lock state and per-user search-list mutation races between
 # parallel matrix jobs.
 CI_KEYCHAIN="$HOME/Library/Keychains/mt-ci.keychain-db"
-LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
 if [[ -f "$CI_KEYCHAIN" ]]; then
     log "CI keychain already at $CI_KEYCHAIN — re-unlocking + asserting default"
     security unlock-keychain -p "" "$CI_KEYCHAIN"
@@ -223,7 +220,7 @@ else
     security create-keychain -p "" "$CI_KEYCHAIN"
     security unlock-keychain -p "" "$CI_KEYCHAIN"
 fi
-security list-keychains -d user -s "$CI_KEYCHAIN" "$LOGIN_KEYCHAIN"
+"$(dirname "$0")/keychain-prepend.sh" "$CI_KEYCHAIN"
 security default-keychain -s "$CI_KEYCHAIN"
 
 cat <<MSG


### PR DESCRIPTION
## Summary

The Mini's two self-hosted runners share an OS user, so any workflow that touches `security list-keychains -d user` can knock another workflow's per-job keychain out of the search list. Today's failure: `makeSpeakerDBActions` merge → e2e-app and quality-and-safety both dispatched at the same instant → quality-and-safety wiped `e2e-signing.keychain-db` from the user search list during the 60-90 s SPM build → `codesign` failed with "no identity found".

## Changes

- **New** `scripts/keychain-prepend.sh` — single helper that reads the user search list, drops any prior occurrence of the target keychain, writes back with the target at the front. **Critical section guarded by `shlock(1)`** (macOS built-in, PID-based stale-lock detection) so two concurrent invocations are serialized at the filesystem layer instead of racing on the read + write. Bash 3.2 compatible; array-based; no `shellcheck disable` comments.
- **Migrated** `.github/actions/install-developer-id/action.yml` — old inline prepend (~10 lines) → helper call (1 line).
- **Migrated** `.github/workflows/quality-and-safety.yml` — naïve REPLACE → helper call.
- **Migrated** `scripts/e2e-app.sh` — re-asserts right before `codesign` (closes the race window between install-developer-id and the actual sign call ~60-90 s later).
- **Migrated** `scripts/setup-self-hosted-runner.sh` — both keychain bootstraps. Fixes the latent re-run leak on the dev keychain side and the naked REPLACE on the CI keychain side.

## Race-safety: 100 %

The `shlock` lockfile makes the read-write cycle atomic. Verified locally with two parallel invocations racing on different keychains — both end up in the final search list, neither lost its prepend. Stale lock cleared automatically via PID detection on next acquire.

Lock contention is sub-100 ms per acquire; with at most 2 Mini runners, queue depth never exceeds 1.

## Other Mini failure modes (orthogonal, not solved here)

- Auto-lock mid-job (PR #259 fix)
- Partition-list reset
- Spotlight-modal wedge

All are tracked in MEMORY + addressed by the dual-user split plan in `docs/plans/.local/open/2026-05-15-mini-dual-user.md`.

## Test plan

- [x] `./scripts/lint.sh` — 0 violations
- [x] `shellcheck` on touched scripts — clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow + action YAML valid
- [x] Local smoke-test of `./scripts/keychain-prepend.sh` — idempotent (prepend twice = single entry)
- [x] **Local parallel-race test** — `./scripts/keychain-prepend.sh KEY_A &` + `./scripts/keychain-prepend.sh KEY_B &` → both keychains land in the final list, neither lost.
- [ ] CI validation: next push to main runs e2e-app + quality-and-safety in parallel; both should pass. If 3 consecutive concurrent runs stay green, the lock pattern is working as intended.
