### PR TITLE
test(app): cover ClaudeCLI subprocess builders via three pure helpers

### DIFF
--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -22,32 +22,17 @@
 
         // MARK: - ProtocolGenerating
 
-        // swiftlint:disable:next function_body_length
         func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
-            var prompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
-            if diarized {
-                prompt += ProtocolGenerator.diarizationNote
-            }
-            prompt += transcript
+            let prompt = Self.buildPrompt(transcript: transcript, diarized: diarized, language: language)
 
             let process = Process()
             let resolvedBin = Self.resolveClaudePath(claudeBin)
             process.executableURL = URL(fileURLWithPath: resolvedBin)
-            var args = ["-p", "-", "--output-format", "stream-json", "--verbose", "--model", "sonnet"]
-            // If using /usr/bin/env fallback, prepend the binary name
-            if resolvedBin == "/usr/bin/env" {
-                args.insert(claudeBin, at: 0)
-            }
-            process.arguments = args
-
-            // Remove CLAUDECODE env var to allow nested Claude CLI invocation
-            var env = ProcessInfo.processInfo.environment
-            env.removeValue(forKey: "CLAUDECODE")
-            // App bundles have a minimal PATH — ensure common bin dirs are included
-            // so wrapper scripts (e.g. claude-work-wrapper calling `exec claude`) work
-            let extraPaths = Self.searchPaths.joined(separator: ":")
-            env["PATH"] = "\(extraPaths):\(env["PATH"] ?? "/usr/bin:/bin")"
-            process.environment = env
+            process.arguments = Self.buildSubprocessArgs(claudeBin: claudeBin, resolvedBin: resolvedBin)
+            process.environment = Self.buildEnvironment(
+                baseEnvironment: ProcessInfo.processInfo.environment,
+                searchPaths: Self.searchPaths,
+            )
 
             let stdinPipe = Pipe()
             let stdoutPipe = Pipe()
@@ -236,6 +221,43 @@
             }
             // Fallback: hope it's in PATH
             return "/usr/bin/env"
+        }
+
+        // MARK: - Pure subprocess builders
+
+        /// Build the prompt: localized base + optional diarization note + transcript.
+        static func buildPrompt(transcript: String, diarized: Bool, language: String) -> String {
+            var prompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
+            if diarized {
+                prompt += ProtocolGenerator.diarizationNote
+            }
+            prompt += transcript
+            return prompt
+        }
+
+        /// Build the CLI argument vector. When `resolvedBin` is the
+        /// `/usr/bin/env` fallback, prepend `claudeBin` so env can resolve
+        /// it from PATH.
+        static func buildSubprocessArgs(claudeBin: String, resolvedBin: String) -> [String] {
+            var args = ["-p", "-", "--output-format", "stream-json", "--verbose", "--model", "sonnet"]
+            if resolvedBin == "/usr/bin/env" {
+                args.insert(claudeBin, at: 0)
+            }
+            return args
+        }
+
+        /// Strip `CLAUDECODE` (avoid nested-session detection by the child
+        /// CLI) and prepend `searchPaths` to `PATH` (app bundles inherit
+        /// a minimal `PATH`).
+        static func buildEnvironment(
+            baseEnvironment: [String: String],
+            searchPaths: [String],
+        ) -> [String: String] {
+            var env = baseEnvironment
+            env.removeValue(forKey: "CLAUDECODE")
+            let extraPaths = searchPaths.joined(separator: ":")
+            env["PATH"] = "\(extraPaths):\(env["PATH"] ?? "/usr/bin:/bin")"
+            return env
         }
     }
 

--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -114,5 +114,99 @@
             XCTAssertTrue(paths.contains("\(NSHomeDirectory())/.local/bin"))
             XCTAssertTrue(paths.contains("\(NSHomeDirectory())/.npm-global/bin"))
         }
+
+        // MARK: - buildPrompt
+
+        func testBuildPromptAppendsTranscript() {
+            let prompt = ClaudeCLIProtocolGenerator.buildPrompt(
+                transcript: "MARKER_TRANSCRIPT",
+                diarized: false,
+                language: "German",
+            )
+            XCTAssertTrue(prompt.hasSuffix("MARKER_TRANSCRIPT"))
+        }
+
+        func testBuildPromptIncludesDiarizationNoteWhenDiarized() {
+            let plain = ClaudeCLIProtocolGenerator.buildPrompt(
+                transcript: "x", diarized: false, language: "German",
+            )
+            let diarized = ClaudeCLIProtocolGenerator.buildPrompt(
+                transcript: "x", diarized: true, language: "German",
+            )
+            XCTAssertGreaterThan(diarized.count, plain.count)
+            XCTAssertTrue(diarized.contains(ProtocolGenerator.diarizationNote))
+            XCTAssertFalse(plain.contains(ProtocolGenerator.diarizationNote))
+        }
+
+        func testBuildPromptSubstitutesLanguage() {
+            // ProtocolGenerator.loadPrompt has a `{LANGUAGE}` placeholder
+            // that applyLanguage swaps in; verify the chosen language
+            // appears in the final prompt.
+            let prompt = ClaudeCLIProtocolGenerator.buildPrompt(
+                transcript: "x", diarized: false, language: "Polish",
+            )
+            XCTAssertTrue(prompt.contains("Polish"))
+        }
+
+        // MARK: - buildSubprocessArgs
+
+        func testBuildSubprocessArgsForAbsolutePathDoesNotPrependBinary() {
+            let args = ClaudeCLIProtocolGenerator.buildSubprocessArgs(
+                claudeBin: "claude",
+                resolvedBin: "/opt/homebrew/bin/claude",
+            )
+            XCTAssertEqual(
+                args,
+                ["-p", "-", "--output-format", "stream-json", "--verbose", "--model", "sonnet"],
+            )
+        }
+
+        func testBuildSubprocessArgsForEnvFallbackPrependsBinaryName() {
+            // /usr/bin/env fallback: the bare name is prepended so env can
+            // resolve it via PATH (set in buildEnvironment).
+            let args = ClaudeCLIProtocolGenerator.buildSubprocessArgs(
+                claudeBin: "claude-work",
+                resolvedBin: "/usr/bin/env",
+            )
+            XCTAssertEqual(
+                args,
+                ["claude-work", "-p", "-", "--output-format", "stream-json", "--verbose", "--model", "sonnet"],
+            )
+        }
+
+        // MARK: - buildEnvironment
+
+        func testBuildEnvironmentRemovesClaudeCodeMarker() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["CLAUDECODE": "1", "PATH": "/usr/bin"],
+                searchPaths: [],
+            )
+            XCTAssertNil(env["CLAUDECODE"], "CLAUDECODE must be stripped so the nested CLI doesn't see itself as embedded")
+        }
+
+        func testBuildEnvironmentPrependsSearchPathsToPATH() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["PATH": "/usr/bin:/bin"],
+                searchPaths: ["/opt/homebrew/bin", "/Users/x/.local/bin"],
+            )
+            XCTAssertEqual(env["PATH"], "/opt/homebrew/bin:/Users/x/.local/bin:/usr/bin:/bin")
+        }
+
+        func testBuildEnvironmentFallsBackToSystemPathWhenNoPATHInBase() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: [:],
+                searchPaths: ["/opt/homebrew/bin"],
+            )
+            XCTAssertEqual(env["PATH"], "/opt/homebrew/bin:/usr/bin:/bin")
+        }
+
+        func testBuildEnvironmentPreservesOtherKeys() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["HOME": "/Users/x", "USER": "x", "PATH": "/usr/bin"],
+                searchPaths: [],
+            )
+            XCTAssertEqual(env["HOME"], "/Users/x")
+            XCTAssertEqual(env["USER"], "x")
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

Extracts three pure-static helpers from `ClaudeCLIProtocolGenerator.generate()` so the subprocess-construction logic becomes unit-testable without spawning a real Claude CLI:

- `buildPrompt(transcript:diarized:language:)` — language substitution + optional diarization note + transcript concatenation
- `buildSubprocessArgs(claudeBin:resolvedBin:)` — argument vector + `/usr/bin/env` fallback prepend
- `buildEnvironment(baseEnvironment:searchPaths:)` — `CLAUDECODE` strip + `PATH` prepend so app bundles can find the CLI installed via Homebrew or `~/.local/bin`

`generate()` now reads as a high-level sketch (build prompt → spawn → stdin → stdout → exit-check) and shrank enough that the `// swiftlint:disable:next function_body_length` suppression is gone.

## Why

`ClaudeCLIProtocolGenerator.swift` was at ~19% coverage before this PR — only the four small static helpers (`parseStreamJSONLine`, `resolveClaudePath`, `availableClaudeBinaries`, `searchPaths`) had tests. The bulk of `generate()` is subprocess plumbing that's hard to test without injection, but the prompt / args / env construction is pure data shaping. This PR makes that shaping testable.

Production behavior is unchanged — the helpers are called from the same call site in the same order.

## Test plan

- [x] `swift test --parallel --filter ClaudeCLIProtocolGeneratorTests` — 24/24 passing locally (15 existing + 9 new)
- [x] `./scripts/lint.sh` — 0 violations
- [x] `./scripts/pre-push.sh` — release build green
- [ ] CI full suite + codecov delta on patch

## Notes

- `OpenAIProtocolGenerator.generate()` has identical inline prompt-building logic. A shared `ProtocolGenerator.buildPrompt(...)` would deduplicate both, but I've kept the extraction local to `ClaudeCLIProtocolGenerator` to keep this PR scoped to coverage. Follow-up candidate.
- Test assertions use direct array equality (e.g., `XCTAssertEqual(args, [...]")`) rather than `contains` chains so a regression surfaces the full diff.