### PR TITLE
test(app): extract OutputSettings display helpers + fix path-prefix bug

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -54,9 +54,10 @@ struct GeneralSettingsView: View {
     }
 
     private var recordOnlyBanner: some View {
-        let path = settings.effectiveOutputDir.appendingPathComponent("recordings").path
-        let home = NSHomeDirectory()
-        let display = path.hasPrefix(home) ? "~" + path.dropFirst(home.count) : path
+        let display = OutputSettingsLogic.displayPath(
+            for: settings.effectiveOutputDir.appendingPathComponent("recordings"),
+            home: FileManager.default.homeDirectoryForCurrentUser,
+        )
         return Label {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Record-only mode is active.")

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -2,6 +2,33 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Pure derivations used by `OutputSettingsView`. Extracted so the wrapping
+/// logic can be unit-tested without instantiating a SwiftUI host.
+enum OutputSettingsLogic {
+    /// Abbreviate `url` for display by replacing the home-directory prefix
+    /// with `~` so paths inside the user's home stay compact. Falls back to
+    /// the full path when `url` is outside `home`. Matches at the path-
+    /// component boundary so `home="/Users/alice"` doesn't abbreviate
+    /// `/Users/alicebob/...` to `~bob/...`.
+    static func displayPath(for url: URL, home: URL) -> String {
+        let path = url.path
+        let homePath = home.path
+        if path == homePath { return "~" }
+        let prefixed = homePath.hasSuffix("/") ? homePath : homePath + "/"
+        guard path.hasPrefix(prefixed) else { return path }
+        return "~/" + path.dropFirst(prefixed.count)
+    }
+
+    /// Merge the currently-selected model into a fetched picker list so the
+    /// user's choice survives even when `/models` doesn't echo it back
+    /// (custom Ollama tags, in-flight rename, offline cache). Returns
+    /// `available` unchanged when `selected` is empty or already present.
+    static func mergePickerOptions(available: [String], selected: String) -> [String] {
+        guard !selected.isEmpty, !available.contains(selected) else { return available }
+        return [selected] + available
+    }
+}
+
 struct OutputSettingsView: View {
     @Bindable var settings: AppSettings
 
@@ -253,11 +280,7 @@ struct OutputSettingsView: View {
     }
 
     private var modelPickerOptions: [String] {
-        var options = availableModels
-        if !settings.openAIModel.isEmpty && !options.contains(settings.openAIModel) {
-            options.insert(settings.openAIModel, at: 0)
-        }
-        return options
+        OutputSettingsLogic.mergePickerOptions(available: availableModels, selected: settings.openAIModel)
     }
 
     private func ensurePromptDirectory() {
@@ -293,13 +316,10 @@ struct OutputSettingsView: View {
     }
 
     private var outputDirDisplay: String {
-        let url = settings.effectiveOutputDir
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let path = url.path
-        if path.hasPrefix(home) {
-            return "~" + path.dropFirst(home.count)
-        }
-        return path
+        OutputSettingsLogic.displayPath(
+            for: settings.effectiveOutputDir,
+            home: FileManager.default.homeDirectoryForCurrentUser,
+        )
     }
 
     private func chooseOutputFolder() {

--- a/app/MeetingTranscriber/Tests/OutputSettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/OutputSettingsViewTests.swift
@@ -1,0 +1,105 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+@MainActor
+final class OutputSettingsViewTests: XCTestCase {
+    // MARK: - OutputSettingsLogic.displayPath
+
+    func testDisplayPathAbbreviatesHomePrefix() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let url = URL(fileURLWithPath: "/Users/alice/Documents/Meetings")
+        XCTAssertEqual(
+            OutputSettingsLogic.displayPath(for: url, home: home),
+            "~/Documents/Meetings",
+        )
+    }
+
+    func testDisplayPathReturnsFullPathOutsideHome() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let url = URL(fileURLWithPath: "/Volumes/External/Meetings")
+        XCTAssertEqual(
+            OutputSettingsLogic.displayPath(for: url, home: home),
+            "/Volumes/External/Meetings",
+        )
+    }
+
+    func testDisplayPathExactlyHomeReturnsTilde() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        XCTAssertEqual(OutputSettingsLogic.displayPath(for: home, home: home), "~")
+    }
+
+    func testDisplayPathDifferentUserHomeReturnsFull() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let url = URL(fileURLWithPath: "/Users/bob/Documents")
+        XCTAssertEqual(
+            OutputSettingsLogic.displayPath(for: url, home: home),
+            "/Users/bob/Documents",
+        )
+    }
+
+    /// Regression guard: a naive `hasPrefix` match treats `/Users/alicebob/foo`
+    /// as inside `/Users/alice` and yields `~bob/foo`. Boundary must be a path
+    /// component (`/` or end-of-string).
+    func testDisplayPathDoesNotMatchAcrossComponentBoundary() {
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let url = URL(fileURLWithPath: "/Users/alicebob/foo")
+        XCTAssertEqual(
+            OutputSettingsLogic.displayPath(for: url, home: home),
+            "/Users/alicebob/foo",
+        )
+    }
+
+    // MARK: - OutputSettingsLogic.mergePickerOptions
+
+    func testMergePickerOptionsPrependsSelectedWhenAbsent() {
+        let result = OutputSettingsLogic.mergePickerOptions(
+            available: ["gpt-4", "gpt-3.5"], selected: "custom-tag:latest",
+        )
+        XCTAssertEqual(result, ["custom-tag:latest", "gpt-4", "gpt-3.5"])
+    }
+
+    func testMergePickerOptionsKeepsListUnchangedWhenSelectedPresent() {
+        let result = OutputSettingsLogic.mergePickerOptions(
+            available: ["gpt-4", "gpt-3.5"], selected: "gpt-4",
+        )
+        XCTAssertEqual(result, ["gpt-4", "gpt-3.5"])
+    }
+
+    func testMergePickerOptionsKeepsListUnchangedForEmptySelected() {
+        let result = OutputSettingsLogic.mergePickerOptions(
+            available: ["gpt-4"], selected: "",
+        )
+        XCTAssertEqual(result, ["gpt-4"])
+    }
+
+    func testMergePickerOptionsEmptyAvailableYieldsJustSelected() {
+        let result = OutputSettingsLogic.mergePickerOptions(
+            available: [], selected: "gpt-4",
+        )
+        XCTAssertEqual(result, ["gpt-4"])
+    }
+
+    func testMergePickerOptionsEmptyAvailableAndEmptySelectedYieldsEmpty() {
+        let result = OutputSettingsLogic.mergePickerOptions(available: [], selected: "")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Render
+
+    func testViewRendersWithDefaultSettings() throws {
+        let settings = AppSettings(defaults: makeIsolatedDefaults())
+        let view = OutputSettingsView(settings: settings)
+        XCTAssertNoThrow(try view.inspect())
+    }
+
+    // MARK: - Helpers
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "OutputSettingsViewTests-\(getpid())-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Could not create test UserDefaults suite")
+        }
+        return defaults
+    }
+}


### PR DESCRIPTION
## Why

`OutputSettingsView.swift` was at **49.5%** line coverage on Codecov and had no dedicated test file. The big uncovered blocks (network test-connection, NSOpenPanel folder picker, NSWorkspace prompt opener) are I/O-bound and can't be reached by pure tests, but two slices of body logic were inline pure expressions ripe for extraction.

The extraction also surfaces a real path-prefix bug: `hasPrefix(homePath)` matches across path-component boundaries, so `home = /Users/alice` abbreviated `/Users/alicebob/foo` to `~bob/foo`. Pre-existing, preserved in `GeneralSettingsView.swift`'s open-coded copy of the same logic.

## What

**Production:**
- New `enum OutputSettingsLogic` at the top of `OutputSettingsView.swift` with two pure static helpers:
  - `displayPath(for url: URL, home: URL) -> String` — abbreviate home prefix to `~`, **at path-component boundary**. New impl: build a `homePath + "/"` sentinel and require `hasPrefix` against that; explicit equality check returns `"~"` when `url == home`.
  - `mergePickerOptions(available:selected:) -> [String]` — prepend the user's currently-selected OpenAI model to a fetched list when `/models` doesn't echo it back.
- `OutputSettingsView` body uses both helpers.
- `GeneralSettingsView.swift`'s open-coded duplicate of the same prefix logic now calls into `OutputSettingsLogic.displayPath` — single source of truth, fix propagates.

**Tests (new file `OutputSettingsViewTests.swift`, 11 tests):**
- 5 `displayPath` cases: inside-home, outside-home, exactly-home, different-user-home, **`/Users/alicebob` boundary regression**.
- 5 `mergePickerOptions` cases: prepend-when-absent, no-op-when-present, no-op-for-empty-selected, just-selected-on-empty-available, empty-empty.
- 1 view render smoke.

## Test plan

- [x] `swift test --filter MeetingTranscriberTests.OutputSettingsViewTests` — 11/11 green
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — full suite green
- [x] `scripts/pre-push.sh --with-appstore` — release-mode + AppStore variant both clean
- [x] `scripts/lint.sh` — 0 violations (174 files)
- [ ] PR-CI green

## /simplify outcome

Three parallel agents found:
- **One real bug** (Agent 2): `hasPrefix` path-boundary collision. Fixed during the extraction + added the `/Users/alicebob` regression test.
- **One reuse opportunity** (Agent 1): `GeneralSettingsView.swift:57-59` had the same inline prefix logic. Consolidated.
- **Two cleanups** applied: dropped block-doc-comment noise on individual tests, removed a misfiled `protocolLanguages` assertion that belonged in `AppSettingsTests`.
- Out of scope: `makeIsolatedDefaults()` is duplicated across 3+ test files — strong hoist candidate for `TestHelpers.swift`, but cross-cutting refactor for a separate PR.

## Coverage expectation

Codecov bot will post exact numbers. Expected: `OutputSettingsView.swift` 49.5% → ~62-65% (10 helper tests + 1 render); plus a small bump on `GeneralSettingsView.swift` from the consolidation.