### PR TITLE
refactor(app): introduce WatchLoopState snapshot value type

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingDetecting.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetecting.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 /// Represents a detected active meeting.
-struct DetectedMeeting {
+struct DetectedMeeting: Equatable {
     let pattern: AppMeetingPattern
     let windowTitle: String
     let ownerName: String

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 
 /// Pattern definition for detecting active meetings via window titles.
-struct AppMeetingPattern {
+struct AppMeetingPattern: Equatable {
     let appName: String
     let ownerNames: [String]
     let meetingPatterns: [String]

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -4,7 +4,7 @@ import os.log
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "WatchLoop")
 
 /// Info about a manually started recording session.
-struct ManualRecordingInfo {
+struct ManualRecordingInfo: Equatable {
     let pid: pid_t
     let appName: String
     let title: String
@@ -125,6 +125,19 @@ class WatchLoop {
 
     var isActive: Bool {
         state != .idle
+    }
+
+    /// Value-type view of the five observable fields. Useful for tests,
+    /// `AppState+RPC` snapshots, and as the input/output shape for the
+    /// upcoming pure-function reducer slice.
+    var snapshot: WatchLoopState {
+        WatchLoopState(
+            phase: state,
+            currentMeeting: currentMeeting,
+            lastError: lastError,
+            detail: detail,
+            manualRecordingInfo: manualRecordingInfo,
+        )
     }
 
     // MARK: - Start / Stop

--- a/app/MeetingTranscriber/Sources/WatchLoopState.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoopState.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Value-type snapshot of `WatchLoop`'s five observable fields. The class
+/// keeps the fields as `@Observable` stored properties (so SwiftUI bindings
+/// continue working); `WatchLoopState` is the form tests and other readers
+/// (e.g. the RPC state snapshot) use for equality checks against a single
+/// value rather than five field-wise comparisons.
+struct WatchLoopState: Equatable {
+    var phase: WatchLoop.State
+    var currentMeeting: DetectedMeeting?
+    var lastError: String?
+    var detail: String
+    var manualRecordingInfo: ManualRecordingInfo?
+
+    /// Initial state at `WatchLoop` construction. Matches the field
+    /// defaults declared on the class — see `WatchLoop.init`.
+    static let initial = Self(
+        phase: .idle,
+        currentMeeting: nil,
+        lastError: nil,
+        detail: "",
+        manualRecordingInfo: nil,
+    )
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopStateTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopStateTests.swift
@@ -1,0 +1,55 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Coverage for the `WatchLoopState` snapshot value type and the
+/// `WatchLoop.snapshot` getter that bundles the five observable fields.
+@MainActor
+final class WatchLoopStateTests: XCTestCase {
+    // MARK: - Equatable / initial
+
+    func testInitialMatchesFreshLoopSnapshot() {
+        let (loop, _) = makeTestWatchLoop()
+        XCTAssertEqual(loop.snapshot, .initial)
+    }
+
+    func testInitialIsIdle() {
+        XCTAssertEqual(WatchLoopState.initial.phase, .idle)
+        XCTAssertNil(WatchLoopState.initial.currentMeeting)
+        XCTAssertNil(WatchLoopState.initial.lastError)
+        XCTAssertEqual(WatchLoopState.initial.detail, "")
+        XCTAssertNil(WatchLoopState.initial.manualRecordingInfo)
+    }
+
+    func testEqualityRequiresAllFieldsToMatch() {
+        let a = WatchLoopState.initial
+        var b = WatchLoopState.initial
+        XCTAssertEqual(a, b)
+
+        b.detail = "watching"
+        XCTAssertNotEqual(a, b, "Snapshots with different detail must not compare equal")
+    }
+
+    // MARK: - Snapshot reflects live fields
+
+    func testSnapshotReflectsPhaseTransition() {
+        let (loop, _) = makeTestWatchLoop()
+        XCTAssertEqual(loop.snapshot.phase, .idle)
+
+        loop.start()
+        XCTAssertEqual(loop.snapshot.phase, .watching)
+        XCTAssertEqual(loop.snapshot.detail, "Polling for meetings...")
+
+        loop.stop()
+        XCTAssertEqual(loop.snapshot.phase, .idle)
+    }
+
+    func testSnapshotReflectsManualRecordingInfo() async throws {
+        let (loop, _) = makeTestWatchLoop()
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Sync")
+        defer { loop.stop() }
+
+        let info = try XCTUnwrap(loop.snapshot.manualRecordingInfo)
+        XCTAssertEqual(info, ManualRecordingInfo(pid: 42, appName: "Chrome", title: "Sync"))
+        XCTAssertEqual(loop.snapshot.phase, .recording)
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `WatchLoopState` as a value-type snapshot of `WatchLoop`'s five `@Observable` fields (`state`, `currentMeeting`, `lastError`, `detail`, `manualRecordingInfo`), exposed via a new `WatchLoop.snapshot` getter.

Pure additive slice — the class keeps the underlying stored properties so SwiftUI's `@Observable` tracking continues unchanged. Tests and the RPC state snapshot can now compare against a single value instead of five field-wise checks.

## Changes

**`Sources/WatchLoopState.swift`** (new)
- `struct WatchLoopState: Equatable` with five `var` fields + `static let initial`.
- Field naming follows the reducer-style convention: `phase: WatchLoop.State` (avoids the future `state.state` redundancy when the reducer slice lands).

**`Sources/WatchLoop.swift`**
- Adds `var snapshot: WatchLoopState { get }` computed property next to `isActive`.
- `struct ManualRecordingInfo` gains `: Equatable` (auto-synthesised — all three fields already conform).

**`Sources/MeetingPatterns.swift`** + **`Sources/MeetingDetecting.swift`**
- `struct AppMeetingPattern` and `struct DetectedMeeting` gain `: Equatable` (auto-synthesised). Required so `WatchLoopState` can be `Equatable`.

**`Tests/WatchLoopStateTests.swift`** (new)
- Five tests covering: `.initial` field-wise defaults, `.initial == loop.snapshot` on a fresh loop, field-wise inequality detection, snapshot reflects `start()`/`stop()` phase transitions, snapshot reflects `startManualRecording(...)` info.

## Test plan

- [x] `swift test --filter "WatchLoopStateTests"` — 5 tests in 2 ms
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — full suite green
- [x] `swift build -c release` — clean, no Sendable diagnostics
- [x] `./scripts/lint.sh` — 0 violations across 180 files
- [x] `./scripts/pre-push.sh --with-appstore` — both build variants compile
- [ ] CI run on PR

## Why this slice is small

Deliberate: routing all 15+ existing scattered mutations through a single `update(_:)` funnel would require manual `@Observable` tracking (the macro only synthesises observation for stored properties; forwarded computed properties need explicit `_$observationRegistrar` calls). That mutation-funnel work naturally lands together with the upcoming event-dispatch slice — coupling them keeps SwiftUI binding semantics easy to reason about.

This slice is the prerequisite shape: a value type and a snapshot accessor. The next slice can compose `WatchLoopState` with a `WatchLoopEvent` enum and a pure reducer without touching the observable storage layout.
