### PR TITLE
refactor(app): extract WatchLoopEndPolicy as pure decision function

### DIFF
--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -298,28 +298,30 @@ class WatchLoop {
     func waitForMeetingEnd(_ meeting: DetectedMeeting) async throws {
         var graceStart: Date?
         let startTime = Date()
+        let config = WatchLoopEndConfig(
+            maxDuration: maxDuration,
+            endGracePeriod: endGracePeriod,
+        )
 
         while !Task.isCancelled {
-            // Enforce max duration
-            if Date().timeIntervalSince(startTime) > maxDuration {
+            let decision = WatchLoopEndPolicy.step(
+                config: config,
+                now: Date(),
+                startTime: startTime,
+                graceStart: graceStart,
+                meetingActive: detector.isMeetingActive(meeting),
+            )
+            switch decision {
+            case .stopMaxDurationExceeded:
                 logger.info("Max recording duration reached (\(Int(self.maxDuration))s)")
                 return
+
+            case .stopGraceExpired:
+                return
+
+            case let .continuePolling(newGraceStart):
+                graceStart = newGraceStart
             }
-
-            let active = detector.isMeetingActive(meeting)
-
-            if active {
-                if graceStart != nil {
-                    graceStart = nil
-                }
-            } else {
-                if graceStart == nil {
-                    graceStart = Date()
-                } else if let start = graceStart, Date().timeIntervalSince(start) >= endGracePeriod {
-                    return
-                }
-            }
-
             try await Task.sleep(for: .seconds(pollInterval))
         }
     }

--- a/app/MeetingTranscriber/Sources/WatchLoopEndPolicy.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoopEndPolicy.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Decision returned by `WatchLoopEndPolicy.step` on each poll of
+/// `WatchLoop.waitForMeetingEnd`.
+enum WatchLoopEndDecision: Equatable {
+    /// Continue polling. The returned `graceStart` is the value the caller
+    /// should hold until the next poll: `nil` when the meeting is currently
+    /// active (grace cleared), the original value when grace is still
+    /// running, or `now` when a fresh grace window just started.
+    case continuePolling(graceStart: Date?)
+    /// Stop because the recording has exceeded its maximum duration. The
+    /// caller is responsible for logging this case if it wants to.
+    case stopMaxDurationExceeded
+    /// Stop because the meeting has been inactive for the full grace
+    /// period — the meeting is definitively over.
+    case stopGraceExpired
+}
+
+/// Static configuration for `WatchLoopEndPolicy.step` — duration limits
+/// owned by the WatchLoop instance and re-used across every poll.
+struct WatchLoopEndConfig: Equatable {
+    let maxDuration: TimeInterval
+    let endGracePeriod: TimeInterval
+}
+
+/// Pure decision logic for `WatchLoop.waitForMeetingEnd`. Separated so
+/// the grace-reset / max-duration / continue-on-active branches can be
+/// asserted directly without driving the async timer loop.
+enum WatchLoopEndPolicy {
+    /// Decide what the meeting-end poller should do given the current
+    /// state of the world.
+    ///
+    /// - Parameters:
+    ///   - config: Duration limits (max recording duration + end-of-meeting
+    ///     grace period).
+    ///   - now: The current wall-clock time. Pass `Date()` from production.
+    ///   - startTime: When the poller first started waiting for end.
+    ///   - graceStart: When the current inactive run started, or `nil`
+    ///     if the meeting was active on the last poll (or has never gone
+    ///     inactive).
+    ///   - meetingActive: Whether the meeting is active right now.
+    static func step(
+        config: WatchLoopEndConfig,
+        now: Date,
+        startTime: Date,
+        graceStart: Date?,
+        meetingActive: Bool,
+    ) -> WatchLoopEndDecision {
+        if now.timeIntervalSince(startTime) > config.maxDuration {
+            return .stopMaxDurationExceeded
+        }
+        if meetingActive {
+            return .continuePolling(graceStart: nil)
+        }
+        guard let start = graceStart else {
+            return .continuePolling(graceStart: now)
+        }
+        if now.timeIntervalSince(start) >= config.endGracePeriod {
+            return .stopGraceExpired
+        }
+        return .continuePolling(graceStart: start)
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopEndPolicyTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopEndPolicyTests.swift
@@ -1,0 +1,159 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Pure-function tests for the decision policy that drives
+/// `WatchLoop.waitForMeetingEnd`. These cover each branch without an async
+/// timer loop, so the grace-reset / grace-expiry / max-duration interactions
+/// are deterministic.
+final class WatchLoopEndPolicyTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+    private static let defaultConfig = WatchLoopEndConfig(maxDuration: 100, endGracePeriod: 10)
+
+    private func step(
+        meetingActive: Bool,
+        elapsedSinceStart: TimeInterval,
+        graceStart: Date? = nil,
+        config: WatchLoopEndConfig = defaultConfig,
+    ) -> WatchLoopEndDecision {
+        WatchLoopEndPolicy.step(
+            config: config,
+            now: t0.addingTimeInterval(elapsedSinceStart),
+            startTime: t0,
+            graceStart: graceStart,
+            meetingActive: meetingActive,
+        )
+    }
+
+    // MARK: - Max duration
+
+    func testStopsWhenMaxDurationExceeded() {
+        XCTAssertEqual(
+            step(meetingActive: true, elapsedSinceStart: 100.1),
+            .stopMaxDurationExceeded,
+        )
+    }
+
+    func testMaxDurationTakesPrecedenceOverGrace() {
+        // Even with an inactive meeting that would otherwise still be in
+        // its grace window, max duration wins.
+        XCTAssertEqual(
+            step(
+                meetingActive: false,
+                elapsedSinceStart: 100.5,
+                graceStart: t0.addingTimeInterval(100),
+            ),
+            .stopMaxDurationExceeded,
+        )
+    }
+
+    // MARK: - Active meeting clears grace
+
+    func testActiveMeetingClearsGrace() {
+        XCTAssertEqual(
+            step(
+                meetingActive: true,
+                elapsedSinceStart: 5,
+                graceStart: t0.addingTimeInterval(2),
+            ),
+            .continuePolling(graceStart: nil),
+        )
+    }
+
+    func testActiveMeetingContinuesWithoutGrace() {
+        XCTAssertEqual(
+            step(meetingActive: true, elapsedSinceStart: 5, graceStart: nil),
+            .continuePolling(graceStart: nil),
+        )
+    }
+
+    // MARK: - Inactive meeting starts grace
+
+    func testInactiveMeetingStartsGraceWhenNoneRunning() {
+        let now = t0.addingTimeInterval(5)
+        XCTAssertEqual(
+            WatchLoopEndPolicy.step(
+                config: Self.defaultConfig,
+                now: now,
+                startTime: t0,
+                graceStart: nil,
+                meetingActive: false,
+            ),
+            .continuePolling(graceStart: now),
+        )
+    }
+
+    // MARK: - Grace expiry
+
+    func testInactiveMeetingStaysInGraceWhenNotYetExpired() {
+        let graceStart = t0.addingTimeInterval(5)
+        XCTAssertEqual(
+            step(meetingActive: false, elapsedSinceStart: 9, graceStart: graceStart),
+            .continuePolling(graceStart: graceStart),
+        )
+    }
+
+    func testInactiveMeetingStopsWhenGraceExpired() {
+        let graceStart = t0.addingTimeInterval(5)
+        XCTAssertEqual(
+            step(meetingActive: false, elapsedSinceStart: 15.5, graceStart: graceStart),
+            .stopGraceExpired,
+        )
+    }
+
+    func testGraceExpiryUsesGreaterThanOrEqual() {
+        // Edge case: elapsed since graceStart == endGracePeriod exactly.
+        // Current production behaviour treats this as expired (>= comparison).
+        let graceStart = t0.addingTimeInterval(0)
+        XCTAssertEqual(
+            step(meetingActive: false, elapsedSinceStart: 10, graceStart: graceStart),
+            .stopGraceExpired,
+        )
+    }
+
+    // MARK: - Reset behaviour
+
+    func testGraceResetsWhenMeetingResumesThenEnds() {
+        // Sequence reproducing the WatchLoop characterization test on the
+        // pure policy: inactive (grace starts) → active (grace clears) →
+        // inactive (fresh grace) → inactive past gracePeriod (stops).
+        var graceStart: Date?
+
+        // t=1: inactive, grace starts.
+        graceStart = expectContinue(step(
+            meetingActive: false, elapsedSinceStart: 1, graceStart: graceStart,
+        ))
+        XCTAssertEqual(graceStart, t0.addingTimeInterval(1))
+
+        // t=2: active, grace clears.
+        graceStart = expectContinue(step(
+            meetingActive: true, elapsedSinceStart: 2, graceStart: graceStart,
+        ))
+        XCTAssertNil(graceStart)
+
+        // t=3: inactive, fresh grace.
+        graceStart = expectContinue(step(
+            meetingActive: false, elapsedSinceStart: 3, graceStart: graceStart,
+        ))
+        XCTAssertEqual(graceStart, t0.addingTimeInterval(3))
+
+        // t=13: elapsed since fresh grace = 10, threshold met → stop.
+        XCTAssertEqual(
+            step(meetingActive: false, elapsedSinceStart: 13, graceStart: graceStart),
+            .stopGraceExpired,
+        )
+
+        // Critical: the first grace started at t=1, so a monotonic timer
+        // would have stopped at t=11. The fact that we are still polling
+        // at t=13 proves the reset.
+    }
+
+    /// Helper: assert decision is `.continuePolling` and return the new
+    /// grace-start carried forward to the next poll.
+    private func expectContinue(_ decision: WatchLoopEndDecision) -> Date? {
+        guard case let .continuePolling(g) = decision else {
+            XCTFail("Expected .continuePolling, got \(decision)")
+            return nil
+        }
+        return g
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -155,6 +155,57 @@ final class WatchLoopTests: XCTestCase {
         XCTAssertLessThan(elapsed, 1.0, "Should not wait too long")
     }
 
+    /// Characterization test pinning the grace-reset behaviour: when the
+    /// meeting becomes inactive, then resumes, then ends again, the
+    /// grace-period timer must restart from scratch — i.e. the second
+    /// grace window has to run its full duration independent of the
+    /// first, partially elapsed one.
+    ///
+    /// Timings are intentionally generous (grace ≫ pollInterval × CI
+    /// sleep-jitter) so that the grace window cannot expire between
+    /// the first inactive poll and the active-resume poll on slow
+    /// hosted runners where `Task.sleep(for:)` typically overshoots
+    /// the requested interval by 2–4×.
+    func testWaitForMeetingEndResetsGraceWhenMeetingResumes() async throws {
+        let detector = PowerAssertionDetector()
+        let activeAssertions: [Int32: [[String: Any]]] = [
+            1234: [["Process Name": "MSTeams", "AssertName": "Microsoft Teams Call in progress"]],
+        ]
+        // Sequence: inactive, ACTIVE, inactive, inactive, …
+        // Without grace-reset the loop returns at poll 3 (graceStart from
+        // poll 1 has had >grace elapsed by then). With grace-reset the
+        // loop returns no earlier than poll 4 because poll 2 clears
+        // graceStart and poll 3 sets a fresh one that hasn't expired yet.
+        let callCount = ManagedCounter()
+        detector.assertionProvider = {
+            let n = callCount.increment()
+            return n == 2 ? activeAssertions : [:]
+        }
+
+        let loop = WatchLoop(
+            detector: detector,
+            pollInterval: 0.1,
+            endGracePeriod: 0.5,
+            maxDuration: 30,
+        )
+
+        let meeting = DetectedMeeting(
+            pattern: .teams,
+            windowTitle: "Test | Microsoft Teams",
+            ownerName: "Microsoft Teams",
+            windowPID: 1234,
+        )
+
+        try await loop.waitForMeetingEnd(meeting)
+
+        XCTAssertGreaterThanOrEqual(
+            callCount.value, 4,
+            "Grace must reset on resume; observed only \(callCount.value) polls — "
+                + "without reset the loop would return at poll 3 once the original "
+                + "grace window had elapsed.",
+        )
+    }
+
     // MARK: - NoMic Configuration
 
     func testNoMicDefault() {
@@ -489,5 +540,16 @@ final class WatchLoopTests: XCTestCase {
 
         try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
         XCTAssertTrue(recorder.startCalled)
+    }
+}
+
+/// Tiny counter for tests that need to observe how many times a captured
+/// closure was invoked. Class reference lets a non-Sendable closure mutate
+/// the count without an `inout`/escaping-capture dance.
+private final class ManagedCounter {
+    private(set) var value = 0
+    func increment() -> Int {
+        value += 1
+        return value
     }
 }


### PR DESCRIPTION
## Summary

First slice of a larger WatchLoop architecture refactor: extract the meeting-end decision logic out of the async timer loop into a pure `WatchLoopEndPolicy`, returning a `WatchLoopEndDecision` enum.

`WatchLoop.waitForMeetingEnd` previously interleaved three concerns in one while-loop body — wall-clock comparisons, grace-state mutation, and side-effects (logging + return). The grace-reset edge case (active → inactive → active → inactive) was only exercised end-to-end by the live-recording E2E lane and had no deterministic unit assertion.

This change moves the branch logic to `WatchLoopEndPolicy.step(config:now:startTime:graceStart:meetingActive:)`. The async loop now only owns the timer + state mutation; every branch decision is a pure function call that can be asserted directly.

## Changes

**`Sources/WatchLoopEndPolicy.swift`** (new)
- `WatchLoopEndDecision` — 3-case enum (`continuePolling(graceStart:)` / `stopMaxDurationExceeded` / `stopGraceExpired`).
- `WatchLoopEndConfig` — value type carrying the two duration limits.
- `WatchLoopEndPolicy.step(...)` — pure decision function.

Mirrors the existing `MicRestartPolicy` / `BadgeKind.compute` pattern: pure-logic enum in its own file, decision returned as an enum, no side effects.

**`Sources/WatchLoop.swift`**
- `waitForMeetingEnd` body shrinks to a `switch decision` over the policy result. `WatchLoopEndConfig` is built once per call (outside the while-loop) to keep the hot path allocation-free.

**`Tests/WatchLoopEndPolicyTests.swift`** (new)
- 9 deterministic branch tests covering: max-duration precedence, active-meeting clearing grace, inactive-meeting starting grace, grace stays/expires, `>=` edge case, and the full reset-on-resume sequence — all without an async timer loop.

**`Tests/WatchLoopTests.swift`**
- Adds `testWaitForMeetingEndResetsGraceWhenMeetingResumes` as a characterization test on the live async path. Pins the same behaviour from the integration side so a future regression that bypasses the policy would still be caught by the existing test suite.

## Coverage

`WatchLoopEndPolicy.swift` is fully covered by the new branch tests; behavioural coverage of `waitForMeetingEnd` is now twofold (unit + characterization). No public API change — `waitForMeetingEnd` keeps its signature.

## Test plan

- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — 1467 tests, 0 failures
- [x] `swift build -c release` — clean, no Sendable diagnostics
- [x] `./scripts/lint.sh` — 0 violations
- [x] `./scripts/pre-push.sh --with-appstore` — both variants compile
- [x] Existing `testWaitForMeetingEndGracePeriod` + `testWaitForMeetingEndMaxDuration` still pass (behaviour-equivalent refactor)
- [ ] CI run on PR

## Why this is the first slice (not the whole reducer split)

This intentionally stays small to establish the policy-extraction pattern on a contained surface (the grace/max-duration decision) before doing the larger work — splitting the central `watchLoop()` task, extracting `WatchLoopState` as a value type, and routing `MeetingDetecting` + `RecordingProvider` side-effects through a runner. Follow-up PRs will tackle those once the pattern is reviewed and accepted.
