### PR TITLE
refactor(app): extract testable buildRecording from DualSourceRecorder.stop()

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -18,6 +18,16 @@ struct RecordingResult {
     let recordingStart: TimeInterval // ProcessInfo.systemUptime
 }
 
+/// The recorder's declared capture format, passed to `buildRecording` so the
+/// processing logic stays free of instance state (and unit-testable).
+/// `requested*` are what we asked the device for (used to flag a USB/Bluetooth
+/// renegotiation in the logs); `targetRate` is the rate we resample/mix to.
+struct CaptureFormat {
+    let requestedChannels: Int
+    let requestedRate: Int
+    let targetRate: Int
+}
+
 /// Abstraction for recording, enabling mock injection in tests.
 @MainActor
 protocol RecordingProvider {
@@ -154,8 +164,10 @@ class DualSourceRecorder: RecordingProvider {
         logger.info("Recording started: PID \(appPID), \(self.recordRate) Hz, \(self.appChannels)ch")
     }
 
-    /// Stop recording and produce a mixed WAV.
-    func stop() throws -> RecordingResult { // swiftlint:disable:this function_body_length
+    /// Stop recording and produce a mixed WAV. The capture session is the only
+    /// hardware-bound part; everything after `session.stop()` is delegated to
+    /// the testable `buildRecording`.
+    func stop() throws -> RecordingResult {
         guard isRecording else {
             throw RecorderError.notRecording
         }
@@ -173,6 +185,30 @@ class DualSourceRecorder: RecordingProvider {
         let captureResult = session.stop()
         captureSession = nil
 
+        let ts = startTimestamp ?? Self.timestamp()
+        startTimestamp = nil
+
+        return try Self.buildRecording(
+            from: captureResult,
+            recordingsDir: Self.recordingsDir,
+            timestamp: ts,
+            recordingStart: recordingStart,
+            format: CaptureFormat(requestedChannels: appChannels, requestedRate: recordRate, targetRate: targetRate),
+        )
+    }
+
+    /// Convert a finished `AudioCaptureResult` (raw app `.tmp` + optional mic
+    /// WAV) into a mixed 16 kHz `RecordingResult`: cross-check the rate, downmix
+    /// + resample the app track, load the mic track, then mix or fall back to a
+    /// single track. Pure file-processing — no capture session, no `@available`
+    /// gate — so it is unit-testable with fixture files.
+    static func buildRecording( // swiftlint:disable:this function_body_length
+        from captureResult: AudioCaptureResult,
+        recordingsDir recDir: URL,
+        timestamp ts: String,
+        recordingStart: TimeInterval,
+        format: CaptureFormat,
+    ) throws -> RecordingResult {
         let micDelay = captureResult.micDelay
         let actualChannels = captureResult.actualChannels
 
@@ -189,7 +225,7 @@ class DualSourceRecorder: RecordingProvider {
             nil
         }
 
-        let actualRate = Self.crossCheckAppRate(
+        let actualRate = crossCheckAppRate(
             deviceRate: captureResult.actualSampleRate,
             appRawBytes: appRawBytes,
             appChannels: actualChannels,
@@ -200,17 +236,13 @@ class DualSourceRecorder: RecordingProvider {
         if micDelay != 0 {
             logger.info("Mic delay: \(micDelay)s")
         }
-        logger.info("App audio: \(actualChannels)ch, \(actualRate) Hz (requested: \(self.appChannels)ch, \(self.recordRate) Hz)")
-        if actualChannels != appChannels {
-            logger.warning("App audio channel count differs: actual=\(actualChannels), expected=\(self.appChannels) — mono USB device?")
+        logger.info("App audio: \(actualChannels)ch, \(actualRate) Hz (requested: \(format.requestedChannels)ch, \(format.requestedRate) Hz)")
+        if actualChannels != format.requestedChannels {
+            logger.warning("App audio channel count differs: actual=\(actualChannels), expected=\(format.requestedChannels) — mono USB device?")
         }
-        if actualRate != recordRate {
-            logger.warning("App audio rate differs: actual=\(actualRate), expected=\(self.recordRate) — USB device may have negotiated different rate")
+        if actualRate != format.requestedRate {
+            logger.warning("App audio rate differs: actual=\(actualRate), expected=\(format.requestedRate) — USB device may have negotiated different rate")
         }
-
-        let recDir = Self.recordingsDir
-        let ts = startTimestamp ?? Self.timestamp()
-        startTimestamp = nil
 
         // ── Convert app audio from temp file to Float32 mono ──
         var appPath: URL?
@@ -234,14 +266,14 @@ class DualSourceRecorder: RecordingProvider {
                 }
             }
 
-            appSamples = Self.downmixToMono(floats, channels: actualChannels)
+            appSamples = downmixToMono(floats, channels: actualChannels)
 
             // Resample to 16kHz and save app track
-            appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: targetRate)
+            appSamples16k = AudioMixer.resample(appSamples, from: actualRate, to: format.targetRate)
             let appFile = recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.app)")
-            try AudioMixer.saveWAV(samples: appSamples16k, sampleRate: targetRate, url: appFile)
+            try AudioMixer.saveWAV(samples: appSamples16k, sampleRate: format.targetRate, url: appFile)
             appPath = appFile
-            logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate)→\(self.targetRate) Hz)")
+            logger.info("App audio saved: \(appFile.lastPathComponent) (\(actualRate)→\(format.targetRate) Hz)")
         } else if FileManager.default.fileExists(atPath: tempURL.path) {
             // Clean up empty temp file left by failed app audio capture
             try? FileManager.default.removeItem(at: tempURL)
@@ -269,7 +301,7 @@ class DualSourceRecorder: RecordingProvider {
 
         // ── Mix via AudioMixer ──
         // Both app and mic are already at 16kHz at this point.
-        let mixRate = targetRate
+        let mixRate = format.targetRate
         let mixPath = recDir.appendingPathComponent("\(ts)\(Self.mixFilenameSuffix)")
 
         if let app = appPath, let mic = micPath {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -1,3 +1,4 @@
+import AudioTapLib
 @testable import MeetingTranscriber
 import XCTest
 
@@ -308,5 +309,148 @@ final class DualSourceRecorderTests: XCTestCase {
         let bogusPID: pid_t = 999_999
         let pids = DualSourceRecorder.resolveTapPIDs(rootPID: bogusPID)
         XCTAssertEqual(pids, [bogusPID])
+    }
+
+    // MARK: - buildRecording
+
+    /// Neither channel produced audio (0-byte app temp, no mic) → noAudioData.
+    func testBuildRecordingThrowsWhenNoAudioCaptured() throws {
+        let dir = try makeTempDirectory(prefix: "build_none")
+        let emptyApp = dir.appendingPathComponent("20260311_100000_app_raw.tmp")
+        try Data().write(to: emptyApp)
+
+        let result = AudioCaptureResult(
+            appAudioFileURL: emptyApp,
+            micAudioFileURL: nil,
+            actualSampleRate: 48000,
+            actualChannels: 2,
+            micDelay: 0,
+        )
+
+        XCTAssertThrowsError(
+            try DualSourceRecorder.buildRecording(
+                from: result,
+                recordingsDir: dir,
+                timestamp: "20260311_100000",
+                recordingStart: 1000,
+                format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+            ),
+        ) { error in
+            guard case RecorderError.noAudioData = error else {
+                return XCTFail("expected noAudioData, got \(error)")
+            }
+        }
+    }
+
+    /// App audio only (no mic) → app track saved, mix falls back to the
+    /// resampled app samples, and the raw `.tmp` is consumed.
+    func testBuildRecordingAppOnlyProducesMixFromResampledApp() throws {
+        let dir = try makeTempDirectory(prefix: "build_app")
+        let appTmp = dir.appendingPathComponent("20260311_120000_app_raw.tmp")
+        // 1 s of 48 kHz interleaved stereo.
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: nil,
+                actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
+            ),
+            recordingsDir: dir, timestamp: "20260311_120000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+        )
+
+        XCTAssertNotNil(result.appPath, "app track should be saved")
+        XCTAssertNil(result.micPath, "no mic track")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: appTmp.path), "raw .tmp should be consumed")
+    }
+
+    /// Mic audio only (0-byte app temp) → mic track surfaces, mix falls back to
+    /// the mic samples.
+    func testBuildRecordingMicOnlyProducesMixFromMic() throws {
+        let dir = try makeTempDirectory(prefix: "build_mic")
+        let appTmp = dir.appendingPathComponent("20260311_130000_app_raw.tmp")
+        try Data().write(to: appTmp)
+        let micWav = dir.appendingPathComponent("20260311_130000_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: micWav,
+                actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
+            ),
+            recordingsDir: dir, timestamp: "20260311_130000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+        )
+
+        XCTAssertNil(result.appPath, "no app track")
+        XCTAssertEqual(result.micPath, micWav)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
+    }
+
+    /// Both channels present → both tracks surface and the mix is produced via
+    /// AudioMixer (delay alignment + mixing).
+    func testBuildRecordingAppAndMicProducesMixedTracks() throws {
+        let dir = try makeTempDirectory(prefix: "build_both")
+        let appTmp = dir.appendingPathComponent("20260311_140000_app_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+        let micWav = dir.appendingPathComponent("20260311_140000_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: micWav,
+                actualSampleRate: 48000, actualChannels: 2, micDelay: 0.1,
+            ),
+            recordingsDir: dir, timestamp: "20260311_140000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+        )
+
+        XCTAssertNotNil(result.appPath)
+        XCTAssertEqual(result.micPath, micWav)
+        XCTAssertEqual(result.micDelay, 0.1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
+    }
+
+    /// Captured channel count below the requested one (mono USB device) still
+    /// produces a valid track — downmix is a passthrough for mono input.
+    func testBuildRecordingToleratesChannelCountMismatch() throws {
+        let dir = try makeTempDirectory(prefix: "build_chmismatch")
+        let appTmp = dir.appendingPathComponent("20260311_150000_app_raw.tmp")
+        // 1 s of 48 kHz MONO — but the recorder requested stereo.
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000), to: appTmp)
+
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: nil,
+                actualSampleRate: 48000, actualChannels: 1, micDelay: 0,
+            ),
+            recordingsDir: dir, timestamp: "20260311_150000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+        )
+
+        XCTAssertNotNil(result.appPath, "mono capture should still produce an app track")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
+    }
+
+    /// Device-negotiated rate differing from the requested one (USB/Bluetooth
+    /// renegotiation) still produces a valid track.
+    func testBuildRecordingToleratesRateMismatch() throws {
+        let dir = try makeTempDirectory(prefix: "build_ratemismatch")
+        let appTmp = dir.appendingPathComponent("20260311_160000_app_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: nil,
+                actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
+            ),
+            // Requested 44.1 kHz but the device delivered 48 kHz.
+            recordingsDir: dir, timestamp: "20260311_160000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 2, requestedRate: 44100, targetRate: 16000),
+        )
+
+        XCTAssertNotNil(result.appPath, "rate mismatch should still produce an app track")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -435,3 +435,11 @@ func createTestAudioFile(in dir: URL) throws -> URL {
     try data.write(to: audioPath)
     return audioPath
 }
+
+/// Write interleaved Float32 PCM as a raw `.tmp` blob (no header) — the format
+/// the CATap IOProc emits and `DualSourceRecorder.buildRecording` reads back.
+/// The headerless inverse of `createTestAudioFile` (which writes a WAV).
+func writeRawFloat32(_ samples: [Float], to url: URL) throws {
+    let data = samples.withUnsafeBufferPointer { Data(buffer: $0) }
+    try data.write(to: url)
+}

--- a/tools/audiotap/Sources/AudioCaptureResult.swift
+++ b/tools/audiotap/Sources/AudioCaptureResult.swift
@@ -12,4 +12,21 @@ public struct AudioCaptureResult: Sendable {
     public let actualChannels: Int
     /// Time delta between app and mic first frames (seconds, positive = mic started later).
     public let micDelay: TimeInterval
+
+    /// A `public` struct's synthesized memberwise init is only `internal`, so
+    /// other modules can't construct one — declare it `public` to complete the
+    /// type's public API. (Lets the app's test target build fixtures directly.)
+    public init(
+        appAudioFileURL: URL,
+        micAudioFileURL: URL?,
+        actualSampleRate: Int,
+        actualChannels: Int,
+        micDelay: TimeInterval,
+    ) {
+        self.appAudioFileURL = appAudioFileURL
+        self.micAudioFileURL = micAudioFileURL
+        self.actualSampleRate = actualSampleRate
+        self.actualChannels = actualChannels
+        self.micDelay = micDelay
+    }
 }


### PR DESCRIPTION
## What

Splits `DualSourceRecorder.stop()` into a thin hardware-bound shell plus a pure, testable `buildRecording(...)`. `stop()` now only drives the capture-session lifecycle; everything after `session.stop()` (read raw `.tmp` → downmix → resample → load mic → mix → branch select) moves into a `static func buildRecording(from:recordingsDir:timestamp:recordingStart:format:)`.

## Why

The recording path hands a finished **file** to the app, and `stop()` owned the capture session, so the ~110 lines of file-processing after `session.stop()` were unreachable from a unit test — they needed real CATap/AVAudioEngine hardware. The hard DSP (`downmixToMono`, `crossCheckAppRate`) was already covered as pure static functions; what stayed dark was the mix-selection orchestration.

The extracted function is un-gated (nothing in the processing body needs macOS 14.2 — only the session does) and takes its inputs as parameters, so it has no instance/hardware coupling.

## Coverage

`AudioCaptureResult` gains a `public init` — a `public` struct's synthesized memberwise init is only `internal`, so the app's test target could not construct a fixture. With it, the four mix-selection branches are now covered by characterization tests feeding raw-PCM and WAV fixtures:

- app + mic → `AudioMixer.mix`
- app only → resampled app samples
- mic only → mic samples
- neither → `noAudioData`

The remaining uncovered lines in this file are `start()` (real session construction) — genuinely hardware-bound, exercised by `e2e-app.yml`.

## Notes

- `CaptureFormat` value type groups the recorder's declared format (requested channels/rate + target rate) so the extracted logic stays free of instance state.
- Behavior-preserving extraction: branch order, temp-file cleanup conditions, `micDelay` handling, and the `startTimestamp` reset are unchanged.

## Test

32/32 `DualSourceRecorderTests` green; lint clean; full debug build clean.