### PR TITLE
feat(app): tap whole bundle PID tree for Electron meeting apps

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AudioTapLib
 
 // `@preconcurrency`: AVFoundation types lack Sendable annotations —
@@ -119,8 +120,15 @@ class DualSourceRecorder: RecordingProvider {
         let appTempURL = recDir.appendingPathComponent("\(ts)_app_raw.tmp")
         let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mic)")
 
+        // Electron/WebView2 apps (Teams 2.x, Slack, Discord) render call
+        // audio in helper/renderer children rather than the shell process
+        // the OS sees as the window owner. Tap the whole bundle tree so we
+        // catch whichever child holds the audio handle; fall back to the
+        // root PID alone if the bundle URL is unavailable.
+        let effectivePids = Self.resolveTapPIDs(rootPID: appPID)
+
         let session = AudioCaptureSession(
-            pid: appPID,
+            pids: effectivePids,
             appOutputURL: appTempURL,
             sampleRate: recordRate,
             channels: appChannels,
@@ -281,6 +289,22 @@ class DualSourceRecorder: RecordingProvider {
             micDelay: micDelay,
             recordingStart: recordingStart,
         )
+    }
+
+    /// Resolve the PID set to tap for a meeting-matched root PID.
+    ///
+    /// Returns `[rootPID]` alone when the running-application bundle URL is
+    /// unavailable (command-line tool, detached process) or enumeration
+    /// finds no PIDs under it. Otherwise returns every PID under the bundle,
+    /// prepending the root if enumeration somehow missed it — order matters
+    /// for the aggregate device's cosmetic name tag (root first).
+    static func resolveTapPIDs(rootPID: pid_t) -> [pid_t] {
+        guard let bundleURL = NSRunningApplication(processIdentifier: rootPID)?.bundleURL else {
+            return [rootPID]
+        }
+        let enumerated = ProcessTreeEnumerator.pidsRooted(in: bundleURL)
+        guard !enumerated.isEmpty else { return [rootPID] }
+        return enumerated.contains(rootPID) ? enumerated : [rootPID] + enumerated
     }
 
     /// Downmix interleaved multi-channel audio to mono. Passthrough if already mono.

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -296,4 +296,17 @@ final class DualSourceRecorderTests: XCTestCase {
         )
         XCTAssertEqual(result, 24000)
     }
+
+    // MARK: - resolveTapPIDs
+
+    /// `NSRunningApplication(processIdentifier:)` returns nil for a PID that
+    /// isn't running — falls back to the single root PID rather than
+    /// silently tapping nothing. This is the safety net for command-line
+    /// tools, exited processes, or detection failures.
+    func testResolveTapPIDsFallsBackWhenBundleURLUnavailable() {
+        // PID_MAX on macOS is 99999. Pick something deliberately past it.
+        let bogusPID: pid_t = 999_999
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: bogusPID)
+        XCTAssertEqual(pids, [bogusPID])
+    }
 }

--- a/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
@@ -4,14 +4,21 @@ import Foundation
 /// Translates PIDs to CoreAudio process `AudioObjectID`s for `CATapDescription`.
 @available(macOS 14.2, *)
 extension AppAudioCapture {
-    /// Translate every stored PID. PIDs that fail translation (helper has
-    /// no audio-object entry, process exited between enumeration and tap
-    /// creation) are dropped — that's expected for Electron helper trees
-    /// where only the audio-emitting renderer owns an audio object.
-    /// Throws when no PID at all could be translated, since the resulting
-    /// tap would have nothing to listen to.
-    func translatePIDs() throws -> [AudioObjectID] {
-        let translated = pids.compactMap { Self.translatePID($0) }
+    /// Translate every stored PID and return (pid, audioObjectID) pairs.
+    /// PIDs that fail translation (helper has no audio-object entry, process
+    /// exited between enumeration and tap creation) are dropped — that's
+    /// expected for Electron helper trees where only the audio-emitting
+    /// renderer owns an audio object. Throws when no PID at all could be
+    /// translated, since the resulting tap would have nothing to listen to.
+    ///
+    /// Returns pairs (not parallel arrays) so callers can log per-PID
+    /// without re-zipping against `pids` — `compactMap` would otherwise
+    /// silently mis-align the two sequences.
+    func translatePIDs() throws -> [(pid: pid_t, audioObjectID: AudioObjectID)] {
+        let translated: [(pid: pid_t, audioObjectID: AudioObjectID)] = pids.compactMap { pid in
+            guard let objectID = Self.translatePID(pid) else { return nil }
+            return (pid: pid, audioObjectID: objectID)
+        }
         guard !translated.isEmpty else {
             throw NSError(
                 domain: "audiotap", code: -1,

--- a/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
@@ -1,0 +1,43 @@
+import CoreAudio
+import Foundation
+
+/// Translates PIDs to CoreAudio process `AudioObjectID`s for `CATapDescription`.
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    /// Translate every stored PID. PIDs that fail translation (helper has
+    /// no audio-object entry, process exited between enumeration and tap
+    /// creation) are dropped — that's expected for Electron helper trees
+    /// where only the audio-emitting renderer owns an audio object.
+    /// Throws when no PID at all could be translated, since the resulting
+    /// tap would have nothing to listen to.
+    func translatePIDs() throws -> [AudioObjectID] {
+        let translated = pids.compactMap { Self.translatePID($0) }
+        guard !translated.isEmpty else {
+            throw NSError(
+                domain: "audiotap", code: -1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Failed to translate any of \(pids.count) PIDs to audio objects",
+                ],
+            )
+        }
+        return translated
+    }
+
+    static func translatePID(_ pid: pid_t) -> AudioObjectID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var objectID = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        var mutablePid = pid
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address,
+            UInt32(MemoryLayout<pid_t>.size), &mutablePid, &size, &objectID,
+        )
+        guard status == noErr, objectID != kAudioObjectUnknown else { return nil }
+        return objectID
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -9,7 +9,9 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// Monitors default output device changes and recreates the tap when needed.
 @available(macOS 14.2, *)
 public class AppAudioCapture {
-    private let pid: pid_t
+    /// `internal` (not `private`) so the cross-file `+PIDTranslation`
+    /// extension can read it; it's not otherwise touched from outside.
+    let pids: [pid_t]
     private let sampleRate: Int
     private let channels: Int
     private let outputFileDescriptor: Int32
@@ -54,50 +56,28 @@ public class AppAudioCapture {
     private var deviceChangeCoordinator = OutputDeviceChangeCoordinator()
 
     /// - Parameters:
-    ///   - pid: Process ID of the app to capture audio from.
+    ///   - pids: Process IDs to capture audio from. Pass the meeting app's
+    ///     root PID plus its helper/renderer child PIDs for Electron-based
+    ///     apps (Teams 2.x, Slack, Discord); pass a single-element array
+    ///     for native Cocoa apps. Helpers whose `translatePIDToProcessObject`
+    ///     lookup fails (no audio-object entry) are skipped silently.
     ///   - outputFileDescriptor: File descriptor to write raw PCM data to.
     ///   - sampleRate: Desired sample rate (default 48000).
     ///   - channels: Number of audio channels (default 2).
     ///   - debugLogging: When true, emit verbose forensic logs (process identity,
     ///     output device, periodic RMS energy of captured samples).
     public init(
-        pid: pid_t,
+        pids: [pid_t],
         outputFileDescriptor: Int32,
         sampleRate: Int = 48000,
         channels: Int = 2,
         debugLogging: Bool = false,
     ) {
-        self.pid = pid
+        self.pids = pids
         self.outputFileDescriptor = outputFileDescriptor
         self.sampleRate = sampleRate
         self.channels = channels
         self.debugLogging = debugLogging
-    }
-
-    /// Translate PID to CoreAudio process AudioObjectID.
-    private func translatePID() throws -> AudioObjectID {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
-        )
-        var objectID = AudioObjectID(kAudioObjectUnknown)
-        var size = UInt32(MemoryLayout<AudioObjectID>.size)
-        var mutablePid = pid
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address,
-            UInt32(MemoryLayout<pid_t>.size), &mutablePid, &size, &objectID,
-        )
-        guard status == noErr, objectID != kAudioObjectUnknown else {
-            throw NSError(
-                domain: "audiotap", code: Int(status),
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "Failed to translate PID \(pid) to audio object (status: \(status))",
-                ],
-            )
-        }
-        return objectID
     }
 
     public func start() throws {
@@ -234,15 +214,17 @@ public class AppAudioCapture {
 
     // swiftlint:disable:next function_body_length
     private func startCapture() throws {
-        let processObjectID = try translatePID()
-        logger.info("Process audio object ID: \(processObjectID)")
+        let processObjectIDs = try translatePIDs()
+        logger.info("Process audio object IDs: \(processObjectIDs) (from \(self.pids.count) PIDs)")
 
         if debugLogging {
-            let bundleID = getProcessBundleID(processObjectID) ?? "?"
-            let exeName = getExecutableName(pid: pid)
-            logger.info(
-                "[debug] Tap target: pid=\(self.pid, privacy: .public) exe=\(exeName, privacy: .public) bundle=\(bundleID, privacy: .public) audioObjectID=\(processObjectID, privacy: .public)",
-            )
+            for (pid, objectID) in zip(pids, processObjectIDs) {
+                let bundleID = getProcessBundleID(objectID) ?? "?"
+                let exeName = getExecutableName(pid: pid)
+                logger.info(
+                    "[debug] Tap target: pid=\(pid, privacy: .public) exe=\(exeName, privacy: .public) bundle=\(bundleID, privacy: .public) audioObjectID=\(objectID, privacy: .public)",
+                )
+            }
         }
 
         // Get default output device UID
@@ -263,8 +245,10 @@ public class AppAudioCapture {
             )
         }
 
-        // Create CATapDescription for the target process
-        let tap = CATapDescription(stereoMixdownOfProcesses: [processObjectID])
+        // Create CATapDescription for the target process(es). For Electron
+        // apps this covers the helper tree so the renderer holding the audio
+        // handle is included; for native apps the array is a single PID.
+        let tap = CATapDescription(stereoMixdownOfProcesses: processObjectIDs)
         tap.uuid = UUID()
         tap.name = "MeetingTranscriber-tap"
         tap.isPrivate = true
@@ -275,7 +259,7 @@ public class AppAudioCapture {
         guard tapStatus == noErr else {
             let hint = Self.describeTapError(tapStatus)
             logger.error(
-                "Failed to create process tap (pid=\(self.pid, privacy: .public)): \(hint, privacy: .public)",
+                "Failed to create process tap (pids=\(self.pids, privacy: .public)): \(hint, privacy: .public)",
             )
             throw NSError(
                 domain: "audiotap", code: Int(tapStatus),
@@ -292,9 +276,11 @@ public class AppAudioCapture {
             )
         }
 
-        // Create aggregate device with the tap
+        // Create aggregate device with the tap. The name embeds the root PID
+        // (first entry) — purely cosmetic for `system_profiler SPAudioDataType`.
+        let nameTag = pids.first.map(String.init) ?? "0"
         let desc: [String: Any] = [
-            kAudioAggregateDeviceNameKey as String: "audiotap-\(pid)",
+            kAudioAggregateDeviceNameKey as String: "audiotap-\(nameTag)",
             kAudioAggregateDeviceUIDKey as String: UUID().uuidString,
             kAudioAggregateDeviceMainSubDeviceKey as String: systemOutputUID,
             kAudioAggregateDeviceIsPrivateKey as String: true,
@@ -405,7 +391,7 @@ public class AppAudioCapture {
         actualSampleRate = Self.resolveActualSampleRate(
             deviceID: aggregateID, tapID: tapID, requestedRate: sampleRate,
         )
-        logger.info("Audio capture started (PID \(self.pid), rate: \(self.actualSampleRate) Hz)")
+        logger.info("Audio capture started (PIDs \(self.pids), rate: \(self.actualSampleRate) Hz)")
     }
 
     private func stopCapture() {

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -214,15 +214,24 @@ public class AppAudioCapture {
 
     // swiftlint:disable:next function_body_length
     private func startCapture() throws {
-        let processObjectIDs = try translatePIDs()
-        logger.info("Process audio object IDs: \(processObjectIDs) (from \(self.pids.count) PIDs)")
+        let translated = try translatePIDs()
+        let processObjectIDs = translated.map(\.audioObjectID)
+
+        // Always log at info level with exe names so a "silent _app.wav"
+        // report can be triaged without the user toggling Verbose Audio
+        // Logging first — process names like "MSTeams Helper (Renderer)"
+        // make issue-#84-style failures actionable.
+        let tapSummary = translated.map { "\(getExecutableName(pid: $0.pid))(\($0.pid))" }.joined(separator: ", ")
+        logger.info(
+            "App audio tap: \(translated.count) PID(s) [\(tapSummary, privacy: .public)]",
+        )
 
         if debugLogging {
-            for (pid, objectID) in zip(pids, processObjectIDs) {
-                let bundleID = getProcessBundleID(objectID) ?? "?"
-                let exeName = getExecutableName(pid: pid)
+            for entry in translated {
+                let bundleID = getProcessBundleID(entry.audioObjectID) ?? "?"
+                let exeName = getExecutableName(pid: entry.pid)
                 logger.info(
-                    "[debug] Tap target: pid=\(pid, privacy: .public) exe=\(exeName, privacy: .public) bundle=\(bundleID, privacy: .public) audioObjectID=\(objectID, privacy: .public)",
+                    "[debug] Tap target: pid=\(entry.pid, privacy: .public) exe=\(exeName, privacy: .public) bundle=\(bundleID, privacy: .public) audioObjectID=\(entry.audioObjectID, privacy: .public)",
                 )
             }
         }

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// Replaces the CLI entry point — call `start()` and `stop()` directly from the host app.
 @available(macOS 14.2, *)
 public class AudioCaptureSession {
-    private let pid: pid_t
+    private let pids: [pid_t]
     private let sampleRate: Int
     private let channels: Int
     private let appOutputURL: URL
@@ -19,8 +19,12 @@ public class AudioCaptureSession {
     private var micCapture: MicCaptureHandler?
     private var appFileHandle: FileHandle?
 
+    /// - Parameter pids: PIDs to capture audio from. For Electron/WebView2
+    ///   apps (Teams 2.x, Slack, Discord) this should include the root PID
+    ///   plus helper/renderer children; for native Cocoa apps a
+    ///   single-element array is fine.
     public init(
-        pid: pid_t,
+        pids: [pid_t],
         appOutputURL: URL,
         sampleRate: Int = 48000,
         channels: Int = 2,
@@ -28,7 +32,7 @@ public class AudioCaptureSession {
         micDeviceUID: String? = nil,
         debugLogging: Bool = false,
     ) {
-        self.pid = pid
+        self.pids = pids
         self.sampleRate = sampleRate
         self.channels = channels
         self.appOutputURL = appOutputURL
@@ -49,7 +53,7 @@ public class AudioCaptureSession {
         let handle = try FileHandle(forWritingTo: appOutputURL)
 
         let capture = AppAudioCapture(
-            pid: pid,
+            pids: pids,
             outputFileDescriptor: handle.fileDescriptor,
             sampleRate: sampleRate,
             channels: channels,
@@ -75,7 +79,7 @@ public class AudioCaptureSession {
             }
         }
 
-        logger.info("Capture session started (PID \(self.pid), rate: \(self.sampleRate), channels: \(self.channels))")
+        logger.info("Capture session started (PIDs \(self.pids), rate: \(self.sampleRate), channels: \(self.channels))")
     }
 
     /// Instantaneous app-audio level in dBFS, decayed to -120 when no buffer has

--- a/tools/audiotap/Sources/ProcessTreeEnumerator.swift
+++ b/tools/audiotap/Sources/ProcessTreeEnumerator.swift
@@ -1,0 +1,77 @@
+import Darwin
+import Foundation
+
+/// Enumerates every running PID whose executable lives under a given `.app`
+/// bundle directory.
+///
+/// Electron/WebView2 apps (Teams 2.x, Slack, Discord) render call audio in
+/// helper/renderer child processes rather than the shell process the OS sees
+/// as the window owner. A single-PID `CATapDescription` on the shell returns
+/// silence. Issue #84 reports this for Microsoft Teams 2.x; see
+/// `docs/plans/.local/open/2026-05-18-multi-pid-audio-tap-electron-apps.md`.
+public enum ProcessTreeEnumerator {
+    /// Returns every running PID whose executable path resides under
+    /// `bundleURL` (a `.app` bundle). Order is the kernel's listing order,
+    /// which is not stable across calls.
+    ///
+    /// The bundle path is matched as a directory prefix (a trailing slash is
+    /// appended) so `/Applications/Foo.app` doesn't accidentally match
+    /// `/Applications/FooBar.app`. `resolvingSymlinksInPath()` normalizes
+    /// bundles installed under symlinked roots (cheap no-op for the standard
+    /// `/Applications/` and `~/Applications/` locations).
+    public static func pidsRooted(in bundleURL: URL) -> [pid_t] {
+        pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: liveRunningPIDs,
+            executablePath: liveExecutablePath,
+        )
+    }
+
+    /// Test seam — same matching logic as the public `pidsRooted(in:)` but
+    /// driven by injected snapshot/lookup closures. Lets unit tests drive the
+    /// kernel-prefix matching without spawning real ad-hoc-unsigned binaries
+    /// (which Apple Silicon AMFI kills before `proc_pidpath` can answer).
+    static func pidsRooted(
+        in bundleURL: URL,
+        allRunningPIDs: () -> [pid_t],
+        executablePath: (pid_t) -> String?,
+    ) -> [pid_t] {
+        let bundlePath = bundleURL.resolvingSymlinksInPath().path + "/"
+        return allRunningPIDs().filter { pid in
+            guard let exePath = executablePath(pid) else { return false }
+            return exePath.hasPrefix(bundlePath)
+        }
+    }
+
+    /// Snapshot of every PID the kernel knows about right now.
+    static func liveRunningPIDs() -> [pid_t] {
+        let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard needed > 0 else { return [] }
+        let capacity = Int(needed) / MemoryLayout<pid_t>.size + 32
+        var pids = [pid_t](repeating: 0, count: capacity)
+        let bytes = pids.withUnsafeMutableBufferPointer { buf in
+            proc_listpids(
+                UInt32(PROC_ALL_PIDS),
+                0,
+                buf.baseAddress,
+                Int32(buf.count * MemoryLayout<pid_t>.size),
+            )
+        }
+        guard bytes > 0 else { return [] }
+        let count = Int(bytes) / MemoryLayout<pid_t>.size
+        return pids.prefix(count).filter { $0 > 0 }
+    }
+
+    /// The kernel's `PROC_PIDPATHINFO_MAXSIZE` (4 × MAXPATHLEN), inlined
+    /// because the macro itself isn't bridged into Swift.
+    private static let procPidPathMaxSize = 4 * Int(MAXPATHLEN)
+
+    /// `proc_pidpath` for a single PID, or nil if the kernel refuses (process
+    /// exited, sandbox boundary, etc.).
+    static func liveExecutablePath(for pid: pid_t) -> String? {
+        var pathBuf = [CChar](repeating: 0, count: procPidPathMaxSize)
+        let n = proc_pidpath(pid, &pathBuf, UInt32(pathBuf.count))
+        guard n > 0 else { return nil }
+        return String(cString: pathBuf)
+    }
+}

--- a/tools/audiotap/Tests/ProcessTreeEnumeratorTests.swift
+++ b/tools/audiotap/Tests/ProcessTreeEnumeratorTests.swift
@@ -1,0 +1,85 @@
+@testable import AudioTapLib
+import XCTest
+
+/// Tests for `ProcessTreeEnumerator.pidsRooted(in:)`.
+///
+/// We drive the matching logic through the test seam that takes injected
+/// `allRunningPIDs` + `executablePath` closures. Spawning real
+/// "rooted-in-temp-bundle" processes to exercise the live code path is
+/// blocked by Apple Silicon's AMFI (copying `/bin/sleep` drops the signature
+/// → unsigned binary refused; hardlinking across the SSV → EPERM), so the
+/// live path is left to the existing live-recording E2E.
+final class ProcessTreeEnumeratorTests: XCTestCase {
+    private let bundleURL = URL(fileURLWithPath: "/Applications/Teams.app")
+
+    func testIncludesAllPidsRunningUnderBundle() {
+        let inputPids: [pid_t] = [100, 200, 300, 400]
+        let paths: [pid_t: String] = [
+            100: "/Applications/Teams.app/Contents/MacOS/MSTeams",
+            200: "/Applications/Teams.app/Contents/Frameworks/Helper.app/Contents/MacOS/Helper",
+            300: "/usr/bin/python3",
+            400: "/Applications/Other.app/Contents/MacOS/Other",
+        ]
+        let found = ProcessTreeEnumerator.pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: { inputPids },
+            executablePath: { paths[$0] },
+        )
+        XCTAssertEqual(Set(found), [100, 200])
+    }
+
+    func testReturnsEmptyWhenNoProcessesUnderBundle() {
+        let found = ProcessTreeEnumerator.pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: { [50, 60] },
+            executablePath: { _ in "/usr/bin/python3" },
+        )
+        XCTAssertEqual(found, [])
+    }
+
+    func testReturnsEmptyWhenNoPidsRunning() {
+        let found = ProcessTreeEnumerator.pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: { [] },
+            executablePath: { _ in "/never/called" },
+        )
+        XCTAssertEqual(found, [])
+    }
+
+    func testSkipsPidsWithUnknownExecutablePath() {
+        // `executablePath` returning nil mirrors `proc_pidpath` refusing
+        // (process exited between listpids and pidpath, sandbox barrier).
+        let found = ProcessTreeEnumerator.pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: { [100, 200] },
+            executablePath: { pid in
+                pid == 100 ? "/Applications/Teams.app/Contents/MacOS/MSTeams" : nil
+            },
+        )
+        XCTAssertEqual(found, [100])
+    }
+
+    func testDoesNotMatchSiblingBundleWithCommonPrefix() {
+        // The directory-boundary trailing-slash matters: `/Applications/Teams.app`
+        // must not match `/Applications/Teams.app.backup/...`.
+        let found = ProcessTreeEnumerator.pidsRooted(
+            in: bundleURL,
+            allRunningPIDs: { [100, 200] },
+            executablePath: { pid in
+                pid == 100
+                    ? "/Applications/Teams.app/Contents/MacOS/MSTeams"
+                    : "/Applications/Teams.app.backup/Contents/MacOS/Old"
+            },
+        )
+        XCTAssertEqual(found, [100])
+    }
+
+    func testLiveSnapshotIncludesCurrentProcess() {
+        // Sanity check that the live helpers actually work — our own xctest
+        // PID must show up in the kernel listing and resolve to a non-nil
+        // executable path. Doesn't depend on bundle matching.
+        let pids = ProcessTreeEnumerator.liveRunningPIDs()
+        XCTAssertTrue(pids.contains(getpid()))
+        XCTAssertNotNil(ProcessTreeEnumerator.liveExecutablePath(for: getpid()))
+    }
+}


### PR DESCRIPTION
## Summary

- Multi-PID `CATapDescription` covers Electron helper trees (Teams 2.x, Slack, Discord) where call audio is rendered in a child PID rather than the shell PID the OS sees as the window owner.
- Native Cocoa apps (Zoom, Webex) trivially resolve to a single PID — behavior unchanged.
- Closes the silent-`_app.wav` issue reported in #84 by Pred8or (mean_volume = -91 dB on three independent recordings).

## What changes

- New `ProcessTreeEnumerator.pidsRooted(in:)` walks `proc_listpids` + `proc_pidpath`, returns every PID whose exe lives under the `.app` bundle.
- `AppAudioCapture` / `AudioCaptureSession` init signatures: `pid: pid_t` → `pids: [pid_t]`. `translatePIDs()` drops PIDs that don't have an audio object (expected for non-audio helpers), throws only when none translate.
- `DualSourceRecorder.resolveTapPIDs(rootPID:)` resolves `NSRunningApplication.bundleURL`, calls the enumerator, falls back to `[rootPID]` when bundle URL is missing or enumeration is empty. Root PID is always included in the tap set.

## Performance impact

Measured / estimated, not benchmarked:
- One-time at recording start: `proc_listpids` (~5-10 ms over ~400 system PIDs) + N × `proc_pidpath` + N × `translatePID`. For Teams 2.x at N≈7-10 helpers: **~15-25 ms total**, trivial vs. existing ~50-100 ms tap-creation overhead.
- Steady-state: CATapDescription stereo mixdown of N PIDs vs. 1 = N float-copies + N-1 adds per render block. At N=7: nanoseconds extra. **Unmeasurable in Activity Monitor.**

## Validation plan

No local repro available — roms's own Teams 2.x recordings don't show the Pred8or signature. Validation depends on the reporter:

1. Merge → next pre-release tag picks up the change.
2. Local sanity already verified: normal Teams 2.x call still produces non-silent `_app.wav` (working case didn't regress).
3. Ask Pred8or + amit-math on issue #84 to re-run the pre-release build through `ffmpeg volumedetect`. Expected: `mean_volume` in the normal `-20 to -30 dB` range instead of `-91 dB`.
4. If reporter logs confirm: merge stays / close #84. If not: their Verbose Audio Logging output will show which helper PID was missing, at which point Variant C (exclude-mode tap) becomes the next move.

## Test plan

- [x] `swift test --filter ProcessTreeEnumeratorTests` (audiotap) — 6/6 green via injectable seam (live-spawn would hit Apple Silicon AMFI; documented in test file).
- [x] `swift test --filter DualSourceRecorderTests` (app) — 28/28 green, includes new `testResolveTapPIDsFallsBackWhenBundleURLUnavailable`.
- [x] Full app suite minus `MenuBarIconSnapshotTests` (pre-existing environment flake on dev machine, verified independently against `main`) — all 1609 tests pass.
- [x] `./scripts/lint.sh` — 0 violations.
- [ ] After merge: pre-release tag + reporter validation per "Validation plan" above.