### PR TITLE
test: cover DebugRMSReporter.tick() + PIDTranslation + NotificationManager.notificationContent

### DIFF
--- a/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
@@ -61,4 +61,111 @@ final class NotificationManagerTests: XCTestCase {
         let b = NotificationManager.shared
         XCTAssertIdentical(a, b)
     }
+
+    // MARK: - notificationContent (pure helper)
+
+    func testNotificationContentRecordingUsesMeetingTitleAndApp() {
+        let content = NotificationManager.notificationContent(
+            for: .recording,
+            status: statusWithMeeting(app: "Teams", title: "Standup"),
+        )
+        XCTAssertEqual(content?.title, "Meeting Detected")
+        XCTAssertEqual(content?.body, "Recording: Standup (Teams)")
+    }
+
+    func testNotificationContentRecordingFallsBackWhenMeetingMissing() {
+        // Defensive: if a recording-state notification ever fires without a
+        // meeting attached (shouldn't happen in production), the body still
+        // renders rather than crashing.
+        let content = NotificationManager.notificationContent(
+            for: .recording,
+            status: statusWithNoMeeting(),
+        )
+        XCTAssertEqual(content?.title, "Meeting Detected")
+        XCTAssertEqual(content?.body, "Recording: Unknown ()")
+    }
+
+    func testNotificationContentProtocolReady() {
+        let content = NotificationManager.notificationContent(
+            for: .protocolReady,
+            status: statusWithMeeting(app: "Zoom", title: "Retro"),
+        )
+        XCTAssertEqual(content?.title, "Protocol Ready")
+        XCTAssertEqual(content?.body, "Protocol for \"Retro\" is ready.")
+    }
+
+    func testNotificationContentProtocolReadyFallsBackToMeetingLabel() {
+        let content = NotificationManager.notificationContent(
+            for: .protocolReady,
+            status: statusWithNoMeeting(),
+        )
+        XCTAssertEqual(content?.body, "Protocol for \"Meeting\" is ready.")
+    }
+
+    func testNotificationContentWaitingForSpeakerNames() {
+        let content = NotificationManager.notificationContent(
+            for: .waitingForSpeakerNames,
+            status: statusWithNoMeeting(),
+        )
+        XCTAssertEqual(content?.title, "Name Speakers")
+        XCTAssertFalse(content?.body.isEmpty ?? true)
+    }
+
+    func testNotificationContentErrorWithMessage() {
+        let status = TranscriberStatus(
+            version: 1, timestamp: "2026-05-21T10:00:00",
+            state: .error, detail: "", meeting: nil,
+            protocolPath: nil, error: "disk full", audioPath: nil, pid: nil,
+        )
+        let content = NotificationManager.notificationContent(for: .error, status: status)
+        XCTAssertEqual(content?.title, "Transcriber Error")
+        XCTAssertEqual(content?.body, "disk full")
+    }
+
+    func testNotificationContentErrorWithoutMessageReturnsNil() {
+        // No error string attached → suppress the notification entirely.
+        // Avoids a "Transcriber Error" banner with a blank body.
+        let content = NotificationManager.notificationContent(
+            for: .error,
+            status: statusWithNoMeeting(),
+        )
+        XCTAssertNil(content)
+    }
+
+    func testNotificationContentReturnsNilForSilentStates() {
+        // .idle / .watching / .transcribing / .generatingProtocol /
+        // .waitingForSpeakerCount / .recordingDone all fall into the
+        // `default` branch — no notification.
+        for state: TranscriberState in [
+            .idle, .watching, .transcribing, .generatingProtocol,
+            .waitingForSpeakerCount, .recordingDone,
+        ] {
+            XCTAssertNil(
+                NotificationManager.notificationContent(
+                    for: state,
+                    status: statusWithNoMeeting(),
+                ),
+                "Expected no notification for state \(state)",
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func statusWithMeeting(app: String, title: String) -> TranscriberStatus {
+        TranscriberStatus(
+            version: 1, timestamp: "2026-05-21T10:00:00",
+            state: .recording, detail: "",
+            meeting: MeetingInfo(app: app, title: title, pid: 1),
+            protocolPath: nil, error: nil, audioPath: nil, pid: nil,
+        )
+    }
+
+    private func statusWithNoMeeting() -> TranscriberStatus {
+        TranscriberStatus(
+            version: 1, timestamp: "2026-05-21T10:00:00",
+            state: .idle, detail: "", meeting: nil,
+            protocolPath: nil, error: nil, audioPath: nil, pid: nil,
+        )
+    }
 }

--- a/tools/audiotap/Tests/AppAudioCapturePIDTranslationTests.swift
+++ b/tools/audiotap/Tests/AppAudioCapturePIDTranslationTests.swift
@@ -1,0 +1,54 @@
+@testable import AudioTapLib
+import CoreAudio
+import Darwin
+import XCTest
+
+@available(macOS 14.2, *)
+final class AppAudioCapturePIDTranslationTests: XCTestCase {
+    // MARK: - static translatePID
+
+    func testTranslatePIDReturnsNilForUnknownPID() {
+        // A PID well above any plausibly running process has no CoreAudio
+        // process-object entry → the `kAudioObjectUnknown` guard fires.
+        XCTAssertNil(AppAudioCapture.translatePID(999_999))
+    }
+
+    func testTranslatePIDForCurrentProcessReturnsValidIDOrNil() {
+        // Exercises the live `AudioObjectGetPropertyData` path with a real
+        // PID. Whether xctest itself has an audio process-object is
+        // environment-dependent — some macOS hosts register one, some
+        // don't. The function must handle both outcomes without crashing
+        // and never return `kAudioObjectUnknown` masquerading as a real ID.
+        if let id = AppAudioCapture.translatePID(getpid()) {
+            XCTAssertNotEqual(id, AudioObjectID(kAudioObjectUnknown))
+        }
+    }
+
+    // MARK: - instance translatePIDs
+
+    func testTranslatePIDsThrowsWhenAllPIDsUntranslatable() {
+        // All bogus PIDs → empty translated set → must throw rather than
+        // hand a `CATapDescription` an empty processObjectIDs array (which
+        // would yield a silent tap).
+        let capture = AppAudioCapture(
+            pids: [999_998, 999_999],
+            outputFileDescriptor: -1,
+        )
+        XCTAssertThrowsError(try capture.translatePIDs()) { error in
+            let ns = error as NSError
+            XCTAssertEqual(ns.domain, "audiotap")
+            XCTAssertEqual(ns.code, -1)
+            XCTAssertTrue(
+                ns.localizedDescription.contains("Failed to translate"),
+                "Error description should mention the failure: \(ns.localizedDescription)",
+            )
+        }
+    }
+
+    func testTranslatePIDsEmptyPidsListThrows() {
+        // Defensive — production callers always pass at least one PID via
+        // `resolveTapPIDs`, but the throw guards against future regressions.
+        let capture = AppAudioCapture(pids: [], outputFileDescriptor: -1)
+        XCTAssertThrowsError(try capture.translatePIDs())
+    }
+}

--- a/tools/audiotap/Tests/DebugRMSReporterTests.swift
+++ b/tools/audiotap/Tests/DebugRMSReporterTests.swift
@@ -52,4 +52,60 @@ final class DebugRMSReporterTests: XCTestCase {
         _ = reporter.tick(intervalSeconds: 3600)
         XCTAssertEqual(reporter.lastLevelDBFS, -6.02, accuracy: 0.02)
     }
+
+    // MARK: - tick() report path
+
+    func testFirstTickReturnsNilAndArmsInterval() {
+        // The first call seeds `nextReportTicks`; no snapshot is emitted on
+        // the very first invocation regardless of how much data has been fed.
+        var reporter = DebugRMSReporter()
+        reporter.add(sumSq: 100 * 0.5 * 0.5, samples: 100)
+        XCTAssertNil(reporter.tick(intervalSeconds: 0))
+    }
+
+    func testSecondTickAfterIntervalEmitsSnapshotAndResetsAccumulators() throws {
+        var reporter = DebugRMSReporter()
+        reporter.add(sumSq: 100 * 0.5 * 0.5, samples: 100)
+
+        // First tick arms the interval (effectively zero).
+        XCTAssertNil(reporter.tick(intervalSeconds: 0))
+
+        // The second tick is past the (zero) interval — must report.
+        let snapshot = try XCTUnwrap(reporter.tick(intervalSeconds: 0))
+        // sumSq=25 over 100 samples → meanSq=0.25 → RMS=0.5 → ~-6.02 dBFS.
+        XCTAssertEqual(snapshot.dBFS, -6.02, accuracy: 0.02)
+        XCTAssertEqual(snapshot.samples, 100)
+
+        // Accumulators reset after a fired snapshot; a follow-up tick with
+        // no new data reports the empty-input floor (-120 dBFS).
+        let next = try XCTUnwrap(reporter.tick(intervalSeconds: 0))
+        XCTAssertEqual(next.dBFS, -120, accuracy: 0.001)
+        XCTAssertEqual(next.samples, 0)
+    }
+
+    func testTickReportsFloorWhenNoSamplesAccumulated() throws {
+        // Guards against divide-by-zero when no `add(...)` calls have run.
+        var reporter = DebugRMSReporter()
+        XCTAssertNil(reporter.tick(intervalSeconds: 0))
+        let snapshot = try XCTUnwrap(reporter.tick(intervalSeconds: 0))
+        XCTAssertEqual(snapshot.dBFS, -120, accuracy: 0.001)
+        XCTAssertEqual(snapshot.samples, 0)
+    }
+
+    func testTickReportsFloorWhenAccumulatedEnergyIsZero() throws {
+        var reporter = DebugRMSReporter()
+        reporter.add(sumSq: 0, samples: 100)
+        XCTAssertNil(reporter.tick(intervalSeconds: 0))
+        let snapshot = try XCTUnwrap(reporter.tick(intervalSeconds: 0))
+        XCTAssertEqual(snapshot.dBFS, -120, accuracy: 0.001)
+        XCTAssertEqual(snapshot.samples, 100)
+    }
+
+    func testTickIntervalThrottlesEmission() {
+        var reporter = DebugRMSReporter()
+        XCTAssertNil(reporter.tick(intervalSeconds: 3600))
+        reporter.add(sumSq: 100 * 0.5 * 0.5, samples: 100)
+        // Within the same hour, a follow-up tick must NOT emit.
+        XCTAssertNil(reporter.tick(intervalSeconds: 3600))
+    }
 }


### PR DESCRIPTION
## Summary
Three test-only atomic commits — no source changes. Picks up previously-uncovered surfaces across audiotap + app that were trivial to test from outside.

### Commit 1: `DebugRMSReporter.tick()` report + reset paths
The existing tests covered `add()` / `lastLevelDBFS` thoroughly but only touched `tick()`'s "interval too long → nil" branch. 5 new tests cover the report-emission path: first-tick arms the interval, second-tick emits + resets, divide-by-zero floor (`sampleCount == 0`), zero-energy floor, and throttle within a long interval.

File-level coverage: **55 % → 100 %** per `llvm-cov`.

### Commit 2: `AppAudioCapture+PIDTranslation` (PR #307 follow-up)
The PID-translation extension shipped in PR #307 was at **0 %** because no tests existed. 4 new tests cover:
- static `translatePID(_:)` returns nil for a bogus PID (999_999)
- static `translatePID(_:)` exercised against `getpid()` — environment-dependent return (some macOS hosts register an audio object for the xctest binary, some don't), so the test tolerates either outcome but rules out `kAudioObjectUnknown` masquerading as a real ID
- instance `translatePIDs()` throws when all PIDs are untranslatable, with the expected `audiotap` / -1 / "Failed to translate" error shape
- instance `translatePIDs()` throws on an empty pids array (defensive guard against future regressions in `resolveTapPIDs`)

File-level coverage: **0 % → 94 %**. The remaining uncovered branch is the success path that yields a non-nil AudioObjectID — only hit by a real audio-emitting process and stays uncovered.

### Commit 3: `NotificationManager.notificationContent` all-states
The static pure helper that maps a `(TranscriberState, TranscriberStatus)` to notification (title, body) was only reached indirectly through `handleTransition`, which short-circuited on `!isSetUp` and discarded the return value — leaving every `case` branch uncovered.

8 new tests cover all branches:
- `.recording` with + without meeting (uses fallback "Unknown")
- `.protocolReady` with + without meeting (uses fallback "Meeting")
- `.waitingForSpeakerNames` standard render
- `.error` with attached error string + nil error (suppresses notification)
- the `default` branch for the six silent states (.idle, .watching, .transcribing, .generatingProtocol, .waitingForSpeakerCount, .recordingDone) — verified via a for-loop assertion

File-level coverage: **49 % → 60 %** per `llvm-cov`. The remaining uncovered surface is the TCC-bound `setUp()` (UNUserNotificationCenter permission prompt) and the `notify(...)` body (which short-circuits on `!isSetUp` and otherwise calls into the OS-only notification API).

## Test plan
- [x] `cd tools/audiotap && swift test` — 101 audiotap tests pass
- [x] `swift test --filter NotificationManagerTests` — 14 tests pass (was 6)
- [x] `./scripts/lint.sh` — zero violations
- [x] `llvm-cov report` confirms the three file-level deltas above