### PR TITLE
ci(mini): exclude ~/Library/Keychains from Spotlight via .metadata_never_index

### DIFF
--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -223,6 +223,30 @@ fi
 "$(dirname "$0")/keychain-prepend.sh" "$CI_KEYCHAIN"
 security default-keychain -s "$CI_KEYCHAIN"
 
+# Spotlight must not index ~/Library/Keychains. Without this exclusion,
+# the first time `mds_stores` walks the directory macOS raises a modal
+# ("Spotlight wants to use the X keychain. Please enter the keychain
+# password.") that blocks until a human clicks Cancel. Until that
+# happens, mds_stores stays in a wait state and every concurrent
+# `renamex_np` on the same volume blocks behind it — meaning a CI run
+# doing codesign / pipeline-queue snapshot / atomic-file-rename hangs
+# indefinitely with no log signal.
+#
+# Apple's documented per-directory exclusion: drop a `.metadata_never_index`
+# marker file in the directory. mds_stores skips the containing tree on
+# its next scan. No sudo (system Spotlight-prefs are admin-only and the
+# self-hosted runner user is intentionally non-sudo), no `mds` restart,
+# survives reboots. Same effect as adding the path to System Settings
+# → Spotlight → Privacy by hand.
+KEYCHAIN_DIR="$HOME/Library/Keychains"
+NEVER_INDEX_MARKER="$KEYCHAIN_DIR/.metadata_never_index"
+if [[ -f "$NEVER_INDEX_MARKER" ]]; then
+    log "Spotlight already excludes $KEYCHAIN_DIR via marker — skipping"
+else
+    touch "$NEVER_INDEX_MARKER"
+    log "Created $NEVER_INDEX_MARKER — Spotlight will skip $KEYCHAIN_DIR on next scan"
+fi
+
 cat <<MSG
 
 [setup] DONE. ✓


### PR DESCRIPTION
## Summary

Drops a `.metadata_never_index` marker file in `~/Library/Keychains` during one-time self-hosted runner setup, so `mds_stores` skips the directory.

## Failure mode this prevents

The first time `mds_stores` tries to index a CI keychain, macOS raises a modal:

> Spotlight wants to use the X keychain. Please enter the keychain password.

The agent has no way to dismiss the modal — it blocks until a human clicks Cancel at the console. Meanwhile `mds_stores` stays in a wait state and every concurrent `renamex_np` on the same volume waits behind it. That cascades into:

- `codesign` hangs (atomic-rename of the signed bundle blocks)
- `PipelineQueue.saveSnapshot` hangs (atomic-rename of the pipeline-queue temp file blocks → app freezes when called from main-thread)
- Test `testOpenAIAPIKeyViaKeychainHelper` reads an empty string back from a keychain that `SecItemAdd` just wrote to, because `SecItemCopyMatching` waits on a lock the modal holds. Surfaces as a flaky-looking single-test failure on `quality-and-safety` that disappears on rerun.

This was the recurring fifth failure mode on the self-hosted Mini sanitizer matrix (the four already-fixed: search-list drift, partition-list reset, mid-job auto-lock, atomic-prepend race). Hit it again on the post-merge run of PR #278 just now, which is what triggered fixing this permanently.

## Mechanism choice — `.metadata_never_index` vs. SpotlightServer plist

Two options exist:

- **System-level**: write `~/Library/Keychains` to `/Library/Preferences/com.apple.SpotlightServer.plist` `Exclusions` array + `killall mds`. Requires `sudo`.
- **User-level**: drop a 0-byte `.metadata_never_index` marker in the directory. Apple's documented mechanism for "Spotlight, please skip this tree". No sudo, no `mds` restart, persists across reboots.

We use the marker file because the self-hosted runner user is intentionally **non-sudo** (correct security posture — the CI agent shouldn't have root). The marker achieves the same outcome without privilege escalation.

## Changes

`scripts/setup-self-hosted-runner.sh` — adds 24 lines before the final "DONE" message:

- Defines `KEYCHAIN_DIR` + `NEVER_INDEX_MARKER` paths.
- Idempotent guard: `[[ -f $NEVER_INDEX_MARKER ]]` skips the touch on re-runs.
- Single `touch` to create the empty marker file.
- 12-line doc comment explaining the multi-layer wedge failure mode the exclusion prevents.

## Operator action required

Each Mini host needs a one-time re-run after merge:

```bash
ssh runner@<mini> 'cd ~/git/Transcriber && git pull && bash scripts/setup-self-hosted-runner.sh'
```

Effect persists across reboots — no per-CI-run cost.

## Test plan

- [x] `bash -n scripts/setup-self-hosted-runner.sh` — syntax clean
- [x] `shellcheck scripts/setup-self-hosted-runner.sh` — clean
- [x] `./scripts/lint.sh` — 0 violations across 184 files
- [ ] Operator validation: run on Mini, confirm `~/Library/Keychains/.metadata_never_index` exists (`-rw-r--r-- 0` bytes)
- [ ] Validate by observing: next 3 quality-and-safety runs on main pass `testOpenAIAPIKeyViaKeychainHelper` without rerun
