### PR TITLE
feat(app): expose Parakeet language picker

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -160,6 +160,21 @@ final class AppSettings {
         qwen3Language.isEmpty ? nil : qwen3Language
     }
 
+    /// Parakeet language hint (ISO 639-1 code). Empty string = auto-detect.
+    /// FluidAudio's v3 TDT decoder uses this for script-aware token filtering;
+    /// auto-detect can drift Cyrillic ↔ Latin on multi-script audio.
+    /// Default is empty (auto-detect): FluidAudio's auto-ID works well on
+    /// monolingual audio, unlike `whisperLanguage="de"` which had to be a
+    /// concrete default for historical reasons (and hurt non-DE users in #256).
+    var parakeetLanguage: String {
+        didSet { defaults.set(parakeetLanguage, forKey: "parakeetLanguage") }
+    }
+
+    /// Language as Optional for Parakeet. Empty string → nil (auto-detect).
+    var parakeetLanguageOrNil: String? {
+        parakeetLanguage.isEmpty ? nil : parakeetLanguage
+    }
+
     /// Path to a custom vocabulary file for Parakeet CTC boosting (one term per line).
     var customVocabularyPath: String {
         didSet { defaults.set(customVocabularyPath, forKey: "customVocabularyPath") }
@@ -346,6 +361,7 @@ final class AppSettings {
             ?? "openai_whisper-large-v3-v20240930_turbo"
         whisperLanguage = defaults.object(forKey: "whisperLanguage") as? String ?? "de"
         qwen3Language = defaults.object(forKey: "qwen3Language") as? String ?? ""
+        parakeetLanguage = defaults.object(forKey: "parakeetLanguage") as? String ?? ""
         customVocabularyPath = defaults.string(forKey: "customVocabularyPath") ?? ""
         diarize = defaults.object(forKey: "diarize") as? Bool ?? true
         vadEnabled = defaults.object(forKey: "vadEnabled") as? Bool ?? false

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -466,10 +466,10 @@ final class AppState {
             if whisperKit.language != next { whisperKit.language = next }
 
         case .parakeet:
-            let next = settings.customVocabularyPath
-            if parakeetEngine.customVocabularyPath != next {
-                parakeetEngine.customVocabularyPath = next
-            }
+            let nextVocab = settings.customVocabularyPath
+            if parakeetEngine.customVocabularyPath != nextVocab { parakeetEngine.customVocabularyPath = nextVocab }
+            let nextLang = settings.parakeetLanguageOrNil
+            if parakeetEngine.language != nextLang { parakeetEngine.language = nextLang }
 
         case .qwen3:
             if #available(macOS 15, *) {
@@ -487,6 +487,7 @@ final class AppState {
             _ = settings.transcriptionEngine
             _ = settings.whisperLanguage
             _ = settings.customVocabularyPath
+            _ = settings.parakeetLanguage
             _ = settings.qwen3Language
         } onChange: { [weak self] in
             Task { @MainActor in

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -20,6 +20,20 @@ final class ParakeetEngine: TranscribingEngine {
     /// Path to a custom vocabulary file for CTC boosting. Set from AppSettings before loadModel().
     var customVocabularyPath: String = ""
 
+    /// Optional ISO 639-1 language hint. Empty/nil = auto-detect (FluidAudio's
+    /// v3 TDT decoder picks the script freely, which can drift Cyrillic ↔ Latin
+    /// on multi-script audio). Codes that don't match `FluidAudio.Language`
+    /// fall back to nil. Set from `AppSettings.parakeetLanguageOrNil`.
+    var language: String?
+
+    /// Maps `language` to the FluidAudio enum at call time. Kept private so
+    /// the public surface stays `String?` and AppState doesn't need to import
+    /// FluidAudio.
+    private var fluidLanguageHint: Language? {
+        guard let language, !language.isEmpty else { return nil }
+        return Language(rawValue: language)
+    }
+
     private var asrManager: AsrManager?
     private var loadingTask: Task<Void, Never>?
 
@@ -91,7 +105,7 @@ final class ParakeetEngine: TranscribingEngine {
 
         transcriptionProgress = 0
         var decoderState = await TdtDecoderState.make(decoderLayers: manager.decoderLayerCount)
-        var result = try await manager.transcribe(audioPath, decoderState: &decoderState)
+        var result = try await manager.transcribe(audioPath, decoderState: &decoderState, language: fluidLanguageHint)
         transcriptionProgress = 1.0
 
         // Apply CTC vocabulary rescoring if configured

--- a/app/MeetingTranscriber/Sources/Settings/PickerLanguages.swift
+++ b/app/MeetingTranscriber/Sources/Settings/PickerLanguages.swift
@@ -44,7 +44,27 @@ enum PickerLanguages {
     /// (FluidAudio.Language enum). `("", "Auto-detect")` maps to nil at the
     /// engine call site and lets the decoder pick the script freely — which
     /// can drift on multi-script audio. Explicit selection prevents that.
-    static let parakeet: [(code: String, label: String)] = []
+    static let parakeet: [(code: String, label: String)] = [
+        ("", "Auto-detect"),
+        ("de", "Deutsch"),
+        ("en", "English"),
+        ("fr", "Fran\u{00E7}ais"),
+        ("es", "Espa\u{00F1}ol"),
+        ("it", "Italiano"),
+        ("pt", "Portugu\u{00EA}s"),
+        ("ro", "Rom\u{00E2}n\u{0103}"),
+        ("pl", "Polski"),
+        ("cs", "\u{010C}e\u{0161}tina"),
+        ("sk", "Sloven\u{010D}ina"),
+        ("sl", "Sloven\u{0161}\u{010D}ina"),
+        ("hr", "Hrvatski"),
+        ("bs", "Bosanski"),
+        ("ru", "\u{0420}\u{0443}\u{0441}\u{0441}\u{043A}\u{0438}\u{0439}"),
+        ("uk", "\u{0423}\u{043A}\u{0440}\u{0430}\u{0457}\u{043D}\u{0441}\u{044C}\u{043A}\u{0430}"),
+        ("be", "\u{0411}\u{0435}\u{043B}\u{0430}\u{0440}\u{0443}\u{0441}\u{043A}\u{0430}\u{044F}"),
+        ("bg", "\u{0411}\u{044A}\u{043B}\u{0433}\u{0430}\u{0440}\u{0441}\u{043A}\u{0438}"),
+        ("sr", "\u{0421}\u{0440}\u{043F}\u{0441}\u{043A}\u{0438}"),
+    ]
 
     static let qwen3: [(code: String, label: String)] = [
         ("de", "Deutsch"),

--- a/app/MeetingTranscriber/Sources/Settings/PickerLanguages.swift
+++ b/app/MeetingTranscriber/Sources/Settings/PickerLanguages.swift
@@ -1,7 +1,8 @@
-/// Picker entries for the WhisperKit and Qwen3 language selectors. Whisper
-/// includes a leading `("", "Auto-detect")` sentinel; Qwen3 has no auto-detect
-/// mode. The two lists overlap by 30 codes but are kept separate because
-/// WhisperKit supports 99+ languages vs Qwen3's 30 and is expected to diverge.
+/// Picker entries for the WhisperKit, Parakeet, and Qwen3 language selectors.
+/// All three include a leading `("", "Auto-detect")` sentinel when the engine
+/// supports nil-language inference. The lists are kept separate because the
+/// engines support different language sets (WhisperKit 99+, Parakeet 18,
+/// Qwen3 30) and are expected to diverge.
 
 enum PickerLanguages {
     static let whisperKit: [(code: String, label: String)] = [
@@ -38,6 +39,12 @@ enum PickerLanguages {
         ("mk", "\u{041C}\u{0430}\u{043A}\u{0435}\u{0434}\u{043E}\u{043D}\u{0441}\u{043A}\u{0438}"),
         ("yue", "\u{7CB5}\u{8A9E}"),
     ]
+
+    /// Parakeet TDT v3 supports 18 languages for script-aware token filtering
+    /// (FluidAudio.Language enum). `("", "Auto-detect")` maps to nil at the
+    /// engine call site and lets the decoder pick the script freely — which
+    /// can drift on multi-script audio. Explicit selection prevents that.
+    static let parakeet: [(code: String, label: String)] = []
 
     static let qwen3: [(code: String, label: String)] = [
         ("de", "Deutsch"),

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -43,6 +43,12 @@ struct TranscriptionSettingsView: View {
                 }
 
                 if settings.transcriptionEngine == .parakeet {
+                    Picker("Language", selection: $settings.parakeetLanguage) {
+                        ForEach(PickerLanguages.parakeet, id: \.code) { lang in
+                            Text(lang.label).tag(lang.code)
+                        }
+                    }
+
                     HStack {
                         TextField("Custom vocabulary file", text: $settings.customVocabularyPath)
                             .textFieldStyle(.roundedBorder)

--- a/app/MeetingTranscriber/Tests/ParakeetLanguagePickerTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetLanguagePickerTests.swift
@@ -1,0 +1,41 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Same class of bug as issue #256 but for Parakeet TDT v3. FluidAudio's
+/// `AsrManager.transcribe(_:decoderState:language:)` takes an optional
+/// `FluidAudio.Language` hint (18 codes incl. pl/cs/sk/sl/hr/bs/ru/uk/be/bg/sr)
+/// for script-aware token filtering — the decoder otherwise drifts to Cyrillic
+/// while transcribing Polish (FluidAudio's own `TokenLanguageFilter.swift`
+/// header cites their issue #512). Our `ParakeetEngine` wrapper has to expose
+/// that hint via a picker; without it, a Polish/Czech user has the same "no
+/// way to set my language" problem as WhisperKit's #256.
+final class ParakeetLanguagePickerTests: XCTestCase {
+    private func codes() -> [String] {
+        PickerLanguages.parakeet.map(\.code)
+    }
+
+    func testIncludesAutoDetect() {
+        XCTAssertTrue(codes().contains(""), "Auto-detect sentinel missing from Parakeet picker")
+    }
+
+    func testIncludesPolish() {
+        XCTAssertTrue(codes().contains("pl"), "Polish (pl) missing from Parakeet picker — same class as issue #256")
+    }
+
+    func testIncludesCzech() {
+        XCTAssertTrue(codes().contains("cs"), "Czech (cs) missing from Parakeet picker")
+    }
+
+    func testIncludesRussian() {
+        XCTAssertTrue(codes().contains("ru"), "Russian (ru) missing from Parakeet picker")
+    }
+
+    func testIncludesUkrainian() {
+        XCTAssertTrue(codes().contains("uk"), "Ukrainian (uk) missing from Parakeet picker")
+    }
+
+    func testNoDuplicateCodes() {
+        let allCodes = codes()
+        XCTAssertEqual(allCodes.count, Set(allCodes).count, "Duplicate language codes in Parakeet picker")
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -228,12 +228,15 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertThrowsError(try body.find(text: "Custom vocabulary file"))
     }
 
-    func testWhisperKitPickersHiddenForParakeet() throws {
+    func testWhisperKitModelPickerHiddenForParakeet() throws {
+        // Parakeet section now shows its own Language picker + Custom-vocab
+        // field, but the WhisperKit-specific Model picker must not leak through.
         let settings = makeSettings()
         settings.transcriptionEngine = .parakeet
         let body = try makeTranscription(settings: settings).inspect()
         XCTAssertNoThrow(try body.find(text: "Custom vocabulary file"))
-        XCTAssertThrowsError(try body.find(text: "Language"))
+        XCTAssertNoThrow(try body.find(text: "Language"))
+        XCTAssertThrowsError(try body.find(text: "Model"))
     }
 
     func testQwen3LanguagePickerShownWhenQwen3Selected() throws {


### PR DESCRIPTION
## Why

Same class of bug as [issue #256](https://github.com/pasrom/meeting-transcriber/issues/256) but for Parakeet TDT v3. FluidAudio's `AsrManager.transcribe(_:decoderState:language:)` accepts an optional `FluidAudio.Language` hint that the v3 TDT decoder uses for script-aware token filtering. Without the hint, the decoder picks the script freely and can drift Cyrillic ↔ Latin on multi-script audio — same failure mode WhisperKit large-v3 showed in #256 on Polish.

Our `ParakeetEngine` wrapper didn't expose that hint, and `TranscriptionSettingsView`'s Parakeet section showed only the custom-vocabulary field — no language picker. A Polish or Czech user on Parakeet had exactly the same "no way to set my language" problem as WhisperKit's #256 reporter.

## What

Two commits.

**`test(app): add red Parakeet language-picker tests + empty stub`**
- New `ParakeetLanguagePickerTests` mirroring the WhisperKit picker tests (`testIncludesAutoDetect` / `pl` / `cs` / `ru` / `uk` / no duplicates).
- Empty `PickerLanguages.parakeet` stub so the test file compiles.
- Confirms 5 of 6 tests fail (RED).

**`feat(app): expose Parakeet language picker (closes parakeet half of #256)`**
- `PickerLanguages.parakeet` filled with 19 entries (Auto-detect + 18 codes from `FluidAudio.Language`: en/es/fr/de/it/pt/ro plus Slavic Latin pl/cs/sk/sl/hr/bs and Cyrillic ru/uk/be/bg/sr).
- `AppSettings.parakeetLanguage: String` + `parakeetLanguageOrNil` getter + UserDefaults init, mirroring the existing whisperLanguage / qwen3Language pattern. Default `""` (auto-detect) — explained in doc comment.
- `ParakeetEngine.language: String?` (public surface) + private `fluidLanguageHint: Language?` computed property that maps the ISO code to the FluidAudio enum. Unknown codes fall back to nil. `transcribeSegments` passes `language: fluidLanguageHint` to `asrManager.transcribe(_:decoderState:language:)`. Keeps AppState from having to import FluidAudio — same pattern as `Qwen3AsrEngine.language: String?`.
- `AppState.syncLanguageSettings` + `observeEngineSettings` extended to propagate `settings.parakeetLanguageOrNil → parakeetEngine.language` whenever the setting changes — idempotent, only writes on diff.
- `TranscriptionSettingsView` Parakeet section now leads with a Language picker above the existing custom-vocab field.

## Test plan

- [x] `swift test --filter MeetingTranscriberTests.ParakeetLanguagePickerTests` — 6/6 green (was 5/6 red on the empty-stub commit)
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — full suite green
- [x] `scripts/pre-push.sh --with-appstore` — release-mode + AppStore variant both build clean
- [x] `scripts/lint.sh` — 0 violations (175 files)
- [ ] PR-CI green

## /simplify outcome

Three parallel agents found:
- **Naming polish**: `fluidLanguage` → `fluidLanguageHint` (more descriptive). Applied.
- **Documented default-empty asymmetry** vs `whisperLanguage="de"` (one-line comment) — `whisperLanguage` is a historical default that hurt non-DE users in #256, Parakeet's auto-detect works well on monolingual audio so empty is the cleaner default. Applied.
- **AppState single-line-`if` style drift**: agent suggested extracting a `syncParakeetSettings()` helper. Tried it, but the helper pushed the class type-body-length over the 400-line lint. Kept the single-line-`if`s in-case — minor style drift accepted to keep within the lint.
- **Out of scope**: shared `*LanguageOrNil` computed-property helper would DRY three near-identical 1-line accessors (deferred until a 4th engine arrives); picker-test mirror could parameterize across whisperKit + parakeet + qwen3 (deferred until qwen3 picker tests exist).