### PR TITLE
fix(audiotap): make IOProc-shared fields atomic to close data races

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -1,6 +1,6 @@
 import CoreAudio
 import Foundation
-import os.log
+import os
 
 private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "AppAudioCapture")
 
@@ -8,11 +8,12 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// No Screen Recording permission needed — only Audio Capture.
 /// Monitors default output device changes and recreates the tap when needed.
 ///
-/// All mutable state is serialized through `writeQueue` (`audiotap.writer`,
+/// Most mutable state is serialized through `writeQueue` (`audiotap.writer`,
 /// userInteractive QoS) or driven from the CoreAudio IOProc callback which
-/// never overlaps with itself for a given tap. The DispatchQueue.main retry
-/// path is the only main-thread touch and it dispatches a single completion
-/// closure. `@unchecked Sendable` reflects that the serialization is manual
+/// never overlaps with itself for a given tap. The two fields the main thread
+/// and the IOProc genuinely touch concurrently — `actualSampleRate` and
+/// `isRunning` — are instead `OSAllocatedUnfairLock`-backed so each access is
+/// atomic. `@unchecked Sendable` reflects that this serialization is manual
 /// rather than expressible to the compiler.
 @available(macOS 14.2, *)
 public class AppAudioCapture: @unchecked Sendable {
@@ -31,7 +32,15 @@ public class AppAudioCapture: @unchecked Sendable {
     private var aggregateID = AudioObjectID(kAudioObjectUnknown)
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var procID: AudioDeviceIOProcID?
-    private var isRunning = false
+    /// Gates the IOProc callback (read on `writeQueue`), set on the start/stop
+    /// path on the main thread. `isRunning = true` must follow `AudioDeviceStart`,
+    /// so it can't be reordered ahead of the callback's read — hence an atomic lock.
+    private let runningLock = OSAllocatedUnfairLock(initialState: false)
+    private var isRunning: Bool {
+        get { runningLock.withLock { $0 } }
+        set { runningLock.withLock { $0 = newValue } }
+    }
+
     private var outputListenerInstalled = false
     /// Stored listener block so we can pass the same instance to remove.
     private var outputDeviceChangeListener: AudioObjectPropertyListenerBlock?
@@ -62,7 +71,15 @@ public class AppAudioCapture: @unchecked Sendable {
     /// mach_absolute_time() of first audio callback.
     public private(set) var appFirstFrameTime: UInt64 = 0
     /// Actual sample rate of the aggregate device (may differ from requested).
-    public private(set) var actualSampleRate: Int = 0
+    /// Touched by the IOProc (`writeQueue`) and the main thread (start/restart
+    /// logs, restart event), so it is `OSAllocatedUnfairLock`-backed for atomic
+    /// cross-thread access; `private(set)` keeps writes internal.
+    private let actualSampleRateLock = OSAllocatedUnfairLock(initialState: 0)
+    public private(set) var actualSampleRate: Int {
+        get { actualSampleRateLock.withLock { $0 } }
+        set { actualSampleRateLock.withLock { $0 = newValue } }
+    }
+
     /// Actual channel count detected from first IOProc callback.
     public private(set) var actualChannels: Int = 0
     private var didLogFormat = false
@@ -402,6 +419,18 @@ public class AppAudioCapture: @unchecked Sendable {
         }
         procID = validProcID
 
+        // Resolve and store the sample rate BEFORE starting the device — value
+        // ordering, not race-safety (the field's lock handles cross-thread
+        // access, see its declaration). Writing the resolved value first lets
+        // the IOProc's first-callback measured-rate correction layer on top
+        // instead of a post-start write clobbering it. Resolving is valid
+        // pre-start: `resolveActualSampleRate` reads only the tap format and the
+        // device's nominal/stream-format properties; the one started-device
+        // query (kAudioDevicePropertyActualSampleRate) lives in the IOProc.
+        actualSampleRate = Self.resolveActualSampleRate(
+            deviceID: aggregateID, tapID: tapID, requestedRate: sampleRate,
+        )
+
         let startStatus = AudioDeviceStart(aggregateID, procID)
         guard startStatus == noErr else {
             AudioHardwareDestroyAggregateDevice(aggregateID)
@@ -417,9 +446,6 @@ public class AppAudioCapture: @unchecked Sendable {
 
         isRunning = true
 
-        actualSampleRate = Self.resolveActualSampleRate(
-            deviceID: aggregateID, tapID: tapID, requestedRate: sampleRate,
-        )
         logger.info("Audio capture started (PIDs \(self.pids), rate: \(self.actualSampleRate) Hz)")
     }
 


### PR DESCRIPTION
## Problem

`actualSampleRate` and `isRunning` on `AppAudioCapture` are accessed from two threads without synchronization:

- The CoreAudio IOProc callback (on `writeQueue`) reads both and writes `actualSampleRate` (the first-callback measured-rate correction).
- The main thread reads/writes them around device start/stop and the output-device-change restart path — the "Audio capture started" log, the restart `.startSucceeded` event, the "tap restarted" log, and `isRunning`'s start/stop toggles.

Both are non-atomic, so these are TSan-visible data races. The class's `@unchecked Sendable` note claimed all mutable state was serialized through `writeQueue`; these two fields were the exceptions.

## Fix

- Back both fields with `OSAllocatedUnfairLock` via computed properties (mirroring `LevelPublisher`). Every existing access site is unchanged; each read/write is now atomic. `actualSampleRate` keeps its `public private(set)` contract.
- Keep resolving and writing `actualSampleRate` before `AudioDeviceStart` — this is value-ordering, not race-safety: it lets the IOProc's measured-rate correction layer on top of the resolved value instead of a post-start write clobbering it. The resolution is valid pre-start (it reads only the tap format and the device's nominal/stream-format properties; the one started-device query lives in the IOProc).

## Testing

`swift build`, `swift build -c release` (Sendable parity), and the full audiotap suite (114 tests) pass; lint clean.

No new unit test: the race only manifests with a live CoreAudio IOProc, which the sandboxed xctest harness cannot start, so neither a unit test nor the TSan lane exercises this path. The fix rests on the atomic primitives, the value-ordering invariant documented at the call site, and code review.