### PR TITLE
perf(scripts): collapse 3× jq invocations per polling tick into one @tsv pass

### DIFF
--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -231,9 +231,15 @@ OBSERVED_SILENT=false
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     assert_app_alive
     STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
-    RECORDING_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.recordingSilent // false')"
-    MIC_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.micSilent // false')"
-    APP_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.appSilent // false')"
+    # Extract all three channelHealth flags in one jq pass. Safe here
+    # because every field has a `// false` default — no empties possible.
+    # `IFS=$'\t' read` would collapse consecutive empties (tab is
+    # whitespace-IFS), so if a non-defaulted field is added later, switch
+    # to `|`-join (see `_poll_for_new_lastjob_terminal` in e2e-app.sh).
+    IFS=$'\t' read -r RECORDING_SILENT MIC_SILENT APP_SILENT < <(
+        echo "$STATE_JSON" \
+            | jq -r '[.channelHealth.recordingSilent // false, .channelHealth.micSilent // false, .channelHealth.appSilent // false] | @tsv'
+    )
     if [ "$RECORDING_SILENT" = "true" ]; then
         OBSERVED_SILENT=true
         echo "  recordingSilent=true (mic=$MIC_SILENT app=$APP_SILENT)"


### PR DESCRIPTION
## Summary

The hot polling loop in `e2e-silent-recording.sh` spawned three sequential `echo "\$STATE_JSON" | jq -r '…'` invocations per tick to pull `recordingSilent`, `micSilent`, `appSilent` out of the same JSON document. Collapse into a single `jq … | @tsv` call + a `read` with `IFS=\$'\t'`.

```bash
# Before — 3 subshells, 3 jq processes per 2 s tick
RECORDING_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.recordingSilent // false')"
MIC_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.micSilent // false')"
APP_SILENT="$(echo "$STATE_JSON" | jq -r '.channelHealth.appSilent // false')"

# After — 1 subshell, 1 jq, 1 parse
IFS=$'\t' read -r RECORDING_SILENT MIC_SILENT APP_SILENT < <(
    echo "$STATE_JSON" \
        | jq -r '[.channelHealth.recordingSilent // false, .channelHealth.micSilent // false, .channelHealth.appSilent // false] | @tsv'
)
```

Wall-clock improvement is invisible at the 2 s polling cadence — the readability win (all three values clearly come from one RPC response) is the actual point.

Stacked on top of #303 (die() helper PR), which is itself stacked on #302 (assert_app_alive extraction).

## Test plan

- [x] `bash -n` syntax check
- [x] Manual jq invocation verified `@tsv` output: `echo '{"channelHealth":{…}}' | jq … | @tsv` → tab-separated booleans
- [ ] CI: same e2e-app.yml silent-recording lane exercises this on merge