### PR TITLE
ci(e2e-app): chain record-only + reimport via --reimport-latest

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -89,27 +89,35 @@ jobs:
       # behavior that the transcript-asserting lane (above) doesn't exercise.
       # `--no-build` reuses the bundle from the previous step to skip ~30 s
       # of rebuild/re-sign.
+      # `--keep-recordings` preserves the produced *_mix.wav across the
+      # script's on-exit cleanup so the next step can re-use it instead of
+      # recording a fresh meeting. Saves ~30 s of redundant playback +
+      # capture and silences the second run on the Mini.
       - name: Run live-recording E2E driver (record-only)
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         timeout-minutes: 10
-        run: bash scripts/e2e-app.sh --no-build --record-only
+        run: bash scripts/e2e-app.sh --no-build --record-only --keep-recordings
 
-      # Re-import lane: chains a record-only meeting with a POST
-      # /action/enqueueFile that feeds the just-recorded WAV back into the
-      # "Open from Recording" pipeline. Asserts the resulting transcript
-      # contains the fixture's spoken keyword, which catches three failure
-      # classes the lanes above miss in isolation:
+      # Re-import lane: feeds the WAV from the previous step back into the
+      # "Open from Recording" pipeline via POST /action/enqueueFile and
+      # asserts the resulting transcript contains the fixture's spoken
+      # keyword. Catches three failure classes the lanes above miss in
+      # isolation:
       #   - Recorder writes a malformed WAV (record-only would still pass).
       #   - AudioMixer.loadAudioAsFloat32 3-tier fallback regresses
       #     (only fixture-tested today, never live).
       #   - Live capture is silent or garbled (transcript lane uses the
       #     fixture WAV directly, doesn't exercise the recorder output).
+      # `--reimport-latest` reuses the WAV from the previous step instead
+      # of re-recording one. Recorder-correctness coverage is preserved
+      # because the previous step already exercised the recorder under
+      # this run's binary.
       - name: Run live-recording E2E driver (re-import recorded WAV)
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         timeout-minutes: 10
-        run: bash scripts/e2e-app.sh --no-build --reimport-recorded
+        run: bash scripts/e2e-app.sh --no-build --reimport-latest
 
       # Best-effort: capture the simulator's stdout for post-mortem if
       # the driver failed before tearing it down.

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -30,6 +30,8 @@ NO_BUILD=false           # skip build/deploy/re-sign — use whatever's at ~/App
 TWO_MEETINGS=false       # trigger two back-to-back meetings to validate cooldown + state reset
 RECORD_ONLY=false        # validate record-only mode (sidecar+WAV instead of transcript)
 REIMPORT_RECORDED=false  # chain a record-only meeting with re-import via POST /action/enqueueFile
+REIMPORT_LATEST=false    # skip live-record phase, re-import the freshest *_mix.wav already on disk
+KEEP_RECORDINGS=false    # leave record-only output on disk for a follow-up --reimport-latest run
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -40,9 +42,13 @@ while [ $# -gt 0 ]; do
         --two-meetings)     TWO_MEETINGS=true ;;
         --record-only)      RECORD_ONLY=true ;;
         --reimport-recorded) REIMPORT_RECORDED=true ;;
+        --reimport-latest)  REIMPORT_LATEST=true ;;
+        --keep-recordings)  KEEP_RECORDINGS=true ;;
         -h|--help)
             cat <<'HELP'
-Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only] [--reimport-recorded] [--fixture path/to.wav]
+Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
+                  [--reimport-recorded | --reimport-latest] [--keep-recordings]
+                  [--fixture path/to.wav]
 
   --no-build           Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
   --keep-app           Leave the dev app running on exit. Default: quit it.
@@ -56,6 +62,16 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only] [--
                        Recording" pipeline and assert the transcript. Covers
                        both the recorder's WAV-encoding correctness and the
                        AudioMixer 3-tier file-load fallback in one pass.
+                       Self-contained — no prior run required.
+  --reimport-latest    Skip the live-record phase and re-import the freshest
+                       *_mix.wav already in ~/Downloads/MeetingTranscriber/recordings/.
+                       Pair with a previous `--record-only --keep-recordings`
+                       run (CI uses this to chain steps without re-recording;
+                       locally also useful for silent fast iteration on the
+                       import pipeline).
+  --keep-recordings    Suppress the on-exit cleanup of record-only output, so
+                       a follow-up --reimport-latest can pick the WAV up.
+                       Only meaningful with --record-only.
   --fixture            Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -64,6 +80,14 @@ HELP
     esac
     shift
 done
+
+# --reimport-recorded and --reimport-latest are advertised as alternatives
+# in the help text — enforce that here so a typo can't silently fall
+# through to whichever branch the dispatch chain checks first.
+if [ "$REIMPORT_RECORDED" = true ] && [ "$REIMPORT_LATEST" = true ]; then
+    echo "Error: --reimport-recorded and --reimport-latest are mutually exclusive" >&2
+    exit 2
+fi
 
 # --reimport-recorded chains a record-only meeting with a follow-up
 # enqueueFile RPC. Phase 1 needs the recordOnly toggle on so WatchLoop
@@ -296,8 +320,10 @@ on_exit() {
         defaults delete com.meetingtranscriber.dev recordOnly 2>/dev/null || true
         # Marker-bounded cleanup: only files created since `touch $MARKER`
         # at launch — never touches pre-existing user data. See feedback
-        # memory `no_destructive_fs_on_real_dirs`.
-        if [ -f "$RECORD_ONLY_MARKER" ]; then
+        # memory `no_destructive_fs_on_real_dirs`. Skipped under
+        # --keep-recordings so a follow-up --reimport-latest run can pick
+        # the WAV up.
+        if [ "$KEEP_RECORDINGS" = false ] && [ -f "$RECORD_ONLY_MARKER" ]; then
             find "$RECORDINGS_DIR" -type f -newer "$RECORD_ONLY_MARKER" -delete 2>/dev/null || true
             rm -f "$RECORD_ONLY_MARKER"
         fi
@@ -548,7 +574,26 @@ run_one_reimport() {
 
 LAST_RECORDED_MIX_PATH=""
 
-if [ "$REIMPORT_RECORDED" = true ]; then
+if [ "$REIMPORT_LATEST" = true ]; then
+    # Skip the live-record phase and reuse a WAV produced by an earlier
+    # `--record-only --keep-recordings` run on this host. Picks the
+    # freshest `*_mix.wav` in $RECORDINGS_DIR — eliminates the audible
+    # ~30 s playback + capture round and the meeting-detector cooldown
+    # that --reimport-recorded incurs.
+    latest_mix="$(find "$RECORDINGS_DIR" -maxdepth 1 -name '*_mix.wav' -type f \
+        -exec stat -f '%m %N' {} + 2>/dev/null \
+        | sort -rn \
+        | head -1 \
+        | cut -d' ' -f2-)"
+    [ -n "$latest_mix" ] && [ -f "$latest_mix" ] \
+        || fail "--reimport-latest: no *_mix.wav found in $RECORDINGS_DIR — run \`e2e-app.sh --record-only --keep-recordings\` first to produce one"
+    log "Reusing latest record-only WAV: $latest_mix"
+    # No `sleep $RECORDER_FINALIZE_WAIT_S` here, unlike --reimport-recorded:
+    # the WAV was produced by a prior script invocation that already exited,
+    # so its AVAudioFile close + tail-byte flush happened on process exit
+    # — nothing left to wait for.
+    run_one_reimport "[reimport-latest]" "$latest_mix"
+elif [ "$REIMPORT_RECORDED" = true ]; then
     # Phase 1: record-only meeting → produces a WAV via the live capture stack.
     run_one_record_only_meeting "[record]"
     [ -n "$LAST_RECORDED_MIX_PATH" ] || fail "record-phase did not surface a mix path; cannot continue"


### PR DESCRIPTION
## Summary

The `--reimport-recorded` lane in `e2e-app.yml` records a meeting via the live capture stack and then re-imports the resulting WAV. The lane *before* it (`--record-only`) already does the first half — records a meeting and produces a `*_mix.wav` — and then deletes it in its `on_exit` trap.

This wires the two lanes together: record-only keeps the WAV, the reimport lane picks it up.

## Changes

**`scripts/e2e-app.sh`**

- New `--reimport-latest` flag: skips the live-record phase and re-imports the freshest `*_mix.wav` in `~/Downloads/MeetingTranscriber/recordings/`. Fails fast with an actionable message if no WAV is present.
- New `--keep-recordings` flag: suppresses the on-exit `find -newer $MARKER -delete` cleanup so a follow-up `--reimport-latest` can read the WAV.
- Mutual-exclusion check between `--reimport-recorded` and `--reimport-latest` (the Usage block already advertised them as alternatives; now enforced).
- `--reimport-recorded` stays unchanged for self-contained standalone use.
- Latest-WAV picker uses `find -exec stat -f '%m %N' {} + | sort -rn | head -1 | cut` — portable on macOS, safe with `find -type f` filtering.

**`.github/workflows/e2e-app.yml`**

- record-only step gains `--keep-recordings`.
- reimport step switches `--reimport-recorded` → `--reimport-latest`.

## CI savings

`--reimport-recorded` Phase 1 = ~30 s (playback + capture + meeting-detector cooldown). That round is eliminated; recorder-correctness coverage is preserved because the previous step already exercised the recorder under the same binary in the same CI run.

## Local iteration

Two-step pattern silences the audible second run when iterating on the import pipeline:

```bash
./scripts/e2e-app.sh --no-build --record-only --keep-recordings   # records once, audible
./scripts/e2e-app.sh --no-build --reimport-latest                 # silent, ~20 s
```

## Test plan

- [x] `shellcheck scripts/e2e-app.sh` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-app.yml'))"` — valid
- [x] `./scripts/lint.sh` — 0 violations
- [x] Mutual-exclusion check: `e2e-app.sh --reimport-recorded --reimport-latest` exits 2 with clear error
- [x] Latest-WAV picker negative case: empty dir → `fail` with hint to run `--record-only --keep-recordings` first
- [x] Latest-WAV picker positive case: two seeded `*_mix.wav` with distinct mtimes → newer wins
- [ ] CI: next post-merge run on main exercises the full chain on the Mac mini self-hosted runner
