### PR TITLE
refactor(app): extract ProtocolGenerator.buildSystemPrompt shared by both LLM generators

### DIFF
--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -23,7 +23,7 @@
         // MARK: - ProtocolGenerating
 
         func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
-            let prompt = Self.buildPrompt(transcript: transcript, diarized: diarized, language: language)
+            let prompt = ProtocolGenerator.buildSystemPrompt(diarized: diarized, language: language) + transcript
 
             let process = Process()
             let resolvedBin = Self.resolveClaudePath(claudeBin)
@@ -224,16 +224,6 @@
         }
 
         // MARK: - Pure subprocess builders
-
-        /// Build the prompt: localized base + optional diarization note + transcript.
-        static func buildPrompt(transcript: String, diarized: Bool, language: String) -> String {
-            var prompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
-            if diarized {
-                prompt += ProtocolGenerator.diarizationNote
-            }
-            prompt += transcript
-            return prompt
-        }
 
         /// Build the CLI argument vector. When `resolvedBin` is the
         /// `/usr/bin/env` fallback, prepend `claudeBin` so env can resolve

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -29,10 +29,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     }
 
     func generate(transcript: String, title _: String, diarized: Bool) async throws -> String {
-        var systemPrompt = ProtocolGenerator.applyLanguage(ProtocolGenerator.loadPrompt(), language: language)
-        if diarized {
-            systemPrompt += ProtocolGenerator.diarizationNote
-        }
+        let systemPrompt = ProtocolGenerator.buildSystemPrompt(diarized: diarized, language: language)
 
         let messages: [[String: Any]] = [
             ["role": "system", "content": systemPrompt],

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -91,6 +91,15 @@ enum ProtocolGenerator {
         return protocolPrompt
     }
 
+    /// Build the localized system prompt: `loadPrompt` + `applyLanguage`
+    /// + optional `diarizationNote`. Excludes the transcript itself —
+    /// callers append or attach it as they see fit.
+    static func buildSystemPrompt(diarized: Bool, language: String) -> String {
+        var prompt = applyLanguage(loadPrompt(), language: language)
+        if diarized { prompt += diarizationNote }
+        return prompt
+    }
+
     // MARK: - File Operations
 
     /// Save a transcript to a text file.

--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -115,39 +115,6 @@
             XCTAssertTrue(paths.contains("\(NSHomeDirectory())/.npm-global/bin"))
         }
 
-        // MARK: - buildPrompt
-
-        func testBuildPromptAppendsTranscript() {
-            let prompt = ClaudeCLIProtocolGenerator.buildPrompt(
-                transcript: "MARKER_TRANSCRIPT",
-                diarized: false,
-                language: "German",
-            )
-            XCTAssertTrue(prompt.hasSuffix("MARKER_TRANSCRIPT"))
-        }
-
-        func testBuildPromptIncludesDiarizationNoteWhenDiarized() {
-            let plain = ClaudeCLIProtocolGenerator.buildPrompt(
-                transcript: "x", diarized: false, language: "German",
-            )
-            let diarized = ClaudeCLIProtocolGenerator.buildPrompt(
-                transcript: "x", diarized: true, language: "German",
-            )
-            XCTAssertGreaterThan(diarized.count, plain.count)
-            XCTAssertTrue(diarized.contains(ProtocolGenerator.diarizationNote))
-            XCTAssertFalse(plain.contains(ProtocolGenerator.diarizationNote))
-        }
-
-        func testBuildPromptSubstitutesLanguage() {
-            // ProtocolGenerator.loadPrompt has a `{LANGUAGE}` placeholder
-            // that applyLanguage swaps in; verify the chosen language
-            // appears in the final prompt.
-            let prompt = ClaudeCLIProtocolGenerator.buildPrompt(
-                transcript: "x", diarized: false, language: "Polish",
-            )
-            XCTAssertTrue(prompt.contains("Polish"))
-        }
-
         // MARK: - buildSubprocessArgs
 
         func testBuildSubprocessArgsForAbsolutePathDoesNotPrependBinary() {

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -172,6 +172,22 @@ final class ProtocolGeneratorTests: XCTestCase {
         XCTAssertTrue(ProtocolGenerator.protocolPrompt.contains("{LANGUAGE}"))
     }
 
+    // MARK: - System Prompt Construction
+
+    func testBuildSystemPromptSubstitutesLanguage() {
+        let prompt = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "Polish")
+        XCTAssertTrue(prompt.contains("Polish"))
+        XCTAssertFalse(prompt.contains("{LANGUAGE}"))
+    }
+
+    func testBuildSystemPromptAppendsDiarizationNoteWhenDiarized() {
+        let plain = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "German")
+        let diarized = ProtocolGenerator.buildSystemPrompt(diarized: true, language: "German")
+        XCTAssertGreaterThan(diarized.count, plain.count)
+        XCTAssertTrue(diarized.contains(ProtocolGenerator.diarizationNote))
+        XCTAssertFalse(plain.contains(ProtocolGenerator.diarizationNote))
+    }
+
     // MARK: - File Save Operations
 
     func testSaveTranscript() throws {


### PR DESCRIPTION
## Summary

- Hoist the localized system-prompt composition (`loadPrompt` + `applyLanguage` + optional `diarizationNote`) into `ProtocolGenerator.buildSystemPrompt(diarized:language:)`.
- `ClaudeCLIProtocolGenerator.generate()` and `OpenAIProtocolGenerator.generate()` both delegate. The old `ClaudeCLIProtocolGenerator.buildPrompt(transcript:diarized:language:)` static is folded — `buildSystemPrompt + transcript` is now one line at the call site, since transcript-append is ClaudeCLI-specific (OpenAI keeps the transcript as a separate `user` message).
- The 3 `testBuildPrompt*` tests migrate from `ClaudeCLIProtocolGeneratorTests` to `ProtocolGeneratorTests` as 2 `testBuildSystemPrompt*` tests. Language-substitution and diarization-conditional behavior remain covered; the transcript-append assertion is dropped since it's now a trivial inline concatenation.

Net diff: **+27 / -48** lines.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter "ProtocolGeneratorTests|ClaudeCLIProtocolGeneratorTests|OpenAI"` passes
- [x] `swift test --filter "testBuildSystemPrompt"` passes (2/2)
- [x] `./scripts/lint.sh` clean (0 violations)