### PR TITLE
feat(app): re-open speaker naming on finished jobs (late re-naming recovery)

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -93,6 +93,7 @@ struct MeetingTranscriberApp: App {
                 onProcessFiles: processAudioFiles,
                 onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
                 onQuit: quit,
+                onReopenNaming: reopenNaming,
             )
         } label: { // swiftlint:disable:this closure_body_length
             Label {
@@ -333,6 +334,10 @@ struct MeetingTranscriberApp: App {
     private func quit() {
         appState.watchLoop?.stop()
         NSApplication.shared.terminate(nil)
+    }
+
+    private func reopenNaming(_ id: UUID) {
+        appState.pipelineQueue.reopenSpeakerNaming(jobID: id)
     }
 
     // MARK: - Pure Helpers (testable without @main)

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -16,6 +16,10 @@ struct MenuBarView: View {
     let onProcessFiles: () -> Void
     let onDismissJob: (UUID) -> Void
     let onQuit: () -> Void
+    /// Re-open the speaker-naming dialog for a finished job that still has a
+    /// retained naming sidecar. Defaulted + last so the many test/preview
+    /// construction sites stay terse.
+    var onReopenNaming: (UUID) -> Void = { _ in }
 
     private var state: TranscriberState {
         status?.state ?? .idle
@@ -190,6 +194,10 @@ struct MenuBarView: View {
             if job.state == .waiting || job.state == .transcribing
                 || job.state == .diarizing || job.state == .generatingProtocol {
                 Button("Cancel") { pipelineQueue.cancelJob(id: job.id) }
+                    .font(.caption2)
+            }
+            if job.state == .done, job.namingSlug != nil {
+                Button("Edit Speaker Names") { onReopenNaming(job.id) }
                     .font(.caption2)
             }
             if job.state == .done || job.state == .error || job.state == .speakerNamingPending {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -103,6 +103,11 @@ class PipelineQueue {
     private var stashedSuggestedAtDialog: [UUID: [String: String]] = [:]
     private var stashedTopCandidates: [UUID: [String: [TopCandidate]]] = [:]
 
+    /// Jobs whose recognition row has already been written. Prevents a
+    /// re-opened + re-confirmed job from double-logging recognition stats.
+    /// Cleared only on full teardown (`removeNamingData`), not on completion.
+    private var recognitionLoggedJobIDs: Set<UUID> = []
+
     /// The currently displayed naming data (first pending item).
     var pendingSpeakerNaming: SpeakerNamingData? {
         guard let firstPendingJob = pendingSpeakerNamingJobs.first else { return nil }
@@ -143,7 +148,6 @@ class PipelineQueue {
     /// Always handles "late" completion — the pipeline never blocks on naming.
     func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
         guard let data = speakerNamingDataByJob[jobID] else { return }
-        let slug = jobs.first { $0.id == jobID }?.namingSlug
 
         switch result {
         case let .confirmed(userMapping):
@@ -151,6 +155,10 @@ class PipelineQueue {
                 jobID: jobID, title: data.meetingTitle,
                 userMapping: userMapping, fallback: data.mapping,
             )
+            // Fold the applied names into the retained sidecar so a later
+            // re-open shows them and the transcript-rewrite anchors correctly
+            // (after this confirm the transcript no longer carries raw labels).
+            persistAppliedNames(jobID: jobID, userMapping: userMapping, base: data)
             // Transition out of .speakerNamingPending synchronously so the
             // UI's close-when-empty check sees the change immediately. The
             // transcript rewrite + protocol generation happens async below.
@@ -171,8 +179,30 @@ class PipelineQueue {
                 jobID: jobID, title: data.meetingTitle,
                 userMapping: nil, fallback: data.mapping,
             )
-            acceptAutoNames(jobID: jobID, slug: slug)
+            acceptAutoNames(jobID: jobID)
         }
+    }
+
+    /// Re-open the speaker-naming dialog for a finished job. Reloads the
+    /// retained naming data (RAM cache, or from the persisted sidecar), flips
+    /// the job back to `.speakerNamingPending`, and posts the show notification
+    /// so the window comes forward. No-op when the job isn't `.done` or its
+    /// naming data is gone (e.g. the recording was already dismissed).
+    func reopenSpeakerNaming(jobID: UUID) {
+        guard let idx = jobs.firstIndex(where: { $0.id == jobID }),
+              jobs[idx].state == .done else { return }
+
+        if speakerNamingDataByJob[jobID] == nil {
+            guard let slug = jobs[idx].namingSlug,
+                  let data = loadNamingData(slug: slug) else {
+                logger.warning("Cannot re-open speaker naming — data missing for job \(jobID)")
+                return
+            }
+            speakerNamingDataByJob[jobID] = data
+        }
+
+        updateJobState(id: jobID, to: .speakerNamingPending)
+        NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
     }
 
     /// Pull stashed forensics for a job and write the recognition-stats row.
@@ -183,6 +213,11 @@ class PipelineQueue {
         // swiftlint:disable:next discouraged_optional_collection
         userMapping: [String: String]?, fallback: [String: String],
     ) {
+        // Log recognition exactly once per job. A re-opened job that is
+        // re-confirmed would otherwise log a second row whose `suggested`
+        // baseline is the already-applied names (stash is gone, fallback is
+        // the folded mapping) — a phantom perfect match that never happened.
+        guard recognitionLoggedJobIDs.insert(jobID).inserted else { return }
         recordRecognition(
             suggested: stashedSuggestedAtDialog[jobID] ?? fallback,
             userMapping: userMapping,
@@ -197,7 +232,7 @@ class PipelineQueue {
     /// to .done. If a protocol generator is configured AND the transcript file
     /// exists, fires off protocol generation in the background; the job
     /// transitions through .generatingProtocol → .done as that completes.
-    private func acceptAutoNames(jobID: UUID, slug: String?) {
+    private func acceptAutoNames(jobID: UUID) {
         // Probe the factory's actual output, not just its existence — the
         // closure is wired even when protocolProvider is `.none`, but
         // returns nil. Without this, the Task path below fizzles silently
@@ -207,7 +242,9 @@ class PipelineQueue {
             && outputDir != nil
             && jobs.first { $0.id == jobID }?.transcriptPath != nil
 
-        removeNamingData(jobID: jobID, slug: slug)
+        // Keep the persisted sidecar on disk so the user can re-open the
+        // naming dialog for this job after it goes .done; only free RAM here.
+        clearNamingCaches(jobID: jobID)
 
         if canGenerateProtocol {
             Task { await generateProtocolForExistingJob(jobID: jobID) }
@@ -409,6 +446,10 @@ class PipelineQueue {
     func removeJob(id: UUID) {
         if let index = jobs.firstIndex(where: { $0.id == id }) {
             markProcessed(mixPath: jobs[index].mixPath)
+            // Explicit Dismiss is the user's signal that the recording is done
+            // with — clean up the naming sidecar we deliberately retained after
+            // .done so it doesn't linger on disk.
+            removeNamingData(jobID: id, slug: jobs[index].namingSlug)
             jobs.remove(at: index)
         }
         saveSnapshot()
@@ -456,7 +497,11 @@ class PipelineQueue {
         if newState == .done || newState == .error {
             markProcessed(mixPath: jobs[index].mixPath)
         }
-        if newState == .done {
+        // Auto-remove finished jobs after a grace period — but not ones that
+        // retain a naming sidecar (signalled by namingSlug). Those stay in the
+        // menu so the user can re-open the naming dialog; they're cleared by
+        // explicit Dismiss.
+        if newState == .done, jobs[index].namingSlug == nil {
             Task { [weak self] in
                 try? await Task.sleep(for: .seconds(self?.completedJobLifetime ?? 60))
                 self?.removeJob(id: id)
@@ -885,7 +930,7 @@ class PipelineQueue {
                             topCandidates: topCandidates,
                             jobID: ctx.jobID, title: ctx.title,
                         )
-                        removeNamingData(jobID: ctx.jobID, slug: nil)
+                        clearNamingCaches(jobID: ctx.jobID)
 
                     case let .rerun(count):
                         speakerCount = count
@@ -1118,8 +1163,6 @@ class PipelineQueue {
         guard let namingData = speakerNamingDataByJob[jobID],
               let jobIndex = jobs.firstIndex(where: { $0.id == jobID }) else { return }
 
-        let slug = jobs[jobIndex].namingSlug
-
         // Update speaker matcher DB
         let matcher = speakerMatcherFactory()
         var fullMapping = namingData.mapping
@@ -1159,7 +1202,7 @@ class PipelineQueue {
             }
         }
 
-        removeNamingData(jobID: jobID, slug: slug)
+        clearNamingCaches(jobID: jobID)
         updateJobState(id: jobID, to: .done)
     }
 
@@ -1310,6 +1353,30 @@ class PipelineQueue {
 
     // MARK: - Speaker Naming Persistence
 
+    /// Fold the user's confirmed names into the persisted naming sidecar so a
+    /// later re-open shows the applied names and the transcript-rewrite anchors
+    /// on them (after a confirm the transcript no longer contains the raw
+    /// auto-name labels). No-op when the job has no slug.
+    private func persistAppliedNames(
+        jobID: UUID, userMapping: [String: String], base: SpeakerNamingData,
+    ) {
+        guard let slug = jobs.first(where: { $0.id == jobID })?.namingSlug else { return }
+        var folded = base.mapping
+        for (label, name) in userMapping where !name.isEmpty {
+            folded[label] = name
+        }
+        saveNamingData(
+            SpeakerNamingData(
+                jobID: base.jobID, meetingTitle: base.meetingTitle,
+                mapping: folded, speakingTimes: base.speakingTimes,
+                embeddings: base.embeddings, audioPath: base.audioPath,
+                segments: base.segments, participants: base.participants,
+                isDualSource: base.isDualSource,
+            ),
+            slug: slug,
+        )
+    }
+
     func saveNamingData(_ data: SpeakerNamingData, slug: String) {
         guard let outputDir else { return }
         let recordingsDir = outputDir.appendingPathComponent("recordings")
@@ -1354,13 +1421,23 @@ class PipelineQueue {
         try? FileManager.default.removeItem(at: path)
     }
 
-    /// Remove all naming-related data for a job: RAM caches, disk JSON, and
-    /// sidecar files. Also clears the recognition-stats stash dicts so they
-    /// don't leak across rerun / stale-cleanup paths.
-    private func removeNamingData(jobID: UUID, slug: String?) {
+    /// Free the in-RAM naming caches + recognition-stats stash for a job
+    /// WITHOUT touching disk. Used on successful completion (Confirm/Skip) so
+    /// the persisted `_naming.json` + audio sidecars survive for a later
+    /// re-name, while transient session state is released. Disk cleanup is
+    /// deferred to `removeJob` (explicit Dismiss) or `cancelJob`.
+    private func clearNamingCaches(jobID: UUID) {
         speakerNamingDataByJob.removeValue(forKey: jobID)
         stashedSuggestedAtDialog.removeValue(forKey: jobID)
         stashedTopCandidates.removeValue(forKey: jobID)
+    }
+
+    /// Remove all naming-related data for a job: RAM caches, disk JSON, and
+    /// sidecar files. Used when the artefacts are no longer needed — cancel or
+    /// explicit Dismiss of a finished job.
+    private func removeNamingData(jobID: UUID, slug: String?) {
+        clearNamingCaches(jobID: jobID)
+        recognitionLoggedJobIDs.remove(jobID)
         deleteNamingData(slug: slug)
         cleanupSidecarFiles(slug: slug)
     }
@@ -1377,16 +1454,16 @@ class PipelineQueue {
     }
 
     /// Auto-resolve pending naming items older than maxAge (default: 24h).
-    /// Generates the protocol with auto-names, transitions them to .done,
-    /// deletes sidecar files.
+    /// Generates the protocol with auto-names and transitions them to .done.
+    /// The persisted sidecar is kept so the user can still re-name later — the
+    /// app retains all recordings indefinitely, so the naming data lives with
+    /// them rather than being reaped on its own.
     func cleanupStalePending(maxAge: TimeInterval = 86400) {
         let now = Date()
         for job in jobs where job.state == .speakerNamingPending {
             if now.timeIntervalSince(job.enqueuedAt) > maxAge {
                 logger.info("Auto-resolving stale pending naming for \(job.meetingTitle)")
-                let jobID = job.id
-                let slug = job.namingSlug
-                acceptAutoNames(jobID: jobID, slug: slug)
+                acceptAutoNames(jobID: job.id)
             }
         }
     }

--- a/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarViewTests.swift
@@ -403,6 +403,75 @@ final class MenuBarViewTests: XCTestCase {
         XCTAssertNoThrow(try body.find(text: "Dismiss"))
     }
 
+    func testEditSpeakerNamesButtonShownForDoneJobWithRetainedNaming() throws {
+        let queue = PipelineQueue()
+        var job = makeRetainedNamingJob()
+        job.namingSlug = "retro_abc123"
+        queue.enqueue(job)
+        queue.updateJobState(id: job.id, to: .done)
+
+        let sut = makeJobRowView(queue: queue)
+        let body = try sut.inspect()
+        XCTAssertNoThrow(try body.find(text: "Edit Speaker Names"))
+    }
+
+    func testEditSpeakerNamesButtonHiddenForDoneJobWithoutNaming() throws {
+        let queue = PipelineQueue()
+        let job = makeRetainedNamingJob() // no namingSlug
+        queue.enqueue(job)
+        queue.updateJobState(id: job.id, to: .done)
+
+        let sut = makeJobRowView(queue: queue)
+        let body = try sut.inspect()
+        XCTAssertThrowsError(try body.find(text: "Edit Speaker Names"))
+    }
+
+    func testEditSpeakerNamesButtonCallsCallbackWithJobID() throws {
+        let queue = PipelineQueue()
+        var job = makeRetainedNamingJob()
+        job.namingSlug = "retro_abc123"
+        queue.enqueue(job)
+        queue.updateJobState(id: job.id, to: .done)
+
+        var reopenedID: UUID?
+        let sut = makeJobRowView(queue: queue) { reopenedID = $0 }
+        let body = try sut.inspect()
+        try body.find(button: "Edit Speaker Names").tap()
+        XCTAssertEqual(reopenedID, job.id)
+    }
+
+    private func makeRetainedNamingJob() -> PipelineJob {
+        PipelineJob(
+            meetingTitle: "Retro", appName: "Zoom",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+    }
+
+    private func makeJobRowView(
+        queue: PipelineQueue,
+        onReopenNaming: @escaping (UUID) -> Void = { _ in },
+    ) -> MenuBarView {
+        MenuBarView(
+            status: makeStatus(),
+            isWatching: false,
+            pipelineQueue: queue,
+            updateChecker: nil,
+            onStartStop: {},
+            onRecordApp: {},
+            onStopManualRecording: nil,
+            onOpenLastProtocol: {},
+            onOpenProtocol: { _ in },
+            onOpenProtocolsFolder: {},
+            onOpenSettings: {},
+            onNameSpeakers: nil,
+            onProcessFiles: {},
+            onDismissJob: { _ in },
+            onQuit: {},
+            onReopenNaming: onReopenNaming,
+        )
+    }
+
     func testProcessFilesButtonCallsCallback() throws {
         var called = false
         let sut = MenuBarView(

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2122,6 +2122,163 @@ final class PipelineQueueTests: XCTestCase {
         }
     }
 
+    // MARK: - Late Speaker Re-naming Recovery (Slice A: deferred sidecar delete)
+
+    /// Builds a queue (outputDir = tmpDir) holding one job whose naming data is
+    /// both cached in RAM and persisted to disk. Returns the queue, the job, and
+    /// the on-disk `_naming.json` path so tests can assert on its lifetime.
+    private func makeQueueWithPersistedNaming(
+        title: String = "Recovery Meeting",
+        state: JobState = .speakerNamingPending,
+    ) -> (PipelineQueue, PipelineJob, URL) {
+        let q = makeProcessingQueue()
+        var job = makeJob(title: title)
+        job.state = state
+        let slug = PipelineQueue.namingSlug(title: title, jobID: job.id)
+        job.namingSlug = slug
+        q.enqueue(job)
+        let data = PipelineQueue.SpeakerNamingData(
+            jobID: job.id, meetingTitle: title,
+            mapping: ["SPEAKER_0": "Speaker 1"],
+            speakingTimes: [:], embeddings: [:],
+            audioPath: nil, segments: [], participants: [], isDualSource: false,
+        )
+        q.speakerNamingDataByJob[job.id] = data
+        q.saveNamingData(data, slug: slug)
+        let path = tmpDir.appendingPathComponent("recordings/\(slug)_naming.json")
+        return (q, job, path)
+    }
+
+    func testSkipKeepsNamingSidecarForLaterRename() {
+        let (q, job, path) = makeQueueWithPersistedNaming()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path.path), "precondition: sidecar persisted")
+
+        q.completeSpeakerNaming(jobID: job.id, result: .skipped)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: path.path),
+            "naming sidecar must survive Skip so the user can re-name a .done job later",
+        )
+    }
+
+    func testSkipClearsInMemoryNamingCache() {
+        let (q, job, _) = makeQueueWithPersistedNaming()
+
+        q.completeSpeakerNaming(jobID: job.id, result: .skipped)
+
+        XCTAssertNil(
+            q.speakerNamingDataByJob[job.id],
+            "RAM cache is freed on completion even though the disk sidecar is kept",
+        )
+    }
+
+    func testDismissDeletesRetainedNamingSidecar() {
+        let (q, job, path) = makeQueueWithPersistedNaming(state: .done)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path.path), "precondition: sidecar persisted")
+
+        q.removeJob(id: job.id)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: path.path),
+            "explicit Dismiss must clean up the retained naming sidecar",
+        )
+    }
+
+    func testDoneJobWithRetainedNamingIsNotAutoRemoved() async throws {
+        // A done job WITHOUT naming data auto-removes after completedJobLifetime.
+        // One that retains a naming sidecar (signalled by a non-nil namingSlug)
+        // must persist so the re-name affordance stays reachable in the menu
+        // until explicit Dismiss.
+        let q = PipelineQueue(
+            engine: MockEngine(),
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { nil },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            completedJobLifetime: 0.2,
+        )
+        var job = makeJob()
+        job.namingSlug = PipelineQueue.namingSlug(title: job.meetingTitle, jobID: job.id)
+        q.enqueue(job)
+
+        q.updateJobState(id: job.id, to: .done)
+        try await Task.sleep(for: .milliseconds(400))
+
+        XCTAssertEqual(q.jobs.count, 1, "done job retaining naming data must not auto-remove")
+    }
+
+    func testDoneJobWithoutNamingStillAutoRemoves() async throws {
+        // Guard the inverse: jobs that never produced naming data (no slug) keep
+        // the original 60s auto-remove behaviour.
+        let q = PipelineQueue(logDir: tmpDir, completedJobLifetime: 0.2)
+        let job = makeJob()
+        q.enqueue(job)
+
+        q.updateJobState(id: job.id, to: .done)
+        try await Task.sleep(for: .milliseconds(400))
+
+        XCTAssertEqual(q.jobs.count, 0, "done job without naming data must auto-remove as before")
+    }
+
+    // MARK: - Late Speaker Re-naming Recovery (Slice B: re-open affordance)
+
+    func testReopenSpeakerNamingTransitionsDoneJobToPending() {
+        let (q, job, _) = makeQueueWithPersistedNaming(state: .done)
+        q.speakerNamingDataByJob[job.id] = nil // simulate post-confirm: RAM freed, disk kept
+
+        q.reopenSpeakerNaming(jobID: job.id)
+
+        XCTAssertEqual(
+            q.jobs.first { $0.id == job.id }?.state, .speakerNamingPending,
+            "re-open must return the job to the naming-pending state",
+        )
+        XCTAssertNotNil(
+            q.speakerNamingDataByJob[job.id],
+            "re-open must reload naming data from disk into the RAM cache",
+        )
+    }
+
+    func testReopenSpeakerNamingIsNoOpWithoutPersistedData() {
+        let q = makeProcessingQueue()
+        var job = makeJob()
+        job.state = .done // no namingSlug, no sidecar
+        q.enqueue(job)
+
+        q.reopenSpeakerNaming(jobID: job.id)
+
+        XCTAssertEqual(
+            q.jobs.first { $0.id == job.id }?.state, .done,
+            "re-open must be a no-op when there is no persisted naming data",
+        )
+    }
+
+    func testReopenSpeakerNamingUsesInMemoryDataWhenPresent() {
+        let (q, job, path) = makeQueueWithPersistedNaming(state: .done)
+        try? FileManager.default.removeItem(at: path) // disk gone, RAM intact
+
+        q.reopenSpeakerNaming(jobID: job.id)
+
+        XCTAssertEqual(
+            q.jobs.first { $0.id == job.id }?.state, .speakerNamingPending,
+            "re-open must use the in-RAM cache without requiring a disk read",
+        )
+    }
+
+    func testConfirmPersistsAppliedNamesForRepeatRename() throws {
+        // After a manual Confirm the transcript carries the applied names, not the
+        // original auto-names. Persisting the applied mapping lets a later re-open
+        // + re-name anchor on the current labels instead of silently no-op'ing.
+        let (q, job, _) = makeQueueWithPersistedNaming(state: .speakerNamingPending)
+
+        q.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+
+        let reloaded = try q.loadNamingData(slug: XCTUnwrap(job.namingSlug))
+        XCTAssertEqual(
+            reloaded?.mapping["SPEAKER_0"], "Alice",
+            "the applied name must be folded into the persisted naming sidecar",
+        )
+    }
+
     // MARK: - knownSpeakerNames cache (issue #155)
 
     //


### PR DESCRIPTION
## Summary

Adds a **recovery path** for the speaker-naming dialog auto-confirm bug: the dialog sometimes confirms before the user names speakers (a stray Enter/Cmd-W while another app holds focus). PR #310 shipped *prevention* (a 750 ms keyboard-shortcut grace); this PR adds the *recovery* that prevention can't fully cover.

A finished (`.done`) meeting that retains its naming data now shows an **"Edit Speaker Names"** button in the menu-bar job row. Clicking it re-opens the naming dialog so the user can name speakers — or re-run diarization — after the fact.

## How it works

- **Retain the naming sidecar** — Confirm/Skip now free only the in-RAM caches (`clearNamingCaches`); the persisted `_naming.json` + audio sidecars stay on disk. Full deletion (`removeNamingData`) happens only on explicit **Dismiss** or cancel. This mirrors what the app already does with every recording: the original `_mix.wav`/`_app.wav`/`_mic.wav` are kept in `recordings/` indefinitely, so the (small) naming data simply lives alongside them rather than being reaped on its own.
- **Don't auto-remove retained jobs** — a `.done` job that retains a sidecar (signalled by a non-nil `namingSlug`) is no longer auto-removed from the menu after `completedJobLifetime`, so the affordance stays reachable. Jobs that never produced naming data keep the original ~60 s auto-clear.
- **Re-open affordance** — `reopenSpeakerNaming(jobID:)` reloads the retained data (RAM, else from disk) and flips `.done → .speakerNamingPending`, reusing the existing `.showSpeakerNaming` path. Confirming folds the applied names back into the sidecar (`persistAppliedNames`) so a *second* re-name anchors on the current transcript labels instead of the original auto-names.
- **Log recognition once per job** — a re-opened + re-confirmed job no longer writes a second recognition-stats row whose `suggested` baseline is the already-applied names (a phantom perfect match).

## Scope / limitations

- Recovery is **in-session**: `.done` jobs are dropped from the snapshot on relaunch, so the menu affordance does not survive an app restart. The retained sidecar stays on disk (alongside the recordings the app already keeps), so a future "recent recordings" browser could surface it — intentionally out of scope here.
- Finished diarized meetings now **persist in the menu** until Dismiss, where previously they auto-cleared after ~60 s. This is the deliberate tradeoff that keeps the re-name affordance reachable.

## Tests

- 9 new tests across `PipelineQueueTests` + `MenuBarViewTests`: deferred-delete, Dismiss cleanup, auto-remove gating (retained vs not), reopen transition / no-op / RAM-vs-disk, applied-name persistence for repeat re-name, and the "Edit Speaker Names" button visibility + callback.
- Full `PipelineQueueTests` and `MenuBarViewTests` green; SwiftLint clean; release-build parity check passes.

## Follow-up (noted, not in this PR)

The retained `_16k.wav` is a downsampled duplicate of the `_mix.wav` the app already keeps forever; `lateDiarization` could regenerate it on demand from the original instead of retaining a separate copy, removing the duplicate entirely.
