### PR TITLE
ci(e2e-app): add codesign pre-flight smoke test to catch trustd drift early

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -71,6 +71,27 @@ jobs:
         if: steps.dev-id.outputs.keychain-path != ''
         run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
 
+      # Smoke test codesign before kicking off the ~70 s build. The
+      # find-identity probe in install-developer-id catches missing/
+      # mismatched certs, but `codesign` delegates to trustd for
+      # trust-chain validation — a separate code path that can fail
+      # (partition-list ACL reset, trustd not respawned for this user)
+      # while find-identity still reports "1 valid". Without this,
+      # such drift surfaces only after the build burns ~70 s.
+      - name: Pre-flight codesign smoke test
+        if: env.E2E_SIGNING_KEYCHAIN != ''
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        run: |
+          TEST_BIN=$(mktemp)
+          trap 'rm -f "$TEST_BIN"' EXIT
+          cp /usr/bin/true "$TEST_BIN"
+          if ! codesign --force --sign "$DEVELOPER_ID" --keychain "$E2E_SIGNING_KEYCHAIN" "$TEST_BIN"; then
+              echo "::error::codesign smoke test failed — likely trustd or partition-list drift on the Mini"
+              echo "::error::Recovery: unlock keychain, respawn trustd for this user, re-apply partition-list ACL, then re-run setup-self-hosted-runner.sh"
+              exit 1
+          fi
+
       - name: Run live-recording E2E driver
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}


### PR DESCRIPTION
## Summary

Adds a single new step in `.github/workflows/e2e-app.yml` that signs a throwaway binary with the same identity + keychain path the production build will use, immediately after `install-developer-id`. Catches trustd drift in ~30 s into the job instead of ~90 s (after the swift build).

## Why

The `install-developer-id` action already runs `find-identity` as a fail-fast probe — that catches missing or mismatched certs in under a second. But `find-identity` hits the keychain API directly while `codesign` delegates to trustd for trust-chain validation, a separate code path.

The Mini has historically diverged here:
- `find-identity` says "1 valid identity"
- `codesign` says "no identity found"

Triggers seen in the wild: partition-list ACL reset, trustd not respawned for the runner user after a reboot. When this happens today, the failure surfaces only after the ~70 s swift build, at the `e2e-app.sh` re-sign step. The new step runs the same trustd path against `/bin/echo` immediately after cert install, so the same drift surfaces ~60 s earlier with an actionable error message.

The `::error::` lines name the recovery sequence inline so reviewers don't have to chase back to `setup-self-hosted-runner.sh`.

## Tradeoffs

- **+~2 s per run on the happy path** — negligible vs the 14-20 min total job budget.
- **Guarded behind `if: env.E2E_SIGNING_KEYCHAIN != ''`** — workflows where `install-developer-id` was a no-op (no Developer ID secret in the repo) still work, falling back to the self-signed cert path from `setup-self-hosted-runner.sh` which has a different trust model.
- **Self-signed path NOT covered** — only the Developer-ID-imported path. The self-signed cert is the daily-driver path that should "just work"; if it doesn't, recovery is `scripts/setup-self-hosted-runner.sh`. Different failure mode.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-app.yml'))"` — YAML parses
- [x] `./scripts/lint.sh` — 0 violations
- [ ] CI run on the PR's e2e-app workflow run (happy path — verifies step exits 0 and doesn't slow the job materially)
- [ ] Manual sanity check on Mini next time trustd drift happens — should fire with the new error message