### PR TITLE
fix(app): reserve "Remote" mic label to prevent dual-track double-count

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -354,7 +354,15 @@ class PipelineQueue {
         self.outputDir = outputDir
         self.diarizeEnabled = diarizeEnabled
         self.numSpeakers = numSpeakers
-        self.micLabel = micLabel
+        // "Remote" is the reserved routing tag for the app/remote track
+        // (DiarizationProcess.remoteSpeakerLabel). If the user names the mic
+        // speaker that too, mergeDualSourceSegments tags both tracks identically
+        // and labelSegments' per-track filters each match every segment → app
+        // audio is double-counted under both speakers. Fall back to the default
+        // so the two routing tags can never collide. (This is the single source
+        // of micLabel for both the tagging and the re-split, so sanitizing here
+        // keeps them consistent.)
+        self.micLabel = micLabel == DiarizationProcess.remoteSpeakerLabel ? "Me" : micLabel
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -790,6 +790,7 @@ final class PipelineQueueTests: XCTestCase {
         engine: MockEngine,
         diar: MockDiarization,
         protocolGen: MockProtocolGen,
+        micLabel: String = "Me",
     ) -> PipelineQueue {
         PipelineQueue(
             engine: engine,
@@ -800,7 +801,7 @@ final class PipelineQueueTests: XCTestCase {
             logDir: tmpDir,
             diarizeEnabled: true,
             numSpeakers: 0,
-            micLabel: "Me",
+            micLabel: micLabel,
         )
     }
 
@@ -914,6 +915,40 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(
             warnings.contains { $0.contains("Mic track diarization failed") },
             "mic-fail fallback should add a warning — got: \(warnings)",
+        )
+    }
+
+    /// A user can set the Mic Speaker Name to "Remote" — the same literal used
+    /// as the reserved app/remote routing tag (`DiarizationProcess.remoteSpeakerLabel`).
+    /// Without sanitization, `mergeDualSourceSegments` tags both tracks "Remote"
+    /// and `labelSegments`' per-track filters both match every segment, so each
+    /// utterance is emitted once per track filter → app audio double-counted.
+    /// PipelineQueue must fall the colliding mic label back to a distinct one.
+    func testDiarizeDualTrackMicLabelRemoteDoesNotDoubleCount() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "ZZWORD")]
+        let diar = MockDiarization()
+        // Both tracks diarize successfully (no mic-fail) → dual-track topology.
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen, micLabel: "Remote")
+
+        try q.enqueue(makeDualSourceJob(title: "Remote MicLabel"))
+        await q.processNext()
+
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        // Dual-source mock transcribes both tracks → "ZZWORD" twice (once per
+        // real track). The double-count bug routes every segment through BOTH
+        // filters → four. Pin two.
+        let occurrences = transcript.components(separatedBy: "ZZWORD").count - 1
+        XCTAssertEqual(
+            occurrences, 2,
+            "app/mic audio must not be double-counted when micName == 'Remote' — got: \(transcript)",
         )
     }
 


### PR DESCRIPTION
## Problem

The **Mic Speaker Name** setting (`settings.micName`) is free text. It flows into `PipelineQueue.micLabel`, which is used as a **routing tag** in two places:

- `mergeDualSourceSegments` tags app-track segments with the reserved `"Remote"` label and mic-track segments with `micLabel`;
- `labelSegments` re-splits the merged segments back into the two tracks by matching those tags.

If the user sets the mic name to **"Remote"** (the same literal as the reserved app/remote tag), both tracks carry the identical tag. `labelSegments`' per-track filters then each match *every* segment, so each utterance is emitted **once per filter** → app audio is double-counted under both speakers in the protocol.

## Fix

Sanitize at the single source — `PipelineQueue`'s full init — falling a `"Remote"` `micLabel` back to the default `"Me"` so the app and mic routing tags can never collide. Both the tagging and the re-split read `self.micLabel`, so one guard keeps them consistent.

Only the *exact* string `"Remote"` collides (a distinct string like `"remote"` produces a distinct tag and routes correctly), so an exact `==` guard is the precise fix.

## Test

`testDiarizeDualTrackMicLabelRemoteDoesNotDoubleCount` runs a dual-source job with `micName == "Remote"` and asserts each utterance appears once per real track (2×), not doubled (4×). Verified RED→GREEN: against the unfixed code the transcript was `SPEAKER_0: ZZWORD ZZWORD ZZWORD ZZWORD` (count 4).

Full suite green.