### PR TITLE
fix(test): split testResamplePreservesSignalEnergy expression for stable type-check

### DIFF
--- a/app/MeetingTranscriber/Tests/AudioMixerTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerTests.swift
@@ -327,8 +327,12 @@ final class AudioMixerTests: XCTestCase {
         try await AudioMixer.resampleFile(from: src, to: dst, targetRate: 16000)
 
         let loaded = try AudioMixer.loadAudioFileAsFloat32(url: dst)
-        // Sine wave should have significant energy (not silence)
-        let rms = sqrt(loaded.map { $0 * $0 }.reduce(0, +) / Float(loaded.count))
+        // Sine wave should have significant energy (not silence). Typed-binding
+        // split — see WhisperKitE2ETests.testResamplePreservesSignalEnergy for the
+        // type-check-time rationale.
+        let loadedSquared: [Float] = loaded.map { $0 * $0 }
+        let loadedSum: Float = loadedSquared.reduce(0, +)
+        let rms: Float = sqrt(loadedSum / Float(loaded.count))
         // AAC encoding + 16-bit quantization reduce amplitude; 0.05 confirms it's not silence
         XCTAssertGreaterThan(rms, 0.05, "Resampled audio should not be silent")
     }

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -142,9 +142,15 @@ final class WhisperKitE2ETests: XCTestCase {
 
         let resampled = AudioMixer.resample(samples, from: sourceRate, to: targetRate)
 
-        // Compute RMS of both
-        let sourceRMS = sqrt(samples.map { $0 * $0 }.reduce(0, +) / Float(samples.count))
-        let targetRMS = sqrt(resampled.map { $0 * $0 }.reduce(0, +) / Float(resampled.count))
+        // Typed-binding split — the single-expression `sqrt(map.reduce / Float(...))`
+        // trips `-warn-long-expression-type-checking` on the CI mini under load.
+        let sourceSquared: [Float] = samples.map { $0 * $0 }
+        let sourceSum: Float = sourceSquared.reduce(0, +)
+        let sourceRMS: Float = sqrt(sourceSum / Float(samples.count))
+
+        let targetSquared: [Float] = resampled.map { $0 * $0 }
+        let targetSum: Float = targetSquared.reduce(0, +)
+        let targetRMS: Float = sqrt(targetSum / Float(resampled.count))
 
         // RMS should be similar (within 10%)
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

`testResamplePreservesSignalEnergy()` in `WhisperKitE2ETests` sat at ~330-340 ms type-check time vs the project's strict 300 ms limit (`-warn-long-expression-type-checking`). Whether it tripped depended on Mac mini CI runner load — flaked **twice in 72 h** on PRs #288 and #302 (both at `WhisperKitE2ETests.swift:132:10`).

The single-expression form forced the type-checker to unify in one pass:
- `sqrt` overloads (Float vs Double)
- `reduce(0, +)`'s generic `Numeric` protocol
- The `.map { $0 * $0 }` closure type
- The `Float(samples.count)` cast

Splitting each RMS computation into three explicitly-typed `let` bindings lets inference resolve each step deterministically with no backtracking.

```swift
// Before — one expression, ~330-340 ms
let sourceRMS = sqrt(samples.map { $0 * $0 }.reduce(0, +) / Float(samples.count))

// After — three steps, each <100 ms
let sourceSquared: [Float] = samples.map { $0 * $0 }
let sourceSum: Float = sourceSquared.reduce(0, +)
let sourceRMS: Float = sqrt(sourceSum / Float(samples.count))
```

Closes the backlog item `docs/plans/.local/open/2026-05-17-whisperkit-e2e-tests-type-check-flake.md` (moved to `done/`).

## Test plan

- [x] `swift test --filter WhisperKitE2ETests/testResamplePreservesSignalEnergy` — passes in 17 ms
- [x] `./scripts/lint.sh` — 0 violations
- [x] `swift build` — no `-warn-long-expression-type-checking` warnings on this file
- [ ] CI on this PR will verify on the Mac mini runner that was tripping the flake