### PR TITLE
perf(app): move migrateProcessedRecordings off the main actor

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1407,26 +1407,33 @@ class PipelineQueue {
 
     /// One-time migration: if no processed_recordings.json exists yet, seed it with
     /// all existing `_mix.wav` files so they don't get recovered on first launch after update.
-    private func migrateProcessedRecordings(recordingsDir: URL) {
+    ///
+    /// Dir scan + JSON encode + atomic write run on a detached task. The
+    /// guard + `ensureLogDir` stay on the main actor so the migration is a
+    /// no-op (no detached task spawned) when the processed file already
+    /// exists — which is the steady-state case.
+    func migrateProcessedRecordings(recordingsDir: URL) async {
         guard !FileManager.default.fileExists(atPath: processedRecordingsPath.path) else { return }
-        let fm = FileManager.default
-        guard let entries = try? fm.contentsOfDirectory(
-            at: recordingsDir, includingPropertiesForKeys: nil,
-        ) else { return }
-
-        var paths = Set<String>()
-        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
-            paths.insert(file.standardizedFileURL.path)
-        }
-        guard !paths.isEmpty else { return }
-        do {
-            ensureLogDir()
-            let data = try JSONEncoder().encode(Array(paths))
-            try data.write(to: processedRecordingsPath, options: .atomic)
-            logger.info("Migration: seeded \(paths.count) existing recordings as processed")
-        } catch {
-            logger.error("Migration failed: \(error)")
-        }
+        ensureLogDir()
+        let processedRecordingsPath = self.processedRecordingsPath
+        await Task.detached(priority: .utility) {
+            let fm = FileManager.default
+            guard let entries = try? fm.contentsOfDirectory(
+                at: recordingsDir, includingPropertiesForKeys: nil,
+            ) else { return }
+            var paths = Set<String>()
+            for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
+                paths.insert(file.standardizedFileURL.path)
+            }
+            guard !paths.isEmpty else { return }
+            do {
+                let data = try JSONEncoder().encode(Array(paths))
+                try data.write(to: processedRecordingsPath, options: .atomic)
+                logger.info("Migration: seeded \(paths.count) existing recordings as processed")
+            } catch {
+                logger.error("Migration failed: \(error)")
+            }
+        }.value
     }
 
     /// Scan `recordingsDir` for `*_mix.wav` files not tracked by any loaded job.
@@ -1444,7 +1451,7 @@ class PipelineQueue {
         // One-time migration: seed processed list with existing recordings
         // Only for the default recordings directory (not test overrides)
         if recordingsDir == AppPaths.recordingsDir {
-            migrateProcessedRecordings(recordingsDir: recordingsDir)
+            await migrateProcessedRecordings(recordingsDir: recordingsDir)
         }
 
         let trackedPaths = Set(jobs.compactMap { $0.mixPath?.standardizedFileURL.path })

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -530,6 +530,70 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(freshQueue.jobs.isEmpty)
     }
 
+    func testMigrateSeedsProcessedRecordingsFromExistingMixFiles() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixA = recDir.appendingPathComponent("20260101_100000_mix.wav")
+        let mixB = recDir.appendingPathComponent("20260102_100000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixA)
+        try Data(repeating: 0xFF, count: 100).write(to: mixB)
+        // Non-mix file must be ignored.
+        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("notes.txt"))
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        await freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
+
+        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: processedPath.path))
+        let paths = try JSONDecoder().decode([String].self, from: Data(contentsOf: processedPath))
+        XCTAssertEqual(Set(paths), Set([
+            mixA.standardizedFileURL.path,
+            mixB.standardizedFileURL.path,
+        ]))
+    }
+
+    func testMigrateIsNoOpWhenProcessedFileAlreadyExists() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("20260101_mix.wav"))
+
+        // Pre-create the processed file with a sentinel value; migration must
+        // not overwrite it.
+        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
+        let sentinel = try JSONEncoder().encode(["/preexisting/path/mix.wav"])
+        try sentinel.write(to: processedPath)
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        await freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
+
+        let paths = try JSONDecoder().decode([String].self, from: Data(contentsOf: processedPath))
+        XCTAssertEqual(paths, ["/preexisting/path/mix.wav"])
+    }
+
+    func testMigrateRunsOffMainActor() async throws {
+        // Smoke test parity with testRecoverRunsDirScanOffMainActor:
+        // verify the dir scan + JSON write don't starve main-actor work.
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        for i in 0 ..< 50 {
+            let mixFile = recDir.appendingPathComponent("20260311_10000\(i)_mix.wav")
+            try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+        }
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        async let migration: Void = freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
+
+        var counter = 0
+        for _ in 0 ..< 10000 {
+            counter += 1
+        }
+        XCTAssertEqual(counter, 10000)
+
+        await migration
+        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: processedPath.path))
+    }
+
     func testRecoverRunsDirScanOffMainActor() async throws {
         // Smoke test that the scan doesn't starve main-actor work: kick
         // off recovery with `async let`, do synchronous work concurrently,


### PR DESCRIPTION
## Summary

Wraps up the off-main story for the `recoverOrphanedRecordings` codepath. PRs #284 (`saveSnapshot`) and #285 (orphan recovery dir scan) moved most of that path off the main actor; the one-time migration that seeds `processed_recordings.json` on first launch was still synchronous. Same iCloud / mds_stores risk class — same fix.

## What changed

- `PipelineQueue.migrateProcessedRecordings` is now `async`. The dir scan + Set construction + JSON encode + atomic write run inside `Task.detached(priority: .utility) { ... }.value`. The existence check + `ensureLogDir` stay on the main actor.
- The single caller (`recoverOrphanedRecordings` on the same class) gets `await`.
- Visibility narrowed from `private` to internal (default) so tests can exercise the function directly.

## Steady-state cost

After the first ever launch, the `processed_recordings.json` file exists permanently and the function short-circuits at the existence guard with zero detached-task overhead. Only the first launch goes off-main.

## Test coverage

Three new tests:
- `testMigrateSeedsProcessedRecordingsFromExistingMixFiles` — 2 mix + 1 non-mix file → only mix paths land in the json.
- `testMigrateIsNoOpWhenProcessedFileAlreadyExists` — pre-existing sentinel file left untouched.
- `testMigrateRunsOffMainActor` — parity with `testRecoverRunsDirScanOffMainActor`: `async let` migration + concurrent main-actor work both complete.

## Test plan

- [x] `swift test --parallel --filter PipelineQueueTests` — all green locally (93 + 3 new = 96 tests)
- [x] `./scripts/lint.sh` — 0 violations
- [x] `./scripts/pre-push.sh` — release build green
- [ ] CI full suite + sanitizer matrix
- [ ] Mini e2e-app run on push to main

## Notes

- Two `Task.detached(priority: .utility) { ... }.value` sites now exist in `PipelineQueue` (this + `recoverOrphanedRecordings`). Extracting a `runOffMain<T>` helper is deferred until a third caller emerges — same heuristic as the existing `AtomicJSONFile<T>` backlog entry.