### PR TITLE
fix(app): enable WhisperKit language detection for auto-detect

### DIFF
--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -120,10 +120,7 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
         // Estimate total 30s windows from audio duration
         let totalWindows = max(1, Self.estimateWindowCount(audioPath: audioPath))
 
-        let options = DecodingOptions(
-            language: language,
-            wordTimestamps: false,
-        )
+        let options = Self.decodingOptions(language: language)
 
         let results = await pipe.transcribe(
             audioPaths: [audioPath.path],
@@ -169,7 +166,7 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
     func transcribeSamples(_ samples: [Float]) async throws -> String {
         try await ensureModel()
         guard let pipe else { throw TranscriptionError.modelNotLoaded }
-        let options = DecodingOptions(language: language, wordTimestamps: false)
+        let options = Self.decodingOptions(language: language)
         let results = try await pipe.transcribe(
             audioArray: samples,
             decodeOptions: options,
@@ -184,6 +181,18 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
             pieces.append(text)
         }
         return pieces.joined(separator: " ")
+    }
+
+    /// Build the WhisperKit `DecodingOptions` for a transcription run.
+    /// `language` is `nil` for "Auto-detect" and a BCP-47 code otherwise.
+    static func decodingOptions(language: String?) -> DecodingOptions {
+        // WhisperKit defaults `detectLanguage` to `!usePrefillPrompt` (= false),
+        // so without this it skips detection and falls back to English (#339).
+        DecodingOptions(
+            language: language,
+            detectLanguage: language == nil,
+            wordTimestamps: false,
+        )
     }
 
     /// Estimate number of 30-second windows WhisperKit will process for the given audio file.

--- a/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitE2ETests.swift
@@ -349,7 +349,7 @@ final class WhisperKitE2ETests: XCTestCase {
         )
     }
 
-    // MARK: - Issue #256: Polish audio must transcribe as Polish, not English
+    // MARK: - Issues #256 / #339: Polish audio must transcribe as Polish, not English
 
     /// E2E reproduction of issue #256. The bug reporter (Polish speaker) saw
     /// most of their meeting "translated to English" because:
@@ -381,7 +381,40 @@ final class WhisperKitE2ETests: XCTestCase {
 
         let transcript = try await engine.transcribe(audioPath: fixture)
         XCTAssertFalse(transcript.isEmpty, "Polish transcript should not be empty")
+        assertTranscriptIsPolishNotEnglish(transcript)
+    }
 
+    /// E2E reproduction of issue #339, the auto-detect counterpart of #256.
+    /// With "Auto-detect" selected (`engine.language = nil`), WhisperKit used
+    /// to skip language detection entirely (`DecodingOptions.detectLanguage`
+    /// defaults to false) and fall back to English. The fix enables detection
+    /// whenever no explicit language is pinned, so the same Polish fixture must
+    /// now transcribe as Polish without the user choosing a language.
+    func testPolishAudioTranscribesAsPolishWithAutoDetect() async throws {
+        try skipIfCIWithoutE2EOptIn("requires WhisperKit model download")
+
+        let fixture = fixtureURL("polish_sample.wav")
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: fixture.path),
+            "Polish fixture not found at \(fixture.path)",
+        )
+
+        let engine = WhisperKitEngine()
+        engine.modelVariant = "openai_whisper-small"
+        engine.language = nil // Auto-detect
+
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "Model should be loaded")
+
+        let transcript = try await engine.transcribe(audioPath: fixture)
+        XCTAssertFalse(transcript.isEmpty, "Auto-detect transcript should not be empty")
+        assertTranscriptIsPolishNotEnglish(transcript)
+    }
+
+    /// Shared assertions for the Polish fixture: the transcript must look like
+    /// Polish (diacritics + word stems) and must not have drifted to English.
+    /// Used by both the explicit-language (#256) and auto-detect (#339) paths.
+    private func assertTranscriptIsPolishNotEnglish(_ transcript: String) {
         let lower = transcript.lowercased()
 
         // Polish letters that don't occur in English at all. `ó` is shared with

--- a/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
@@ -1,8 +1,34 @@
 @testable import MeetingTranscriber
+import WhisperKit
 import XCTest
 
 @MainActor
 final class WhisperKitEngineTests: XCTestCase {
+    /// Regression for #339: "Auto-detect" (language == nil) silently fell back
+    /// to English because WhisperKit's `DecodingOptions.detectLanguage` defaults
+    /// to `!usePrefillPrompt` (= false), so the language-detection path in
+    /// TranscribeTask was skipped and the output defaulted to "en".
+    func testAutoDetectEnablesLanguageDetection() {
+        let options = WhisperKitEngine.decodingOptions(language: nil)
+        XCTAssertNil(options.language, "Auto-detect must not pin a language")
+        XCTAssertTrue(
+            options.detectLanguage,
+            "Auto-detect (language == nil) must enable WhisperKit language detection, "
+                + "otherwise transcription falls back to English",
+        )
+    }
+
+    /// When an explicit language is chosen, detection must stay off so the
+    /// user's choice is honoured verbatim.
+    func testExplicitLanguageDisablesDetection() {
+        let options = WhisperKitEngine.decodingOptions(language: "pl")
+        XCTAssertEqual(options.language, "pl")
+        XCTAssertFalse(
+            options.detectLanguage,
+            "An explicit language must not trigger auto-detection",
+        )
+    }
+
     func testDefaultModel() {
         let engine = WhisperKitEngine()
         XCTAssertEqual(engine.modelVariant, "openai_whisper-large-v3-v20240930_turbo")


### PR DESCRIPTION
## Problem

When the WhisperKit language is **"Auto-detect"** (`language == nil`), all transcription output was English regardless of the spoken language. Reported in #339 (confirmed Polish audio → English output).

## Root cause

WhisperKit's `DecodingOptions` defaults `detectLanguage` to `!usePrefillPrompt` (= `false`, because `usePrefillPrompt` defaults to `true`). `TranscribeTask` only runs language detection when `options.language == nil && options.detectLanguage`, so with `detectLanguage == false` it skipped detection entirely and fell back to `Constants.defaultLanguageCode` (`"en"`).

The engine constructed `DecodingOptions` inline and never set `detectLanguage`, so auto-detect was non-functional for every non-English speaker — on **both** the batch (`transcribeSegments`) and live-caption (`transcribeSamples`) paths.

## Fix

Centralize `DecodingOptions` construction in a single `decodingOptions(language:)` helper used by both paths, and set `detectLanguage: language == nil` — detection is enabled exactly when no explicit language is pinned. An explicit language keeps detection off so the user's choice is honoured verbatim.

## Tests

- **Unit** (`WhisperKitEngineTests`, fast, runs in CI): `testAutoDetectEnablesLanguageDetection` pins `detectLanguage == true` for `nil`; `testExplicitLanguageDisablesDetection` pins it `false` for an explicit code. The first reproduced the bug (RED) before the fix.
- **E2E** (`WhisperKitE2ETests`, model-download lane): `testPolishAudioTranscribesAsPolishWithAutoDetect` — the auto-detect counterpart of the existing explicit-language #256 test, on the same `polish_sample.wav` fixture. Shared assertions extracted into `assertTranscriptIsPolishNotEnglish`.

Closes #339.