### PR TITLE
fix(scripts): detect dev .app crash in e2e-app.sh polling loop

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -340,6 +340,12 @@ _poll_for_new_lastjob_terminal() {
     local lj_id="" lj_state="" pipe_active="" pipe_processing="" pending_naming=""
 
     while true; do
+        # Fail fast if the dev .app died — otherwise the loop just sees
+        # the `|| true` swallow rpc/state errors and we'd burn the full
+        # ${PIPELINE_TIMEOUT_S}s before surfacing as "no new pipeline
+        # job reached terminal state", masking the real crash.
+        assert_app_alive
+
         lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""; pending_naming=""
         IFS='|' read -r lj_id lj_state pipe_active pipe_processing pending_naming < <(
             rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing, .pipeline.pendingNamingJobCount] | join("|")'

--- a/scripts/e2e-channel-health.sh
+++ b/scripts/e2e-channel-health.sh
@@ -67,10 +67,7 @@ if [ "$NO_BUILD" = false ]; then
     "$ROOT/scripts/run_app.sh" --build-only >/dev/null
 fi
 
-if [ ! -x "$BIN" ]; then
-    echo "FAIL: dev binary not found at $BIN — run without --no-build first" >&2
-    exit 1
-fi
+[ -x "$BIN" ] || die "dev binary not found at $BIN — run without --no-build first"
 
 if [ ! -x "$MTCLI" ]; then
     echo "▸ Building mt-cli…"
@@ -96,10 +93,7 @@ APP_PID=$!
 # --- 4. Wait for RPC server to come up (max 30 s) ------------------------
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-if ! wait_for_rpc "$MTCLI" 30; then
-    echo "FAIL: RPC server did not start within 30 s" >&2
-    exit 1
-fi
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
 echo "  RPC up"
 
 # --- 5. Assert channelHealth state ---------------------------------------
@@ -112,16 +106,12 @@ read -r MIC_SILENT APP_SILENT < <(
 echo "▸ channelHealth: micSilent=$MIC_SILENT appSilent=$APP_SILENT"
 
 if [ "$MIC_SILENT" != "true" ]; then
-    echo "FAIL: channelHealth.micSilent expected 'true', got '$MIC_SILENT'" >&2
     echo "Full state JSON:" >&2
     echo "$STATE_JSON" | jq . >&2
-    exit 1
+    die "channelHealth.micSilent expected 'true', got '$MIC_SILENT'"
 fi
 
-if [ "$APP_SILENT" != "false" ]; then
-    echo "FAIL: channelHealth.appSilent expected 'false', got '$APP_SILENT'" >&2
-    exit 1
-fi
+[ "$APP_SILENT" = "false" ] || die "channelHealth.appSilent expected 'false', got '$APP_SILENT'"
 
 # --- 6. Optional visual proof --------------------------------------------
 

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -215,16 +215,6 @@ SIM_PID=$!
 
 # --- 6. Wait for WatchLoop to enter recording state ------------------------
 
-# Bail fast if the app died — otherwise the polling loop below would just
-# see `{}` for 50 s and surface as "recordingSilent never went true",
-# masking a real crash as a product bug.
-assert_app_alive() {
-    if ! kill -0 "$APP_PID" 2>/dev/null; then
-        echo "FAIL: app process (PID $APP_PID) died during polling" >&2
-        exit 1
-    fi
-}
-
 echo "▸ Waiting for app to detect + start recording (max 30 s)…"
 # `isProcessing` flips true while a job is in the queue. It's informational
 # only — if it never flips we still let step 7 run and time out there,

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -111,8 +111,8 @@ if [ "$NO_BUILD" = false ]; then
     # earlier failure would be silently dropped and surface ~60 lines down
     # as the confusing "required binary missing" guard. Wait individually so
     # whichever build failed is the failure that actually halts the script.
-    wait "$SIM_BUILD_PID" || { echo "FAIL: meeting-simulator build failed" >&2; exit 1; }
-    wait "$CLI_BUILD_PID" || { echo "FAIL: mt-cli build failed" >&2; exit 1; }
+    wait "$SIM_BUILD_PID" || die "meeting-simulator build failed"
+    wait "$CLI_BUILD_PID" || die "mt-cli build failed"
 
     # Deploy to the stable path and re-sign with the runner's dev cert so
     # the PPPC profile keeps granting Microphone + Screen Recording. Same
@@ -130,7 +130,7 @@ if [ "$NO_BUILD" = false ]; then
         SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
         [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
         codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
-            || { echo "FAIL: Developer ID re-sign failed" >&2; exit 1; }
+            || die "Developer ID re-sign failed"
     else
         # Local-dev path: self-signed cert from setup-self-hosted-runner.sh.
         # Resolve the SHA-1 directly from the keychain (the .pem written
@@ -152,11 +152,10 @@ if [ "$NO_BUILD" = false ]; then
                 "$ROOT/scripts/keychain-prepend.sh" "$DEV_KEYCHAIN" 2>/dev/null || true
                 codesign --force --sign "$DEV_CERT_HASH" --keychain "$DEV_KEYCHAIN" \
                     "$DEV_BUNDLE_DEPLOY" >/dev/null \
-                    || { echo "FAIL: dev-cert re-sign failed" >&2; exit 1; }
+                    || die "dev-cert re-sign failed"
             else
-                echo "FAIL: dev keychain present but no '$DEV_CERT_NAME' identity inside" >&2
-                echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it"
-                exit 1
+                echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it" >&2
+                die "dev keychain present but no '$DEV_CERT_NAME' identity inside"
             fi
         else
             echo "▸ WARNING: no DEVELOPER_ID and no $DEV_KEYCHAIN — TCC may deny capture" >&2
@@ -166,10 +165,7 @@ if [ "$NO_BUILD" = false ]; then
 fi
 
 for path in "$BIN" "$MTCLI" "$SIM"; do
-    if [ ! -x "$path" ]; then
-        echo "FAIL: required binary missing: $path — run without --no-build first" >&2
-        exit 1
-    fi
+    [ -x "$path" ] || die "required binary missing: $path — run without --no-build first"
 done
 
 # --- 2. Snapshot + override defaults so the test is deterministic -----------
@@ -192,10 +188,7 @@ env MEETINGTRANSCRIBER_DEBUG_RPC=1 "$BIN" &
 APP_PID=$!
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-if ! wait_for_rpc "$MTCLI" 30; then
-    echo "FAIL: RPC server did not start within 30 s" >&2
-    exit 1
-fi
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
 echo "  RPC up"
 
 # --- 5. Trigger a "silent meeting" via meeting-simulator --------------------
@@ -250,10 +243,9 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 done
 
 if [ "$OBSERVED_SILENT" != "true" ]; then
-    echo "FAIL: channelHealth.recordingSilent never went true within 50 s" >&2
     echo "Final state:" >&2
     "$MTCLI" state 2>/dev/null | jq . >&2 || true
-    exit 1
+    die "channelHealth.recordingSilent never went true within 50 s"
 fi
 
 echo

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -94,6 +94,19 @@ wait_for_rpc() {
     "$mtcli" healthz >/dev/null 2>&1
 }
 
+# Print "FAIL: <msg>" to stderr and exit 1. The e2e drivers fail-fast
+# on the first error, so a one-liner is more readable than the
+# `{ echo "FAIL: …" >&2; exit 1; }` block that gets repeated across
+# `||` chains and bare guards.
+#
+# Callers that need a script-specific prefix (e.g. e2e-app.sh's
+# `[e2e-app] FAIL:`) keep their own local `fail()` — `die()` is for
+# scripts that don't have one yet.
+die() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
 # Assert that a process matching `$pattern` is running. Exits 1 with a
 # clear error if not. Intended for polling loops that would otherwise
 # burn their full timeout if the app crashed mid-poll — the loop just
@@ -107,8 +120,7 @@ wait_for_rpc() {
 assert_app_alive() {
     local pattern="${1:-MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber}"
     if ! pgrep -f "$pattern" >/dev/null 2>&1; then
-        echo "FAIL: app process matching '$pattern' is not running" >&2
-        exit 1
+        die "app process matching '$pattern' is not running"
     fi
 }
 

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -94,6 +94,24 @@ wait_for_rpc() {
     "$mtcli" healthz >/dev/null 2>&1
 }
 
+# Assert that a process matching `$pattern` is running. Exits 1 with a
+# clear error if not. Intended for polling loops that would otherwise
+# burn their full timeout if the app crashed mid-poll — the loop just
+# sees `{}` (or no /state response) and surfaces a misleading
+# "expected X never happened" error.
+#
+# Pattern-based (via `pgrep -f`) rather than PID-based so it works for
+# both `&`-launched scripts (e2e-silent-recording.sh) and
+# `open`-launched scripts (e2e-app.sh) without two APIs. The default
+# matches the deployed dev .app — same string as `quit_running_app`.
+assert_app_alive() {
+    local pattern="${1:-MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber}"
+    if ! pgrep -f "$pattern" >/dev/null 2>&1; then
+        echo "FAIL: app process matching '$pattern' is not running" >&2
+        exit 1
+    fi
+}
+
 # Restore a defaults boolean from a snapshotted value as returned by
 # `defaults read`. That command returns "0"/"1" but `-bool` only
 # accepts the literal tokens `true`/`false`/`yes`/`no`; without this


### PR DESCRIPTION
## Summary

Sibling of PR #301 — same masked-crash failure mode, this time in `e2e-app.sh`'s `_poll_for_new_lastjob_terminal`.

The polling loop ran `rpc /state | jq … || true` every 5 s up to `PIPELINE_TIMEOUT_S` (default 600 s). The `|| true` silently swallowed any rpc failure — app crash, RPC port unbound, curl `--max-time` hit. `read` left all five output variables empty, the loop fell through, and the timeout branch eventually surfaced as the misleading

> no new pipeline job reached terminal state within \${TIMEOUT}s

— a product-bug message when the actual root cause was the app dying mid-pipeline.

## Changes

1. **`refactor(scripts): extract assert_app_alive to e2e-helpers, migrate caller`** — moves the inline `assert_app_alive` that PR #301 added to `e2e-silent-recording.sh` into `lib/e2e-helpers.sh`. Switches the check from PID-based (`kill -0`) to pattern-based (`pgrep -f`) so the helper works for both `&`-launched and `open`-launched callers. Default pattern matches the dev .app — same string `quit_running_app` already defaults to.

2. **`fix(scripts): detect dev .app crash in e2e-app.sh polling loop`** — adds an `assert_app_alive` call at the top of each polling iteration. Detection lag drops from up to 600 s (full timeout) to 5 s (one tick).

## Test plan

- [x] `bash -n` on both touched scripts (syntax clean)
- [x] `quit_running_app` is called immediately before launch in both callers, so at polling time exactly one matching process exists → pgrep and `kill -0 $APP_PID` resolve to the same answer
- [ ] CI: the `e2e-app.yml` workflow runs both lanes on every main push — will exercise both code paths on merge