### PR TITLE
ci(e2e-app): run silent-recording detector e2e as additional lane

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -160,6 +160,24 @@ jobs:
           path: /tmp/e2e-channel-health-menubar.png
           if-no-files-found: ignore
 
+      # Silent-recording detector e2e (PR #295): drives the real
+      # production polling chain — meeting-simulator plays the fixture
+      # at volume=0 so the CATapDescription tap captures buffers of
+      # all-zero content, AppState's 10 Hz polling task accumulates
+      # both-silent ticks, and after 30 s of sustained silence
+      # `SilentRecordingMonitor` fires `.started` which the script
+      # asserts via `/state.channelHealth.recordingSilent`. Unlike
+      # `e2e-channel-health.sh` above, this does NOT use a
+      # FORCE-flag env hook — reverting `activeRecorder = recorder`
+      # in `WatchLoop.handleMeeting` or removing the monitor wiring
+      # in AppState makes this step fail. Closes the polling-chain
+      # bypass gap from #286.
+      # `--no-build` reuses the already-deployed bundle + the
+      # meeting-simulator + mt-cli built during the earlier lanes.
+      - name: Run silent-recording detector E2E
+        timeout-minutes: 3
+        run: bash scripts/e2e-silent-recording.sh --no-build
+
       # Best-effort: capture the simulator's stdout for post-mortem if
       # the driver failed before tearing it down.
       - name: Upload simulator log


### PR DESCRIPTION
## Summary

PR #295 introduced `scripts/e2e-silent-recording.sh` and verified it end-to-end live on the Mini three times, but didn't wire it into CI — the script ran on-demand only. This PR promotes it to an automatic lane inside `e2e-app.yml`.

## Why a new lane in `e2e-app.yml`, not a separate workflow

The earlier backlog research file leaned toward a separate workflow file, but in practice:

- Same Developer ID / signing-keychain setup as the other lanes — duplicating that in a sibling workflow would cost ~50 lines for zero operational benefit.
- Same audio-routing runner (`audio` label). A sibling workflow would serialise behind this one anyway via the runner label — no parallelism gained.
- `--no-build` reuses the bundle + simulator + mt-cli the prior lanes already built. ~30 s saved vs cold.
- Single status check + single schedule + single concurrency group to manage.

## What this lane catches that the existing channel-health lane doesn't

The existing channel-health lane (already in `e2e-app.yml`) uses `MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT=1` to set the AppState observable directly. It verifies the env-hook → SwiftUI → RPC chain but **not** the polling-task chain that turns real audio data into observable state. The polling chain is exactly what PR #286 shipped with a bug in (`activeRecorder = nil` in the auto-watch path).

Reverting `activeRecorder = recorder` in `WatchLoop.handleMeeting` or removing the `SilentRecordingMonitor.update(...)` call in `applyChannelHealthTick`:
- The channel-health lane keeps passing (it doesn't exercise the polling chain).
- The new silent-recording lane fails at the `recordingSilent never went true within 50 s` assertion.

That's the contract this lane enforces.

## Test plan

- [x] YAML syntactically valid.
- [x] Lane ordering correct: after `channel-health` (FORCE-flag smoke), before the signing-keychain cleanup.
- [x] `--no-build` reuses the deployed bundle from the prior lanes (same pattern as the channel-health step).
- [x] 3 min timeout covers the worst case: 75 s simulator playback + 30 s sustained-silence debounce + 15 s slack for the polling task + ~30 s of overhead.
- [x] Verified end-to-end on the Mini runner during PR #295's development (three live runs, all green).
- [ ] First post-merge CI run will execute it on main. Will follow up if it surfaces any flake.