### PR TITLE
perf(app): dispatch PipelineQueue.saveSnapshot off the main actor

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1529,13 +1529,52 @@ class PipelineQueue {
         logDirCreated = true
     }
 
+    // Latest jobs array queued for the snapshot worker. Overwritten on
+    // each `saveSnapshot()` so a burst of state changes collapses into a
+    // single write of the final state instead of N sequential writes.
+    // nil ≠ `[]`: nil means "nothing to write", `[]` would mean "write
+    // the empty-jobs state" (valid when the last job was removed).
+    // swiftlint:disable:next discouraged_optional_collection
+    private var pendingSnapshotJobs: [PipelineJob]?
+    private var snapshotWorker: Task<Void, Never>?
+
+    /// Persist the current `jobs` array to disk. The write runs on a
+    /// detached task — a stalled `replaceItemAt` (macOS 26 `mds_stores`
+    /// rename deadlock) can't freeze the UI / RPC / watch loop. Rapid
+    /// successive calls coalesce: only the last state is actually written.
     func saveSnapshot() {
-        do {
-            ensureLogDir()
-            try PipelineSnapshot.save(jobs, to: logDir)
-        } catch {
-            logger.error("Failed to write queue snapshot: \(error)")
+        ensureLogDir()
+        pendingSnapshotJobs = jobs
+        guard snapshotWorker == nil else { return }
+        let dir = logDir
+        snapshotWorker = Task.detached(priority: .utility) { [weak self] in
+            while let next = await self?.takeNextSnapshotBatch() {
+                do {
+                    try PipelineSnapshot.save(next, to: dir)
+                } catch {
+                    logger.error("Failed to write queue snapshot: \(error)")
+                }
+            }
         }
+    }
+
+    // swiftlint:disable discouraged_optional_collection
+    @MainActor
+    private func takeNextSnapshotBatch() -> [PipelineJob]? {
+        guard let next = pendingSnapshotJobs else {
+            snapshotWorker = nil
+            return nil
+        }
+        pendingSnapshotJobs = nil
+        return next
+    }
+
+    // swiftlint:enable discouraged_optional_collection
+
+    /// Wait for any queued snapshot writes to land on disk. Mostly used by
+    /// tests; production code does not need to call this.
+    func awaitSnapshotFlush() async {
+        await snapshotWorker?.value
     }
 
     private func appendLog(jobID: UUID, event: String, from: JobState?, to: JobState) {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1577,6 +1577,12 @@ class PipelineQueue {
         await snapshotWorker?.value
     }
 
+    /// Test-only: true while a background snapshot worker is running.
+    /// Lets tests assert the worker drains and clears itself.
+    var isSnapshotWorkerActive: Bool {
+        snapshotWorker != nil
+    }
+
     private func appendLog(jobID: UUID, event: String, from: JobState?, to: JobState) {
         let entry: [String: String] = [
             "timestamp": Self.isoFormatter.string(from: Date()),

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -237,10 +237,16 @@ class PipelineQueue {
         return { SpeakerMatcher(dbPath: path) }
     }
 
+    /// Performs the actual disk write for the snapshot worker. Defaults to
+    /// `PipelineSnapshot.save`; tests inject substitutes to count writes or
+    /// simulate a stalled `replaceItemAt`.
+    let snapshotWriter: @Sendable ([PipelineJob], URL) throws -> Void
+
     /// Simple init for skeleton tests and basic queue usage.
     init(
         logDir: URL? = nil,
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
+        snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
@@ -252,6 +258,7 @@ class PipelineQueue {
         self.numSpeakers = 0
         self.micLabel = "Me"
         self.speakerMatcherFactory = speakerMatcherFactory
+        self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
         self.recognitionStatsLog = nil
         self.completedJobLifetime = completedJobLifetime
@@ -312,6 +319,7 @@ class PipelineQueue {
         numSpeakers: Int = 0,
         micLabel: String = "Me",
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
+        snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
         recognitionStatsLog: RecognitionStatsLog? = nil,
         completedJobLifetime: TimeInterval = 60,
@@ -325,6 +333,7 @@ class PipelineQueue {
         self.numSpeakers = numSpeakers
         self.micLabel = micLabel
         self.speakerMatcherFactory = speakerMatcherFactory
+        self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig
         self.recognitionStatsLog = recognitionStatsLog
         self.completedJobLifetime = completedJobLifetime
@@ -1547,10 +1556,11 @@ class PipelineQueue {
         pendingSnapshotJobs = jobs
         guard snapshotWorker == nil else { return }
         let dir = logDir
+        let writer = snapshotWriter
         snapshotWorker = Task.detached(priority: .utility) { [weak self] in
             while let next = await self?.takeNextSnapshotBatch() {
                 do {
-                    try PipelineSnapshot.save(next, to: dir)
+                    try writer(next, dir)
                 } catch {
                     logger.error("Failed to write queue snapshot: \(error)")
                 }
@@ -1571,8 +1581,10 @@ class PipelineQueue {
 
     // swiftlint:enable discouraged_optional_collection
 
-    /// Wait for any queued snapshot writes to land on disk. Mostly used by
-    /// tests; production code does not need to call this.
+    /// Wait for any queued snapshot writes to land on disk. Used by tests
+    /// asserting on the file; production code may call this before quit if
+    /// it needs the last snapshot durable, but the recovery path doesn't
+    /// require it (orphans are re-scanned at next launch).
     func awaitSnapshotFlush() async {
         await snapshotWorker?.value
     }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -40,19 +40,46 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(queue.jobs.count, 2)
     }
 
-    func testSnapshotWrittenOnEnqueue() {
+    func testSnapshotWrittenOnEnqueue() async {
         queue.enqueue(makeJob())
+        await queue.awaitSnapshotFlush()
         let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotPath.path))
     }
 
-    func testSnapshotIsValidJSON() throws {
+    func testSnapshotIsValidJSON() async throws {
         queue.enqueue(makeJob(title: "Standup"))
+        await queue.awaitSnapshotFlush()
         let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         let data = try Data(contentsOf: snapshotPath)
         let jobs = try JSONDecoder().decode([PipelineJob].self, from: data)
         XCTAssertEqual(jobs.count, 1)
         XCTAssertEqual(jobs[0].meetingTitle, "Standup")
+    }
+
+    func testSaveSnapshotDoesNotBlockMainActor() {
+        // Regression guard — if saveSnapshot ever goes synchronous again,
+        // a stalled `replaceItemAt` would freeze the UI / RPC / watch loop.
+        queue.enqueue(makeJob())
+        let start = Date()
+        queue.saveSnapshot()
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 0.05, "saveSnapshot returned in \(elapsed)s — should be near-instant")
+    }
+
+    func testConsecutiveSnapshotsPersistLastStateOnDisk() async throws {
+        // Coalescing: a burst of saves must collapse to a single write of
+        // the final state, never an interleaved earlier snapshot.
+        for i in 1 ... 5 {
+            queue.enqueue(makeJob(title: "Job \(i)"))
+        }
+        await queue.awaitSnapshotFlush()
+
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
+        let data = try Data(contentsOf: snapshotPath)
+        let jobs = try JSONDecoder().decode([PipelineJob].self, from: data)
+        XCTAssertEqual(jobs.count, 5)
+        XCTAssertEqual(jobs.map(\.meetingTitle), ["Job 1", "Job 2", "Job 3", "Job 4", "Job 5"])
     }
 
     func testLogAppendedOnEnqueue() throws {
@@ -883,6 +910,7 @@ final class PipelineQueueTests: XCTestCase {
         queue1.enqueue(job)
         queue1.updateJobState(id: job.id, to: .transcribing)
         queue1.saveSnapshot()
+        await queue1.awaitSnapshotFlush()
 
         let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
         XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotPath.path))
@@ -942,6 +970,7 @@ final class PipelineQueueTests: XCTestCase {
         queue1.enqueue(job)
         queue1.updateJobState(id: job.id, to: .diarizing)
         queue1.saveSnapshot()
+        await queue1.awaitSnapshotFlush()
 
         let engine2 = MockEngine()
         engine2.segmentsToReturn = [

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -82,6 +82,49 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(jobs.map(\.meetingTitle), ["Job 1", "Job 2", "Job 3", "Job 4", "Job 5"])
     }
 
+    func testSnapshotWorkerClearsItselfAfterFlush() async {
+        // Lifecycle guard: a drained worker must set `snapshotWorker = nil`
+        // so the next saveSnapshot starts a fresh task. Without this, a
+        // leak-then-skip bug would silently drop later writes.
+        queue.enqueue(makeJob())
+        XCTAssertTrue(queue.isSnapshotWorkerActive)
+        await queue.awaitSnapshotFlush()
+        XCTAssertFalse(queue.isSnapshotWorkerActive, "worker should clear itself after the queue drains")
+
+        // Second burst spawns a fresh worker — verifies the first didn't
+        // get stuck in a way that prevents re-spawn.
+        queue.enqueue(makeJob(title: "Second"))
+        XCTAssertTrue(queue.isSnapshotWorkerActive)
+        await queue.awaitSnapshotFlush()
+        XCTAssertFalse(queue.isSnapshotWorkerActive)
+    }
+
+    func testSnapshotMatchesInMemoryStateAfterStateTransitionBurst() async throws {
+        // Pipeline-shaped load: enqueue several jobs, then drive each
+        // through transcribing → diarizing → generatingProtocol → done.
+        // 12 updateJobState calls + 3 enqueues = 15 saveSnapshot triggers
+        // in rapid succession. The on-disk state must match in-memory at
+        // the end regardless of how many coalesced batches actually ran.
+        let jobs = (1 ... 3).map { makeJob(title: "Job \($0)") }
+        for job in jobs {
+            queue.enqueue(job)
+        }
+        let transitions: [JobState] = [.transcribing, .diarizing, .generatingProtocol, .done]
+        for job in jobs {
+            for next in transitions {
+                queue.updateJobState(id: job.id, to: next)
+            }
+        }
+        await queue.awaitSnapshotFlush()
+
+        let snapshotPath = tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename)
+        let data = try Data(contentsOf: snapshotPath)
+        let onDisk = try JSONDecoder().decode([PipelineJob].self, from: data)
+        XCTAssertEqual(onDisk.count, queue.jobs.count)
+        XCTAssertEqual(onDisk.map(\.id), queue.jobs.map(\.id))
+        XCTAssertEqual(onDisk.map(\.state), queue.jobs.map(\.state))
+    }
+
     func testLogAppendedOnEnqueue() throws {
         queue.enqueue(makeJob())
         let logPath = tmpDir.appendingPathComponent("pipeline_log.jsonl")

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable file_length
 @testable import MeetingTranscriber
+import os
 import XCTest
 
 @MainActor
@@ -97,6 +98,54 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(queue.isSnapshotWorkerActive)
         await queue.awaitSnapshotFlush()
         XCTAssertFalse(queue.isSnapshotWorkerActive)
+    }
+
+    func testCoalescingReducesActualWriteCount() async {
+        // Inject a counting writer to verify the worker collapses many
+        // rapid saves into fewer disk writes. testConsecutive... only
+        // asserts final state matches — this proves coalescing is real.
+        let count = OSAllocatedUnfairLock<Int>(initialState: 0)
+        // swiftlint:disable trailing_closure
+        let testQueue = PipelineQueue(
+            logDir: tmpDir,
+            snapshotWriter: { _, _ in count.withLock { $0 += 1 } },
+        )
+        // swiftlint:enable trailing_closure
+        for i in 1 ... 20 {
+            testQueue.enqueue(makeJob(title: "Job \(i)"))
+        }
+        await testQueue.awaitSnapshotFlush()
+
+        let writes = count.withLock { $0 }
+        XCTAssertGreaterThan(writes, 0, "writer must be called at least once")
+        XCTAssertLessThan(writes, 20, "coalescing should collapse 20 saves to fewer writes (got \(writes))")
+    }
+
+    func testSaveSnapshotReturnsImmediatelyWhileWriterIsWedged() async {
+        // Direct regression test for the original bug: a stalled writer
+        // (modelling `renamex_np` deadlock) must NOT block follow-up
+        // saveSnapshot calls on the main actor. With the synchronous-on-
+        // main implementation, the second call would hang waiting on the
+        // first; with the off-main worker, it returns instantly.
+        let gate = DispatchSemaphore(value: 0)
+        // swiftlint:disable trailing_closure
+        let testQueue = PipelineQueue(
+            logDir: tmpDir,
+            snapshotWriter: { _, _ in
+                gate.wait()
+                gate.signal() // re-arm so subsequent callers fall through
+            },
+        )
+        // swiftlint:enable trailing_closure
+        testQueue.enqueue(makeJob()) // triggers worker → blocks in writer
+
+        let start = Date()
+        testQueue.saveSnapshot() // would deadlock if main-actor were waiting
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 0.05, "saveSnapshot blocked while writer was wedged (\(elapsed)s)")
+
+        gate.signal() // release the wedged write so the worker can drain
+        await testQueue.awaitSnapshotFlush()
     }
 
     func testSnapshotMatchesInMemoryStateAfterStateTransitionBurst() async throws {


### PR DESCRIPTION
## Summary

- `PipelineQueue.saveSnapshot()` now dispatches JSON-encode + atomic-rename onto a detached background task with a coalescing worker, so the main actor never blocks on `replaceItemAt` (the syscall that wedged the app during the May 13 mini incident).
- A burst of rapid saves collapses to a single write of the latest state; under a FS stall the pending-task chain stays bounded at one in-flight worker plus the pending `[PipelineJob]` slot.
- New `awaitSnapshotFlush()` test helper drains the worker deterministically for assertions on the snapshot file.

## Why

`saveSnapshot()` was synchronous and called from `AppState.toggleWatching` → `makePipelineQueue` → `recoverOrphanedRecordings`/`loadSnapshot`. Under a macOS 26 `mds_stores`/`fseventsd` rename deadlock, `replaceItemAt` lowered to `renamex_np` and blocked indefinitely. With the call on the main actor, the UI, RPC server, and watch loop all froze; the only recovery was killing the daemon. `PipelineSnapshot.save(_:to:)` was already extracted as a pure static function in the prior refactor, so the off-main move was mechanical.

Coalescing keeps the design honest under load: the snapshot file's value is always "the current jobs array", so a backlog of N pending writes carries no information beyond the final one. The worker re-reads `pendingSnapshotJobs` after each I/O so rapid state transitions during pipeline processing produce one write instead of N.

## Test plan

- [x] `swift test --parallel --filter "PipelineQueueTests|PipelineSnapshotTests|AppStateTests"` — 165/165 passing locally
- [x] `./scripts/lint.sh` — 0 violations across 192 files
- [x] `./scripts/pre-push.sh` — release build green
- [ ] CI full suite + sanitizer matrix
- [ ] Mini e2e-app run on push to main

## Notes

- `awaitSnapshotFlush()` is intentionally `internal`, not `private`; tests call it directly via `@testable import`. A future caller wanting to flush before app termination could use the same primitive — keeping it documented as "mostly tests" rather than locking it down.
- `pendingSnapshotJobs: [PipelineJob]?` carries a load-bearing nil vs `[]` distinction (suppressed via `swiftlint:disable discouraged_optional_collection` block): nil = "nothing queued", `[]` = "write the empty state" after the last job is removed.