### PR TITLE
docs: sync CLAUDE.md and architecture-macos.md with the current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,12 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     MeetingTranscriberApp.swift  # @main, UI shell (scenes, NSOpenPanel, NSWorkspace)
     AppState.swift         # @Observable @MainActor ViewModel (business state, badge logic, pipeline wiring)
     AppState+RPC.swift     # RPC state snapshot helper for DebugRPCServer (#if !APPSTORE)
+    EngineController.swift   # @Observable @MainActor engine selection + model lifecycle controller (language/vocabulary sync, preload)
     AudioConstants.swift   # Shared audio pipeline constants (target sample rate)
     MenuBarView.swift      # Menu bar dropdown UI
     MenuBarIcon.swift      # Animated waveform menu bar icon + BadgeKind.compute() pure function
     ChannelHealthMonitor.swift  # Pure state machine for per-channel asymmetric silence detection (mic vs app audio)
+    ChannelHealthController.swift  # @Observable controller polling channel levels and driving ChannelHealthMonitor
     SettingsView.swift     # Settings window (TabView shell hosting six sub-views in Settings/)
     Settings/
       GeneralSettingsView.swift  # Apps to Watch · Detection · Updates
@@ -32,6 +34,10 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     LiveCaptionsState.swift # @Observable live-captions state (per-channel hypotheses + finalised utterances) + RPC-wire types
     LiveCaptionsOverlay.swift # SwiftUI caption-bar content (recent finals + per-channel hypotheses) hosted in LiveCaptionsWindow
     LiveCaptionsWindowController.swift # Borderless click-through NSPanel hosting the caption overlay (⌥-drag to reposition; origin persisted)
+    LiveCaptionPipeline.swift # Per-channel live captioning strategy protocol (WhisperKit word-level | EOU streaming)
+    LiveCaptionsGate.swift   # Pure decision logic for live captions routing (which pipeline per channel, shared by AppState + controller)
+    EouStreamingCaptionSession.swift # EOU streaming caption session (FluidAudio end-of-utterance ASR, UtteranceRingBuffer-backed)
+    UtteranceRingBuffer.swift # Rolling 16 kHz sample buffer addressable by absolute timestamp (feeds EOU streaming)
     PairedImportPanelDelegate.swift  # NSOpenPanel delegate + accessory view for paired dual-source file import
     PairedRecordingResolver.swift    # Groups recording URLs into dual-source groups for reimport
     AppPaths.swift         # Centralized paths (ipcDir, dataDir, logSubsystem, speakersDB)
@@ -62,16 +68,20 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     PipelineJob.swift      # Pipeline job model
     PipelineSnapshot.swift  # Pure I/O helpers for persisting pipeline queue jobs to disk (atomic rename)
     SnapshotWriterActor.swift  # Actor isolating pipeline queue snapshot writes (prevents main-actor stalls)
+    PipelineController.swift  # @Observable controller owning PipelineQueue lifecycle (wired by AppState)
     LiveTranscriptionController.swift # Wires StreamingTranscriber to both DualSourceRecorder sinks (mic + app), feeds LiveCaptionsState (PoC)
+    LiveTranscriptionCoordinator.swift # @Observable coordinator: builds + arms LiveTranscriptionController, feeds LiveCaptionsState
     ProtocolGenerator.swift   # Shared protocol utilities: prompts, file I/O, ProtocolError
     ClaudeCLIProtocolGenerator.swift # Claude CLI subprocess protocol generation (#if !APPSTORE)
     OpenAIProtocolGenerator.swift # OpenAI-compatible API protocol generation (Ollama, LM Studio, etc.)
     WatchLoop.swift        # @MainActor watch loop: detect → record → enqueue PipelineJob
     WatchLoopEndPolicy.swift  # Pure decision logic for WatchLoop.waitForMeetingEnd (grace-period / max-duration)
     WatchLoopState.swift   # Value-type snapshot of WatchLoop's observable fields (for tests and RPC)
+    WatchingController.swift  # @Observable controller owning WatchLoop lifecycle (wired by AppState)
     ManualRecordingMonitorPolicy.swift  # Pure decision logic for manual recording stop conditions (process-died vs max-duration)
     SilentRecordingMonitor.swift  # Pure state machine detecting fully-silent recordings (both channels below threshold)
     DualSourceRecorder.swift  # App audio (AudioTapLib) + mic recording (captures startTime in start())
+    WavHeaderRepair.swift     # Repairs unfinalized WAV files from crash-interrupted recordings (RIFF/data chunk size fix)
     MeetingDetecting.swift # MeetingDetecting protocol + DetectedMeeting model
     MeetingDetector.swift  # Window title matching (counts each pattern once per poll)
     FFmpegHelper.swift     # ffmpeg CLI detection + audio extraction for MKV/WebM/OGG
@@ -80,6 +90,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     SampleRateDriftDetector.swift # Watches actual vs declared CATap sample rate (catches USB hot-plug + HFP↔A2DP renegotiation drift)
     MicRecorder.swift      # Microphone recording via AVAudioEngine
     PermissionHealthCheck.swift # Permission health check (TCC verdict + live probe → PermissionStatus)
+    PermissionsController.swift # @Observable controller for permission health checks (wired by AppState)
     PermissionRow.swift    # Permission status row UI component
     Permissions.swift      # Permission checks (mic, screen recording)
     ParticipantReader.swift # Reads meeting participants via accessibility
@@ -87,6 +98,8 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     PowerAssertionDetector.swift  # Meeting detection via IOKit power assertions (sandbox-safe)
     UpdateChecker.swift    # GitHub release update checker
     Bundle+AppVersion.swift # Bundle extension: appVersion + gitCommitHash from Info.plist
+    FileManager+OwnerOnly.swift # FileManager extension: owner-only file permission constant (rw-------, single source of truth)
+    SingleFlight.swift        # Single-flight async deduplication coordinator (concurrent callers await one shared run)
     DiagnosticExporter.swift # Reads log entries → shareable .log file (Settings → Advanced → Export Diagnostics)
     PersistentDiagnosticLog.swift # Persistent log stream subprocess with sliding-window restart policy
     String+LogRedaction.swift # String extensions: .pseudonymized and .redactedName for log privacy
@@ -96,6 +109,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     HTTPResponse.swift     # HTTP/1.1 response serialization for DebugRPCServer (line-cap split)
     RPCStateSnapshot.swift # JSON-serializable RPC state snapshot (#if !APPSTORE)
     RPCResourceMetrics.swift # Cumulative CPU/RAM/instructions self-report via proc_pid_rusage (#if !APPSTORE, served at GET /metrics)
+    RPCServerController.swift  # @Observable controller owning DebugRPCServer lifecycle (#if !APPSTORE, wired by AppState)
     Assets.xcassets        # App icon assets
     Info.plist             # Bundle metadata
   Entitlements/
@@ -122,6 +136,16 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     OutputDeviceChangeCoordinator.swift # State machine for output device change + tap restart flow
     ProcessTreeEnumerator.swift  # Enumerates all PIDs under an .app bundle (Electron/Teams child-process support)
     SampleRateQuery.swift  # Pure functions for sample rate detection and cross-validation
+    AVAudioNode+SafeInstallTap.swift  # Safe installTap wrapper catching NSException via CExceptionCatcher (issue #379)
+    AppAudioCapture+Resampling.swift  # Capture-time resampling for CATap buffers (line-cap split)
+    AppAudioCapture+TapError.swift    # Tap-creation error mapping for AppAudioCapture (line-cap split)
+    CExceptionCatcher/               # Obj-C module catching AVFoundation NSException from installTapOnBus
+    DebugTapFault.swift              # Fault-injection configuration for mic device-change E2E (issue #379)
+    MicCaptureHandler+Timeline.swift  # Timeline tracking for MicCaptureHandler across device-change restarts
+    MicRestartRetryPolicy.swift      # Retry/backoff policy for failed mic engine restarts
+    StreamingMonoResampler.swift     # Streaming mono resampler for live 16 kHz audio path
+    TapFormatResolver.swift          # Derives mic tap format from hardware format (prevents installTap channel mismatch)
+    TimelineAnchor.swift             # Wall-clock timeline anchor across device-change restarts (aligns track to real time)
   Tests/
     AudioCaptureResultTests.swift
     HelpersTests.swift
@@ -162,6 +186,9 @@ scripts/
   keychain-prepend.sh       # Idempotent keychain search-list prepend (used by setup-self-hosted-runner.sh)
   generate_menu_bar_gifs.swift      # Generate menu bar animation GIFs
   assert-red-pixels.swift   # Visual regression assertion for menu-bar red-tint indicator (counts red pixels in PNG)
+  bless_quality_baseline.sh  # Project quality results into slim baseline JSON for CI regression gate
+  generate_social_preview.py  # Generate GitHub social preview card (docs/social-preview.png)
+  generate_test_audio_en.sh  # Generate English 2-speaker test WAV fixture (two_speakers_en.wav, requires say + sox)
   lib/e2e-helpers.sh        # Shared helpers sourced by e2e-app.sh, e2e-channel-health.sh, e2e-silent-recording.sh
   tests/
     test_build_release_signing.sh  # Regression test for build_release.sh codesign-identity detection
@@ -178,6 +205,9 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   build-perf-tracking.yml  # Weekly build performance trend analysis (flags regressions vs 28-day baseline)
   quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
+  e2e-crash-recovery.yml    # E2E — crash recovery: SIGKILL mid-recording + verify pipeline recovers via WAV header repair
+  e2e-mic-device-change.yml # E2E — mic device-change NSException survival (issue #379, fault-injection build)
+  pages.yml                 # Deploy landing page to GitHub Pages (site/ → GitHub Pages, main push + dispatch)
 docs/
   architecture-macos.md        # High-level architecture quick-reference
   menu-bar-*.gif               # Menu bar icon animation GIFs (idle, recording, transcribing, diarizing, protocol, permission, record-only, channel-silent-app, channel-silent-mic)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
   Package.swift            # SPM manifest (WhisperKit + FluidAudio + AudioTapLib runtime deps; ViewInspector + SnapshotTesting test deps)
   Sources/
     MeetingTranscriberApp.swift  # @main, UI shell (scenes, NSOpenPanel, NSWorkspace)
-    AppState.swift         # @Observable @MainActor ViewModel (business state, badge logic, pipeline wiring)
+    AppState.swift         # @Observable @MainActor composition root: wires the concern controllers (engines/watching/pipeline/permissions/channelHealth/liveTranscription/rpc) + exposes derived UI props (badge, status label)
     AppState+RPC.swift     # RPC state snapshot helper for DebugRPCServer (#if !APPSTORE)
     EngineController.swift   # @Observable @MainActor engine selection + model lifecycle controller (language/vocabulary sync, preload)
     AudioConstants.swift   # Shared audio pipeline constants (target sample rate)
@@ -147,12 +147,28 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     TapFormatResolver.swift          # Derives mic tap format from hardware format (prevents installTap channel mismatch)
     TimelineAnchor.swift             # Wall-clock timeline anchor across device-change restarts (aligns track to real time)
   Tests/
+    AppAudioCaptureDebugLoggingTests.swift
+    AppAudioCaptureLiveSinkTests.swift
+    AppAudioCapturePIDTranslationTests.swift
+    AppAudioCaptureResamplingTests.swift
+    AppAudioCaptureStatusTests.swift
     AudioCaptureResultTests.swift
+    CExceptionCatcherTests.swift
+    CurrentLevelTests.swift
+    DebugRMSReporterTests.swift
     HelpersTests.swift
+    LevelPublisherTests.swift
+    LiveAudioBufferTests.swift
     MicCaptureErrorTests.swift
+    MicCaptureHandlerTimelineTests.swift
     MicRestartPolicyTests.swift
+    MicRestartRetryPolicyTests.swift
     OutputDeviceChangeCoordinatorTests.swift
+    ProcessTreeEnumeratorTests.swift
     SampleRateQueryTests.swift
+    StreamingMonoResamplerTests.swift
+    TapFormatResolverTests.swift
+    TimelineAnchorTests.swift
 tools/meeting-simulator/   # Meeting simulator tool for testing
   Package.swift
   Sources/main.swift
@@ -405,7 +421,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 **Record-only mode:**
 - When `AppSettings.recordOnly` is true, `WatchLoop.enqueueRecording()` moves the dual-source WAVs into `<settings.effectiveOutputDir>/recordings/` and writes a `<basename>_meta.json` `RecordingSidecar` next to them, skipping the entire post-processing pipeline (VAD, transcription, diarization, protocol generation). Both call sites — auto-detected meetings (`handleMeeting`) and manual recordings (`stopManualRecording`) — flow through the same branch. The destination is wrapped in `startAccessingSecurityScopedResource()` to honour user-picked Output Folder bookmarks (relevant for the App Store sandboxed build).
-- Sidecar JSON contains: `version` (currently `RecordingSidecar.currentVersion = 1`), `title`, `appName`, `startedAt`/`stoppedAt` (ISO 8601, reconstructed from `recordingStart` uptime), `participants`, `micDelaySeconds`, `files` (basenames only). Optional `app` / `mic` filenames are omitted when nil. Suffix constants live as static lets on the relevant types: `RecordingSidecar.filenameSuffix = "_meta.json"`, `DualSourceRecorder.mixFilenameSuffix = "_mix.wav"`.
+- Sidecar JSON contains: `version` (currently `RecordingSidecar.currentVersion = 1`), `title`, `appName`, `startedAt`/`stoppedAt` (ISO 8601, reconstructed from `recordingStart` uptime), `participants`, `micDelaySeconds`, `files` (basenames only). Optional `app` / `mic` filenames are omitted when nil. Suffix constants live as static lets: the audio-file suffixes on `RecordingFileSuffix` (`mix = "_mix.wav"`, `app`, `mic`, and the raw-temp `appRaw`/`legacyAppRaw`), and the sidecar suffix on `RecordingSidecar.filenameSuffix = "_meta.json"`.
 - Intended for fleet topologies where macOS clients capture and a separate machine (e.g. Linux GPU host) processes the audio via Syncthing or similar.
 - Menu bar: the small red dot is rendered as a **persistent overlay** (`MenuBarIcon.image(..., recordOnlyOverlay:)`) on top of *whatever* primary badge `BadgeKind.compute(...)` would otherwise show — idle, recording, transcribing, etc. — so the mode is always visible. Permission overlay (red exclamation) takes precedence when both apply, since a permission problem actually breaks recording. Settings tabs dim Transcription / Protocol / VAD / Diarization sections via `View.recordOnlyDisabled(_:)` and show a banner in the General tab pointing at the active output dir.
 - Sidecar write failures notify the user via `NotificationManager` (injected as `any AppNotifying` on `WatchLoop`) since record-only does not transition state to `.error`.

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -129,6 +129,15 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `PipelineSnapshot.swift` | Pure I/O helpers for persisting `PipelineQueue` jobs to disk (atomic rename) |
 | `SnapshotWriterActor.swift` | Actor isolating pipeline queue snapshot writes (prevents main-actor stalls on macOS 26 rename deadlock) |
 | `LiveTranscriptionController.swift` | Wires `StreamingTranscriber` to both `DualSourceRecorder` sinks (mic + app), feeds `LiveCaptionsState` (PoC) |
+| `LiveTranscriptionCoordinator.swift` | `@Observable` coordinator: builds + arms `LiveTranscriptionController`, feeds `LiveCaptionsState` |
+| `LiveCaptionPipeline.swift` | Per-channel live captioning strategy protocol (WhisperKit word-level \| EOU streaming) |
+| `LiveCaptionsGate.swift` | Pure decision logic for live captions routing — which pipeline per channel; shared by `AppState`, coordinator, and controller |
+| `EouStreamingCaptionSession.swift` | EOU streaming caption session via FluidAudio end-of-utterance ASR, backed by `UtteranceRingBuffer` |
+| `UtteranceRingBuffer.swift` | Rolling 16 kHz sample buffer addressable by absolute ms timestamp (feeds EOU streaming session) |
+| `EngineController.swift` | `@Observable @MainActor` engine selection + model lifecycle controller (language/vocabulary sync, preload) |
+| `PipelineController.swift` | `@Observable` controller owning `PipelineQueue` lifecycle (wired by `AppState`) |
+| `WatchingController.swift` | `@Observable` controller owning `WatchLoop` lifecycle (wired by `AppState`) |
+| `WavHeaderRepair.swift` | Repairs unfinalized WAV files from crash-interrupted recordings (RIFF/data chunk size fix) |
 | `FluidDiarizer.swift` | On-device speaker diarization via FluidAudio CoreML/ANE |
 | `FluidDiarizer+SortformerEmbeddings.swift` | Post-hoc WeSpeaker embedding extraction for Sortformer mode — overlap-excluded masks feed `SpeakerMatcher` (DiariZen-style hybrid) |
 | `SpeakerMatcher.swift` | Speaker embedding DB + cosine similarity matching |
@@ -143,6 +152,7 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `RecordingFileSuffix.swift` | Filename suffix constants for dual-source recordings (`_app.wav`, `_mic.wav`, `_mix.wav`) |
 | `SilentRecordingMonitor.swift` | Pure state machine detecting fully-silent recordings (both channels below threshold) |
 | `ChannelHealthMonitor.swift` | Pure state machine for per-channel asymmetric silence detection (one channel live, other dead) |
+| `ChannelHealthController.swift` | `@Observable` controller polling channel dBFS levels and driving `ChannelHealthMonitor` |
 | `PairedImportPanelDelegate.swift` | `NSOpenPanel` delegate + accessory view for paired dual-source file import |
 | `PairedRecordingResolver.swift` | Groups recording URLs into dual-source groups (app + mic pairs, singletons) for reimport |
 
@@ -169,9 +179,19 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `tools/audiotap/Sources/DebugRMSReporter.swift` | Throttled RMS accumulator/reporter for audio debug logging |
 | `tools/audiotap/Sources/Helpers.swift` | `machTicksToSeconds`, `getDefaultOutputDeviceUID`, `writeAllToFileHandle` |
 | `tools/audiotap/Sources/MicRestartPolicy.swift` | Pure decision logic for mic engine restart on device change |
+| `tools/audiotap/Sources/MicRestartRetryPolicy.swift` | Retry/backoff policy for failed mic engine restarts |
 | `tools/audiotap/Sources/OutputDeviceChangeCoordinator.swift` | State machine for output device change + tap restart flow |
 | `tools/audiotap/Sources/ProcessTreeEnumerator.swift` | Enumerates all PIDs under an `.app` bundle (Electron/Teams child-process support) |
 | `tools/audiotap/Sources/SampleRateQuery.swift` | Pure functions for sample rate detection and cross-validation |
+| `tools/audiotap/Sources/AVAudioNode+SafeInstallTap.swift` | Safe `installTapOnBus` wrapper catching `NSException` via `CExceptionCatcher` (issue #379) |
+| `tools/audiotap/Sources/AppAudioCapture+Resampling.swift` | Capture-time resampling for CATap buffers (line-cap split from `AppAudioCapture`) |
+| `tools/audiotap/Sources/AppAudioCapture+TapError.swift` | Tap-creation error mapping (line-cap split from `AppAudioCapture`) |
+| `tools/audiotap/Sources/CExceptionCatcher/` | Obj-C module catching AVFoundation `NSException` from `installTapOnBus` |
+| `tools/audiotap/Sources/DebugTapFault.swift` | Fault-injection config for mic device-change E2E to verify NSException recovery |
+| `tools/audiotap/Sources/MicCaptureHandler+Timeline.swift` | Timeline tracking for `MicCaptureHandler` across device-change restarts |
+| `tools/audiotap/Sources/StreamingMonoResampler.swift` | Streaming mono resampler for the live 16 kHz audio path |
+| `tools/audiotap/Sources/TapFormatResolver.swift` | Derives mic tap format from hardware format (prevents installTap channel-count mismatch) |
+| `tools/audiotap/Sources/TimelineAnchor.swift` | Wall-clock timeline anchor across device-change restarts (keeps track aligned to real time) |
 
 ### Support
 
@@ -194,6 +214,10 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `DiagnosticExporter.swift` | Reads log entries and writes shareable `.log` file (Settings → Advanced → Export Diagnostics) |
 | `PersistentDiagnosticLog.swift` | Persistent `log stream` subprocess with sliding-window restart policy for long-term log retention |
 | `String+LogRedaction.swift` | String extensions: `.pseudonymized` (SHA-256 4-hex prefix) and `.redactedName` for log privacy |
+| `FileManager+OwnerOnly.swift` | `FileManager` extension: owner-only file permission constant (`rw-------`) as single source of truth |
+| `SingleFlight.swift` | Single-flight async deduplication coordinator (concurrent callers await one shared run instead of starting their own) |
+| `RPCServerController.swift` | `@Observable` controller owning `DebugRPCServer` lifecycle (`#if !APPSTORE`, wired by `AppState`) |
+| `PermissionsController.swift` | `@Observable` controller for permission health checks (wired by `AppState`, re-runs on activation) |
 
 ### Companion CLIs
 

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -27,7 +27,7 @@ Native SwiftUI menu bar application that orchestrates meeting detection, recordi
                          │                  ┌──────────────────────────┐
                          │                  │  DebugRPCServer          │
                          │                  │  127.0.0.1:9876          │
-                         │                  │  /state /healthz         │
+                         │                  │  /state /healthz /metrics│
                          │                  │  /screenshot             │
                          │                  │  /action/openSettings    │
                          │                  │  /action/closeSettings   │
@@ -60,7 +60,7 @@ Native SwiftUI menu bar application that orchestrates meeting detection, recordi
         │      └─ TranscribingEngine: WhisperKit | Parakeet | Qwen3      │
         │         (dual-source: each track separately, then merge)       │
         │ 4. (opt) Diarize via FluidDiarizer                             │
-        │      └─ Mode: .offlineDiarizer | .sortformer                   │
+        │      └─ Mode: .offline | .sortformer                           │
         │      └─ Dual-source: app + mic diarized separately,            │
         │         IDs prefixed R_ (remote) / M_ (mic), then merged       │
         │ 5. SpeakerMatcher: cosine match against speakers.json          │
@@ -85,7 +85,7 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | File | Role |
 |------|------|
 | `MeetingTranscriberApp.swift` | `@main` UI shell — SwiftUI scenes, windows, NSOpenPanel, NSWorkspace. Observes `.showSettings` / `.closeSettings` / `.showSpeakerNaming` notifications for RPC- and pipeline-driven scene control |
-| `AppState.swift` | `@Observable @MainActor` ViewModel — business state, badge logic, pipeline wiring |
+| `AppState.swift` | `@Observable @MainActor` composition root — wires the concern controllers (`engines`, `watching`, `pipeline`, `permissions`, `channelHealth`, `liveTranscription`, `rpcController`) and exposes the derived UI state (badge, status label) rather than owning it |
 | `MenuBarView.swift` | Menu bar dropdown (state, actions, meeting info) |
 | `SettingsView.swift` | Settings window — `TabView` shell hosting six topic-grouped sub-views in `Sources/Settings/` |
 | `Settings/GeneralSettingsView.swift` | Apps to Watch · Detection (Poll Interval, Grace Period) · Updates |
@@ -94,6 +94,7 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `Settings/SpeakersSettingsView.swift` | Diarization · Mic Speaker Name · Known Voices · Recognition Stats |
 | `Settings/OutputSettingsView.swift` | LLM provider · protocol language · output folder · custom prompt |
 | `Settings/AdvancedSettingsView.swift` | Permissions · Diagnostics · About |
+| `Settings/View+RecordOnly.swift` | `recordOnlyDisabled(_:)` view modifier — dims + disables the Transcription/Protocol/VAD/Diarization sections when record-only mode is on |
 | `SpeakerNamingView.swift` | Speaker naming dialog after diarization |
 | `KnownVoicesView.swift` | Manage persisted speaker DB (rename, delete, merge) — embedded in `SpeakersSettingsView` |
 | `RecognitionStatsView.swift` | Recognition stats display — aggregate counts from `recognition_log.jsonl` |
@@ -306,8 +307,7 @@ AudioTapLib (CATapDescription)
 ### Processing (DualSourceRecorder.stop())
 
 ```
-Raw float32 (mono or stereo, actual channel count from AudioCaptureResult) → mono
-  → Resample to 16kHz
+App temp: already 16kHz mono float32 (resampled in-IOProc at capture time)
   → Save app.wav (16kHz mono)
   → Load mic.wav (already 16kHz from MicCaptureHandler)
   → Apply mute mask (zero mic during muted periods)
@@ -380,7 +380,7 @@ All recordings are normalized to 16kHz at capture time — no resampling needed 
 On-device speaker diarization using FluidAudio (CoreML/ANE). No HuggingFace token or Python subprocess needed. Models downloaded automatically on first run (~50 MB).
 
 Two modes selected via `AppSettings.diarizerMode`:
-- **`.offlineDiarizer`** (default) — `OfflineDiarizerManager`, standard speaker segmentation
+- **`.offline`** (default) — `OfflineDiarizerManager`, standard speaker segmentation
 - **`.sortformer`** — `SortformerDiarizer`, overlap-aware diarization (handles simultaneous speech); speaker embeddings extracted post-hoc via `FluidDiarizer+SortformerEmbeddings` using overlap-excluded WeSpeaker masks
 
 Flow: `FluidDiarizer.run(audioPath, numSpeakers)` → selected diarizer → `DiarizationResult` with segments, speaking times, and speaker embeddings.
@@ -498,7 +498,7 @@ AppSettings (UserDefaults)
 | ProtocolGenerator | `claudeBin` parameter |
 | AppNotifying | `notifier` parameter in `AppState.init` (`SilentNotifier` default, `RecordingNotifier` in tests) |
 | BadgeKind.compute | Pure static function — call directly with any input combination, no WatchLoop needed |
-| DebugRPCServer | Out-of-process inspection via HTTP. Endpoints: `GET /state /healthz /screenshot`, `POST /action/openSettings /action/closeSettings`. `#if !APPSTORE` + env-gated. `boundPort` exposes OS-assigned port for in-process integration tests. `tools/mt-cli/` is the matching CLI. `scripts/test_rpc.sh` is a live smoketest (build + launch + drive + assert). |
+| DebugRPCServer | Out-of-process inspection via HTTP. Endpoints: `GET /state /healthz /metrics /screenshot`, `POST /action/openSettings /action/closeSettings`. `#if !APPSTORE` + env-gated. `boundPort` exposes OS-assigned port for in-process integration tests. `tools/mt-cli/` is the matching CLI. `scripts/test_rpc.sh` is a live smoketest (build + launch + drive + assert). |
 
 ---
 
@@ -568,5 +568,5 @@ The overlay lives over the *currently active* animation (idle, recording, transc
 7. **5s cooldown** — Prevents re-detecting same meeting after handling
 8. **FluidAudio on-device diarization** — Replaces Python pyannote subprocess, no external dependencies
 9. **Dual-track diarization** — App and mic tracks diarized separately, avoiding echo/cross-talk interference
-10. **Embedded debug RPC** — In-process HTTP server (`DebugRPCServer`) exposes state + screenshot + scene actions for shell-driven inspection and integration tests. Off by default, opt-in via `MEETINGTRANSCRIBER_DEBUG_RPC=1`, excluded from App Store builds via `#if !APPSTORE`. Action endpoints route through existing `Notification.Name` observers in `MeetingTranscriberApp`, so RPC-driven flows mirror real menu-bar paths.
+10. **Embedded debug RPC** — In-process HTTP server (`DebugRPCServer`) exposes state, resource metrics (`GET /metrics`), screenshot, and scene actions for shell-driven inspection and integration tests. Off by default, opt-in via the `Settings → Advanced → Debug RPC Server` toggle or the `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var, excluded from App Store builds via `#if !APPSTORE`. Action endpoints route through existing `Notification.Name` observers in `MeetingTranscriberApp`, so RPC-driven flows mirror real menu-bar paths.
 11. **No expensive work in SwiftUI hot paths** — view bodies, computed properties read by the body, and per-render closures must not call disk I/O, JSON decode, factory constructors, regex compilation, or other non-trivial work. SwiftUI re-renders on every `@State`/`@Observable` change and fans out aggressively, so what looks cheap once becomes a CPU pin fast. Push heavy values up: store as `@State`, inject as a stored property, or surface via an `@Observable` model. Caches that mirror the underlying source (e.g. `PipelineQueue.knownSpeakerNames` mirroring the speakers DB) must wire invalidation from every mutation site in the same PR — see issue #155 → PR #158 → PR #159 for the cautionary tale.


### PR DESCRIPTION
Brings both architecture docs back in line with the code. Two commits: the first **adds** the files that landed since the docs were last touched; the second **corrects** statements that drifted and finishes partial listings.

## Added (file listings)
- **App controllers:** `EngineController`, `ChannelHealthController`, `PipelineController`, `WatchingController`, `PermissionsController`, `RPCServerController`, `LiveTranscriptionCoordinator`.
- **Live captions:** `LiveCaptionPipeline`, `LiveCaptionsGate`, `EouStreamingCaptionSession`, `UtteranceRingBuffer`.
- **Durability / misc:** `WavHeaderRepair`, `SingleFlight`, `FileManager+OwnerOnly`.
- **AudioTapLib (#379 work):** `AVAudioNode+SafeInstallTap`, `CExceptionCatcher/`, `StreamingMonoResampler`, `TimelineAnchor`, `TapFormatResolver`, `MicRestartRetryPolicy`, `MicCaptureHandler+Timeline`, `AppAudioCapture+Resampling`, `AppAudioCapture+TapError`, `DebugTapFault`.
- **Workflows / scripts:** `e2e-crash-recovery.yml`, `e2e-mic-device-change.yml`, `pages.yml`, `bless_quality_baseline.sh`, `generate_social_preview.py`, `generate_test_audio_en.sh`.

## Corrected (drifted statements)
- **AppState** is a composition root wiring the concern controllers, not a monolithic ViewModel (CLAUDE.md + architecture).
- **Suffix constants** live on `RecordingFileSuffix` (`mix`/`app`/`mic`/`appRaw`); `DualSourceRecorder.mixFilenameSuffix` no longer exists.
- **Processing diagram:** the app track is resampled to 16 kHz in-IOProc at capture, so `stop()`/`buildRecording` no longer resamples — the old diagram contradicted the line right below it.
- **Diarizer mode enum** is `.offline`, not `.offlineDiarizer` (mode diagram + Diarization section).
- **`GET /metrics`** added to the RPC endpoint lists (ASCII diagram, testing-hooks table) and the embedded-RPC decision, which also now notes the `Settings → Advanced` toggle.
- **audiotap Tests** list completed (6 → 22 files); added the `Settings/View+RecordOnly.swift` row.

## Verification
Mechanical cross-check: every `Sources/` and `audiotap/Tests/` file is now listed in CLAUDE.md, and every app/audiotap `Sources/` file appears in architecture-macos.md. No remaining `.offlineDiarizer` / `mixFilenameSuffix` references. ASCII box borders re-aligned.