### PR TITLE
refactor(scripts): collapse echo-FAIL/exit-1 pattern into shared die() helper

### DIFF
--- a/scripts/e2e-channel-health.sh
+++ b/scripts/e2e-channel-health.sh
@@ -67,10 +67,7 @@ if [ "$NO_BUILD" = false ]; then
     "$ROOT/scripts/run_app.sh" --build-only >/dev/null
 fi
 
-if [ ! -x "$BIN" ]; then
-    echo "FAIL: dev binary not found at $BIN — run without --no-build first" >&2
-    exit 1
-fi
+[ -x "$BIN" ] || die "dev binary not found at $BIN — run without --no-build first"
 
 if [ ! -x "$MTCLI" ]; then
     echo "▸ Building mt-cli…"
@@ -96,10 +93,7 @@ APP_PID=$!
 # --- 4. Wait for RPC server to come up (max 30 s) ------------------------
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-if ! wait_for_rpc "$MTCLI" 30; then
-    echo "FAIL: RPC server did not start within 30 s" >&2
-    exit 1
-fi
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
 echo "  RPC up"
 
 # --- 5. Assert channelHealth state ---------------------------------------
@@ -112,16 +106,12 @@ read -r MIC_SILENT APP_SILENT < <(
 echo "▸ channelHealth: micSilent=$MIC_SILENT appSilent=$APP_SILENT"
 
 if [ "$MIC_SILENT" != "true" ]; then
-    echo "FAIL: channelHealth.micSilent expected 'true', got '$MIC_SILENT'" >&2
     echo "Full state JSON:" >&2
     echo "$STATE_JSON" | jq . >&2
-    exit 1
+    die "channelHealth.micSilent expected 'true', got '$MIC_SILENT'"
 fi
 
-if [ "$APP_SILENT" != "false" ]; then
-    echo "FAIL: channelHealth.appSilent expected 'false', got '$APP_SILENT'" >&2
-    exit 1
-fi
+[ "$APP_SILENT" = "false" ] || die "channelHealth.appSilent expected 'false', got '$APP_SILENT'"
 
 # --- 6. Optional visual proof --------------------------------------------
 

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -111,8 +111,8 @@ if [ "$NO_BUILD" = false ]; then
     # earlier failure would be silently dropped and surface ~60 lines down
     # as the confusing "required binary missing" guard. Wait individually so
     # whichever build failed is the failure that actually halts the script.
-    wait "$SIM_BUILD_PID" || { echo "FAIL: meeting-simulator build failed" >&2; exit 1; }
-    wait "$CLI_BUILD_PID" || { echo "FAIL: mt-cli build failed" >&2; exit 1; }
+    wait "$SIM_BUILD_PID" || die "meeting-simulator build failed"
+    wait "$CLI_BUILD_PID" || die "mt-cli build failed"
 
     # Deploy to the stable path and re-sign with the runner's dev cert so
     # the PPPC profile keeps granting Microphone + Screen Recording. Same
@@ -130,7 +130,7 @@ if [ "$NO_BUILD" = false ]; then
         SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
         [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
         codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
-            || { echo "FAIL: Developer ID re-sign failed" >&2; exit 1; }
+            || die "Developer ID re-sign failed"
     else
         # Local-dev path: self-signed cert from setup-self-hosted-runner.sh.
         # Resolve the SHA-1 directly from the keychain (the .pem written
@@ -152,11 +152,10 @@ if [ "$NO_BUILD" = false ]; then
                 "$ROOT/scripts/keychain-prepend.sh" "$DEV_KEYCHAIN" 2>/dev/null || true
                 codesign --force --sign "$DEV_CERT_HASH" --keychain "$DEV_KEYCHAIN" \
                     "$DEV_BUNDLE_DEPLOY" >/dev/null \
-                    || { echo "FAIL: dev-cert re-sign failed" >&2; exit 1; }
+                    || die "dev-cert re-sign failed"
             else
-                echo "FAIL: dev keychain present but no '$DEV_CERT_NAME' identity inside" >&2
-                echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it"
-                exit 1
+                echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it" >&2
+                die "dev keychain present but no '$DEV_CERT_NAME' identity inside"
             fi
         else
             echo "▸ WARNING: no DEVELOPER_ID and no $DEV_KEYCHAIN — TCC may deny capture" >&2
@@ -166,10 +165,7 @@ if [ "$NO_BUILD" = false ]; then
 fi
 
 for path in "$BIN" "$MTCLI" "$SIM"; do
-    if [ ! -x "$path" ]; then
-        echo "FAIL: required binary missing: $path — run without --no-build first" >&2
-        exit 1
-    fi
+    [ -x "$path" ] || die "required binary missing: $path — run without --no-build first"
 done
 
 # --- 2. Snapshot + override defaults so the test is deterministic -----------
@@ -192,10 +188,7 @@ env MEETINGTRANSCRIBER_DEBUG_RPC=1 "$BIN" &
 APP_PID=$!
 
 echo "▸ Waiting for RPC on 127.0.0.1:9876…"
-if ! wait_for_rpc "$MTCLI" 30; then
-    echo "FAIL: RPC server did not start within 30 s" >&2
-    exit 1
-fi
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
 echo "  RPC up"
 
 # --- 5. Trigger a "silent meeting" via meeting-simulator --------------------
@@ -255,10 +248,9 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 done
 
 if [ "$OBSERVED_SILENT" != "true" ]; then
-    echo "FAIL: channelHealth.recordingSilent never went true within 50 s" >&2
     echo "Final state:" >&2
     "$MTCLI" state 2>/dev/null | jq . >&2 || true
-    exit 1
+    die "channelHealth.recordingSilent never went true within 50 s"
 fi
 
 echo

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -94,6 +94,19 @@ wait_for_rpc() {
     "$mtcli" healthz >/dev/null 2>&1
 }
 
+# Print "FAIL: <msg>" to stderr and exit 1. The e2e drivers fail-fast
+# on the first error, so a one-liner is more readable than the
+# `{ echo "FAIL: …" >&2; exit 1; }` block that gets repeated across
+# `||` chains and bare guards.
+#
+# Callers that need a script-specific prefix (e.g. e2e-app.sh's
+# `[e2e-app] FAIL:`) keep their own local `fail()` — `die()` is for
+# scripts that don't have one yet.
+die() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
 # Assert that a process matching `$pattern` is running. Exits 1 with a
 # clear error if not. Intended for polling loops that would otherwise
 # burn their full timeout if the app crashed mid-poll — the loop just
@@ -107,8 +120,7 @@ wait_for_rpc() {
 assert_app_alive() {
     local pattern="${1:-MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber}"
     if ! pgrep -f "$pattern" >/dev/null 2>&1; then
-        echo "FAIL: app process matching '$pattern' is not running" >&2
-        exit 1
+        die "app process matching '$pattern' is not running"
     fi
 }
 


### PR DESCRIPTION
## Summary

Adds a `die()` one-liner to `scripts/lib/e2e-helpers.sh` and migrates the two e2e drivers that don't have their own `fail()` wrapper:
- `e2e-silent-recording.sh` — 7 callsites
- `e2e-channel-health.sh` — 3 callsites

The `||`-chain callsites collapse cleanly:

```bash
# Before
codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
    || { echo "FAIL: Developer ID re-sign failed" >&2; exit 1; }

# After
codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
    || die "Developer ID re-sign failed"
```

`e2e-app.sh` keeps its local `fail()` — it includes a script-specific `[e2e-app] FAIL:` prefix that `die()` doesn't add. Convention: scripts with multi-script log streams want a prefix and define their own; everyone else uses `die()`.

Stacked on top of #302 (assert_app_alive extraction). The diff against main currently includes #302's changes — GitHub will narrow that automatically once #302 merges.

## Test plan

- [x] `bash -n` on all three touched scripts
- [x] `grep -c 'echo "FAIL:'` returns 0 for both migrated scripts
- [ ] Both lanes in `e2e-app.yml` (channel-health + silent-recording) exercise the migrated scripts on every main push