### PR TITLE
perf(app): cut AppState.init type-check time below the 300ms limit

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -104,26 +104,65 @@ final class AppState { // swiftlint:disable:this type_body_length
         private(set) var persistentLogStreamer: PersistentDiagnosticLog.Streamer?
     #endif
 
+    // MARK: - Dependency factories
+
+    // These exist purely to keep the dependency-default construction out of
+    // `init`'s type-check budget — see the comment at the top of `init`.
+    // Each has an explicit return type so the call site resolves to a plain
+    // function reference instead of re-solving the dependency's init.
+
+    private static func makeDefaultSettings() -> AppSettings {
+        AppSettings()
+    }
+
+    private static func makeWhisperKit() -> WhisperKitEngine {
+        WhisperKitEngine()
+    }
+
+    private static func makeParakeet() -> ParakeetEngine {
+        ParakeetEngine()
+    }
+
+    private static func makeUpdateChecker() -> UpdateChecker {
+        UpdateChecker()
+    }
+
+    @available(macOS 15, *)
+    private static func makeQwen3() -> Qwen3AsrEngine {
+        Qwen3AsrEngine()
+    }
+
     // MARK: - Init
 
     init(
-        settings: AppSettings = AppSettings(),
+        settings: AppSettings = AppState.makeDefaultSettings(),
         whisperKit: WhisperKitEngine? = nil,
         parakeetEngine: ParakeetEngine? = nil,
         qwen3Engine: AnyObject? = nil,
         notifier: any AppNotifying = SilentNotifier(),
         updateChecker: UpdateChecker? = nil,
     ) {
+        // Dependency defaults are resolved through explicitly-typed factory
+        // helpers (above) rather than inline `?? SomeType()` expressions (and
+        // an inline `AppSettings()` default argument). Each inline
+        // `@Observable` / protocol-existential constructor forces the
+        // type-checker to re-solve the dependency's own init constraints at
+        // this call site; summed across the engine + settings dependencies
+        // that pushed this init's body-type-check time right up against the
+        // 300 ms hard limit enforced in Package.swift, where it flaked
+        // intermittently under heavy CI load. A factory with a declared
+        // return type collapses the inference here to a plain function
+        // reference. Behaviour is identical.
         self.settings = settings
-        self.whisperKit = whisperKit ?? WhisperKitEngine()
-        self.parakeetEngine = parakeetEngine ?? ParakeetEngine()
+        self.whisperKit = whisperKit ?? Self.makeWhisperKit()
+        self.parakeetEngine = parakeetEngine ?? Self.makeParakeet()
         if #available(macOS 15, *) {
-            self._qwen3Engine = (qwen3Engine as? Qwen3AsrEngine) ?? Qwen3AsrEngine()
+            self._qwen3Engine = (qwen3Engine as? Qwen3AsrEngine) ?? Self.makeQwen3()
         } else {
             self._qwen3Engine = nil
         }
         self.notifier = notifier
-        self.updateChecker = updateChecker ?? UpdateChecker()
+        self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
         self.pipelineQueue = PipelineQueue()
         self.channelHealthMonitor = ChannelHealthMonitor(
             debounceSeconds: settings.asymmetricSilenceWarningSeconds,


### PR DESCRIPTION
## Problem

`AppState.init` was the heaviest single function body in `AppState.swift` to type-check, and it sat right against the **300 ms** hard limit that `Package.swift` enforces via `-warn-long-function-bodies=300` + `.treatAllWarnings(as: .error)`.

Type-check time is wall-clock, so it scales with machine load. On one commit, the `build (homebrew)` job passed (init type-checked under 300 ms) while the `test (homebrew)` job — coverage-instrumented and more heavily parallel — measured **305 ms** and **failed the build**:

```
AppState.swift:109:5: error: initializer 'init(settings:whisperKit:parakeetEngine:qwen3Engine:notifier:updateChecker:)' took 305ms to type-check (limit: 300ms)
```

This is a standing fragility — `AppState.swift` was not touched by the work that tripped it. The init simply lived too close to the cliff, so CI load variance flaked it intermittently.

## Root cause

The init constructed its dependency defaults inline:
- the `settings: AppSettings = AppSettings()` **default argument** (default-argument expressions are type-checked as part of the enclosing init's body), and
- the `?? WhisperKitEngine()` / `?? ParakeetEngine()` / `?? Qwen3AsrEngine()` / `?? UpdateChecker()` fallbacks in the body.

Each inline `@Observable` / protocol-existential constructor forces the type-checker to re-solve that dependency's own init constraints at this call site. Per-expression measurement (`-warn-long-expression-type-checking=1`, isolated local recompile):

| Expression | ms (idle) |
|---|---|
| `AppSettings()` default argument | ~46 |
| `?? ParakeetEngine()` | ~19 |
| `?? WhisperKitEngine()` | ~12 |
| `(… as? Qwen3AsrEngine) ?? Qwen3AsrEngine()` | ~11 |
| `?? UpdateChecker()` | ~5 |

Those sum to the full init body cost.

## Fix

Move each default construction into a small `private static` factory with an **explicit return type** (`makeDefaultSettings` / `makeWhisperKit` / `makeParakeet` / `makeUpdateChecker` / `makeQwen3`). A call to a function with a declared return type collapses inference at the call site to a plain function reference, so the dependency-init constraint solving no longer counts against the init's budget.

Public API is unchanged: `AppState()` still resolves all the same defaults, and the `??` fallback semantics are identical. Behaviour-preserving.

## Measured before / after

Init body type-check time, isolated local recompile (`-warn-long-function-bodies=1`):

- **before:** ~66–103 ms idle (**305 ms** observed under CI load → failure)
- **after:** ~14–15 ms idle

That is roughly **14x headroom** under the 300 ms limit — comfortably absorbing the load multiplier that tipped CI over the edge, so this should not flake again.

## Verification

- `swift build` — clean
- `swift build -c release` — clean
- `./scripts/lint.sh` — 0 violations
- `swift test --filter AppStateTests` — 74/74 pass
- `swift test --filter AppStateRPCActionsTests` — 13/13 pass