### PR TITLE
ci: gate quality runs against a committed WER/DER baseline

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -5,8 +5,8 @@ name: Quality & Safety
 #   - TSan/ASan sanitizer sweeps (catches races/UB the static checker
 #     can't see; ~10–15 min per leg).
 #   - WER/DER quality regression (downloads ~1 GB of model weights and
-#     runs real ASR; produces the baseline artifact future PRs diff
-#     against).
+#     runs real ASR, then diffs the result against the committed baseline
+#     in Tests/Fixtures/quality/quality-baseline.json; fails on regression).
 #
 # Triggers: push to main, nightly cron, and explicit manual dispatch.
 # Never runs on pull requests — review iteration stays fast.
@@ -137,6 +137,20 @@ jobs:
           QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
           WHISPERKIT_MODEL: openai_whisper-large-v3-v20240930_turbo
         run: cd app/MeetingTranscriber && swift test --filter "WhisperKitQualityTests|FluidDiarizerQualityTests|ParakeetQualityTests"
+      # Diff this run's WER/DER against the committed baseline
+      # (Tests/Fixtures/quality/quality-baseline.json). Fails the job if any
+      # metric regressed beyond tolerance — a relative regression the per-test
+      # catastrophic floors (0.5/0.6/0.85) wouldn't catch. MUST stay a separate
+      # `swift test` invocation: folding the gate into the measurement filter
+      # wouldn't guarantee the gate class runs last (XCTest orders classes
+      # alphabetically), so it could read a half-flushed results file and
+      # silently treat not-yet-run engines as "missing". Intended quality
+      # changes re-bless via scripts/bless_quality_baseline.sh in the same PR.
+      - name: Compare against quality baseline
+        env:
+          RUN_QUALITY_TESTS: "1"
+          QUALITY_RESULTS_PATH: ${{ github.workspace }}/quality-results.json
+        run: cd app/MeetingTranscriber && swift test --filter QualityBaselineGateTests
       - name: Upload quality results
         if: always()
         uses: actions/upload-artifact@v7

--- a/app/MeetingTranscriber/Tests/Fixtures/quality/quality-baseline.json
+++ b/app/MeetingTranscriber/Tests/Fixtures/quality/quality-baseline.json
@@ -1,0 +1,44 @@
+[
+  {
+    "der": 0.6811,
+    "engine": "fluidDiarizer.offline",
+    "fixture": "three_speakers_de"
+  },
+  {
+    "der": 0.5325,
+    "engine": "fluidDiarizer.offline",
+    "fixture": "two_speakers_de"
+  },
+  {
+    "der": 0.0898,
+    "engine": "fluidDiarizer.sortformer",
+    "fixture": "three_speakers_de"
+  },
+  {
+    "der": 0.0597,
+    "engine": "fluidDiarizer.sortformer",
+    "fixture": "two_speakers_de"
+  },
+  {
+    "engine": "parakeet",
+    "fixture": "three_speakers_de",
+    "wer": 0.4528
+  },
+  {
+    "engine": "parakeet",
+    "fixture": "two_speakers_de",
+    "wer": 0.4286
+  },
+  {
+    "engine": "whisperKit",
+    "fixture": "three_speakers_de",
+    "modelVariant": "openai_whisper-large-v3-v20240930_turbo",
+    "wer": 0.2642
+  },
+  {
+    "engine": "whisperKit",
+    "fixture": "two_speakers_de",
+    "modelVariant": "openai_whisper-large-v3-v20240930_turbo",
+    "wer": 0.2857
+  }
+]

--- a/app/MeetingTranscriber/Tests/Quality/QualityBaselineGate.swift
+++ b/app/MeetingTranscriber/Tests/Quality/QualityBaselineGate.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Format a metric value for human-readable gate output (notes + summaries).
+private func qualityMetricString(_ value: Double) -> String {
+    String(format: "%.4f", value)
+}
+
+/// Human-readable row label (`engine/fixture [variant]`) shared by gate notes
+/// and regression summaries so the two never drift.
+private func qualityRowLabel(engine: String, fixture: String, modelVariant: String?) -> String {
+    "\(engine)/\(fixture)\(modelVariant.map { " [\($0)]" } ?? "")"
+}
+
+/// One blessed data point in the committed `quality-baseline.json`. The slim
+/// counterpart to `QualityResult`: only the fields the gate compares on, none
+/// of the volatile ones (`timestamp`, `durationSeconds`, `appVersion`,
+/// breakdowns) so re-blessing produces a clean, reviewable diff.
+struct QualityBaselineEntry: Codable, Equatable {
+    let engine: String
+    let fixture: String
+    let modelVariant: String?
+    let wer: Double?
+    let der: Double?
+}
+
+/// Which metric a regression is about.
+enum QualityMetric: String, Equatable {
+    case wer
+    case der
+}
+
+/// How much a metric may regress before the gate fails. The effective
+/// allowance for a row is `max(absolute, relativeFraction * baseline)`:
+/// the absolute floor keeps low-baseline metrics (e.g. Sortformer DER ~0.06)
+/// honest, while the proportional term gives high-baseline metrics (e.g.
+/// offline DER ~0.6) room for the larger absolute jitter they naturally show.
+/// Both absorb the small CoreML/ANE run-to-run variance on GitHub-hosted
+/// runners. Conservative by default; tighten once observed variance is known.
+struct QualityTolerance: Equatable {
+    /// Minimum allowed regression regardless of baseline magnitude.
+    let absolute: Double
+    /// Extra allowance as a fraction of the baseline value.
+    let relativeFraction: Double
+
+    static let `default` = Self(absolute: 0.03, relativeFraction: 0.20)
+
+    /// Effective absolute allowance for a given baseline value.
+    func allowance(forBaseline baseline: Double) -> Double {
+        max(absolute, relativeFraction * baseline)
+    }
+}
+
+/// A single metric that regressed beyond tolerance (or disappeared).
+struct QualityRegression: Equatable {
+    let engine: String
+    let fixture: String
+    let modelVariant: String?
+    let metric: QualityMetric
+    let baseline: Double
+    /// `nil` when the current run produced the row but dropped the metric.
+    let current: Double?
+    let tolerance: Double
+
+    var summary: String {
+        let label = qualityRowLabel(engine: engine, fixture: fixture, modelVariant: modelVariant)
+        guard let current else {
+            return "\(label) \(metric.rawValue): measurement disappeared (baseline \(qualityMetricString(baseline)))"
+        }
+        let delta = current - baseline
+        return "\(label) \(metric.rawValue): \(qualityMetricString(baseline)) → \(qualityMetricString(current)) "
+            + "(+\(qualityMetricString(delta)) > tol \(qualityMetricString(tolerance)))"
+    }
+}
+
+/// Outcome of comparing a fresh `quality-results.json` against the committed
+/// baseline. Only `regressions` fail the gate; `notes` are informational
+/// (improvements, new/unbaselined rows, rows missing from the current run).
+struct QualityGateReport: Equatable {
+    let regressions: [QualityRegression]
+    let notes: [String]
+    var passed: Bool {
+        regressions.isEmpty
+    }
+}
+
+/// Pure comparison logic for the quality regression gate plus the thin file-IO
+/// wrapper the CI step uses. Lives in the test target — it is CI/test
+/// infrastructure, never linked into the app.
+enum QualityBaselineGate {
+    private struct Key: Hashable {
+        let engine: String
+        let fixture: String
+        let modelVariant: String?
+    }
+
+    /// A decrease smaller than this is treated as stable, not an improvement —
+    /// it's below the baseline's 4-decimal rounding granularity, so the current
+    /// full-precision value dipping a hair under the rounded baseline is noise.
+    private static let improvementEpsilon = 0.001
+
+    static func compare(
+        baseline: [QualityBaselineEntry],
+        current: [QualityResult],
+        tolerance: QualityTolerance = .default,
+    ) -> QualityGateReport {
+        // Index the current run by key; a duplicate key keeps the later row.
+        var currentByKey: [Key: QualityResult] = [:]
+        for row in current {
+            currentByKey[Key(engine: row.engine, fixture: row.fixture, modelVariant: row.modelVariant)] = row
+        }
+        let baselineKeys = Set(baseline.map { Key(engine: $0.engine, fixture: $0.fixture, modelVariant: $0.modelVariant) })
+
+        var regressions: [QualityRegression] = []
+        var notes: [String] = []
+
+        for entry in baseline {
+            let key = Key(engine: entry.engine, fixture: entry.fixture, modelVariant: entry.modelVariant)
+            guard let row = currentByKey[key] else {
+                notes.append("missing from current run: \(label(key))")
+                continue
+            }
+            let metrics: [(QualityMetric, Double?, Double?)] = [
+                (.wer, entry.wer, row.wer),
+                (.der, entry.der, row.der),
+            ]
+            for (metric, base, cur) in metrics {
+                switch evaluate(metric, baseline: base, current: cur, entry: entry, tolerance: tolerance) {
+                case let .regression(regression): regressions.append(regression)
+                case let .improvement(note): notes.append(note)
+                case .ok: break
+                }
+            }
+        }
+
+        for row in current {
+            let key = Key(engine: row.engine, fixture: row.fixture, modelVariant: row.modelVariant)
+            guard !baselineKeys.contains(key) else { continue }
+            notes.append("unbaselined (no baseline entry): \(label(key)) — bless to start tracking it")
+        }
+
+        return QualityGateReport(regressions: regressions, notes: notes.sorted())
+    }
+
+    /// Decode both files and compare. Throws if either file is missing or malformed.
+    static func loadAndCompare(
+        baselineURL: URL,
+        resultsURL: URL,
+        tolerance: QualityTolerance = .default,
+    ) throws -> QualityGateReport {
+        let baseline = try JSONDecoder().decode([QualityBaselineEntry].self, from: Data(contentsOf: baselineURL))
+        let current = try JSONDecoder().decode([QualityResult].self, from: Data(contentsOf: resultsURL))
+        return compare(baseline: baseline, current: current, tolerance: tolerance)
+    }
+
+    /// Committed baseline: `quality-baseline.json` in the shared quality
+    /// fixtures dir (reused from `GroundTruth`). `QUALITY_BASELINE_PATH`
+    /// overrides it.
+    static var committedBaselineURL: URL {
+        if let override = ProcessInfo.processInfo.environment["QUALITY_BASELINE_PATH"] {
+            return URL(fileURLWithPath: override)
+        }
+        return GroundTruth.qualityFixturesDir.appendingPathComponent("quality-baseline.json")
+    }
+
+    // MARK: - Helpers
+
+    private enum MetricOutcome {
+        case regression(QualityRegression)
+        case improvement(String)
+        case ok
+    }
+
+    /// Pure verdict for one metric of one baseline row. Returns `.ok` when the
+    /// baseline doesn't track this metric or the current value is within
+    /// tolerance, `.regression` when it exceeded tolerance or disappeared, and
+    /// `.improvement` when it dropped meaningfully below the baseline.
+    private static func evaluate(
+        _ metric: QualityMetric,
+        baseline: Double?,
+        current: Double?,
+        entry: QualityBaselineEntry,
+        tolerance: QualityTolerance,
+    ) -> MetricOutcome {
+        guard let baseline else { return .ok } // baseline doesn't track this metric for this row
+        let allowance = tolerance.allowance(forBaseline: baseline)
+        guard let current else {
+            return .regression(.init(
+                engine: entry.engine, fixture: entry.fixture, modelVariant: entry.modelVariant,
+                metric: metric, baseline: baseline, current: nil, tolerance: allowance,
+            ))
+        }
+        let delta = current - baseline
+        if delta > allowance {
+            return .regression(.init(
+                engine: entry.engine, fixture: entry.fixture, modelVariant: entry.modelVariant,
+                metric: metric, baseline: baseline, current: current, tolerance: allowance,
+            ))
+        }
+        if delta < -improvementEpsilon {
+            let label = qualityRowLabel(engine: entry.engine, fixture: entry.fixture, modelVariant: entry.modelVariant)
+            return .improvement("improvement: \(label) \(metric.rawValue) "
+                + "\(qualityMetricString(baseline)) → \(qualityMetricString(current))")
+        }
+        return .ok
+    }
+
+    private static func label(_ key: Key) -> String {
+        qualityRowLabel(engine: key.engine, fixture: key.fixture, modelVariant: key.modelVariant)
+    }
+}

--- a/app/MeetingTranscriber/Tests/Quality/QualityBaselineGateTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/QualityBaselineGateTests.swift
@@ -1,0 +1,312 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Pure-logic + file-IO tests for the quality baseline gate. These run on every
+/// `swift test` (no `RUN_QUALITY_TESTS` gate) because they exercise only the
+/// comparison logic against synthetic rows — no models, no fixtures.
+///
+/// The one heavyweight, env-gated assertion (`test_qualityResultsMatchBaseline`)
+/// lives at the bottom and skips unless the dedicated quality job set up the
+/// results file.
+final class QualityBaselineGateTests: XCTestCase {
+    // MARK: - compare(): regressions
+
+    func test_compare_flagsWERRegressionBeyondTolerance() {
+        let baseline = [entry(engine: "whisperKit", fixture: "two", wer: 0.20)]
+        let current = [result(engine: "whisperKit", fixture: "two", wer: 0.30)]
+
+        let report = QualityBaselineGate.compare(
+            baseline: baseline,
+            current: current,
+            tolerance: .init(absolute: 0.05, relativeFraction: 0),
+        )
+
+        XCTAssertFalse(report.passed)
+        XCTAssertEqual(report.regressions.count, 1)
+        let r = try? XCTUnwrap(report.regressions.first)
+        XCTAssertEqual(r?.metric, .wer)
+        XCTAssertEqual(r?.engine, "whisperKit")
+        XCTAssertEqual(r?.fixture, "two")
+        XCTAssertEqual(r?.baseline, 0.20)
+        XCTAssertEqual(r?.current, 0.30)
+    }
+
+    func test_compare_passesWithinTolerance() {
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "whisperKit", fixture: "two", wer: 0.20)],
+            current: [result(engine: "whisperKit", fixture: "two", wer: 0.24)],
+            tolerance: .init(absolute: 0.05, relativeFraction: 0),
+        )
+
+        XCTAssertTrue(report.passed)
+        XCTAssertTrue(report.regressions.isEmpty)
+    }
+
+    func test_compare_improvementIsNotARegression() {
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "whisperKit", fixture: "two", wer: 0.30)],
+            current: [result(engine: "whisperKit", fixture: "two", wer: 0.20)],
+        )
+
+        XCTAssertTrue(report.passed)
+        XCTAssertTrue(
+            report.notes.contains { $0.lowercased().contains("improv") },
+            "expected an improvement note, got: \(report.notes)",
+        )
+    }
+
+    func test_compare_disappearedMetricIsRegression() {
+        // Baseline measured DER; current run produced the row but no DER value
+        // (a broken diarizer test would do this). Losing a measurement must fail.
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "fluidDiarizer.offline", fixture: "two", der: 0.50)],
+            current: [result(engine: "fluidDiarizer.offline", fixture: "two")],
+        )
+
+        XCTAssertFalse(report.passed)
+        XCTAssertEqual(report.regressions.first?.metric, .der)
+        XCTAssertNil(report.regressions.first?.current)
+    }
+
+    func test_relativeToleranceCatchesLowBaselineRegression() {
+        // Sortformer-style low DER: a +0.04 jump on a 0.06 baseline is a large
+        // relative regression that the old flat-0.05 tolerance waved through.
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "fluidDiarizer.sortformer", fixture: "two", der: 0.06)],
+            current: [result(engine: "fluidDiarizer.sortformer", fixture: "two", der: 0.10)],
+            tolerance: .init(absolute: 0.03, relativeFraction: 0.20),
+        )
+
+        XCTAssertFalse(report.passed)
+        XCTAssertEqual(report.regressions.first?.metric, .der)
+    }
+
+    func test_relativeToleranceAllowsProportionalDriftOnHighBaseline() {
+        // Offline DER ~0.60: a +0.10 absolute move is within the proportional
+        // band (0.20 × 0.60 = 0.12), so it must not fail the gate.
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "fluidDiarizer.offline", fixture: "two", der: 0.60)],
+            current: [result(engine: "fluidDiarizer.offline", fixture: "two", der: 0.70)],
+            tolerance: .init(absolute: 0.03, relativeFraction: 0.20),
+        )
+
+        XCTAssertTrue(report.passed)
+    }
+
+    // MARK: - compare(): structural mismatches are warnings, not failures
+
+    func test_compare_unbaselinedCurrentEntryIsNoteNotRegression() {
+        let report = QualityBaselineGate.compare(
+            baseline: [],
+            current: [result(engine: "parakeet", fixture: "two", wer: 0.40)],
+        )
+
+        XCTAssertTrue(report.passed)
+        XCTAssertTrue(
+            report.notes.contains { $0.contains("parakeet") },
+            "expected an unbaselined note mentioning the engine, got: \(report.notes)",
+        )
+    }
+
+    func test_compare_missingFromCurrentRunIsNoteNotRegression() {
+        let report = QualityBaselineGate.compare(
+            baseline: [entry(engine: "whisperKit", fixture: "two", wer: 0.20)],
+            current: [],
+        )
+
+        XCTAssertTrue(report.passed)
+        XCTAssertTrue(
+            report.notes.contains { $0.contains("whisperKit") },
+            "expected a missing-row note mentioning the engine, got: \(report.notes)",
+        )
+    }
+
+    // MARK: - compare(): key discrimination + multi-metric
+
+    func test_compare_keyIncludesModelVariant() {
+        // Same engine+fixture, different model variant → distinct rows. A current
+        // row for variant A must not satisfy the baseline for variant B.
+        let baseline = [
+            entry(engine: "whisperKit", fixture: "two", modelVariant: "turbo", wer: 0.20),
+            entry(engine: "whisperKit", fixture: "two", modelVariant: "tiny", wer: 0.40),
+        ]
+        let current = [result(engine: "whisperKit", fixture: "two", modelVariant: "turbo", wer: 0.21)]
+
+        let report = QualityBaselineGate.compare(baseline: baseline, current: current)
+
+        XCTAssertTrue(report.passed, "turbo within tolerance, tiny just missing")
+        XCTAssertTrue(
+            report.notes.contains { $0.contains("tiny") },
+            "expected the unmatched tiny variant to be reported missing, got: \(report.notes)",
+        )
+    }
+
+    func test_compare_handlesWERandDERRowsIndependently() {
+        let baseline = [
+            entry(engine: "whisperKit", fixture: "two", wer: 0.20),
+            entry(engine: "fluidDiarizer.offline", fixture: "two", der: 0.50),
+        ]
+        let current = [
+            result(engine: "whisperKit", fixture: "two", wer: 0.21), // ok
+            result(engine: "fluidDiarizer.offline", fixture: "two", der: 0.70), // regressed
+        ]
+
+        let report = QualityBaselineGate.compare(
+            baseline: baseline,
+            current: current,
+            tolerance: .init(absolute: 0.05, relativeFraction: 0),
+        )
+
+        XCTAssertEqual(report.regressions.count, 1)
+        XCTAssertEqual(report.regressions.first?.metric, .der)
+        XCTAssertEqual(report.regressions.first?.engine, "fluidDiarizer.offline")
+    }
+
+    // MARK: - JSON decoding of the real wire shapes
+
+    func test_baselineEntryDecodesSlimShapeWithOmittedKeys() throws {
+        // The committed baseline omits nil keys (modelVariant / the unused metric).
+        let json = """
+        [
+          { "engine": "parakeet", "fixture": "two_speakers_de", "wer": 0.4286 },
+          { "engine": "whisperKit", "fixture": "two_speakers_de", "modelVariant": "turbo", "wer": 0.2857 },
+          { "engine": "fluidDiarizer.offline", "fixture": "two_speakers_de", "der": 0.5325 }
+        ]
+        """
+        let entries = try JSONDecoder().decode([QualityBaselineEntry].self, from: Data(json.utf8))
+
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertNil(entries[0].modelVariant)
+        XCTAssertEqual(entries[0].wer, 0.4286)
+        XCTAssertNil(entries[0].der)
+        XCTAssertEqual(entries[1].modelVariant, "turbo")
+        XCTAssertEqual(entries[2].der, 0.5325)
+    }
+
+    func test_qualityResultArrayDecodesFromWriterOutput() throws {
+        // Shape produced by QualityResultsWriter.flush() — nil keys omitted.
+        let json = """
+        [
+          {
+            "appVersion": "16.0", "durationSeconds": 1.6, "engine": "parakeet",
+            "fixture": "two_speakers_de", "timestamp": "2026-05-31T20:01:14Z",
+            "wer": 0.4286,
+            "werBreakdown": { "deletions": 4, "insertions": 1, "referenceLength": 28, "substitutions": 7 }
+          }
+        ]
+        """
+        let rows = try JSONDecoder().decode([QualityResult].self, from: Data(json.utf8))
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].engine, "parakeet")
+        XCTAssertEqual(rows[0].wer, 0.4286)
+        XCTAssertNil(rows[0].der)
+        XCTAssertNil(rows[0].modelVariant)
+    }
+
+    // MARK: - loadAndCompare(): file IO
+
+    func test_loadAndCompareReadsBothFilesAndDetectsRegression() throws {
+        let dir = try makeTempDirectory(prefix: "quality-gate")
+        let baselineURL = dir.appendingPathComponent("baseline.json")
+        let resultsURL = dir.appendingPathComponent("results.json")
+
+        try Data("""
+        [ { "engine": "whisperKit", "fixture": "two", "modelVariant": "turbo", "wer": 0.20 } ]
+        """.utf8).write(to: baselineURL)
+
+        try Data("""
+        [ {
+          "appVersion": "dev", "durationSeconds": 1.0, "engine": "whisperKit",
+          "fixture": "two", "modelVariant": "turbo", "timestamp": "t", "wer": 0.40
+        } ]
+        """.utf8).write(to: resultsURL)
+
+        let report = try QualityBaselineGate.loadAndCompare(
+            baselineURL: baselineURL,
+            resultsURL: resultsURL,
+            tolerance: .init(absolute: 0.05, relativeFraction: 0),
+        )
+
+        XCTAssertFalse(report.passed)
+        XCTAssertEqual(report.regressions.first?.metric, .wer)
+    }
+
+    func test_loadAndCompareThrowsWhenResultsFileMissing() throws {
+        let dir = try makeTempDirectory(prefix: "quality-gate")
+        let baselineURL = dir.appendingPathComponent("baseline.json")
+        try Data("[]".utf8).write(to: baselineURL)
+
+        XCTAssertThrowsError(
+            try QualityBaselineGate.loadAndCompare(
+                baselineURL: baselineURL,
+                resultsURL: dir.appendingPathComponent("does-not-exist.json"),
+            ),
+        )
+    }
+
+    // MARK: - CI gate (env-gated, heavyweight)
+
+    /// The actual regression gate the `quality-and-safety` workflow runs as a
+    /// separate step after the measurement classes have flushed
+    /// `QUALITY_RESULTS_PATH`. Skipped unless that job opted in, so a normal
+    /// `swift test` never needs the results file to exist.
+    func test_qualityResultsMatchBaseline() throws {
+        try skipUnlessQualityRun()
+        let resultsPath = try XCTUnwrap(
+            ProcessInfo.processInfo.environment["QUALITY_RESULTS_PATH"],
+            "QUALITY_RESULTS_PATH must be set for the gate (written by the measurement step)",
+        )
+        let report = try QualityBaselineGate.loadAndCompare(
+            baselineURL: QualityBaselineGate.committedBaselineURL,
+            resultsURL: URL(fileURLWithPath: resultsPath),
+        )
+
+        for note in report.notes {
+            print("[quality-gate] note: \(note)")
+        }
+        for r in report.regressions {
+            print("[quality-gate] REGRESSION: \(r.summary)")
+        }
+
+        XCTAssertTrue(
+            report.passed,
+            "Quality regressed vs the committed baseline. Re-bless with "
+                + "scripts/bless_quality_baseline.sh once the change is intended.\n"
+                + report.regressions.map(\.summary).joined(separator: "\n"),
+        )
+    }
+
+    // MARK: - Builders
+
+    private func entry(
+        engine: String,
+        fixture: String,
+        modelVariant: String? = nil,
+        wer: Double? = nil,
+        der: Double? = nil,
+    ) -> QualityBaselineEntry {
+        QualityBaselineEntry(engine: engine, fixture: fixture, modelVariant: modelVariant, wer: wer, der: der)
+    }
+
+    private func result(
+        engine: String,
+        fixture: String,
+        modelVariant: String? = nil,
+        wer: Double? = nil,
+        der: Double? = nil,
+    ) -> QualityResult {
+        QualityResult(
+            engine: engine,
+            fixture: fixture,
+            modelVariant: modelVariant,
+            wer: wer,
+            der: der,
+            werBreakdown: nil,
+            derBreakdown: nil,
+            appVersion: "dev",
+            timestamp: "t",
+            durationSeconds: 0,
+        )
+    }
+}

--- a/scripts/bless_quality_baseline.sh
+++ b/scripts/bless_quality_baseline.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Project a full `quality-results.json` (array of QualityResult rows, as
+# produced by the quality-and-safety workflow) into the slim, reviewable
+# `quality-baseline.json` that the CI regression gate diffs against.
+#
+# The slim baseline keeps only the comparison surface — engine, fixture,
+# modelVariant, wer, der — and drops the volatile fields (timestamp,
+# durationSeconds, appVersion, breakdowns) so a re-bless produces a clean diff.
+# Metric/variant keys that are null are omitted, matching the writer's output.
+# Values are rounded to 4 decimals (far finer than the gate tolerance).
+#
+# Re-bless workflow when a quality change is intended:
+#   1. Download the latest main `quality-results.json` artifact, OR run the
+#      quality suite locally with QUALITY_RESULTS_PATH set.
+#   2. ./scripts/bless_quality_baseline.sh path/to/quality-results.json
+#   3. Review + commit the updated baseline in the SAME PR as the change.
+#
+# Usage: scripts/bless_quality_baseline.sh <quality-results.json>
+
+set -euo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is required"; exit 1; }
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <quality-results.json>" >&2
+    exit 2
+fi
+
+RESULTS="$1"
+[ -f "$RESULTS" ] || { echo "ERROR: results file not found: $RESULTS" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+OUT="$PROJECT_DIR/app/MeetingTranscriber/Tests/Fixtures/quality/quality-baseline.json"
+
+python3 - "$RESULTS" "$OUT" <<'PY'
+import json, sys
+
+results_path, out_path = sys.argv[1], sys.argv[2]
+with open(results_path) as f:
+    rows = json.load(f)
+
+def slim(row):
+    out = {"engine": row["engine"], "fixture": row["fixture"]}
+    if row.get("modelVariant") is not None:
+        out["modelVariant"] = row["modelVariant"]
+    for metric in ("wer", "der"):
+        if row.get(metric) is not None:
+            out[metric] = round(row[metric], 4)
+    return out
+
+baseline = [slim(r) for r in rows]
+baseline.sort(key=lambda r: (r["engine"], r["fixture"], r.get("modelVariant") or ""))
+
+with open(out_path, "w") as f:
+    json.dump(baseline, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+print(f"Wrote {len(baseline)} baseline rows to {out_path}")
+PY


### PR DESCRIPTION
## Problem

The `quality-and-safety` workflow already runs real ASR + diarization on the
German fixtures and uploads `quality-results.json` (per-engine WER, per-diarizer
DER). But **nothing ever compared a run against a baseline** — the artifact just
accumulated. The per-test thresholds (0.5 / 0.6 / 0.85) only catch *catastrophic*
breakage (corrupted model, audio not loaded); a relative drop like WER 0.28 → 0.40
clears the floor and lands silently.

## What this adds

A regression gate that diffs each run against a committed, reviewable baseline.

- **`QualityBaselineGate`** — a pure comparator (test target, never linked into
  the app). Joins a run's `QualityResult` rows to the baseline on
  `(engine, fixture, modelVariant)` and flags any metric that regressed past its
  allowance.
- **Combined tolerance:** `max(absolute, relativeFraction × baseline)`
  (defaults 0.03 / 0.20). The absolute floor keeps low-baseline metrics honest
  (Sortformer DER ~0.06 can't quietly double), while the proportional term gives
  high-baseline metrics (offline DER ~0.6) room for the larger absolute jitter
  they naturally show.
- **Structural changes are warnings, not failures:** a row missing from the run,
  or a new/unbaselined row, is logged but doesn't fail the gate — so adding or
  removing a fixture doesn't break CI. A *vanished metric* (row present, value
  gone) **is** a regression.
- **Committed baseline** `Tests/Fixtures/quality/quality-baseline.json`, seeded
  from the latest green main run. Slim shape (comparison surface only — no
  volatile timestamps/durations) so re-blessing yields a clean diff.
- **`scripts/bless_quality_baseline.sh`** projects a full `quality-results.json`
  into that slim shape. When a quality change is intended, re-bless and commit
  the new baseline in the same PR.
- **CI wiring:** a `Compare against quality baseline` step runs after the
  measurement step flushes the results file (separate `swift test` invocation so
  it reads the written file rather than racing the measurement classes in one
  process). Runs on main push + nightly only — a post-merge regression detector,
  not a PR blocker (the suite is ~45 min + ~1 GB of models).

## Verification (local)

- Comparator + file-IO fully unit-tested (14 pure tests, all green); the
  heavyweight gate assertion is gated behind `RUN_QUALITY_TESTS` so a normal
  `swift test` never needs the results file.
- Ran the gate against the real main artifact: **passes** on identical data
  (no spurious notes).
- Tampered a Sortformer DER 0.06 → 0.10 (which the old flat-0.05 tolerance would
  have waved through): **fails** with `+0.0403 > tol 0.0300`. Tampered a
  WhisperKit WER 0.29 → 0.40: **fails**. Acceptance per the "e2e must exercise
  the real chain" rule — corrupt the data, the gate goes red.
- Lint clean.