### PR TITLE
docs(app): sync stale comments and notes with the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 **Concurrency:**
 - `WatchLoop` is `@MainActor`. Tests for this class must also be `@MainActor`.
 - All three engine `loadModel()` methods deduplicate concurrent calls via `loadingTask` — second caller awaits the first's task. Safe to call from multiple places.
-- `ProtocolGenerator` uses async process I/O: `terminationHandler` + `withCheckedContinuation` instead of `process.waitUntilExit()`. stdout/stderr are read in detached `Task`s.
+- `ClaudeCLIProtocolGenerator` uses async process I/O: the process `terminationHandler` yields into an `AsyncStream<Void>` that the caller awaits, instead of blocking on `process.waitUntilExit()`. The stream is installed before `process.run()` and buffers the yield, so an early exit is never missed. stdin/stdout are written/read in detached `Task`s.
 
 **View architecture:**
 - `SettingsView` receives engine instances as stored properties (not `@State`). Constructor: `SettingsView(settings:whisperKitEngine:parakeetEngine:qwen3Engine:updateChecker:)`. `qwen3Engine` is `(any TranscribingEngine)?` — nil on macOS <15.

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -41,7 +41,7 @@
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            // C5 fix: Set terminationHandler BEFORE process.run() to avoid race
+            // Set terminationHandler BEFORE process.run() to avoid race
             // where the process exits before the handler is installed.
             // AsyncStream buffers the yield, so even if the process exits before
             // we iterate, the value is not lost.
@@ -61,12 +61,12 @@
                 throw ProtocolError.cliNotFound(claudeBin)
             }
 
-            // C5 fix: Guard against process having already exited before we awaited.
+            // Guard against process having already exited before we awaited.
             // If the process already exited, terminationHandler may have already fired,
             // but AsyncStream buffers the yield so we won't miss it.
             // No additional check needed — AsyncStream handles the race.
 
-            // C6 fix: Write stdin in a detached task to avoid deadlock on large transcripts.
+            // Write stdin in a detached task to avoid deadlock on large transcripts.
             // The pipe buffer is finite (~64KB); if the prompt exceeds it, a synchronous
             // write blocks until the reader drains — but we haven't started reading yet.
             let promptData = Data(prompt.utf8)
@@ -154,7 +154,7 @@
                     throw ProtocolError.timeout
                 }
 
-                // I1 fix: Wrap blocking availableData in Task.detached to avoid
+                // Wrap blocking availableData in Task.detached to avoid
                 // blocking Swift's cooperative thread pool. availableData blocks
                 // until data is available or EOF, which would starve other tasks.
                 let chunk = await Task.detached { handle.availableData }.value

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -11,9 +11,11 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Streami
 /// and calls `engine.transcribeSamples` once per ~400 ms while speaking
 /// (partial) and once per detected speech end / 5 s force-flush (final).
 ///
-/// App-channel buffers (interleaved 48 kHz stereo) are accepted but ignored
-/// for now — they need a downmix+resample stage before they're usable here.
-/// That's a follow-up.
+/// Both mic and app channels are supported. App-channel buffers (typically
+/// interleaved 48 kHz stereo from `CATapDescription`) are downmixed and
+/// resampled to 16 kHz mono upstream in `LiveTranscriptionController` (via
+/// `LiveAudioResampler`) before they reach `ingest`, so this actor always
+/// sees the 16 kHz mono format described above.
 actor StreamingTranscriber {
     enum Event {
         case partial(String)


### PR DESCRIPTION
Three documentation/comment-only corrections found drifting out of sync with the code. No behavior change.

## Fixes

1. **`StreamingTranscriber.swift` header** — the doc-comment said app-channel buffers are "accepted but ignored for now ... a follow-up". The app channel is in fact supported: `LiveTranscriptionController.handleAppBuffer` downmixes and resamples app buffers to 16 kHz mono via `LiveAudioResampler` before calling `ingest`. Rewrote the sentence to describe the upstream resampling and that the actor always sees 16 kHz mono.

2. **`CLAUDE.md` → Architecture Notes → Concurrency** — bullet claimed `ProtocolGenerator` uses `terminationHandler` + `withCheckedContinuation`. There are zero `withCheckedContinuation` uses in the repo; `ClaudeCLIProtocolGenerator` signals process exit via an `AsyncStream<Void>` fed by the process `terminationHandler` (installed before `process.run()`, buffers the yield so an early exit is never missed). Corrected the bullet.

3. **`ClaudeCLIProtocolGenerator.swift` comments** — stripped opaque internal review-tag prefixes from four comments, keeping all explanatory text. These tags don't belong in committed code.

## Verification

- `swift build` — Build complete (25.4s).
- `./scripts/lint.sh` — 0 violations, 0 serious in 240 files.
- No new tests (comment/doc-only, no behavior change).