### PR TITLE
test(app): extract Parakeet token-grouping + Qwen3 chunking into testable sibling types

### DIFF
--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -122,7 +122,7 @@ final class ParakeetEngine: TranscribingEngine {
             ]
         }
 
-        return Self.groupTokensIntoSegments(timings)
+        return ParakeetTokenGrouping.groupIntoSegments(timings)
     }
 
     /// Run CTC keyword spotting on the audio and rescore the TDT transcript.
@@ -164,38 +164,6 @@ final class ParakeetEngine: TranscribingEngine {
             ctcDetectedTerms: detected.isEmpty ? nil : detected,
             ctcAppliedTerms: applied.isEmpty ? nil : applied,
         )
-    }
-
-    /// Group token-level timings into sentence-level `TimestampedSegment`s.
-    ///
-    /// Ends a segment at sentence-terminating punctuation (`. ! ?`) or
-    /// after 20 tokens to keep segment lengths reasonable.
-    private static func groupTokensIntoSegments(_ timings: [TokenTiming]) -> [TimestampedSegment] {
-        var segments: [TimestampedSegment] = []
-        var group: [TokenTiming] = []
-
-        for timing in timings {
-            let token = timing.token
-            guard !token.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty else { continue }
-            group.append(timing)
-
-            let endsWithPunct = token.hasSuffix(".") || token.hasSuffix("!") || token.hasSuffix("?")
-            if endsWithPunct || group.count >= 20 {
-                if let seg = makeSegment(from: group) { segments.append(seg) }
-                group = []
-            }
-        }
-        if let seg = makeSegment(from: group) { segments.append(seg) }
-
-        return segments
-    }
-
-    private static func makeSegment(from timings: [TokenTiming]) -> TimestampedSegment? {
-        guard !timings.isEmpty else { return nil }
-        let text = timings.map(\.token).joined().trimmingCharacters(in: CharacterSet.whitespaces)
-        guard !text.isEmpty else { return nil }
-        // swiftlint:disable:next force_unwrapping
-        return TimestampedSegment(start: timings.first!.startTime, end: timings.last!.endTime, text: text)
     }
 
     // MARK: - Custom Vocabulary

--- a/app/MeetingTranscriber/Sources/ParakeetTokenGrouping.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetTokenGrouping.swift
@@ -1,0 +1,48 @@
+import FluidAudio
+import Foundation
+
+/// Pure token-grouping logic for Parakeet ASR output.
+///
+/// Extracted from `ParakeetEngine` so the segmentation rules (sentence-end
+/// punctuation, 20-token cap) can be unit-tested without loading a model.
+enum ParakeetTokenGrouping {
+    /// Maximum tokens per segment before forcing a split — keeps segments
+    /// short enough that they remain useful for the protocol generator
+    /// even when the model emits long runs without terminal punctuation.
+    static let maxTokensPerSegment = 20
+
+    /// Group token-level timings into sentence-level `TimestampedSegment`s.
+    ///
+    /// Ends a segment at sentence-terminating punctuation (`. ! ?`) or
+    /// after `maxTokensPerSegment` tokens, whichever comes first. Tokens
+    /// that are blank after whitespace-trimming are skipped entirely.
+    static func groupIntoSegments(_ timings: [TokenTiming]) -> [TimestampedSegment] {
+        var segments: [TimestampedSegment] = []
+        var group: [TokenTiming] = []
+
+        for timing in timings {
+            let token = timing.token
+            guard !token.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty else { continue }
+            group.append(timing)
+
+            let endsWithPunct = token.hasSuffix(".") || token.hasSuffix("!") || token.hasSuffix("?")
+            if endsWithPunct || group.count >= maxTokensPerSegment {
+                if let seg = makeSegment(from: group) { segments.append(seg) }
+                group = []
+            }
+        }
+        if let seg = makeSegment(from: group) { segments.append(seg) }
+
+        return segments
+    }
+
+    /// Build a `TimestampedSegment` from a contiguous group of token timings.
+    /// Returns nil if `timings` is empty or yields an all-whitespace text.
+    static func makeSegment(from timings: [TokenTiming]) -> TimestampedSegment? {
+        guard !timings.isEmpty else { return nil }
+        let text = timings.map(\.token).joined().trimmingCharacters(in: CharacterSet.whitespaces)
+        guard !text.isEmpty else { return nil }
+        // swiftlint:disable:next force_unwrapping
+        return TimestampedSegment(start: timings.first!.startTime, end: timings.last!.endTime, text: text)
+    }
+}

--- a/app/MeetingTranscriber/Sources/Qwen3AsrChunking.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrChunking.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Pure chunking logic for `Qwen3AsrEngine` audio segmentation.
+///
+/// Qwen3-ASR's stateful decoder caps each call at `Qwen3AsrConfig.maxAudioSeconds`
+/// (30 s at 16 kHz). Long audio is split into back-to-back chunks of at most
+/// that size and transcribed one chunk per call. Extracting the index math
+/// makes it testable without a model.
+enum Qwen3AsrChunking {
+    /// Compute the sample-index ranges that partition `totalCount` samples
+    /// into contiguous, non-overlapping chunks of at most `maxSamples` each.
+    ///
+    /// - Ranges are returned in order.
+    /// - The final range may be shorter than `maxSamples`.
+    /// - Returns `[]` for zero-length input.
+    ///
+    /// Precondition: `maxSamples > 0`.
+    static func chunkRanges(totalCount: Int, maxSamples: Int) -> [Range<Int>] {
+        precondition(maxSamples > 0, "maxSamples must be positive")
+        guard totalCount > 0 else { return [] }
+        var ranges: [Range<Int>] = []
+        var offset = 0
+        while offset < totalCount {
+            let end = min(offset + maxSamples, totalCount)
+            ranges.append(offset ..< end)
+            offset = end
+        }
+        return ranges
+    }
+}

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -98,14 +98,15 @@ final class Qwen3AsrEngine: TranscribingEngine {
 
         // Chunk audio into <=30s segments (Qwen3AsrConfig.maxAudioSeconds)
         let maxSamples = Int(Qwen3AsrConfig.maxAudioSeconds * 16000)
+        let chunkRanges = Qwen3AsrChunking.chunkRanges(
+            totalCount: resampled.count,
+            maxSamples: maxSamples,
+        )
+        let totalChunks = max(1, chunkRanges.count)
         var allText: [String] = []
-        var offset = 0
-        let totalChunks = max(1, (resampled.count + maxSamples - 1) / maxSamples)
-        var chunkIndex = 0
 
-        while offset < resampled.count {
-            let end = min(offset + maxSamples, resampled.count)
-            let chunk = Array(resampled[offset ..< end])
+        for (chunkIndex, range) in chunkRanges.enumerated() {
+            let chunk = Array(resampled[range])
             let chunkText = try await manager.transcribe(
                 audioSamples: chunk,
                 language: resolvedLanguage,
@@ -114,9 +115,7 @@ final class Qwen3AsrEngine: TranscribingEngine {
             if !trimmed.isEmpty {
                 allText.append(trimmed)
             }
-            chunkIndex += 1
-            transcriptionProgress = Double(chunkIndex) / Double(totalChunks)
-            offset = end
+            transcriptionProgress = Double(chunkIndex + 1) / Double(totalChunks)
         }
         transcriptionProgress = 1.0
 

--- a/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
@@ -1,0 +1,141 @@
+import FluidAudio
+@testable import MeetingTranscriber
+import XCTest
+
+final class ParakeetTokenGroupingTests: XCTestCase {
+    // MARK: - groupIntoSegments
+
+    func testGroupIntoSegmentsEmptyInputReturnsNoSegments() {
+        XCTAssertTrue(ParakeetTokenGrouping.groupIntoSegments([]).isEmpty)
+    }
+
+    func testGroupIntoSegmentsSingleTokenWithoutPunctEmitsOneSegment() {
+        // No terminating punctuation and below the 20-token cap → the
+        // trailing-flush at the end of the loop emits the single segment.
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("Hello", start: 0, end: 1),
+        ])
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].text, "Hello")
+        XCTAssertEqual(segments[0].start, 0)
+        XCTAssertEqual(segments[0].end, 1)
+    }
+
+    func testGroupIntoSegmentsSplitsOnPeriod() {
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("Hello", start: 0, end: 1),
+            timing(" world.", start: 1, end: 2),
+            timing(" Next", start: 2, end: 3),
+            timing(" sentence.", start: 3, end: 4),
+        ])
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].text, "Hello world.")
+        XCTAssertEqual(segments[1].text, "Next sentence.")
+    }
+
+    func testGroupIntoSegmentsSplitsOnExclamationAndQuestion() {
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("Wow", start: 0, end: 1),
+            timing("!", start: 1, end: 2),
+            timing("Really", start: 2, end: 3),
+            timing("?", start: 3, end: 4),
+        ])
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].text, "Wow!")
+        XCTAssertEqual(segments[1].text, "Really?")
+    }
+
+    func testGroupIntoSegmentsForcesSplitAt20TokenCap() {
+        // 25 tokens with no punctuation — must split at the 20-token cap.
+        let timings = (0 ..< 25).map { i in
+            timing("w\(i) ", start: Double(i), end: Double(i) + 1)
+        }
+        let segments = ParakeetTokenGrouping.groupIntoSegments(timings)
+        XCTAssertEqual(segments.count, 2, "First segment caps at 20; remaining 5 flush at end")
+        // First segment: w0..w19
+        XCTAssertTrue(segments[0].text.hasPrefix("w0"))
+        XCTAssertTrue(segments[0].text.contains("w19"))
+        XCTAssertFalse(segments[0].text.contains("w20"))
+        // Second segment: w20..w24
+        XCTAssertTrue(segments[1].text.contains("w24"))
+    }
+
+    func testGroupIntoSegmentsSkipsBlankTokensInsideGroup() {
+        // Whitespace-only tokens must not count toward the 20-cap and must
+        // not appear in the joined text. They're stripped before grouping.
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("Hello", start: 0, end: 1),
+            timing("   ", start: 1, end: 1.5),
+            timing("\t", start: 1.5, end: 2),
+            timing(" world.", start: 2, end: 3),
+        ])
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].text, "Hello world.")
+    }
+
+    func testGroupIntoSegmentsPreservesFirstAndLastTimestamps() {
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("A", start: 1.5, end: 2.0),
+            timing(" B", start: 2.0, end: 2.4),
+            timing(" C.", start: 2.4, end: 3.1),
+        ])
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].start, 1.5, "Start = first token's startTime")
+        XCTAssertEqual(segments[0].end, 3.1, "End = last token's endTime")
+    }
+
+    func testGroupIntoSegmentsTrailingPartialGroupFlushed() {
+        // After the punct-terminated first sentence, two more tokens have
+        // no terminator — the trailing-flush at the end of groupIntoSegments
+        // must still emit them as a second segment.
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("First.", start: 0, end: 1),
+            timing(" then", start: 1, end: 2),
+            timing(" more", start: 2, end: 3),
+        ])
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].text, "First.")
+        XCTAssertEqual(segments[1].text, "then more")
+    }
+
+    func testGroupIntoSegmentsAllBlankTokensProducesNoSegments() {
+        let segments = ParakeetTokenGrouping.groupIntoSegments([
+            timing("   ", start: 0, end: 1),
+            timing("\t", start: 1, end: 2),
+        ])
+        XCTAssertTrue(segments.isEmpty)
+    }
+
+    // MARK: - makeSegment
+
+    func testMakeSegmentEmptyTimingsReturnsNil() {
+        XCTAssertNil(ParakeetTokenGrouping.makeSegment(from: []))
+    }
+
+    func testMakeSegmentAllWhitespaceTokensReturnsNil() {
+        // After trimming the joined text is empty — should be rejected so
+        // callers don't get a zero-content segment in the output.
+        let result = ParakeetTokenGrouping.makeSegment(from: [
+            timing("   ", start: 0, end: 1),
+        ])
+        XCTAssertNil(result)
+    }
+
+    func testMakeSegmentJoinsTokenTextVerbatim() {
+        // Token boundaries are NOT decorated with whitespace by the helper —
+        // the caller's tokens carry their own leading/trailing spaces (the
+        // ASR tokenizer emits them). The helper just joins.
+        let result = ParakeetTokenGrouping.makeSegment(from: [
+            timing("Hello", start: 0, end: 1),
+            timing(",", start: 1, end: 1.2),
+            timing(" world", start: 1.2, end: 2),
+        ])
+        XCTAssertEqual(result?.text, "Hello, world")
+    }
+
+    // MARK: - Helpers
+
+    private func timing(_ token: String, start: TimeInterval, end: TimeInterval) -> TokenTiming {
+        TokenTiming(token: token, tokenId: 0, startTime: start, endTime: end, confidence: 1.0)
+    }
+}

--- a/app/MeetingTranscriber/Tests/Qwen3AsrChunkingTests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3AsrChunkingTests.swift
@@ -1,0 +1,74 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class Qwen3AsrChunkingTests: XCTestCase {
+    func testChunkRangesZeroTotalReturnsEmpty() {
+        XCTAssertTrue(Qwen3AsrChunking.chunkRanges(totalCount: 0, maxSamples: 100).isEmpty)
+    }
+
+    func testChunkRangesFitsInOneChunk() {
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 50, maxSamples: 100)
+        XCTAssertEqual(ranges, [0 ..< 50])
+    }
+
+    func testChunkRangesExactMultipleEmitsFullSizeChunks() {
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 300, maxSamples: 100)
+        XCTAssertEqual(ranges, [0 ..< 100, 100 ..< 200, 200 ..< 300])
+    }
+
+    func testChunkRangesUnevenTailIsShorter() {
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 250, maxSamples: 100)
+        XCTAssertEqual(ranges, [0 ..< 100, 100 ..< 200, 200 ..< 250])
+        XCTAssertEqual(ranges.last?.count, 50)
+    }
+
+    func testChunkRangesSingleSampleTail() {
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 101, maxSamples: 100)
+        XCTAssertEqual(ranges, [0 ..< 100, 100 ..< 101])
+    }
+
+    func testChunkRangesBoundaryEqualsMaxSamples() {
+        // totalCount == maxSamples → exactly one range, no off-by-one
+        // emitting an empty trailing chunk.
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 100, maxSamples: 100)
+        XCTAssertEqual(ranges, [0 ..< 100])
+    }
+
+    func testChunkRangesAreContiguousAndCoverFullInput() {
+        // Property check: concatenated ranges must cover [0, totalCount)
+        // with no gaps or overlaps. This is the contract `transcribeSegments`
+        // relies on to feed the manager.
+        let total = 12345
+        let max = 1000
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: total, maxSamples: max)
+        XCTAssertEqual(ranges.first?.lowerBound, 0)
+        XCTAssertEqual(ranges.last?.upperBound, total)
+        for i in 1 ..< ranges.count {
+            XCTAssertEqual(
+                ranges[i].lowerBound,
+                ranges[i - 1].upperBound,
+                "Range \(i) must start where range \(i - 1) ended",
+            )
+        }
+        let totalLength = ranges.reduce(0) { $0 + $1.count }
+        XCTAssertEqual(totalLength, total)
+    }
+
+    func testChunkRangesRespectsMaxSamplesUpperBound() {
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 12345, maxSamples: 1000)
+        for range in ranges {
+            XCTAssertLessThanOrEqual(range.count, 1000)
+        }
+    }
+
+    func testChunkRangesProduction30SecondCap() {
+        // Real-world sanity: 75 s of 16 kHz audio is 1_200_000 samples; with
+        // the production 30 s cap (480_000 samples), expect three chunks
+        // ending at 480k / 960k / 1_200k.
+        let ranges = Qwen3AsrChunking.chunkRanges(totalCount: 1_200_000, maxSamples: 480_000)
+        XCTAssertEqual(ranges.count, 3)
+        XCTAssertEqual(ranges[0].upperBound, 480_000)
+        XCTAssertEqual(ranges[1].upperBound, 960_000)
+        XCTAssertEqual(ranges[2].upperBound, 1_200_000)
+    }
+}


### PR DESCRIPTION
## Summary
Tier-2 pure-helper extractions for the two engines whose existing E2E tests skip on CI behind `E2E_ENABLED=1` (model downloads). Moves the testable surface — sentence-boundary rules + audio-chunk math — into sibling types that run in the regular CI suite and contribute to Codecov.

Two atomic commits, one PR.

### Commit 1: Parakeet token-grouping
- New `ParakeetTokenGrouping` enum with `groupIntoSegments(_:)` + `makeSegment(from:)`.
- Magic literal `20` → named `maxTokensPerSegment`.
- 12 unit tests: empty, single-token flush, punct splits (period / `!` / `?`), 20-cap split, blank-token skip inside group, timestamp preservation, trailing partial flush, all-blank input, makeSegment edge cases.

### Commit 2: Qwen3 chunking
- New `Qwen3AsrChunking` enum with `chunkRanges(totalCount:maxSamples:) -> [Range<Int>]`.
- Replaces inline `while offset < count` loop with `.enumerated()` over the returned ranges — same observable progress sequence (`1/N, 2/N, …, N/N`).
- 9 unit tests: zero input, fits-in-one, exact multiple, uneven tail, single-sample tail, `totalCount == maxSamples` boundary, contiguous-and-covering property check, upper-bound respect, production 30 s / 75 s sanity.

## Pattern
Same as PRs #311 (ClaudeCLI helpers) and #313 (FFmpegHelper helpers): pure logic that was buried as `private static` inside an engine class becomes a sibling top-level helper type. No `private → internal` widening — the helpers are net-new and internally scoped from the start.

## Coverage
- `ParakeetTokenGrouping.swift` + `Qwen3AsrChunking.swift` start at 100 % via the new unit tests (verified locally).
- The corresponding inline code is removed from the engine files; net effect for Codecov is the previously-uncovered private static lines move to the new files where they ARE covered.

## Test plan
- [x] `swift test --filter ParakeetTokenGroupingTests` — 12 pass
- [x] `swift test --filter Qwen3AsrChunkingTests` — 9 pass
- [x] `swift build` — clean
- [x] `./scripts/lint.sh` — zero violations
- [x] Existing engine tests still pass — `ParakeetEngine.transcribeSegments` now delegates to `ParakeetTokenGrouping.groupIntoSegments`; `Qwen3AsrEngine.transcribeSegments` iterates the returned ranges.