### PR TITLE
refactor(scripts): extract poll_until helper for e2e drivers

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -318,11 +318,11 @@ log "Launching $DEV_BUNDLE_DEPLOY"
 open "$DEV_BUNDLE_DEPLOY"
 
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
-deadline=$(( $(date +%s) + RPC_READY_TIMEOUT_S ))
-while [ ! -f "$RPC_TOKEN_FILE" ] || ! { RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null; }; do
-    [ "$(date +%s)" -lt "$deadline" ] || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
-    sleep 1
-done
+# Assigns RPC_TOKEN in caller scope on success so subsequent `rpc` calls
+# carry the bearer token.
+_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready \
+    || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
 log "RPC up"
 
 # Single trap covers the simulator process + record-only side-effects for

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -183,11 +183,11 @@ log "Launching $DEV_BUNDLE_DEPLOY"
 open "$DEV_BUNDLE_DEPLOY"
 
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
-deadline=$(( $(date +%s) + RPC_READY_TIMEOUT_S ))
-while [ ! -f "$RPC_TOKEN_FILE" ] || ! { RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null; }; do
-    [ "$(date +%s)" -lt "$deadline" ] || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
-    sleep 1
-done
+# Assigns RPC_TOKEN in caller scope on success so subsequent `rpc` calls
+# carry the bearer token.
+_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready \
+    || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
 log "RPC up"
 
 # Cleanup trap — kill simulator + restore defaults.

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -208,43 +208,35 @@ echo "▸ Waiting for app to detect + start recording (max 30 s)…"
 # `isProcessing` flips true while a job is in the queue. It's informational
 # only — if it never flips we still let step 7 run and time out there,
 # which gives a clearer "recordingSilent never went true" failure than
-# bailing here would.
-for _ in $(seq 1 30); do
+# bailing here would. Hence `|| true`: a timeout here is non-fatal.
+_processing_started() {
     assert_app_alive
-    STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
-    PROCESSING="$(echo "$STATE_JSON" | jq -r '.pipeline.isProcessing // false')"
-    if [ "$PROCESSING" = "true" ]; then
-        break
-    fi
-    sleep 1
-done
+    local state; state="$("$MTCLI" state 2>/dev/null || echo '{}')"
+    [ "$(echo "$state" | jq -r '.pipeline.isProcessing // false')" = "true" ]
+}
+poll_until 30 1 _processing_started || true
 
 # --- 7. Poll for recordingSilent flag -----------------------------------------
 
 echo "▸ Polling for channelHealth.recordingSilent (threshold 30 s + 20 s slack)…"
-DEADLINE=$(( $(date +%s) + 50 ))
-OBSERVED_SILENT=false
-while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+# Extract all three channelHealth flags in one jq pass. Safe with @tsv
+# because every field has a `// false` default — no empties possible.
+# `IFS=$'\t' read` would collapse consecutive empties (tab is
+# whitespace-IFS), so if a non-defaulted field is added later, switch to
+# `|`-join (see `_poll_for_new_lastjob_terminal` in e2e-app.sh). MIC_SILENT
+# and APP_SILENT leak to caller scope for the success log line below.
+_recording_silent() {
     assert_app_alive
-    STATE_JSON="$("$MTCLI" state 2>/dev/null || echo '{}')"
-    # Extract all three channelHealth flags in one jq pass. Safe here
-    # because every field has a `// false` default — no empties possible.
-    # `IFS=$'\t' read` would collapse consecutive empties (tab is
-    # whitespace-IFS), so if a non-defaulted field is added later, switch
-    # to `|`-join (see `_poll_for_new_lastjob_terminal` in e2e-app.sh).
+    local state; state="$("$MTCLI" state 2>/dev/null || echo '{}')"
     IFS=$'\t' read -r RECORDING_SILENT MIC_SILENT APP_SILENT < <(
-        echo "$STATE_JSON" \
+        echo "$state" \
             | jq -r '[.channelHealth.recordingSilent // false, .channelHealth.micSilent // false, .channelHealth.appSilent // false] | @tsv'
     )
-    if [ "$RECORDING_SILENT" = "true" ]; then
-        OBSERVED_SILENT=true
-        echo "  recordingSilent=true (mic=$MIC_SILENT app=$APP_SILENT)"
-        break
-    fi
-    sleep 2
-done
-
-if [ "$OBSERVED_SILENT" != "true" ]; then
+    [ "$RECORDING_SILENT" = "true" ]
+}
+if poll_until 50 2 _recording_silent; then
+    echo "  recordingSilent=true (mic=$MIC_SILENT app=$APP_SILENT)"
+else
     echo "Final state:" >&2
     "$MTCLI" state 2>/dev/null | jq . >&2 || true
     die "channelHealth.recordingSilent never went true within 50 s"

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -124,6 +124,36 @@ assert_app_alive() {
     fi
 }
 
+# Poll a predicate until it succeeds or a timeout elapses. The loop
+# mechanics (deadline tracking, probe-then-sleep, timeout result) live
+# here so the e2e drivers stop re-deriving them inline.
+#
+# Usage: poll_until <timeout_s> <interval_s> <predicate> [args...]
+#
+# <predicate> is a command — typically a shell function — re-run each
+# tick in the CURRENT shell, so it can both read and assign caller-scope
+# variables (e.g. stash a parsed /state field for post-loop asserts).
+# Running in an `if` condition also suspends `set -e` for the predicate
+# body, so intermediate `jq`/`curl` hiccups don't abort the script.
+# Probe-then-sleep: an already-true condition returns on the first tick,
+# and one final probe runs right before the deadline check.
+#
+# Returns 0 on success, 1 on timeout. The caller decides how to report a
+# timeout (its own prefixed `fail()`, `die`, or a custom diagnostic
+# dump) — this stays agnostic to per-script conventions.
+poll_until() {
+    local timeout="$1" interval="$2"
+    shift 2
+    local deadline=$(( $(date +%s) + timeout ))
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        [ "$(date +%s)" -lt "$deadline" ] || return 1
+        sleep "$interval"
+    done
+}
+
 # Snapshot a defaults value for later restoration, or empty when the
 # key isn't set. The caller's `$()` command substitution strips the
 # trailing newline that `defaults read` emits, so internal whitespace


### PR DESCRIPTION
## What

Adds a generic `poll_until <timeout_s> <interval_s> <predicate> [args…]` helper to `scripts/lib/e2e-helpers.sh` and migrates four inline polling loops that each re-derived the same deadline / probe-then-sleep / timeout mechanics:

- RPC `/healthz` readiness wait in `e2e-app.sh` and `e2e-live-captions.sh`
- the `isProcessing` and `recordingSilent` polls in `e2e-silent-recording.sh`

## Why

The loop mechanics were copy-pasted across the drivers — every copy is a place a deadline-math or `set -e` bug can hide. One tested helper removes that surface.

Design notes:
- The predicate runs via `"$@"` in the **current shell** (not a subshell), so it can both read and assign caller-scope variables — `RPC_TOKEN` for the RPC waits, `MIC_SILENT`/`APP_SILENT` for the silent-recording success log. That's the load-bearing reason the helper doesn't capture predicate output in a `$()`; documented in the docstring.
- `poll_until` returns `1` on timeout rather than failing itself, so each caller keeps its own reporting convention: a prefixed `fail()`, `die()` + state dump, or a non-fatal `|| true` for the informational `isProcessing` probe.

## Intentionally left un-migrated

- `_poll_for_new_lastjob_terminal` — interleaves naming-dialog draining + change-detection logging per tick (not a pure predicate).
- The channel-health screenshot poll — attempt-based with a final unsuppressed run for diagnostics.
- The record-only sidecar / caption polls — depend on function-local dynamic scope.

Forcing those through the helper would cost more readability than it saves.

## Verification

- `bash -n` clean on all four scripts; `shellcheck` introduces no new warnings (shell isn't linted in CI, kept clean anyway).
- Smoke-tested `poll_until` in isolation: immediate-success (no sleep), timeout→1, caller-scope variable leak, and `set -e` suspension inside the predicate body all behave as designed.
- Behavior-equivalence reviewed against each original loop: identical wall-clock budget; the only divergence is one extra probe exactly at the deadline boundary (strictly more lenient, never less coverage).