### PR TITLE
test(app): cover AppState.makeProtocolGenerator .none provider branch

### DIFF
--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -533,6 +533,13 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
     #endif
 
+    func testMakeProtocolGeneratorReturnsNilForNoneProvider() {
+        let settings = AppSettings()
+        settings.protocolProvider = .none
+        let state = AppState(settings: settings)
+        XCTAssertNil(state.makeProtocolGenerator())
+    }
+
     // MARK: - configurePipelineCallbacks
 
     func testConfigurePipelineCallbacksDoneFiresNotification() throws {


### PR DESCRIPTION
## Summary

- Adds `testMakeProtocolGeneratorReturnsNilForNoneProvider` to close the only fully-pure-switch gap remaining in `AppState.makeProtocolGenerator()`.
- Existing tests cover `.openAICompatible` and `.claudeCLI` (the latter `#if !APPSTORE`); the `.none` branch (line 588) returned an Optional nil that was untested.

Honest scope: 7 lines, +1 test, ~+0.03pp project coverage. Done as a focused hygiene PR — no scope creep into the larger architecture-bound uncovered regions in `AppState.swift` (RPC server lifecycle, async Task bodies, live TCC probe) which would require closure-injection or full `@Observable` ViewModel migration.

## Test plan

- [x] `swift test --filter AppStateTests.testMakeProtocolGenerator` passes (3/3)
- [x] `./scripts/lint.sh` clean (0 violations)