### PR TITLE
refactor(tools): meeting-simulator on swift-argument-parser

### DIFF
--- a/tools/meeting-simulator/Package.resolved
+++ b/tools/meeting-simulator/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "242004f256e82b9c9b949a0a5f7c8edbdc81038e77664b71083d5a604ec4bb23",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tools/meeting-simulator/Package.swift
+++ b/tools/meeting-simulator/Package.swift
@@ -1,10 +1,19 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 import PackageDescription
 
 let package = Package(
     name: "meeting-simulator",
     platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+    ],
     targets: [
-        .executableTarget(name: "meeting-simulator", path: "Sources"),
+        .executableTarget(
+            name: "meeting-simulator",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources",
+        ),
     ]
 )

--- a/tools/meeting-simulator/Sources/main.swift
+++ b/tools/meeting-simulator/Sources/main.swift
@@ -1,177 +1,262 @@
 import AppKit
+import ArgumentParser
 import AVFoundation
 import Foundation
 import IOKit.pwr_mgt
 
-// --- CLI parsing ---
-// Backwards-compatible: positional args [audio.wav] [window-title] still work.
-// Flag args (any position): --silent, --duration=<seconds>.
+@main
+struct MeetingSimulator: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "meeting-simulator",
+        abstract: "Synthetic meeting trigger for the dev app's auto-detect path.",
+        discussion: """
+        Pops a window with a MeetingDetector-matching title and creates the same
+        IOKit power assertion a real Teams / Zoom call would. Plays the fixture
+        WAV through the system output so the CATapDescription tap captures real
+        audio. With --silent, the fixture is played at volume=0 so the audio
+        device stays active but the tap captures only zero-content buffers —
+        used by scripts/e2e-silent-recording.sh to exercise the
+        SilentRecordingMonitor path end-to-end.
+        """,
+    )
 
-var silentMode = false
-var durationOverride: TimeInterval?
-var positionals: [String] = []
+    @Argument(help: "Path to fixture WAV. Defaults to the repo's two_speakers_de.wav.")
+    var audioPath: String?
 
-for arg in CommandLine.arguments.dropFirst() {
-    if arg == "--silent" {
-        silentMode = true
-    } else if arg.hasPrefix("--duration=") {
-        let raw = String(arg.dropFirst("--duration=".count))
-        guard let sec = TimeInterval(raw), sec > 0 else {
-            print("ERROR: --duration expects a positive number of seconds, got '\(raw)'")
-            exit(2)
+    @Argument(help: "Window title. Must match a MeetingDetector pattern for auto-detect to fire.")
+    var windowTitle: String = "Simulator Meeting | MeetingSimulator"
+
+    @Flag(help: """
+    Play the fixture at volume=0 so the audio device stays active but produces
+    zero-content buffers. Without this the CATapDescription tap has no producer
+    and gets no IOProc callbacks, so the recording file ends up zero bytes.
+    """)
+    var silent = false
+
+    @Option(name: .long, help: """
+    Auto-terminate after N seconds. Defaults: audio duration + 2 s (without
+    --silent) or 60 s (with --silent, where there's no
+    audioPlayerDidFinishPlaying callback to drive the natural exit).
+    """)
+    var duration: Double?
+
+    func validate() throws {
+        if let duration, duration <= 0 {
+            throw ValidationError("--duration must be a positive number of seconds, got \(duration).")
         }
-        durationOverride = sec
-    } else if arg == "-h" || arg == "--help" {
-        print("""
-        Usage: meeting-simulator [audio.wav] [window-title] [--silent] [--duration=<seconds>]
+    }
 
-          audio.wav       Path to a fixture WAV played through the system output.
-                          Ignored when --silent is set.
-          window-title    Window title (must match a MeetingDetector pattern for
-                          the app to auto-detect this as a meeting).
-          --silent        Skip audio playback entirely. The window + power
-                          assertion still fire so detection triggers, but the
-                          CATapDescription tap sees only zero buffers — exercises
-                          the silent-recording detection path end-to-end.
-          --duration=N    Auto-terminate after N seconds. Default: audio duration
-                          + 2s when playing, or 60s when --silent.
-        """)
-        exit(0)
+    func run() {
+        let fixturePath = audioPath ?? Self.findFixture()
+        runSimulator(fixturePath: fixturePath, windowTitle: windowTitle, silent: silent, duration: duration)
+    }
+
+    /// Locate the repo's bundled fixture WAV.
+    ///
+    /// `#filePath` resolves to the absolute path of this source file at
+    /// compile time, so walking up from it lands at the repo root regardless
+    /// of where the binary is later executed — works for both `swift run`
+    /// in the package dir and a built binary copied elsewhere, as long as
+    /// the source was compiled from the repo checkout.
+    private static let fixtureRepoRelativePath = "app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
+
+    private static func findFixture() -> String {
+        // Walk Sources/ → meeting-simulator/ → tools/ → repo root. The
+        // fourth deletion is the one that actually lands at the repo
+        // root; without it we'd end up at `tools/` and append a path
+        // that has never existed.
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fromSource = repoRoot.appendingPathComponent(fixtureRepoRelativePath)
+        if FileManager.default.fileExists(atPath: fromSource.path) {
+            return fromSource.path
+        }
+        // Fallback for binaries run from the repo root.
+        if FileManager.default.fileExists(atPath: fixtureRepoRelativePath) {
+            return fixtureRepoRelativePath
+        }
+        FileHandle.standardError.write(Data(
+            "ERROR: Fixture not found at \(fromSource.path) or \(fixtureRepoRelativePath)\n".utf8,
+        ))
+        FileHandle.standardError.write(Data(
+            "Pass the audio path as the first positional argument, or `--help` for usage.\n".utf8,
+        ))
+        Self.exit(withError: ExitCode.failure)
+    }
+}
+
+// MARK: - Simulator runtime
+
+/// Default --duration when --silent is set, since silent mode has no
+/// `audioPlayerDidFinishPlaying` to drive a natural exit.
+private let defaultSilentDuration: Double = 60
+
+/// AppKit lifecycle isn't reentrant — `NSApplication.shared.run()` blocks
+/// forever once started. This runs the whole window + audio + assertion
+/// dance from inside ArgumentParser's `run()` and never returns.
+func runSimulator(fixturePath: String, windowTitle: String, silent: Bool, duration: Double?) {
+    // Fail fast before any AppKit / IOKit state is created.
+    guard FileManager.default.fileExists(atPath: fixturePath) else {
+        FileHandle.standardError.write(Data("ERROR: Audio file not found: \(fixturePath)\n".utf8))
+        exit(1)
+    }
+
+    let app = NSApplication.shared
+    app.setActivationPolicy(.regular)
+
+    let (window, label) = buildMeetingWindow(title: windowTitle)
+    window.makeKeyAndOrderFront(nil)
+    app.activate(ignoringOtherApps: true)
+
+    let assertionID = createPowerAssertion()
+    print("Window: \"\(windowTitle)\"")
+    print("PID: \(ProcessInfo.processInfo.processIdentifier)")
+    print(silent ? "Audio: <silent mode — zero-volume playback>" : "Audio: \(fixturePath)")
+    print("Leave button visible for AX verification")
+
+    let delegate = AppDelegate(assertionID: assertionID)
+    app.delegate = delegate
+    window.delegate = delegate
+
+    // Non-silent mode without an explicit --duration exits via the audio
+    // player's finish callback, so its effective duration is nil.
+    let effectiveDuration = duration ?? (silent ? defaultSilentDuration : nil)
+    startPlayback(
+        fixturePath: fixturePath,
+        silent: silent,
+        silentDuration: effectiveDuration ?? defaultSilentDuration,
+        label: label,
+        delegate: delegate,
+    )
+
+    if let effectiveDuration {
+        DispatchQueue.main.asyncAfter(deadline: .now() + effectiveDuration) {
+            print("Duration elapsed — closing.")
+            NSApplication.shared.terminate(nil)
+        }
+    }
+
+    app.run()
+}
+
+/// Builds the window + content view + Teams-style toolbar. Returns the
+/// window and the status label so callers can update it during playback.
+private func buildMeetingWindow(title: String) -> (NSWindow, NSTextField) {
+    let window = NSWindow(
+        contentRect: NSRect(x: 200, y: 200, width: 800, height: 600),
+        styleMask: [.titled, .closable, .resizable],
+        backing: .buffered,
+        defer: false,
+    )
+    window.title = title
+    window.isReleasedWhenClosed = false
+
+    let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+
+    let label = NSTextField(labelWithString: "Loading audio...")
+    label.font = .systemFont(ofSize: 24)
+    label.alignment = .center
+    label.frame = NSRect(x: 50, y: 300, width: 700, height: 100)
+    contentView.addSubview(label)
+
+    let toolbar = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 60))
+    toolbar.wantsLayer = true
+    toolbar.layer?.backgroundColor = NSColor.darkGray.cgColor
+
+    let muteBtn = NSButton(title: "Mute", target: nil, action: nil)
+    muteBtn.frame = NSRect(x: 200, y: 15, width: 80, height: 30)
+    muteBtn.setAccessibilityLabel("Mute")
+    toolbar.addSubview(muteBtn)
+
+    let cameraBtn = NSButton(title: "Camera", target: nil, action: nil)
+    cameraBtn.frame = NSRect(x: 300, y: 15, width: 80, height: 30)
+    toolbar.addSubview(cameraBtn)
+
+    let shareBtn = NSButton(title: "Share", target: nil, action: nil)
+    shareBtn.frame = NSRect(x: 400, y: 15, width: 80, height: 30)
+    toolbar.addSubview(shareBtn)
+
+    let leaveBtn = NSButton(title: "Leave", target: nil, action: #selector(AppDelegate.leaveClicked))
+    leaveBtn.frame = NSRect(x: 520, y: 15, width: 80, height: 30)
+    leaveBtn.bezelColor = .systemRed
+    leaveBtn.setAccessibilityLabel("Leave")
+    leaveBtn.setAccessibilityIdentifier("leave-call")
+    toolbar.addSubview(leaveBtn)
+
+    contentView.addSubview(toolbar)
+    window.contentView = contentView
+    return (window, label)
+}
+
+/// Creates the same IOKit "prevent display sleep" assertion a real Teams /
+/// Zoom call creates; `PowerAssertionDetector` picks it up via
+/// `IOPMCopyAssertionsByProcess`. Returns the assertion ID so `AppDelegate`
+/// can release it on termination.
+private func createPowerAssertion() -> IOPMAssertionID {
+    var assertionID: IOPMAssertionID = 0
+    let result = IOPMAssertionCreateWithName(
+        "PreventUserIdleDisplaySleep" as CFString,
+        IOPMAssertionLevel(kIOPMAssertionLevelOn),
+        "Simulator Meeting Call in progress" as CFString,
+        &assertionID,
+    )
+    if result == kIOReturnSuccess {
+        print("Power assertion created (ID: \(assertionID))")
     } else {
-        positionals.append(arg)
+        print("WARNING: Could not create power assertion (status: \(result))")
+    }
+    return assertionID
+}
+
+private func startPlayback(
+    fixturePath: String,
+    silent: Bool,
+    silentDuration: Double,
+    label: NSTextField,
+    delegate: AppDelegate,
+) {
+    let audioURL = URL(fileURLWithPath: fixturePath)
+    do {
+        let player = try AVAudioPlayer(contentsOf: audioURL)
+        player.delegate = delegate
+        if silent {
+            // Volume=0 + loop forever keeps the audio device active so the
+            // CATapDescription tap fires its IOProc and captures
+            // zero-content buffers. Skipping playback entirely (no
+            // `AVAudioPlayer` at all) leaves the device with no producer —
+            // the tap stays subscribed but gets no callbacks, and the
+            // recording file ends up zero bytes.
+            player.volume = 0
+            player.numberOfLoops = -1
+            let seconds = Int(silentDuration)
+            label.stringValue = "SILENT MODE\n(zero-volume playback, \(seconds)s)"
+            print("Silent mode: playing fixture at volume=0 for \(seconds)s.")
+        } else {
+            label.stringValue = "Playing \(audioURL.lastPathComponent)\n"
+                + "(\(String(format: "%.0f", player.duration))s)"
+            print("Playing audio (\(String(format: "%.1f", player.duration))s)...")
+            print("Window closes automatically after playback.")
+        }
+        player.prepareToPlay()
+        player.play()
+        delegate.audioPlayer = player
+    } catch {
+        print("ERROR: Could not play audio: \(error)")
+        label.stringValue = "Audio error: \(error.localizedDescription)"
     }
 }
 
-// Fixture is needed even in --silent mode: AVAudioPlayer needs SOME
-// PCM source to pump zero-content frames through the audio device
-// so CATapDescription's IOProc fires and the recorder produces full
-// silent buffers (rather than the no-producer case where the device
-// goes idle and the recording is zero bytes).
-let fixturePath: String = if let arg = positionals.first {
-    arg
-} else {
-    findFixture()
-}
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, AVAudioPlayerDelegate {
+    let assertionID: IOPMAssertionID
+    var audioPlayer: AVAudioPlayer?
 
-let windowTitle = positionals.count > 1
-    ? positionals[1]
-    : "Simulator Meeting | MeetingSimulator"
-
-// --- Find fixture audio ---
-//
-// The fixture lives at `app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav`
-// in the repo. `#filePath` resolves to the absolute path of this source
-// file at compile time, so walking up from it lands at the repo root
-// regardless of where the binary is later executed — works for both
-// `swift run` in the package dir and a built binary copied elsewhere,
-// as long as the source was compiled from the repo checkout.
-private let fixtureRepoRelativePath = "app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
-
-func findFixture() -> String {
-    // Walk Sources/ → meeting-simulator/ → tools/ → repo root. Four
-    // deletions: the fourth is the one that actually lands at the repo
-    // root; without it we'd end up at `tools/` and append a path that
-    // has never existed.
-    let repoRoot = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-    let fromSource = repoRoot.appendingPathComponent(fixtureRepoRelativePath)
-    if FileManager.default.fileExists(atPath: fromSource.path) {
-        return fromSource.path
+    init(assertionID: IOPMAssertionID) {
+        self.assertionID = assertionID
     }
-    // Fallback: a CWD-relative lookup so a user running the binary from
-    // the repo root (e.g. `tools/meeting-simulator/.build/.../meeting-simulator`)
-    // still works even if `#filePath` resolved to a stale clone path.
-    if FileManager.default.fileExists(atPath: fixtureRepoRelativePath) {
-        return fixtureRepoRelativePath
-    }
-    print("ERROR: Fixture not found at \(fromSource.path) or \(fixtureRepoRelativePath)")
-    print("Usage: meeting-simulator [audio.wav] [window-title] [--silent] [--duration=<seconds>]")
-    exit(1)
-}
 
-// --- Setup NSApplication ---
-let app = NSApplication.shared
-app.setActivationPolicy(.regular)
-
-// Create window
-let window = NSWindow(
-    contentRect: NSRect(x: 200, y: 200, width: 800, height: 600),
-    styleMask: [.titled, .closable, .resizable],
-    backing: .buffered,
-    defer: false,
-)
-window.title = windowTitle
-window.isReleasedWhenClosed = false
-
-// --- Build meeting-like UI ---
-let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
-
-// Status label
-let label = NSTextField(labelWithString: "Loading audio...")
-label.font = .systemFont(ofSize: 24)
-label.alignment = .center
-label.frame = NSRect(x: 50, y: 300, width: 700, height: 100)
-contentView.addSubview(label)
-
-// Meeting toolbar (mimics Teams call controls)
-let toolbar = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 60))
-toolbar.wantsLayer = true
-toolbar.layer?.backgroundColor = NSColor.darkGray.cgColor
-
-// Mute button
-let muteBtn = NSButton(title: "Mute", target: nil, action: nil)
-muteBtn.frame = NSRect(x: 200, y: 15, width: 80, height: 30)
-muteBtn.setAccessibilityLabel("Mute")
-toolbar.addSubview(muteBtn)
-
-// Camera button
-let cameraBtn = NSButton(title: "Camera", target: nil, action: nil)
-cameraBtn.frame = NSRect(x: 300, y: 15, width: 80, height: 30)
-toolbar.addSubview(cameraBtn)
-
-// Share button
-let shareBtn = NSButton(title: "Share", target: nil, action: nil)
-shareBtn.frame = NSRect(x: 400, y: 15, width: 80, height: 30)
-toolbar.addSubview(shareBtn)
-
-// Leave button (red, like Teams)
-let leaveBtn = NSButton(title: "Leave", target: nil, action: #selector(AppDelegate.leaveClicked))
-leaveBtn.frame = NSRect(x: 520, y: 15, width: 80, height: 30)
-leaveBtn.bezelColor = .systemRed
-leaveBtn.setAccessibilityLabel("Leave")
-leaveBtn.setAccessibilityIdentifier("leave-call")
-toolbar.addSubview(leaveBtn)
-
-contentView.addSubview(toolbar)
-window.contentView = contentView
-
-window.makeKeyAndOrderFront(nil)
-app.activate(ignoringOtherApps: true)
-
-// --- Create power assertion (triggers PowerAssertionDetector) ---
-var assertionID: IOPMAssertionID = 0
-let assertionResult = IOPMAssertionCreateWithName(
-    "PreventUserIdleDisplaySleep" as CFString,
-    IOPMAssertionLevel(kIOPMAssertionLevelOn),
-    "Simulator Meeting Call in progress" as CFString,
-    &assertionID,
-)
-if assertionResult == kIOReturnSuccess {
-    print("Power assertion created (ID: \(assertionID))")
-} else {
-    print("WARNING: Could not create power assertion (status: \(assertionResult))")
-}
-
-print("Window: \"\(windowTitle)\"")
-print("PID: \(ProcessInfo.processInfo.processIdentifier)")
-print(silentMode ? "Audio: <silent mode — no playback>" : "Audio: \(fixturePath)")
-print("Leave button visible for AX verification")
-
-// --- App delegate to handle window close + audio end ---
-class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, AVAudioPlayerDelegate {
     func applicationWillTerminate(_: Notification) {
         IOPMAssertionRelease(assertionID)
     }
@@ -194,77 +279,3 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, AVAudioPla
         NSApplication.shared.terminate(nil)
     }
 }
-
-let delegate = AppDelegate()
-app.delegate = delegate
-window.delegate = delegate
-
-var audioPlayer: AVAudioPlayer?
-
-if silentMode {
-    let duration = durationOverride ?? 60
-    // Play the fixture at volume=0. AVAudioPlayer still pumps PCM
-    // frames through the system audio chain — the default output
-    // device stays active, CATapDescription's IOProc fires, the
-    // tap captures buffers (all zeros after the volume scaling).
-    // Without playing anything at all the tap stays subscribed but
-    // gets no callbacks because the device has no producer, so
-    // the recording file ends up zero bytes — wrong failure mode
-    // for the symmetric-silence detector under test.
-    let audioURL = URL(fileURLWithPath: fixturePath)
-    if FileManager.default.fileExists(atPath: fixturePath) {
-        do {
-            audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
-            audioPlayer?.delegate = delegate
-            audioPlayer?.volume = 0
-            audioPlayer?.numberOfLoops = -1 // loop until the duration timer fires
-            audioPlayer?.prepareToPlay()
-            audioPlayer?.play()
-            label.stringValue = "SILENT MODE\n(zero-volume playback, \(Int(duration))s)"
-            print("Silent mode: playing fixture at volume=0 for \(duration)s.")
-        } catch {
-            print("ERROR: Could not play fixture at volume 0: \(error)")
-            label.stringValue = "Silent mode (audio error — tap may be inactive)"
-        }
-    } else {
-        // Fallback for environments without the fixture: still pop
-        // the window + power assertion, but warn that the recorder
-        // path may produce zero-byte files because nothing drives
-        // the audio device.
-        label.stringValue = "SILENT MODE\n(no fixture — tap will be inactive)"
-        print("Silent mode: fixture not found, no audio device producer.")
-    }
-    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-        print("Duration elapsed — closing.")
-        NSApplication.shared.terminate(nil)
-    }
-} else {
-    // --- Play audio ---
-    let audioURL = URL(fileURLWithPath: fixturePath)
-    guard FileManager.default.fileExists(atPath: fixturePath) else {
-        print("ERROR: Audio file not found: \(fixturePath)")
-        exit(1)
-    }
-    do {
-        audioPlayer = try AVAudioPlayer(contentsOf: audioURL)
-        audioPlayer?.delegate = delegate
-        audioPlayer?.prepareToPlay()
-        audioPlayer?.play()
-        let duration = audioPlayer?.duration ?? 0
-        label.stringValue = "Playing \(URL(fileURLWithPath: fixturePath).lastPathComponent)\n(\(String(format: "%.0f", duration))s)"
-        print("Playing audio (\(String(format: "%.1f", duration))s)...")
-        print("Window closes automatically after playback.")
-    } catch {
-        print("ERROR: Could not play audio: \(error)")
-        label.stringValue = "Audio error: \(error.localizedDescription)"
-    }
-    if let override = durationOverride {
-        DispatchQueue.main.asyncAfter(deadline: .now() + override) {
-            print("Duration elapsed — closing.")
-            NSApplication.shared.terminate(nil)
-        }
-    }
-}
-
-// Run
-app.run()


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `CommandLine.arguments` parser in `tools/meeting-simulator` with `swift-argument-parser`'s `ParsableCommand`. Same CLI surface — positional `<audio-path>` + `<window-title>`, `--silent`, `--duration` — but standard `--help` formatting and proper `ValidationError` for bad values (e.g. `--duration 0`).
- Splits the 92-line top-level script into a `MeetingSimulator` struct plus three private helpers (`buildMeetingWindow`, `createPowerAssertion`, `startPlayback`) so each setup concern is isolated and the `function_body_length` lint passes.
- Side effects from the rewrite: `assertionID` is constructor-injected into `AppDelegate` (clearer ownership of the IOPMAssertion); fixture-not-found now exits before any AppKit / IOKit state is created; the silent-mode default duration (60 s) lives in a single `defaultSilentDuration` constant.

## Test plan

- [x] `swift build` in `tools/meeting-simulator/` — clean
- [x] `./scripts/lint.sh` — 0 violations (was 2 before the helper split)
- [x] `meeting-simulator --help` renders the ArgumentParser usage block
- [ ] e2e on Mini (`e2e-app.yml` includes silent-recording lane via `scripts/e2e-silent-recording.sh`) — runs on merge to main

## Notes

Based on the `fix/meeting-simulator-fixture-path` branch (PR #298) which contains the prerequisite findFixture path fix. Will rebase onto main once #298 lands.