### PR TITLE
fix(app): make .private explicit for meeting-title logging

### DIFF
--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -259,12 +259,12 @@ enum AudioMixer {
             return (samples, sampleRate)
         } catch let audioFileError {
             // Fallback 1: AVAsset for video containers (MP4, MOV)
-            logger.info("AVAudioFile failed for \(url.lastPathComponent): \(audioFileError.localizedDescription), trying AVAsset fallback")
+            logger.info("AVAudioFile failed for \(url.lastPathComponent, privacy: .private): \(audioFileError.localizedDescription), trying AVAsset fallback")
             do {
                 return try await loadAudioFromAVAsset(url: url)
             } catch {
                 // Fallback 2: ffmpeg for unsupported formats
-                logger.info("AVAsset failed for \(url.lastPathComponent): \(error.localizedDescription), trying ffmpeg fallback")
+                logger.info("AVAsset failed for \(url.lastPathComponent, privacy: .private): \(error.localizedDescription), trying ffmpeg fallback")
                 return try await FFmpegHelper.loadAudioWithFFmpeg(url: url)
             }
         }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -378,7 +378,7 @@ class PipelineQueue {
         jobs.append(job)
         appendLog(jobID: job.id, event: "enqueued", from: nil, to: job.state)
         saveSnapshot()
-        logger.info("Enqueued job: \(job.meetingTitle) (\(job.id))")
+        logger.info("Enqueued job: \(job.meetingTitle, privacy: .private) (\(job.id))")
         triggerProcessing()
     }
 
@@ -1010,7 +1010,7 @@ class PipelineQueue {
         // --- Save Transcript & Audio (always) ---
         let protocolsDir = outputDir.appendingPathComponent("protocols")
         let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: ctx.title, dir: protocolsDir)
-        logger.info("[\(ctx.shortID, privacy: .public)] transcript_saved file=\(txtPath.lastPathComponent, privacy: .public)")
+        logger.info("[\(ctx.shortID, privacy: .public)] transcript_saved file=\(txtPath.lastPathComponent, privacy: .private)")
 
         if let idx = jobs.firstIndex(where: { $0.id == ctx.jobID }) {
             jobs[idx].transcriptPath = txtPath
@@ -1097,7 +1097,7 @@ class PipelineQueue {
             let mdPath = try ProtocolGenerator.saveProtocol(
                 fullMD, title: title, dir: protocolsDir,
             )
-            logger.info("[\(shortID, privacy: .public)] protocol_saved file=\(mdPath.lastPathComponent, privacy: .public)")
+            logger.info("[\(shortID, privacy: .public)] protocol_saved file=\(mdPath.lastPathComponent, privacy: .private)")
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
                 jobs[idx].protocolPath = mdPath
             }
@@ -1388,7 +1388,7 @@ class PipelineQueue {
         let now = Date()
         for job in jobs where job.state == .speakerNamingPending {
             if now.timeIntervalSince(job.enqueuedAt) > maxAge {
-                logger.info("Auto-resolving stale pending naming for \(job.meetingTitle)")
+                logger.info("Auto-resolving stale pending naming for \(job.meetingTitle, privacy: .private)")
                 let jobID = job.id
                 let slug = job.namingSlug
                 acceptAutoNames(jobID: jobID, slug: slug)
@@ -1550,15 +1550,15 @@ class PipelineQueue {
             // re-picks the new name on next launch). The file is already at its
             // final home; keep it put.
             if src.deletingLastPathComponent().standardizedFileURL == outputDirStd {
-                logger.info("Audio already in output dir, skipping rename: \(src.lastPathComponent)")
+                logger.info("Audio already in output dir, skipping rename: \(src.lastPathComponent, privacy: .private)")
                 continue
             }
             do {
                 if fm.fileExists(atPath: dst.path) { try fm.removeItem(at: dst) }
                 try fm.moveItem(at: src, to: dst)
-                logger.info("Audio moved: \(name)")
+                logger.info("Audio moved: \(name, privacy: .private)")
             } catch {
-                logger.warning("Failed to move audio \(name): \(error.localizedDescription)")
+                logger.warning("Failed to move audio \(name, privacy: .private): \(error.localizedDescription)")
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -113,7 +113,7 @@ enum ProtocolGenerator {
         try text.write(to: url, atomically: true, encoding: .utf8)
         // Transcripts contain verbatim meeting speech — restrict to owner-only.
         try FileManager.default.restrictToOwner(url)
-        logger.info("Transcript saved: \(url.lastPathComponent)")
+        logger.info("Transcript saved: \(url.lastPathComponent, privacy: .private)")
         return url
     }
 
@@ -128,7 +128,7 @@ enum ProtocolGenerator {
         try markdown.write(to: url, atomically: true, encoding: .utf8)
         // Protocol markdown summarises the meeting — restrict to owner-only.
         try FileManager.default.restrictToOwner(url)
-        logger.info("Protocol saved: \(url.lastPathComponent)")
+        logger.info("Protocol saved: \(url.lastPathComponent, privacy: .private)")
         return url
     }
 

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -215,7 +215,7 @@ class WatchLoop {
             await self.monitorManualRecording(pid: pid)
         }
 
-        logger.info("Manual recording started for \(appName) (PID \(pid)): \(title)")
+        logger.info("Manual recording started for \(appName) (PID \(pid)): \(title, privacy: .private)")
     }
 
     func stopManualRecording() {
@@ -427,7 +427,7 @@ class WatchLoop {
             participants: participants,
         )
         pipelineQueue?.enqueue(job)
-        logger.info("Enqueued pipeline job for: \(title)")
+        logger.info("Enqueued pipeline job for: \(title, privacy: .private)")
     }
 
     /// Convert a `ProcessInfo.systemUptime`-based timestamp captured at recording
@@ -480,7 +480,7 @@ class WatchLoop {
                 micFilename: movedMic?.lastPathComponent,
             )
             try sidecar.write(toDirectory: destDir, basename: basename)
-            logger.info("Record-only: wrote sidecar + WAVs to \(destDir.path) for \(title)")
+            logger.info("Record-only: wrote sidecar + WAVs to \(destDir.path) for \(title, privacy: .private)")
         } catch {
             logger.error("Record-only: \(error.localizedDescription)")
             update { next in


### PR DESCRIPTION
## Why

`os.Logger` interpolations that carry meeting titles or recording/transcript file basenames (which embed the sanitized title slug) currently rely on Swift's **implicit** default that dynamic `String` interpolation is `.private` (redacted in the persisted/streamed unified log). That's safe today, but a future refactor adding `, privacy: .public` to one of these sites would silently leak meeting titles into the unified log captured by the persistent diagnostic log stream.

This makes the `.private` intent **explicit** at these sites — matching how live-caption text is already explicitly tagged. Pure log-redaction change, **no runtime behavior change**.

Two basename sites (`transcript_saved` / `protocol_saved`) were previously tagged `.public`; since those filenames embed the title slug, they are switched to `.private`.

## Sites tagged

**WatchLoop.swift**
- manual-recording-started: `title`
- enqueued pipeline job: `title`
- record-only sidecar write: `title`

**PipelineQueue.swift**
- enqueued job: `meetingTitle`
- auto-resolve stale pending naming: `meetingTitle`
- `transcript_saved` basename (`.public` → `.private`)
- `protocol_saved` basename (`.public` → `.private`)
- audio skip-rename basename, audio-moved basename, audio-move-failed basename (all embed the slug via `<date>_<slug>` filenames)

**ProtocolGenerator.swift**
- transcript-saved basename, protocol-saved basename (`filename(title:ext:)` → `<date>_<slug>.<ext>`)

**AudioMixer.swift**
- AVAudioFile fallback, AVAsset fallback log basenames — the general-purpose loader (`loadAudioAsFloat32`) can carry a slug-bearing or user-imported filename, so these are tagged conservatively.

## Out of scope (intentionally untouched)

- `DualSourceRecorder.swift` log sites: their filenames are pure `<timestamp>_<suffix>` (the title slug is only prepended later during pipeline rename) — no title leak, so no change.
- The OpenAI/Claude-CLI stderr/error-body `.public` logging — separate concern, not edited here.
- Already-correct sites (e.g. the existing explicit `title=…, privacy: .private` and the pseudonymized `[shortID, privacy: .public]` tags) left as-is.

## Tests

`os.Logger` privacy is a format-string attribute, not runtime-observable behavior, so it isn't meaningfully unit-testable — consistent with how the existing live-caption `.private` tagging carries no test. No test added or widened.

## Verify

- `swift build` and `swift build -c release` both green.
- `./scripts/lint.sh` → SwiftFormat 0/240 require formatting, SwiftLint 0 violations.