### PR TITLE
test(app): pin WatchLoop's recorder start-arg threading

### DIFF
--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -179,6 +179,8 @@ func makeTestWatchLoop(
     recordOnly: @escaping () -> Bool = { false },
     recordOnlyOutputDir: @escaping () -> URL = { AppPaths.recordingsDir },
     notifier: any AppNotifying = SilentNotifier(),
+    noMic: Bool = false,
+    micDeviceUID: String? = nil,
 ) -> (WatchLoop, MockRecorder) {
     let recorder = MockRecorder()
     recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
@@ -188,6 +190,8 @@ func makeTestWatchLoop(
         pipelineQueue: pipelineQueue,
         pollInterval: 0.05,
         endGracePeriod: 0.1,
+        noMic: noMic,
+        micDeviceUID: micDeviceUID,
         recordOnly: recordOnly,
         recordOnlyDestination: { .unscoped(recordOnlyOutputDir()) },
         notifier: notifier,
@@ -261,14 +265,25 @@ class MockRecorder: RecordingProvider {
     var startCalled = false
     var stopCalled = false
 
+    /// Args captured from the last `start(...)` so tests can pin that `WatchLoop`
+    /// threads them through (appPID, noMic, micDeviceUID) instead of only checking
+    /// `startCalled`. Defaults are deliberately "impossible" values so an unset or
+    /// dropped argument fails an equality assertion rather than passing silently.
+    var capturedAppPID: pid_t = -1
+    var capturedNoMic = false
+    var capturedMicDeviceUID: String?
+
     /// Per-channel level overrides for asymmetric-silence tests. Both default to -120
     /// (silence) so existing tests that don't touch these see the same behavior as
     /// the protocol's default implementations.
     var micLevelDBFS: Double = -120
     var appLevelDBFS: Double = -120
 
-    func start(appPID _: pid_t, noMic _: Bool, micDeviceUID _: String?, debugLogging _: Bool) {
+    func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging _: Bool) {
         startCalled = true
+        capturedAppPID = appPID
+        capturedNoMic = noMic
+        capturedMicDeviceUID = micDeviceUID
     }
 
     func stop() throws -> RecordingResult {

--- a/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
@@ -10,8 +10,17 @@ private final class CapturingRecorder: RecordingProvider {
     var appLevelDBFS: Double = -120
     var micLevelDBFS: Double = -120
 
-    func start(appPID _: pid_t, noMic _: Bool, micDeviceUID _: String?, debugLogging _: Bool) {
+    // Captured start(...) args — appPID + noMic only, since this file's test
+    // doesn't exercise micDeviceUID threading (covered in WatchLoopTests).
+    // Defaults are deliberately "impossible" so a dropped/inverted argument
+    // fails an equality assertion instead of passing.
+    var capturedAppPID: pid_t = -1
+    var capturedNoMic = false
+
+    func start(appPID: pid_t, noMic: Bool, micDeviceUID _: String?, debugLogging _: Bool) {
         startCalled = true
+        capturedAppPID = appPID
+        capturedNoMic = noMic
     }
 
     func stop() -> RecordingResult {
@@ -76,6 +85,14 @@ final class WatchLoopActiveRecorderTests: XCTestCase {
         try await loop.handleMeeting(meeting)
 
         XCTAssertTrue(recorder.startCalled, "recorder.start must be called during handleMeeting")
+        XCTAssertEqual(
+            recorder.capturedAppPID, meeting.windowPID,
+            "auto-watch start must tap the detected meeting's window PID",
+        )
+        XCTAssertTrue(
+            recorder.capturedNoMic,
+            "loop's noMic=true must reach the recorder on the auto-watch path",
+        )
         XCTAssertTrue(recorder.stopCalled, "recorder.stop must be called during handleMeeting")
         XCTAssertIdentical(
             captured as AnyObject?,

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -184,6 +184,21 @@ final class WatchLoopTests: XCTestCase {
         XCTAssertTrue(recorder.startCalled)
     }
 
+    /// Pins that `startManualRecording` threads its `pid` plus the loop's
+    /// `noMic`/`micDeviceUID` into `recorder.start(...)` — not just that start
+    /// was called. A regression that dropped the PID, inverted `noMic`, or lost
+    /// `micDeviceUID` would tap the wrong process / wrong mic config and used to
+    /// pass unnoticed (the mock ignored every argument).
+    func testStartManualRecordingThreadsRecorderParams() async throws {
+        let (loop, recorder) = makeTestWatchLoop(noMic: true, micDeviceUID: "mock-mic-uid")
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+
+        XCTAssertEqual(recorder.capturedAppPID, 42, "manual start must tap the requested PID")
+        XCTAssertTrue(recorder.capturedNoMic, "loop's noMic=true must reach the recorder")
+        XCTAssertEqual(recorder.capturedMicDeviceUID, "mock-mic-uid", "loop's micDeviceUID must reach the recorder")
+    }
+
     func testManualRecordingHasMeetingInfo() async throws {
         let (loop, _) = makeTestWatchLoop()
         try await loop.startManualRecording(pid: 42, appName: "Safari", title: "Standup")


### PR DESCRIPTION
## Problem

The recorder test-doubles (`MockRecorder`, `CapturingRecorder`) discarded **every** argument to `start(appPID:noMic:micDeviceUID:debugLogging:)` — all params were `_`. So every recorder-start test asserted only `recorder.startCalled == true`. A regression that dropped the `appPID`, inverted `noMic`, or lost `micDeviceUID` would tap the wrong process or the wrong mic configuration and pass unnoticed.

## Change

Capture the `start(...)` args in both mocks and pin that `WatchLoop` threads them on both recording paths:

- **auto-watch** (`handleMeeting`): `appPID == meeting.windowPID`, plus `noMic`.
- **manual** (`startManualRecording`): `appPID == pid`, plus `noMic` and `micDeviceUID` (new focused test, distinctive non-default values via `makeTestWatchLoop(noMic:micDeviceUID:)`).

Capture defaults are deliberately impossible values (`appPID = -1`, etc.) so a dropped/inverted argument fails an equality assertion instead of passing silently. The assertions were verified to fail when the production threading is temporarily broken (passing `appPID: 0` / `noMic: false` → 5 assertion failures), so they are non-vacuous.

Test-only change; no production code touched.