### PR TITLE
build(app): bump transitive swift-argument-parser 1.7.0 → 1.7.1

### DIFF
--- a/app/MeetingTranscriber/Package.resolved
+++ b/app/MeetingTranscriber/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {


### PR DESCRIPTION
## What

Bumps the app package's transitive `swift-argument-parser` pin from 1.7.0 to 1.7.1.

## Why

`tools/mt-cli` and `tools/meeting-simulator` already resolve to 1.7.1; only `app/MeetingTranscriber/Package.resolved` lagged behind at 1.7.0. The app doesn't depend on argument-parser directly — it comes in transitively — so this is purely an alignment of the resolved revision across the workspace.

Patch-level upgrade, no API surface change. Verified with a clean `swift build` of the app package.