### PR TITLE
fix(ci): avoid SIGPIPE in e2e-app --reimport-latest mix selection

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -639,10 +639,16 @@ if [ "$REIMPORT_LATEST" = true ]; then
     # freshest `*_mix.wav` in $RECORDINGS_DIR — eliminates the audible
     # ~30 s playback + capture round and the meeting-detector cooldown
     # that --reimport-recorded incurs.
+    # Pick the freshest *_mix.wav by mtime. A single awk max-pass replaces
+    # `sort -rn | head -1`: under `set -o pipefail`, `head` closing the pipe
+    # after one line left `sort` writing into a closed pipe → SIGPIPE (exit
+    # 141) → `set -e` aborted with "sort: Broken pipe" once two or more
+    # recordings had accumulated. awk reads the whole stream, so the upstream
+    # find/stat finish cleanly. (`$1` = mtime, `$0` = "mtime path"; cut keeps
+    # the path, tolerating spaces.)
     latest_mix="$(find "$RECORDINGS_DIR" -maxdepth 1 -name '*_mix.wav' -type f \
         -exec stat -f '%m %N' {} + 2>/dev/null \
-        | sort -rn \
-        | head -1 \
+        | awk 'NR == 1 || $1 > newest { newest = $1; line = $0 } END { if (NR) print line }' \
         | cut -d' ' -f2-)"
     [ -n "$latest_mix" ] && [ -f "$latest_mix" ] \
         || fail "--reimport-latest: no *_mix.wav found in $RECORDINGS_DIR — run \`e2e-app.sh --record-only --keep-recordings\` first to produce one"


### PR DESCRIPTION
## Problem

`E2E (Production App)` went red on the latest `main` push. The driver aborted with `sort: Broken pipe` (exit 2) during `--reimport-latest`, before any pipeline ran.

Root cause is in `scripts/e2e-app.sh`: it selected the freshest `*_mix.wav` with

```sh
find … -exec stat -f '%m %N' {} + | sort -rn | head -1 | cut -d' ' -f2-
```

Under `set -euo pipefail`, `head -1` closes the pipe after the first line; `sort` (which buffers all input, then writes it sorted) is left writing into a closed pipe → **SIGPIPE (exit 141)** → `pipefail` + `set -e` abort the whole script. It surfaces once two or more recordings accumulate on the self-hosted runner (`--keep-recordings`), so it is **not** a transient flake — it gets more likely as recordings pile up. Unrelated to any app/pipeline code.

## Fix

Replace `sort -rn | head -1` with a single-pass `awk` max-by-mtime that reads the **whole** stream (so the upstream `find`/`stat` finish cleanly), preserving the newest-by-mtime selection:

```sh
… | awk 'NR == 1 || $1 > newest { newest = $1; line = $0 } END { if (NR) print line }' | cut -d' ' -f2-
```

## Verification

Local repro under `set -euo pipefail`:
- old `… | sort -rn | head -1` on a stream large enough to exceed the pipe buffer → **exit 141** (broken pipe);
- new `… | awk …` → **exit 0**;
- with distinct mtimes, both select the same newest file (semantically equivalent).

Empty input still yields an empty result so the existing "no `*_mix.wav` found" guard fires; paths with spaces survive (`cut -d' ' -f2-` keeps everything after the first space). `e2e-app.yml` runs on the main push, so this is validated end-to-end once merged.