### PR TITLE
feat(app): link diarizer mode + speaker count across Settings & naming dialog

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -45,7 +45,11 @@ enum TranscriptionEngineSetting: String, CaseIterable, Codable {
     }
 }
 
-enum DiarizerMode: String, CaseIterable {
+enum DiarizerMode: String, CaseIterable, Codable {
+    // RawValues are implicit (= case name). Future case renames must
+    // either keep the rawValue stable (`case foo = "offline"`) or add a
+    // migration step — `AppSettingsTests.testDiarizerModeRawValuesPinJSONShape`
+    // is the regression gate that surfaces the need.
     case offline
     case sortformer
 
@@ -53,6 +57,20 @@ enum DiarizerMode: String, CaseIterable {
         switch self {
         case .offline: "Offline (Clustering)"
         case .sortformer: "Sortformer (Overlap-aware)"
+        }
+    }
+
+    /// Maximum selectable speaker count for this mode. Sortformer's cap
+    /// is a hard architectural limit (`SortformerConfig.numSpeakers = 4`
+    /// in FluidAudio). Offline's cap is the upper bound of the Settings
+    /// Stepper — the diarizer has no hard limit, but anything above 10
+    /// is past the useful range for typical meetings. Surfaced as a
+    /// single source of truth so the Stepper ranges in Settings + the
+    /// SpeakerNamingView re-run UI + the cap-hint label all agree.
+    var speakerCap: Int {
+        switch self {
+        case .offline: 10
+        case .sortformer: 4
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -868,21 +868,28 @@ final class AppState { // swiftlint:disable:this type_body_length
         configurePipelineCallbacks()
     }
 
+    /// One-stop FluidDiarizer instantiation. Captures the current tuning
+    /// fields from settings so both the global-mode factory and the
+    /// per-job mode-override factory stay in sync. Tuning only affects
+    /// `.offline` mode, but is harmless when passed to `.sortformer`.
+    private func makeFluidDiarizer(mode: DiarizerMode) -> FluidDiarizer {
+        FluidDiarizer(
+            mode: mode,
+            tuning: OfflineDiarizerTuning(
+                clusterThreshold: settings.clusterThreshold,
+                warmStartFa: settings.warmStartFa,
+                warmStartFb: settings.warmStartFb,
+                minSegmentDurationSeconds: settings.minSegmentDurationSeconds,
+                excludeOverlap: settings.excludeOverlap,
+            ),
+        )
+    }
+
     func makePipelineQueue() -> PipelineQueue {
         let queue = PipelineQueue(
             engine: activeTranscriptionEngine,
-            diarizationFactory: { [self] in
-                FluidDiarizer(
-                    mode: settings.diarizerMode,
-                    tuning: OfflineDiarizerTuning(
-                        clusterThreshold: settings.clusterThreshold,
-                        warmStartFa: settings.warmStartFa,
-                        warmStartFb: settings.warmStartFb,
-                        minSegmentDurationSeconds: settings.minSegmentDurationSeconds,
-                        excludeOverlap: settings.excludeOverlap,
-                    ),
-                )
-            },
+            diarizationFactory: { [self] in makeFluidDiarizer(mode: settings.diarizerMode) },
+            diarizationFactoryWithMode: { [self] mode in makeFluidDiarizer(mode: mode) },
             protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
             outputDir: settings.effectiveOutputDir,
             diarizeEnabled: settings.diarize,

--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -21,6 +21,11 @@ struct DiarizationResult {
 /// inference is thread-safe, mocks must follow the same contract.
 protocol DiarizationProvider: Sendable {
     var isAvailable: Bool { get }
+    /// The diarizer mode this provider was instantiated with. Read post-run
+    /// by `PipelineQueue` to record `PipelineJob.usedDiarizerMode`, so the
+    /// re-run UI in `SpeakerNamingView` can initialise its mode picker to
+    /// the mode that was actually used at recording time.
+    var mode: DiarizerMode { get }
     func run(audioPath: URL, numSpeakers: Int?, meetingTitle: String) async throws -> DiarizationResult
 }
 

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -260,6 +260,8 @@ struct MeetingTranscriberApp: App {
         SpeakerNamingView(
             data: data,
             knownSpeakerNames: appState.pipelineQueue.knownSpeakerNames,
+            currentDiarizerMode: appState.pipelineQueue.usedDiarizerMode(forJobID: data.jobID)
+                ?? appState.settings.diarizerMode,
         ) { result in
             appState.pipelineQueue.completeSpeakerNaming(jobID: data.jobID, result: result)
             if appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -57,6 +57,15 @@ struct PipelineJob: Identifiable, Codable {
     var transcriptPath: URL?
     var protocolPath: URL?
     var namingSlug: String?
+    /// Diarizer mode that produced the *current* `speakerNamingDataByJob`
+    /// entry. Set by `PipelineQueue` after diarisation completes (in the
+    /// initial pipeline run and after `lateDiarization`). Used by the
+    /// re-run UI in `SpeakerNamingView` to initialise the mode picker to
+    /// the mode that was actually used, not the current global setting
+    /// (which the user may have changed after recording).
+    /// `nil` for legacy jobs persisted before this field existed —
+    /// callers fall back to the current global setting.
+    var usedDiarizerMode: DiarizerMode?
 
     init(
         meetingTitle: String,
@@ -82,5 +91,6 @@ struct PipelineJob: Identifiable, Codable {
         self.transcriptPath = nil
         self.protocolPath = nil
         self.namingSlug = nil
+        self.usedDiarizerMode = nil
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -14,6 +14,11 @@ class PipelineQueue {
     // Dependencies for processing
     let engine: (any TranscribingEngine)?
     let diarizationFactory: (() -> any DiarizationProvider)?
+    /// Optional mode-overriding factory used by `lateDiarization` when the
+    /// user picks a different mode in the re-run UI. `nil` = mode override
+    /// not supported, `lateDiarization` falls back to `diarizationFactory()`
+    /// (current global setting). Production wires both via `AppState`.
+    let diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)?
     let protocolGeneratorFactory: (() -> (any ProtocolGenerating)?)?
     let outputDir: URL?
     let diarizeEnabled: Bool
@@ -77,7 +82,12 @@ class PipelineQueue {
     /// Result from the speaker naming popup.
     enum SpeakerNamingResult {
         case confirmed([String: String]) // user confirmed with mapping
-        case rerun(Int) // re-run diarization with N speakers
+        case rerun(Int) // re-run diarization with N speakers (current mode)
+        /// Re-run diarization with a different mode AND speaker count. New in
+        /// the Mode↔Count-coupling follow-up: lets the user recover from a
+        /// wrong-mode-at-recording-time (e.g. Sortformer's 4-speaker cap hit
+        /// on a 6-speaker meeting) without leaving the naming dialog.
+        case rerunWithMode(DiarizerMode, Int)
         case skipped // user skipped
     }
 
@@ -117,6 +127,13 @@ class PipelineQueue {
         return pendingSpeakerNaming
     }
 
+    /// Diarizer mode used to produce the current `speakerNamingDataByJob`
+    /// entry for the given job. `nil` for legacy jobs persisted before the
+    /// field existed — callers fall back to the current global setting.
+    func usedDiarizerMode(forJobID jobID: UUID) -> DiarizerMode? {
+        jobs.first { $0.id == jobID }?.usedDiarizerMode
+    }
+
     /// Jobs in speakerNamingPending state.
     var pendingSpeakerNamingJobs: [PipelineJob] {
         jobs.filter { $0.state == .speakerNamingPending }
@@ -145,6 +162,9 @@ class PipelineQueue {
 
         case let .rerun(count):
             Task { await lateDiarization(jobID: jobID, speakerCount: count) }
+
+        case let .rerunWithMode(mode, count):
+            Task { await lateDiarization(jobID: jobID, speakerCount: count, mode: mode) }
 
         case .skipped:
             recordRecognition(
@@ -252,6 +272,7 @@ class PipelineQueue {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.engine = nil
         self.diarizationFactory = nil
+        self.diarizationFactoryWithMode = nil
         self.protocolGeneratorFactory = nil
         self.outputDir = nil
         self.diarizeEnabled = false
@@ -312,6 +333,7 @@ class PipelineQueue {
     init(
         engine: any TranscribingEngine,
         diarizationFactory: @escaping () -> any DiarizationProvider,
+        diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)? = nil,
         protocolGeneratorFactory: @escaping () -> (any ProtocolGenerating)?,
         outputDir: URL,
         logDir: URL? = nil,
@@ -327,6 +349,7 @@ class PipelineQueue {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.engine = engine
         self.diarizationFactory = diarizationFactory
+        self.diarizationFactoryWithMode = diarizationFactoryWithMode
         self.protocolGeneratorFactory = protocolGeneratorFactory
         self.outputDir = outputDir
         self.diarizeEnabled = diarizeEnabled
@@ -741,6 +764,7 @@ class PipelineQueue {
                             saveNamingData(namingData, slug: slug)
                             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                                 jobs[idx].namingSlug = slug
+                                jobs[idx].usedDiarizerMode = diarizeProcess.mode
                             }
 
                             stopElapsedTimer()
@@ -780,6 +804,19 @@ class PipelineQueue {
                                     updateJobState(id: jobID, to: .diarizing)
                                     startElapsedTimer()
                                     logger.info("Re-running diarization with \(count) speakers")
+                                    continue diarizationLoop
+
+                                case let .rerunWithMode(_, count):
+                                    // Mode override is only honoured by the
+                                    // production `completeSpeakerNaming` ->
+                                    // `lateDiarization` path. The inline
+                                    // test-handler loop can't swap providers
+                                    // mid-iteration without rebuilding the
+                                    // factory; treat as a same-mode re-run.
+                                    speakerCount = count
+                                    updateJobState(id: jobID, to: .diarizing)
+                                    startElapsedTimer()
+                                    logger.info("Re-running diarization with \(count) speakers (mode override ignored in inline path)")
                                     continue diarizationLoop
 
                                 case .skipped:
@@ -1051,7 +1088,21 @@ class PipelineQueue {
     // MARK: - Late Re-diarization
 
     /// Re-run diarization from persisted 16kHz audio after pipeline completed.
-    private func lateDiarization(jobID: UUID, speakerCount: Int) async {
+    ///
+    /// - Parameters:
+    ///   - jobID: the job to re-diarize.
+    ///   - speakerCount: target speaker count (ignored by Sortformer mode).
+    ///   - mode: optional override for the diarizer mode. `nil` (default)
+    ///     keeps the original behaviour — re-instantiate the diarizer with
+    ///     the current global setting via `diarizationFactory()`. Non-nil
+    ///     uses `diarizationFactoryWithMode` to instantiate a one-off
+    ///     diarizer in the requested mode, so the user can recover from a
+    ///     wrong-mode-at-recording-time without leaving the naming dialog.
+    private func lateDiarization(
+        jobID: UUID,
+        speakerCount: Int,
+        mode: DiarizerMode? = nil,
+    ) async {
         guard let namingData = speakerNamingDataByJob[jobID],
               let jobIndex = jobs.firstIndex(where: { $0.id == jobID }),
               let diarizationFactory,
@@ -1062,7 +1113,17 @@ class PipelineQueue {
         }
 
         let recordingsDir = outputDir.appendingPathComponent("recordings")
-        let diarizeProcess = diarizationFactory()
+        let diarizeProcess: any DiarizationProvider = {
+            if let mode, let factory = diarizationFactoryWithMode {
+                return factory(mode)
+            }
+            if let mode {
+                logger.warning(
+                    "Late re-diarize requested mode=\(mode.rawValue, privacy: .public) but no mode-aware factory wired; falling back to global setting",
+                )
+            }
+            return diarizationFactory()
+        }()
         guard diarizeProcess.isAvailable else {
             logger.warning("Diarization not available for late re-run")
             return
@@ -1073,27 +1134,12 @@ class PipelineQueue {
 
         do {
             let title = jobs[jobIndex].meetingTitle
-            let diarization: DiarizationResult
-
-            if namingData.isDualSource {
-                let app16k = recordingsDir.appendingPathComponent("\(slug)_app_16k.wav")
-                let mic16k = recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav")
-                async let appDiar = diarizeProcess.run(
-                    audioPath: app16k, numSpeakers: speakerCount, meetingTitle: title,
-                )
-                async let micDiar = diarizeProcess.run(
-                    audioPath: mic16k, numSpeakers: nil, meetingTitle: title,
-                )
-                diarization = try await DiarizationProcess.mergeDualTrackDiarization(
-                    appDiarization: appDiar, micDiarization: micDiar,
-                )
-            } else {
-                let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
-                diarization = try await diarizeProcess.run(
-                    audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
-                )
-            }
-
+            let diarization = try await runLateDiarization(
+                diarizer: diarizeProcess,
+                audioBase: (dir: recordingsDir, slug: slug),
+                isDualSource: namingData.isDualSource,
+                speakerCount: speakerCount, title: title,
+            )
             stopElapsedTimer()
 
             guard let newNamingData = buildNamingData(
@@ -1105,15 +1151,15 @@ class PipelineQueue {
                 return
             }
 
-            // Update disk + RAM
             speakerNamingDataByJob[jobID] = newNamingData
             saveNamingData(newNamingData, slug: slug)
+            // Track which mode produced this fresh naming data so the next
+            // dialog open initialises the mode picker correctly.
+            jobs[jobIndex].usedDiarizerMode = diarizeProcess.mode
 
-            // Show naming dialog again
             updateJobState(id: jobID, to: .speakerNamingPending)
             NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
 
-            // If test handler is set, call it directly
             if let handler = speakerNamingHandler {
                 let result = await handler(newNamingData)
                 completeSpeakerNaming(jobID: jobID, result: result)
@@ -1123,6 +1169,37 @@ class PipelineQueue {
             stopElapsedTimer()
             updateJobState(id: jobID, to: .speakerNamingPending)
         }
+    }
+
+    /// Re-diarize the persisted 16 kHz audio for a job. Dispatches between
+    /// dual-source (separate app + mic tracks merged) and single-source
+    /// (mix only). Pure I/O helper extracted from `lateDiarization` to
+    /// keep its function body under the lint cap.
+    private func runLateDiarization(
+        diarizer: any DiarizationProvider,
+        audioBase: (dir: URL, slug: String),
+        isDualSource: Bool,
+        speakerCount: Int,
+        title: String,
+    ) async throws -> DiarizationResult {
+        let (recordingsDir, slug) = audioBase
+        if isDualSource {
+            let app16k = recordingsDir.appendingPathComponent("\(slug)_app_16k.wav")
+            let mic16k = recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav")
+            async let appDiar = diarizer.run(
+                audioPath: app16k, numSpeakers: speakerCount, meetingTitle: title,
+            )
+            async let micDiar = diarizer.run(
+                audioPath: mic16k, numSpeakers: nil, meetingTitle: title,
+            )
+            return try await DiarizationProcess.mergeDualTrackDiarization(
+                appDiarization: appDiar, micDiarization: micDiar,
+            )
+        }
+        let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
+        return try await diarizer.run(
+            audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
+        )
     }
 
     /// Build SpeakerNamingData from fresh diarization, reusing context from prior naming data.

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -20,46 +20,25 @@ struct SpeakersSettingsView: View {
     @State private var sheetMatcher: SpeakerMatcher?
     @State private var experimentalTuningExpanded = false
 
+    /// Stepper range for `numSpeakers` given the active diarizer mode.
+    /// Upper bound from `DiarizerMode.speakerCap` (single source of truth
+    /// shared with the SpeakerNamingView re-run UI). 0 = Auto.
+    static func speakerCountRange(for mode: DiarizerMode) -> ClosedRange<Int> {
+        0 ... mode.speakerCap
+    }
+
+    /// Clamp a desired `numSpeakers` to the cap that applies for the given
+    /// mode. 0 = Auto stays 0. Pure so unit tests can pin behaviour.
+    static func clampSpeakerCount(_ count: Int, for mode: DiarizerMode) -> Int {
+        guard count > 0 else { return 0 }
+        return min(count, mode.speakerCap)
+    }
+
     var body: some View {
-        // swiftlint:disable:next closure_body_length
         Form {
-            Section("Diarization") {
-                Toggle("Speaker Diarization", isOn: $settings.diarize)
-
-                if settings.diarize {
-                    Picker("Diarizer", selection: $settings.diarizerMode) {
-                        ForEach(DiarizerMode.allCases, id: \.self) { mode in
-                            Text(mode.label).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-
-                    if settings.diarizerMode == .sortformer {
-                        Label(
-                            "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
-                            systemImage: "info.circle",
-                        )
-                        .foregroundStyle(.secondary)
-                        .font(.caption)
-                    }
-
-                    HStack {
-                        Text("Expected Speakers")
-                        Spacer()
-                        Text(settings.numSpeakers == 0 ? "Auto" : "\(settings.numSpeakers)")
-                            .frame(width: 40)
-                            .multilineTextAlignment(.trailing)
-                        Stepper("", value: $settings.numSpeakers, in: 0 ... 10)
-                            .labelsHidden()
-                    }
-
-                    if settings.diarizerMode == .offline {
-                        experimentalTuningDisclosure
-                    }
-                }
-            }
-            .accessibilityIdentifier("diarizationSection")
-            .recordOnlyDisabled(settings.recordOnly)
+            diarizationSection
+                .accessibilityIdentifier("diarizationSection")
+                .recordOnlyDisabled(settings.recordOnly)
 
             if !settings.noMic {
                 Section("Speaker Identity") {
@@ -100,6 +79,59 @@ struct SpeakersSettingsView: View {
                     onMutate: onSpeakerMutate,
                 )
             }
+        }
+    }
+
+    // MARK: - Diarization Section
+
+    private var diarizationSection: some View {
+        Section("Diarization") {
+            Toggle("Speaker Diarization", isOn: $settings.diarize)
+            if settings.diarize {
+                diarizationModePicker
+                if settings.diarizerMode == .sortformer {
+                    Label(
+                        "Sortformer supports up to \(DiarizerMode.sortformer.speakerCap) speakers per meeting. Switch to Offline mode for meetings with more participants.",
+                        systemImage: "info.circle",
+                    )
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                }
+                expectedSpeakersRow
+                if settings.diarizerMode == .offline {
+                    experimentalTuningDisclosure
+                }
+            }
+        }
+    }
+
+    private var diarizationModePicker: some View {
+        Picker("Diarizer", selection: $settings.diarizerMode) {
+            ForEach(DiarizerMode.allCases, id: \.self) { mode in
+                Text(mode.label).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .onChange(of: settings.diarizerMode) { _, newMode in
+            // Clamp K to the new mode's cap so the value visible in the
+            // Stepper agrees with what the diarizer will actually honour.
+            settings.numSpeakers = Self.clampSpeakerCount(settings.numSpeakers, for: newMode)
+        }
+    }
+
+    private var expectedSpeakersRow: some View {
+        HStack {
+            Text("Expected Speakers")
+            Spacer()
+            Text(settings.numSpeakers == 0 ? "Auto" : "\(settings.numSpeakers)")
+                .frame(width: 40)
+                .multilineTextAlignment(.trailing)
+            Stepper(
+                "",
+                value: $settings.numSpeakers,
+                in: Self.speakerCountRange(for: settings.diarizerMode),
+            )
+            .labelsHidden()
         }
     }
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -65,11 +65,15 @@ func formattedTime(_ seconds: Double) -> String {
 }
 
 /// Window that lets the user name speakers after diarization.
-struct SpeakerNamingView: View {
+struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
     let data: PipelineQueue.SpeakerNamingData
     /// Names of speakers known from previous meetings, surfaced as quick-pick chips
     /// in addition to the current meeting's participants. Empty array hides the row.
     let knownSpeakerNames: [String]
+    /// Diarizer mode used to produce `data`. Initial value for the re-run
+    /// mode picker. `nil` for legacy jobs without a recorded mode — the
+    /// picker initialises to `.offline` in that case.
+    let currentDiarizerMode: DiarizerMode?
     let onComplete: (PipelineQueue.SpeakerNamingResult) -> Void
 
     /// Window after the dialog appears (or after Re-run produces a fresh `data.revision`)
@@ -86,11 +90,13 @@ struct SpeakerNamingView: View {
     init(
         data: PipelineQueue.SpeakerNamingData,
         knownSpeakerNames: [String] = [],
+        currentDiarizerMode: DiarizerMode? = nil,
         gracePeriod: TimeInterval = Self.defaultKeyboardGracePeriod,
         onComplete: @escaping (PipelineQueue.SpeakerNamingResult) -> Void,
     ) {
         self.data = data
         self.knownSpeakerNames = knownSpeakerNames
+        self.currentDiarizerMode = currentDiarizerMode
         self.gracePeriod = gracePeriod
         self.onComplete = onComplete
         // Seed `names` and `rerunCount` synchronously so the view renders
@@ -100,11 +106,28 @@ struct SpeakerNamingView: View {
         // never trigger SwiftUI lifecycle still see the correct surface.
         let speakerList = Self.computeSpeakers(from: data)
         _names = State(initialValue: Self.computeInitialNames(speakers: speakerList))
-        _rerunCount = State(initialValue: max(2, speakerList.count + 1))
+        let initialMode = currentDiarizerMode ?? .offline
+        _rerunMode = State(initialValue: initialMode)
+        let initialCount = max(2, speakerList.count + 1)
+        _rerunCount = State(initialValue: Self.clampCount(initialCount, for: initialMode))
         // Initialize the grace-period gate to "active" when the period is positive
         // so the buttons start disabled. When tests pass gracePeriod = 0 the gate
         // starts open (no grace) and the unlock task is a no-op.
         _keyboardGracePeriodActive = State(initialValue: gracePeriod > 0)
+    }
+
+    /// Clamp a desired speaker count to the cap that applies for the
+    /// given mode. Returns at most the upper bound of `rerunCountRange`
+    /// so callers can write the result back into the Stepper without
+    /// risking an out-of-range value on the next frame.
+    /// Pure so tests can pin it without instantiating the view.
+    static func clampCount(_ count: Int, for mode: DiarizerMode) -> Int {
+        max(1, min(count, rerunCountRange(for: mode).upperBound))
+    }
+
+    /// Re-run Stepper range for the given mode.
+    static func rerunCountRange(for mode: DiarizerMode) -> ClosedRange<Int> {
+        1 ... mode.speakerCap
     }
 
     @State private var keyboardGracePeriodActive: Bool = true
@@ -117,6 +140,7 @@ struct SpeakerNamingView: View {
     @State private var completedJobID: UUID?
     @State private var player: AVAudioPlayer?
     @State private var playingLabel: String?
+    @State private var rerunMode: DiarizerMode = .offline
     @State private var rerunCount: Int = 2
     /// Indices of speaker rows where the user clicked "More…" to reveal the full
     /// known-names list instead of the top-N ranked subset.
@@ -126,6 +150,78 @@ struct SpeakerNamingView: View {
 
     private var speakers: [(label: String, autoName: String?, speakingTime: Double)] {
         Self.computeSpeakers(from: data)
+    }
+
+    /// Re-run controls: mode picker, speaker-count Stepper, and Re-run button.
+    /// Stepper range narrows in Sortformer mode (1...4); mode-flip clamps
+    /// `rerunCount` to the new range. Re-run posts `.rerunWithMode(mode, count)`
+    /// when the picked mode differs from `currentDiarizerMode`, otherwise the
+    /// legacy `.rerun(count)` form (so consumers that don't care about
+    /// mode-switching stay unaffected).
+    private var rerunSection: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                Text("Wrong count?").font(.caption).foregroundStyle(.secondary)
+                // Hide the mode picker for callers that don't track per-job
+                // diarizer mode (currently the voice-enrollment flow): they
+                // can't honour `.rerunWithMode`, so a visible-but-inert
+                // picker would silently discard the user's choice.
+                if currentDiarizerMode != nil {
+                    rerunModePicker
+                }
+                Stepper(
+                    "\(rerunCount) speakers", value: $rerunCount,
+                    in: Self.rerunCountRange(for: rerunMode),
+                )
+                .font(.caption)
+                .accessibilityIdentifier("rerun-stepper")
+                rerunButton
+            }
+            if currentDiarizerMode != nil, rerunMode == .sortformer {
+                Text("Sortformer caps at \(DiarizerMode.sortformer.speakerCap) speakers — switch to Offline for larger meetings.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("sortformer-cap-hint")
+            }
+        }
+    }
+
+    private var rerunModePicker: some View {
+        Picker("", selection: $rerunMode) {
+            Text("Sortformer").tag(DiarizerMode.sortformer)
+            Text("Offline").tag(DiarizerMode.offline)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 200)
+        .font(.caption)
+        .accessibilityIdentifier("rerun-mode-picker")
+        .onChange(of: rerunMode) { _, newMode in
+            rerunCount = Self.clampCount(rerunCount, for: newMode)
+        }
+    }
+
+    private var rerunButton: some View {
+        Button("Re-run") {
+            guard completedJobID != data.jobID else { return }
+            completedJobID = data.jobID
+            player?.stop()
+            // `nil` currentDiarizerMode = legacy / enrollment caller that
+            // doesn't track per-job mode → keep the legacy `.rerun(count)`
+            // shape so those consumers stay unaffected. When the caller
+            // provides a mode, always fire `.rerunWithMode` so the picker's
+            // selection is authoritative — even when it matches the
+            // recorded mode. Otherwise lateDiarization would fall back to
+            // the no-arg factory (current global setting), which can differ
+            // from the recorded mode if the user touched Settings between
+            // recording and re-run.
+            if currentDiarizerMode != nil {
+                onComplete(.rerunWithMode(rerunMode, rerunCount))
+            } else {
+                onComplete(.rerun(rerunCount))
+            }
+        }
+        .font(.caption)
+        .accessibilityIdentifier("rerun-button")
     }
 
     static func computeSpeakers(
@@ -160,22 +256,7 @@ struct SpeakerNamingView: View {
 
             Divider()
 
-            HStack(spacing: 8) {
-                Text("Wrong count?")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Stepper("\(rerunCount) speakers", value: $rerunCount, in: 1 ... 10)
-                    .font(.caption)
-                    .accessibilityIdentifier("rerun-stepper")
-                Button("Re-run") {
-                    guard completedJobID != data.jobID else { return }
-                    completedJobID = data.jobID
-                    player?.stop()
-                    onComplete(.rerun(rerunCount))
-                }
-                .font(.caption)
-                .accessibilityIdentifier("rerun-button")
-            }
+            rerunSection
 
             HStack(spacing: 12) {
                 Button("Skip") {
@@ -238,7 +319,16 @@ struct SpeakerNamingView: View {
     private func resetForCurrentPresentation() {
         completedJobID = nil
         names = Self.computeInitialNames(speakers: speakers)
-        rerunCount = max(2, speakers.count + 1)
+        // Re-seed `rerunMode` from the prop so cross-job dialog switches
+        // (same view identity, different data) start with the correct
+        // picker selection instead of inheriting the previous job's mode.
+        // Then clamp the count to the active mode's Stepper range so the
+        // value never sits outside `in:` on first frame (Sortformer caps
+        // at 4 even when the diarizer detected 4 speakers, which would
+        // otherwise compute max(2, 4+1) = 5).
+        let mode = currentDiarizerMode ?? rerunMode
+        rerunMode = mode
+        rerunCount = Self.clampCount(max(2, speakers.count + 1), for: mode)
         // Indices are speaker-position based; a different speaker count would
         // leave stale entries pointing at no-longer-rendered rows.
         knownExpanded.removeAll()

--- a/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
+++ b/app/MeetingTranscriber/Sources/VoiceEnrollmentView.swift
@@ -268,6 +268,13 @@ enum VoiceEnrollmentLogic {
 
         case let .rerun(count):
             return .rerun(url: payload.url, numSpeakers: count)
+
+        case let .rerunWithMode(_, count):
+            // Voice-enrollment flow re-runs against a single fixed audio
+            // file; the mode override case carries the same speaker-count
+            // semantics. The enrollment helper doesn't expose mode toggling,
+            // so the mode component is ignored here.
+            return .rerun(url: payload.url, numSpeakers: count)
         }
     }
 

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -410,4 +410,30 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(KeychainHelper.exists(key: "HF_TOKEN_TEST"))
         XCTAssertNil(KeychainHelper.read(key: "HF_TOKEN_TEST"))
     }
+
+    /// `DiarizerMode` is persisted via `PipelineSnapshot` (PipelineJob.usedDiarizerMode)
+    /// and via UserDefaults (AppSettings.diarizerMode). The JSON/UserDefaults
+    /// shape is keyed off the implicit rawValues `"offline"` / `"sortformer"`
+    /// — a future case rename without a stable rawValue would silently break
+    /// snapshot decode. This test pins the wire format so any rename forces
+    /// an explicit migration decision.
+    func testDiarizerModeRawValuesPinJSONShape() throws {
+        XCTAssertEqual(DiarizerMode.offline.rawValue, "offline")
+        XCTAssertEqual(DiarizerMode.sortformer.rawValue, "sortformer")
+
+        let json = try JSONEncoder().encode([DiarizerMode.offline, .sortformer])
+        XCTAssertEqual(String(bytes: json, encoding: .utf8), #"["offline","sortformer"]"#)
+
+        let roundTrip = try JSONDecoder().decode([DiarizerMode].self, from: json)
+        XCTAssertEqual(roundTrip, [.offline, .sortformer])
+    }
+
+    /// `DiarizerMode.speakerCap` is the single source of truth for the
+    /// max-speaker constraint shared by `SpeakersSettingsView` and
+    /// `SpeakerNamingView`. Lock the values so a FluidAudio bump that
+    /// changes Sortformer's cap will surface here first.
+    func testDiarizerModeSpeakerCap() {
+        XCTAssertEqual(DiarizerMode.sortformer.speakerCap, 4)
+        XCTAssertEqual(DiarizerMode.offline.speakerCap, 10)
+    }
 }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -703,6 +703,7 @@ final class PipelineQueueTests: XCTestCase {
     private func makeMockProcessingQueue(
         engine: MockEngine? = nil,
         diarizationFactory: @escaping () -> any DiarizationProvider = { MockDiarization() },
+        diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)? = nil,
         diarizeEnabled: Bool = false,
         numSpeakers: Int = 0,
     ) -> (PipelineQueue, MockEngine) {
@@ -710,6 +711,7 @@ final class PipelineQueueTests: XCTestCase {
         let q = PipelineQueue(
             engine: engine,
             diarizationFactory: diarizationFactory,
+            diarizationFactoryWithMode: diarizationFactoryWithMode,
             protocolGeneratorFactory: { MockProtocolGen() },
             outputDir: tmpDir,
             logDir: tmpDir,
@@ -1717,6 +1719,233 @@ final class PipelineQueueTests: XCTestCase {
 
         XCTAssertTrue(rerunHandlerCalled, "Handler should be called with new diarization results")
         XCTAssertEqual(pQueue.jobs.first?.state, .done)
+    }
+
+    /// Factory helper for the mode-override integration tests. Returns a
+    /// `MockDiarization` with `.mode` set + a small fixture result keyed off
+    /// the mode, so the two test bodies can verify which provider was used.
+    private func makeModeOverrideDiar(_ mode: DiarizerMode) -> MockDiarization {
+        let mock = MockDiarization()
+        mock.mode = mode
+        mock.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 2, speaker: "SPEAKER_0"),
+                .init(start: 2, end: 5, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 2, "SPEAKER_1": 3],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0]],
+        )
+        return mock
+    }
+
+    /// `.rerunWithMode(.sortformer, _)` swaps the `DiarizationProvider`
+    /// through the mode-aware factory and writes the new mode back onto
+    /// `PipelineJob.usedDiarizerMode`. Regression gate for the mode↔count
+    /// coupling: a missing wire-through here means the picker in
+    /// `SpeakerNamingView` becomes ghost UI in Sortformer mode.
+    func testLateRerunWithModeOverrideSwapsProviderAndRecordsMode() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let offlineDiar = makeModeOverrideDiar(.offline)
+        let sortformerDiar = makeModeOverrideDiar(.sortformer)
+        let modeOverrideCalls = OSAllocatedUnfairLock<[DiarizerMode]>(initialState: [])
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { offlineDiar },
+            diarizationFactoryWithMode: { mode in
+                modeOverrideCalls.withLock { $0.append(mode) }
+                return mode == .sortformer ? sortformerDiar : offlineDiar
+            },
+            diarizeEnabled: true,
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Mode Override Test", appName: "TestApp",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+        XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .offline)
+
+        pQueue.speakerNamingHandler = { _ in .confirmed([:]) }
+        let doneExpectation = XCTestExpectation(description: "done after mode override")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { doneExpectation.fulfill() }
+        }
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerunWithMode(.sortformer, 2))
+        await fulfillment(of: [doneExpectation], timeout: 60)
+
+        XCTAssertEqual(modeOverrideCalls.withLock(\.self), [.sortformer])
+        XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .sortformer)
+        XCTAssertEqual(pQueue.jobs.first?.state, .done)
+    }
+
+    /// `.rerunWithMode(_, _)` falls back to the no-arg factory when no
+    /// mode-aware factory is wired (covers tests and any callsite that
+    /// hasn't been migrated yet). The mode metadata follows the actual
+    /// provider — so a default-mode `MockDiarization` keeps the job's
+    /// `usedDiarizerMode` consistent with what ran.
+    func testLateRerunWithModeOverrideFallsBackToDefaultFactory() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.mode = .offline
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        // No `diarizationFactoryWithMode` provided — covers the fallback path.
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Mode Override Fallback Test",
+            appName: "TestApp",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending {
+                pendingExpectation.fulfill()
+            }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+
+        pQueue.speakerNamingHandler = { _ in .confirmed([:]) }
+        let doneExpectation = XCTestExpectation(description: "done after fallback")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done {
+                doneExpectation.fulfill()
+            }
+        }
+
+        pQueue.completeSpeakerNaming(
+            jobID: job.id,
+            result: .rerunWithMode(.sortformer, 2),
+        )
+        await fulfillment(of: [doneExpectation], timeout: 60)
+
+        // Without a mode-aware factory, the fallback runs the no-arg
+        // factory and the resulting provider's mode (.offline) wins.
+        XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .offline)
+    }
+
+    /// `lateDiarization` swallows diarizer errors and rolls the job back
+    /// to `.speakerNamingPending` (so the user can try again) without
+    /// touching `usedDiarizerMode` — the cached naming data still
+    /// reflects the prior successful run.
+    func testLateRerunRollsBackToPendingWhenDiarizerThrows() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let mockDiar = MockDiarization()
+        mockDiar.mode = .offline
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Late Rerun Throw Test", appName: "TestApp",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+        XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .offline)
+
+        // Make the diarizer throw on the next run (the `_16k.wav` re-run path).
+        mockDiar.throwOnPathSuffix = "_16k.wav"
+
+        let rolledBack = XCTestExpectation(description: "rolled back to pending after throw")
+        var seenStates: [JobState] = []
+        pQueue.onJobStateChange = { _, _, newState in
+            seenStates.append(newState)
+            if seenStates.contains(.diarizing), newState == .speakerNamingPending {
+                rolledBack.fulfill()
+            }
+        }
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(2))
+        await fulfillment(of: [rolledBack], timeout: 10)
+
+        XCTAssertEqual(pQueue.jobs.first?.state, .speakerNamingPending)
+        // usedDiarizerMode is unchanged from the prior successful run
+        // because the cached naming data still reflects that run.
+        XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .offline)
+    }
+
+    /// `isAvailable == false` short-circuits lateDiarization without
+    /// changing the job state — there's no recoverable path so the
+    /// user is left to fix the configuration (model download, etc.).
+    func testLateRerunIsNoOpWhenDiarizerNotAvailable() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let mockDiar = MockDiarization()
+        mockDiar.mode = .offline
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Late Rerun Unavailable", appName: "TestApp",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+
+        // Flip the mock to "not available" so the late-rerun guard at the
+        // top of lateDiarization trips.
+        mockDiar.isAvailable = false
+        let initialState = pQueue.jobs.first?.state
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        // Yield once to let the Task dispatched from completeSpeakerNaming
+        // observe the unavailable guard and return early.
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(pQueue.jobs.first?.state, initialState)
     }
 
     func testLateConfirmationWithNoNamingDataIsNoOp() {

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -289,7 +289,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.diarizerMode = .sortformer
         let body = try makeSpeakers(settings: settings).inspect()
         XCTAssertNoThrow(try body.find(
-            text: "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
+            text: "Sortformer supports up to \(DiarizerMode.sortformer.speakerCap) speakers per meeting. Switch to Offline mode for meetings with more participants.",
         ))
     }
 
@@ -299,8 +299,29 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         settings.diarizerMode = .offline
         let body = try makeSpeakers(settings: settings).inspect()
         XCTAssertThrowsError(try body.find(
-            text: "Sortformer supports up to 4 speakers per meeting. Switch to Offline mode for meetings with more participants.",
+            text: "Sortformer supports up to \(DiarizerMode.sortformer.speakerCap) speakers per meeting. Switch to Offline mode for meetings with more participants.",
         ))
+    }
+
+    // MARK: - Speakers Settings ↔ Diarizer Mode coupling
+
+    func testSpeakerCountRangePerMode() {
+        XCTAssertEqual(SpeakersSettingsView.speakerCountRange(for: .sortformer), 0 ... 4)
+        XCTAssertEqual(SpeakersSettingsView.speakerCountRange(for: .offline), 0 ... 10)
+    }
+
+    func testClampSpeakerCountPerMode() {
+        // Auto (0) is preserved across both modes.
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(0, for: .sortformer), 0)
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(0, for: .offline), 0)
+        // Sortformer caps at 4.
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(2, for: .sortformer), 2)
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(4, for: .sortformer), 4)
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(10, for: .sortformer), 4)
+        // Offline preserves up to 10; out-of-band values still clamp.
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(7, for: .offline), 7)
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(10, for: .offline), 10)
+        XCTAssertEqual(SpeakersSettingsView.clampSpeakerCount(99, for: .offline), 10)
     }
 
     // SpeakerMatcher.init reads + decodes speakers.json. It must run only

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -714,4 +714,113 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         XCTAssertFalse(confirm.isDisabled())
         XCTAssertFalse(skip.isDisabled())
     }
+
+    // MARK: - Mode↔Count coupling (Sortformer 4-speaker cap)
+
+    func testRerunCountRangeIsOneToFourForSortformer() {
+        XCTAssertEqual(SpeakerNamingView.rerunCountRange(for: .sortformer), 1 ... 4)
+    }
+
+    func testRerunCountRangeIsOneToTenForOffline() {
+        XCTAssertEqual(SpeakerNamingView.rerunCountRange(for: .offline), 1 ... 10)
+    }
+
+    func testClampCountKeepsValueInsideSortformerCap() {
+        XCTAssertEqual(SpeakerNamingView.clampCount(2, for: .sortformer), 2)
+        XCTAssertEqual(SpeakerNamingView.clampCount(4, for: .sortformer), 4)
+    }
+
+    func testClampCountClampsValueAboveSortformerCap() {
+        XCTAssertEqual(SpeakerNamingView.clampCount(8, for: .sortformer), 4)
+        XCTAssertEqual(SpeakerNamingView.clampCount(10, for: .sortformer), 4)
+    }
+
+    func testClampCountIsIdentityForOfflineMode() {
+        XCTAssertEqual(SpeakerNamingView.clampCount(2, for: .offline), 2)
+        XCTAssertEqual(SpeakerNamingView.clampCount(8, for: .offline), 8)
+        XCTAssertEqual(SpeakerNamingView.clampCount(10, for: .offline), 10)
+    }
+
+    func testRerunFiresLegacyShapeWhenCurrentModeIsNil() throws {
+        // Legacy/enrollment callers don't pass `currentDiarizerMode`.
+        // The Re-run button must keep firing the legacy `.rerun(count)`
+        // shape so callers that pattern-match on `.rerun` keep working.
+        var captured: PipelineQueue.SpeakerNamingResult?
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { result in
+            captured = result
+        }
+        try sut.inspect().find(button: "Re-run").tap()
+        guard case .rerun = captured else {
+            XCTFail("Expected .rerun for nil currentDiarizerMode, got \(String(describing: captured))")
+            return
+        }
+    }
+
+    func testRerunFiresRerunWithModeWhenCurrentModeIsSet() throws {
+        // Whenever the caller supplies a `currentDiarizerMode`, the Re-run
+        // button always fires `.rerunWithMode(picked, count)` — even when
+        // the picker matches the recorded mode. This makes the picker
+        // authoritative; lateDiarization sees an explicit mode and uses
+        // the mode-aware factory rather than falling back to the global
+        // setting (which can differ if the user touched Settings between
+        // recording and re-run).
+        var captured: PipelineQueue.SpeakerNamingResult?
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            currentDiarizerMode: .offline,
+            gracePeriod: 0,
+        ) { result in captured = result }
+        try sut.inspect().find(button: "Re-run").tap()
+        guard case let .rerunWithMode(mode, _) = captured else {
+            XCTFail("Expected .rerunWithMode when currentDiarizerMode is set, got \(String(describing: captured))")
+            return
+        }
+        XCTAssertEqual(mode, .offline)
+    }
+
+    func testModePickerHiddenWhenCurrentModeIsNil() throws {
+        // Voice-enrollment caller doesn't pass currentDiarizerMode. The
+        // picker must be hidden in that flow — otherwise the user can
+        // pick Sortformer but the Re-run button always emits `.rerun`
+        // (legacy shape), silently discarding the mode choice.
+        let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { _ in }
+        let body = try sut.inspect()
+        XCTAssertThrowsError(
+            try body.find(viewWithAccessibilityIdentifier: "rerun-mode-picker"),
+            "Mode picker must not render when currentDiarizerMode is nil",
+        )
+    }
+
+    func testModePickerShownWhenCurrentModeIsSet() throws {
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            currentDiarizerMode: .offline,
+            gracePeriod: 0,
+        ) { _ in }
+        let body = try sut.inspect()
+        XCTAssertNoThrow(
+            try body.find(viewWithAccessibilityIdentifier: "rerun-mode-picker"),
+        )
+    }
+
+    /// Pure `rerunCountRange` + `clampCount` already pin the math directly.
+    /// This test pins the *contract* (mode picker hidden ⇒ legacy `.rerun`,
+    /// mode picker shown ⇒ `.rerunWithMode` with the current rerunMode)
+    /// for the Sortformer cap path — the integration of "user flips picker,
+    /// view clamps rerunCount" is harder via ViewInspector and is covered
+    /// at the system level by the live-recording e2e (PR #325 lane).
+    func testRerunWithSortformerModeCarriesMode() throws {
+        var captured: PipelineQueue.SpeakerNamingResult?
+        let sut = SpeakerNamingView(
+            data: makeData(),
+            currentDiarizerMode: .sortformer,
+            gracePeriod: 0,
+        ) { result in captured = result }
+        try sut.inspect().find(button: "Re-run").tap()
+        guard case let .rerunWithMode(mode, _) = captured else {
+            XCTFail("Expected .rerunWithMode, got \(String(describing: captured))")
+            return
+        }
+        XCTAssertEqual(mode, .sortformer)
+    }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -293,6 +293,7 @@ class MockRecorder: RecordingProvider {
 /// exercising the diarizer; XCTest serialises per class.
 final class MockDiarization: DiarizationProvider, @unchecked Sendable {
     var isAvailable: Bool = true
+    var mode: DiarizerMode = .offline
     var runCount = 0
     var throwOnPathSuffix: String?
     var resultToReturn: DiarizationResult?

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -248,6 +248,26 @@ final class VoiceEnrollmentViewTests: XCTestCase { // swiftlint:disable:this bal
         XCTAssertEqual(count, 3)
     }
 
+    /// Enrollment flow doesn't expose mode toggling — `.rerunWithMode`
+    /// collapses to `.rerun` semantics, the mode component is ignored.
+    /// Today the SpeakerNamingView in enrollment context hides its mode
+    /// picker (Phase 2 of #165 follow-up), so this branch is defensive,
+    /// but it MUST still produce the same forwarding shape as `.rerun`.
+    func testHandleNamingResultRerunWithModeCollapsesToRerun() {
+        let url = URL(fileURLWithPath: "/tmp/mode-override.wav")
+        let outcome = VoiceEnrollmentLogic.handleNamingResult(
+            .rerunWithMode(.sortformer, 4),
+            payload: makeNamingPayload(url: url),
+            matcher: SpeakerMatcher(dbPath: dbPath),
+        )
+        guard case let .rerun(rerunURL, count) = outcome else {
+            XCTFail("Expected .rerun, got \(outcome)")
+            return
+        }
+        XCTAssertEqual(rerunURL, url)
+        XCTAssertEqual(count, 4)
+    }
+
     // MARK: - VoiceEnrollmentLogic.buildNamingPayload
 
     func testBuildNamingPayloadFallsBackToIdentityWhenMatcherEmpty() {


### PR DESCRIPTION
## Summary

Follow-up to PR #325 (Phase 1 of issue #165). Adds a single cross-constraint — **Sortformer caps at 4 speakers** — consistently to both UI surfaces where the user touches diarization, so the cap stops being a silent failure mode.

**Settings → Speakers**
- "Expected Speakers" Stepper range narrows to `0...4` when Sortformer is selected
- Mode flip auto-clamps the value (8 in Offline → 4 in Sortformer)

**Speaker-naming dialog (re-run section)**
- New segmented Sortformer/Offline picker beside the existing Stepper
- Same range constraint
- Mode initialises to the mode that was actually used at recording time (`PipelineJob.usedDiarizerMode`), not the current global setting
- Sortformer cap caption shown inline when picked
- Lets the user recover from a wrong-mode-at-recording-time without leaving the dialog

## Mechanism

- `PipelineJob.usedDiarizerMode` records the mode that produced the current naming-data entry; persisted via existing `PipelineSnapshot` writer
- `DiarizationProvider.mode` exposes the mode without leaking the FluidDiarizer concrete type
- New `SpeakerNamingResult.rerunWithMode(DiarizerMode, Int)` carries the override out of the dialog; legacy `.rerun(Int)` callers untouched
- New `PipelineQueue.diarizationFactoryWithMode` is wired by AppState alongside the existing factory; `lateDiarization(jobID:speakerCount:mode:)` uses it when a mode override is requested. `nil` falls back to the no-arg factory so existing tests + the voice-enrollment flow stay binary-compatible

## Test plan

- [x] `swift test --parallel` — 1786 tests pass, 0 errors
- [x] Pure helpers (`SpeakerNamingView.{clampCount, rerunCountRange}`, `SpeakersSettingsView.{clampSpeakerCount, speakerCountRange}`) unit-tested
- [x] Integration test `testLateRerunWithModeOverrideSwapsProviderAndRecordsMode` exercises the full mode-override path end-to-end
- [x] Fallback test `testLateRerunWithModeOverrideFallsBackToDefaultFactory` covers the no-mode-aware-factory branch
- [x] `./scripts/lint.sh` — clean (the 2 remaining violations are from an untracked A/B-experiment file not part of this PR)
- [x] `./scripts/pre-push.sh` — release-build parity check passes (no Sendable diagnostics)
- [x] Manual: open Settings → Speakers, flip Sortformer ↔ Offline with stepper at 8 → confirm clamp to 4 on Sortformer + range narrows
- [x] Manual: record a meeting with Sortformer, open naming dialog → confirm picker initialises to Sortformer, switch to Offline + stepper to 6 → re-run → naming dialog reopens with 6 speakers and `usedDiarizerMode` updates