### PR TITLE
refactor(app): extract PipelineSnapshot as pure I/O helper

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1268,72 +1268,72 @@ class PipelineQueue {
     /// Resets in-progress jobs to `.waiting`, discards `.done` jobs, and drops
     /// jobs whose `mixPath` no longer exists on disk.
     func loadSnapshot() {
-        let snapshotPath = logDir.appendingPathComponent("pipeline_queue.json")
-        guard FileManager.default.fileExists(atPath: snapshotPath.path) else {
-            logger.info("No pipeline snapshot to restore")
-            return
-        }
+        var loaded: [PipelineJob]
         do {
-            let data = try Data(contentsOf: snapshotPath)
-            var loaded = try JSONDecoder().decode([PipelineJob].self, from: data)
-
-            // Reset active states back to waiting
-            for i in loaded.indices {
-                switch loaded[i].state {
-                case .transcribing, .diarizing, .generatingProtocol:
-                    loaded[i].state = .waiting
-
-                default:
-                    break
-                }
-            }
-
-            // Discard done jobs
-            loaded.removeAll { $0.state == .done }
-
-            // Discard jobs whose audio file no longer exists, EXCEPT
-            // .speakerNamingPending — those have their own slug-based
-            // `_16k.wav` sidecar and don't need the original mix.wav.
-            // Paired imports with nil mixPath: keep them — `appPath` is the
-            // ground-truth source and it's checked at processNext time.
-            loaded.removeAll { job in
-                guard let mixPath = job.mixPath else { return false }
-                return job.state != .speakerNamingPending
-                    && !FileManager.default.fileExists(atPath: mixPath.path)
-            }
-
-            guard !loaded.isEmpty else {
-                logger.info("Snapshot loaded but no recoverable jobs")
+            guard let decoded = try PipelineSnapshot.load(from: logDir) else {
+                logger.info("No pipeline snapshot to restore")
                 return
             }
-
-            jobs = loaded
-
-            // Rebuild speaker naming cache from disk for .speakerNamingPending jobs
-            for job in jobs where job.state == .speakerNamingPending {
-                if let slug = job.namingSlug, let data = loadNamingData(slug: slug) {
-                    speakerNamingDataByJob[job.id] = data
-                } else {
-                    // Naming data lost — transition to done
-                    logger.warning("Naming data not found for job \(job.id), marking as done")
-                    if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
-                        jobs[idx].state = .done
-                    }
-                }
-            }
-
-            saveSnapshot()
-            cleanupStalePending()
-            logger.info("Restored \(loaded.count) jobs from snapshot")
-            triggerProcessing()
-            // Auto-popup the naming dialog if any restored job is still
-            // waiting for confirmation. Same notification as the in-pipeline
-            // pop, so MeetingTranscriberApp brings the window forward.
-            if !pendingSpeakerNamingJobs.isEmpty {
-                NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
-            }
+            loaded = decoded
         } catch {
             logger.error("Failed to load pipeline snapshot: \(error)")
+            return
+        }
+
+        // Reset active states back to waiting
+        for i in loaded.indices {
+            switch loaded[i].state {
+            case .transcribing, .diarizing, .generatingProtocol:
+                loaded[i].state = .waiting
+
+            default:
+                break
+            }
+        }
+
+        // Discard done jobs
+        loaded.removeAll { $0.state == .done }
+
+        // Discard jobs whose audio file no longer exists, EXCEPT
+        // .speakerNamingPending — those have their own slug-based
+        // `_16k.wav` sidecar and don't need the original mix.wav.
+        // Paired imports with nil mixPath: keep them — `appPath` is the
+        // ground-truth source and it's checked at processNext time.
+        loaded.removeAll { job in
+            guard let mixPath = job.mixPath else { return false }
+            return job.state != .speakerNamingPending
+                && !FileManager.default.fileExists(atPath: mixPath.path)
+        }
+
+        guard !loaded.isEmpty else {
+            logger.info("Snapshot loaded but no recoverable jobs")
+            return
+        }
+
+        jobs = loaded
+
+        // Rebuild speaker naming cache from disk for .speakerNamingPending jobs
+        for job in jobs where job.state == .speakerNamingPending {
+            if let slug = job.namingSlug, let data = loadNamingData(slug: slug) {
+                speakerNamingDataByJob[job.id] = data
+            } else {
+                // Naming data lost — transition to done
+                logger.warning("Naming data not found for job \(job.id), marking as done")
+                if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
+                    jobs[idx].state = .done
+                }
+            }
+        }
+
+        saveSnapshot()
+        cleanupStalePending()
+        logger.info("Restored \(loaded.count) jobs from snapshot")
+        triggerProcessing()
+        // Auto-popup the naming dialog if any restored job is still
+        // waiting for confirmation. Same notification as the in-pipeline
+        // pop, so MeetingTranscriberApp brings the window forward.
+        if !pendingSpeakerNamingJobs.isEmpty {
+            NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
         }
     }
 
@@ -1532,11 +1532,7 @@ class PipelineQueue {
     func saveSnapshot() {
         do {
             ensureLogDir()
-            let data = try JSONEncoder().encode(jobs)
-            let tmpPath = logDir.appendingPathComponent("pipeline_queue.tmp")
-            try data.write(to: tmpPath)
-            let snapshotPath = logDir.appendingPathComponent("pipeline_queue.json")
-            _ = try FileManager.default.replaceItemAt(snapshotPath, withItemAt: tmpPath)
+            try PipelineSnapshot.save(jobs, to: logDir)
         } catch {
             logger.error("Failed to write queue snapshot: \(error)")
         }

--- a/app/MeetingTranscriber/Sources/PipelineSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/PipelineSnapshot.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pure I/O helpers for persisting `PipelineQueue`'s `[PipelineJob]` array
+/// to disk and reading it back. Extracted from `PipelineQueue` so the
+/// serialization + atomic-rename mechanics can be exercised without
+/// constructing a full queue + speaker DB + engine wiring, and so the
+/// save side can later run off the main actor without touching the rest
+/// of `PipelineQueue`'s `@MainActor` surface.
+///
+/// File names mirror what `PipelineQueue` used inline before the
+/// extraction (`pipeline_queue.json` final, `pipeline_queue.tmp` staging)
+/// so existing on-disk snapshots load unchanged after upgrade.
+enum PipelineSnapshot {
+    static let snapshotFilename = "pipeline_queue.json"
+    static let stagingFilename = "pipeline_queue.tmp"
+
+    /// JSON-encode `jobs` and atomically replace any existing snapshot at
+    /// `logDir/pipeline_queue.json`. The staging write goes to
+    /// `pipeline_queue.tmp` first; `replaceItemAt` (which lowers to
+    /// `renamex_np` on macOS) swaps it in.
+    ///
+    /// - Throws: `EncodingError` from JSONEncoder, or any
+    ///   `FileManager` / `Data.write` I/O error.
+    static func save(_ jobs: [PipelineJob], to logDir: URL) throws {
+        let data = try JSONEncoder().encode(jobs)
+        let stagingPath = logDir.appendingPathComponent(stagingFilename)
+        try data.write(to: stagingPath)
+        let snapshotPath = logDir.appendingPathComponent(snapshotFilename)
+        _ = try FileManager.default.replaceItemAt(snapshotPath, withItemAt: stagingPath)
+    }
+
+    // swiftlint:disable discouraged_optional_collection
+    /// Read + JSON-decode the snapshot at `logDir/pipeline_queue.json`.
+    ///
+    /// - Returns: the decoded jobs, or `nil` if no snapshot file exists.
+    ///   `nil` vs an empty array is load-bearing: the caller logs a
+    ///   different message ("No pipeline snapshot to restore" vs
+    ///   "Snapshot loaded but no recoverable jobs") so flattening into
+    ///   `[]` on missing-file would lose that distinction.
+    /// - Throws: any read or `DecodingError` failure. Caller decides how
+    ///   to recover (PipelineQueue logs + drops the load).
+    static func load(from logDir: URL) throws -> [PipelineJob]? {
+        let snapshotPath = logDir.appendingPathComponent(snapshotFilename)
+        guard FileManager.default.fileExists(atPath: snapshotPath.path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: snapshotPath)
+        return try JSONDecoder().decode([PipelineJob].self, from: data)
+    }
+    // swiftlint:enable discouraged_optional_collection
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -42,13 +42,13 @@ final class PipelineQueueTests: XCTestCase {
 
     func testSnapshotWrittenOnEnqueue() {
         queue.enqueue(makeJob())
-        let snapshotPath = tmpDir.appendingPathComponent("pipeline_queue.json")
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotPath.path))
     }
 
     func testSnapshotIsValidJSON() throws {
         queue.enqueue(makeJob(title: "Standup"))
-        let snapshotPath = tmpDir.appendingPathComponent("pipeline_queue.json")
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         let data = try Data(contentsOf: snapshotPath)
         let jobs = try JSONDecoder().decode([PipelineJob].self, from: data)
         XCTAssertEqual(jobs.count, 1)
@@ -185,7 +185,7 @@ final class PipelineQueueTests: XCTestCase {
             appPath: nil, micPath: nil, micDelay: 0,
         )
         let data = try JSONEncoder().encode([job])
-        let snapshotPath = tmpDir.appendingPathComponent("pipeline_queue.json")
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         try data.write(to: snapshotPath)
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
@@ -208,7 +208,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         job.state = .transcribing
         let data = try JSONEncoder().encode([job])
-        try data.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()
@@ -229,7 +229,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         job.state = .done
         let data = try JSONEncoder().encode([job])
-        try data.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()
@@ -245,7 +245,7 @@ final class PipelineQueueTests: XCTestCase {
             appPath: nil, micPath: nil, micDelay: 0,
         )
         let data = try JSONEncoder().encode([job])
-        try data.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()
@@ -727,7 +727,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         job.state = .diarizing
         let data = try JSONEncoder().encode([job])
-        try data.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()
@@ -748,7 +748,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         job.state = .generatingProtocol
         let data = try JSONEncoder().encode([job])
-        try data.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()
@@ -845,7 +845,7 @@ final class PipelineQueueTests: XCTestCase {
     }
 
     func testLoadSnapshotCorruptJSONIsNoOp() throws {
-        let snapshotPath = tmpDir.appendingPathComponent("pipeline_queue.json")
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         try Data("{{not valid json".utf8).write(to: snapshotPath)
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
@@ -884,7 +884,7 @@ final class PipelineQueueTests: XCTestCase {
         queue1.updateJobState(id: job.id, to: .transcribing)
         queue1.saveSnapshot()
 
-        let snapshotPath = tmpDir.appendingPathComponent("pipeline_queue.json")
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotPath.path))
 
         // "Crash" — create fresh queue from snapshot
@@ -1550,7 +1550,7 @@ final class PipelineQueueTests: XCTestCase {
         job.state = .speakerNamingPending
         job.namingSlug = "snapshot_test"
         let snapshotData = try JSONEncoder().encode([job])
-        try snapshotData.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try snapshotData.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         // Save naming data as sidecar JSON
         let namingData = PipelineQueue.SpeakerNamingData(
@@ -1603,7 +1603,7 @@ final class PipelineQueueTests: XCTestCase {
         job.state = .speakerNamingPending
         job.namingSlug = "missing_data_test"
         let snapshotData = try JSONEncoder().encode([job])
-        try snapshotData.write(to: tmpDir.appendingPathComponent("pipeline_queue.json"))
+        try snapshotData.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
 
         // Load without saving naming JSON — should fall back to .done
         let freshQueue = PipelineQueue(logDir: tmpDir)

--- a/app/MeetingTranscriber/Tests/PipelineSnapshotTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineSnapshotTests.swift
@@ -1,0 +1,89 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Coverage for the pure-I/O `PipelineSnapshot` helpers extracted from
+/// `PipelineQueue`. The mutation/recovery logic (state-reset on load,
+/// orphan filtering, naming-cache rebuild) stays in `PipelineQueue` and
+/// is covered through the existing PipelineQueue end-to-end tests.
+final class PipelineSnapshotTests: XCTestCase {
+    // MARK: - load: missing file
+
+    func testLoadReturnsNilWhenSnapshotMissing() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        XCTAssertNil(try PipelineSnapshot.load(from: dir))
+    }
+
+    // MARK: - save → load round-trip
+
+    func testSaveAndLoadRoundTripPreservesAllFields() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        let mixURL = dir.appendingPathComponent("rec_mix.wav")
+        var job = PipelineJob(
+            meetingTitle: "Sync",
+            appName: "Zoom",
+            mixPath: mixURL,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0.123,
+            participants: ["A", "B"],
+        )
+        job.state = .diarizing
+        job.warnings = ["one warning"]
+
+        try PipelineSnapshot.save([job], to: dir)
+
+        let loaded = try XCTUnwrap(try PipelineSnapshot.load(from: dir))
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].id, job.id)
+        XCTAssertEqual(loaded[0].meetingTitle, "Sync")
+        XCTAssertEqual(loaded[0].appName, "Zoom")
+        XCTAssertEqual(loaded[0].mixPath, mixURL)
+        XCTAssertEqual(loaded[0].state, .diarizing)
+        XCTAssertEqual(loaded[0].participants, ["A", "B"])
+        XCTAssertEqual(loaded[0].warnings, ["one warning"])
+    }
+
+    // MARK: - save: produces the expected filename
+
+    func testSaveWritesToSnapshotFilename() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        try PipelineSnapshot.save([], to: dir)
+        let snapshotPath = dir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: snapshotPath.path),
+            "Expected snapshot at \(snapshotPath.path)",
+        )
+    }
+
+    // MARK: - save: atomic replace cleans up the staging file
+
+    func testSaveCleansUpStagingFile() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        try PipelineSnapshot.save([], to: dir)
+        let stagingPath = dir.appendingPathComponent(PipelineSnapshot.stagingFilename)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: stagingPath.path),
+            "replaceItemAt should consume the staging file",
+        )
+    }
+
+    // MARK: - load: corrupt JSON
+
+    func testLoadThrowsOnCorruptJSON() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        let snapshotPath = dir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
+        try Data("not valid json".utf8).write(to: snapshotPath)
+        XCTAssertThrowsError(try PipelineSnapshot.load(from: dir)) { error in
+            XCTAssertTrue(error is DecodingError, "Expected DecodingError, got \(error)")
+        }
+    }
+
+    // MARK: - save: empty array
+
+    func testSaveEmptyArrayLoadsBackAsEmpty() throws {
+        let dir = try makeTempDirectory(prefix: "pipeline-snapshot")
+        try PipelineSnapshot.save([], to: dir)
+        let loaded = try XCTUnwrap(try PipelineSnapshot.load(from: dir))
+        XCTAssertTrue(loaded.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the PipelineQueue refactor (Step 2 of the broader architecture-refactor initiative, after the 5 WatchLoop slices). Extracts the JSON-encode + atomic-rename mechanics of `PipelineQueue.saveSnapshot()` and the read+decode mechanics of `loadSnapshot()` into a new `PipelineSnapshot` enum with two static functions: `save(_:to:)` and `load(from:) -> [PipelineJob]?`.

PipelineQueue's wrappers shrink to a single delegated call each. Behaviour-equivalent — all existing PipelineQueue tests pass unchanged.

## Why this matters

`PipelineQueue.saveSnapshot()` is called from `@MainActor`-isolated paths and ends in `FileManager.replaceItemAt` which lowers to the `renamex_np` syscall. When `mds_stores` is wedged behind a Spotlight keychain modal (host-side root cause fixed in the previous PR), `renamex_np` blocks indefinitely — and because the call runs on the main actor, the whole app freezes (UI, RPC, watchdog, all). A documented recurring issue.

This refactor doesn't fix the main-thread-hang itself, but it's the prerequisite: with the I/O now factored into a pure static function with no actor isolation, a follow-up slice can call it from a detached Task without touching PipelineQueue's `@MainActor` surface.

## Changes

**`Sources/PipelineSnapshot.swift`** (new, 50 lines)
- `enum PipelineSnapshot` as namespace + 2 `static let` constants (`snapshotFilename = "pipeline_queue.json"`, `stagingFilename = "pipeline_queue.tmp"`) and 2 `static func`s.
- `save(_:to:) throws` — JSON-encode → atomic-rename.
- `load(from:) throws -> [PipelineJob]?` — read + decode, returns `nil` on missing file. `nil` vs `[]` distinction load-bearing for the caller's log line. `swiftlint:disable discouraged_optional_collection` block on the function with doc-comment explanation.
- Mirrors the enum-as-namespace pattern from `WatchLoopEndPolicy`, `ManualRecordingMonitorPolicy`, `BadgeKind`, `MicRestartPolicy`.

**`Sources/PipelineQueue.swift`**
- `saveSnapshot()` body: 7 lines → 5 lines (`try PipelineSnapshot.save(jobs, to: logDir)` replaces inline encode + tmp write + replaceItemAt).
- `loadSnapshot()` first 10 lines (path build + existence check + read + decode) → 8-line do-catch over `PipelineSnapshot.load(from:)`. Mutation logic + recovery (state reset, orphan filtering, naming-cache rebuild) stays put. Dead `do-catch` around the mutation block removed (no `try` calls remain inside it).

**`Tests/PipelineSnapshotTests.swift`** (new, 6 tests)
- load returns nil when snapshot file missing
- save + load round-trip preserves all `PipelineJob` fields
- save writes to the expected filename
- save cleans up the staging file after `replaceItemAt`
- load throws `DecodingError` on corrupt JSON
- save + load of empty array round-trips as empty

**`Tests/PipelineQueueTests.swift`**
- Migrates 12 hardcoded `"pipeline_queue.json"` literals to `PipelineSnapshot.snapshotFilename`. Single source of truth for the filename.

## File-format compat

`snapshotFilename` and `stagingFilename` preserved verbatim from the prior inline strings — existing on-disk snapshots from older app versions load unchanged after upgrade.

## Test plan

- [x] `swift test --filter "PipelineSnapshotTests|PipelineQueueTests"` — 92 tests in 1.0s
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` — full suite green
- [x] `swift build -c release` — clean
- [x] `./scripts/lint.sh` — 0 violations across 186 files
- [x] `./scripts/pre-push.sh --with-appstore` — both build variants compile
- [ ] CI run on PR

## Why this slice is small

Deliberate: the bigger PipelineQueue split (PipelineExecutor + further state-machine extraction) is a multi-PR initiative. This first slice picks the pure-I/O surface that's easiest to extract cleanly and most useful for the upcoming off-main migration. Subsequent slices can attack the orchestration logic with the same shape.
