### PR TITLE
feat(app): keyboard-grace period prevents accidental speaker-name confirms

### DIFF
--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -72,13 +72,26 @@ struct SpeakerNamingView: View {
     let knownSpeakerNames: [String]
     let onComplete: (PipelineQueue.SpeakerNamingResult) -> Void
 
+    /// Window after the dialog appears (or after Re-run produces a fresh `data.revision`)
+    /// during which Confirm and Skip remain disabled. Prevents accidental confirms from
+    /// stray Enter/Escape keystrokes that leak from another app's focus when
+    /// `bringWindowToFront` steals focus mid-keystroke. Historical pipeline_log data
+    /// shows ~19% of speaker-naming sessions exiting within 2-3 s — an isolated cluster
+    /// outside the log-normal human-confirm distribution. See
+    /// `docs/plans/.local/research/2026-05-19-late-speaker-renaming-after-done.md`.
+    static let defaultKeyboardGracePeriod: TimeInterval = 0.75
+
+    let gracePeriod: TimeInterval
+
     init(
         data: PipelineQueue.SpeakerNamingData,
         knownSpeakerNames: [String] = [],
+        gracePeriod: TimeInterval = Self.defaultKeyboardGracePeriod,
         onComplete: @escaping (PipelineQueue.SpeakerNamingResult) -> Void,
     ) {
         self.data = data
         self.knownSpeakerNames = knownSpeakerNames
+        self.gracePeriod = gracePeriod
         self.onComplete = onComplete
         // Seed `names` and `rerunCount` synchronously so the view renders
         // its chip rows on first body evaluation (the chips depend on
@@ -88,8 +101,13 @@ struct SpeakerNamingView: View {
         let speakerList = Self.computeSpeakers(from: data)
         _names = State(initialValue: Self.computeInitialNames(speakers: speakerList))
         _rerunCount = State(initialValue: max(2, speakerList.count + 1))
+        // Initialize the grace-period gate to "active" when the period is positive
+        // so the buttons start disabled. When tests pass gracePeriod = 0 the gate
+        // starts open (no grace) and the unlock task is a no-op.
+        _keyboardGracePeriodActive = State(initialValue: gracePeriod > 0)
     }
 
+    @State private var keyboardGracePeriodActive: Bool = true
     @State private var names: [String] = []
     /// Job-ID for which this view has already fired `onComplete`. Tracked
     /// per-job (not just a Bool) so that when the window switches to a
@@ -166,6 +184,7 @@ struct SpeakerNamingView: View {
                     onComplete(.skipped)
                 }
                 .keyboardShortcut(.escape)
+                .disabled(keyboardGracePeriodActive)
                 .accessibilityIdentifier("skip-button")
 
                 Button("Confirm") {
@@ -175,6 +194,7 @@ struct SpeakerNamingView: View {
                 }
                 .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
+                .disabled(keyboardGracePeriodActive)
                 .accessibilityIdentifier("confirm-button")
             }
             .padding(.bottom, 8)
@@ -190,6 +210,21 @@ struct SpeakerNamingView: View {
         // `completedJobID` guard kept Confirm/Skip/Re-run dead.
         .onChange(of: data.revision) { _, _ in
             resetForCurrentPresentation()
+        }
+        // Keyboard-grace gate: keep Confirm + Skip disabled for `gracePeriod`
+        // seconds after the dialog appears AND after each Re-run produces a
+        // fresh `data.revision`. The `task(id:)` cancels + restarts when
+        // `data.revision` changes, re-locking the buttons each time.
+        .task(id: data.revision) {
+            guard gracePeriod > 0 else {
+                keyboardGracePeriodActive = false
+                return
+            }
+            keyboardGracePeriodActive = true
+            try? await Task.sleep(for: .seconds(gracePeriod))
+            if !Task.isCancelled {
+                keyboardGracePeriodActive = false
+            }
         }
         // No onDisappear → .skipped: in the non-blocking architecture closing
         // the window (Cmd+Q, click X, app quit) leaves the job in

--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -119,6 +119,11 @@ struct VoiceEnrollmentView: View {
             SpeakerNamingView(
                 data: payload.namingData,
                 knownSpeakerNames: payload.knownNames,
+                // Enrollment flow is user-initiated from Settings — no focus-steal
+                // mid-keystroke from another app, so the keyboard-grace gate (which
+                // protects the post-meeting dialog) isn't needed here and would just
+                // feel sluggish.
+                gracePeriod: 0,
             ) { result in
                 switch VoiceEnrollmentLogic.handleNamingResult(
                     result, payload: payload, matcher: matcher,

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -73,7 +73,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
 
     func testSkipButtonCallsOnCompleteWithSkipped() throws {
         var result: PipelineQueue.SpeakerNamingResult?
-        let sut = SpeakerNamingView(data: makeData()) { result = $0 }
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { result = $0 }
         let body = try sut.inspect()
         try body.find(button: "Skip").tap()
         if case .skipped = result {
@@ -85,7 +85,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
 
     func testConfirmButtonCallsOnComplete() throws {
         var result: PipelineQueue.SpeakerNamingResult?
-        let sut = SpeakerNamingView(data: makeData()) { result = $0 }
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { result = $0 }
         let body = try sut.inspect()
         try body.find(button: "Confirm").tap()
         if case .confirmed = result {
@@ -103,13 +103,13 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         var jobIDsConfirmed: [UUID] = []
 
         let dataA = makeData(title: "Meeting A")
-        let viewA = SpeakerNamingView(data: dataA) { result in
+        let viewA = SpeakerNamingView(data: dataA, gracePeriod: 0) { result in
             if case .confirmed = result { jobIDsConfirmed.append(dataA.jobID) }
         }
         try viewA.inspect().find(button: "Confirm").tap()
 
         let dataB = makeData(title: "Meeting B")
-        let viewB = SpeakerNamingView(data: dataB) { result in
+        let viewB = SpeakerNamingView(data: dataB, gracePeriod: 0) { result in
             if case .confirmed = result { jobIDsConfirmed.append(dataB.jobID) }
         }
         try viewB.inspect().find(button: "Confirm").tap()
@@ -128,13 +128,13 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         var jobIDsSkipped: [UUID] = []
 
         let dataA = makeData(title: "Meeting A")
-        let viewA = SpeakerNamingView(data: dataA) { result in
+        let viewA = SpeakerNamingView(data: dataA, gracePeriod: 0) { result in
             if case .skipped = result { jobIDsSkipped.append(dataA.jobID) }
         }
         try viewA.inspect().find(button: "Skip").tap()
 
         let dataB = makeData(title: "Meeting B")
-        let viewB = SpeakerNamingView(data: dataB) { result in
+        let viewB = SpeakerNamingView(data: dataB, gracePeriod: 0) { result in
             if case .skipped = result { jobIDsSkipped.append(dataB.jobID) }
         }
         try viewB.inspect().find(button: "Skip").tap()
@@ -214,7 +214,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
 
     func testRerunButtonCallsOnCompleteWithRerun() throws {
         var result: PipelineQueue.SpeakerNamingResult?
-        let sut = SpeakerNamingView(data: makeData()) { result = $0 }
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { result = $0 }
         let body = try sut.inspect()
         try body.find(button: "Re-run").tap()
         if case .rerun = result {
@@ -476,6 +476,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         let sut = SpeakerNamingView(
             data: makeData(),
             knownSpeakerNames: ["Alice"],
+            gracePeriod: 0,
         ) { result = $0 }
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(button: "Alice").tap())
@@ -551,7 +552,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
             participants: ["Dave"],
             isDualSource: false,
         )
-        let sut = SpeakerNamingView(data: data) { result = $0 }
+        let sut = SpeakerNamingView(data: data, gracePeriod: 0) { result = $0 }
         let body = try sut.inspect()
         XCTAssertNoThrow(try body.find(button: "Dave").tap())
         try body.find(button: "Confirm").tap()
@@ -660,5 +661,57 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
 
     func testLongestSegmentReturnsNilForEmptyInput() {
         XCTAssertNil(SpeakerNamingView.longestSegment(forSpeaker: "A", in: []))
+    }
+
+    // MARK: - Keyboard grace period
+
+    /// Regression test for the ~19% auto-confirm bug surfaced in
+    /// `pipeline_log.jsonl` analysis on 2026-05-20: stray Enter from the
+    /// previous-focused app fires Confirm within 2-3 s of the dialog
+    /// appearing. With a positive `gracePeriod`, the Confirm button must
+    /// start disabled so the stray keystroke is dropped.
+    func testConfirmDisabledDuringGracePeriod() throws {
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 1.0) { _ in }
+        let body = try sut.inspect()
+        let confirm = try body.find(button: "Confirm")
+        XCTAssertTrue(
+            confirm.isDisabled(),
+            "Confirm must be disabled during the keyboard-grace period",
+        )
+    }
+
+    func testSkipDisabledDuringGracePeriod() throws {
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 1.0) { _ in }
+        let body = try sut.inspect()
+        let skip = try body.find(button: "Skip")
+        XCTAssertTrue(
+            skip.isDisabled(),
+            "Skip must be disabled during the keyboard-grace period",
+        )
+    }
+
+    /// Re-run is a deliberate click-only action (no `.keyboardShortcut`) so
+    /// the grace period doesn't need to gate it. Pinning this here also
+    /// guards against a future refactor that adds a keyboard shortcut to
+    /// Re-run without restoring the grace gate.
+    func testRerunNotDisabledDuringGracePeriod() throws {
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 1.0) { _ in }
+        let body = try sut.inspect()
+        let rerun = try body.find(button: "Re-run")
+        XCTAssertFalse(
+            rerun.isDisabled(),
+            "Re-run must remain clickable during the keyboard-grace period",
+        )
+    }
+
+    /// When `gracePeriod = 0` (test-only shortcut, also a safety hatch),
+    /// buttons must be active immediately so existing tap-based tests work.
+    func testConfirmAndSkipEnabledWhenGracePeriodIsZero() throws {
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { _ in }
+        let body = try sut.inspect()
+        let confirm = try body.find(button: "Confirm")
+        let skip = try body.find(button: "Skip")
+        XCTAssertFalse(confirm.isDisabled())
+        XCTAssertFalse(skip.isDisabled())
     }
 }


### PR DESCRIPTION
## Summary

- Adds a ~750 ms grace period after the speaker-naming dialog appears (and after each Re-run produces a fresh `data.revision`) during which Confirm + Skip stay disabled. Re-run remains clickable.
- Slice C of the 3-slice plan for the late-speaker-renaming gap (`docs/plans/.local/research/2026-05-19-late-speaker-renaming-after-done.md`). Slices A (defer sidecar delete) + B (per-job "Edit Speaker Names" button) follow in subsequent PRs once this prevention layer lands.

## Why this matters — empirical evidence

Analysis of `~/Library/Application Support/MeetingTranscriber/ipc/pipeline_log.jsonl` across 89 jobs from 2026-05-02 to 2026-05-20:

```
Duration in speakerNamingPending → generatingProtocol:
  0-1s     0   (none — SwiftUI window load gates instant confirm)
  2-3s    17   █████████████████  ← BUG CLUSTER (19% of all sessions)
  4-5s     9   █████████
  6-10s   22   ██████████████████████  ← real fast human-confirm
 11-30s   20   ████████████████████    ← typical "scan + confirm"
 31-120s  11   ███████████
  >120s   10   ██████████              ← user came back later
```

The bimodal distribution (clear cluster at 2-3 s, isolated from the log-normal human-confirm tail) confirms the keystroke-leak hypothesis: `bringWindowToFront` already calls `NSApp.activate(ignoringOtherApps: true) + makeKeyAndOrderFront`, and the Confirm button is `.borderedProminent` with `.keyboardShortcut(.return)`. When the dialog pops while the user is mid-Enter in another app (e.g. sending a Teams chat), the keystroke fires on the just-focused dialog and auto-confirms with whatever auto-mapping was suggested.

19% prevalence over 18 days, across many independent sessions — not a one-off.

## What changes

`SpeakerNamingView.swift`:
- New `gracePeriod: TimeInterval` init param, default 0.75 s. `Self.defaultKeyboardGracePeriod` static constant.
- New `@State private var keyboardGracePeriodActive: Bool` initialized to `gracePeriod > 0`.
- New `.task(id: data.revision)` modifier that sleeps `gracePeriod`, then sets the gate to `false`. Re-run produces a new `data.revision` → task restarts → gate re-locks.
- Confirm + Skip buttons: `.disabled(keyboardGracePeriodActive)`.

`SpeakerNamingViewTests.swift`:
- 4 new tests (Confirm disabled, Skip disabled, Re-run not disabled, gracePeriod=0 bypass).
- 8 existing tap-tests updated to construct with `gracePeriod: 0` so buttons are active when `.tap()` fires.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter SpeakerNamingViewTests` — 58/58 pass (54 existing + 4 new)
- [x] `./scripts/lint.sh` — 0 violations
- [ ] Manual smoke: open the speaker-naming dialog (trigger via meeting-simulator or "Process Audio/Video Files..."), verify Confirm/Skip start greyed out and become active after ~750 ms. Verify Enter / Esc within first 750 ms is dropped.
- [ ] CI: e2e + e2e-app + sanitizer matrix

## What this does NOT fix (follow-ups)

This is **prevention**, not **recovery**. After this PR:
- ~19% of accidental auto-confirms become dropped keystrokes during grace → success path: user notices the dialog, presses Enter again, normal confirm.
- The residual ~10% (Cmd+W, click X on dialog, app quit) still leave the job in `.speakerNamingPending` without a way to re-open from a `.done` job.

Slices A+B in the linked backlog file handle the recovery side (defer sidecar delete + per-job "Edit Speaker Names…" button on `.done` jobs).

## Cross-references

- `docs/plans/.local/research/2026-05-19-late-speaker-renaming-after-done.md` (full slicing rationale + risks)