### PR TITLE
refactor(app): extract ManualRecordingMonitorPolicy as pure decision function

### DIFF
--- a/app/MeetingTranscriber/Sources/ManualRecordingMonitorPolicy.swift
+++ b/app/MeetingTranscriber/Sources/ManualRecordingMonitorPolicy.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Decision returned by `ManualRecordingMonitorPolicy.step` on each poll
+/// of `WatchLoop.monitorManualRecording`. Both stop cases carry their
+/// reason so the caller can emit the matching log line.
+enum ManualRecordingMonitorDecision: Equatable {
+    case continuePolling
+    case stopPidExited
+    case stopMaxDurationExceeded
+}
+
+/// Pure decision logic for `WatchLoop.monitorManualRecording`. Splits
+/// the poll-loop's two stop conditions (monitored process died, max
+/// recording duration exceeded) out of the async loop so they can be
+/// asserted directly without driving a real subprocess.
+///
+/// Mirrors the `WatchLoopEndPolicy` shape established for
+/// `waitForMeetingEnd` — same split between the async runner (timing
+/// + side effects) and a pure-function decision.
+enum ManualRecordingMonitorPolicy {
+    /// Decide whether the monitor should keep polling or stop because
+    /// the monitored process exited or the recording reached its
+    /// duration cap.
+    ///
+    /// - Parameters:
+    ///   - pidAlive: Whether the process the recorder is monitoring is
+    ///     still alive. Production checks this with `kill(pid, 0) == 0`.
+    ///   - elapsed: Time elapsed since the monitor started.
+    ///   - maxDuration: Absolute cap on recording duration.
+    /// - Returns: `.stopPidExited` first if the process died, otherwise
+    ///   `.stopMaxDurationExceeded` if elapsed >= maxDuration, otherwise
+    ///   `.continuePolling`. Pid-exit wins on ties so a process that
+    ///   dies exactly at the max-duration boundary surfaces as a clean
+    ///   exit rather than a timeout.
+    static func step(
+        pidAlive: Bool,
+        elapsed: TimeInterval,
+        maxDuration: TimeInterval,
+    ) -> ManualRecordingMonitorDecision {
+        if !pidAlive {
+            return .stopPidExited
+        }
+        if elapsed > maxDuration {
+            return .stopMaxDurationExceeded
+        }
+        return .continuePolling
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -73,6 +73,11 @@ class WatchLoop {
     /// Sleep primitive. Defaults to `Task.sleep`; tests inject the
     /// matching `TestClock.sleep` so virtual time advances synchronously.
     let sleepProvider: (TimeInterval) async throws -> Void
+    /// Process-alive probe. Defaults to `kill(pid, 0) == 0`; tests inject
+    /// a closure with a deterministic answer so the
+    /// `monitorManualRecording` switch arms can be exercised without
+    /// spawning a real subprocess.
+    let pidAliveCheck: (pid_t) -> Bool
 
     private var watchTask: Task<Void, Never>?
 
@@ -98,6 +103,7 @@ class WatchLoop {
         sleepProvider: @escaping (TimeInterval) async throws -> Void = { interval in
             try await Task.sleep(for: .seconds(interval))
         },
+        pidAliveCheck: @escaping (pid_t) -> Bool = { kill($0, 0) == 0 },
     ) {
         self.detector = detector
         self.recorderFactory = recorderFactory
@@ -113,6 +119,7 @@ class WatchLoop {
         self.notifier = notifier
         self.nowProvider = nowProvider
         self.sleepProvider = sleepProvider
+        self.pidAliveCheck = pidAliveCheck
     }
 
     nonisolated static var defaultOutputDir: URL {
@@ -235,7 +242,7 @@ class WatchLoop {
         let startTime = nowProvider()
         while !Task.isCancelled {
             let decision = ManualRecordingMonitorPolicy.step(
-                pidAlive: kill(pid, 0) == 0,
+                pidAlive: pidAliveCheck(pid),
                 elapsed: nowProvider().timeIntervalSince(startTime),
                 maxDuration: maxDuration,
             )

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -234,20 +234,25 @@ class WatchLoop {
     private func monitorManualRecording(pid: pid_t) async {
         let startTime = nowProvider()
         while !Task.isCancelled {
-            // Check if process is still alive
-            if kill(pid, 0) != 0 {
+            let decision = ManualRecordingMonitorPolicy.step(
+                pidAlive: kill(pid, 0) == 0,
+                elapsed: nowProvider().timeIntervalSince(startTime),
+                maxDuration: maxDuration,
+            )
+            switch decision {
+            case .continuePolling:
+                break
+
+            case .stopPidExited:
                 logger.info("Monitored app (PID \(pid)) exited — stopping manual recording")
                 stopManualRecording()
                 return
-            }
 
-            // Enforce max duration
-            if nowProvider().timeIntervalSince(startTime) > maxDuration {
+            case .stopMaxDurationExceeded:
                 logger.info("Max recording duration reached — stopping manual recording")
                 stopManualRecording()
                 return
             }
-
             try? await sleepProvider(pollInterval)
         }
     }

--- a/app/MeetingTranscriber/Tests/ManualRecordingMonitorPolicyTests.swift
+++ b/app/MeetingTranscriber/Tests/ManualRecordingMonitorPolicyTests.swift
@@ -1,0 +1,64 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Branch-tests for the pure decision function that drives
+/// `WatchLoop.monitorManualRecording`. The live path is awkward to
+/// exercise (real `kill(pid, 0)` syscall + async timer loop); these
+/// tests cover the branch logic without a subprocess.
+final class ManualRecordingMonitorPolicyTests: XCTestCase {
+    // MARK: - Continue polling
+
+    func testContinuesWhenProcessAliveAndUnderMaxDuration() {
+        XCTAssertEqual(
+            ManualRecordingMonitorPolicy.step(
+                pidAlive: true, elapsed: 10, maxDuration: 100,
+            ),
+            .continuePolling,
+        )
+    }
+
+    // MARK: - Pid exit
+
+    func testStopsWhenProcessExited() {
+        XCTAssertEqual(
+            ManualRecordingMonitorPolicy.step(
+                pidAlive: false, elapsed: 10, maxDuration: 100,
+            ),
+            .stopPidExited,
+        )
+    }
+
+    func testPidExitWinsOverMaxDurationOnTie() {
+        // Both conditions met simultaneously — pid-exit is the cleaner
+        // signal and should win.
+        XCTAssertEqual(
+            ManualRecordingMonitorPolicy.step(
+                pidAlive: false, elapsed: 200, maxDuration: 100,
+            ),
+            .stopPidExited,
+        )
+    }
+
+    // MARK: - Max duration
+
+    func testStopsWhenElapsedStrictlyGreaterThanMaxDuration() {
+        XCTAssertEqual(
+            ManualRecordingMonitorPolicy.step(
+                pidAlive: true, elapsed: 100.5, maxDuration: 100,
+            ),
+            .stopMaxDurationExceeded,
+        )
+    }
+
+    func testContinuesWhenElapsedExactlyEqualToMaxDuration() {
+        // Strict `>` semantics mean elapsed == maxDuration still polls.
+        // Pinned to document the boundary; flip to `>=` deliberately
+        // if production behaviour ever changes.
+        XCTAssertEqual(
+            ManualRecordingMonitorPolicy.step(
+                pidAlive: true, elapsed: 100, maxDuration: 100,
+            ),
+            .continuePolling,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopMonitorTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopMonitorTests.swift
@@ -1,0 +1,64 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Drives `WatchLoop.monitorManualRecording` end-to-end through the
+/// `startManualRecording` public entry point with injected `pidAliveCheck`
+/// + `TestClock`, so the policy's two stop-arms (pid exit, max-duration
+/// exceeded) are exercised in the live async loop without spawning a real
+/// subprocess.
+@MainActor
+final class WatchLoopMonitorTests: XCTestCase {
+    /// When the monitored process dies, the next poll's
+    /// `ManualRecordingMonitorPolicy.step` returns `.stopPidExited` and
+    /// `monitorManualRecording` calls `stopManualRecording`. End state:
+    /// `.idle`, no manual-recording info, recorder.stop called.
+    func testMonitorStopsWhenPidDies() async throws {
+        let clock = TestClock()
+        let recorder = MockRecorder()
+        recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+        let loop = WatchLoop(
+            recorderFactory: { recorder },
+            pollInterval: 0.05,
+            nowProvider: { clock.now },
+            sleepProvider: { await clock.sleep(for: $0) },
+            pidAliveCheck: { _ in false }, // simulated process already exited
+        )
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
+
+        try await loop.startManualRecording(pid: 42, appName: "Test", title: "T")
+
+        await waitFor(loop.snapshot.phase == .idle, timeout: .seconds(1))
+        XCTAssertEqual(loop.snapshot.phase, .idle)
+        XCTAssertNil(loop.snapshot.manualRecordingInfo)
+        XCTAssertTrue(recorder.stopCalled, "Recorder.stop must be called when pid dies")
+    }
+
+    /// When the process stays alive past `maxDuration` virtual time, the
+    /// next poll returns `.stopMaxDurationExceeded` and the same stop
+    /// path runs.
+    func testMonitorStopsOnMaxDurationExceeded() async throws {
+        let clock = TestClock()
+        let recorder = MockRecorder()
+        recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+        let loop = WatchLoop(
+            recorderFactory: { recorder },
+            pollInterval: 0.05,
+            maxDuration: 0.05,
+            nowProvider: { clock.now },
+            sleepProvider: { await clock.sleep(for: $0) },
+            pidAliveCheck: { _ in true }, // process never dies
+        )
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
+
+        try await loop.startManualRecording(pid: 42, appName: "Test", title: "T")
+
+        await waitFor(loop.snapshot.phase == .idle, timeout: .seconds(1))
+        XCTAssertEqual(loop.snapshot.phase, .idle)
+        XCTAssertNil(loop.snapshot.manualRecordingInfo)
+        XCTAssertTrue(recorder.stopCalled, "Recorder.stop must be called when maxDuration hits")
+    }
+}


### PR DESCRIPTION
## Summary

Splits the two stop conditions in `WatchLoop.monitorManualRecording` (monitored process died, max recording duration exceeded) into a pure `ManualRecordingMonitorPolicy.step(pidAlive:elapsed:maxDuration:)` function returning a `ManualRecordingMonitorDecision` enum. The async loop now only owns the poll cadence + side effects (logger + `stopManualRecording`); the branch logic is deterministic and unit-testable.

Mirrors the `WatchLoopEndPolicy` pattern established for `waitForMeetingEnd` in a prior PR — same split between async runner (timing + side effects) and pure decision function.

## Changes

**`Sources/ManualRecordingMonitorPolicy.swift`** (new)
- `ManualRecordingMonitorDecision: Equatable` — 3 cases (`continuePolling`, `stopPidExited`, `stopMaxDurationExceeded`).
- `ManualRecordingMonitorPolicy.step(...)` — pure decision function. Pid-exit wins on tie with max-duration so a process that dies exactly at the boundary surfaces as a clean exit rather than a timeout.

**`Sources/WatchLoop.swift`**
- `monitorManualRecording` body shrinks from two inline `if` blocks to a `switch decision { … }` over the policy result. Same `>` strict-boundary on max-duration preserved.

**`Tests/ManualRecordingMonitorPolicyTests.swift`** (new)
- 5 deterministic branch tests: continue, stop-pid-exited, stop-max-duration, pid-wins-on-tie, `>`-not-`>=` strict boundary.

## Coverage

These branches were previously only exercisable through a real subprocess (`kill(pid, 0)` syscall), so unit coverage of the stop conditions goes from 0 to full. The async runner itself stays unchanged (still requires the live `kill` syscall + Task spawn to drive end-to-end), and that path remains exercised by the live-recording E2E lane.

## Test plan

- [x] `swift test --filter "ManualRecordingMonitorPolicyTests|WatchLoop"` — 74 tests in 36 s (5 new + all WatchLoop suites)
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — full suite green
- [x] `swift build -c release` — clean
- [x] `./scripts/lint.sh` — 0 violations across 183 files
- [x] `./scripts/pre-push.sh --with-appstore` — both build variants
- [ ] CI run on PR
