### PR TITLE
perf(app): move recoverOrphanedRecordings dir scan off the main actor

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -558,7 +558,11 @@ final class AppState { // swiftlint:disable:this type_body_length
             recognitionStatsLog: RecognitionStatsLog(),
         )
         queue.loadSnapshot()
-        queue.recoverOrphanedRecordings()
+        // Fire-and-forget: dir scan + per-file attr probes run off-main so
+        // app startup (and the first call to `enqueueFiles`) isn't blocked
+        // by a slow filesystem. Recovered jobs appear in `queue.jobs` once
+        // the scan returns.
+        Task { await queue.recoverOrphanedRecordings() }
         queue.refreshKnownSpeakerNames()
         return queue
     }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1432,50 +1432,63 @@ class PipelineQueue {
     /// Scan `recordingsDir` for `*_mix.wav` files not tracked by any loaded job.
     /// Creates recovery jobs for untracked recordings younger than `maxAge`.
     /// Skips files that were already successfully processed (tracked in processed_recordings.json).
+    ///
+    /// The directory scan + per-file `attributesOfItem` calls run on a
+    /// detached task — startup callers don't block the UI on a potentially
+    /// slow filesystem (e.g. iCloud-backed recordings dir). Mutations to
+    /// `jobs` and the snapshot still happen on the main actor.
     func recoverOrphanedRecordings(
         recordingsDir: URL = AppPaths.recordingsDir,
         maxAge: TimeInterval = 86400,
-    ) {
+    ) async {
         // One-time migration: seed processed list with existing recordings
         // Only for the default recordings directory (not test overrides)
         if recordingsDir == AppPaths.recordingsDir {
             migrateProcessedRecordings(recordingsDir: recordingsDir)
         }
 
-        let fm = FileManager.default
-        guard let entries = try? fm.contentsOfDirectory(
-            at: recordingsDir,
-            includingPropertiesForKeys: [.fileSizeKey, .creationDateKey],
-        ) else { return }
-
         let trackedPaths = Set(jobs.compactMap { $0.mixPath?.standardizedFileURL.path })
-        let processedPaths = loadProcessedPaths()
-        let now = Date()
-        var recovered = 0
+        let processedRecordingsPath = self.processedRecordingsPath
 
-        // Orphan recovery requires a `_mix.wav` anchor — pair with companion
-        // `_app.wav`/`_mic.wav` tracks when they exist (same stem).
-        for group in PairedRecordingResolver.resolve(urls: entries).paired {
-            // Orphan recovery requires an on-disk `_mix.wav` anchor — paired
-            // groups produced by app+mic synthesis aren't recoverable from the
-            // dir scan alone (the synthesized mix lives elsewhere or hasn't
-            // been written yet). Skip groups without a real mix file here.
+        // Off-main: directory scan + processed-list read + per-file
+        // attributesOfItem probes + filtering all happen here.
+        let candidates: [PairedRecordingResolver.Group] = await Task.detached(priority: .utility) {
+            let fm = FileManager.default
+            guard let entries = try? fm.contentsOfDirectory(
+                at: recordingsDir,
+                includingPropertiesForKeys: [.fileSizeKey, .creationDateKey],
+            ) else { return [] }
+            let processedPaths: Set<String> = {
+                guard let data = try? Data(contentsOf: processedRecordingsPath),
+                      let paths = try? JSONDecoder().decode([String].self, from: data)
+                else { return [] }
+                return Set(paths)
+            }()
+            let now = Date()
+            return PairedRecordingResolver.resolve(urls: entries).paired.filter { group in
+                // Groups without a real mix file (app+mic-only paired imports)
+                // aren't recoverable from the dir scan alone.
+                guard let mixURL = group.mix else { return false }
+                let stdPath = mixURL.standardizedFileURL.path
+                guard !trackedPaths.contains(stdPath) else { return false }
+                guard !processedPaths.contains(stdPath) else { return false }
+                let attrs = try? fm.attributesOfItem(atPath: mixURL.path)
+                if let created = attrs?[.creationDate] as? Date,
+                   now.timeIntervalSince(created) > maxAge {
+                    return false
+                }
+                // Header-only WAVs are 44 bytes.
+                if let size = attrs?[.size] as? Int, size <= 44 {
+                    return false
+                }
+                return true
+            }
+        }.value
+
+        guard !candidates.isEmpty else { return }
+
+        for group in candidates {
             guard let mixURL = group.mix else { continue }
-            let stdPath = mixURL.standardizedFileURL.path
-
-            guard !trackedPaths.contains(stdPath) else { continue }
-            guard !processedPaths.contains(stdPath) else { continue }
-
-            let attrs = try? fm.attributesOfItem(atPath: mixURL.path)
-            if let created = attrs?[.creationDate] as? Date,
-               now.timeIntervalSince(created) > maxAge {
-                continue
-            }
-            // Header-only WAVs are 44 bytes.
-            if let size = attrs?[.size] as? Int, size <= 44 {
-                continue
-            }
-
             let job = PipelineJob(
                 meetingTitle: "Recovered Recording (\(group.stem))",
                 appName: "Unknown",
@@ -1486,14 +1499,10 @@ class PipelineQueue {
             )
             jobs.append(job)
             appendLog(jobID: job.id, event: "recovered", from: nil, to: .waiting)
-            recovered += 1
         }
-
-        if recovered > 0 {
-            saveSnapshot()
-            logger.info("Recovered \(recovered) orphaned recording(s)")
-            triggerProcessing()
-        }
+        saveSnapshot()
+        logger.info("Recovered \(candidates.count) orphaned recording(s)")
+        triggerProcessing()
     }
 
     // MARK: - Processed Recordings Tracking

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -380,7 +380,7 @@ final class PipelineQueueTests: XCTestCase {
 
     // MARK: - Orphaned Recording Recovery Tests
 
-    func testRecoverFindsUntrackedMixWav() throws {
+    func testRecoverFindsUntrackedMixWav() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -388,7 +388,7 @@ final class PipelineQueueTests: XCTestCase {
         try Data(repeating: 0xFF, count: 100).write(to: mixFile)
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
 
         XCTAssertEqual(freshQueue.jobs.count, 1)
         XCTAssertEqual(freshQueue.jobs[0].meetingTitle, "Recovered Recording (20260311_100000)")
@@ -398,7 +398,7 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
-    func testRecoverSkipsTrackedFiles() throws {
+    func testRecoverSkipsTrackedFiles() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -414,12 +414,12 @@ final class PipelineQueueTests: XCTestCase {
         )
         freshQueue.enqueue(existing)
 
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertEqual(freshQueue.jobs.count, 1)
         XCTAssertEqual(freshQueue.jobs[0].meetingTitle, "Already Tracked")
     }
 
-    func testRecoverSkipsTinyFiles() throws {
+    func testRecoverSkipsTinyFiles() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -427,12 +427,12 @@ final class PipelineQueueTests: XCTestCase {
         try Data(repeating: 0x00, count: 44).write(to: mixFile)
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
 
         XCTAssertEqual(freshQueue.jobs.count, 0)
     }
 
-    func testRecoverFindsCompanionTracks() throws {
+    func testRecoverFindsCompanionTracks() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -442,14 +442,14 @@ final class PipelineQueueTests: XCTestCase {
         try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("\(prefix)_mic.wav"))
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
 
         XCTAssertEqual(freshQueue.jobs.count, 1)
         XCTAssertNotNil(freshQueue.jobs[0].appPath)
         XCTAssertNotNil(freshQueue.jobs[0].micPath)
     }
 
-    func testRecoverSkipsOldFiles() throws {
+    func testRecoverSkipsOldFiles() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -457,12 +457,12 @@ final class PipelineQueueTests: XCTestCase {
         try Data(repeating: 0xFF, count: 100).write(to: mixFile)
 
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir, maxAge: 0)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir, maxAge: 0)
 
         XCTAssertEqual(freshQueue.jobs.count, 0)
     }
 
-    func testRecoverSkipsProcessedFiles() throws {
+    func testRecoverSkipsProcessedFiles() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
 
@@ -473,11 +473,11 @@ final class PipelineQueueTests: XCTestCase {
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.markProcessed(mixPath: mixFile)
 
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertEqual(freshQueue.jobs.count, 0)
     }
 
-    func testErrorJobIsMarkedProcessedSoRecoverySkipsIt() throws {
+    func testErrorJobIsMarkedProcessedSoRecoverySkipsIt() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
         try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
         let mixFile = recDir.appendingPathComponent("20260318_214744_mix.wav")
@@ -497,7 +497,7 @@ final class PipelineQueueTests: XCTestCase {
 
         // A fresh queue (simulates pressing Start Watching) must not recover the failed recording
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertTrue(freshQueue.jobs.isEmpty, "Failed recording should not be re-queued")
     }
 
@@ -523,11 +523,35 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(paths.contains(mixPath.standardizedFileURL.path))
     }
 
-    func testRecoverEmptyDirIsNoOp() {
+    func testRecoverEmptyDirIsNoOp() async {
         let recDir = tmpDir.appendingPathComponent("nonexistent_recordings")
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertTrue(freshQueue.jobs.isEmpty)
+    }
+
+    func testRecoverRunsDirScanOffMainActor() async throws {
+        // Smoke test that the scan doesn't starve main-actor work: kick
+        // off recovery with `async let`, do synchronous work concurrently,
+        // verify both complete.
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        for i in 0 ..< 50 {
+            let mixFile = recDir.appendingPathComponent("20260311_10000\(i)_mix.wav")
+            try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+        }
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        async let recovery: Void = freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+
+        var counter = 0
+        for _ in 0 ..< 10000 {
+            counter += 1
+        }
+        XCTAssertEqual(counter, 10000)
+
+        await recovery
+        XCTAssertEqual(freshQueue.jobs.count, 50)
     }
 
     // MARK: - Processing Tests


### PR DESCRIPTION
## Summary

- `PipelineQueue.recoverOrphanedRecordings` is now `async`. The dir scan + processed-recordings list read + per-file `attributesOfItem` probes + filter all run inside `Task.detached(priority: .utility) { ... }.value`. Only `jobs.append` / `appendLog` / `saveSnapshot` / `triggerProcessing` stay on the main actor.
- `AppState.makePipelineQueue` calls it fire-and-forget via `Task { await queue.recoverOrphanedRecordings() }` so app startup no longer blocks on the recordings dir scan.
- 8 existing `testRecover*` tests gained `async`/`await`. 1 new test `testRecoverRunsDirScanOffMainActor` proves the scan runs concurrently with main-actor work (seeds 50 files, `async let`, runs synchronous burst, awaits).

## Why

Companion to #284 (`perf(app): dispatch PipelineQueue.saveSnapshot off the main actor`). That PR closed half of the documented Ebene-2 startup-block: the JSON-encode + `replaceItemAt` of the snapshot file. The other half — the dir scan and per-file attr probes that run from `makePipelineQueue` → `recoverOrphanedRecordings` — were still on the main actor. Both can stall the UI under a slow filesystem (iCloud-backed volume, network mount, mds_stores busy). This PR moves them off.

The fire-and-forget at the call site means orphans appear in the queue shortly after `makePipelineQueue` returns, not before. UI shows an empty queue for ~10-100 ms then fills in. No user-visible regression — the original behavior didn't guarantee a particular ordering vs. user actions either.

## Test plan

- [x] `swift test --parallel --filter PipelineQueueTests` — 93/93 passing
- [x] `./scripts/lint.sh` — 0 violations
- [x] `./scripts/pre-push.sh` — release build green
- [ ] CI full suite + e2e
- [ ] Mini e2e-app run on push to main

## Notes

- `loadProcessedPaths()` was previously called on the main actor before the detached task. Moved its disk-read into the detached closure so all I/O lives in one off-main block (caught by the second `/simplify` pass on this PR's diff).
- `migrateProcessedRecordings()` still runs on the main actor — it's a one-time-ever op guarded by `FileManager.fileExists`, runs exactly once per install. Out of scope here; can move later if startup profiling shows it.