### PR TITLE
feat(app): show configured mic speaker name in live caption overlay

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -90,8 +90,11 @@ final class AppState { // swiftlint:disable:this type_body_length
 
     /// Observable state for the live caption overlay. Always present (the
     /// `LiveCaptionsOverlay` window observes this); content is only populated
-    /// when live transcription is on AND a recording is active.
-    let liveCaptions: LiveCaptionsState = .init()
+    /// when live transcription is on AND a recording is active. Constructed
+    /// in `init` so the mic label reflects `settings.micName` from the
+    /// first overlay render. Kept in sync with later settings changes via
+    /// `setupLiveTranscriptionPrewarm`.
+    let liveCaptions: LiveCaptionsState
 
     #if !APPSTORE
         /// Lazy-started debug RPC server. Only constructed if the env var is
@@ -131,6 +134,7 @@ final class AppState { // swiftlint:disable:this type_body_length
         self.silentRecordingMonitor = SilentRecordingMonitor(
             debounceSeconds: settings.asymmetricSilenceWarningSeconds,
         )
+        self.liveCaptions = LiveCaptionsState(micLabel: settings.micName)
 
         #if !APPSTORE
             // E2E hook: force a per-channel flag on at launch so a driver
@@ -158,6 +162,7 @@ final class AppState { // swiftlint:disable:this type_body_length
         syncLanguageSettings()
         observeEngineSettings()
         setupLiveTranscriptionPrewarm()
+        setupMicLabelSync()
 
         #if !APPSTORE
             // Env var force-enables at launch only — preserves back-compat with
@@ -858,6 +863,25 @@ final class AppState { // swiftlint:disable:this type_body_length
                 guard let self else { return }
                 self.liveTranscriptionController = nil
                 self.setupLiveTranscriptionPrewarm()
+            }
+        }
+    }
+
+    /// Keep `liveCaptions.micLabel` synced with `settings.micName`. Separate
+    /// from `setupLiveTranscriptionPrewarm` because a rename does **not**
+    /// need a controller rebuild — `LiveTranscriptionController` reads the
+    /// label from `captions` on every final, so the new value flows
+    /// automatically. Finals already committed keep their per-line speaker
+    /// snapshot (no retroactive relabel), matching PR #318's engine-swap
+    /// behaviour: captions in flight use the cached value, the next final
+    /// picks up the new name.
+    private func setupMicLabelSync() {
+        liveCaptions.micLabel = settings.micName
+        withObservationTracking {
+            _ = settings.micName
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.setupMicLabelSync()
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
@@ -5,9 +5,12 @@ import SwiftUI
 ///
 /// Layout (top to bottom): up to `maxFinalsKept` recent finalised utterances
 /// at full opacity, then the per-channel hypotheses at 60 % opacity. Each
-/// row is prefixed with its speaker label ("Du" / "Remote"). When the state
-/// is empty the rounded background collapses to a tiny pill — the wrapping
-/// panel uses `hasContent` to hide entirely.
+/// row is prefixed with its speaker label — finals carry their own
+/// `LiveCaptionLine.speaker` so a settings rename after commit doesn't
+/// retroactively re-label them, while live hypotheses read the current
+/// `LiveCaptionsState.micLabel` / `.appLabel`. When the state is empty the
+/// rounded background collapses to a tiny pill — the wrapping panel uses
+/// `hasContent` to hide entirely.
 ///
 /// The content is bottom-anchored inside the fixed-size NSPanel (see
 /// `LiveCaptionsWindowController`) so the bar visually grows upward as new
@@ -37,13 +40,13 @@ struct LiveCaptionsOverlay: View {
     private var content: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(state.recentFinals.suffix(LiveCaptionsState.maxFinalsKept), id: \.self) { line in
-                row(channel: line.channel, text: line.text, opacity: 1.0)
+                row(speaker: line.speaker, text: line.text, opacity: 1.0)
             }
             if !state.hypothesisApp.isEmpty {
-                row(channel: .app, text: state.hypothesisApp, opacity: 0.6)
+                row(speaker: state.appLabel, text: state.hypothesisApp, opacity: 0.6)
             }
             if !state.hypothesisMic.isEmpty {
-                row(channel: .mic, text: state.hypothesisMic, opacity: 0.6)
+                row(speaker: state.micLabel, text: state.hypothesisMic, opacity: 0.6)
             }
         }
         .font(.system(size: 22, weight: .medium, design: .rounded))
@@ -55,9 +58,9 @@ struct LiveCaptionsOverlay: View {
         .shadow(color: .black.opacity(0.25), radius: 12, x: 0, y: 4)
     }
 
-    private func row(channel: LiveCaptionChannel, text: String, opacity: Double) -> some View {
+    private func row(speaker: String, text: String, opacity: Double) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(channel.label + ":")
+            Text(speaker + ":")
                 .foregroundStyle(.white.opacity(min(opacity, 0.85)))
                 .fontWeight(.semibold)
             Text(text)

--- a/app/MeetingTranscriber/Sources/LiveCaptionsState.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsState.swift
@@ -1,26 +1,27 @@
 import Foundation
 import Observation
 
-/// Which capture source a caption came from. Drives the speaker prefix in
-/// the overlay ("Du" for the local mic, "Remote" for the meeting app audio).
-/// String raw values double as the RPC wire format — the `/state.liveCaptions
-/// .recentFinals[].channel` JSON field carries `"mic"` / `"app"` directly.
+/// Which capture source a caption came from. Distinct from the displayed
+/// speaker label — the channel identifies the audio source, the label is
+/// settings-driven (`LiveCaptionsState.micLabel` / `.appLabel`) and may be
+/// per-final-overridden in slice 2 once the app channel gets per-speaker
+/// matching. String raw values double as the RPC wire format — the
+/// `/state.liveCaptions.recentFinals[].channel` JSON field carries
+/// `"mic"` / `"app"` directly.
 enum LiveCaptionChannel: String, Hashable, Codable {
     case mic
     case app
-
-    var label: String {
-        switch self {
-        case .mic: "Du"
-        case .app: "Remote"
-        }
-    }
 }
 
-/// A finalised utterance with its source channel attached.
+/// A finalised utterance with its source channel and rendered speaker label.
+/// `speaker` is derived at finalize time from the current label source — the
+/// mic channel uses `LiveCaptionsState.micLabel` (driven by `settings.micName`),
+/// the app channel uses `.appLabel`. Captured per-line so a settings flip
+/// after the line is committed doesn't retroactively re-label it.
 struct LiveCaptionLine: Hashable, Codable {
     let channel: LiveCaptionChannel
     let text: String
+    let speaker: String
 }
 
 /// Observable state powering the live caption-bar overlay.
@@ -37,6 +38,22 @@ struct LiveCaptionLine: Hashable, Codable {
 @Observable
 @MainActor
 final class LiveCaptionsState {
+    /// Display label for the local-mic channel. Defaults to `"Me"` to match
+    /// `PipelineQueue.micLabel`'s batch default. `AppState` overwrites this
+    /// with `settings.micName` at construction and on every settings change
+    /// so partials + new finals pick up rename without rebuilding state.
+    var micLabel: String
+
+    /// Display label for the meeting-app audio channel. Will become per-line
+    /// in slice 2 (known-speaker matching). Slice 1 keeps the channel-level
+    /// fallback.
+    var appLabel: String
+
+    init(micLabel: String = "Me", appLabel: String = "Remote") {
+        self.micLabel = micLabel
+        self.appLabel = appLabel
+    }
+
     private(set) var hypothesisMic: String = ""
     private(set) var hypothesisApp: String = ""
 
@@ -71,17 +88,32 @@ final class LiveCaptionsState {
         scheduleAutoClear()
     }
 
-    func applyFinalized(_ text: String, channel: LiveCaptionChannel) {
+    func applyFinalized(_ text: String, channel: LiveCaptionChannel, speaker: String) {
         switch channel {
         case .mic: hypothesisMic = ""
         case .app: hypothesisApp = ""
         }
-        recentFinals.append(LiveCaptionLine(channel: channel, text: text))
+        recentFinals.append(LiveCaptionLine(channel: channel, text: text, speaker: speaker))
         if recentFinals.count > Self.maxFinalsKept {
             recentFinals.removeFirst(recentFinals.count - Self.maxFinalsKept)
         }
         lastEventAt = Date()
         scheduleAutoClear()
+    }
+
+    /// Convenience: derives the speaker from the channel's current label.
+    /// Production wiring goes through the explicit-speaker overload so that
+    /// slice 2 can pass a matched name without needing to push it through
+    /// `micLabel`/`appLabel`. Kept on the type to keep test fixtures terse.
+    func applyFinalized(_ text: String, channel: LiveCaptionChannel) {
+        applyFinalized(text, channel: channel, speaker: label(for: channel))
+    }
+
+    func label(for channel: LiveCaptionChannel) -> String {
+        switch channel {
+        case .mic: micLabel
+        case .app: appLabel
+        }
     }
 
     func clear() {

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -113,8 +113,13 @@ final class LiveTranscriptionController {
         // engine's `@MainActor`-isolated `transcribeSamples`, which hops back
         // to the main actor on every invocation.
         let proxy = EngineProxy(engine: engine)
+        // Log prefix uses the raw channel id, not the user-visible speaker
+        // label. The speaker label is settings-driven (`settings.micName`)
+        // and the log args here are `privacy: .public` — using it here
+        // would leak the user's display name into the unified log.
+        let logChannel = channel.rawValue
         return StreamingTranscriber(
-            channelLabel: channel.label,
+            channelLabel: logChannel,
             vad: vad,
             transcribe: { samples in
                 try await proxy.transcribeSamples(samples)
@@ -129,15 +134,22 @@ final class LiveTranscriptionController {
                             // in `log show` / Console.app unless the system
                             // is in Private Data Capture mode. Defence in
                             // depth on top of the gate.
-                            logger.info("[\(channel.label, privacy: .public)] partial: \(text, privacy: .private)")
+                            logger.info("[\(logChannel, privacy: .public)] partial: \(text, privacy: .private)")
                         }
                         self.captions.applyPartial(text, channel: channel)
 
                     case let .finalized(text):
                         if self.verboseDiagnostics() {
-                            logger.info("[\(channel.label, privacy: .public)] final: \(text, privacy: .private)")
+                            logger.info("[\(logChannel, privacy: .public)] final: \(text, privacy: .private)")
                         }
-                        self.captions.applyFinalized(text, channel: channel)
+                        // Slice 1: speaker = channel default label. Slice 2
+                        // will replace this with a matched name on the app
+                        // channel.
+                        self.captions.applyFinalized(
+                            text,
+                            channel: channel,
+                            speaker: self.captions.label(for: channel),
+                        )
                     }
                 }
             },

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -834,6 +834,37 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertTrue(notifier.calls.first?.body.contains("Accessibility") ?? false)
     }
+
+    // MARK: - Live captions mic label sync
+
+    func testLiveCaptionsMicLabelInitialisedFromSettings() {
+        let settings = AppSettings()
+        settings.micName = "Roman"
+        let state = AppState(settings: settings, notifier: RecordingNotifier())
+        XCTAssertEqual(
+            state.liveCaptions.micLabel, "Roman",
+            "liveCaptions.micLabel must reflect settings.micName at construction",
+        )
+        XCTAssertEqual(state.liveCaptions.appLabel, "Remote")
+    }
+
+    func testLiveCaptionsMicLabelTracksSettingsRename() async {
+        let settings = AppSettings()
+        settings.micName = "Roman"
+        let state = AppState(settings: settings, notifier: RecordingNotifier())
+        XCTAssertEqual(state.liveCaptions.micLabel, "Roman")
+
+        // withObservationTracking fires asynchronously — give the
+        // re-arming Task<MainActor> a tick to settle. One main-actor
+        // hop is sufficient: the onChange callback enqueues a Task on
+        // MainActor, which becomes runnable as soon as we suspend.
+        settings.micName = "Anna"
+        for _ in 0 ..< 20 {
+            await Task.yield()
+            if state.liveCaptions.micLabel == "Anna" { break }
+        }
+        XCTAssertEqual(state.liveCaptions.micLabel, "Anna")
+    }
 }
 
 // MARK: - Private helpers

--- a/app/MeetingTranscriber/Tests/LiveCaptionWireFormatTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionWireFormatTests.swift
@@ -26,23 +26,37 @@ final class LiveCaptionWireFormatTests: XCTestCase {
     }
 
     func testLineRoundTripPreservesValues() throws {
-        let original = LiveCaptionLine(channel: .app, text: "Hello world")
+        let original = LiveCaptionLine(channel: .app, text: "Hello world", speaker: "Anna")
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(LiveCaptionLine.self, from: data)
         XCTAssertEqual(decoded, original)
     }
 
     func testLineEncodesExpectedShape() throws {
-        let line = LiveCaptionLine(channel: .mic, text: "Du sprichst")
+        let line = LiveCaptionLine(channel: .mic, text: "Du sprichst", speaker: "Roman")
         let data = try JSONEncoder().encode(line)
         let json = try XCTUnwrap(
             JSONSerialization.jsonObject(with: data) as? [String: Any],
         )
-        // Two top-level keys, no nested or renamed fields. If anyone
-        // wraps the line in a container or renames `text` → `content`,
-        // this fails before it can break mt-cli's snapshot expectations.
+        // Three top-level keys. Pins the addition of `speaker` (slice 1 of
+        // live-speaker-labels) so a future rename or removal — or a wrapper
+        // that nests these in a container — breaks here before it bricks
+        // `mt-cli` / `e2e-live-captions.sh`.
         XCTAssertEqual(json["channel"] as? String, "mic")
         XCTAssertEqual(json["text"] as? String, "Du sprichst")
-        XCTAssertEqual(json.count, 2)
+        XCTAssertEqual(json["speaker"] as? String, "Roman")
+        XCTAssertEqual(json.count, 3)
+    }
+
+    func testLineDecodesFromWireFormat() throws {
+        // Forward compatibility check: a payload produced by mt-cli or the
+        // RPC server must round-trip through `LiveCaptionLine` cleanly.
+        let payload = Data("""
+        {"channel":"app","text":"Hi there","speaker":"Anna"}
+        """.utf8)
+        let line = try JSONDecoder().decode(LiveCaptionLine.self, from: payload)
+        XCTAssertEqual(line.channel, .app)
+        XCTAssertEqual(line.text, "Hi there")
+        XCTAssertEqual(line.speaker, "Anna")
     }
 }

--- a/app/MeetingTranscriber/Tests/LiveCaptionsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionsStateTests.swift
@@ -45,7 +45,10 @@ final class LiveCaptionsStateTests: XCTestCase {
         XCTAssertEqual(state.hypothesisMic, "")
         XCTAssertEqual(state.hypothesisApp, "they are speaking")
         XCTAssertEqual(state.recentFinals.count, 1)
-        XCTAssertEqual(state.recentFinals[0], LiveCaptionLine(channel: .mic, text: "you done."))
+        XCTAssertEqual(
+            state.recentFinals[0],
+            LiveCaptionLine(channel: .mic, text: "you done.", speaker: "Me"),
+        )
     }
 
     func testFinalsRotationCapDropsOldestFirst() {
@@ -91,9 +94,55 @@ final class LiveCaptionsStateTests: XCTestCase {
         XCTAssertTrue(state.hasContent)
     }
 
-    func testChannelLabelStrings() {
-        XCTAssertEqual(LiveCaptionChannel.mic.label, "Du")
-        XCTAssertEqual(LiveCaptionChannel.app.label, "Remote")
+    func testDefaultLabelsMatchPipelineQueue() {
+        // "Me" matches PipelineQueue.micLabel's batch default, so live and
+        // batch transcripts render the same prefix when no rename is set.
+        // "Remote" stays the app-channel fallback until slice 2 introduces
+        // per-speaker matching.
+        let state = LiveCaptionsState()
+        XCTAssertEqual(state.micLabel, "Me")
+        XCTAssertEqual(state.appLabel, "Remote")
+    }
+
+    func testInitCustomMicLabelOverridesDefault() {
+        let state = LiveCaptionsState(micLabel: "Roman")
+        XCTAssertEqual(state.micLabel, "Roman")
+        XCTAssertEqual(state.appLabel, "Remote")
+    }
+
+    func testLabelForChannelTracksCurrentValues() {
+        let state = LiveCaptionsState(micLabel: "Roman")
+        XCTAssertEqual(state.label(for: .mic), "Roman")
+        XCTAssertEqual(state.label(for: .app), "Remote")
+        state.micLabel = "Roman P."
+        state.appLabel = "Anna"
+        XCTAssertEqual(state.label(for: .mic), "Roman P.")
+        XCTAssertEqual(state.label(for: .app), "Anna")
+    }
+
+    func testApplyFinalizedConvenienceUsesCurrentMicLabel() {
+        let state = LiveCaptionsState(micLabel: "Roman")
+        state.applyFinalized("hello world", channel: .mic)
+        XCTAssertEqual(state.recentFinals.first?.speaker, "Roman")
+    }
+
+    func testApplyFinalizedConvenienceCapturesLabelAtCommit() {
+        // Renaming after a final is committed must NOT retroactively
+        // relabel that line — the speaker is captured per-line.
+        let state = LiveCaptionsState(micLabel: "Roman")
+        state.applyFinalized("first utterance", channel: .mic)
+        state.micLabel = "Anna"
+        state.applyFinalized("second utterance", channel: .mic)
+        XCTAssertEqual(state.recentFinals[0].speaker, "Roman")
+        XCTAssertEqual(state.recentFinals[1].speaker, "Anna")
+    }
+
+    func testApplyFinalizedExplicitSpeakerOverridesLabel() {
+        // The explicit-speaker overload (used by slice 2's matched name)
+        // wins over the channel default.
+        let state = LiveCaptionsState()
+        state.applyFinalized("hi there", channel: .app, speaker: "Anna")
+        XCTAssertEqual(state.recentFinals.first?.speaker, "Anna")
     }
 
     // MARK: - Opacity fade (pure function of lastEventAt vs passed-in date)

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
@@ -69,6 +69,14 @@ final class LiveTranscriptionE2ETests: XCTestCase {
         // robustness layer.
         let micText = micFinals.map(\.text).joined(separator: " ").lowercased()
         XCTAssertFalse(micText.isEmpty)
+        // Speaker tagging: the captions state was built with
+        // `micLabel: "Roman"`, so every mic final must carry that label.
+        // Catches regressions that bypass `captions.label(for:)` and emit
+        // a hard-coded string (e.g. legacy "Du" or "Me").
+        XCTAssertTrue(
+            micFinals.allSatisfy { $0.speaker == "Roman" },
+            "every mic final must carry the configured speaker label, got: \(micFinals.map(\.speaker))",
+        )
 
         // (3) App channel: feed the same fixture into the app sink, wait
         // for a final on the .app channel. Re-uses the same engine + VAD
@@ -80,6 +88,13 @@ final class LiveTranscriptionE2ETests: XCTestCase {
         XCTAssertFalse(
             appFinals.isEmpty,
             "expected at least one .app-channel final, got channels: \(setup.captions.recentFinals.map(\.channel))",
+        )
+        // App-channel default label stays "Remote" until slice 2 introduces
+        // per-speaker matching. Pinning it here surfaces a regression if
+        // someone wires the mic label into both channels.
+        XCTAssertTrue(
+            appFinals.allSatisfy { $0.speaker == "Remote" },
+            "every app final must carry the channel-default app label, got: \(appFinals.map(\.speaker))",
         )
     }
 
@@ -98,7 +113,11 @@ final class LiveTranscriptionE2ETests: XCTestCase {
             "Test fixture not found at \(fixture.path)",
         )
         let samples = try await loadFixtureAs16kMono(fixture)
-        let captions = LiveCaptionsState()
+        // Custom mic label so the assertion in the test asserts that the
+        // controller actually consults `captions.label(for:)` on every
+        // final — a regression that hard-codes the legacy "Du" / "Me"
+        // string would flip this to a mismatch.
+        let captions = LiveCaptionsState(micLabel: "Roman")
         let engine = ParakeetEngine()
         let vad = FluidVAD(threshold: 0.5)
         let controller = LiveTranscriptionController(


### PR DESCRIPTION
## Summary

Slice 1 of the live-speaker-labels follow-up to PR #318. Replaces the hard-coded mic prefix `Du` in the live caption overlay with `settings.micName`, so the bar reads e.g. `Roman:` instead of `Du:`. App-channel default stays `Remote` — slice 2 (known-speaker matching on the app track) will replace that.

- New per-line `LiveCaptionLine.speaker` field on the RPC wire format, pinned in `LiveCaptionWireFormatTests` so a future rename fails locally before it bricks `mt-cli` / `e2e-live-captions.sh`.
- Label source moves from `LiveCaptionChannel.label` (compile-time enum) into `LiveCaptionsState.micLabel` / `.appLabel` (Observable, settings-driven).
- `LiveTranscriptionController` reads the label at every final, so a rename takes effect on the next final without rebuilding the controller — already-committed finals keep their per-line snapshot.
- Privacy: `StreamingTranscriber`'s `.public` log prefix uses the raw channel id (`mic` / `app`) instead of the user-visible name, so the unified log never sees the display name.

## Test plan

- [x] `swift build` (debug + release)
- [x] `swift test --parallel` — full suite green (1791 tests)
- [x] `./scripts/lint.sh` — clean (only pre-existing untracked Sortformer A/B-experiment violations, not part of this PR)
- [x] `LiveTranscriptionE2ETests` asserts mic finals carry `Roman`, app finals stay `Remote`
- [x] `AppStateTests/testLiveCaptionsMicLabelTracksSettingsRename` pins the live rename path
- [ ] CI green