### PR TITLE
fix(scripts): surface real failures in e2e-silent-recording instead of masking them

### DIFF
--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -215,12 +215,23 @@ SIM_PID=$!
 
 # --- 6. Wait for WatchLoop to enter recording state ------------------------
 
+# Bail fast if the app died — otherwise the polling loop below would just
+# see `{}` for 50 s and surface as "recordingSilent never went true",
+# masking a real crash as a product bug.
+assert_app_alive() {
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+        echo "FAIL: app process (PID $APP_PID) died during polling" >&2
+        exit 1
+    fi
+}
+
 echo "▸ Waiting for app to detect + start recording (max 30 s)…"
 # `isProcessing` flips true while a job is in the queue. It's informational
 # only — if it never flips we still let step 7 run and time out there,
 # which gives a clearer "recordingSilent never went true" failure than
 # bailing here would.
 for _ in $(seq 1 30); do
+    assert_app_alive
     STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
     PROCESSING="$(echo "$STATE_JSON" | jq -r '.pipeline.isProcessing // false')"
     if [ "$PROCESSING" = "true" ]; then
@@ -231,10 +242,11 @@ done
 
 # --- 7. Poll for recordingSilent flag -----------------------------------------
 
-echo "▸ Polling for channelHealth.recordingSilent (threshold 30 s + 15 s slack)…"
+echo "▸ Polling for channelHealth.recordingSilent (threshold 30 s + 20 s slack)…"
 DEADLINE=$(( $(date +%s) + 50 ))
 OBSERVED_SILENT=false
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    assert_app_alive
     STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
     RECORDING_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.recordingSilent // false')"
     MIC_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.micSilent // false')"

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -107,7 +107,12 @@ if [ "$NO_BUILD" = false ]; then
     SIM_BUILD_PID=$!
     (cd "$ROOT/tools/mt-cli" && swift build >/dev/null) &
     CLI_BUILD_PID=$!
-    wait $SIM_BUILD_PID $CLI_BUILD_PID
+    # `wait $PID1 $PID2` only returns the exit code of the LAST PID — an
+    # earlier failure would be silently dropped and surface ~60 lines down
+    # as the confusing "required binary missing" guard. Wait individually so
+    # whichever build failed is the failure that actually halts the script.
+    wait "$SIM_BUILD_PID" || { echo "FAIL: meeting-simulator build failed" >&2; exit 1; }
+    wait "$CLI_BUILD_PID" || { echo "FAIL: mt-cli build failed" >&2; exit 1; }
 
     # Deploy to the stable path and re-sign with the runner's dev cert so
     # the PPPC profile keeps granting Microphone + Screen Recording. Same


### PR DESCRIPTION
## Summary

Two pre-existing correctness bugs in `scripts/e2e-silent-recording.sh` (originally landed in #295) that mask real failures as a generic "recordingSilent never went true" timeout. Found via a `/simplify` review on PR #298. Splitting out as its own atomic PR since neither bug was introduced by #298.

### 1. Parallel build failures got silently dropped

```bash
wait $SIM_BUILD_PID $CLI_BUILD_PID
```

`wait` with multiple PIDs returns the exit code of only the *last* PID — an earlier failure was lost. If the meeting-simulator build broke but mt-cli succeeded (or vice versa), the script kept running and died ~60 lines later at the `[ ! -x "$SIM" ]` guard with a confusing "required binary missing" error that doesn't say *which* build broke.

Wait on each PID individually so the actual failing target is what halts the script.

### 2. Polling loops swallowed RPC death

Both polling loops used `"$MTCLI" state 2>/dev/null || echo '{}'`, which masked every failure mode (app crash, RPC port unbound, mt-cli timeout, malformed JSON). The loop then ran `jq -r '… // false'` on `{}`, got `false`, and quietly polled for the full 50 s deadline. The failure surfaced as a generic "recordingSilent never went true" — a false negative that looked like a product bug rather than "the app died mid-test".

Added `assert_app_alive` (kill -0 on `$APP_PID`) at the top of each loop iteration. The 2 s polling cadence caps the detection lag at one tick.

Also fixed a factually-wrong "30 s + 15 s slack" comment in the same hunk — the actual deadline is +50 s, so the slack is 20 s, not 15.

## Test plan

- [x] `bash -n scripts/e2e-silent-recording.sh` (syntax check)
- [x] `shellcheck scripts/e2e-silent-recording.sh` (clean apart from the pre-existing SC1091 source-resolution info)
- [ ] CI: the silent-recording E2E lane in `e2e-app.yml` exercises this script on every push to main — that'll cover it on merge.