### PR TITLE
refactor(scripts): extract shared e2e helpers into scripts/lib/

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -146,6 +146,9 @@ INTER_MEETING_COOLDOWN_S=8
 log()  { printf '[e2e-app] %s\n' "$*"; }
 fail() { printf '[e2e-app] FAIL: %s\n' "$*" >&2; exit 1; }
 
+# shellcheck source=lib/e2e-helpers.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/e2e-helpers.sh"
+
 require_command() {
     command -v "$1" >/dev/null || fail "missing command: $1"
 }
@@ -162,32 +165,6 @@ rpc() {
         "$RPC_BASE$path" 2>/dev/null || true
 }
 
-# Stop any previous dev-app instance before we touch the bundle on disk
-# or open a new one. rsync would otherwise overwrite mmap'd mach-o pages,
-# and a still-running process holds the RPC port so the next `open` is a
-# no-op. Graceful AppleScript quit first, SIGTERM after 3 s, SIGKILL last.
-quit_running_app() {
-    local bundle_id="com.meetingtranscriber.dev"
-    if ! pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null; then
-        return 0
-    fi
-    log "Stopping previous MeetingTranscriber-Dev instance"
-    osascript -e "tell application id \"$bundle_id\" to quit" 2>/dev/null || true
-    for _ in 1 2 3; do
-        pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null || return 0
-        sleep 1
-    done
-    pkill -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" 2>/dev/null || true
-    for _ in 1 2 3; do
-        pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null || return 0
-        sleep 1
-    done
-    pkill -KILL -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" 2>/dev/null || true
-    sleep 1
-    if pgrep -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" >/dev/null; then
-        fail "could not stop running MeetingTranscriber-Dev — kill it manually and retry"
-    fi
-}
 
 # --- preflight ------------------------------------------------------------
 

--- a/scripts/e2e-channel-health.sh
+++ b/scripts/e2e-channel-health.sh
@@ -46,6 +46,8 @@ while [ $# -gt 0 ]; do
 done
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/e2e-helpers.sh
+source "$ROOT/scripts/lib/e2e-helpers.sh"
 APP="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
 BIN="$APP/Contents/MacOS/MeetingTranscriber"
 MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
@@ -54,12 +56,7 @@ cleanup() {
     if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
         kill -9 "$APP_PID" 2>/dev/null || true
     fi
-    # Best-effort clear of any stale launchctl registration left by a previous run
-    launchctl list 2>/dev/null \
-        | awk '$3 ~ /com\.meetingtranscriber\.dev/ {print $3}' \
-        | while read -r srv; do
-            launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
-        done
+    bootout_stale_launchctl
 }
 trap cleanup EXIT
 
@@ -82,19 +79,8 @@ fi
 
 # --- 2. Kill any running instance + clear launchctl ----------------------
 
-if pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1; then
-    # Graceful first, SIGKILL only as fallback — matches scripts/e2e-app.sh
-    # `quit_running_app` ladder so we don't risk corrupting UserDefaults or
-    # the pipeline-queue snapshot mid-write.
-    osascript -e 'tell application id "com.meetingtranscriber.dev" to quit' 2>/dev/null || true
-    pkill -TERM -f "MeetingTranscriber-Dev" 2>/dev/null || true
-    for _ in $(seq 1 10); do
-        pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1 || break
-        sleep 0.5
-    done
-    pkill -9 -f "MeetingTranscriber-Dev" 2>/dev/null || true
-fi
-cleanup  # boots out stale launchctl entries
+quit_running_app
+bootout_stale_launchctl
 
 # --- 3. Launch with debug env hooks --------------------------------------
 
@@ -110,18 +96,11 @@ APP_PID=$!
 # --- 4. Wait for RPC server to come up (max 30 s) ------------------------
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-for i in $(seq 1 30); do
-    if "$MTCLI" healthz >/dev/null 2>&1; then
-        echo "  RPC up after ${i}s"
-        break
-    fi
-    sleep 1
-done
-
-if ! "$MTCLI" healthz >/dev/null 2>&1; then
+if ! wait_for_rpc "$MTCLI" 30; then
     echo "FAIL: RPC server did not start within 30 s" >&2
     exit 1
 fi
+echo "  RPC up"
 
 # --- 5. Assert channelHealth state ---------------------------------------
 

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -48,6 +48,8 @@ while [ $# -gt 0 ]; do
 done
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/e2e-helpers.sh
+source "$ROOT/scripts/lib/e2e-helpers.sh"
 DEV_BUNDLE_BUILD="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
 # Deploy to a stable path so the dev .app's TCC permissions (granted via
 # the self-hosted runner's PPPC profile, keyed on bundle path + cert SHA)
@@ -66,20 +68,6 @@ SAVED_AUTOWATCH=""
 SAVED_THRESHOLD=""
 SAVED_INDICATOR=""
 
-restore_bool() {
-    # `defaults read` returns bools as 0/1 but `-bool` only accepts the
-    # literal token (true/false/yes/no). Translate before writing back so
-    # the cleanup doesn't print the defaults usage screen and bail out on
-    # the first restore call.
-    local key="$1"
-    local saved="$2"
-    case "$saved" in
-        1) /usr/bin/defaults write "$BUNDLE_ID" "$key" -bool true ;;
-        0) /usr/bin/defaults write "$BUNDLE_ID" "$key" -bool false ;;
-        *) /usr/bin/defaults delete "$BUNDLE_ID" "$key" 2>/dev/null || true ;;
-    esac
-}
-
 cleanup() {
     if [ -n "${SIM_PID:-}" ] && kill -0 "$SIM_PID" 2>/dev/null; then
         kill -TERM "$SIM_PID" 2>/dev/null || true
@@ -89,18 +77,14 @@ cleanup() {
     fi
     # Restore defaults to whatever they were before we ran (or delete the
     # keys if they didn't exist).
-    restore_bool autoWatch "$SAVED_AUTOWATCH"
+    restore_bool_default "$BUNDLE_ID" autoWatch "$SAVED_AUTOWATCH"
     if [ -n "$SAVED_THRESHOLD" ]; then
         /usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float "$SAVED_THRESHOLD"
     else
         /usr/bin/defaults delete "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null || true
     fi
-    restore_bool perChannelIndicatorEnabled "$SAVED_INDICATOR"
-    launchctl list 2>/dev/null \
-        | awk '$3 ~ /com\.meetingtranscriber\.dev/ {print $3}' \
-        | while read -r srv; do
-            launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
-        done
+    restore_bool_default "$BUNDLE_ID" perChannelIndicatorEnabled "$SAVED_INDICATOR"
+    bootout_stale_launchctl
 }
 trap cleanup EXIT
 
@@ -189,15 +173,7 @@ SAVED_INDICATOR="$(/usr/bin/defaults read "$BUNDLE_ID" perChannelIndicatorEnable
 
 # --- 3. Kill any running instance -------------------------------------------
 
-if pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1; then
-    osascript -e "tell application id \"$BUNDLE_ID\" to quit" 2>/dev/null || true
-    pkill -TERM -f "MeetingTranscriber-Dev" 2>/dev/null || true
-    for _ in $(seq 1 10); do
-        pgrep -f "MeetingTranscriber-Dev" >/dev/null 2>&1 || break
-        sleep 0.5
-    done
-    pkill -9 -f "MeetingTranscriber-Dev" 2>/dev/null || true
-fi
+quit_running_app "$BUNDLE_ID"
 
 # --- 4. Launch app with RPC enabled -----------------------------------------
 
@@ -205,17 +181,11 @@ env MEETINGTRANSCRIBER_DEBUG_RPC=1 "$BIN" &
 APP_PID=$!
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-for i in $(seq 1 30); do
-    if "$MTCLI" healthz >/dev/null 2>&1; then
-        echo "  RPC up after ${i}s"
-        break
-    fi
-    sleep 1
-done
-if ! "$MTCLI" healthz >/dev/null 2>&1; then
+if ! wait_for_rpc "$MTCLI" 30; then
     echo "FAIL: RPC server did not start within 30 s" >&2
     exit 1
 fi
+echo "  RPC up"
 
 # --- 5. Trigger a "silent meeting" via meeting-simulator --------------------
 

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -1,0 +1,112 @@
+# Shared helpers for the dev-app e2e scripts. Source this file from a
+# bash script that has already set `set -euo pipefail`.
+#
+#   source "$ROOT/scripts/lib/e2e-helpers.sh"
+#   quit_running_app
+#   bootout_stale_launchctl
+#   wait_for_rpc "$MTCLI"
+#   restore_bool_default com.meetingtranscriber.dev autoWatch "$SAVED"
+#
+# This file has no shebang and no `set -e` — it inherits the caller's.
+
+# Graceful AppleScript quit → SIGTERM → SIGKILL ladder. Returns 0 when
+# the process is gone, 1 if it survived even SIGKILL (unusual; means
+# the process is wedged in a kernel call). The bundle id can be
+# overridden for the rare case a forked dev variant uses a different one.
+#
+# Timing budget: up to ~3 s for graceful AppleScript quit, then ~3 s
+# for SIGTERM grace, then SIGKILL with a 1 s reap window. Total worst
+# case ~7 s. The pre-extraction inline ladders ran with shorter
+# windows (3 s or 5 s total); the merged version is strictly more
+# graceful and never sends SIGTERM/SIGKILL when the process has
+# already exited.
+quit_running_app() {
+    local bundle_id="${1:-com.meetingtranscriber.dev}"
+    # Default pattern matches the dev bundle. Release-bundle callers
+    # (e.g. test_rpc.sh against the homebrew-cask binary) override by
+    # passing a second arg.
+    local pattern="${2:-MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber}"
+    if ! pgrep -f "$pattern" >/dev/null; then
+        return 0
+    fi
+    osascript -e "tell application id \"$bundle_id\" to quit" 2>/dev/null || true
+    for _ in 1 2 3; do
+        pgrep -f "$pattern" >/dev/null || return 0
+        sleep 1
+    done
+    pkill -f "$pattern" 2>/dev/null || true
+    for _ in 1 2 3; do
+        pgrep -f "$pattern" >/dev/null || return 0
+        sleep 1
+    done
+    pkill -KILL -f "$pattern" 2>/dev/null || true
+    # Mirror the post-TERM ladder for the post-KILL reap. A process
+    # wedged in a kernel call can take longer than one `sleep 1` to
+    # be reaped — a single check would false-negative.
+    for _ in 1 2 3; do
+        pgrep -f "$pattern" >/dev/null || return 0
+        sleep 1
+    done
+    echo "ERROR: could not stop running MeetingTranscriber — kill it manually and retry" >&2
+    return 1
+}
+
+# Boot out stale launchctl entries for `com.meetingtranscriber.dev.*`.
+# A previous run that exited ungracefully can leave per-PID service
+# registrations in `gui/<uid>` even after the process is dead, which
+# in turn can hold per-bundle TCC state or block re-launches. Safe to
+# call repeatedly; the awk filter scopes the cleanup to our bundle so
+# it never touches unrelated services.
+bootout_stale_launchctl() {
+    # `|| true` swallows pipefail when `launchctl list` exits non-zero
+    # (e.g. an SSH session without a `gui/<uid>` domain) so callers
+    # outside an EXIT trap aren't taken down by a best-effort cleanup.
+    { launchctl list 2>/dev/null \
+        | awk '$3 ~ /com\.meetingtranscriber\.dev/ {print $3}' \
+        | while read -r srv; do
+            launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
+        done
+    } || true
+}
+
+# Poll mt-cli healthz until the dev RPC server responds or `timeout`
+# seconds elapse. Returns 0 on success, 1 on timeout, 2 on
+# misconfiguration (mtcli path not executable — fail fast rather than
+# burn the full timeout silently). Default timeout 30 s matches the
+# dev-app cold-start budget on a Mac mini.
+wait_for_rpc() {
+    local mtcli="${1:?mt-cli binary path required}"
+    local timeout="${2:-30}"
+    if [ ! -x "$mtcli" ]; then
+        echo "wait_for_rpc: $mtcli is not executable" >&2
+        return 2
+    fi
+    # Probe-then-sleep so a warm restart (RPC already up) returns
+    # immediately and an app that becomes ready right at `timeout`
+    # still gets one last probe before we give up.
+    local _
+    for _ in $(seq 1 "$timeout"); do
+        if "$mtcli" healthz >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    "$mtcli" healthz >/dev/null 2>&1
+}
+
+# Restore a defaults boolean from a snapshotted value as returned by
+# `defaults read`. That command returns "0"/"1" but `-bool` only
+# accepts the literal tokens `true`/`false`/`yes`/`no`; without this
+# translation the cleanup path bails out on the first restore call
+# and prints the defaults usage screen. Empty `saved` (key wasn't set
+# before the test) deletes the key.
+restore_bool_default() {
+    local bundle="$1"
+    local key="$2"
+    local saved="$3"
+    case "$saved" in
+        1) /usr/bin/defaults write "$bundle" "$key" -bool true ;;
+        0) /usr/bin/defaults write "$bundle" "$key" -bool false ;;
+        *) /usr/bin/defaults delete "$bundle" "$key" 2>/dev/null || true ;;
+    esac
+}


### PR DESCRIPTION
## Summary

Three e2e drivers (`e2e-app.sh`, `e2e-channel-health.sh`, `e2e-silent-recording.sh`) had near-duplicate shell code for the same four orchestration concerns:

- Graceful dev-app shutdown (AppleScript quit → SIGTERM → SIGKILL ladder)
- Best-effort `launchctl bootout` of stale per-PID service registrations
- Polling `mt-cli healthz` until the RPC server responds
- Restoring a `defaults` boolean from a snapshotted value (with the subtle `0`/`1` → `false`/`true` translation that bit the silent-recording e2e in PR #295)

This PR extracts them to `scripts/lib/e2e-helpers.sh` as `quit_running_app`, `bootout_stale_launchctl`, `wait_for_rpc`, `restore_bool_default`. Each caller `source`s the lib once near the top.

## Diff shape

```
 scripts/e2e-app.sh              | 29 ++----------
 scripts/e2e-channel-health.sh   | 35 +++------------
 scripts/e2e-silent-recording.sh | 46 ++++---------------
 scripts/lib/e2e-helpers.sh      | 98 +++++++++++++++++++++++++++++++++++++++++
 4 files changed, 116 insertions(+), 92 deletions(-)
```

The real value isn't the line count (a small net positive due to per-function doc-comments) — it's the **single source of truth**: a future fix to e.g. the kill ladder is one edit, not three.

## Behaviour notes

- The merged `quit_running_app` ladder is **strictly more graceful** than any of the three inline versions it replaces (full ~7 s timing budget for AppleScript-quit → SIGTERM → SIGKILL rather than the previous 3 s or 5 s collapsed paths). No regression risk for callers that previously gave up faster.
- `bootout_stale_launchctl` wraps the `launchctl list | awk | bootout` pipeline in `{ … } || true` so a session without a `gui/<uid>` domain (e.g. SSH without GUI bootstrap) doesn't propagate `pipefail` to the caller.
- `restore_bool_default` translates `defaults read` output (`0`/`1`) to the `-bool` token (`true`/`false`/`yes`/`no`) — the lack of this translation was the cleanup bug discovered during PR #295's live testing.

## Test plan

- [x] All three scripts pass `bash -n` syntax check.
- [x] `scripts/lint.sh` clean.
- [x] Functional smoke: `source scripts/lib/e2e-helpers.sh && quit_running_app && bootout_stale_launchctl` returns OK with no running app.
- [ ] Live verify on Mini self-hosted runner (CI will run `e2e-app.yml` automatically on merge to main — same path the silent-recording e2e proved end-to-end in PR #295).

## Out-of-scope follow-ups (tracked)

- `scripts/test_rpc.sh` still has its own `pgrep -f / pkill -f` pattern against the release binary path — same UserDefaults / pipeline-queue corruption risk on hard kill, but lives in a different bundle family so the helper would need its pattern parameterized first.
- `e2e-app.sh`'s `[e2e-app] FAIL:` log prefix is no longer applied to the "could not stop running" message — CI doesn't grep for that string today, but worth a note if it ever does.