### PR TITLE
refactor(app): unify diarize() speaker-assignment paths into DiarizationProcess.labelSegments

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -31,6 +31,12 @@ protocol DiarizationProvider: Sendable {
 
 /// Speaker assignment utilities.
 enum DiarizationProcess {
+    /// Speaker tag carried by app/remote-audio segments in a dual-source mix.
+    /// Written by `TranscribingEngine.mergeDualSourceSegments` and read back
+    /// here when splitting cached segments per track — both sides must agree,
+    /// so the literal lives in one place.
+    static let remoteSpeakerLabel = "Remote"
+
     /// Assign speaker labels to transcript segments by maximum temporal overlap.
     /// Uses `autoNames` to replace raw labels (e.g. "SPEAKER_0") with human names.
     /// When no overlap exists, falls back to the nearest diarization segment by gap distance.
@@ -193,6 +199,78 @@ enum DiarizationProcess {
         var result = labeledApp + labeledMic
         result.sort { $0.start < $1.start }
         return result
+    }
+}
+
+extension DiarizationProcess {
+    /// The three diarization topologies the pipeline produces, each carrying
+    /// the data its speaker assignment needs. `labelSegments` collapses what
+    /// used to be three near-duplicate inline assignment blocks in
+    /// `PipelineQueue.diarize` — the merge + formatting tail they all shared is
+    /// now applied once at the call site.
+    enum LabelingTopology {
+        /// Single mixed track: every transcript segment is assigned against one
+        /// diarization.
+        case single(segments: [TimestampedSegment], diarization: DiarizationResult)
+        /// Dual track, both diarizations succeeded: cached segments are split by
+        /// their `Remote` / `micLabel` tag and assigned against their own
+        /// `R_` / `M_`-unprefixed diarization.
+        case dualTrack(cached: [TimestampedSegment], micLabel: String, app: DiarizationResult, mic: DiarizationResult)
+        /// Dual track, mic diarization failed: app segments are assigned against
+        /// the app diarization; mic segments keep their raw `micLabel` rather
+        /// than being force-matched.
+        case dualTrackAppOnly(cached: [TimestampedSegment], micLabel: String, app: DiarizationResult)
+    }
+
+    /// Apply speaker labels for any diarization topology, returning segments
+    /// ready for `mergeConsecutiveSpeakers` + formatting. `autoNames` carries
+    /// the speaker→name mapping (`R_`/`M_`-prefixed for the dual-track cases).
+    static func labelSegments(_ topology: LabelingTopology, autoNames: [String: String]) -> [TimestampedSegment] {
+        switch topology {
+        case let .single(segments, diarization):
+            let named = DiarizationResult(
+                segments: diarization.segments,
+                speakingTimes: diarization.speakingTimes,
+                autoNames: autoNames,
+                embeddings: diarization.embeddings,
+            )
+            return assignSpeakers(transcript: segments, diarization: named)
+
+        case let .dualTrack(cached, micLabel, app, mic):
+            let namedApp = DiarizationResult(
+                segments: app.segments,
+                speakingTimes: app.speakingTimes,
+                autoNames: unprefixNames(autoNames, prefix: "R_"),
+                embeddings: app.embeddings,
+            )
+            let namedMic = DiarizationResult(
+                segments: mic.segments,
+                speakingTimes: mic.speakingTimes,
+                autoNames: unprefixNames(autoNames, prefix: "M_"),
+                embeddings: mic.embeddings,
+            )
+            let appSegs = cached.filter { $0.speaker == remoteSpeakerLabel }
+            let micSegs = cached.filter { $0.speaker == micLabel }
+            return assignSpeakersDualTrack(
+                appSegments: appSegs,
+                micSegments: micSegs,
+                appDiarization: namedApp,
+                micDiarization: namedMic,
+            )
+
+        case let .dualTrackAppOnly(cached, micLabel, app):
+            let namedApp = DiarizationResult(
+                segments: app.segments,
+                speakingTimes: app.speakingTimes,
+                autoNames: unprefixNames(autoNames, prefix: "R_"),
+                embeddings: app.embeddings,
+            )
+            let appSegs = cached.filter { $0.speaker == remoteSpeakerLabel }
+            let micSegs = cached.filter { $0.speaker == micLabel }
+            let labeledApp = assignSpeakers(transcript: appSegs, diarization: namedApp)
+            // micSegs keep their original micLabel speaker tag.
+            return (labeledApp + micSegs).sorted { $0.start < $1.start }
+        }
     }
 }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -920,72 +920,33 @@ class PipelineQueue {
                 break diarizationLoop
             }
 
-            // Apply speaker names to segments
+            // Apply speaker names to segments. The three topologies (dual-track,
+            // mic-fail app-only fallback, single-source) share the same
+            // merge + format tail, applied once here.
+            let topology: DiarizationProcess.LabelingTopology?
             if useDualTrack, let appDiar = appDiarization, let micDiar = micDiarization,
                let cached = cachedSegments {
-                // Dual-track: assign from respective diarizations
-                let namedAppDiar = DiarizationResult(
-                    segments: appDiar.segments,
-                    speakingTimes: appDiar.speakingTimes,
-                    autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "R_"),
-                    embeddings: appDiar.embeddings,
-                )
-                let namedMicDiar = DiarizationResult(
-                    segments: micDiar.segments,
-                    speakingTimes: micDiar.speakingTimes,
-                    autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "M_"),
-                    embeddings: micDiar.embeddings,
-                )
-
-                let appSegs = cached.filter { $0.speaker == "Remote" }
-                let micSegs = cached.filter { $0.speaker == micLabel }
-                let labeled = DiarizationProcess.assignSpeakersDualTrack(
-                    appSegments: appSegs,
-                    micSegments: micSegs,
-                    appDiarization: namedAppDiar,
-                    micDiarization: namedMicDiar,
-                )
-                let merged = DiarizationProcess.mergeConsecutiveSpeakers(labeled)
-                finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
+                topology = .dualTrack(cached: cached, micLabel: micLabel, app: appDiar, mic: micDiar)
             } else if useDualTrack, let appDiar = appDiarization, let cached = cachedSegments {
-                // Mic diarization failed (silent track / no input
-                // device). Diarize the app track normally and keep
-                // the mic transcript with its raw `micLabel` —
-                // better than emitting "speakers not identified"
-                // on a recording that has perfectly good remote
-                // audio.
-                let namedAppDiar = DiarizationResult(
-                    segments: appDiar.segments,
-                    speakingTimes: appDiar.speakingTimes,
-                    autoNames: DiarizationProcess.unprefixNames(autoNames, prefix: "R_"),
-                    embeddings: appDiar.embeddings,
-                )
-                let appSegs = cached.filter { $0.speaker == "Remote" }
-                let micSegs = cached.filter { $0.speaker == micLabel }
-                let labeledApp = DiarizationProcess.assignSpeakers(
-                    transcript: appSegs, diarization: namedAppDiar,
-                )
-                // micSegs keep their original micLabel speaker tag.
-                let combined = (labeledApp + micSegs).sorted { $0.start < $1.start }
-                let merged = DiarizationProcess.mergeConsecutiveSpeakers(combined)
-                finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
+                // Mic diarization failed (silent track / no input device). Keep
+                // the mic transcript with its raw `micLabel` — better than
+                // emitting "speakers not identified" on a recording that has
+                // perfectly good remote audio.
+                topology = .dualTrackAppOnly(cached: cached, micLabel: micLabel, app: appDiar)
             } else if let currentDiarization = diarization {
-                // Single-source: standard assignment
-                let namedDiarization = DiarizationResult(
-                    segments: currentDiarization.segments,
-                    speakingTimes: currentDiarization.speakingTimes,
-                    autoNames: autoNames,
-                    embeddings: currentDiarization.embeddings,
-                )
-                let segments: [TimestampedSegment] = if let cached = cachedSegments {
+                // Single-source: standard assignment. cachedSegments is set by
+                // the transcribe stage in practice; re-transcribe defensively.
+                let segments = if let cached = cachedSegments {
                     cached
                 } else {
                     try await engine.transcribeSegments(audioPath: mix16k)
                 }
-                let labeled = DiarizationProcess.assignSpeakers(
-                    transcript: segments,
-                    diarization: namedDiarization,
-                )
+                topology = .single(segments: segments, diarization: currentDiarization)
+            } else {
+                topology = nil
+            }
+            if let topology {
+                let labeled = DiarizationProcess.labelSegments(topology, autoNames: autoNames)
                 let merged = DiarizationProcess.mergeConsecutiveSpeakers(labeled)
                 finalTranscript = merged.map(\.formattedLine).joined(separator: "\n")
             }

--- a/app/MeetingTranscriber/Sources/TranscribingEngine.swift
+++ b/app/MeetingTranscriber/Sources/TranscribingEngine.swift
@@ -48,7 +48,7 @@ extension TranscribingEngine {
         }
 
         for i in app.indices {
-            app[i].speaker = "Remote"
+            app[i].speaker = DiarizationProcess.remoteSpeakerLabel
         }
         for i in mic.indices {
             mic[i].speaker = micLabel

--- a/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
@@ -1,0 +1,78 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `DiarizationProcess.labelSegments`, the topology-dispatching
+/// speaker-assignment entry point that unifies the three formerly-inline
+/// assignment blocks in `PipelineQueue.diarize` (single-source / dual-track /
+/// dual-track mic-fail app-only fallback).
+final class DiarizationLabelSegmentsTests: XCTestCase {
+    func testLabelSegmentsSingleAppliesAutoNames() {
+        let segments = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "World"),
+        ]
+        let diarization = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let result = DiarizationProcess.labelSegments(
+            .single(segments: segments, diarization: diarization),
+            autoNames: ["SPEAKER_0": "Alice", "SPEAKER_1": "Bob"],
+        )
+        XCTAssertEqual(result.map(\.speaker), ["Alice", "Bob"])
+    }
+
+    func testLabelSegmentsDualTrackUnprefixesAndAssignsPerTrack() {
+        // App track tagged "Remote", mic track tagged with micLabel "Me".
+        let cached = [
+            TimestampedSegment(start: 0, end: 5, text: "app line", speaker: "Remote"),
+            TimestampedSegment(start: 5, end: 10, text: "mic line", speaker: "Me"),
+        ]
+        let app = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "S0")],
+            speakingTimes: ["S0": 5], autoNames: [:], embeddings: nil,
+        )
+        let mic = DiarizationResult(
+            segments: [.init(start: 5, end: 10, speaker: "S0")],
+            speakingTimes: ["S0": 5], autoNames: [:], embeddings: nil,
+        )
+        // autoNames arrive R_/M_-prefixed (as mergeDualTrackDiarization produces).
+        let result = DiarizationProcess.labelSegments(
+            .dualTrack(cached: cached, micLabel: "Me", app: app, mic: mic),
+            autoNames: ["R_S0": "Alice", "M_S0": "Bob"],
+        )
+        XCTAssertEqual(result.map(\.speaker), ["Alice", "Bob"])
+        XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
+    }
+
+    func testLabelSegmentsDualTrackAppOnlyKeepsRawMicLabel() {
+        let cached = [
+            TimestampedSegment(start: 0, end: 5, text: "app line", speaker: "Remote"),
+            TimestampedSegment(start: 5, end: 10, text: "mic line", speaker: "Me"),
+        ]
+        // In the real mic-fail path diarize() passes the *unprefixed* app
+        // diarization (`diarization = appDiarization`), so segment IDs and
+        // autoNames keys are raw ("SPEAKER_0"), not R_-prefixed.
+        let app = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5], autoNames: [:], embeddings: nil,
+        )
+        let result = DiarizationProcess.labelSegments(
+            .dualTrackAppOnly(cached: cached, micLabel: "Me", app: app),
+            autoNames: ["SPEAKER_0": "Alice"],
+        )
+        // Mic segments keep their raw micLabel (intended). App segments
+        // currently surface the raw diarizer ID rather than "Alice":
+        // labelSegments unprefixes autoNames with "R_", but the app-only
+        // fallback's keys are already unprefixed, so the mapping is dropped.
+        // Pinned as current behavior — the app-track name-loss in this fallback
+        // is a known issue tracked for a separate fix.
+        XCTAssertEqual(result.map(\.speaker), ["SPEAKER_0", "Me"])
+        XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -768,25 +768,151 @@ final class PipelineQueueTests: XCTestCase {
         ]
         let (pQueue, _) = makeMockProcessingQueue(engine: engine)
 
-        let audioPath = try createTestAudioFile(in: tmpDir)
-        let appPath = tmpDir.appendingPathComponent("app_audio.wav")
-        let micPath = tmpDir.appendingPathComponent("mic_audio.wav")
-        try FileManager.default.copyItem(at: audioPath, to: appPath)
-        try FileManager.default.copyItem(at: audioPath, to: micPath)
-
-        let job = PipelineJob(
-            meetingTitle: "Dual Source",
-            appName: "Teams",
-            mixPath: audioPath,
-            appPath: appPath,
-            micPath: micPath,
-            micDelay: 0,
-        )
-        pQueue.enqueue(job)
+        try pQueue.enqueue(makeDualSourceJob(title: "Dual Source"))
         await pQueue.processNext()
 
         // Dual source: transcribes app + mic = 2 calls
         XCTAssertEqual(engine.transcribeCallCount, 2)
+    }
+
+    // MARK: - diarize() assign-phase characterization
+
+    //
+    // These pin the final speaker-labeled transcript that diarize() hands to
+    // protocol generation, for each of its three assignment topologies
+    // (single-source / dual-track-both / dual-track-mic-fail). They guard the
+    // extraction of the assignment logic into DiarizationProcess: the
+    // observable output must stay identical across the refactor. `embeddings:
+    // nil` short-circuits the matcher + naming dialog so the job flows straight
+    // through to the assignment branch.
+
+    private func makeCapturingQueue(
+        engine: MockEngine,
+        diar: MockDiarization,
+        protocolGen: MockProtocolGen,
+    ) -> PipelineQueue {
+        PipelineQueue(
+            engine: engine,
+            diarizationFactory: { diar },
+            diarizationFactoryWithMode: nil,
+            protocolGeneratorFactory: { protocolGen },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            diarizeEnabled: true,
+            numSpeakers: 0,
+            micLabel: "Me",
+        )
+    }
+
+    private func makeDualSourceJob(title: String) throws -> PipelineJob {
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let appPath = tmpDir.appendingPathComponent("app_audio.wav")
+        let micPath = tmpDir.appendingPathComponent("mic_audio.wav")
+        try? FileManager.default.removeItem(at: appPath)
+        try? FileManager.default.removeItem(at: micPath)
+        try FileManager.default.copyItem(at: audioPath, to: appPath)
+        try FileManager.default.copyItem(at: audioPath, to: micPath)
+        return PipelineJob(
+            meetingTitle: title, appName: "Teams",
+            mixPath: audioPath, appPath: appPath, micPath: micPath, micDelay: 0,
+        )
+    }
+
+    func testDiarizeSingleSourceLabelsTranscriptWithAutoNames() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello world")]
+        let diar = MockDiarization()
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: ["SPEAKER_0": "Alice"],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        q.enqueue(PipelineJob(
+            meetingTitle: "Single", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        ))
+        await q.processNext()
+
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        XCTAssertTrue(
+            transcript.contains("Alice: Hello world"),
+            "single-source: SPEAKER_0 should map to Alice — got: \(transcript)",
+        )
+    }
+
+    func testDiarizeDualTrackLabelsBothTracks() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let diar = MockDiarization()
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: ["SPEAKER_0": "Alice"],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        try q.enqueue(makeDualSourceJob(title: "Dual"))
+        await q.processNext()
+
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        // Both tracks' segments are assigned via their (R_/M_-unprefixed) diarization → Alice.
+        XCTAssertTrue(transcript.contains("Alice:"), "dual-track: speakers should be named — got: \(transcript)")
+        XCTAssertFalse(transcript.contains("Remote:"), "dual-track: raw 'Remote' app label should be replaced")
+        XCTAssertFalse(
+            transcript.contains("] Me:"),
+            "dual-track: raw 'Me' mic label should be replaced when mic diarization succeeds — got: \(transcript)",
+        )
+    }
+
+    func testDiarizeDualTrackMicFailKeepsRawMicLabel() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let diar = MockDiarization()
+        diar.throwOnPathSuffix = "mic_16k.wav" // mic diarization fails → app-only fallback
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: ["SPEAKER_0": "Alice"],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        try q.enqueue(makeDualSourceJob(title: "Dual MicFail"))
+        await q.processNext()
+
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        // App-only fallback: mic segments keep their raw 'Me' label (not force-matched).
+        XCTAssertTrue(
+            transcript.contains("] Me:"),
+            "mic-fail fallback: mic segments keep raw mic label — got: \(transcript)",
+        )
+        // Pin the app track too, so this test actually exercises labelSegments
+        // (asserting only the surviving raw mic label would pass even against a
+        // no-op). The app segment is assigned via assignSpeakers; the diarizer
+        // ID "SPEAKER_0" surfaces because the app-only fallback unprefixes
+        // autoNames with "R_" against already-unprefixed keys (the documented
+        // name-loss) — but it must no longer carry the raw "Remote" tag.
+        XCTAssertTrue(
+            transcript.contains("SPEAKER_0:"),
+            "mic-fail fallback: app segments are assigned (raw diarizer ID surfaces) — got: \(transcript)",
+        )
+        XCTAssertFalse(
+            transcript.contains("Remote:"),
+            "mic-fail fallback: app segments must lose their raw 'Remote' tag — got: \(transcript)",
+        )
+        let warnings = try XCTUnwrap(q.jobs.first?.warnings)
+        XCTAssertTrue(
+            warnings.contains { $0.contains("Mic track diarization failed") },
+            "mic-fail fallback should add a warning — got: \(warnings)",
+        )
     }
 
     func testSpeakerNamingHandlerCalled() async throws {


### PR DESCRIPTION
## What

`PipelineQueue.diarize` carried three near-identical speaker-assignment branches — single-source, dual-track, and the mic-fail app-only fallback — each building a named `DiarizationResult`, assigning speakers, then running the same `mergeConsecutiveSpeakers` + `formattedLine` tail. The tail was duplicated verbatim three times, and the branch logic was only reachable through the full pipeline.

This extracts the assignment into a pure, directly-testable `DiarizationProcess.labelSegments(_:autoNames:)` that dispatches on a `LabelingTopology` enum; the caller now applies the shared merge + format tail once.

## Why

`diarize()` is the largest remaining monolith in `PipelineQueue` and the home of the dual-/single-track divergence. Pulling the assignment out:

- removes the 3× duplicated merge + format tail,
- makes the per-topology assignment logic unit-testable in isolation rather than only through the pipeline,
- de-risks a later extraction of the diarization stage out of the queue.

Behavior is preserved exactly.

## How it's verified

- **Characterization first:** end-to-end tests pin the final speaker-labeled transcript `diarize()` produces for all three topologies (observed via the captured protocol-generator transcript). Confirmed green against the *unrefactored* code, then kept green through the extraction.
- **Unit tests** for `labelSegments` covering each topology directly.
- Full `PipelineQueueTests` + `DiarizationProcessTests` + new tests: **137 green**.
- Strict lint + format clean; release-build parity check passes.

## Notes / follow-ups

- The `"Remote"` app-track tag is now a shared `DiarizationProcess.remoteSpeakerLabel` constant — it was previously hardcoded independently in the engine's dual-source merge and the diarize filter, which had to agree by hand.
- `diarize()` shrinks but stays above the body-length threshold, so its lint suppression remains; fully removing it needs a separate extraction of the speaker-naming loop, left for a follow-up.
- The mic-fail app-only fallback currently surfaces raw diarizer speaker IDs instead of matched names (it strips an `R_` prefix from keys that are already unprefixed). This is pinned as current behavior by a test and flagged for a separate fix — out of scope for this behavior-preserving refactor.