### PR TITLE
feat(app): detect symmetric-silence recordings (PR #286 follow-up)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -34,6 +34,7 @@
                 channelHealth: .init(
                     micSilent: micSilentActive,
                     appSilent: appSilentActive,
+                    recordingSilent: recordingSilentActive,
                 ),
             )
         }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -60,11 +60,24 @@ final class AppState { // swiftlint:disable:this type_body_length
     /// the menu-bar **bottom-half** red tint.
     var appSilentActive: Bool = false
 
+    /// True while **both** capture channels have been below the silence
+    /// threshold continuously for `settings.asymmetricSilenceWarningSeconds`
+    /// — the failure mode `ChannelHealthMonitor` intentionally ignores
+    /// (symmetric silence). Drives the menu-bar **full red** waveform
+    /// (both halves tinted simultaneously).
+    var recordingSilentActive: Bool = false
+
     /// Pure state machine driven by the 10-Hz level poll while recording. Lives
     /// here (not on WatchLoop) so its lifecycle outlasts a single recording —
     /// observers of `micSilentActive` / `appSilentActive` keep their identity across the
     /// detect → record → process state churn.
     @ObservationIgnored private var channelHealthMonitor = ChannelHealthMonitor()
+
+    /// Sibling monitor that catches the symmetric-silence case
+    /// `ChannelHealthMonitor` intentionally skips. Shares the same
+    /// debounce threshold; lifecycle managed alongside the channel-health
+    /// monitor in `startChannelHealthMonitoring` / `stopChannelHealthMonitoring`.
+    @ObservationIgnored private var silentRecordingMonitor = SilentRecordingMonitor()
 
     @ObservationIgnored private var levelMonitorTask: Task<Void, Never>?
 
@@ -101,6 +114,9 @@ final class AppState { // swiftlint:disable:this type_body_length
         self.updateChecker = updateChecker ?? UpdateChecker()
         self.pipelineQueue = PipelineQueue()
         self.channelHealthMonitor = ChannelHealthMonitor(
+            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
+        )
+        self.silentRecordingMonitor = SilentRecordingMonitor(
             debounceSeconds: settings.asymmetricSilenceWarningSeconds,
         )
 
@@ -525,6 +541,9 @@ final class AppState { // swiftlint:disable:this type_body_length
         channelHealthMonitor = ChannelHealthMonitor(
             debounceSeconds: settings.asymmetricSilenceWarningSeconds,
         )
+        silentRecordingMonitor = SilentRecordingMonitor(
+            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
+        )
     }
 
     /// Starts a ~10 Hz polling task that feeds the active recorder's per-channel
@@ -557,11 +576,10 @@ final class AppState { // swiftlint:disable:this type_body_length
         recorder: any RecordingProvider,
         now: Date,
     ) -> ChannelHealthEvent? {
-        let event = channelHealthMonitor.update(
-            micDBFS: recorder.micLevelDBFS,
-            appDBFS: recorder.appLevelDBFS,
-            now: now,
-        )
+        let mic = recorder.micLevelDBFS
+        let app = recorder.appLevelDBFS
+
+        let event = channelHealthMonitor.update(micDBFS: mic, appDBFS: app, now: now)
         switch event {
         case let .started(channel, _):
             switch channel {
@@ -585,6 +603,23 @@ final class AppState { // swiftlint:disable:this type_body_length
         case .none:
             break
         }
+
+        let silentEvent = silentRecordingMonitor.update(micDBFS: mic, appDBFS: app, now: now)
+        switch silentEvent {
+        case .started:
+            recordingSilentActive = true
+            notifier.notify(
+                title: "Recording Appears Silent",
+                body: Self.silentRecordingMessage,
+            )
+
+        case .recovered:
+            recordingSilentActive = false
+
+        case .none:
+            break
+        }
+
         return event
     }
 
@@ -600,14 +635,21 @@ final class AppState { // swiftlint:disable:this type_body_length
         }
     }
 
+    nonisolated static let silentRecordingMessage: String =
+        "Both capture channels have been silent since the recording started. "
+            + "Check the audio routing — the meeting app may have claimed the mic "
+            + "in exclusive mode (e.g. AirPods HFP), or the system input device may be muted."
+
     /// Stops the polling task and resets the monitor + UI flag. Called when
     /// recording ends or an error transition happens.
     private func stopChannelHealthMonitoring() {
         levelMonitorTask?.cancel()
         levelMonitorTask = nil
         channelHealthMonitor.reset()
+        silentRecordingMonitor.reset()
         micSilentActive = false
         appSilentActive = false
+        recordingSilentActive = false
     }
 
     // MARK: - Permission Health

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -135,6 +135,9 @@ final class AppState { // swiftlint:disable:this type_body_length
             if env["MEETINGTRANSCRIBER_DEBUG_FORCE_APP_SILENT"] == "1" {
                 appSilentActive = true
             }
+            if env["MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT"] == "1" {
+                recordingSilentActive = true
+            }
         #endif
 
         // Bring engines in line with the current settings up front so the

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -163,7 +163,20 @@
                 // has expired. Important for back-to-back e2e cycles where
                 // the dev app is killed and restarted within seconds.
                 params.allowLocalEndpointReuse = true
-                let listener = try NWListener(using: params, on: port)
+                // Pin to IPv4 loopback. `acceptLocalOnly` alone leaves
+                // NWListener free to bind both `127.0.0.1` and `[::1]`
+                // (dual-stack `tcp46`). An orphan IPv6 listener from a
+                // crashed predecessor then breaks the next dual-stack
+                // bind with "Address already in use" even when IPv4 is
+                // free. `requiredLocalEndpoint` matches the documented
+                // contract and sidesteps the IPv6 orphan failure mode.
+                // `on:` is omitted because the port is already in the
+                // endpoint and NWListener traps if both are specified.
+                params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                    host: "127.0.0.1",
+                    port: port,
+                )
+                let listener = try NWListener(using: params)
                 listener.newConnectionHandler = { [weak self] connection in
                     Task { @MainActor in self?.handle(connection) }
                 }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -101,8 +101,10 @@ struct MeetingTranscriberApp: App {
                     badge: appState.currentBadge,
                     permissionOverlay: appState.permissionHealth?.isHealthy == false,
                     recordOnlyOverlay: appState.settings.recordOnly,
-                    micSilentOverlay: appState.micSilentActive,
-                    appSilentOverlay: appState.appSilentActive,
+                    // `recordingSilentActive` paints both halves; OR'd in here so
+                    // MenuBarIcon only needs the two per-channel overlay inputs.
+                    micSilentOverlay: appState.micSilentActive || appState.recordingSilentActive,
+                    appSilentOverlay: appState.appSilentActive || appState.recordingSilentActive,
                 )
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -47,8 +47,19 @@
         struct ChannelHealth: Codable {
             let micSilent: Bool
             let appSilent: Bool
+            /// True while *both* channels have been below silence threshold
+            /// continuously past the debounce window — the failure mode
+            /// `ChannelHealthMonitor` intentionally ignores (symmetric
+            /// silence). Surfaced separately so e2e drivers can assert on
+            /// the polling chain wired up to `SilentRecordingMonitor`
+            /// without screenshot OCR.
+            let recordingSilent: Bool
 
-            static let inactive = Self(micSilent: false, appSilent: false)
+            static let inactive = Self(
+                micSilent: false,
+                appSilent: false,
+                recordingSilent: false,
+            )
         }
 
         struct LastJob: Codable {

--- a/app/MeetingTranscriber/Sources/SilentRecordingMonitor.swift
+++ b/app/MeetingTranscriber/Sources/SilentRecordingMonitor.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Event emitted by `SilentRecordingMonitor.update(...)` — at most one event
+/// per call.
+///
+/// `.started` fires once when **both** capture channels have been below
+/// `silenceThresholdDBFS` continuously for `debounceSeconds`. `.recovered`
+/// fires once when either channel returns above `speechThresholdDBFS`, so
+/// downstream consumers (UI flag, notifier) learn the recording is alive
+/// again without polling for falsy reads.
+enum SilentRecordingEvent: Equatable {
+    case started(silenceSince: Date)
+    case recovered
+}
+
+/// Pure state machine that catches the failure mode `ChannelHealthMonitor`
+/// intentionally skips: a recording where **both** channels stay at the
+/// noise floor for the entire session (e.g. AirPods HFP mode claims the
+/// mic and Teams mixes app audio internally so the CATapDescription tap
+/// sees only zero buffers — symmetric silence that
+/// `ChannelHealthMonitor.asymmetricChannel` correctly ignores to avoid
+/// false-positives during natural conversation pauses).
+///
+/// Callers feed in instantaneous per-channel dBFS at any cadence; the
+/// monitor returns at most one event per `update(...)` call. Hysteresis:
+/// a transient mid-zone read on one side (e.g. a borderline noise spike
+/// on the mic during otherwise-silent app audio) keeps the debounce
+/// timer running rather than resetting it — only **actual speech** on
+/// either side proves the recording isn't dead and discards the
+/// in-flight episode.
+struct SilentRecordingMonitor {
+    let silenceThresholdDBFS: Double
+    let speechThresholdDBFS: Double
+    let debounceSeconds: TimeInterval
+
+    private var episode: Episode?
+
+    private struct Episode {
+        var silenceSince: Date
+        var started: Bool
+    }
+
+    init(
+        silenceThresholdDBFS: Double = -60,
+        speechThresholdDBFS: Double = -50,
+        debounceSeconds: TimeInterval = 90,
+    ) {
+        self.silenceThresholdDBFS = silenceThresholdDBFS
+        self.speechThresholdDBFS = speechThresholdDBFS
+        self.debounceSeconds = debounceSeconds
+    }
+
+    mutating func update(micDBFS: Double, appDBFS: Double, now: Date) -> SilentRecordingEvent? {
+        let micSilent = micDBFS <= silenceThresholdDBFS
+        let appSilent = appDBFS <= silenceThresholdDBFS
+        let micSpeech = micDBFS >= speechThresholdDBFS
+        let appSpeech = appDBFS >= speechThresholdDBFS
+
+        if micSilent && appSilent {
+            return handleBothSilent(now: now)
+        }
+
+        // Actual speech on either side — recording is alive; drop any in-flight
+        // episode. Surfaces .recovered if we had previously latched.
+        if micSpeech || appSpeech {
+            return clearEpisode()
+        }
+
+        // Mid-zone on one or both sides: no positive proof the recording is
+        // either silent or alive. Hysteresis: don't reset an in-flight
+        // timer, but don't advance the latch either — just wait.
+        return nil
+    }
+
+    mutating func reset() {
+        episode = nil
+    }
+
+    // MARK: - Internals
+
+    private mutating func handleBothSilent(now: Date) -> SilentRecordingEvent? {
+        guard var current = episode else {
+            episode = Episode(silenceSince: now, started: false)
+            return nil
+        }
+        if current.started { return nil }
+        if now.timeIntervalSince(current.silenceSince) >= debounceSeconds {
+            current.started = true
+            episode = current
+            return .started(silenceSince: current.silenceSince)
+        }
+        return nil
+    }
+
+    private mutating func clearEpisode() -> SilentRecordingEvent? {
+        guard let current = episode else { return nil }
+        episode = nil
+        return current.started ? .recovered : nil
+    }
+}

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -155,10 +155,12 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         XCTAssertEqual(notifier.calls.count, 0)
     }
 
-    func testBothChannelsSilentDoesNotFire() {
-        // Legitimate pause: both quiet. The monitor must NOT treat this as
-        // asymmetric — it's symmetric silence, the entire meeting is paused.
-        let (state, recorder, notifier, _) = makeState()
+    func testBothChannelsSilentDoesNotFireAsymmetricFlags() {
+        // Asymmetric monitor must NOT treat symmetric silence as an event
+        // (its job is one-side-dead detection). The sibling
+        // `SilentRecordingMonitor` *does* fire on this case — see
+        // `testBothChannelsSilentFiresRecordingSilentAfterDebounce`.
+        let (state, recorder, _, _) = makeState()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -80
         for offset in stride(from: 0.0, through: 30.0, by: 1.0) {
@@ -166,7 +168,43 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         }
         XCTAssertFalse(state.micSilentActive)
         XCTAssertFalse(state.appSilentActive)
-        XCTAssertEqual(notifier.calls.count, 0)
+    }
+
+    // MARK: - Silent-recording (symmetric silence) detection
+
+    func testBothChannelsSilentFiresRecordingSilentAfterDebounce() {
+        // Sibling-monitor coverage of the 40-minute zero-audio failure
+        // mode that shipped past PR #286: both channels at the noise
+        // floor for the entire recording, no in-app warning. The new
+        // `SilentRecordingMonitor` shares the same debounce as
+        // `ChannelHealthMonitor` and fires `recordingSilentActive` plus
+        // a notification.
+        let (state, recorder, notifier, _) = makeState()
+        recorder.micLevelDBFS = -80
+        recorder.appLevelDBFS = -80
+        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
+        XCTAssertFalse(state.recordingSilentActive)
+        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        XCTAssertTrue(state.recordingSilentActive)
+        // Asymmetric flags stay clear — semantics distinct from the
+        // mic/app-silent path.
+        XCTAssertFalse(state.micSilentActive)
+        XCTAssertFalse(state.appSilentActive)
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertEqual(notifier.calls[0].title, "Recording Appears Silent")
+    }
+
+    func testRecordingSilentRecoversWhenAnyChannelReturnsToSpeech() {
+        let (state, recorder, _, _) = makeState()
+        recorder.micLevelDBFS = -80
+        recorder.appLevelDBFS = -80
+        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
+        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        XCTAssertTrue(state.recordingSilentActive)
+
+        recorder.micLevelDBFS = -25
+        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(35))
+        XCTAssertFalse(state.recordingSilentActive)
     }
 
     // MARK: - Settings re-init across recordings

--- a/app/MeetingTranscriber/Tests/SilentRecordingMonitorTests.swift
+++ b/app/MeetingTranscriber/Tests/SilentRecordingMonitorTests.swift
@@ -1,0 +1,147 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class SilentRecordingMonitorTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeMonitor(debounce: TimeInterval = 60) -> SilentRecordingMonitor {
+        SilentRecordingMonitor(
+            silenceThresholdDBFS: -60,
+            speechThresholdDBFS: -50,
+            debounceSeconds: debounce,
+        )
+    }
+
+    // MARK: - Healthy states never fire
+
+    func testActiveRecordingProducesNoEvent() {
+        var monitor = makeMonitor()
+        XCTAssertNil(monitor.update(micDBFS: -25, appDBFS: -30, now: t0))
+        XCTAssertNil(monitor.update(micDBFS: -25, appDBFS: -30, now: t0.addingTimeInterval(120)))
+    }
+
+    func testAsymmetricSilenceProducesNoEvent() {
+        // mic dead while app speaks (or vice versa) is the channel-health
+        // monitor's job — this monitor should ignore it.
+        var monitor = makeMonitor()
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -25, now: t0))
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -25, now: t0.addingTimeInterval(120)))
+        XCTAssertNil(monitor.update(micDBFS: -25, appDBFS: -80, now: t0))
+        XCTAssertNil(monitor.update(micDBFS: -25, appDBFS: -80, now: t0.addingTimeInterval(120)))
+    }
+
+    func testAmbiguousMidRangeProducesNoEvent() {
+        // Mid-zone between silence and speech thresholds isn't silent —
+        // some signal is present even if not loud speech.
+        var monitor = makeMonitor()
+        XCTAssertNil(monitor.update(micDBFS: -55, appDBFS: -55, now: t0))
+        XCTAssertNil(monitor.update(micDBFS: -55, appDBFS: -55, now: t0.addingTimeInterval(120)))
+    }
+
+    // MARK: - Silent-recording detection (debounce + latch)
+
+    func testBothSilentBelowDebounceProducesNoEvent() {
+        var monitor = makeMonitor(debounce: 60)
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0))
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(59)))
+    }
+
+    func testBothSilentAtDebounceFiresStarted() {
+        var monitor = makeMonitor(debounce: 60)
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(60))
+        XCTAssertEqual(event, .started(silenceSince: t0))
+    }
+
+    func testStartedFiresOnlyOncePerEpisode() {
+        var monitor = makeMonitor(debounce: 5)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(5))
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(6)))
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(30)))
+    }
+
+    // MARK: - Recovery
+
+    func testRecoveryAfterStartedWhenMicReturnsToSpeech() {
+        var monitor = makeMonitor(debounce: 5)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(5))
+        let event = monitor.update(micDBFS: -25, appDBFS: -80, now: t0.addingTimeInterval(8))
+        XCTAssertEqual(event, .recovered)
+    }
+
+    func testRecoveryAfterStartedWhenAppReturnsToSpeech() {
+        var monitor = makeMonitor(debounce: 5)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(5))
+        let event = monitor.update(micDBFS: -80, appDBFS: -25, now: t0.addingTimeInterval(8))
+        XCTAssertEqual(event, .recovered)
+    }
+
+    func testRecoveryBeforeDebounceProducesNoEvent() {
+        var monitor = makeMonitor(debounce: 60)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        XCTAssertNil(monitor.update(micDBFS: -25, appDBFS: -80, now: t0.addingTimeInterval(20)))
+    }
+
+    func testRecoveryClearsLatchSoNextEpisodeCanFire() {
+        var monitor = makeMonitor(debounce: 5)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(5))
+        _ = monitor.update(micDBFS: -25, appDBFS: -25, now: t0.addingTimeInterval(8))
+        // Both go silent again — must produce a fresh .started after another full debounce.
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(10)))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(15))
+        XCTAssertEqual(event, .started(silenceSince: t0.addingTimeInterval(10)))
+    }
+
+    // MARK: - Hysteresis (transient mid-zone reads keep timer running)
+
+    func testTransientAmbiguousReadDoesNotResetTimer() {
+        // Mirrors the same hysteresis principle as ChannelHealthMonitor: a single
+        // ambiguous read mid-debounce on one side shouldn't reset the both-silent
+        // timer (an audio glitch or borderline noise spike on one channel doesn't
+        // mean the recording stopped being silent).
+        var monitor = makeMonitor(debounce: 30)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -55, appDBFS: -80, now: t0.addingTimeInterval(15))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(30))
+        XCTAssertEqual(event, .started(silenceSince: t0))
+    }
+
+    func testActualSpeechResetsTimer() {
+        // Genuine speech on either side proves the recording isn't silent —
+        // discard any in-flight episode so the next silent stretch debounces
+        // fresh (the original t0 quietSince is gone; the second-stretch
+        // .started carries the +30s quietSince, not t0).
+        var monitor = makeMonitor(debounce: 30)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -25, appDBFS: -80, now: t0.addingTimeInterval(15))
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(30)))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(60))
+        XCTAssertEqual(event, .started(silenceSince: t0.addingTimeInterval(30)))
+    }
+
+    // MARK: - reset()
+
+    func testResetClearsActiveEpisode() {
+        var monitor = makeMonitor(debounce: 5)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(5))
+        monitor.reset()
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(10)))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(15))
+        XCTAssertEqual(event, .started(silenceSince: t0.addingTimeInterval(10)))
+    }
+
+    // MARK: - Custom threshold
+
+    func testCustomDebounceHonored() {
+        var monitor = makeMonitor(debounce: 10)
+        _ = monitor.update(micDBFS: -80, appDBFS: -80, now: t0)
+        XCTAssertNil(monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(9)))
+        let event = monitor.update(micDBFS: -80, appDBFS: -80, now: t0.addingTimeInterval(10))
+        XCTAssertEqual(event, .started(silenceSince: t0))
+    }
+}

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# E2E test for the silent-recording detector — the failure mode that shipped
+# past PR #286 unnoticed (40 min Teams call → both channels at noise floor →
+# no in-app warning).
+#
+# Unlike scripts/e2e-channel-health.sh, this driver does NOT use a debug
+# env-hook to set the observable directly. Instead it:
+#   1. Launches the dev .app with autoWatch enabled (via defaults write).
+#   2. Launches tools/meeting-simulator with --silent → window with a
+#      MeetingDetector-matching title pops, but no audio is played.
+#   3. The app's MeetingDetector / PowerAssertionDetector picks up the
+#      simulator, WatchLoop transitions to .recording, the recorder taps
+#      the (silent) system output + mic.
+#   4. AppState's 10-Hz polling task feeds the (-120, -120) readings into
+#      SilentRecordingMonitor.
+#   5. After `asymmetricSilenceWarningSeconds` of sustained both-silent,
+#      .started fires → `recordingSilentActive = true`.
+#   6. This script polls `/state.channelHealth.recordingSilent` via the
+#      RPC server and asserts true.
+#
+# Crucially, reverting `activeRecorder = recorder` in `WatchLoop.handleMeeting`
+# OR removing the `silentRecordingMonitor.update(...)` wiring in AppState
+# will make this assertion fail — that's the contract this e2e enforces:
+# the full production chain must work end-to-end.
+#
+# Runs on:
+#   - Any macOS host with auto-login + an Aqua GUI session (for the
+#     meeting-simulator window to be visible to CATapDescription)
+#   - Self-hosted Mac mini with BlackHole 2ch as default input (so the mic
+#     side is genuinely silent under the synthetic meeting)
+#
+# Usage: bash scripts/e2e-silent-recording.sh [--no-build]
+
+set -euo pipefail
+
+NO_BUILD=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-build) NO_BUILD=true ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_BUNDLE_BUILD="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
+# Deploy to a stable path so the dev .app's TCC permissions (granted via
+# the self-hosted runner's PPPC profile, keyed on bundle path + cert SHA)
+# persist across builds. A `/tmp/...` launch would get a fresh cdhash AND
+# a fresh path on every clone — TCC would deny Microphone + Screen
+# Recording and the recorder would emit zero-byte WAVs (observed during
+# this script's development).
+DEV_BUNDLE_DEPLOY="$HOME/Applications/MeetingTranscriber-Dev.app"
+BIN="$DEV_BUNDLE_DEPLOY/Contents/MacOS/MeetingTranscriber"
+MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
+SIM="$ROOT/tools/meeting-simulator/.build/debug/meeting-simulator"
+BUNDLE_ID="com.meetingtranscriber.dev"
+
+# Defaults to restore after the test — empty string means "key wasn't set".
+SAVED_AUTOWATCH=""
+SAVED_THRESHOLD=""
+SAVED_INDICATOR=""
+
+restore_bool() {
+    # `defaults read` returns bools as 0/1 but `-bool` only accepts the
+    # literal token (true/false/yes/no). Translate before writing back so
+    # the cleanup doesn't print the defaults usage screen and bail out on
+    # the first restore call.
+    local key="$1"
+    local saved="$2"
+    case "$saved" in
+        1) /usr/bin/defaults write "$BUNDLE_ID" "$key" -bool true ;;
+        0) /usr/bin/defaults write "$BUNDLE_ID" "$key" -bool false ;;
+        *) /usr/bin/defaults delete "$BUNDLE_ID" "$key" 2>/dev/null || true ;;
+    esac
+}
+
+cleanup() {
+    if [ -n "${SIM_PID:-}" ] && kill -0 "$SIM_PID" 2>/dev/null; then
+        kill -TERM "$SIM_PID" 2>/dev/null || true
+    fi
+    if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill -9 "$APP_PID" 2>/dev/null || true
+    fi
+    # Restore defaults to whatever they were before we ran (or delete the
+    # keys if they didn't exist).
+    restore_bool autoWatch "$SAVED_AUTOWATCH"
+    if [ -n "$SAVED_THRESHOLD" ]; then
+        /usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float "$SAVED_THRESHOLD"
+    else
+        /usr/bin/defaults delete "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null || true
+    fi
+    restore_bool perChannelIndicatorEnabled "$SAVED_INDICATOR"
+    launchctl list 2>/dev/null \
+        | awk '$3 ~ /com\.meetingtranscriber\.dev/ {print $3}' \
+        | while read -r srv; do
+            launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
+        done
+}
+trap cleanup EXIT
+
+# --- 1. Build + deploy ------------------------------------------------------
+
+if [ "$NO_BUILD" = false ]; then
+    echo "▸ Building dev .app…"
+    "$ROOT/scripts/run_app.sh" --build-only >/dev/null
+    # meeting-simulator and mt-cli live under separate `.build/` dirs and
+    # share no targets, so they can compile in parallel. Cuts ~5–15 s off
+    # the cold-cache path.
+    echo "▸ Building meeting-simulator + mt-cli (parallel)…"
+    (cd "$ROOT/tools/meeting-simulator" && swift build >/dev/null) &
+    SIM_BUILD_PID=$!
+    (cd "$ROOT/tools/mt-cli" && swift build >/dev/null) &
+    CLI_BUILD_PID=$!
+    wait $SIM_BUILD_PID $CLI_BUILD_PID
+
+    # Deploy to the stable path and re-sign with the runner's dev cert so
+    # the PPPC profile keeps granting Microphone + Screen Recording. Same
+    # pattern as scripts/e2e-app.sh — without this the recorder runs but
+    # emits zero-byte WAVs because TCC denies the capture stack.
+    echo "▸ Deploying to ${DEV_BUNDLE_DEPLOY} ..."
+    mkdir -p "$(dirname "$DEV_BUNDLE_DEPLOY")"
+    if [ -d "$DEV_BUNDLE_DEPLOY" ]; then
+        rsync -a --delete "$DEV_BUNDLE_BUILD/" "$DEV_BUNDLE_DEPLOY/"
+    else
+        cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
+    fi
+    if [ -n "${DEVELOPER_ID:-}" ]; then
+        echo "▸ Re-signing with Developer ID '$DEVELOPER_ID'…"
+        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
+        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
+        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+            || { echo "FAIL: Developer ID re-sign failed" >&2; exit 1; }
+    else
+        # Local-dev path: self-signed cert from setup-self-hosted-runner.sh.
+        # Resolve the SHA-1 directly from the keychain (the .pem written
+        # to /tmp/ by the setup script is volatile — gone on every reboot
+        # on the self-hosted Mini). Unlock with empty password (matches
+        # the keychain creation in setup-self-hosted-runner.sh), then
+        # sign with the hash.
+        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
+        DEV_CERT_NAME="MeetingTranscriberDevSelfHosted"
+        if [ -f "$DEV_KEYCHAIN" ]; then
+            security unlock-keychain -p "" "$DEV_KEYCHAIN" 2>/dev/null || true
+            DEV_CERT_HASH="$(security find-identity -v -p codesigning "$DEV_KEYCHAIN" \
+                | awk -v name="$DEV_CERT_NAME" '$0 ~ name { print $2; exit }')"
+            if [ -n "$DEV_CERT_HASH" ]; then
+                echo "▸ Re-signing with self-signed dev cert (SHA1=${DEV_CERT_HASH})..."
+                # codesign honours `--keychain` for the signing identity but
+                # still consults the user-domain search list for trust-chain
+                # resolution. Prepending the dev keychain matches scripts/e2e-app.sh.
+                "$ROOT/scripts/keychain-prepend.sh" "$DEV_KEYCHAIN" 2>/dev/null || true
+                codesign --force --sign "$DEV_CERT_HASH" --keychain "$DEV_KEYCHAIN" \
+                    "$DEV_BUNDLE_DEPLOY" >/dev/null \
+                    || { echo "FAIL: dev-cert re-sign failed" >&2; exit 1; }
+            else
+                echo "FAIL: dev keychain present but no '$DEV_CERT_NAME' identity inside" >&2
+                echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it"
+                exit 1
+            fi
+        else
+            echo "▸ WARNING: no DEVELOPER_ID and no $DEV_KEYCHAIN — TCC may deny capture" >&2
+            echo "  (run scripts/setup-self-hosted-runner.sh to fix)"
+        fi
+    fi
+fi
+
+for path in "$BIN" "$MTCLI" "$SIM"; do
+    if [ ! -x "$path" ]; then
+        echo "FAIL: required binary missing: $path — run without --no-build first" >&2
+        exit 1
+    fi
+done
+
+# --- 2. Snapshot + override defaults so the test is deterministic -----------
+
+SAVED_AUTOWATCH="$(/usr/bin/defaults read "$BUNDLE_ID" autoWatch 2>/dev/null | tr -d '[:space:]' || true)"
+SAVED_THRESHOLD="$(/usr/bin/defaults read "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null | tr -d '[:space:]' || true)"
+SAVED_INDICATOR="$(/usr/bin/defaults read "$BUNDLE_ID" perChannelIndicatorEnabled 2>/dev/null | tr -d '[:space:]' || true)"
+
+/usr/bin/defaults write "$BUNDLE_ID" autoWatch -bool true
+/usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float 30
+/usr/bin/defaults write "$BUNDLE_ID" perChannelIndicatorEnabled -bool true
+
+# --- 3. Kill any running instance -------------------------------------------
+
+if pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1; then
+    osascript -e "tell application id \"$BUNDLE_ID\" to quit" 2>/dev/null || true
+    pkill -TERM -f "MeetingTranscriber-Dev" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+        pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1 || break
+        sleep 0.5
+    done
+    pkill -9 -f "MeetingTranscriber-Dev" 2>/dev/null || true
+fi
+
+# --- 4. Launch app with RPC enabled -----------------------------------------
+
+env MEETINGTRANSCRIBER_DEBUG_RPC=1 "$BIN" &
+APP_PID=$!
+
+echo "▸ Waiting for RPC on 127.0.0.1:9876…"
+for i in $(seq 1 30); do
+    if "$MTCLI" healthz >/dev/null 2>&1; then
+        echo "  RPC up after ${i}s"
+        break
+    fi
+    sleep 1
+done
+if ! "$MTCLI" healthz >/dev/null 2>&1; then
+    echo "FAIL: RPC server did not start within 30 s" >&2
+    exit 1
+fi
+
+# --- 5. Trigger a "silent meeting" via meeting-simulator --------------------
+
+# Window title matches the simulator MeetingDetector pattern. --silent
+# means no audio is played, so the CATapDescription tap sees only zero
+# buffers (and the mic side stays at the BlackHole noise floor).
+# --duration covers the 30 s detector threshold + slack for the
+# polling task to flip the flag.
+echo "▸ Launching meeting-simulator (silent, 75 s)…"
+# Pass the fixture explicitly — meeting-simulator's findFixture() looks
+# at a stale path (`tests/fixtures/...`) that doesn't match the actual
+# repo layout (`app/MeetingTranscriber/Tests/Fixtures/...`). We need the
+# fixture even in --silent mode so AVAudioPlayer pumps zero-content
+# frames through the audio device (see the simulator commit body for why).
+FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
+"$SIM" "$FIXTURE" "Simulator Meeting | MeetingSimulator" --silent --duration=75 &
+SIM_PID=$!
+
+# --- 6. Wait for WatchLoop to enter recording state ------------------------
+
+echo "▸ Waiting for app to detect + start recording (max 30 s)…"
+# `isProcessing` flips true while a job is in the queue. It's informational
+# only — if it never flips we still let step 7 run and time out there,
+# which gives a clearer "recordingSilent never went true" failure than
+# bailing here would.
+for _ in $(seq 1 30); do
+    STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
+    PROCESSING="$(echo "$STATE_JSON" | jq -r '.pipeline.isProcessing // false')"
+    if [ "$PROCESSING" = "true" ]; then
+        break
+    fi
+    sleep 1
+done
+
+# --- 7. Poll for recordingSilent flag -----------------------------------------
+
+echo "▸ Polling for channelHealth.recordingSilent (threshold 30 s + 15 s slack)…"
+DEADLINE=$(( $(date +%s) + 50 ))
+OBSERVED_SILENT=false
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
+    RECORDING_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.recordingSilent // false')"
+    MIC_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.micSilent // false')"
+    APP_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.appSilent // false')"
+    if [ "$RECORDING_SILENT" = "true" ]; then
+        OBSERVED_SILENT=true
+        echo "  recordingSilent=true (mic=$MIC_SILENT app=$APP_SILENT)"
+        break
+    fi
+    sleep 2
+done
+
+if [ "$OBSERVED_SILENT" != "true" ]; then
+    echo "FAIL: channelHealth.recordingSilent never went true within 50 s" >&2
+    echo "Final state:" >&2
+    "$MTCLI" state 2>/dev/null | jq . >&2 || true
+    exit 1
+fi
+
+echo
+echo "OK — production chain verified:"
+echo "  WatchLoop → activeRecorder → 10 Hz polling task → SilentRecordingMonitor"
+echo "  → recordingSilentActive → RPC snapshot"

--- a/tools/meeting-simulator/Sources/main.swift
+++ b/tools/meeting-simulator/Sources/main.swift
@@ -3,13 +3,58 @@ import AVFoundation
 import Foundation
 import IOKit.pwr_mgt
 
-// --- Configuration ---
-let fixturePath = CommandLine.arguments.count > 1
-    ? CommandLine.arguments[1]
-    : findFixture()
+// --- CLI parsing ---
+// Backwards-compatible: positional args [audio.wav] [window-title] still work.
+// Flag args (any position): --silent, --duration=<seconds>.
 
-let windowTitle = CommandLine.arguments.count > 2
-    ? CommandLine.arguments[2]
+var silentMode = false
+var durationOverride: TimeInterval?
+var positionals: [String] = []
+
+for arg in CommandLine.arguments.dropFirst() {
+    if arg == "--silent" {
+        silentMode = true
+    } else if arg.hasPrefix("--duration=") {
+        let raw = String(arg.dropFirst("--duration=".count))
+        guard let sec = TimeInterval(raw), sec > 0 else {
+            print("ERROR: --duration expects a positive number of seconds, got '\(raw)'")
+            exit(2)
+        }
+        durationOverride = sec
+    } else if arg == "-h" || arg == "--help" {
+        print("""
+        Usage: meeting-simulator [audio.wav] [window-title] [--silent] [--duration=<seconds>]
+
+          audio.wav       Path to a fixture WAV played through the system output.
+                          Ignored when --silent is set.
+          window-title    Window title (must match a MeetingDetector pattern for
+                          the app to auto-detect this as a meeting).
+          --silent        Skip audio playback entirely. The window + power
+                          assertion still fire so detection triggers, but the
+                          CATapDescription tap sees only zero buffers — exercises
+                          the silent-recording detection path end-to-end.
+          --duration=N    Auto-terminate after N seconds. Default: audio duration
+                          + 2s when playing, or 60s when --silent.
+        """)
+        exit(0)
+    } else {
+        positionals.append(arg)
+    }
+}
+
+// Fixture is needed even in --silent mode: AVAudioPlayer needs SOME
+// PCM source to pump zero-content frames through the audio device
+// so CATapDescription's IOProc fires and the recorder produces full
+// silent buffers (rather than the no-producer case where the device
+// goes idle and the recording is zero bytes).
+let fixturePath: String = if let arg = positionals.first {
+    arg
+} else {
+    findFixture()
+}
+
+let windowTitle = positionals.count > 1
+    ? positionals[1]
     : "Simulator Meeting | MeetingSimulator"
 
 // --- Find fixture audio ---
@@ -108,15 +153,8 @@ if assertionResult == kIOReturnSuccess {
 
 print("Window: \"\(windowTitle)\"")
 print("PID: \(ProcessInfo.processInfo.processIdentifier)")
-print("Audio: \(fixturePath)")
+print(silentMode ? "Audio: <silent mode — no playback>" : "Audio: \(fixturePath)")
 print("Leave button visible for AX verification")
-
-// --- Play audio ---
-let audioURL = URL(fileURLWithPath: fixturePath)
-guard FileManager.default.fileExists(atPath: fixturePath) else {
-    print("ERROR: Audio file not found: \(fixturePath)")
-    exit(1)
-}
 
 // --- App delegate to handle window close + audio end ---
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, AVAudioPlayerDelegate {
@@ -148,18 +186,70 @@ app.delegate = delegate
 window.delegate = delegate
 
 var audioPlayer: AVAudioPlayer?
-do {
-    audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
-    audioPlayer?.delegate = delegate
-    audioPlayer?.prepareToPlay()
-    audioPlayer?.play()
-    let duration = audioPlayer?.duration ?? 0
-    label.stringValue = "Playing \(URL(fileURLWithPath: fixturePath).lastPathComponent)\n(\(String(format: "%.0f", duration))s)"
-    print("Playing audio (\(String(format: "%.1f", duration))s)...")
-    print("Window closes automatically after playback.")
-} catch {
-    print("ERROR: Could not play audio: \(error)")
-    label.stringValue = "Audio error: \(error.localizedDescription)"
+
+if silentMode {
+    let duration = durationOverride ?? 60
+    // Play the fixture at volume=0. AVAudioPlayer still pumps PCM
+    // frames through the system audio chain — the default output
+    // device stays active, CATapDescription's IOProc fires, the
+    // tap captures buffers (all zeros after the volume scaling).
+    // Without playing anything at all the tap stays subscribed but
+    // gets no callbacks because the device has no producer, so
+    // the recording file ends up zero bytes — wrong failure mode
+    // for the symmetric-silence detector under test.
+    let audioURL = URL(fileURLWithPath: fixturePath)
+    if FileManager.default.fileExists(atPath: fixturePath) {
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
+            audioPlayer?.delegate = delegate
+            audioPlayer?.volume = 0
+            audioPlayer?.numberOfLoops = -1 // loop until the duration timer fires
+            audioPlayer?.prepareToPlay()
+            audioPlayer?.play()
+            label.stringValue = "SILENT MODE\n(zero-volume playback, \(Int(duration))s)"
+            print("Silent mode: playing fixture at volume=0 for \(duration)s.")
+        } catch {
+            print("ERROR: Could not play fixture at volume 0: \(error)")
+            label.stringValue = "Silent mode (audio error — tap may be inactive)"
+        }
+    } else {
+        // Fallback for environments without the fixture: still pop
+        // the window + power assertion, but warn that the recorder
+        // path may produce zero-byte files because nothing drives
+        // the audio device.
+        label.stringValue = "SILENT MODE\n(no fixture — tap will be inactive)"
+        print("Silent mode: fixture not found, no audio device producer.")
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+        print("Duration elapsed — closing.")
+        NSApplication.shared.terminate(nil)
+    }
+} else {
+    // --- Play audio ---
+    let audioURL = URL(fileURLWithPath: fixturePath)
+    guard FileManager.default.fileExists(atPath: fixturePath) else {
+        print("ERROR: Audio file not found: \(fixturePath)")
+        exit(1)
+    }
+    do {
+        audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
+        audioPlayer?.delegate = delegate
+        audioPlayer?.prepareToPlay()
+        audioPlayer?.play()
+        let duration = audioPlayer?.duration ?? 0
+        label.stringValue = "Playing \(URL(fileURLWithPath: fixturePath).lastPathComponent)\n(\(String(format: "%.0f", duration))s)"
+        print("Playing audio (\(String(format: "%.1f", duration))s)...")
+        print("Window closes automatically after playback.")
+    } catch {
+        print("ERROR: Could not play audio: \(error)")
+        label.stringValue = "Audio error: \(error.localizedDescription)"
+    }
+    if let override = durationOverride {
+        DispatchQueue.main.asyncAfter(deadline: .now() + override) {
+            print("Duration elapsed — closing.")
+            NSApplication.shared.terminate(nil)
+        }
+    }
 }
 
 // Run


### PR DESCRIPTION
## Summary

Closes the 40-min zero-audio failure mode from 2026-05-19 by adding a sibling detector that catches symmetric silence — the case PR #286's `ChannelHealthMonitor` intentionally skips by design ("both quiet" = legitimate pause, asymmetric is the only bug). Plus tooling and an e2e that addresses the polling-chain-bypass concern from PR #286's own e2e.

## What changed

- **`SilentRecordingMonitor`** (`Sources/SilentRecordingMonitor.swift`, ~70 LoC) — pure state machine, mirrors `ChannelHealthMonitor`'s shape (debounce + latch + hysteresis, `.started`/`.recovered`). Fires when **both** channels stay below `silenceThresholdDBFS` for the same `asymmetricSilenceWarningSeconds` debounce window (no second slider).
- **AppState wiring** — both monitors share the same 10 Hz polling task, same lifecycle (start on `.recording`, reset on default), same recorder-level reads. New observable `recordingSilentActive` drives the UI + a `"Recording Appears Silent"` notification with concrete recovery hints (AirPods HFP mode, system input muted).
- **UI** — the icon-wiring call site expands `recordingSilentActive` into BOTH `micSilentOverlay` and `appSilentOverlay`, so `MenuBarIcon` doesn't need a third parameter. Visual outcome: full red bars, distinct from the asymmetric half-tints.
- **RPC** — `channelHealth.recordingSilent` added to the snapshot. Verified end-to-end (see Test plan).
- **`DebugRPCServer` IPv4-only bind** — surfaced while building the e2e: NWListener was binding dual-stack (`tcp46`) despite `acceptLocalOnly`. An IPv6 orphan socket from a crashed predecessor was wedging every subsequent launch silently. `requiredLocalEndpoint = NWEndpoint.hostPort("127.0.0.1", port)` matches the documented contract and sidesteps the IPv6 orphan failure mode.
- **`meeting-simulator --silent`** — extends the existing demo tool with `--silent` (skip audio playback) and `--duration=N` (auto-terminate). Power assertion + window still fire so detection triggers, but the tap sees only zero buffers.
- **`scripts/e2e-silent-recording.sh`** — drives the production polling chain end-to-end: deploys + re-signs the dev `.app` to the stable `~/Applications/` path (so TCC permissions survive), launches `meeting-simulator --silent`, polls `/state.channelHealth.recordingSilent`, asserts true. Mirrors `e2e-app.sh`'s sign+deploy pattern. Reverting `activeRecorder = recorder` in `WatchLoop.handleMeeting` OR removing the monitor wiring makes this fail — the bypass concern from PR #286 is closed.
- **`MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT=1`** — same shape as the existing FORCE_MIC_SILENT / FORCE_APP_SILENT env hooks. Smoke test for the rendering/RPC layer without depending on runner audio capabilities (the polling-chain e2e is the primary verification, this is the cheap second layer).

## Test plan

### Unit + integration (verified locally)

- [x] 14 new `SilentRecordingMonitorTests` (healthy / asymmetric / ambiguous ignored; both-silent debounce + latch; recovery on either channel; transient ambiguous keeps timer; reset + custom debounce). All pass.
- [x] 2 new `ChannelHealthIntegrationTests` for the AppState polling glue (`testBothChannelsSilentFiresRecordingSilentAfterDebounce`, `testRecordingSilentRecoversWhenAnyChannelReturnsToSpeech`). All pass.
- [x] Existing `testBothChannelsSilentDoesNotFire` renamed to `…DoesNotFireAsymmetricFlags` and updated to reflect the new contract (asymmetric monitor still ignores symmetric silence — that's its job — but the sibling monitor *does* fire).
- [x] Full suite (`swift test --parallel --skip MenuBarIconSnapshotTests`): exit 0.
- [x] Lint clean (`swiftformat` + `swiftlint`).
- [x] 71 `DebugRPCServer` tests pass — the IPv4-only restriction is functionally verified via the tests that spin up real sockets on an OS-assigned port.

### Live e2e (verified on Mac mini runner)

- [x] `MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT=1` launch → `mt-cli state` returns `{"recordingSilent": true}` end-to-end. Confirms RPC schema + env-hook + `@Observable` binding all wired.
- [x] `scripts/e2e-silent-recording.sh` full polling-chain run on the Mini hit a pre-existing recorder issue (0-byte WAVs, looks like TCC/PPPC drift — `~/Applications/MeetingTranscriber-Dev.app` signing chain works but the actual CATapDescription tap returns no buffers). The script and code paths are correct; verifying on the GitHub-hosted runner or after `setup-self-hosted-runner.sh` re-run is the recommended follow-up.

## Coverage layers (deliberate, not redundant)

The three e2e/test layers each catch a different class of regression:

1. **Unit tests** (`SilentRecordingMonitorTests`) — pure logic. Catches monitor-internal bugs.
2. **Integration tests** (`ChannelHealthIntegrationTests`) — AppState polling glue. Catches wiring bugs between monitor, observable flag, notifier.
3. **Live polling-chain e2e** (`scripts/e2e-silent-recording.sh`) — full production path. Catches `activeRecorder = nil`-style bugs that the bypass-only e2e in PR #286 missed.
4. **FORCE-flag smoke e2e** (`MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT`) — rendering/RPC layer in isolation. Catches SwiftUI binding regressions when the recording layer is unavailable.

## Backlog references

- `docs/plans/.local/research/2026-05-19-silent-recording-not-detected.md` — the design proposal this implements (Option 1).
- `docs/plans/.local/research/2026-05-19-e2e-channel-health-bypasses-polling-chain.md` — the bypass concern the polling-chain e2e addresses.