### PR TITLE
fix(test): scope keychain delete to the one test that needs it

### DIFF
--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -13,6 +13,14 @@ final class AppSettingsTests: XCTestCase {
     /// Each test gets its own volatile `UserDefaults(suiteName:)` so
     /// `swift test --parallel` doesn't race on the shared on-disk plist.
     /// AppSettings receives the suite via constructor injection.
+    ///
+    /// Keychain state is per-user (not per-process), so we deliberately do
+    /// NOT touch any production keychain accounts here — `swift test
+    /// --parallel` spawns a fresh `xctest` process per test method, and an
+    /// unconditional delete in setUp would race with the write performed
+    /// by `testOpenAIAPIKeyViaKeychainHelper` running in a sibling process.
+    /// The one test that needs a clean keychain slot manages the slot
+    /// itself.
     override func setUp() {
         super.setUp()
         testSuiteName = "AppSettingsTests-\(getpid())-\(UUID().uuidString)"
@@ -21,7 +29,6 @@ final class AppSettingsTests: XCTestCase {
             return
         }
         defaults = suite
-        KeychainHelper.delete(key: "openAIAPIKey")
         settings = AppSettings(defaults: defaults)
     }
 
@@ -192,6 +199,12 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testOpenAIAPIKeyViaKeychainHelper() {
+        // Reset the keychain slot before + after so a crashed prior run
+        // can't seed `"sk-test-key"` and a failure here doesn't leak it
+        // to the next invocation.
+        KeychainHelper.delete(key: "openAIAPIKey")
+        defer { KeychainHelper.delete(key: "openAIAPIKey") }
+
         XCTAssertEqual(settings.openAIAPIKey, "")
 
         settings.openAIAPIKey = "sk-test-key"


### PR DESCRIPTION
## Summary

Real fix for the recurring `testOpenAIAPIKeyViaKeychainHelper` flake that's been showing up across both the self-hosted Mini and `macos-26` GitHub-hosted runners — it has the same root cause on both, and it's not a keychain-setup issue.

`swift test --parallel` spawns a fresh `xctest` subprocess **per test method**. The shared `AppSettingsTests.setUp()` was unconditionally calling `KeychainHelper.delete(key: "openAIAPIKey")` — the same hardcoded account name that production uses — for every test method in the class. With ~35 methods scheduled across CPU cores, the deletes from sibling setUp's race against the write performed by `testOpenAIAPIKeyViaKeychainHelper`:

```swift
197:  settings.openAIAPIKey = "sk-test-key"
198:  XCTAssertEqual(KeychainHelper.read(...), "sk-test-key")  // ✓
199:  XCTAssertEqual(settings.openAIAPIKey, "sk-test-key")     // ✗ "" — sibling setUp wiped it
```

That race window (microseconds between two reads against the same key) is what produced the `XCTAssertEqual ("") != ("sk-test-key")` we kept seeing.

## Fix

- Drop the blanket `KeychainHelper.delete(key: "openAIAPIKey")` from `setUp()`. Nothing else in `AppSettingsTests` reads or writes that account.
- Move the reset into the single test that touches it, with a `defer { delete }` so a crashed run doesn't leave `"sk-test-key"` behind for the next invocation.

This makes the keychain slot owned by exactly the one process that exercises it — no cross-process race possible.

## Test plan

- [x] `swift test --parallel --filter AppSettingsTests` → 40/40 green
- [x] `swift test --parallel --filter AppSettingsTests -Xswiftc -DAPPSTORE` → 36/36 green (AppStore variant, where the failure was last seen)
- [x] `./scripts/lint.sh` → clean
- [ ] CI green on both `test (homebrew)` and `test (appstore)` legs