### PR TITLE
Post-merge review follow-ups: ingest doc, OpenAI branch tests, ffmpeg log privacy

### DIFF
--- a/app/MeetingTranscriber/Sources/FFmpegHelper.swift
+++ b/app/MeetingTranscriber/Sources/FFmpegHelper.swift
@@ -100,7 +100,7 @@ enum FFmpegHelper {
             throw AudioMixerError.ffmpegNotAvailable
         }
 
-        logger.info("ffmpeg converting: \(url.lastPathComponent)")
+        logger.info("ffmpeg converting: \(url.lastPathComponent, privacy: .private)")
 
         // Read stderr in background to prevent pipe buffer deadlock
         async let stderrRead = Task.detached {
@@ -132,7 +132,7 @@ enum FFmpegHelper {
 
         // Load the temp WAV file
         let samples = try AudioMixer.loadAudioFileAsFloat32(url: tempURL)
-        logger.info("ffmpeg extracted \(samples.count) samples at 16kHz from \(url.lastPathComponent)")
+        logger.info("ffmpeg extracted \(samples.count) samples at 16kHz from \(url.lastPathComponent, privacy: .private)")
         return (samples, AudioConstants.targetSampleRate)
     }
 

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -65,8 +65,10 @@ actor StreamingTranscriber {
     }
 
     /// Feed a captured buffer into the streaming pipeline. Buffers that don't
-    /// match the expected 16 kHz mono shape are dropped silently — for now,
-    /// only mic-channel buffers are supported.
+    /// match the expected 16 kHz mono shape are dropped silently. Both mic and
+    /// app channels are normalized to that shape upstream (mic via
+    /// `MicCaptureHandler`, app via `LiveAudioResampler` in
+    /// `LiveTranscriptionController`) before reaching here.
     func ingest(_ buffer: LiveAudioBuffer) async {
         guard buffer.channelCount == 1, buffer.sampleRate == 16000 else { return }
         inputAccumulator.append(contentsOf: buffer.samples)

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -157,6 +157,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
     override func tearDown() {
         MockURLProtocol.handler = nil
         MockURLProtocol.errorHandler = nil
+        MockURLProtocol.rawResponseHandler = nil
         super.tearDown()
     }
 
@@ -341,6 +342,70 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         }
     }
 
+    func testGenerateNonHTTPResponseThrowsConnectionFailed() async {
+        // A delivered response that isn't an HTTPURLResponse must map to
+        // .connectionFailed("Invalid response") — generate()'s
+        // `response as? HTTPURLResponse` guard, not a crash or hang.
+        MockURLProtocol.rawResponseHandler = { request in
+            // swiftlint:disable:next force_unwrapping
+            let response = URLResponse(url: request.url!, mimeType: "text/plain", expectedContentLength: 0, textEncodingName: nil)
+            return (response, Data())
+        }
+
+        let gen = makeGenerator(session: makeMockSession())
+        do {
+            _ = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
+            XCTFail("Expected connectionFailed")
+        } catch let error as ProtocolError {
+            guard case .connectionFailed = error else {
+                XCTFail("Expected connectionFailed, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Expected ProtocolError.connectionFailed, got \(error)")
+        }
+    }
+
+    func testTestConnectionMalformed2xxBodyReturnsEmptySuccess() async {
+        // A 2xx whose JSON lacks a "data" array is a soft success with no
+        // models, not a failure.
+        MockURLProtocol.handler = { request in
+            self.mockResponse(request, body: Data(#"{"object":"list"}"#.utf8))
+        }
+
+        let result = await OpenAIProtocolGenerator.testConnection(
+            endpoint: "http://test.local/v1/chat/completions",
+            model: "test",
+            apiKey: nil,
+            session: makeMockSession(),
+        )
+        if case let .success(models) = result {
+            XCTAssertEqual(models, [])
+        } else {
+            XCTFail("Expected empty success, got \(result)")
+        }
+    }
+
+    func testTestConnectionSortsModelNames() async {
+        // Model ids are returned sorted regardless of the server's order.
+        let modelsJSON = #"{"data":[{"id":"mistral"},{"id":"alpaca"},{"id":"llama3"}]}"#
+        MockURLProtocol.handler = { request in
+            self.mockResponse(request, body: Data(modelsJSON.utf8))
+        }
+
+        let result = await OpenAIProtocolGenerator.testConnection(
+            endpoint: "http://test.local/v1/chat/completions",
+            model: "test",
+            apiKey: nil,
+            session: makeMockSession(),
+        )
+        if case let .success(models) = result {
+            XCTAssertEqual(models, ["alpaca", "llama3", "mistral"])
+        } else {
+            XCTFail("Expected success, got \(result)")
+        }
+    }
+
     func testTestConnectionInvalidEndpoint() async {
         let result = await OpenAIProtocolGenerator.testConnection(
             endpoint: "",
@@ -422,6 +487,9 @@ private final class MockURLProtocol: URLProtocol {
     // (mirrors a connection refused / DNS failure / dropped socket). Takes
     // precedence over `handler` so the generator's catch path is exercised.
     nonisolated(unsafe) static var errorHandler: ((URLRequest) -> any Error)?
+    // When set, delivers a NON-HTTP `URLResponse` (takes precedence over
+    // `handler`) so the generator's `response as? HTTPURLResponse` guard fails.
+    nonisolated(unsafe) static var rawResponseHandler: ((URLRequest) -> (URLResponse, Data))?
 
     override static func canInit(with _: URLRequest) -> Bool {
         true
@@ -434,6 +502,13 @@ private final class MockURLProtocol: URLProtocol {
     override func startLoading() {
         if let errorHandler = Self.errorHandler {
             client?.urlProtocol(self, didFailWithError: errorHandler(request))
+            return
+        }
+        if let rawResponseHandler = Self.rawResponseHandler {
+            let (response, data) = rawResponseHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
             return
         }
         guard let handler = Self.handler else {


### PR DESCRIPTION
Three small follow-ups surfaced while re-reviewing the recently-merged doc/test/privacy changes (#345 / #346 / #347). Independent, one atomic commit each.

## Commits
- **`docs(app)`** — the StreamingTranscriber header was corrected to say both channels are supported, but the `ingest` method doc 50 lines below still said "only mic-channel buffers are supported" (same stale claim, file self-contradicted). Aligned it.
- **`test(app)`** — cover three previously-uncovered `OpenAIProtocolGenerator` branches: `generate()` non-HTTPURLResponse → `connectionFailed` (via a new `rawResponseHandler` on the test `MockURLProtocol`), `testConnection()` 2xx-without-`data`-array → empty `.success`, and `testConnection()` sorts model names (feeds unsorted, asserts sorted).
- **`fix(app)`** — the two ffmpeg conversion logs interpolate the source basename, which for user-imported files can carry a meeting title; marked them `privacy: .private` to match the other title/basename log sites (the 3rd fallback tier of the same import chain whose earlier tiers were already tagged).

## Verification
`swift build` + `swift build -c release` clean; `swift test --filter OpenAIProtocolGeneratorTests` → 37/37 (was 34); `./scripts/lint.sh` → 0 violations.