### PR TITLE
test(app): extract + cover three ClaudeCLI pure helpers

### DIFF
--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -94,19 +94,28 @@
 
             if process.terminationStatus != 0 {
                 let stderrData = await stderrRead
-                let stderrText = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let stderrText = String(data: stderrData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 logger.error(
                     "claude_cli_failed exit=\(process.terminationStatus, privacy: .public) stderr=\(stderrText, privacy: .public)",
                 )
-                throw ProtocolError.cliFailed(Int(process.terminationStatus), stderrText)
+                throw Self.makeFailureError(exitCode: process.terminationStatus, stderrText: stderrText)
             }
 
+            return try Self.validateGeneratedText(text)
+        }
+
+        /// Pair an already-decoded stderr string with `exitCode` as a
+        /// `ProtocolError.cliFailed`.
+        static func makeFailureError(exitCode: Int32, stderrText: String) -> ProtocolError {
+            .cliFailed(Int(exitCode), stderrText)
+        }
+
+        /// Trim whitespace from CLI output. Throws `.emptyProtocol` when
+        /// the subprocess exited successfully but produced no usable text.
+        static func validateGeneratedText(_ text: String) throws -> String {
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
-                logger.error("claude_cli_empty_response — subprocess exited 0 with empty output")
-                throw ProtocolError.emptyProtocol
-            }
-
+            guard !trimmed.isEmpty else { throw ProtocolError.emptyProtocol }
             return trimmed
         }
 
@@ -138,23 +147,36 @@
                 if chunk.isEmpty { break } // EOF
 
                 buffer.append(chunk)
-
-                // Process complete lines
-                while let newlineRange = buffer.range(of: Data([0x0A])) {
-                    let lineData = buffer[buffer.startIndex ..< newlineRange.lowerBound]
-                    buffer.removeSubrange(buffer.startIndex ... newlineRange.lowerBound)
-
-                    guard let line = String(data: lineData, encoding: .utf8)?
-                        .trimmingCharacters(in: .whitespacesAndNewlines),
-                        !line.isEmpty else { continue }
-
-                    if let text = parseStreamJSONLine(line) {
-                        parts.append(text)
-                    }
-                }
+                parts.append(contentsOf: drainStreamJSONLines(buffer: &buffer))
             }
 
             return parts.joined()
+        }
+
+        /// Drain every newline-terminated line currently in `buffer`, parsing
+        /// each via `parseStreamJSONLine`. Returns the extracted text
+        /// fragments in order. Lines that are empty after trimming, lines
+        /// that don't decode as UTF-8, and lines that `parseStreamJSONLine`
+        /// rejects are silently skipped.
+        ///
+        /// Trailing bytes without a terminating newline stay in `buffer`
+        /// for the next call to consume — the caller must keep the buffer
+        /// across iterations.
+        static func drainStreamJSONLines(buffer: inout Data) -> [String] {
+            var fragments: [String] = []
+            while let newlineIdx = buffer.firstIndex(of: 0x0A) {
+                let lineData = buffer[buffer.startIndex ..< newlineIdx]
+                buffer.removeSubrange(buffer.startIndex ... newlineIdx)
+
+                guard let line = String(data: lineData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                    !line.isEmpty else { continue }
+
+                if let text = parseStreamJSONLine(line) {
+                    fragments.append(text)
+                }
+            }
+            return fragments
         }
 
         /// Parse a single stream-json line and extract text content.

--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -175,5 +175,164 @@
             XCTAssertEqual(env["HOME"], "/Users/x")
             XCTAssertEqual(env["USER"], "x")
         }
+
+        // MARK: - drainStreamJSONLines
+
+        func testDrainStreamJSONLinesEmptyBufferReturnsNothing() {
+            var buffer = Data()
+            XCTAssertEqual(ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer), [])
+            XCTAssertEqual(buffer, Data())
+        }
+
+        func testDrainStreamJSONLinesPartialLineRemainsInBuffer() {
+            // Single line without trailing newline — must stay in the buffer
+            // for the next chunk to complete it.
+            let original = Data(#"{"type":"content_block_delta""#.utf8)
+            var buffer = original
+            let fragments = ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer)
+            XCTAssertEqual(fragments, [])
+            XCTAssertEqual(buffer, original)
+        }
+
+        /// Joins parts with `\n`; `trailingNewline` controls whether the last
+        /// part is terminated.
+        private func makeBuffer(_ parts: [String], trailingNewline: Bool) -> Data {
+            var data = Data()
+            for (i, part) in parts.enumerated() {
+                data.append(contentsOf: part.utf8)
+                if i < parts.count - 1 || trailingNewline {
+                    data.append(0x0A)
+                }
+            }
+            return data
+        }
+
+        func testDrainStreamJSONLinesSingleCompleteLineDrains() {
+            var buffer = makeBuffer(
+                [#"{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}"#],
+                trailingNewline: true,
+            )
+            let fragments = ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer)
+            XCTAssertEqual(fragments, ["Hi"])
+            XCTAssertEqual(buffer, Data())
+        }
+
+        func testDrainStreamJSONLinesMultipleCompleteLinesPreserveOrder() {
+            var buffer = makeBuffer(
+                [
+                    #"{"type":"content_block_delta","delta":{"type":"text_delta","text":"A"}}"#,
+                    #"{"type":"content_block_delta","delta":{"type":"text_delta","text":"B"}}"#,
+                ],
+                trailingNewline: true,
+            )
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer),
+                ["A", "B"],
+            )
+            XCTAssertEqual(buffer, Data())
+        }
+
+        func testDrainStreamJSONLinesMixOfCompleteAndPartialLeavesTailInBuffer() {
+            let partial = #"{"type":"content_block_delta","del"#
+            var buffer = makeBuffer(
+                [#"{"type":"content_block_delta","delta":{"type":"text_delta","text":"Done"}}"#, partial],
+                trailingNewline: false,
+            )
+            let fragments = ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer)
+            XCTAssertEqual(fragments, ["Done"])
+            XCTAssertEqual(buffer, Data(partial.utf8))
+        }
+
+        func testDrainStreamJSONLinesSkipsEmptyAndWhitespaceLines() {
+            // Empty lines and whitespace-only lines must be skipped — Claude
+            // CLI sometimes emits blank lines between JSON events.
+            var buffer = makeBuffer(
+                [
+                    "",
+                    "   ",
+                    #"{"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}"#,
+                ],
+                trailingNewline: true,
+            )
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer),
+                ["OK"],
+            )
+        }
+
+        func testDrainStreamJSONLinesSkipsUnparseableLines() {
+            // Unknown event type → parseStreamJSONLine returns nil; drainer
+            // must not break the loop, continue with the next line.
+            var buffer = makeBuffer(
+                [
+                    #"{"type":"message_stop"}"#,
+                    #"{"type":"content_block_delta","delta":{"type":"text_delta","text":"After"}}"#,
+                ],
+                trailingNewline: true,
+            )
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer),
+                ["After"],
+            )
+        }
+
+        func testDrainStreamJSONLinesAcrossTwoChunks() {
+            // Simulate readStreamJSON: drain after the first chunk leaves
+            // a partial line; the second chunk supplies the rest plus a
+            // following complete line.
+            var buffer = Data(#"{"type":"content_block_delta","delta":{"type":"text_delta","tex"#.utf8)
+            XCTAssertEqual(ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer), [])
+
+            buffer.append(contentsOf: #"t":"Hello"}}"#.utf8)
+            buffer.append(0x0A)
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.drainStreamJSONLines(buffer: &buffer),
+                ["Hello"],
+            )
+            XCTAssertEqual(buffer, Data())
+        }
+
+        // MARK: - validateGeneratedText
+
+        func testValidateGeneratedTextReturnsTrimmed() throws {
+            let result = try ClaudeCLIProtocolGenerator.validateGeneratedText("  Hello world  \n")
+            XCTAssertEqual(result, "Hello world")
+        }
+
+        func testValidateGeneratedTextWhitespaceOnlyThrowsEmptyProtocol() {
+            // Covers both empty input and whitespace-only — the guard
+            // operates on the trimmed string, so they share a branch.
+            XCTAssertThrowsError(try ClaudeCLIProtocolGenerator.validateGeneratedText("   \n\t  ")) { error in
+                guard case ProtocolError.emptyProtocol = error else {
+                    XCTFail("Expected .emptyProtocol, got \(error)")
+                    return
+                }
+            }
+        }
+
+        // MARK: - makeFailureError
+
+        func testMakeFailureErrorWrapsExitCodeAndStderr() {
+            let err = ClaudeCLIProtocolGenerator.makeFailureError(
+                exitCode: 2,
+                stderrText: "fatal: model not found",
+            )
+            guard case let .cliFailed(code, stderr) = err else {
+                XCTFail("Expected .cliFailed, got \(err)")
+                return
+            }
+            XCTAssertEqual(code, 2)
+            XCTAssertEqual(stderr, "fatal: model not found")
+        }
+
+        func testMakeFailureErrorEmptyStderrPassesThrough() {
+            let err = ClaudeCLIProtocolGenerator.makeFailureError(exitCode: 1, stderrText: "")
+            guard case let .cliFailed(code, stderr) = err else {
+                XCTFail("Expected .cliFailed, got \(err)")
+                return
+            }
+            XCTAssertEqual(code, 1)
+            XCTAssertEqual(stderr, "")
+        }
     }
 #endif


### PR DESCRIPTION
## Summary
Pulls `drainStreamJSONLines`, `validateGeneratedText`, and `makeFailureError` out of the inline subprocess driver in `generate()` and `readStreamJSON`. Each helper is now individually testable; the async subprocess-driving code still can't be exercised in xctest without spawning a fake CLI, but the previously-inline logic that parsed/validated/wrapped its output is no longer entangled with the process lifecycle.

- `drainStreamJSONLines(buffer:)` — newline-delimited `Data` buffer drainer. Uses `firstIndex(of: 0x0A)` (no per-iteration needle allocation, vs. the original inline `range(of: Data([0x0A]))`).
- `validateGeneratedText(_:)` — trim + throw `.emptyProtocol`.
- `makeFailureError(exitCode:stderrText:)` — wrap a decoded stderr string in `.cliFailed`. stderr decoding stays at the call site so the failure-log line still sees the trimmed string.

Per-function coverage after this PR (via `llvm-cov`): all three helpers at **100 %**. `generate()` and `readStreamJSON` remain at 0 % (subprocess driver).

12 new unit tests cover empty/partial/multi-chunk drain paths, the empty-protocol guard, and the failure-error wrapper. 33 tests total in this file (was 21).

## /simplify pass
Three reviewers ran in parallel. Real findings applied:

1. **Round-trip pattern-match (reviewer 2):** original draft had `makeFailureError(stderrData: Data)` and the caller pattern-matched the returned `.cliFailed` to recover the stderr string for logging. Replaced with `makeFailureError(exitCode:stderrText:)` taking the already-decoded string — caller decodes once and logs once.
2. **Redundant do/catch (reviewer 2):** wrapping `try Self.validateGeneratedText(text)` in a `do/catch` that only re-throws was pure overhead — dropped. The one log line on empty output goes via `ProtocolError.emptyProtocol`'s `errorDescription` instead.
3. **Per-iteration `Data` allocation (reviewer 3):** `buffer.range(of: Data([0x0A]))` allocated a 1-byte needle on every loop iteration. Replaced with `buffer.firstIndex(of: 0x0A)` — straight byte scan, no allocation.

## Part of
Tier-1 plan toward 80 % project coverage. Step 1 (`Helpers.swift`) shipped as PR #309 (75.4 % → ~77 %). This step targets `ClaudeCLIProtocolGenerator.swift` (~32 % → ~40 % per llvm-cov; +~30 covered lines projected for Codecov).

## Test plan
- [x] `cd app/MeetingTranscriber && swift test --filter ClaudeCLIProtocolGeneratorTests` — 33 tests pass
- [x] `./scripts/lint.sh` — zero violations
- [x] `swift build` — clean