### PR TITLE
fix(app): keep app-track speaker names in the mic-fail diarization fallback

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -259,10 +259,14 @@ extension DiarizationProcess {
             )
 
         case let .dualTrackAppOnly(cached, micLabel, app):
+            // Mic diarization failed, so `combined` is the *unprefixed* app
+            // diarization — autoNames keys are raw ("SPEAKER_0"), not "R_"-prefixed.
+            // Pass them through directly; unprefixing would drop every mapping and
+            // surface raw diarizer IDs instead of matched names.
             let namedApp = DiarizationResult(
                 segments: app.segments,
                 speakingTimes: app.speakingTimes,
-                autoNames: unprefixNames(autoNames, prefix: "R_"),
+                autoNames: autoNames,
                 embeddings: app.embeddings,
             )
             let appSegs = cached.filter { $0.speaker == remoteSpeakerLabel }

--- a/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
@@ -66,13 +66,10 @@ final class DiarizationLabelSegmentsTests: XCTestCase {
             .dualTrackAppOnly(cached: cached, micLabel: "Me", app: app),
             autoNames: ["SPEAKER_0": "Alice"],
         )
-        // Mic segments keep their raw micLabel (intended). App segments
-        // currently surface the raw diarizer ID rather than "Alice":
-        // labelSegments unprefixes autoNames with "R_", but the app-only
-        // fallback's keys are already unprefixed, so the mapping is dropped.
-        // Pinned as current behavior — the app-track name-loss in this fallback
-        // is a known issue tracked for a separate fix.
-        XCTAssertEqual(result.map(\.speaker), ["SPEAKER_0", "Me"])
+        // App segments are assigned their matched name (the autoNames keys are
+        // already unprefixed in this fallback, since `combined == appDiarization`).
+        // Mic segments keep their raw micLabel (mic wasn't diarized).
+        XCTAssertEqual(result.map(\.speaker), ["Alice", "Me"])
         XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
     }
 }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -894,15 +894,17 @@ final class PipelineQueueTests: XCTestCase {
             transcript.contains("] Me:"),
             "mic-fail fallback: mic segments keep raw mic label — got: \(transcript)",
         )
-        // Pin the app track too, so this test actually exercises labelSegments
-        // (asserting only the surviving raw mic label would pass even against a
-        // no-op). The app segment is assigned via assignSpeakers; the diarizer
-        // ID "SPEAKER_0" surfaces because the app-only fallback unprefixes
-        // autoNames with "R_" against already-unprefixed keys (the documented
-        // name-loss) — but it must no longer carry the raw "Remote" tag.
+        // The app track is still diarized + named: its segment gets the matched
+        // name "Alice", not the raw diarizer ID and not the pre-assignment
+        // "Remote" tag. (This is the bug fix — the app-only fallback used to
+        // drop app-track names by unprefixing already-unprefixed keys.)
         XCTAssertTrue(
+            transcript.contains("Alice:"),
+            "mic-fail fallback: app segments keep their matched name — got: \(transcript)",
+        )
+        XCTAssertFalse(
             transcript.contains("SPEAKER_0:"),
-            "mic-fail fallback: app segments are assigned (raw diarizer ID surfaces) — got: \(transcript)",
+            "mic-fail fallback: app segments must not surface the raw diarizer ID — got: \(transcript)",
         )
         XCTAssertFalse(
             transcript.contains("Remote:"),


### PR DESCRIPTION
## Bug

On a dual-source recording where the **mic track fails to diarize** (silent mic / no input device — e.g. a host without a real input), remote/app speakers surfaced as raw diarizer IDs (`SPEAKER_0`) in the transcript instead of their recognised names.

## Cause

In that case the pipeline falls back to app-only: `combined` becomes the *unprefixed* app diarization, so the matched names land in `autoNames` under raw keys (`SPEAKER_0`), not `R_`-prefixed ones. But `DiarizationProcess.labelSegments`' `.dualTrackAppOnly` case still unprefixed them with `"R_"` — which matched nothing and dropped the entire mapping, so `assignSpeakers` fell back to the raw diarizer ID.

## Fix

Pass `autoNames` straight through in the `.dualTrackAppOnly` case. The dual-track **both** case still unprefixes, because there the names come from the prefixed dual-track merge (`mergeDualTrackDiarization`) while the per-track segments are unprefixed — that asymmetry is now explicit in the code.

## Verification

- TDD: the unit test that previously pinned the wrong output (`["SPEAKER_0", "Me"]`) now asserts the matched name survives (`["Alice", "Me"]`); confirmed RED against the old code, GREEN after the fix.
- The end-to-end mic-fail characterization test asserts the transcript now contains the matched name and neither the raw diarizer ID nor the pre-assignment `Remote` tag.
- Single-source and dual-track-both paths traced + their regression tests unchanged and green. 137 tests pass; strict lint + release-build parity clean.

## Scope

Targeted fix for the batch pipeline path. A separate, lower-frequency sibling exists in the late re-diarization path (clicking Re-run in the naming dialog on a mic-fail dual-source job rebuilds prefixed dual-track topology without a mic-fail fallback) — tracked as its own follow-up, not bundled here to keep this change atomic.