### PR TITLE
fix(ci): align meeting-simulator binary path with e2e-app.sh (release)

### DIFF
--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -60,7 +60,10 @@ DEV_BUNDLE_BUILD="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app
 DEV_BUNDLE_DEPLOY="$HOME/Applications/MeetingTranscriber-Dev.app"
 BIN="$DEV_BUNDLE_DEPLOY/Contents/MacOS/MeetingTranscriber"
 MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
-SIM="$ROOT/tools/meeting-simulator/.build/debug/meeting-simulator"
+# `release/` to align with `scripts/e2e-app.sh` — when both scripts run
+# in the same CI workflow, e2e-app.sh's release build is reused via
+# `--no-build` rather than rebuilt in debug mode.
+SIM="$ROOT/tools/meeting-simulator/.build/release/meeting-simulator"
 BUNDLE_ID="com.meetingtranscriber.dev"
 
 # Defaults to restore after the test — empty string means "key wasn't set".
@@ -95,9 +98,12 @@ if [ "$NO_BUILD" = false ]; then
     "$ROOT/scripts/run_app.sh" --build-only >/dev/null
     # meeting-simulator and mt-cli live under separate `.build/` dirs and
     # share no targets, so they can compile in parallel. Cuts ~5–15 s off
-    # the cold-cache path.
+    # the cold-cache path. meeting-simulator is built in release to match
+    # scripts/e2e-app.sh's `SIMULATOR_BIN` path — re-using its
+    # pre-existing build under `--no-build` instead of producing a second
+    # debug copy.
     echo "▸ Building meeting-simulator + mt-cli (parallel)…"
-    (cd "$ROOT/tools/meeting-simulator" && swift build >/dev/null) &
+    (cd "$ROOT/tools/meeting-simulator" && swift build -c release >/dev/null) &
     SIM_BUILD_PID=$!
     (cd "$ROOT/tools/mt-cli" && swift build >/dev/null) &
     CLI_BUILD_PID=$!


### PR DESCRIPTION
## Summary

The silent-recording lane added to `e2e-app.yml` in #297 runs `scripts/e2e-silent-recording.sh --no-build` after `scripts/e2e-app.sh` has already built the simulator. e2e-app.sh builds in **release** mode (`SIMULATOR_BIN=.build/release/meeting-simulator`), but `e2e-silent-recording.sh` hard-coded `.build/debug/meeting-simulator` — so the `--no-build` path failed with:

```
FAIL: required binary missing: …/tools/meeting-simulator/.build/debug/meeting-simulator
— run without --no-build first
```

First failing run after #297 merged to main: https://github.com/pasrom/meeting-transcriber/actions/runs/26145002758

## Changes

- `SIM` now points at `.build/release/meeting-simulator` to match `e2e-app.sh`.
- The standalone build path (the not-`--no-build` branch) switches to `swift build -c release` so a local `bash scripts/e2e-silent-recording.sh` also lands the binary at the same location.

Both invocation orders — standalone-then-CI or CI-then-standalone on the same checkout — now find the binary.

mt-cli stays in debug because `scripts/e2e-channel-health.sh` (which runs between e2e-app.sh and the silent-recording lane) builds it in debug too. Aligning mt-cli is out of scope here.

## Test plan

- [x] `bash -n scripts/e2e-silent-recording.sh` clean.
- [x] `scripts/lint.sh` clean.
- [x] Local `swift build -c release` produces `.build/release/meeting-simulator`.
- [ ] First post-merge CI run on main re-executes the silent-recording lane against the release binary.