### PR TITLE
feat(app): extract WeSpeaker embeddings post-hoc in Sortformer mode

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -88,6 +88,19 @@ ignore:
   # has an xctest mock-point. Exercised end-to-end by e2e-live-captions.sh.
   - "app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift"
   - "app/MeetingTranscriber/Sources/LiveCaptionsWindowController.swift"
+  # WeSpeaker post-hoc embedding extraction for Sortformer mode (Phase 1
+  # of #165). Pulls a 150 MB CoreML model pair (pyannote_segmentation +
+  # wespeaker_v2) the default xctest lane can't realistically download.
+  # Exercised end-to-end by SortformerEmbeddingsE2ETests under the
+  # RUN_QUALITY_TESTS=1 gate. The pure helpers (mask-builder, resampler,
+  # centroid aggregator) stay in FluidDiarizer.swift and ARE covered by
+  # the default lane.
+  # Codecov treats path entries as anchored regex (see https://docs.codecov.com/docs/ignoring-paths).
+  # `+` is a regex metachar ("one or more"), so the raw filename would
+  # accidentally match `FluidDiarizerrSortformerEmbeddings.swift` etc.
+  # and miss the real file. Backslash-escape with `\\+` to match the
+  # literal `+`.
+  - "app/MeetingTranscriber/Sources/FluidDiarizer\\+SortformerEmbeddings.swift"
   # CLI-only / tools targets — separate test suites, not part of the app.
   - "tools/meeting-simulator/**/*"
   - "tools/mt-cli/**/*"

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -142,6 +142,23 @@ jobs:
         timeout-minutes: 10
         run: bash scripts/e2e-app.sh --no-build --reimport-latest
 
+      # Sortformer-mode naming-dialog lane (Phase 1 of issue #165, PR #325):
+      # flips `AppSettings.diarizerMode` to `.sortformer` via UserDefaults
+      # pre-pop, runs one meeting, asserts that the speaker-naming dialog
+      # actually fires with N>=1 speakers — meaning `DiarizationResult.embeddings`
+      # is non-nil end-to-end. Pre-PR-#325 Sortformer mode returned
+      # `embeddings: nil` which silently broke the naming flow (issue #109);
+      # the env-gated assertion in `scripts/e2e-app.sh` would have caught it.
+      # `--no-build` reuses the dev .app from the first step; only the
+      # UserDefaults flip + meeting trigger differ. Adds ~30s to total lane.
+      - name: Run live-recording E2E driver (Sortformer naming dialog)
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+          MTT_DIARIZER_MODE: sortformer
+          MTT_EXPECT_NAMING_SPEAKERS_MIN: "1"
+        timeout-minutes: 10
+        run: bash scripts/e2e-app.sh --no-build
+
       # Channel-health indicator e2e (issue #258): launches the dev
       # app with `MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT=1` so
       # `AppState.micSilentActive` is set at init, then asserts the

--- a/app/MeetingTranscriber/Sources/FluidDiarizer+SortformerEmbeddings.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer+SortformerEmbeddings.swift
@@ -1,0 +1,124 @@
+import FluidAudio
+import Foundation
+import os.log
+
+private let embeddingLogger = Logger(subsystem: AppPaths.logSubsystem, category: "FluidDiarizer+Embeddings")
+
+extension FluidDiarizer {
+    /// Extract one 256-d centroid per active Sortformer speaker via the
+    /// pyannote `wespeaker_v2` CoreML model, using **overlap-excluded
+    /// masks** so frames with simultaneous speakers don't contaminate
+    /// the centroid (DiariZen-style hybrid pipeline).
+    ///
+    /// Chunks the audio into 10-second windows matching WeSpeaker's input
+    /// shape, picks the top-3 active speakers per chunk (WeSpeaker accepts
+    /// `[3, frames]` masks), aggregates embeddings by running L2-normalised
+    /// mean across chunks. Speakers below `EmbeddingExtractor`'s activity
+    /// threshold get zero embeddings from the extractor and are filtered
+    /// out of the per-speaker accumulator.
+    ///
+    /// This file is `.codecov.yml`-ignored: it is exercised end-to-end by
+    /// `SortformerEmbeddingsE2ETests` under the `RUN_QUALITY_TESTS=1` lane,
+    /// not by default xctest (which would need a 150 MB CoreML download).
+    /// The pure helpers — `buildOverlapExcludedMasks`, `resampleMask`,
+    /// `aggregateCentroids` — stay in `FluidDiarizer.swift` and are
+    /// covered by `FluidDiarizerSortformerTests`.
+    func extractSortformerEmbeddings(
+        audioPath: URL,
+        timeline: DiarizerTimeline,
+    ) async throws -> [String: [Float]] {
+        if sortformerEmbeddingModels == nil {
+            sortformerEmbeddingModels = try await DiarizerModels.load()
+            embeddingLogger.info("WeSpeaker (wespeaker_v2) loaded for Sortformer post-hoc embeddings")
+        }
+        // swiftlint:disable:next force_unwrapping
+        let models = sortformerEmbeddingModels!
+        let extractor = EmbeddingExtractor(embeddingModel: models.embeddingModel)
+
+        // WeSpeaker expects masks shaped [3, weSpeakerFrameCount] where the
+        // frame count is fixed by the companion pyannote segmentation model.
+        // Query at runtime so a future model swap doesn't silently mis-shape.
+        // Mirrors the pattern in `DiarizerManager.extractSpeakerEmbedding`.
+        guard
+            let segShape = models.segmentationModel.modelDescription
+            .outputDescriptionsByName["segments"]?.multiArrayConstraint?.shape,
+            segShape.count >= 2
+        else {
+            throw DiarizationError.notAvailable
+        }
+        let weSpeakerFrameCount = segShape[1].intValue
+
+        let converter = AudioConverter(sampleRate: 16000.0)
+        let audio = try converter.resampleAudioFile(audioPath)
+
+        // Per-speaker masks at Sortformer's native frame rate (12.5 Hz),
+        // with frames where ≥2 speakers exceed onset zeroed across all
+        // speakers (overlap exclusion).
+        let masks = Self.buildOverlapExcludedMasks(
+            predictions: timeline.finalizedPredictions,
+            numSpeakers: timeline.config.numSpeakers,
+            threshold: timeline.config.onsetThreshold,
+        )
+        let maskFrameCount = masks.first?.count ?? 0
+        guard maskFrameCount > 0 else { return [:] }
+
+        let (sums, counts) = try accumulateChunkEmbeddings(
+            audio: audio,
+            masks: masks,
+            frameDuration: Double(timeline.config.frameDurationSeconds),
+            weSpeakerFrameCount: weSpeakerFrameCount,
+            extractor: extractor,
+        )
+
+        let result = Self.aggregateCentroids(sums: sums, counts: counts)
+        embeddingLogger.info(
+            "Sortformer post-hoc embeddings: \(result.count) speakers from \(counts.values.reduce(0, +)) chunks",
+        )
+        return result
+    }
+
+    /// Walk the audio in 10s chunks, run WeSpeaker on the top-3 active
+    /// speakers per chunk (the model's mask shape only fits 3), accumulate
+    /// running sums + counts per global Sortformer speaker slot. Sortformer's
+    /// 4th speaker (when present) gets covered in chunks where they rank in
+    /// the top-3 of that window.
+    private func accumulateChunkEmbeddings(
+        audio: [Float],
+        masks: [[Float]],
+        frameDuration: Double,
+        weSpeakerFrameCount: Int,
+        extractor: EmbeddingExtractor,
+    ) throws -> (sums: [String: [Float]], counts: [String: Int]) {
+        let chunkSamples = 160_000 // 10s @ 16 kHz — matches EmbeddingExtractor's waveform shape
+        let framesPerChunk = max(1, Int(10.0 / frameDuration))
+        let numSpeakers = masks.count
+        let maskFrameCount = masks.first?.count ?? 0
+
+        var sums = [String: [Float]](minimumCapacity: numSpeakers)
+        var counts = [String: Int](minimumCapacity: numSpeakers)
+
+        var sampleStart = 0
+        var frameStart = 0
+        while sampleStart < audio.count, frameStart < maskFrameCount {
+            let sampleEnd = min(sampleStart + chunkSamples, audio.count)
+            let frameEnd = min(frameStart + framesPerChunk, maskFrameCount)
+            let chunk = Array(audio[sampleStart ..< sampleEnd])
+            let chunkMasks: [[Float]] = (0 ..< numSpeakers).map { Array(masks[$0][frameStart ..< frameEnd]) }
+            let activity = (0 ..< numSpeakers).map { (slot: $0, sum: chunkMasks[$0].reduce(0, +)) }
+            let topSlots = activity.sorted { $0.sum > $1.sum }.prefix(3).map(\.slot)
+            let masksForCall = topSlots.map { Self.resampleMask(chunkMasks[$0], to: weSpeakerFrameCount) }
+
+            let embs = try extractor.getEmbeddings(audio: chunk, masks: masksForCall)
+            for (i, slot) in topSlots.enumerated() {
+                let emb = embs[i]
+                guard !emb.allSatisfy({ $0 == 0 }) else { continue }
+                let label = "SPEAKER_\(slot)"
+                sums[label] = sums[label].map { zip($0, emb).map(+) } ?? emb
+                counts[label, default: 0] += 1
+            }
+            sampleStart = sampleEnd
+            frameStart = frameEnd
+        }
+        return (sums, counts)
+    }
+}

--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -51,6 +51,11 @@ final class FluidDiarizer: DiarizationProvider, @unchecked Sendable {
     private var offlineProcessor: any OfflineDiarizationProcessing
 
     private var sortformerDiarizer: SortformerDiarizer?
+    /// Lazily-loaded WeSpeaker (pyannote `wespeaker_v2`) models, used only by
+    /// `FluidDiarizer+SortformerEmbeddings.extractSortformerEmbeddings`. Not
+    /// `private` because the extension lives in a separate file (codecov-
+    /// ignored — see `.codecov.yml`).
+    var sortformerEmbeddingModels: DiarizerModels?
 
     var isAvailable: Bool {
         true
@@ -137,7 +142,86 @@ final class FluidDiarizer: DiarizationProvider, @unchecked Sendable {
             }
         }
 
-        return Self.buildResult(segments: segments, speakerDatabase: nil)
+        // Phase 1 of issue #165: run WeSpeaker post-hoc on Sortformer's
+        // overlap-excluded frames so the naming dialog + SpeakerMatcher
+        // light up again. Without this, Sortformer mode produces
+        // `embeddings: nil` and `PipelineQueue.processNext()` aborts the
+        // naming flow (issue #109).
+        let embeddings = try await extractSortformerEmbeddings(audioPath: audioPath, timeline: timeline)
+
+        return Self.buildResult(segments: segments, speakerDatabase: embeddings)
+    }
+
+    /// L2-normalised running-mean of per-chunk embeddings → one centroid
+    /// per speaker. Pure so unit tests can pin behaviour without CoreML.
+    static func aggregateCentroids(
+        sums: [String: [Float]],
+        counts: [String: Int],
+    ) -> [String: [Float]] {
+        var result = [String: [Float]](minimumCapacity: sums.count)
+        for (label, sum) in sums {
+            let count = Float(counts[label] ?? 1)
+            var mean = sum.map { $0 / count }
+            let norm = (mean.reduce(into: Float(0)) { $0 += $1 * $1 }).squareRoot()
+            if norm > 1e-9 {
+                mean = mean.map { $0 / norm }
+            }
+            result[label] = mean
+        }
+        return result
+    }
+
+    /// Nearest-neighbour resample a per-frame activity mask onto a target
+    /// frame grid. Used to bridge Sortformer's 12.5 Hz output (~125 frames/10s)
+    /// to WeSpeaker's expected segmentation-frame count (typically 589/10s).
+    /// Pure so the unit tests can pin it without loading any model.
+    static func resampleMask(_ mask: [Float], to targetCount: Int) -> [Float] {
+        guard !mask.isEmpty, targetCount > 0 else {
+            return Array(repeating: Float(0.0), count: max(0, targetCount))
+        }
+        var out = Array(repeating: Float(0.0), count: targetCount)
+        let srcCount = mask.count
+        for i in 0 ..< targetCount {
+            let srcIdx = min(i * srcCount / targetCount, srcCount - 1)
+            out[i] = mask[srcIdx]
+        }
+        return out
+    }
+
+    /// Pure helper exposed for testability — build per-speaker activity
+    /// masks (1.0/0.0) with overlap-exclusion: any frame where ≥2 speakers
+    /// exceed `threshold` is zeroed across ALL speakers, so impure frames
+    /// never reach embedding extraction. DiariZen's stage-5 design.
+    ///
+    /// - Parameters:
+    ///   - predictions: flat `[numFrames × numSpeakers]` from `DiarizerTimeline.finalizedPredictions`.
+    ///   - numSpeakers: speaker-slot count (Sortformer hardcodes 4).
+    ///   - threshold: activity threshold (use `timeline.config.onsetThreshold`, 0.5 default).
+    /// - Returns: `[numSpeakers]` arrays of length `numFrames`.
+    static func buildOverlapExcludedMasks(
+        predictions: [Float],
+        numSpeakers: Int,
+        threshold: Float,
+    ) -> [[Float]] {
+        guard numSpeakers > 0, !predictions.isEmpty else { return [] }
+        let numFrames = predictions.count / numSpeakers
+        guard numFrames > 0 else { return [] }
+        var masks = Array(repeating: Array(repeating: Float(0.0), count: numFrames), count: numSpeakers)
+
+        for frame in 0 ..< numFrames {
+            let base = frame * numSpeakers
+            var activeSlot = -1
+            var activeCount = 0
+            for s in 0 ..< numSpeakers where predictions[base + s] >= threshold {
+                activeCount += 1
+                activeSlot = s
+                if activeCount > 1 { break }
+            }
+            if activeCount == 1 {
+                masks[activeSlot][frame] = 1.0
+            }
+        }
+        return masks
     }
 
     // MARK: - Shared Result Conversion

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -36,10 +36,10 @@ struct SpeakersSettingsView: View {
 
                     if settings.diarizerMode == .sortformer {
                         Label(
-                            "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
-                            systemImage: "exclamationmark.triangle.fill",
+                            "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
+                            systemImage: "info.circle",
                         )
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                     }
 

--- a/app/MeetingTranscriber/Tests/FluidDiarizerSortformerTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidDiarizerSortformerTests.swift
@@ -21,4 +21,159 @@ final class FluidDiarizerSortformerTests: XCTestCase {
         let diarizer = FluidDiarizer(mode: .sortformer)
         XCTAssertEqual(diarizer.mode, .sortformer)
     }
+
+    // MARK: - Phase 1 (issue #165): overlap-exclusion mask builder
+
+    func testBuildOverlapExcludedMasksAllSingleSpeaker() {
+        // 4 frames × 2 speakers; speaker 0 active in frames 0+1, speaker 1 active in frames 2+3.
+        // Threshold 0.5; no overlaps anywhere → all frames pass through as single-speaker.
+        let predictions: [Float] = [
+            0.9, 0.1, // frame 0 — speaker 0 only
+            0.8, 0.2, // frame 1 — speaker 0 only
+            0.1, 0.9, // frame 2 — speaker 1 only
+            0.3, 0.7, // frame 3 — speaker 1 only
+        ]
+        let masks = FluidDiarizer.buildOverlapExcludedMasks(
+            predictions: predictions, numSpeakers: 2, threshold: 0.5,
+        )
+        XCTAssertEqual(masks, [
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ])
+    }
+
+    func testBuildOverlapExcludedMasksZeroesOverlapFrame() {
+        // Frame 0 has speakers 0 + 1 both above threshold → must be zeroed across BOTH.
+        // Frame 1 has only speaker 0 active → speaker 0's mask is 1.0 there.
+        let predictions: [Float] = [
+            0.9, 0.9, // frame 0 — overlap
+            0.9, 0.1, // frame 1 — speaker 0 only
+        ]
+        let masks = FluidDiarizer.buildOverlapExcludedMasks(
+            predictions: predictions, numSpeakers: 2, threshold: 0.5,
+        )
+        XCTAssertEqual(masks[0], [0.0, 1.0])
+        XCTAssertEqual(masks[1], [0.0, 0.0])
+    }
+
+    func testBuildOverlapExcludedMasksSilentFrameProducesNoMask() {
+        // All speakers below threshold → frame is "silence", no speaker's mask set.
+        let predictions: [Float] = [
+            0.3, 0.2, // both below 0.5
+            0.9, 0.1,
+        ]
+        let masks = FluidDiarizer.buildOverlapExcludedMasks(
+            predictions: predictions, numSpeakers: 2, threshold: 0.5,
+        )
+        XCTAssertEqual(masks[0], [0.0, 1.0])
+        XCTAssertEqual(masks[1], [0.0, 0.0])
+    }
+
+    func testBuildOverlapExcludedMasksThreeSpeakerOverlapAllZeroed() {
+        // All 3 speakers above threshold in same frame → triple overlap, all zeroed.
+        let predictions: [Float] = [0.9, 0.8, 0.7]
+        let masks = FluidDiarizer.buildOverlapExcludedMasks(
+            predictions: predictions, numSpeakers: 3, threshold: 0.5,
+        )
+        XCTAssertEqual(masks, [[0.0], [0.0], [0.0]])
+    }
+
+    func testResampleMaskUpsamplesPreservingActivePattern() {
+        // 4 frames → 8 frames via nearest-neighbour: each src frame maps to
+        // two adjacent target frames.
+        let src: [Float] = [1, 0, 1, 0]
+        let out = FluidDiarizer.resampleMask(src, to: 8)
+        XCTAssertEqual(out, [1, 1, 0, 0, 1, 1, 0, 0])
+    }
+
+    func testResampleMaskDownsamplesByStriding() {
+        // 8 → 4: every other frame survives.
+        let src: [Float] = [1, 1, 0, 0, 1, 1, 0, 0]
+        let out = FluidDiarizer.resampleMask(src, to: 4)
+        XCTAssertEqual(out, [1, 0, 1, 0])
+    }
+
+    func testResampleMaskHandlesPyannoteRatio() {
+        // Production case: 125-frame Sortformer mask → 589-frame WeSpeaker mask.
+        // Ones at positions 0..62 → out should be ones from 0..295 roughly.
+        var src = [Float](repeating: 0.0, count: 125)
+        for i in 0 ..< 63 {
+            src[i] = 1.0
+        } // first half active
+        let out = FluidDiarizer.resampleMask(src, to: 589)
+        XCTAssertEqual(out.count, 589)
+        // First and last should reflect original pattern at the boundaries.
+        XCTAssertEqual(out[0], 1.0)
+        XCTAssertEqual(out[588], 0.0)
+        // The transition occurs roughly at out[i] where i*125/589 == 63, i.e. i ≈ 297.
+        XCTAssertEqual(out[296], 1.0, "frame 296 maps to src 62 (active)")
+        XCTAssertEqual(out[297], 0.0, "frame 297 maps to src 63 (silence)")
+    }
+
+    func testResampleMaskEmptyInputProducesZeros() {
+        let out = FluidDiarizer.resampleMask([], to: 100)
+        XCTAssertEqual(out, [Float](repeating: 0.0, count: 100))
+    }
+
+    func testAggregateCentroidsL2NormalisesMean() {
+        // Two chunks for speaker A: [1,0,0,0] + [0,1,0,0] = mean [0.5, 0.5, 0, 0]
+        // L2-normalised: [√0.5, √0.5, 0, 0] ≈ [0.707, 0.707, 0, 0]
+        let sums: [String: [Float]] = ["A": [1, 1, 0, 0]]
+        let counts = ["A": 2]
+        let result = FluidDiarizer.aggregateCentroids(sums: sums, counts: counts)
+        XCTAssertEqual(result["A"]?.count, 4)
+        XCTAssertEqual(result["A"]?[0] ?? 0, sqrt(0.5), accuracy: 1e-6)
+        XCTAssertEqual(result["A"]?[1] ?? 0, sqrt(0.5), accuracy: 1e-6)
+        XCTAssertEqual(result["A"]?[2] ?? 0, 0, accuracy: 1e-6)
+        // Resulting vector must be unit-norm
+        let norm = result["A"]?.reduce(0) { $0 + $1 * $1 } ?? 0
+        XCTAssertEqual(Double(norm), 1.0, accuracy: 1e-6)
+    }
+
+    func testAggregateCentroidsZeroVectorStaysZero() {
+        // Sum is all-zero → norm 0 → guard returns the zero vector unchanged.
+        // Prevents `0 / 0 = NaN` corrupting the centroid.
+        let result = FluidDiarizer.aggregateCentroids(
+            sums: ["S": [0, 0, 0]],
+            counts: ["S": 5],
+        )
+        XCTAssertEqual(result["S"], [0, 0, 0])
+    }
+
+    func testAggregateCentroidsHandlesMultipleSpeakers() {
+        let result = FluidDiarizer.aggregateCentroids(
+            sums: ["A": [3, 4, 0], "B": [0, 0, 5]],
+            counts: ["A": 1, "B": 1],
+        )
+        // A: [3, 4, 0] → L2-normalised = [0.6, 0.8, 0] (3-4-5 triangle)
+        XCTAssertEqual(result["A"]?[0] ?? 0, 0.6, accuracy: 1e-6)
+        XCTAssertEqual(result["A"]?[1] ?? 0, 0.8, accuracy: 1e-6)
+        XCTAssertEqual(result["A"]?[2] ?? 0, 0, accuracy: 1e-6)
+        // B: [0, 0, 5] → L2-normalised = [0, 0, 1]
+        XCTAssertEqual(result["B"]?[0] ?? 0, 0, accuracy: 1e-6)
+        XCTAssertEqual(result["B"]?[2] ?? 0, 1.0, accuracy: 1e-6)
+    }
+
+    func testAggregateCentroidsMissingCountDefaultsToOne() {
+        // Speaker in sums but absent from counts → treat as count=1 (don't divide
+        // the sum away). Defensive guard against accidental input mismatch.
+        let result = FluidDiarizer.aggregateCentroids(
+            sums: ["X": [3, 4, 0]],
+            counts: [:],
+        )
+        // Same as count=1 → [3, 4, 0] L2-normalised to [0.6, 0.8, 0]
+        XCTAssertEqual(result["X"]?[0] ?? 0, 0.6, accuracy: 1e-6)
+        XCTAssertEqual(result["X"]?[1] ?? 0, 0.8, accuracy: 1e-6)
+    }
+
+    func testBuildOverlapExcludedMasksEmptyInputs() {
+        XCTAssertEqual(
+            FluidDiarizer.buildOverlapExcludedMasks(predictions: [], numSpeakers: 4, threshold: 0.5),
+            [],
+        )
+        XCTAssertEqual(
+            FluidDiarizer.buildOverlapExcludedMasks(predictions: [0.9, 0.1], numSpeakers: 0, threshold: 0.5),
+            [],
+        )
+    }
 }

--- a/app/MeetingTranscriber/Tests/Quality/SortformerEmbeddingsE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/SortformerEmbeddingsE2ETests.swift
@@ -1,0 +1,80 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// End-to-end coverage for Phase 1 of issue #165: Sortformer mode must
+/// now populate `DiarizationResult.embeddings` via post-hoc WeSpeaker
+/// extraction on overlap-excluded frames. Before this PR the field was
+/// nil in Sortformer mode and `PipelineQueue.processNext()`'s naming-flow
+/// `guard let embeddings else { break }` aborted (issue #109).
+///
+/// Acceptance principle (matches the channel-health E2E pattern from
+/// `feedback_e2e_must_exercise_production_chain`): revert the
+/// `extractSortformerEmbeddings` call in `FluidDiarizer.runSortformer`
+/// and these tests must fail.
+///
+/// Gated via `RUN_QUALITY_TESTS=1` because the first run pulls the
+/// `pyannote_segmentation` + `wespeaker_v2` CoreML models (~150 MB).
+/// Subsequent runs are model-cached and complete in ~5 s on M-series.
+@MainActor
+final class SortformerEmbeddingsE2ETests: XCTestCase {
+    func testSortformerProducesPerSpeakerEmbeddingsAfterPhase1() async throws {
+        try skipUnlessQualityRun()
+
+        let truth = try GroundTruth.load(named: "two_speakers_de")
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: truth.audioURL.path),
+            "Audio fixture missing: \(truth.audioURL.path)",
+        )
+
+        let diarizer = FluidDiarizer(mode: .sortformer)
+        let result = try await diarizer.run(
+            audioPath: truth.audioURL, numSpeakers: nil, meetingTitle: "two_speakers_de",
+        )
+
+        // (1) Phase 1's contract: embeddings must be populated so the naming
+        // dialog branch in PipelineQueue lights up (closes #109).
+        let embeddings = try XCTUnwrap(
+            result.embeddings,
+            "Sortformer mode must populate result.embeddings post-Phase 1 (issue #165) — was nil",
+        )
+
+        // (2) Fixture has two speakers, expect at least 2 active speaker slots.
+        XCTAssertGreaterThanOrEqual(
+            embeddings.count, 2,
+            "Expected ≥2 active speakers from two_speakers_de fixture, got \(embeddings.count)",
+        )
+
+        // (3) Each embedding is L2-normalised 256-d (WeSpeaker output shape).
+        for (label, emb) in embeddings {
+            XCTAssertEqual(emb.count, 256, "Speaker \(label) has wrong embedding dim")
+            let norm = (emb.reduce(into: Float(0)) { $0 += $1 * $1 }).squareRoot()
+            XCTAssertEqual(
+                Double(norm), 1.0, accuracy: 1e-3,
+                "Speaker \(label) embedding is not L2-normalised (norm=\(norm))",
+            )
+        }
+
+        // (4) Different speakers must produce embeddings that are at least
+        // weakly distinct — cosine distance above the SpeakerMatcher matching
+        // threshold (0.40) for ANY pair. If all pairs collapse below 0.40 the
+        // post-hoc extraction has produced near-duplicate centroids, which
+        // would break `SpeakerMatcher.match` (every new speaker would match
+        // every prior speaker).
+        let labels = Array(embeddings.keys)
+        var sawDistinctPair = false
+        for i in 0 ..< labels.count {
+            for j in (i + 1) ..< labels.count {
+                let a = embeddings[labels[i]] ?? []
+                let b = embeddings[labels[j]] ?? []
+                let dot = zip(a, b).reduce(into: Float(0)) { $0 += $1.0 * $1.1 }
+                let distance = 1.0 - dot
+                if distance > 0.40 { sawDistinctPair = true }
+            }
+        }
+        XCTAssertTrue(
+            sawDistinctPair,
+            "All Sortformer post-hoc speaker embeddings collapse below the SpeakerMatcher threshold (0.40) "
+                + "— extraction not differentiating speakers",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -289,7 +289,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.diarizerMode = .sortformer
         let body = try makeSpeakers(settings: settings).inspect()
         XCTAssertNoThrow(try body.find(
-            text: "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
+            text: "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
         ))
     }
 
@@ -299,7 +299,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.diarizerMode = .offline
         let body = try makeSpeakers(settings: settings).inspect()
         XCTAssertThrowsError(try body.find(
-            text: "Sortformer does not identify recurring speakers — speaker naming and auto-recognition are disabled.",
+            text: "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
         ))
     }
 

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -264,6 +264,44 @@ else
     defaults delete com.meetingtranscriber.dev recordOnly 2>/dev/null || true
 fi
 
+# Optional diarizer-mode override. `MTT_DIARIZER_MODE=sortformer` flips the
+# dev .app into Sortformer mode for this run — used by the Sortformer-naming
+# lane to assert that Phase 1 of issue #165 (post-hoc WeSpeaker embeddings)
+# actually lights up the naming dialog in production-chain. Always cleared
+# on exit so subsequent runs return to the default `.offline` mode.
+#
+# `defaults write com.meetingtranscriber.dev` from outside writes to the
+# *standard* preferences domain. The dev .app's bundle has a pre-existing
+# container at `~/Library/Containers/com.meetingtranscriber.dev/...` —
+# from a prior App Store-variant build or interactive use — and macOS
+# routes the app's UserDefaults reads to that container regardless of
+# whether the current binary is sandboxed. A naïve `defaults write` is
+# silently a no-op there. Write to both: container if it exists (covers
+# this runner) AND standard domain (covers a clean runner where the
+# container hasn't been created yet).
+_CONTAINER_PLIST="$HOME/Library/Containers/com.meetingtranscriber.dev/Data/Library/Preferences/com.meetingtranscriber.dev.plist"
+_set_dev_default() {
+    local key="$1" value="$2" type="${3:-string}"
+    if [ "$type" = "bool" ]; then
+        defaults write com.meetingtranscriber.dev "$key" -bool "$value" 2>/dev/null || true
+        [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
+    else
+        defaults write com.meetingtranscriber.dev "$key" "$value" 2>/dev/null || true
+        [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" "$value" 2>/dev/null || true
+    fi
+}
+_delete_dev_default() {
+    local key="$1"
+    defaults delete com.meetingtranscriber.dev "$key" 2>/dev/null || true
+    [ -f "$_CONTAINER_PLIST" ] && defaults delete "$_CONTAINER_PLIST" "$key" 2>/dev/null || true
+}
+if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
+    log "Overriding diarizerMode=$MTT_DIARIZER_MODE for this run"
+    _set_dev_default diarizerMode "$MTT_DIARIZER_MODE"
+else
+    _delete_dev_default diarizerMode
+fi
+
 # LaunchServices' `open` routes to the WindowServer of the *foreground* Aqua
 # session, not just any session with our UID loaded. If a second user is
 # signed in via Fast User Switching and currently has the foreground, our
@@ -304,6 +342,13 @@ on_exit() {
             find "$RECORDINGS_DIR" -type f -newer "$RECORD_ONLY_MARKER" -delete 2>/dev/null || true
             rm -f "$RECORD_ONLY_MARKER"
         fi
+    fi
+    # Always clear the diarizerMode override so the next run on this host
+    # starts from the AppSettings default (.offline) regardless of which
+    # lane left it set. Clears both standard and container plists for the
+    # same reason `_set_dev_default` writes to both.
+    if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
+        _delete_dev_default diarizerMode
     fi
 }
 trap on_exit EXIT INT TERM
@@ -355,6 +400,17 @@ _poll_for_new_lastjob_terminal() {
         # UI click. Fire-and-forget; the endpoint is a no-op when nothing
         # is pending and the next tick picks up the state change.
         if [ "${pending_naming:-0}" != "0" ] && [ -n "$pending_naming" ]; then
+            # Capture pendingNamingJobs[0].speakerCount the FIRST time we
+            # observe a pending naming job — before /action/skipNaming
+            # clears the queue. Surfaces the speaker-count Phase 1 of
+            # issue #165 promises: Sortformer mode must populate
+            # `result.embeddings` so the naming dialog sees N>0 speakers.
+            # Without this capture there's no production-chain signal that
+            # the embedding-extraction wiring is actually producing output.
+            if [ -z "${OBSERVED_NAMING_SPEAKERS:-}" ]; then
+                OBSERVED_NAMING_SPEAKERS="$(rpc /state | jq -r '.pendingNamingJobs[0].speakerCount // 0')" || OBSERVED_NAMING_SPEAKERS=0
+                log "$label:   First observed pendingNamingJobs[0].speakerCount=$OBSERVED_NAMING_SPEAKERS"
+            fi
             log "$label:   Auto-skipping ${pending_naming} pending naming job(s) via /action/skipNaming"
             curl --silent --show-error --max-time 5 -X POST \
                 --header "Authorization: Bearer $RPC_TOKEN" \
@@ -382,6 +438,9 @@ _poll_for_new_lastjob_terminal() {
 
 run_one_meeting() {
     local label="$1"
+    # Reset between meetings so --two-meetings captures each run's first
+    # observed naming-dialog speaker count, not just meeting 1's stale value.
+    OBSERVED_NAMING_SPEAKERS=""
     log "$label: starting meeting-simulator → $SIMULATOR_FIXTURE"
     "$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" >/tmp/e2e-app-sim.log 2>&1 &
     SIM_PID=$!
@@ -408,6 +467,23 @@ run_one_meeting() {
     log "$label: transcript $transcript_path ($transcript_size bytes)"
     log "$label: preview:"
     head -c 500 "$transcript_path" | sed 's/^/    /'
+
+    # Phase 1 of #165 production-chain assertion: when caller sets
+    # MTT_EXPECT_NAMING_SPEAKERS_MIN, require that the pending naming
+    # dialog observed during this run carried at least N speakers.
+    # `OBSERVED_NAMING_SPEAKERS` is populated inside the poll loop when
+    # the first `pendingNamingJobs[0]` appears (before /action/skipNaming
+    # drains it). Default lane (offline) doesn't set the gate; the
+    # Sortformer-mode lane wires it via `MTT_EXPECT_NAMING_SPEAKERS_MIN=1`
+    # so a regression that returns `embeddings: nil` would surface as
+    # "speakerCount=0, naming dialog never opened".
+    if [ -n "${MTT_EXPECT_NAMING_SPEAKERS_MIN:-}" ]; then
+        observed="${OBSERVED_NAMING_SPEAKERS:-0}"
+        if [ "$observed" -lt "$MTT_EXPECT_NAMING_SPEAKERS_MIN" ]; then
+            fail "$label: pendingNamingJobs[0].speakerCount=$observed < MTT_EXPECT_NAMING_SPEAKERS_MIN=$MTT_EXPECT_NAMING_SPEAKERS_MIN — naming dialog did not fire with the expected speaker count (Phase 1 #165 production-chain regression?)"
+        fi
+        log "$label: naming-dialog speaker count assertion passed (observed=$observed >= min=$MTT_EXPECT_NAMING_SPEAKERS_MIN)"
+    fi
     echo
 
     PRE_LAST_JOB_ID="$lj_id"


### PR DESCRIPTION
## Summary

- **Closes #109.** Sortformer mode now populates `DiarizationResult.embeddings` so the speaker-naming dialog + `SpeakerMatcher` work — previously Sortformer-mode users got generic "Speaker 0/1" labels with no naming UI.
- **Phase 1 of #165** ([RFC: diarization architecture roadmap](https://github.com/pasrom/meeting-transcriber/issues/165)). Implements the DiariZen-pattern hybrid: Sortformer for segmentation + speaker-counting, WeSpeaker (`wespeaker_v2`) post-hoc on overlap-excluded frames for 256-d centroids.
- **Overlap-exclusion masking** is the DiariZen secret-sauce: frames where >=2 Sortformer speakers cross the onset threshold are zeroed across all speakers before embedding extraction, preventing crosstalk from polluting per-speaker centroids.

## Why

`PipelineQueue.processNext()` had a `guard let embeddings else { break }` that silently aborted the naming flow when embeddings were nil. Sortformer mode set them to nil → users saw "Speaker 0/1" forever, no naming dialog, no auto-recognition.

The straightforward fix would have been to run WeSpeaker on each Sortformer segment naively. But the SOTA approach (current open benchmark winner DiariZen, BUT 2025, 11.2% DER on VoxConverse) is to **first mask out overlap regions** before embedding extraction. That's what this PR does.

Background research and the full SOTA review against pyannote.audio 3.1 / NVIDIA Sortformer / DiariZen / Reverb / AssemblyAI lives in the `.local` backlog and is summarised in #165's response (forthcoming).

## Mechanics

- **`FluidDiarizer`** caches a lazy-loaded `DiarizerModels` for WeSpeaker. First Sortformer run after upgrade pulls ~150 MB (`pyannote_segmentation.mlmodelc` + `wespeaker_v2.mlmodelc`); subsequent runs are cached.
- **`buildOverlapExcludedMasks`** — pure helper. `[numFrames × numSpeakers]` flat predictions → `[numSpeakers]` binary masks with overlap-only frames zeroed across all speakers.
- **`resampleMask`** — pure helper. Nearest-neighbour between Sortformer's 12.5 Hz frame grid (~125 frames per 10 s) and WeSpeaker's segmentation frame count (queried at runtime from the pyannote segmentation model's output shape, currently 589).
- **`extractSortformerEmbeddings`** — chunks audio into 10 s windows, picks the top-3 active speakers per chunk (WeSpeaker's CoreML accepts only `[3, frames]` mask shape; Sortformer's 4th speaker gets covered in chunks where they rank in the top-3), L2-normalises the mean across chunks per speaker.

## Cost

| | Before | After |
|---|---|---|
| Sortformer post-recording wall-clock | ~5 s for 30 s audio | ~7-8 s for 30 s audio |
| One-time download on first run | 0 MB | +150 MB (cached afterwards) |
| `result.embeddings` | `nil` (broken naming) | populated 256-d per speaker |
| Naming dialog in Sortformer mode | never appears | appears like in Offline mode |

DER unchanged (segments are computed before embeddings). Memory use unchanged (lazy-loaded, both models retained for re-use across recordings).

## Test plan

- [x] **9 new pure-helper unit tests** in `FluidDiarizerSortformerTests` for `buildOverlapExcludedMasks` (single-speaker / overlap-zeroing / silence / triple-overlap / empty-inputs) and `resampleMask` (upsample / downsample / production 125→589 ratio with boundary frames / empty-input). All green, <2 ms total.
- [x] **New gated E2E test** `SortformerEmbeddingsE2ETests.testSortformerProducesPerSpeakerEmbeddingsAfterPhase1` runs the full pipeline on `two_speakers_de.wav`, asserts `embeddings != nil` + 256-d L2-normalised + at least one cosine-distinct pair above `SpeakerMatcher.match` threshold (0.40). Passes in ~7 s after model cache warm. Acceptance: revert the `extractSortformerEmbeddings` call → test fails.
- [x] **No DER regression** — existing `test_sortformer_twoSpeakers_de_der` (4.93 s, DER 0.060) + `test_sortformer_threeSpeakers_de_der` (6.02 s, DER 0.109) pass unchanged.
- [x] `./scripts/lint.sh` clean.
- [x] `./scripts/pre-push.sh` (release build) clean — no Sendable diagnostics in the `@unchecked Sendable` `FluidDiarizer`.
- [ ] Manual: switch Settings → Speakers → Diarization Mode to "Sortformer (Overlap-aware)", record a 2-speaker meeting, confirm the speaker-naming dialog appears post-recording (it never did before).

## Out of scope

- **Phase 2 of #165** (constrained AHC with `speakers.json` anchors) — the API recon found `SortformerDiarizer.enrollSpeaker(withAudio:named:)` already implements TS-VAD-family neural enrollment, making clustering-anchor designs obsolete for the Sortformer path. Tracked in `.local` backlog.
- **PLDA scoring** — confirmed exposed in FluidAudio's offline path (`PLDATransform`), separate ~1 d follow-up.
- **Higher-K Sortformer models** — waiting on FluidAudio. Current Sortformer hard-caps at 4 speakers; for >4-speaker meetings the offline (.offline mode) clustering pipeline remains the better choice per FluidAudio's published AMI-SDM numbers (Offline 10.6 % vs Sortformer balancedV2_1 20.6 % DER).