### PR TITLE
feat(app): import paired _app+_mic recordings as one dual-track job

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -183,11 +183,7 @@ final class AppState { // swiftlint:disable:this type_body_length
                 return true
             }
             let enqueueFilesRPC: ([URL]) -> Int = { [weak self] urls in
-                guard let self else { return 0 }
-                let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
-                guard !existing.isEmpty else { return 0 }
-                Task { @MainActor in self.enqueueFiles(existing) }
-                return existing.count
+                self?.enqueueExistingFiles(urls) ?? 0
             }
             let server = DebugRPCServer(
                 snapshot: snapshot,
@@ -404,6 +400,17 @@ final class AppState { // swiftlint:disable:this type_body_length
     func stopManualRecording() {
         watchLoop?.stopManualRecording()
         watchLoop = nil
+    }
+
+    /// Filters `urls` to files that currently exist on disk, forwards them to
+    /// `enqueueFiles`, and returns the existing count. RPC-friendly entry
+    /// point; nil-callers (weak self) treat absent app as 0-enqueued.
+    @discardableResult
+    func enqueueExistingFiles(_ urls: [URL]) -> Int {
+        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !existing.isEmpty else { return 0 }
+        enqueueFiles(existing)
+        return existing.count
     }
 
     func enqueueFiles(_ urls: [URL]) {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppKit
 import Foundation
 import Observation
@@ -22,7 +23,7 @@ protocol AppNotifying {
 /// - `BadgeKind.compute(...)` can be called directly in tests.
 @Observable
 @MainActor
-final class AppState {
+final class AppState { // swiftlint:disable:this type_body_length
     // MARK: - Dependencies
 
     let settings: AppSettings
@@ -181,11 +182,19 @@ final class AppState {
                 Task { @MainActor in self.enqueueFiles([url]) }
                 return true
             }
+            let enqueueFilesRPC: ([URL]) -> Int = { [weak self] urls in
+                guard let self else { return 0 }
+                let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+                guard !existing.isEmpty else { return 0 }
+                Task { @MainActor in self.enqueueFiles(existing) }
+                return existing.count
+            }
             let server = DebugRPCServer(
                 snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
                 skipNaming: skipNaming,
                 enqueueFile: enqueueFile,
+                enqueueFiles: enqueueFilesRPC,
             )
             server.start()
             debugRPCServer = server
@@ -400,7 +409,31 @@ final class AppState {
     func enqueueFiles(_ urls: [URL]) {
         ensurePipelineQueue()
 
-        for url in urls {
+        let resolution = PairedRecordingResolver.resolve(urls: urls)
+
+        for group in resolution.paired {
+            let sidecar = RecordingSidecar.read(
+                fromDirectory: group.directory,
+                basename: group.stem,
+            )
+            let title = sidecar?.title ?? group.stem
+            let appName = sidecar?.appName ?? "File"
+            let micDelay = sidecar?.micDelaySeconds ?? 0
+            let participants = sidecar?.participants ?? []
+
+            // For paired groups: pass `group.mix` directly (nil when only app+mic
+            // were selected — the pipeline mixes app+mic into the workdir cache
+            // on the fly, no persistent `_mix.wav` is written to the user's
+            // recordings dir).
+            let job = PipelineJob(
+                meetingTitle: title, appName: appName,
+                mixPath: group.mix, appPath: group.app, micPath: group.mic,
+                micDelay: micDelay, participants: participants,
+            )
+            pipelineQueue.enqueue(job)
+        }
+
+        for url in resolution.singletons {
             let title = url.deletingPathExtension().lastPathComponent
             let job = PipelineJob(
                 meetingTitle: title,

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -79,6 +79,9 @@
         /// caller's path is missing or doesn't exist on disk; the RPC layer
         /// translates that to 400.
         private let enqueueFile: (URL) -> Bool
+        /// Multi-file counterpart for paired-import testing. Returns the number
+        /// of URLs that existed on disk and were forwarded to `enqueueFiles`.
+        private let enqueueFiles: ([URL]) -> Int
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -96,6 +99,7 @@
             speakerActions: SpeakerDBActions = .noop,
             skipNaming: @escaping () -> Void = {},
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
+            enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -103,6 +107,7 @@
             self.speakerActions = speakerActions
             self.skipNaming = skipNaming
             self.enqueueFile = enqueueFile
+            self.enqueueFiles = enqueueFiles
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -214,6 +219,7 @@
 
         // MARK: - Routing
 
+        // swiftlint:disable:next cyclomatic_complexity
         func route(_ request: HTTPRequest) async -> HTTPResponse {
             if let origin = request.headers["origin"], !origin.isEmpty, origin != "null" {
                 return HTTPResponse.forbidden()
@@ -263,6 +269,20 @@
                 let url = URL(fileURLWithPath: p.path)
                 guard enqueueFile(url) else { return HTTPResponse.badRequest() }
                 return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+
+            case ("POST", "/action/enqueueFiles"):
+                // Multi-file variant — drives the same paired-pairing resolver
+                // the file picker uses. Lets driver scripts exercise the
+                // paired-import path (`_app + _mic + _mix` selection) without
+                // touching NSOpenPanel. Returns `{"enqueued": N}` for the
+                // count of URLs that existed on disk.
+                guard let p = try? JSONDecoder().decode(EnqueueFilesPayload.self, from: request.body),
+                      !p.paths.isEmpty
+                else { return HTTPResponse.badRequest() }
+                let urls = p.paths.map { URL(fileURLWithPath: $0) }
+                let count = enqueueFiles(urls)
+                let body = Data(#"{"enqueued":\#(count)}"#.utf8)
+                return HTTPResponse.ok(body: body, contentType: "application/json")
 
             case ("POST", "/action/renameSpeaker"),
                  ("POST", "/action/deleteSpeaker"),
@@ -340,6 +360,10 @@
 
         private struct EnqueueFilePayload: Decodable {
             let path: String
+        }
+
+        private struct EnqueueFilesPayload: Decodable {
+            let paths: [String]
         }
 
         /// Map the action outcome to an HTTP response. `notFound` → 404,

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -51,7 +51,7 @@ class DualSourceRecorder: RecordingProvider {
 
     /// Suffix on the merged-output WAV file, used by downstream code (the
     /// record-only sidecar writer) to recover the recording basename.
-    static let mixFilenameSuffix = "_mix.wav"
+    static let mixFilenameSuffix = RecordingFileSuffix.mix
 
     /// Remove leftover `*_app_raw.tmp` files from a previous crash.
     static func cleanupTempFiles(recordingsDir: URL = AppPaths.recordingsDir) {
@@ -87,7 +87,7 @@ class DualSourceRecorder: RecordingProvider {
 
         // ── AudioTapLib capture session ──
         let appTempURL = recDir.appendingPathComponent("\(ts)_app_raw.tmp")
-        let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)_mic.wav")
+        let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mic)")
 
         let session = AudioCaptureSession(
             pid: appPID,
@@ -191,7 +191,7 @@ class DualSourceRecorder: RecordingProvider {
 
             // Resample to 16kHz and save app track
             appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: targetRate)
-            let appFile = recDir.appendingPathComponent("\(ts)_app.wav")
+            let appFile = recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.app)")
             try AudioMixer.saveWAV(samples: appSamples16k, sampleRate: targetRate, url: appFile)
             appPath = appFile
             logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate)→\(self.targetRate) Hz)")

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -263,6 +263,11 @@ struct MeetingTranscriberApp: App {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
 
+        let pairingDelegate = PairedImportPanelDelegate()
+        panel.delegate = pairingDelegate
+        panel.accessoryView = pairingDelegate.accessoryView
+        panel.isAccessoryViewDisclosed = true
+
         guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
         appState.enqueueFiles(panel.urls)
     }

--- a/app/MeetingTranscriber/Sources/PairedImportPanelDelegate.swift
+++ b/app/MeetingTranscriber/Sources/PairedImportPanelDelegate.swift
@@ -1,0 +1,60 @@
+import AppKit
+import Foundation
+
+/// `NSOpenPanel` delegate + accessory view that previews how the selected
+/// files will be grouped when imported. Refreshes whenever the user changes
+/// the selection so they see "1 paired recording + 1 single file → 2
+/// transcripts" instead of being surprised after pressing Open.
+@MainActor
+final class PairedImportPanelDelegate: NSObject, NSOpenSavePanelDelegate {
+    let accessoryView: NSView
+    private let label: NSTextField
+
+    override init() {
+        let label = NSTextField(labelWithString: " ")
+        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(label)
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 28),
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+
+        self.label = label
+        self.accessoryView = container
+        super.init()
+    }
+
+    func panelSelectionDidChange(_ sender: Any?) {
+        let urls = (sender as? NSOpenPanel)?.urls ?? []
+        label.stringValue = PairedImportSummary.text(forSelectedURLs: urls)
+    }
+}
+
+enum PairedImportSummary {
+    static func text(forSelectedURLs urls: [URL]) -> String {
+        // Non-empty so the `NSTextField` keeps its baseline height between selections.
+        guard !urls.isEmpty else { return " " }
+        let resolution = PairedRecordingResolver.resolve(urls: urls)
+        let pairedCount = resolution.paired.count
+        let singletonCount = resolution.singletons.count
+        let total = pairedCount + singletonCount
+
+        var parts: [String] = []
+        if pairedCount > 0 {
+            parts.append("\(pairedCount) paired recording\(pairedCount == 1 ? "" : "s")")
+        }
+        if singletonCount > 0 {
+            parts.append("\(singletonCount) single file\(singletonCount == 1 ? "" : "s")")
+        }
+        let lhs = parts.joined(separator: " + ")
+        return "\(lhs) → \(total) transcript\(total == 1 ? "" : "s")"
+    }
+}

--- a/app/MeetingTranscriber/Sources/PairedRecordingResolver.swift
+++ b/app/MeetingTranscriber/Sources/PairedRecordingResolver.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Groups a flat list of URLs into dual-source recording groups (`_app`+`_mic`
+/// or `_mix` sharing a stem) plus singletons — so re-importing a recording
+/// produces one dual-track `PipelineJob` instead of two independent jobs.
+enum PairedRecordingResolver {
+    struct Group: Equatable {
+        let stem: String
+        let directory: URL
+        let mix: URL?
+        let app: URL?
+        let mic: URL?
+    }
+
+    struct Resolution: Equatable {
+        let paired: [Group]
+        let singletons: [URL]
+    }
+
+    static func resolve(urls: [URL]) -> Resolution {
+        struct Key: Hashable {
+            let directory: String
+            let stem: String
+        }
+        struct Partial {
+            var mix: URL?
+            var app: URL?
+            var mic: URL?
+            var firstIndex: Int = .max
+        }
+
+        var partials: [Key: Partial] = [:]
+        var singletonsWithIndex: [(Int, URL)] = []
+
+        for (index, url) in urls.enumerated() {
+            guard let (stem, suffix) = RecordingFileSuffix.stripSuffix(from: url.lastPathComponent) else {
+                singletonsWithIndex.append((index, url))
+                continue
+            }
+            let directory = url.deletingLastPathComponent()
+            let key = Key(directory: directory.standardizedFileURL.path, stem: stem)
+            var partial = partials[key] ?? Partial()
+            partial.firstIndex = min(partial.firstIndex, index)
+            switch suffix {
+            case RecordingFileSuffix.mix: partial.mix = url
+            case RecordingFileSuffix.app: partial.app = url
+            case RecordingFileSuffix.mic: partial.mic = url
+            default: break
+            }
+            partials[key] = partial
+        }
+
+        var paired: [(Int, Group)] = []
+        for (key, partial) in partials {
+            // A group is paired when it can feed the dual-track pipeline: either
+            // both `_app`+`_mic` tracks (mix will be synthesized at enqueue time)
+            // or a pre-mixed `_mix.wav`. A lone `_app` or `_mic` without partner
+            // falls back to a singleton.
+            let hasDualTracks = partial.app != nil && partial.mic != nil
+            if hasDualTracks || partial.mix != nil {
+                let directoryURL = URL(fileURLWithPath: key.directory, isDirectory: true)
+                let group = Group(
+                    stem: key.stem,
+                    directory: directoryURL,
+                    mix: partial.mix,
+                    app: partial.app,
+                    mic: partial.mic,
+                )
+                paired.append((partial.firstIndex, group))
+            } else if let solo = partial.app ?? partial.mic {
+                singletonsWithIndex.append((partial.firstIndex, solo))
+            }
+        }
+
+        paired.sort { $0.0 < $1.0 }
+        singletonsWithIndex.sort { $0.0 < $1.0 }
+
+        return Resolution(
+            paired: paired.map(\.1),
+            singletons: singletonsWithIndex.map(\.1),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -42,7 +42,10 @@ struct PipelineJob: Identifiable, Codable {
 
     let meetingTitle: String
     let appName: String
-    let mixPath: URL
+    /// nil when the job is a paired-import without a `_mix.wav` source — the
+    /// pipeline mixes `appPath`+`micPath` directly to the workdir `mix_16k.wav`
+    /// in that case, so no persistent mix file is written.
+    let mixPath: URL?
     let appPath: URL?
     let micPath: URL?
     let micDelay: TimeInterval
@@ -58,7 +61,7 @@ struct PipelineJob: Identifiable, Codable {
     init(
         meetingTitle: String,
         appName: String,
-        mixPath: URL,
+        mixPath: URL?,
         appPath: URL?,
         micPath: URL?,
         micDelay: TimeInterval,

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -535,6 +535,12 @@ class PipelineQueue {
                 transcript = segments.map(\.formattedLine).joined(separator: "\n")
             } else {
                 // Single-source: resample mix to 16kHz
+                guard let mixPath else {
+                    throw NSError(
+                        domain: "PipelineQueue", code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "Single-source job missing mixPath"],
+                    )
+                }
                 let mix16k = workDir.appendingPathComponent("mix_16k.wav")
                 try await AudioMixer.resampleFile(from: mixPath, to: mix16k)
 
@@ -571,8 +577,9 @@ class PipelineQueue {
             guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 // Compute input RMS only on the failure path — loading the whole
                 // mix file is expensive (~MB-per-minute) and we only need it when
-                // diagnosing why transcription produced nothing.
-                let inputRMS = AudioMixer.rmsDecibels(forFileAt: mixPath) ?? .nan
+                // diagnosing why transcription produced nothing. Paired imports
+                // without a real mix file report NaN (RMS unavailable).
+                let inputRMS = mixPath.flatMap { AudioMixer.rmsDecibels(forFileAt: $0) } ?? .nan
                 logger.warning(
                     "[\(shortID, privacy: .public)] transcription_empty inputRMSdBFS=\(inputRMS, privacy: .public). Likely silent input or ASR misconfiguration — check microphone level and engine settings.",
                 )
@@ -590,10 +597,25 @@ class PipelineQueue {
                     updateJobState(id: jobID, to: .diarizing)
                     startElapsedTimer()
 
-                    // Use mix audio for diarization (already resampled in single-source path)
+                    // Use mix audio for diarization (already resampled in single-source path).
+                    // Paired imports without a real `_mix.wav` source mix `app + mic`
+                    // directly into the workdir cache — no persistent mix file written.
                     let mix16k = workDir.appendingPathComponent("mix_16k.wav")
                     if !FileManager.default.fileExists(atPath: mix16k.path) {
-                        try await AudioMixer.resampleFile(from: mixPath, to: mix16k)
+                        if let mixPath, FileManager.default.fileExists(atPath: mixPath.path) {
+                            try await AudioMixer.resampleFile(from: mixPath, to: mix16k)
+                        } else if let appAudioPath = appPath, let micAudioPath = micPath {
+                            try AudioMixer.mix(
+                                appAudioPath: appAudioPath, micAudioPath: micAudioPath,
+                                outputPath: mix16k, micDelay: micDelay,
+                                sampleRate: AudioConstants.targetSampleRate,
+                            )
+                        } else {
+                            throw NSError(
+                                domain: "PipelineQueue", code: -1,
+                                userInfo: [NSLocalizedDescriptionKey: "No mix audio available for diarization"],
+                            )
+                        }
                     }
 
                     do {
@@ -1272,9 +1294,12 @@ class PipelineQueue {
             // Discard jobs whose audio file no longer exists, EXCEPT
             // .speakerNamingPending — those have their own slug-based
             // `_16k.wav` sidecar and don't need the original mix.wav.
+            // Paired imports with nil mixPath: keep them — `appPath` is the
+            // ground-truth source and it's checked at processNext time.
             loaded.removeAll { job in
-                job.state != .speakerNamingPending
-                    && !FileManager.default.fileExists(atPath: job.mixPath.path)
+                guard let mixPath = job.mixPath else { return false }
+                return job.state != .speakerNamingPending
+                    && !FileManager.default.fileExists(atPath: mixPath.path)
             }
 
             guard !loaded.isEmpty else {
@@ -1314,11 +1339,27 @@ class PipelineQueue {
 
     // MARK: - Audio File Copy
 
-    /// Copy recording audio files to the protocol output directory.
+    /// Copy recording audio files to the protocol output directory. Nil
+    /// `mixPath` (paired imports without a `_mix.wav` source) → mix slot
+    /// is skipped, no persistent mix is written.
     private static func copyAudioToOutput(
-        mixPath: URL, appPath: URL?, micPath: URL?,
+        mixPath: URL?, appPath: URL?, micPath: URL?,
         title: String, outputDir: URL,
     ) {
+        // Each move below renames-in-place — if two of the three URLs point at
+        // the same file, the first move destroys the source for the next one.
+        // Loud failure in dev/CI > silent data destruction.
+        if let mixStd = mixPath?.standardizedFileURL {
+            precondition(
+                appPath.map { mixStd != $0.standardizedFileURL } ?? true,
+                "copyAudioToOutput: mixPath aliases appPath — would destroy source",
+            )
+            precondition(
+                micPath.map { mixStd != $0.standardizedFileURL } ?? true,
+                "copyAudioToOutput: mixPath aliases micPath — would destroy source",
+            )
+        }
+
         let accessing = outputDir.startAccessingSecurityScopedResource()
         defer { if accessing { outputDir.stopAccessingSecurityScopedResource() } }
 
@@ -1326,13 +1367,23 @@ class PipelineQueue {
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         let slug = ProtocolGenerator.filename(title: title, ext: "").dropLast() // remove trailing "."
         let audioPaths: [(URL, String)] = [
-            (mixPath, "\(slug)\(RecordingFileSuffix.mix)"),
+            mixPath.map { ($0, "\(slug)\(RecordingFileSuffix.mix)") },
             appPath.map { ($0, "\(slug)\(RecordingFileSuffix.app)") },
             micPath.map { ($0, "\(slug)\(RecordingFileSuffix.mic)") },
         ].compactMap(\.self)
 
+        let outputDirStd = outputDir.standardizedFileURL
         for (src, name) in audioPaths {
             let dst = outputDir.appendingPathComponent(name)
+            // Source already in the target dir → move would just rename in place
+            // with a fresh `<today_timestamp>_<title>` prefix, which produces an
+            // endless compounding-rename loop on every re-import (orphan recovery
+            // re-picks the new name on next launch). The file is already at its
+            // final home; keep it put.
+            if src.deletingLastPathComponent().standardizedFileURL == outputDirStd {
+                logger.info("Audio already in output dir, skipping rename: \(src.lastPathComponent)")
+                continue
+            }
             do {
                 if fm.fileExists(atPath: dst.path) { try fm.removeItem(at: dst) }
                 try fm.moveItem(at: src, to: dst)
@@ -1388,48 +1439,40 @@ class PipelineQueue {
             includingPropertiesForKeys: [.fileSizeKey, .creationDateKey],
         ) else { return }
 
-        let trackedPaths = Set(jobs.map(\.mixPath.standardizedFileURL.path))
+        let trackedPaths = Set(jobs.compactMap { $0.mixPath?.standardizedFileURL.path })
         let processedPaths = loadProcessedPaths()
         let now = Date()
         var recovered = 0
 
-        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
-            let stdPath = file.standardizedFileURL.path
+        // Orphan recovery requires a `_mix.wav` anchor — pair with companion
+        // `_app.wav`/`_mic.wav` tracks when they exist (same stem).
+        for group in PairedRecordingResolver.resolve(urls: entries).paired {
+            // Orphan recovery requires an on-disk `_mix.wav` anchor — paired
+            // groups produced by app+mic synthesis aren't recoverable from the
+            // dir scan alone (the synthesized mix lives elsewhere or hasn't
+            // been written yet). Skip groups without a real mix file here.
+            guard let mixURL = group.mix else { continue }
+            let stdPath = mixURL.standardizedFileURL.path
 
-            // Skip already tracked by active jobs
             guard !trackedPaths.contains(stdPath) else { continue }
-
-            // Skip already successfully processed
             guard !processedPaths.contains(stdPath) else { continue }
 
-            // Skip files older than maxAge
-            if let attrs = try? fm.attributesOfItem(atPath: file.path),
-               let created = attrs[.creationDate] as? Date,
+            let attrs = try? fm.attributesOfItem(atPath: mixURL.path)
+            if let created = attrs?[.creationDate] as? Date,
                now.timeIntervalSince(created) > maxAge {
                 continue
             }
-
-            // Skip empty WAVs (header only = 44 bytes)
-            if let attrs = try? fm.attributesOfItem(atPath: file.path),
-               let size = attrs[.size] as? Int, size <= 44 {
+            // Header-only WAVs are 44 bytes.
+            if let size = attrs?[.size] as? Int, size <= 44 {
                 continue
             }
 
-            // Derive timestamp prefix (e.g. "20260311_143000" from "20260311_143000_mix.wav")
-            let prefix = String(file.lastPathComponent.dropLast(RecordingFileSuffix.mix.count))
-
-            // Look for companion tracks
-            let appFile = recordingsDir.appendingPathComponent("\(prefix)\(RecordingFileSuffix.app)")
-            let micFile = recordingsDir.appendingPathComponent("\(prefix)\(RecordingFileSuffix.mic)")
-            let appPath = fm.fileExists(atPath: appFile.path) ? appFile : nil
-            let micPath = fm.fileExists(atPath: micFile.path) ? micFile : nil
-
             let job = PipelineJob(
-                meetingTitle: "Recovered Recording (\(prefix))",
+                meetingTitle: "Recovered Recording (\(group.stem))",
                 appName: "Unknown",
-                mixPath: file,
-                appPath: appPath,
-                micPath: micPath,
+                mixPath: mixURL,
+                appPath: group.app,
+                micPath: group.mic,
                 micDelay: 0,
             )
             jobs.append(job)
@@ -1459,8 +1502,11 @@ class PipelineQueue {
         return Set(paths)
     }
 
-    /// Record that a job's mix file was successfully processed.
-    func markProcessed(mixPath: URL) {
+    /// Record that a job's mix file was successfully processed. Nil mixPath
+    /// (paired imports without a `_mix.wav` source) is a no-op — there's no
+    /// path to track for orphan recovery.
+    func markProcessed(mixPath: URL?) {
+        guard let mixPath else { return }
         var paths = loadProcessedPaths()
         paths.insert(mixPath.standardizedFileURL.path)
         do {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1326,9 +1326,9 @@ class PipelineQueue {
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         let slug = ProtocolGenerator.filename(title: title, ext: "").dropLast() // remove trailing "."
         let audioPaths: [(URL, String)] = [
-            (mixPath, "\(slug)_mix.wav"),
-            appPath.map { ($0, "\(slug)_app.wav") },
-            micPath.map { ($0, "\(slug)_mic.wav") },
+            (mixPath, "\(slug)\(RecordingFileSuffix.mix)"),
+            appPath.map { ($0, "\(slug)\(RecordingFileSuffix.app)") },
+            micPath.map { ($0, "\(slug)\(RecordingFileSuffix.mic)") },
         ].compactMap(\.self)
 
         for (src, name) in audioPaths {
@@ -1355,7 +1355,7 @@ class PipelineQueue {
         ) else { return }
 
         var paths = Set<String>()
-        for file in entries where file.lastPathComponent.hasSuffix("_mix.wav") {
+        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
             paths.insert(file.standardizedFileURL.path)
         }
         guard !paths.isEmpty else { return }
@@ -1393,7 +1393,7 @@ class PipelineQueue {
         let now = Date()
         var recovered = 0
 
-        for file in entries where file.lastPathComponent.hasSuffix("_mix.wav") {
+        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
             let stdPath = file.standardizedFileURL.path
 
             // Skip already tracked by active jobs
@@ -1416,12 +1416,11 @@ class PipelineQueue {
             }
 
             // Derive timestamp prefix (e.g. "20260311_143000" from "20260311_143000_mix.wav")
-            let name = file.deletingPathExtension().lastPathComponent
-            let prefix = String(name.dropLast("_mix".count))
+            let prefix = String(file.lastPathComponent.dropLast(RecordingFileSuffix.mix.count))
 
             // Look for companion tracks
-            let appFile = recordingsDir.appendingPathComponent("\(prefix)_app.wav")
-            let micFile = recordingsDir.appendingPathComponent("\(prefix)_mic.wav")
+            let appFile = recordingsDir.appendingPathComponent("\(prefix)\(RecordingFileSuffix.app)")
+            let micFile = recordingsDir.appendingPathComponent("\(prefix)\(RecordingFileSuffix.mic)")
             let appPath = fm.fileExists(atPath: appFile.path) ? appFile : nil
             let micPath = fm.fileExists(atPath: micFile.path) ? micFile : nil
 

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -131,13 +131,36 @@ enum ProtocolGenerator {
         .union(CharacterSet(charactersIn: "-_"))
 
     static func sanitizeSlug(_ title: String) -> String {
-        let slug = String(title
+        let slug = String(stripExistingTimestampPrefix(title)
             .lowercased()
             .replacingOccurrences(of: " ", with: "_")
             .unicodeScalars
             .filter { slugAllowed.contains($0) }
             .map(Character.init))
         return slug.isEmpty ? "meeting" : slug
+    }
+
+    /// Re-importing a previously-processed recording feeds its slug-based stem
+    /// back as a title (e.g. `20260516_1319_20260503_174538`). `filename` would
+    /// then prepend ANOTHER `yyyyMMdd_HHmm_` → compounding-prefix loop on every
+    /// reprocess. Strip a leading `yyyyMMdd_HHmm[ss]_` so the slug stays
+    /// idempotent across reprocesses.
+    static func stripExistingTimestampPrefix(_ title: String) -> String {
+        let patterns = [#"^\d{8}_\d{6}_"#, #"^\d{8}_\d{4}_"#]
+        var result = title
+        // Apply repeatedly — input may already contain multiple compounded layers
+        // from earlier buggy runs; one call should normalize the worst case.
+        var changed = true
+        while changed {
+            changed = false
+            for pattern in patterns {
+                if let range = result.range(of: pattern, options: .regularExpression) {
+                    result.removeSubrange(range)
+                    changed = true
+                }
+            }
+        }
+        return result.isEmpty ? title : result
     }
 
     /// Generate a filename: `{yyyyMMdd_HHmm}_{slug}.{ext}`

--- a/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
+++ b/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Filename suffixes for the three audio files produced by a dual-source recording.
+enum RecordingFileSuffix {
+    static let mix = "_mix.wav"
+    static let app = "_app.wav"
+    static let mic = "_mic.wav"
+
+    static let all: [String] = [mix, app, mic]
+
+    static func stripSuffix(from filename: String) -> (stem: String, suffix: String)? {
+        for suffix in all where filename.hasSuffix(suffix) {
+            return (String(filename.dropLast(suffix.count)), suffix)
+        }
+        return nil
+    }
+}

--- a/app/MeetingTranscriber/Sources/RecordingSidecar.swift
+++ b/app/MeetingTranscriber/Sources/RecordingSidecar.swift
@@ -61,4 +61,13 @@ struct RecordingSidecar: Codable {
         try data.write(to: url, options: .atomic)
         return url
     }
+
+    /// Decode `<directory>/<basename>\(filenameSuffix)`, or nil when missing/malformed.
+    static func read(fromDirectory directory: URL, basename: String) -> Self? {
+        let url = directory.appendingPathComponent("\(basename)\(Self.filenameSuffix)")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(Self.self, from: data)
+    }
 }

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -429,12 +429,8 @@ class WatchLoop {
         let startedAt = wallClockDate(forUptime: recording.recordingStart, now: stoppedAt)
 
         let mixName = recording.mixPath.lastPathComponent
-        let mixSuffix = DualSourceRecorder.mixFilenameSuffix
-        let basename: String = if mixName.hasSuffix(mixSuffix) {
-            String(mixName.dropLast(mixSuffix.count))
-        } else {
-            recording.mixPath.deletingPathExtension().lastPathComponent
-        }
+        let basename = RecordingFileSuffix.stripSuffix(from: mixName)?.stem
+            ?? recording.mixPath.deletingPathExtension().lastPathComponent
 
         do {
             let destination = recordOnlyDestination()

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -313,6 +313,104 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertNil(state.pipelineQueue.jobs[0].micPath)
     }
 
+    func testEnqueueFilesPairsTripletAsOneDualTrackJob() {
+        let (state, _) = makeState()
+        let urls = [
+            URL(fileURLWithPath: "/tmp/standup_app.wav"),
+            URL(fileURLWithPath: "/tmp/standup_mic.wav"),
+            URL(fileURLWithPath: "/tmp/standup_mix.wav"),
+        ]
+
+        state.enqueueFiles(urls)
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(job.mixPath?.lastPathComponent, "standup_mix.wav")
+        XCTAssertEqual(job.appPath?.lastPathComponent, "standup_app.wav")
+        XCTAssertEqual(job.micPath?.lastPathComponent, "standup_mic.wav")
+    }
+
+    func testEnqueueFilesAppPlusMicWithoutMixHasNilMixPath() {
+        // No `_mix.wav` in selection — job carries nil mixPath; the pipeline
+        // mixes app+mic into the workdir cache on the fly, no persistent mix
+        // is written to recordings/.
+        let (state, _) = makeState()
+        let urls = [
+            URL(fileURLWithPath: "/tmp/20260311_143000_app.wav"),
+            URL(fileURLWithPath: "/tmp/20260311_143000_mic.wav"),
+        ]
+
+        state.enqueueFiles(urls)
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        let job = state.pipelineQueue.jobs[0]
+        XCTAssertNil(job.mixPath, "paired without mix → nil mixPath")
+        XCTAssertEqual(job.appPath?.lastPathComponent, "20260311_143000_app.wav")
+        XCTAssertEqual(job.micPath?.lastPathComponent, "20260311_143000_mic.wav")
+    }
+
+    func testEnqueueFilesLoneAppFallsBackToSingleton() {
+        let (state, _) = makeState()
+        let urls = [URL(fileURLWithPath: "/tmp/orphan_app.wav")]
+
+        state.enqueueFiles(urls)
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(job.mixPath?.lastPathComponent, "orphan_app.wav")
+        XCTAssertNil(job.appPath)
+        XCTAssertNil(job.micPath)
+    }
+
+    func testEnqueueFilesMixedPairAndSingleton() {
+        let (state, _) = makeState()
+        let urls = [
+            URL(fileURLWithPath: "/tmp/meeting_app.wav"),
+            URL(fileURLWithPath: "/tmp/meeting_mic.wav"),
+            URL(fileURLWithPath: "/tmp/meeting_mix.wav"),
+            URL(fileURLWithPath: "/tmp/podcast.mp3"),
+        ]
+
+        state.enqueueFiles(urls)
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 2)
+        let paired = state.pipelineQueue.jobs.first { $0.appPath != nil }
+        let single = state.pipelineQueue.jobs.first { $0.appPath == nil }
+        XCTAssertEqual(paired?.meetingTitle, "meeting")
+        XCTAssertEqual(single?.meetingTitle, "podcast")
+    }
+
+    func testEnqueueFilesUsesSidecarMetadataWhenPresent() throws {
+        let (state, _) = makeState()
+        let tmpDir = try makeTempDirectory(prefix: "enqueue-sidecar")
+        let basename = "20260311_143000"
+
+        try RecordingSidecar(
+            title: "Sprint Review",
+            appName: "Microsoft Teams",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            stoppedAt: Date(timeIntervalSince1970: 1_777_001_800),
+            participants: ["Speaker A", "Speaker B"],
+            micDelaySeconds: 0.25,
+            mixFilename: "\(basename)_mix.wav",
+            appFilename: "\(basename)_app.wav",
+            micFilename: "\(basename)_mic.wav",
+        ).write(toDirectory: tmpDir, basename: basename)
+
+        state.enqueueFiles([
+            tmpDir.appendingPathComponent("\(basename)_app.wav"),
+            tmpDir.appendingPathComponent("\(basename)_mic.wav"),
+            tmpDir.appendingPathComponent("\(basename)_mix.wav"),
+        ])
+
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(job.meetingTitle, "Sprint Review")
+        XCTAssertEqual(job.appName, "Microsoft Teams")
+        XCTAssertEqual(job.participants, ["Speaker A", "Speaker B"])
+        XCTAssertEqual(job.micDelay, 0.25, accuracy: 0.0001)
+    }
+
     // MARK: - ensurePipelineQueue
 
     func testEnsurePipelineQueueReplacesBareQueue() {

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -4,6 +4,20 @@ import XCTest
 
 @MainActor
 final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_length
+    // swiftlint:disable:previous balanced_xctest_lifecycle
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // AppState.makePipelineQueue (triggered by ensurePipelineQueue from
+        // enqueueFiles) loads/saves a snapshot at
+        // `AppPaths.ipcDir/pipeline_queue.json`. Tests that enqueue real or
+        // fake URLs persist that snapshot, leaking jobs into the next test in
+        // the same process. Wipe before every test.
+        try? FileManager.default.removeItem(
+            at: AppPaths.ipcDir.appendingPathComponent("pipeline_queue.json"),
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeState() -> (AppState, RecordingNotifier) {
@@ -328,6 +342,36 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertEqual(job.mixPath?.lastPathComponent, "standup_mix.wav")
         XCTAssertEqual(job.appPath?.lastPathComponent, "standup_app.wav")
         XCTAssertEqual(job.micPath?.lastPathComponent, "standup_mic.wav")
+    }
+
+    func testEnqueueExistingFilesEmptyArrayReturnsZero() {
+        let (state, _) = makeState()
+        XCTAssertEqual(state.enqueueExistingFiles([]), 0)
+        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+    }
+
+    func testEnqueueExistingFilesAllMissingReturnsZeroAndDoesNotEnqueue() {
+        let (state, _) = makeState()
+        let urls = [
+            URL(fileURLWithPath: "/tmp/never-exists-\(UUID().uuidString).wav"),
+            URL(fileURLWithPath: "/tmp/also-missing-\(UUID().uuidString).wav"),
+        ]
+        XCTAssertEqual(state.enqueueExistingFiles(urls), 0)
+        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+    }
+
+    func testEnqueueExistingFilesPartialExistenceForwardsOnlyExisting() throws {
+        let (state, _) = makeState()
+        let tmpDir = try makeTempDirectory(prefix: "enqueue-existing")
+        let existing = tmpDir.appendingPathComponent("present.wav")
+        let missing = tmpDir.appendingPathComponent("absent.wav")
+        try Data("RIFF".utf8).write(to: existing)
+
+        let count = state.enqueueExistingFiles([existing, missing])
+
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        XCTAssertEqual(state.pipelineQueue.jobs[0].mixPath?.lastPathComponent, "present.wav")
     }
 
     func testEnqueueFilesAppPlusMicWithoutMixHasNilMixPath() {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -30,12 +30,14 @@
         private func startServer(
             snapshot: RPCStateSnapshot = .empty,
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
+            enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
                 token: Self.testToken,
                 snapshot: { snapshot },
                 enqueueFile: enqueueFile,
+                enqueueFiles: enqueueFiles,
             )
             self.server = server
             server.start()
@@ -192,6 +194,68 @@
                 try await Task.sleep(for: .milliseconds(25))
             }
             XCTAssertEqual(received, tmp.path)
+        }
+
+        // MARK: - /action/enqueueFiles (paired import)
+
+        func testEnqueueFilesMissingPathsReturns400() async throws {
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("action/enqueueFiles"), headers: authHeader)
+            req.httpBody = Data("{}".utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testEnqueueFilesEmptyArrayReturns400() async throws {
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("action/enqueueFiles"), headers: authHeader)
+            req.httpBody = Data(#"{"paths":[]}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testEnqueueFilesValidPathsReturns200WithCount() async throws {
+            let tmpA = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("rpc-files-a-\(UUID().uuidString).wav")
+            let tmpB = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("rpc-files-b-\(UUID().uuidString).wav")
+            FileManager.default.createFile(atPath: tmpA.path, contents: Data("RIFF".utf8))
+            FileManager.default.createFile(atPath: tmpB.path, contents: Data("RIFF".utf8))
+            defer {
+                try? FileManager.default.removeItem(at: tmpA)
+                try? FileManager.default.removeItem(at: tmpB)
+            }
+
+            actor CountBox {
+                var receivedCount: Int = 0
+                func record(_ n: Int) {
+                    receivedCount = n
+                }
+            }
+            let box = CountBox()
+            // Explicit param to disambiguate from `enqueueFile: (URL) -> Bool`
+            // (trailing-closure would bind to the wrong overload).
+            let multi: ([URL]) -> Int = { urls in
+                Task { await box.record(urls.count) }
+                return urls.count
+            }
+            let base = try await startServer(enqueueFiles: multi)
+
+            var req = request("POST", base.appendingPathComponent("action/enqueueFiles"), headers: authHeader)
+            req.httpBody = Data(#"{"paths":["\#(tmpA.path)","\#(tmpB.path)"]}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+
+            let body = try XCTUnwrap(String(data: data, encoding: .utf8))
+            XCTAssertEqual(body, #"{"enqueued":2}"#)
+
+            var received = 0
+            for _ in 0 ..< 20 {
+                received = await box.receivedCount
+                if received > 0 { break }
+                try await Task.sleep(for: .milliseconds(25))
+            }
+            XCTAssertEqual(received, 2)
         }
 
         // MARK: - M6: Host header allowlist (raw-socket)

--- a/app/MeetingTranscriber/Tests/PairedImportPanelDelegateTests.swift
+++ b/app/MeetingTranscriber/Tests/PairedImportPanelDelegateTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class PairedImportPanelDelegateTests: XCTestCase {
+    func testInitCreatesAccessoryViewWithLabel() {
+        let delegate = PairedImportPanelDelegate()
+        XCTAssertFalse(delegate.accessoryView.subviews.isEmpty, "accessory view should contain the status label")
+        let labels = delegate.accessoryView.subviews.compactMap { $0 as? NSTextField }
+        XCTAssertEqual(labels.count, 1)
+        XCTAssertEqual(labels.first?.alignment, .center)
+    }
+
+    func testPanelSelectionDidChangeWithNilSenderShowsBlank() {
+        let delegate = PairedImportPanelDelegate()
+        delegate.panelSelectionDidChange(nil)
+        let label = (delegate.accessoryView.subviews.compactMap { $0 as? NSTextField }).first
+        XCTAssertEqual(label?.stringValue, " ", "empty selection keeps a non-empty string so the label preserves its baseline height")
+    }
+
+    func testPanelSelectionDidChangeWithEmptyPanelShowsBlank() {
+        let delegate = PairedImportPanelDelegate()
+        let panel = NSOpenPanel()
+        // Fresh panel has no urls — same fallback as nil sender.
+        delegate.panelSelectionDidChange(panel)
+        let label = (delegate.accessoryView.subviews.compactMap { $0 as? NSTextField }).first
+        XCTAssertEqual(label?.stringValue, " ")
+    }
+
+    func testPanelSelectionDidChangeWithNonPanelSenderShowsBlank() {
+        // Defensive branch: sender is not an NSOpenPanel → urls fallback to [].
+        let delegate = PairedImportPanelDelegate()
+        delegate.panelSelectionDidChange(NSObject())
+        let label = (delegate.accessoryView.subviews.compactMap { $0 as? NSTextField }).first
+        XCTAssertEqual(label?.stringValue, " ")
+    }
+}

--- a/app/MeetingTranscriber/Tests/PairedImportSummaryTests.swift
+++ b/app/MeetingTranscriber/Tests/PairedImportSummaryTests.swift
@@ -1,0 +1,63 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class PairedImportSummaryTests: XCTestCase {
+    private func url(_ name: String) -> URL {
+        URL(fileURLWithPath: "/tmp/\(name)")
+    }
+
+    func testEmptySelectionShowsBlank() {
+        XCTAssertEqual(PairedImportSummary.text(forSelectedURLs: []), " ")
+    }
+
+    func testSinglePairWithMixAnchorIs1Transcript() {
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("meeting_app.wav"),
+            url("meeting_mic.wav"),
+            url("meeting_mix.wav"),
+        ])
+        XCTAssertEqual(text, "1 paired recording → 1 transcript")
+    }
+
+    func testTwoPairsArePluralized() {
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("a_app.wav"), url("a_mic.wav"), url("a_mix.wav"),
+            url("b_app.wav"), url("b_mic.wav"), url("b_mix.wav"),
+        ])
+        XCTAssertEqual(text, "2 paired recordings → 2 transcripts")
+    }
+
+    func testMixedPairAndSingleton() {
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("meeting_app.wav"),
+            url("meeting_mic.wav"),
+            url("meeting_mix.wav"),
+            url("podcast.mp3"),
+        ])
+        XCTAssertEqual(text, "1 paired recording + 1 single file → 2 transcripts")
+    }
+
+    func testAppPlusMicWithoutMixIsOnePairedRecording() {
+        // app+mic without mix is paired — synthesizer creates the mix on enqueue.
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("meeting_app.wav"),
+            url("meeting_mic.wav"),
+        ])
+        XCTAssertEqual(text, "1 paired recording → 1 transcript")
+    }
+
+    func testOnlySingletons() {
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("one.mp3"),
+            url("two.m4a"),
+        ])
+        XCTAssertEqual(text, "2 single files → 2 transcripts")
+    }
+
+    func testLoneAppFallsBackAndIsCountedAsSingle() {
+        let text = PairedImportSummary.text(forSelectedURLs: [
+            url("orphan_app.wav"),
+        ])
+        XCTAssertEqual(text, "1 single file → 1 transcript")
+    }
+}

--- a/app/MeetingTranscriber/Tests/PairedRecordingResolverTests.swift
+++ b/app/MeetingTranscriber/Tests/PairedRecordingResolverTests.swift
@@ -1,0 +1,180 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class PairedRecordingResolverTests: XCTestCase {
+    private let dir = URL(fileURLWithPath: "/tmp/rec")
+
+    private func url(_ name: String) -> URL {
+        dir.appendingPathComponent(name)
+    }
+
+    // MARK: - Single recording groups
+
+    func testFullTriplet() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("standup_app.wav"),
+            url("standup_mic.wav"),
+            url("standup_mix.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 1)
+        XCTAssertEqual(result.singletons.count, 0)
+
+        let group = result.paired[0]
+        XCTAssertEqual(group.stem, "standup")
+        XCTAssertNotNil(group.app)
+        XCTAssertNotNil(group.mic)
+        XCTAssertEqual(group.mix?.lastPathComponent, "standup_mix.wav")
+    }
+
+    func testMixOnlyIsPaired() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("meeting_mix.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 1)
+        XCTAssertEqual(result.singletons.count, 0)
+
+        let group = result.paired[0]
+        XCTAssertEqual(group.stem, "meeting")
+        XCTAssertEqual(group.mix?.lastPathComponent, "meeting_mix.wav")
+        XCTAssertNil(group.app)
+        XCTAssertNil(group.mic)
+    }
+
+    func testAppPlusMicWithoutMixIsPaired() {
+        // Both tracks present → dual-track pipeline can run; `mix` will be
+        // synthesized from app+mic at enqueue time.
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("20260311_143000_app.wav"),
+            url("20260311_143000_mic.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 1)
+        XCTAssertEqual(result.singletons.count, 0)
+
+        let group = result.paired[0]
+        XCTAssertEqual(group.stem, "20260311_143000")
+        XCTAssertNil(group.mix, "no mix in selection — synthesizer will create one")
+        XCTAssertEqual(group.app?.lastPathComponent, "20260311_143000_app.wav")
+        XCTAssertEqual(group.mic?.lastPathComponent, "20260311_143000_mic.wav")
+    }
+
+    // MARK: - Singleton fallback
+
+    func testLoneAppFallsBackToSingleton() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("alone_app.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 0)
+        XCTAssertEqual(result.singletons.count, 1)
+        XCTAssertEqual(result.singletons[0].lastPathComponent, "alone_app.wav")
+    }
+
+    func testLoneMicFallsBackToSingleton() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("alone_mic.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 0)
+        XCTAssertEqual(result.singletons.count, 1)
+        XCTAssertEqual(result.singletons[0].lastPathComponent, "alone_mic.wav")
+    }
+
+    func testUnrecognizedSuffixIsSingleton() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("podcast.mp3"),
+            url("interview.m4a"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 0)
+        XCTAssertEqual(result.singletons.count, 2)
+    }
+
+    // MARK: - Mixed batches
+
+    func testOnePairPlusOneSingleton() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("meeting_app.wav"),
+            url("meeting_mic.wav"),
+            url("meeting_mix.wav"),
+            url("standalone.mp3"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 1)
+        XCTAssertEqual(result.singletons.count, 1)
+        XCTAssertEqual(result.singletons[0].lastPathComponent, "standalone.mp3")
+    }
+
+    func testTwoSeparatePairs() {
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("aaa_app.wav"), url("aaa_mic.wav"), url("aaa_mix.wav"),
+            url("bbb_app.wav"), url("bbb_mic.wav"), url("bbb_mix.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 2)
+        XCTAssertEqual(result.singletons.count, 0)
+
+        let stems = Set(result.paired.map(\.stem))
+        XCTAssertEqual(stems, ["aaa", "bbb"])
+    }
+
+    func testSameStemDifferentDirectoriesAreSeparateGroups() {
+        let dirA = URL(fileURLWithPath: "/tmp/a")
+        let dirB = URL(fileURLWithPath: "/tmp/b")
+        let result = PairedRecordingResolver.resolve(urls: [
+            dirA.appendingPathComponent("meeting_app.wav"),
+            dirA.appendingPathComponent("meeting_mic.wav"),
+            dirA.appendingPathComponent("meeting_mix.wav"),
+            dirB.appendingPathComponent("meeting_app.wav"),
+            dirB.appendingPathComponent("meeting_mic.wav"),
+            dirB.appendingPathComponent("meeting_mix.wav"),
+        ])
+
+        XCTAssertEqual(result.paired.count, 2)
+        XCTAssertEqual(result.singletons.count, 0)
+    }
+
+    func testEmptyInput() {
+        let result = PairedRecordingResolver.resolve(urls: [])
+        XCTAssertTrue(result.paired.isEmpty)
+        XCTAssertTrue(result.singletons.isEmpty)
+    }
+
+    // MARK: - Regression: mixPath aliasing
+
+    func testResolverNeverAliasesMixWithAppOrMic() {
+        // When a `_mix.wav` is part of the selection, it must be distinct from
+        // app/mic by suffix construction. Groups without a mix carry `nil`,
+        // and the synthesizer creates a real mix file at enqueue time.
+        let cases: [[URL]] = [
+            [url("a_app.wav"), url("a_mic.wav"), url("a_mix.wav")],
+            [url("b_mix.wav")],
+            [url("c_app.wav"), url("c_mix.wav")],
+            [url("d_mic.wav"), url("d_mix.wav")],
+        ]
+        for urls in cases {
+            let result = PairedRecordingResolver.resolve(urls: urls)
+            for group in result.paired where group.mix != nil {
+                XCTAssertNotEqual(group.mix, group.app)
+                XCTAssertNotEqual(group.mix, group.mic)
+            }
+        }
+    }
+
+    func testGroupOrderFollowsFirstURLIndex() {
+        // Mix at index 0 → pair "early" is enqueued first;
+        // singleton at index 1; pair "late" (mix at index 2) is enqueued second.
+        let result = PairedRecordingResolver.resolve(urls: [
+            url("early_mix.wav"), // 0 — pair "early" earliest member
+            url("solo.mp3"), // 1 — singleton
+            url("late_mix.wav"), // 2 — pair "late" earliest member
+            url("early_app.wav"), // 3 — pair "early" later member (irrelevant for order)
+            url("late_mic.wav"), // 4
+        ])
+
+        XCTAssertEqual(result.paired.map(\.stem), ["early", "late"])
+        XCTAssertEqual(result.singletons.map(\.lastPathComponent), ["solo.mp3"])
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -274,7 +274,7 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(freshQueue.jobs.count, 1)
         XCTAssertEqual(freshQueue.jobs[0].meetingTitle, "Recovered Recording (20260311_100000)")
         XCTAssertEqual(
-            freshQueue.jobs[0].mixPath.standardizedFileURL,
+            freshQueue.jobs[0].mixPath?.standardizedFileURL,
             mixFile.standardizedFileURL,
         )
     }

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -356,4 +356,63 @@ final class ProtocolGeneratorTests: XCTestCase {
         XCTAssertNotNil(error.errorDescription)
         XCTAssertEqual(error.errorDescription?.contains("14.2"), true)
     }
+
+    // MARK: - filename timestamp-prefix compounding regression
+
+    func testStripExistingTimestampPrefix_HHmm() {
+        // The exact failure mode from PR #274: re-importing a previously-
+        // slug-renamed `<today1>_<original_stem>_app.wav` would feed the
+        // slug back as title, and filename would prepend ANOTHER today's
+        // timestamp → compounding.
+        XCTAssertEqual(
+            ProtocolGenerator.stripExistingTimestampPrefix("20260516_1319_20260503_174538"),
+            "20260503_174538",
+        )
+    }
+
+    func testStripExistingTimestampPrefix_HHmmss() {
+        // DualSourceRecorder's native format is `yyyyMMdd_HHmmss_<suffix>.wav`.
+        XCTAssertEqual(
+            ProtocolGenerator.stripExistingTimestampPrefix("20260503_174538_daily_standup"),
+            "daily_standup",
+        )
+    }
+
+    func testStripExistingTimestampPrefix_doubleCompound() {
+        // Multi-layer compound left over from earlier buggy runs — strip all layers.
+        XCTAssertEqual(
+            ProtocolGenerator.stripExistingTimestampPrefix("20260516_1601_20260516_1319_meeting"),
+            "meeting",
+        )
+    }
+
+    func testStripExistingTimestampPrefix_noPrefix() {
+        XCTAssertEqual(
+            ProtocolGenerator.stripExistingTimestampPrefix("Daily standup"),
+            "Daily standup",
+        )
+    }
+
+    func testStripExistingTimestampPrefix_titleIsOnlyTimestamp() {
+        // No trailing `_`, no suffix to keep — return original to avoid an empty slug.
+        XCTAssertEqual(
+            ProtocolGenerator.stripExistingTimestampPrefix("20260503_174538"),
+            "20260503_174538",
+        )
+    }
+
+    func testFilenameDoesNotCompoundOnReimport() {
+        // The actual regression: re-importing a previously-processed file with
+        // a slug stem should produce a single-prefixed filename, not stack
+        // today's prefix on top of yesterday's.
+        let result = ProtocolGenerator.filename(
+            title: "20260516_1319_20260503_174538", ext: "md",
+        )
+        // Today's timestamp + the original recording timestamp, NOT today's twice.
+        XCTAssertTrue(result.hasSuffix("_20260503_174538.md"), "got: \(result)")
+        XCTAssertFalse(
+            result.contains("_20260516_1319_"),
+            "yesterday's prefix should have been stripped: \(result)",
+        )
+    }
 }

--- a/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
+++ b/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
@@ -72,4 +72,25 @@ final class RecordingSidecarTests: XCTestCase {
         XCTAssertEqual(url.lastPathComponent, "\(basename)_meta.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
+
+    func test_read_roundTripsTitleAndParticipants() throws {
+        let dir = try makeTempDirectory(prefix: "rs")
+        let basename = "20260503_083000"
+        try makeFullSidecar().write(toDirectory: dir, basename: basename)
+
+        let decoded = try XCTUnwrap(
+            RecordingSidecar.read(fromDirectory: dir, basename: basename),
+        )
+
+        XCTAssertEqual(decoded.title, "Standup")
+        XCTAssertEqual(decoded.appName, "Microsoft Teams")
+        XCTAssertEqual(decoded.participants, ["Alice", "Bob"])
+        XCTAssertEqual(decoded.micDelaySeconds, 0.12, accuracy: 0.0001)
+        XCTAssertEqual(decoded.files.mix, "20260503_083000_mix.wav")
+    }
+
+    func test_read_returnsNilWhenMissing() throws {
+        let dir = try makeTempDirectory(prefix: "rs")
+        XCTAssertNil(RecordingSidecar.read(fromDirectory: dir, basename: "absent"))
+    }
 }

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -1,8 +1,10 @@
+// swiftlint:disable file_length
 @testable import MeetingTranscriber
 import XCTest
 
 @MainActor
-final class WorkflowIntegrationTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
+final class WorkflowIntegrationTests: XCTestCase {
+    // swiftlint:disable:previous balanced_xctest_lifecycle type_body_length
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var tmpDir: URL!
 
@@ -181,6 +183,142 @@ final class WorkflowIntegrationTests: XCTestCase { // swiftlint:disable:this bal
         )
 
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
+
+    // MARK: - Paired Import Regression
+
+    /// Reproduces the bug behind the "feat: paired import" PR's first iteration.
+    /// When the picker selected only `_app.wav` + `_mic.wav` (no `_mix.wav`), the
+    /// constructed job had `mixPath == appPath`. `copyAudioToOutput`'s first
+    /// move renamed the source to `<slug>_mix.wav`; the second move silently
+    /// failed; `recoverOrphanedRecordings` re-picked the renamed file on every
+    /// launch, producing an endless compounding-rename chain on disk.
+    ///
+    /// This test runs the full mock pipeline through a paired triplet
+    /// (`_app + _mic + _mix`) and asserts the output dir contains a clean
+    /// triplet — no `<slug>_app_mix.wav`, `<slug>_mic_mix.wav`, or similar
+    /// aliasing artifacts.
+    func testWorkflowPairedImportTripletProducesCleanOutputTriplet() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: false)
+
+        let importDir = try makeTempDirectory(prefix: "import-source")
+        let mixURL = importDir.appendingPathComponent("standup_mix.wav")
+        let appURL = importDir.appendingPathComponent("standup_app.wav")
+        let micURL = importDir.appendingPathComponent("standup_mic.wav")
+        for url in [mixURL, appURL, micURL] {
+            try FileManager.default.copyItem(at: h.audioPath, to: url)
+        }
+
+        let resolution = PairedRecordingResolver.resolve(urls: [mixURL, appURL, micURL])
+        XCTAssertEqual(resolution.paired.count, 1)
+        let group = try XCTUnwrap(resolution.paired.first)
+        XCTAssertNotEqual(group.mix, group.app, "regression: mixPath must not alias appPath")
+        XCTAssertNotEqual(group.mix, group.mic, "regression: mixPath must not alias micPath")
+
+        let job = try PipelineJob(
+            meetingTitle: group.stem,
+            appName: "File",
+            mixPath: XCTUnwrap(group.mix),
+            appPath: group.app,
+            micPath: group.mic,
+            micDelay: 0,
+        )
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)) ?? []
+        let audioWAVs = names.filter { $0.hasSuffix(".wav") && !$0.contains("_16k") }
+
+        // Exactly one triplet — no aliasing artifacts.
+        XCTAssertEqual(audioWAVs.count { $0.hasSuffix(RecordingFileSuffix.mix) }, 1)
+        XCTAssertEqual(audioWAVs.count { $0.hasSuffix(RecordingFileSuffix.app) }, 1)
+        XCTAssertEqual(audioWAVs.count { $0.hasSuffix(RecordingFileSuffix.mic) }, 1)
+        for name in audioWAVs {
+            XCTAssertFalse(
+                name.contains("_app_mix.wav") || name.contains("_mic_mix.wav"),
+                "Aliasing artifact in output filename: \(name)",
+            )
+        }
+    }
+
+    /// app+mic without an on-disk `_mix.wav` (`mixPath: nil`) runs the dual-track
+    /// pipeline without writing any persistent mix file to the recordings dir.
+    /// The pipeline mixes app+mic into the workdir cache on the fly.
+    func testWorkflowAppPlusMicWithNilMixPathProducesTranscriptOnly() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true)
+        h.queue.speakerNamingHandler = { _ in .skipped }
+
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let appURL = recordingsDir.appendingPathComponent("meeting_app.wav")
+        let micURL = recordingsDir.appendingPathComponent("meeting_mic.wav")
+        try FileManager.default.copyItem(at: h.audioPath, to: appURL)
+        try FileManager.default.copyItem(at: h.audioPath, to: micURL)
+
+        let job = PipelineJob(
+            meetingTitle: "meeting", appName: "File",
+            mixPath: nil, appPath: appURL, micPath: micURL,
+            micDelay: 0,
+        )
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path), "user app source preserved")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "user mic source preserved")
+
+        // No `<slug>_mix.wav` artefact in the recordings dir — only the
+        // user's app + mic sources + 16k caches.
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)) ?? []
+        let extraneousMixes = names.filter { name in
+            name.hasSuffix(RecordingFileSuffix.mix) && name != "meeting_mix.wav"
+        }
+        XCTAssertTrue(
+            extraneousMixes.isEmpty,
+            "no slug-renamed mix should be written; got: \(extraneousMixes)",
+        )
+    }
+
+    /// Re-importing a recording from `outputDir/recordings/` used to rename the
+    /// source file in place with a fresh `<today_timestamp>_<title>` prefix,
+    /// and `recoverOrphanedRecordings` would re-pick the new name on the next
+    /// launch — endless compounding-rename loop on disk. Fix: skip the move
+    /// when the source already lives in the target directory.
+    func testWorkflowSourceFilesInOutputDirAreNotRenamed() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: false)
+
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let mixURL = recordingsDir.appendingPathComponent("standup_mix.wav")
+        let appURL = recordingsDir.appendingPathComponent("standup_app.wav")
+        let micURL = recordingsDir.appendingPathComponent("standup_mic.wav")
+        for url in [mixURL, appURL, micURL] {
+            try FileManager.default.copyItem(at: h.audioPath, to: url)
+        }
+
+        let job = PipelineJob(
+            meetingTitle: "standup",
+            appName: "File",
+            mixPath: mixURL,
+            appPath: appURL,
+            micPath: micURL,
+            micDelay: 0,
+        )
+        h.queue.enqueue(job)
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixURL.path), "mix source preserved")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path), "app source preserved")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "mic source preserved")
+
+        // No prefixed copies — original filenames untouched.
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)) ?? []
+        let extraMixes = names.filter { $0.hasSuffix("_mix.wav") && $0 != "standup_mix.wav" }
+        XCTAssertTrue(extraMixes.isEmpty, "no prefixed _mix.wav copies, found: \(extraMixes)")
     }
 
     // MARK: - Error Scenarios


### PR DESCRIPTION
## Summary

- Re-importing a recording via "Process Audio Files…" used to enqueue each selected URL as an independent job, so two-track recordings got diarized track-by-track in isolation and merged worse than the original live-recording pipeline.
- The file picker now groups `<stem>_app.wav` + `<stem>_mic.wav` (with optional `_mix.wav`) by basename stem and feeds the same dual-track branch of `PipelineQueue` that live recordings already use.
- The picker shows a live accessory line: "1 paired recording + 1 single file → 2 transcripts" so the grouping is visible before pressing Open.

Closes #254.

## What's in here

**Commit 1 — refactor: centralize recording-file suffix constants**
- New `RecordingFileSuffix` enum with `mix`/`app`/`mic` static lets + `stripSuffix(from:)` helper.
- Migrates inline strings in `DualSourceRecorder`, `PipelineQueue` (`copyAudioToOutput` + `migrateProcessedRecordings` + orphan-recovery suffix), and `WatchLoop.enqueueRecording`. No behaviour change.

**Commit 2 — feat: paired import**
- `PairedRecordingResolver` — pure function returning `(paired: [Group], singletons: [URL])` keyed on `(directory, stem)`. Strict pairing: lone `_app.wav` without a `_mic.wav` partner falls back to a singleton job; `_mix.wav` alone is paired (mix-only).
- `RecordingSidecar.read(fromDirectory:basename:)` — opportunistically restores `meetingTitle` / `appName` / `participants` / `micDelaySeconds` when the recording came from record-only mode and has a `<stem>_meta.json`.
- `PairedImportPanelDelegate` + `PairedImportSummary` — `NSOpenSavePanelDelegate` plus a pure status-line formatter, both unit-tested.
- `AppState.enqueueFiles` rewritten to enqueue one job per paired group; singleton URLs keep today's per-file behaviour.
- `PipelineQueue.recoverOrphanedRecordings` reuses the same resolver instead of re-implementing the suffix-pairing rule (drops 10 LOC).

## UI

The file picker is the standard macOS open panel with one new bottom line:

```
ℹ︎ 1 paired recording + 1 single file → 2 transcripts
```

Updates live on every selection change. Empty selection keeps the picker's baseline height.

## Tests

- `PairedRecordingResolverTests` — 12 cases: app+mic pair, full triplet, mix-only, lone app→singleton, lone mic→singleton, unrecognized suffix, mixed batch, two separate pairs, same stem across directories, empty input, input-order preservation, primary-path priority.
- `PairedImportSummaryTests` — 6 cases covering pluralization, mixed counts, lone-app fallback.
- `AppStateTests` — 5 new cases: pair as one job, triplet uses mix as primary, lone app falls back, mixed pair + singleton, sidecar metadata applied.
- `RecordingSidecarTests` — 2 new cases: round-trip via `read(…)`, missing file returns nil.

## Test plan

- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — 1441 tests, 0 failures (the existing `testOpenAIAPIKeyViaKeychainHelper` is a known local-keychain flake; passes in isolation).
- [x] `./scripts/lint.sh` — clean.
- [x] `./scripts/pre-push.sh --with-appstore` — release-mode builds green for Homebrew + AppStore variants.
- [ ] Manual smoke test on dev app: select `_app.wav` + `_mic.wav` pair, confirm accessory shows "1 paired recording → 1 transcript", confirm a single dual-track job is queued.