### PR TITLE
fix(app): restrict sensitive file writes to owner-only (0600)

### DIFF
--- a/app/MeetingTranscriber/Sources/FileManager+OwnerOnly.swift
+++ b/app/MeetingTranscriber/Sources/FileManager+OwnerOnly.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension FileManager {
+    /// POSIX mode for owner-only read/write (`rw-------`). Single source of
+    /// truth for the sensitive-file permission constant so every writer
+    /// agrees and the value can't drift between call sites.
+    static let ownerOnlyPermissions = 0o600
+
+    /// Restrict an already-written file to owner-only read/write (mode 0600),
+    /// clearing the world/group-readable bits that a plain `.write(to:)`
+    /// inherits from the process umask (typically 0644).
+    ///
+    /// Call this *after* the file is written. For atomic writes (temp-file +
+    /// rename) the rename does not preserve a chmod applied to the staging
+    /// file, so the permissions must be set on the final path once it exists.
+    ///
+    /// Used for biometric-adjacent voice embeddings (`speakers.json`),
+    /// transcripts, protocol markdown, naming/sidecar JSON, and pipeline
+    /// logs — none of which should be readable by other local users on a
+    /// shared Mac. Mirrors the 0600 treatment already applied to audio
+    /// captures and the recognition log.
+    func restrictToOwner(_ url: URL) throws {
+        try setAttributes(
+            [.posixPermissions: Self.ownerOnlyPermissions],
+            ofItemAtPath: url.path,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1145,6 +1145,9 @@ class PipelineQueue {
                     }
                 }
                 try transcript.write(to: transcriptPath, atomically: true, encoding: .utf8)
+                // Re-applying speaker names rewrites the transcript — keep it
+                // owner-only (the original save in saveTranscript already is).
+                try FileManager.default.restrictToOwner(transcriptPath)
 
                 if let outputDir {
                     await generateProtocol(
@@ -1327,6 +1330,8 @@ class PipelineQueue {
             )
             let json = try encoder.encode(data)
             try json.write(to: path, options: .atomic)
+            // Carries per-speaker voice embeddings — restrict to owner-only.
+            try FileManager.default.restrictToOwner(path)
         } catch {
             // Silent failure here means late-confirm won't work after a
             // restart. Make it visible: log + warning on the job.
@@ -1797,6 +1802,10 @@ class PipelineQueue {
                 handle.write(line.data(using: .utf8)!)
             } else {
                 try line.write(to: logPath, atomically: true, encoding: .utf8)
+                // First write creates the file — restrict it to owner-only so
+                // the meeting log isn't world-readable. Subsequent appends go
+                // through the FileHandle branch and inherit these permissions.
+                try FileManager.default.restrictToOwner(logPath)
             }
         } catch {
             logger.error("Failed to append pipeline log: \(error)")

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -111,6 +111,8 @@ enum ProtocolGenerator {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent(filename(title: title, ext: "txt"))
         try text.write(to: url, atomically: true, encoding: .utf8)
+        // Transcripts contain verbatim meeting speech — restrict to owner-only.
+        try FileManager.default.restrictToOwner(url)
         logger.info("Transcript saved: \(url.lastPathComponent)")
         return url
     }
@@ -124,6 +126,8 @@ enum ProtocolGenerator {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent(filename(title: title, ext: "md"))
         try markdown.write(to: url, atomically: true, encoding: .utf8)
+        // Protocol markdown summarises the meeting — restrict to owner-only.
+        try FileManager.default.restrictToOwner(url)
         logger.info("Protocol saved: \(url.lastPathComponent)")
         return url
     }

--- a/app/MeetingTranscriber/Sources/RecordingSidecar.swift
+++ b/app/MeetingTranscriber/Sources/RecordingSidecar.swift
@@ -59,6 +59,9 @@ struct RecordingSidecar: Codable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(self)
         try data.write(to: url, options: .atomic)
+        // Holds meeting title + participants — match the owner-only (0600)
+        // treatment of the audio it sits beside.
+        try FileManager.default.restrictToOwner(url)
         return url
     }
 

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -437,6 +437,10 @@ class SpeakerMatcher {
                 .appendingPathComponent("speakers.json.tmp")
             try data.write(to: tmp)
             _ = try FileManager.default.replaceItemAt(dbPath, withItemAt: tmp)
+            // Voice embeddings/centroids are biometric-adjacent — restrict the
+            // persisted DB to owner-only. The temp-file rename does not carry a
+            // chmod applied pre-rename, so set it on the final path.
+            try FileManager.default.restrictToOwner(dbPath)
         } catch {
             logger.error("Failed to save speaker DB: \(error)")
         }

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -431,4 +431,29 @@ final class ProtocolGeneratorTests: XCTestCase {
             "yesterday's prefix should have been stripped: \(result)",
         )
     }
+
+    // MARK: - File permissions
+
+    /// Transcripts contain verbatim meeting speech — they must be owner-only
+    /// (0600), not world-readable from the inherited umask.
+    func testSaveTranscriptWritesOwnerOnlyPermissions() throws {
+        let dir = try makeTempDirectory(prefix: "ProtocolGenSaveTranscript")
+        let url = try ProtocolGenerator.saveTranscript("hello world", title: "Standup", dir: dir)
+
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600)
+    }
+
+    /// Protocol markdown summarises the meeting — same owner-only requirement.
+    func testSaveProtocolWritesOwnerOnlyPermissions() throws {
+        let dir = try makeTempDirectory(prefix: "ProtocolGenSaveProtocol")
+        let url = try ProtocolGenerator.saveProtocol("# Notes", title: "Standup", dir: dir)
+
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600)
+    }
 }

--- a/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
+++ b/app/MeetingTranscriber/Tests/RecordingSidecarTests.swift
@@ -93,4 +93,16 @@ final class RecordingSidecarTests: XCTestCase {
         let dir = try makeTempDirectory(prefix: "rs")
         XCTAssertNil(RecordingSidecar.read(fromDirectory: dir, basename: "absent"))
     }
+
+    /// The sidecar records meeting title + participants; it must be owner-only
+    /// (0600), not world-readable, matching the audio it sits next to.
+    func test_write_setsOwnerOnlyPermissions() throws {
+        let dir = try makeTempDirectory(prefix: "rs")
+        let url = try makeFullSidecar().write(toDirectory: dir, basename: "20260503_083000")
+
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600)
+    }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -1072,4 +1072,19 @@ final class SpeakerMatcherTests: XCTestCase {
         }
         XCTAssertEqual(names.count, count, "Final DB has wrong entry count")
     }
+
+    // MARK: - File permissions
+
+    /// `speakers.json` holds biometric-adjacent voice embeddings/centroids;
+    /// it must never carry the world/group-readable bits a plain `.write(to:)`
+    /// inherits from the umask. Asserts the persisted DB is owner-only (0600).
+    func testSaveDBWritesOwnerOnlyPermissions() throws {
+        let matcher = SpeakerMatcher(dbPath: dbPath)
+        matcher.saveDB([StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]])])
+
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: dbPath.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600)
+    }
 }


### PR DESCRIPTION
## Problem

Several sensitive files were written with plain `write(to:)`, inheriting the process umask (typically mode `0644`) and leaving the world/group-readable bit set. On a shared Mac this exposed:

- **biometric-adjacent voice embeddings** (`speakers.json` centroids + the `*_naming.json` late-confirm cache)
- verbatim meeting transcripts (`.txt`)
- protocol summaries (`.md`)
- record-only sidecar metadata (`_meta.json` — meeting title + participants)
- the pipeline event log (`pipeline_log.jsonl`)

This was an inconsistency as much as a hardening gap: sibling writes already set `0600` on write — audio captures (`AudioMixer`, `MicCaptureHandler`, `AudioCaptureSession`), the recognition log (`recognition_log.jsonl`), and the RPC token.

## Fix

Centralized the `0600` constant and the post-write chmod into a focused `FileManager.restrictToOwner(_:)` helper so every writer agrees on the mode and it can't drift between call sites. Each sensitive write now calls it after writing.

Permissions are applied to the **final** path after the write because atomic writes (temp-file + rename, used by `speakers.json`'s `replaceItemAt` and the `.atomic` writes) do not preserve a chmod applied to the staging file. The `pipeline_log.jsonl` case sets the mode on first creation; subsequent `FileHandle` appends inherit it.

## Tests

Regression tests assert the resulting file mode is `0600` (masked with `0o777`):

- `SpeakerMatcherTests.testSaveDBWritesOwnerOnlyPermissions` — `speakers.json` via the save path
- `ProtocolGeneratorTests.testSaveTranscriptWritesOwnerOnlyPermissions` / `testSaveProtocolWritesOwnerOnlyPermissions`
- `RecordingSidecarTests.test_write_setsOwnerOnlyPermissions`

Written test-first: all four failed against the prior `0644` behaviour (`420 != 384`), then passed after the fix.

## Verification

- `swift build` + `swift build -c release` — both pass
- Affected test classes (`SpeakerMatcherTests` 86, `RecordingSidecarTests` + `ProtocolGeneratorTests` 126) — all pass
- `./scripts/lint.sh` — 0 violations, SwiftFormat 0/240 require formatting