### PR TITLE
fix(app): apply mic-fail fallback to late re-diarization

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -830,22 +830,44 @@ class PipelineQueue {
             return DiarizationRun(app: nil, mic: nil, combined: diarization)
         }
 
+        return try await runDualTrackDiarization(
+            diarizeProcess: diarizeProcess,
+            tracks: (
+                app: workDir.appendingPathComponent("app_16k.wav"),
+                mic: workDir.appendingPathComponent("mic_16k.wav"),
+            ),
+            speakerCount: speakerCount, title: ctx.title, jobID: ctx.jobID,
+        )
+    }
+
+    /// Diarize the app + mic tracks separately, tolerating a mic-track failure
+    /// (silent track on a host without a real input device). The app track is
+    /// required; on mic failure the `combined` result is the *unprefixed* app
+    /// diarization — so downstream naming keys stay consistent with the
+    /// persisted app-only transcript — rather than the `R_`/`M_`-prefixed merge.
+    /// Shared by the batch (`runDiarization`) and late re-run
+    /// (`runLateDiarization`) paths so the mic-fail fallback can't diverge
+    /// between them.
+    private func runDualTrackDiarization(
+        diarizeProcess: any DiarizationProvider,
+        tracks: (app: URL, mic: URL),
+        speakerCount: Int?, title: String, jobID: UUID,
+    ) async throws -> DiarizationRun {
         let appDiarization = try await diarizeProcess.run(
-            audioPath: workDir.appendingPathComponent("app_16k.wav"),
-            numSpeakers: speakerCount, meetingTitle: ctx.title,
+            audioPath: tracks.app, numSpeakers: speakerCount, meetingTitle: title,
         )
         var micDiarization: DiarizationResult?
         do {
             micDiarization = try await diarizeProcess.run(
-                audioPath: workDir.appendingPathComponent("mic_16k.wav"),
+                audioPath: tracks.mic,
                 numSpeakers: nil, // auto-detect local speakers
-                meetingTitle: ctx.title,
+                meetingTitle: title,
             )
         } catch {
             logger.warning(
-                "[\(ctx.shortID, privacy: .public)] mic_diarization_failed error=\(error.localizedDescription, privacy: .public) — falling back to app-only diarization",
+                "[\(PipelineJob.shortID(for: jobID), privacy: .public)] mic_diarization_failed error=\(error.localizedDescription, privacy: .public) — falling back to app-only diarization",
             )
-            addWarning(id: ctx.jobID, "Mic track diarization failed — speaker labels reflect remote audio only")
+            addWarning(id: jobID, "Mic track diarization failed — speaker labels reflect remote audio only")
             micDiarization = nil
         }
 
@@ -1239,7 +1261,7 @@ class PipelineQueue {
             let title = jobs[jobIndex].meetingTitle
             let diarization = try await runLateDiarization(
                 diarizer: diarizeProcess,
-                audioBase: (dir: recordingsDir, slug: slug),
+                recording: (dir: recordingsDir, slug: slug, jobID: jobID),
                 isDualSource: namingData.isDualSource,
                 speakerCount: speakerCount, title: title,
             )
@@ -1280,24 +1302,30 @@ class PipelineQueue {
     /// keep its function body under the lint cap.
     private func runLateDiarization(
         diarizer: any DiarizationProvider,
-        audioBase: (dir: URL, slug: String),
+        recording: (dir: URL, slug: String, jobID: UUID),
         isDualSource: Bool,
         speakerCount: Int,
         title: String,
     ) async throws -> DiarizationResult {
-        let (recordingsDir, slug) = audioBase
+        let (recordingsDir, slug, jobID) = recording
         if isDualSource {
-            let app16k = recordingsDir.appendingPathComponent("\(slug)_app_16k.wav")
-            let mic16k = recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav")
-            async let appDiar = diarizer.run(
-                audioPath: app16k, numSpeakers: speakerCount, meetingTitle: title,
+            // Mirror the batch path's mic-fail fallback (via the shared helper):
+            // a silent/failing mic track must degrade to the unprefixed app-only
+            // diarization, not throw (a no-op re-run) or emit prefixed keys the
+            // persisted app-only transcript can't match.
+            let run = try await runDualTrackDiarization(
+                diarizeProcess: diarizer,
+                tracks: (
+                    app: recordingsDir.appendingPathComponent("\(slug)_app_16k.wav"),
+                    mic: recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav"),
+                ),
+                speakerCount: speakerCount, title: title, jobID: jobID,
             )
-            async let micDiar = diarizer.run(
-                audioPath: mic16k, numSpeakers: nil, meetingTitle: title,
-            )
-            return try await DiarizationProcess.mergeDualTrackDiarization(
-                appDiarization: appDiar, micDiarization: micDiar,
-            )
+            // Dual-track always yields a combined result (the merge or the
+            // app-only fallback); the optional is only the diarize-loop
+            // placeholder's concern.
+            guard let combined = run.combined else { throw DiarizationError.notAvailable }
+            return combined
         }
         let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
         return try await diarizer.run(

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2036,6 +2036,71 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(pQueue.jobs.first?.usedDiarizerMode, .offline)
     }
 
+    /// Late re-run of a dual-source job whose mic track fails to diarize must
+    /// fall back to the *unprefixed* app-only diarization — mirroring the batch
+    /// `runDiarization` path — instead of throwing (a silent no-op that bounces
+    /// the job back to pending) or emitting `R_`-prefixed keys that no longer
+    /// match the persisted app-only transcript. Regression guard for the
+    /// late-path sibling of the batch mic-fail app-name-loss bug.
+    func testLateRerunDualSourceMicFailFallsBackToAppOnly() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let mockDiar = MockDiarization()
+        mockDiar.mode = .offline
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        // First run: both tracks succeed → reach speakerNamingPending with
+        // persisted naming data + namingSlug + persisted _app_16k/_mic_16k audio.
+        try pQueue.enqueue(makeDualSourceJob(title: "Late MicFail"))
+        let job = try XCTUnwrap(pQueue.jobs.first)
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+
+        // Re-run: make ONLY the mic track fail. The fallback must still drive the
+        // naming dialog (no silent no-op) with the raw, unprefixed app keys.
+        mockDiar.throwOnPathSuffix = "_mic_16k.wav"
+        var rerunKeys: [String] = []
+        // The handler firing at all proves the fallback ran — the buggy path
+        // throws on the mic track and bounces back to pending without calling it.
+        let handlerCalled = XCTestExpectation(description: "naming handler called after mic-fail fallback")
+        pQueue.speakerNamingHandler = { data in
+            rerunKeys = Array(data.mapping.keys)
+            handlerCalled.fulfill()
+            return .confirmed([:])
+        }
+
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(2))
+        await fulfillment(of: [handlerCalled], timeout: 10)
+
+        XCTAssertTrue(
+            rerunKeys.contains("SPEAKER_0"),
+            "fallback should expose the raw app diarization keys — got: \(rerunKeys)",
+        )
+        XCTAssertFalse(
+            rerunKeys.contains { $0.hasPrefix("R_") || $0.hasPrefix("M_") },
+            "mic-fail fallback must use the unprefixed app diarization, not the R_/M_ merge — got: \(rerunKeys)",
+        )
+        let warnings = try XCTUnwrap(pQueue.jobs.first?.warnings)
+        XCTAssertTrue(
+            warnings.contains { $0.contains("Mic track diarization failed") },
+            "late mic-fail fallback should add a warning, like the batch path — got: \(warnings)",
+        )
+    }
+
     /// `isAvailable == false` short-circuits lateDiarization without
     /// changing the job state — there's no recoverable path so the
     /// user is left to fix the configuration (model download, etc.).


### PR DESCRIPTION
## Problem

The dual-source **late re-diarization** path (the speaker-naming dialog's **Re-run** button → `runLateDiarization`) diverged from the batch path (`runDiarization`):

- It diarized the mic track with **no try/catch** and **always merged** the two tracks with `R_`/`M_` prefixes.
- The batch path, by contrast, tolerates a mic-track failure (a silent track on a host without a real input device) by falling back to the **unprefixed app-only** diarization.

So on a dual-source job whose mic track fails to diarize, a Re-run either:

1. **Silently no-ops** — the mic diarization throws, the merge throws, `lateDiarization` catches it and bounces the job straight back to `.speakerNamingPending`. Clicking Re-run appears to do nothing; or
2. **Drops the app-track names** — if the (usually silent) mic track yields a spurious cluster, the rebuilt naming keys become `R_SPEAKER_0` etc., which the persisted app-only transcript (raw, unprefixed labels) can never match.

This is the late-path sibling of the batch mic-fail bug fixed earlier.

## Fix

Factor the batch path's mic try/catch + unprefixed app-only fallback into a shared `runDualTrackDiarization()` that **both** `runDiarization` (batch) and `runLateDiarization` (late) call, so the fallback can no longer diverge between the two paths. On mic failure the `combined` result is the unprefixed app diarization, keeping downstream naming keys consistent with the persisted transcript; a matching warning is surfaced on both paths.

The shared helper runs the two tracks sequentially (matching the well-tested batch path) so the mic-only failure can be caught and degraded cleanly — a deliberate trade against the late path's former `async let` concurrency, on a rare user-triggered action.

## Test

`testLateRerunDualSourceMicFailFallsBackToAppOnly` drives a dual-source late re-run with a failing mic track and asserts the naming dialog still fires (no silent no-op) with **unprefixed** keys, plus a mic-fail warning. It fails against the pre-fix code (the handler is never called) and passes after.

Full suite green; release-build parity clean.