### PR TITLE
fix(scripts): poll for menu-bar red tint in channel-health e2e

### DIFF
--- a/scripts/e2e-channel-health.sh
+++ b/scripts/e2e-channel-health.sh
@@ -122,12 +122,31 @@ if [ "$TAKE_SCREENSHOT" = true ]; then
     # does succeed, run the pixel-level assertion so a SwiftUI/MenuBarIcon
     # render regression that keeps the AppState flag true but doesn't show
     # the red tint is caught here.
-    if screencapture -R 0,0,3000,30 "$OUT" 2>/dev/null && [ -s "$OUT" ]; then
-        echo "▸ Menubar screenshot saved to $OUT"
-        "$ROOT/scripts/assert-red-pixels.swift" "$OUT"
-    else
+    #
+    # SwiftUI's MenuBarExtra → NSStatusItem composite can trail RPC readiness
+    # by 1-2 frames, so the assertion is polled rather than run once. Cold
+    # `swift` invocation per attempt provides the natural pacing.
+    if ! screencapture -R 0,0,3000,30 "$OUT" 2>/dev/null || [ ! -s "$OUT" ]; then
         echo "▸ Menubar screenshot skipped (no display rect available — pixel assertion skipped)"
         rm -f "$OUT"
+    else
+        attempt=1
+        max_attempts=25
+        while [ "$attempt" -le "$max_attempts" ]; do
+            if [ "$attempt" -eq "$max_attempts" ]; then
+                # Final attempt: unsuppressed so the pixel count and FAIL
+                # message surface on exhaustion (set -e propagates).
+                echo "▸ Menubar screenshot saved to $OUT (attempt $attempt/$max_attempts)"
+                "$ROOT/scripts/assert-red-pixels.swift" "$OUT"
+                break
+            fi
+            if "$ROOT/scripts/assert-red-pixels.swift" "$OUT" >/dev/null 2>&1; then
+                echo "▸ Menubar screenshot saved to $OUT (attempt $attempt/$max_attempts)"
+                break
+            fi
+            attempt=$((attempt + 1))
+            screencapture -R 0,0,3000,30 "$OUT" 2>/dev/null || true
+        done
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Wrap the channel-health screenshot block in a retry loop that retakes the screenshot until red pixels appear, up to ~5 s (25 × 200 ms).
- Absorbs the timing gap between RPC server readiness and SwiftUI's `MenuBarExtra` → NSStatusItem first composite, which started biting after 11 successful runs of a borderline race.

## Why

The e2e-app run on `a2f2009` failed at the channel-health screenshot lane:

```
▸ channelHealth: micSilent=true appSilent=false
▸ Menubar screenshot saved to /tmp/e2e-channel-health-menubar.png
FAIL: expected ≥30 red pixels in menubar screenshot, got 0.
```

RPC state was correct (flag is set synchronously in `AppState.init()`), but the screenshot 80 ms later caught the menubar before SwiftUI had pushed the first composite carrying the `micSilentOverlay=true` input into NSStatusItem.

Side-by-side of the uploaded artifacts:
- **Pass (3c1c540, 05:56):** waveform icon visible with red tint on the right side of the menubar.
- **Fail (a2f2009, 08:26):** same icon position, no red tint — composite hadn't picked up the overlay flag yet.

Eleven prior runs landed on the fast side of the same race; this one didn't. The previous PR (`a2f2009` = dead-code deletion) doesn't touch any runtime code — the race has always been there, the assert was just borderline.

The final, non-suppressed assertion still runs after the loop exhausts so a genuine render-pipeline regression surfaces with the original FAIL message + pixel count.

## Test plan

- [x] `bash -n scripts/e2e-channel-health.sh` syntax OK
- [x] `./scripts/lint.sh` clean
- [ ] CI: e2e-app workflow's `Run channel-health indicator E2E` step passes on this PR