### PR TITLE
refactor(scripts): add snapshot_default + restore_float_default helpers

### DIFF
--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -80,13 +80,9 @@ cleanup() {
     fi
     # Restore defaults to whatever they were before we ran (or delete the
     # keys if they didn't exist).
-    restore_bool_default "$BUNDLE_ID" autoWatch "$SAVED_AUTOWATCH"
-    if [ -n "$SAVED_THRESHOLD" ]; then
-        /usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float "$SAVED_THRESHOLD"
-    else
-        /usr/bin/defaults delete "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null || true
-    fi
-    restore_bool_default "$BUNDLE_ID" perChannelIndicatorEnabled "$SAVED_INDICATOR"
+    restore_bool_default  "$BUNDLE_ID" autoWatch                       "$SAVED_AUTOWATCH"
+    restore_float_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds "$SAVED_THRESHOLD"
+    restore_bool_default  "$BUNDLE_ID" perChannelIndicatorEnabled      "$SAVED_INDICATOR"
     bootout_stale_launchctl
 }
 trap cleanup EXIT
@@ -170,9 +166,9 @@ done
 
 # --- 2. Snapshot + override defaults so the test is deterministic -----------
 
-SAVED_AUTOWATCH="$(/usr/bin/defaults read "$BUNDLE_ID" autoWatch 2>/dev/null | tr -d '[:space:]' || true)"
-SAVED_THRESHOLD="$(/usr/bin/defaults read "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null | tr -d '[:space:]' || true)"
-SAVED_INDICATOR="$(/usr/bin/defaults read "$BUNDLE_ID" perChannelIndicatorEnabled 2>/dev/null | tr -d '[:space:]' || true)"
+SAVED_AUTOWATCH="$(snapshot_default "$BUNDLE_ID" autoWatch)"
+SAVED_THRESHOLD="$(snapshot_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds)"
+SAVED_INDICATOR="$(snapshot_default "$BUNDLE_ID" perChannelIndicatorEnabled)"
 
 /usr/bin/defaults write "$BUNDLE_ID" autoWatch -bool true
 /usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float 30

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -124,6 +124,18 @@ assert_app_alive() {
     fi
 }
 
+# Snapshot a defaults value for later restoration, or empty when the
+# key isn't set. The caller's `$()` command substitution strips the
+# trailing newline that `defaults read` emits, so internal whitespace
+# in string values (e.g. "hello world") is preserved — important once
+# this gets used for keys beyond the current numeric/bool callsites.
+# Trailing `|| true` keeps a missing key from tripping `set -e`.
+snapshot_default() {
+    local bundle="$1"
+    local key="$2"
+    /usr/bin/defaults read "$bundle" "$key" 2>/dev/null || true
+}
+
 # Restore a defaults boolean from a snapshotted value as returned by
 # `defaults read`. That command returns "0"/"1" but `-bool` only
 # accepts the literal tokens `true`/`false`/`yes`/`no`; without this
@@ -139,4 +151,20 @@ restore_bool_default() {
         0) /usr/bin/defaults write "$bundle" "$key" -bool false ;;
         *) /usr/bin/defaults delete "$bundle" "$key" 2>/dev/null || true ;;
     esac
+}
+
+# Float companion to `restore_bool_default`. Empty `saved` (key wasn't
+# set before the test) deletes the key; anything else is written back
+# as `-float`. `defaults read` returns floats as plain numeric strings
+# (e.g. "30" or "30.5"), and `-float "30"` is happily accepted by
+# `defaults write` even without a decimal point.
+restore_float_default() {
+    local bundle="$1"
+    local key="$2"
+    local saved="$3"
+    if [ -n "$saved" ]; then
+        /usr/bin/defaults write "$bundle" "$key" -float "$saved"
+    else
+        /usr/bin/defaults delete "$bundle" "$key" 2>/dev/null || true
+    fi
 }


### PR DESCRIPTION
## Summary

Adds two helpers to `scripts/lib/e2e-helpers.sh`:

- **`snapshot_default(bundle, key)`** — reads a defaults value, strips whitespace, returns empty when unset. Replaces the `defaults read … | tr -d '[:space:]' || true` pattern that was inlined three times in `e2e-silent-recording.sh`.
- **`restore_float_default(bundle, key, saved)`** — float companion to the existing `restore_bool_default`. Same shape: empty `saved` deletes the key; non-empty writes back as `-float`.

The migration in `e2e-silent-recording.sh`:

```bash
# Before — snapshot block
SAVED_AUTOWATCH="$(/usr/bin/defaults read "$BUNDLE_ID" autoWatch 2>/dev/null | tr -d '[:space:]' || true)"
SAVED_THRESHOLD="$(/usr/bin/defaults read "$BUNDLE_ID" asymmetricSilenceWarningSeconds 2>/dev/null | tr -d '[:space:]' || true)"
SAVED_INDICATOR="$(/usr/bin/defaults read "$BUNDLE_ID" perChannelIndicatorEnabled 2>/dev/null | tr -d '[:space:]' || true)"

# After
SAVED_AUTOWATCH="$(snapshot_default "$BUNDLE_ID" autoWatch)"
SAVED_THRESHOLD="$(snapshot_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds)"
SAVED_INDICATOR="$(snapshot_default "$BUNDLE_ID" perChannelIndicatorEnabled)"
```

And the cleanup block drops the asymmetric inline float branch, lining all three restores up in a clean column.

Stacked on top of #304 (jq collapse) → #303 (die helper) → #302 (assert_app_alive). Final PR in the post-#301 cleanup chain.

## Test plan

- [x] `bash -n` on both touched files
- [ ] CI on merge: same silent-recording lane exercises both snapshot+restore paths