### PR TITLE
test(app): isolate AppStateTests pipeline-queue snapshot per test method

### DIFF
--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -5,17 +5,17 @@ import XCTest
 @MainActor
 final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_length
     // swiftlint:disable:previous balanced_xctest_lifecycle
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var testLogDir: URL!
 
     override func setUp() async throws {
         try await super.setUp()
-        // AppState.makePipelineQueue (triggered by ensurePipelineQueue from
-        // enqueueFiles) loads/saves a snapshot at
-        // `AppPaths.ipcDir/pipeline_queue.json`. Tests that enqueue real or
-        // fake URLs persist that snapshot, leaking jobs into the next test in
-        // the same process. Wipe before every test.
-        try? FileManager.default.removeItem(
-            at: AppPaths.ipcDir.appendingPathComponent("pipeline_queue.json"),
-        )
+        // Per-test isolated logDir for the PipelineQueue snapshot file.
+        // Without it, concurrent test methods (xctest spawns a subprocess
+        // per method under `--parallel`) race on the production
+        // `AppPaths.ipcDir/pipeline_queue.json`, leaking jobs across
+        // tests as `count == 2` where `count == 1` is expected.
+        testLogDir = try makeTempDirectory(prefix: "AppStateTests")
     }
 
     // MARK: - Helpers
@@ -23,10 +23,23 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     private func makeState() -> (AppState, RecordingNotifier) {
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)
+        // Inject a PipelineQueue with mocks + the per-test isolated logDir.
+        // The engine != nil arm short-circuits `ensurePipelineQueue()` so
+        // it doesn't replace our queue with one wired to the production
+        // `AppPaths.ipcDir` path on the first `enqueueFiles` call.
+        state.pipelineQueue = PipelineQueue(
+            engine: MockEngine(),
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { MockProtocolGen() },
+            outputDir: testLogDir,
+            logDir: testLogDir,
+        )
         return (state, notifier)
     }
 
-    /// AppState whose pipelineQueue writes to a temp dir (no real filesystem side effects).
+    /// AppState with a caller-provided logDir. Use when a test wants to
+    /// inspect snapshot contents at a known path; otherwise prefer
+    /// `makeState()` which uses the per-test isolated `testLogDir`.
     private func makeIsolatedState(logDir: URL) -> (AppState, RecordingNotifier) {
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)
@@ -458,7 +471,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     // MARK: - ensurePipelineQueue
 
     func testEnsurePipelineQueueReplacesBareQueue() {
-        let (state, _) = makeState()
+        // Bare queue (no engine) — uses the no-engine init; logDir is the
+        // production path but this test never enqueues so no I/O hits it.
+        let notifier = RecordingNotifier()
+        let state = AppState(notifier: notifier)
+        state.pipelineQueue = PipelineQueue(logDir: testLogDir)
         XCTAssertNil(state.pipelineQueue.engine, "Precondition: fresh queue has no engine")
 
         state.ensurePipelineQueue()


### PR DESCRIPTION
## Summary

Replaces the shared-`setUp`-wipe pattern in `AppStateTests` with per-test isolated logDir injection so that `swift test --parallel` (which spawns a subprocess per test method) no longer races on the production `AppPaths.ipcDir/pipeline_queue.json` snapshot file.

## Failure mode

The previous `setUp` defended against snapshot leak by removing the file before every test, but only worked when tests ran sequentially. Under parallel execution:

- Test A `setUp`: snapshot wiped
- Test B `enqueueFiles`: `saveSnapshot` writes one job
- Test A `enqueueFiles` → `ensurePipelineQueue` → `makePipelineQueue` → `loadSnapshot` reads B's job into A's queue
- Test A asserts `count == 1`, sees `count == 2`

Symptom: intermittent CI failures in `testEnqueueFiles*` and `testEnqueueExistingFiles*` family, recognisable as the `1 test, 2 failures` pattern. Latest hit was on the post-merge `Quality & Safety` run after PR #281 — same root-cause family as the `testOpenAIAPIKeyViaKeychainHelper` race that PR #282 fixed (parallel-xctest-per-method-subprocess racing on a shared resource), just on a different shared resource (pipeline queue snapshot file).

## Changes

**`Tests/AppStateTests.swift`**

- `setUp` populates `testLogDir = try makeTempDirectory(prefix: "AppStateTests")`. `XCTestCase.makeTempDirectory` (from `TestHelpers`) registers an `addTeardownBlock` so each tmpDir is cleaned up automatically.
- `makeState()` now constructs `state.pipelineQueue = PipelineQueue(engine: MockEngine(), diarizationFactory: ..., protocolGeneratorFactory: ..., outputDir: testLogDir, logDir: testLogDir)`. The mock engine is load-bearing: without it, `AppState.ensurePipelineQueue()` checks `pipelineQueue.engine == nil` on the first `enqueueFiles` call and replaces the test's queue with `makePipelineQueue()` (which wires to `AppPaths.ipcDir`), undoing the isolation.
- `testEnsurePipelineQueueReplacesBareQueue` explicitly tests the bare-queue replacement; now constructs its own `PipelineQueue(logDir: testLogDir)` inline so it doesn't inherit the engine-pre-populated `makeState()` queue. Still safe in parallel because the test never enqueues — no snapshot I/O hits the shared production path.
- `makeIsolatedState(logDir:)` retained — three tests (`testConfigurePipelineCallbacks*`) inspect snapshot contents at a known path and explicitly construct their own tmp dir.

## Verification

- `swift test --parallel --filter AppStateTests` × 3 runs: 0 failures each. The flake is gone.
- 0 lint violations across 192 files.

## Test plan

- [x] `swift test --parallel --filter AppStateTests` — 0 failures (3 consecutive runs)
- [x] `./scripts/lint.sh` — 0 violations across 192 files
- [ ] CI run on PR (full suite)
- [ ] CI post-merge `Quality & Safety` run on main — `testEnqueueFiles*` and `testEnqueueExistingFiles*` should be first-try green (no rerun required)

## Future follow-ups

`WatchLoopTests` and `ManualRecordingTests` also construct `PipelineQueue()` instances. Most never enqueue (so no snapshot I/O hits the shared path), but `ManualRecordingTests.testStopManualRecordingEnqueuesJob` does call `loop.stopManualRecording()` which enqueues. Same pattern would apply if the flake ever shows up there. Tracked separately, not bundled here to keep this PR focused on the actual recurring CI issue.
