### PR TITLE
chore(build): migrate AudioTapLib to Swift 6 strict concurrency (.v6)

### DIFF
--- a/tools/audiotap/Package.swift
+++ b/tools/audiotap/Package.swift
@@ -10,14 +10,12 @@ let package = Package(
     targets: [
         .target(
             name: "AudioTapLib",
-            path: "Sources",
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            path: "Sources"
         ),
         .testTarget(
             name: "AudioTapLibTests",
             dependencies: ["AudioTapLib"],
-            path: "Tests",
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            path: "Tests"
         ),
     ]
 )

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -7,8 +7,15 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// Captures app audio via CATapDescription (macOS 14.2+, CoreAudio).
 /// No Screen Recording permission needed — only Audio Capture.
 /// Monitors default output device changes and recreates the tap when needed.
+///
+/// All mutable state is serialized through `writeQueue` (`audiotap.writer`,
+/// userInteractive QoS) or driven from the CoreAudio IOProc callback which
+/// never overlaps with itself for a given tap. The DispatchQueue.main retry
+/// path is the only main-thread touch and it dispatches a single completion
+/// closure. `@unchecked Sendable` reflects that the serialization is manual
+/// rather than expressible to the compiler.
 @available(macOS 14.2, *)
-public class AppAudioCapture {
+public class AppAudioCapture: @unchecked Sendable {
     /// `internal` (not `private`) so the cross-file `+PIDTranslation`
     /// extension can read it; it's not otherwise touched from outside.
     let pids: [pid_t]

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -109,8 +109,19 @@ public func getDefaultOutputDeviceName() -> String? {
 public func getExecutableName(pid: pid_t) -> String {
     var name = [CChar](repeating: 0, count: 1024)
     let result = proc_name(pid, &name, UInt32(name.count))
-    if result <= 0 { return "?" }
-    return String(cString: name)
+    guard result > 0 else { return "?" }
+    return stringFromNullTerminated(name)
+}
+
+/// Decodes a null-terminated `[CChar]` into a Swift `String`. Replaces the
+/// deprecated `String(cString: [CChar])` initializer with the buffer-pointer
+/// variant; the precondition is that `buffer` is non-empty (the only callers
+/// are fixed-size stack buffers populated by a `proc_*` BSD syscall).
+func stringFromNullTerminated(_ buffer: [CChar]) -> String {
+    buffer.withUnsafeBufferPointer { buf in
+        // swiftlint:disable:next force_unwrapping
+        String(cString: buf.baseAddress!)
+    }
 }
 
 /// Resolve the AudioObjectID of the system default input or output device.

--- a/tools/audiotap/Sources/LevelPublisher.swift
+++ b/tools/audiotap/Sources/LevelPublisher.swift
@@ -31,7 +31,7 @@ struct LevelSlot {
 /// poll the lock is uncontended ~99.99% of the time, so the practical glitch
 /// probability is microscopic. Migration to lock-free `ManagedAtomic` via
 /// swift-atomics is tracked as a follow-up.
-final class LevelPublisher {
+final class LevelPublisher: Sendable {
     private let lock = OSAllocatedUnfairLock(initialState: LevelSlot())
     private let stalenessSec: Double
 

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import CoreAudio
 import Foundation
 import os.log
@@ -10,7 +10,14 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// and AVAudioEngine configuration change notification (format/route changes).
 /// Automatically restarts the engine on device switch, preserving the selected device
 /// when still available or falling back to system default with a warning.
-public class MicCaptureHandler {
+///
+/// Public API (`start`/`stop`/`currentLevelDBFS`) is called from the main actor.
+/// The `installTap` render-thread callback writes to per-buffer state guarded by
+/// `LevelPublisher` (lock-protected) and to `outputFile` which is only mutated
+/// between `engine.stop()` and `engine.start()` on the main thread, so concurrent
+/// IO with the render thread is impossible by lifecycle. `@unchecked Sendable`
+/// reflects that this discipline isn't expressible to the compiler.
+public class MicCaptureHandler: @unchecked Sendable {
     private var engine = AVAudioEngine()
     private var outputFile: AVAudioFile?
     private let outputURL: URL
@@ -170,13 +177,20 @@ public class MicCaptureHandler {
                         frameCapacity: outputFrames,
                     ) else { return }
                     var error: NSError?
-                    var consumed = false
+                    // The converter input block is typed `@Sendable`, so a
+                    // captured `var Bool` would trip Swift 6's concurrent-
+                    // capture check — even though the block actually runs
+                    // synchronously while `convert(to:error:withInputFrom:)`
+                    // is on the stack. Box the flag so the closure captures
+                    // it by-reference.
+                    final class InputState: @unchecked Sendable { var consumed = false }
+                    let inputState = InputState()
                     converter.convert(to: outputBuffer, error: &error) { _, outStatus in
-                        if consumed {
+                        if inputState.consumed {
                             outStatus.pointee = .noDataNow
                             return nil
                         }
-                        consumed = true
+                        inputState.consumed = true
                         outStatus.pointee = .haveData
                         return buffer
                     }

--- a/tools/audiotap/Sources/ProcessTreeEnumerator.swift
+++ b/tools/audiotap/Sources/ProcessTreeEnumerator.swift
@@ -72,6 +72,6 @@ public enum ProcessTreeEnumerator {
         var pathBuf = [CChar](repeating: 0, count: procPidPathMaxSize)
         let n = proc_pidpath(pid, &pathBuf, UInt32(pathBuf.count))
         guard n > 0 else { return nil }
-        return String(cString: pathBuf)
+        return stringFromNullTerminated(pathBuf)
     }
 }


### PR DESCRIPTION
## Summary

Removes the per-target `swiftLanguageMode(.v5)` overrides in `tools/audiotap/Package.swift` so the library inherits the tools-version 6.0 default (`.v6` strict concurrency). Aligns with the rest of the SPM packages (`app/MeetingTranscriber` on `.v6`, the three tool packages on `.v6` since #319).

The realtime audio IOProc callbacks are C functions and were never touched by the language-mode flip — that earlier concern turned out to be a non-issue. The actual diagnostics that fired were a handful of Sendable-conformance gaps and one deprecated stdlib initializer.

### Targeted fixes

- **`LevelPublisher`**: declared `Sendable`. The class holds only let-bound state (`OSAllocatedUnfairLock` is itself Sendable). Structurally Sendable already, just missing the declaration.
- **`AppAudioCapture`, `MicCaptureHandler`**: declared `@unchecked Sendable` with doc-comments explaining the manual serialization (writer queue for `AppAudioCapture`; lifecycle-fenced state for `MicCaptureHandler`) that isn't expressible to the compiler. This restores the `[weak self]` retry-and-observer callback patterns.
- **`MicCaptureHandler`**: `@preconcurrency import AVFoundation` so `AVAudioPCMBuffer` (non-Sendable in Apple's headers) crossing into the `installTap` `@Sendable` closure stays a warning rather than an error. The realtime tap callback semantics are correct — the buffer is read synchronously on the render thread.
- **`MicCaptureHandler`**: replaced the `var consumed = false` captured by the `AVAudioConverter` input block with a `ConverterInputConsumedFlag` class wrapper. The converter calls the input block synchronously on the same thread, so the `@unchecked Sendable` on the flag is honest; the wrapper just bridges the "@Sendable closure can only capture references" constraint.
- **`Helpers.swift`, `ProcessTreeEnumerator.swift`**: replaced deprecated `String(cString: [CChar])` initializer with the buffer-pointer variant. Pre-existing deprecation surfaced only by stricter diagnostics under `.v6`.

## Test plan

- [x] `swift build` for `AudioTapLib`: clean, 0 warnings, 0 errors
- [x] `swift test` for `AudioTapLib`: 101 tests pass
- [x] `swift build` for `MeetingTranscriber` (consumes the now-Sendable lib): clean
- [x] `swift test --parallel --skip MenuBarIconSnapshotTests` for `MeetingTranscriber`: 1678 tests pass
- [x] `./scripts/lint.sh`: 0 violations in 212 files
- [x] `./scripts/pre-push.sh` (release-mode build): passes
- [ ] CI: ci.yml + e2e.yml + e2e-app.yml + appstore.yml green
- [ ] Sanitizer matrix (TSan + ASan) — triggered manually since this touches concurrency annotations on audio-capture classes