### PR TITLE
refactor(app): extract PermissionsController from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -46,7 +46,10 @@ final class AppState { // swiftlint:disable:this type_body_length
     var pipelineQueue: PipelineQueue
     var updateChecker: UpdateChecker
     var selectedNamingJobID: UUID?
-    var permissionHealth: HealthCheckResult?
+
+    /// Live TCC permission-health concern, extracted into its own controller.
+    /// `currentBadge` composes its `health` into the `.error` state.
+    let permissions: PermissionsController
 
     /// True while the **mic** channel is silent and the app channel is carrying
     /// speech continuously for `settings.asymmetricSilenceWarningSeconds`. Drives
@@ -162,6 +165,7 @@ final class AppState { // swiftlint:disable:this type_body_length
             self._qwen3Engine = nil
         }
         self.notifier = notifier
+        self.permissions = PermissionsController(notifier: notifier)
         self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
         self.pipelineQueue = PipelineQueue()
         self.channelHealthMonitor = ChannelHealthMonitor(
@@ -363,7 +367,7 @@ final class AppState { // swiftlint:disable:this type_body_length
             transcriberState: watchLoop?.transcriberState ?? .idle,
             activeJobState: pipelineQueue.activeJobs.first?.state,
             updateAvailable: updateChecker.availableUpdate != nil,
-            permissionProblem: permissionHealth?.isHealthy == false,
+            permissionProblem: permissions.health?.isHealthy == false,
         )
     }
 
@@ -372,6 +376,15 @@ final class AppState { // swiftlint:disable:this type_body_length
             return loop.transcriberState.label
         }
         return "Idle"
+    }
+
+    /// Whether the live permission health check currently reports a problem.
+    /// Hoisted out of the SwiftUI menu-bar body: resolving the
+    /// `permissions.health?.isHealthy == false` chain inline pushed that body's
+    /// type-check over the 300 ms budget on slower CI runners. Reading it as a
+    /// named `Bool` property keeps the body cheap.
+    var hasPermissionProblem: Bool {
+        permissions.health?.isHealthy == false
     }
 
     private static let isoFormatter = ISO8601DateFormatter()
@@ -495,7 +508,7 @@ final class AppState { // swiftlint:disable:this type_body_length
 
                 attachStateChangeHandler(to: loop, notifyOnRecording: true)
 
-                if let health = permissionHealth {
+                if let health = permissions.health {
                     loop.permissionChecker = { health }
                 }
 
@@ -541,7 +554,7 @@ final class AppState { // swiftlint:disable:this type_body_length
             attachStateChangeHandler(to: loop, notifyOnRecording: false)
 
             // Use cached health check result instead of live probe
-            if let health = permissionHealth {
+            if let health = permissions.health {
                 loop.permissionChecker = { health }
             }
 
@@ -768,46 +781,6 @@ final class AppState { // swiftlint:disable:this type_body_length
         micSilentActive = false
         appSilentActive = false
         recordingSilentActive = false
-    }
-
-    // MARK: - Permission Health
-
-    func handlePermissionHealth(_ result: HealthCheckResult) {
-        let previousProblems = permissionHealth?.problems ?? []
-        permissionHealth = result
-        let line = "[PermissionHealthCheck] screen=\(result.screenRecording) mic=\(result.microphone) " +
-            "ax=\(result.accessibility) healthy=\(result.isHealthy) problems=\(result.problems)"
-        PermissionHealthCheck.debugLog(line)
-
-        let problems = result.problems
-        if !problems.isEmpty, problems != previousProblems {
-            PermissionHealthCheck.debugLog("[PermissionHealthCheck] Sending notification: \(result.notificationBody)")
-            notifier.notify(
-                title: "Permission Problem",
-                body: result.notificationBody,
-            )
-        }
-    }
-
-    /// Timestamp of the last completed `checkPermissions()` run. Used to debounce repeated
-    /// calls triggered by `NSApplication.didBecomeActiveNotification` so the 500 ms mic
-    /// probe doesn't churn the audio HAL on every Cmd-Tab.
-    private var lastPermissionCheckAt: Date?
-
-    /// Run the live permission health check.
-    ///
-    /// - Parameter minimumInterval: if non-nil, skip the run when the last completed check
-    ///   happened less than `minimumInterval` seconds ago. The initial startup call passes
-    ///   `nil` so it always runs; the `didBecomeActive` handler passes a small value to
-    ///   avoid HAL churn on rapid re-activations.
-    func checkPermissions(minimumInterval: TimeInterval? = nil) async {
-        if let minimumInterval, let last = lastPermissionCheckAt,
-           Date().timeIntervalSince(last) < minimumInterval {
-            return
-        }
-        let result = await PermissionHealthCheck.runLive()
-        lastPermissionCheckAt = Date()
-        handlePermissionHealth(result)
     }
 
     // MARK: - Pipeline

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -100,7 +100,7 @@ struct MeetingTranscriberApp: App {
             } icon: {
                 AnimatedMenuBarIcon(
                     badge: appState.currentBadge,
-                    permissionOverlay: appState.permissionHealth?.isHealthy == false,
+                    permissionOverlay: appState.hasPermissionProblem,
                     recordOnlyOverlay: appState.settings.recordOnly,
                     // `recordingSilentActive` paints both halves; OR'd in here so
                     // MenuBarIcon only needs the two per-channel overlay inputs.
@@ -143,14 +143,14 @@ struct MeetingTranscriberApp: App {
                 appState.updateChecker.startPeriodicChecks(settings: appState.settings)
             }
             .task {
-                await appState.checkPermissions()
+                await appState.permissions.check()
             }
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 // Re-check permissions when the user returns to the app (e.g. from System
                 // Settings after toggling a permission). Debounced so rapid Cmd-Tab cycles
                 // don't repeatedly churn the mic HAL via the 500 ms probe.
                 Task { @MainActor in
-                    await appState.checkPermissions(minimumInterval: 3)
+                    await appState.permissions.check(minimumInterval: 3)
                 }
             }
             .onChange(of: appState.shouldShowLiveCaptions, initial: true) { _, visible in

--- a/app/MeetingTranscriber/Sources/PermissionsController.swift
+++ b/app/MeetingTranscriber/Sources/PermissionsController.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Observation
+
+// MARK: - PermissionsController
+
+/// Owns live TCC permission-health state and the debounced re-check.
+///
+/// Extracted from `AppState` as the first concern-specific controller (see the
+/// AppState god-class split). `AppState` exposes it as a sub-controller and
+/// composes its `health` into `currentBadge`.
+///
+/// The `probe` seam lets tests exercise the debounce + notification logic
+/// without the real ~500 ms `PermissionHealthCheck.runLive()` TCC probe, which
+/// churns the audio HAL and was untestable while wired directly into AppState.
+@Observable
+@MainActor
+final class PermissionsController {
+    /// Latest health result from `check()` / `handle(_:)`. Drives the menu-bar
+    /// permission-problem overlay and the `currentBadge` `.error` state.
+    private(set) var health: HealthCheckResult?
+
+    /// Timestamp of the last completed `check()` run. Used to debounce repeated
+    /// calls triggered by `NSApplication.didBecomeActiveNotification` so the
+    /// 500 ms mic probe doesn't churn the audio HAL on every Cmd-Tab.
+    private(set) var lastCheckAt: Date?
+
+    private let notifier: any AppNotifying
+    private let probe: () async -> HealthCheckResult
+
+    init(
+        notifier: any AppNotifying,
+        probe: @escaping () async -> HealthCheckResult = { await PermissionHealthCheck.runLive() },
+    ) {
+        self.notifier = notifier
+        self.probe = probe
+    }
+
+    /// Store the latest health result and notify on a newly-appeared problem
+    /// set. A repeated identical problem set is deduped (no re-notify); a
+    /// recovery to healthy clears the dedup memory so the next problem notifies.
+    func handle(_ result: HealthCheckResult) {
+        let previousProblems = health?.problems ?? []
+        health = result
+        let line = "[PermissionHealthCheck] screen=\(result.screenRecording) mic=\(result.microphone) " +
+            "ax=\(result.accessibility) healthy=\(result.isHealthy) problems=\(result.problems)"
+        PermissionHealthCheck.debugLog(line)
+
+        let problems = result.problems
+        if !problems.isEmpty, problems != previousProblems {
+            PermissionHealthCheck.debugLog("[PermissionHealthCheck] Sending notification: \(result.notificationBody)")
+            notifier.notify(
+                title: "Permission Problem",
+                body: result.notificationBody,
+            )
+        }
+    }
+
+    /// Run the live permission health check.
+    ///
+    /// - Parameter minimumInterval: if non-nil, skip the run when the last completed check
+    ///   happened less than `minimumInterval` seconds ago. The initial startup call passes
+    ///   `nil` so it always runs; the `didBecomeActive` handler passes a small value to
+    ///   avoid HAL churn on rapid re-activations.
+    func check(minimumInterval: TimeInterval? = nil) async {
+        if let minimumInterval, let last = lastCheckAt,
+           Date().timeIntervalSince(last) < minimumInterval {
+            return
+        }
+        let result = await probe()
+        lastCheckAt = Date()
+        handle(result)
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -614,7 +614,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testStartManualRecordingSendsNotification() async {
         let (state, notifier) = makeState()
-        state.permissionHealth = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
         addTeardownBlock { state.watchLoop?.stop() }
 
         state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
@@ -629,7 +629,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testStartManualRecordingStopsExistingAutoWatchLoop() async {
         let (state, _) = makeState()
-        state.permissionHealth = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
         let (existingLoop, _) = makeTestWatchLoop()
         existingLoop.start()
         state.watchLoop = existingLoop
@@ -759,80 +759,6 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         state.settings.numSpeakers = 4
         let queue = state.makePipelineQueue()
         XCTAssertEqual(queue.numSpeakers, 4)
-    }
-
-    // MARK: - Permission Health Check
-
-    func testHandlePermissionHealthBrokenSendsNotification() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        state.handlePermissionHealth(HealthCheckResult(
-            screenRecording: .broken,
-            microphone: .healthy,
-        ))
-        XCTAssertEqual(notifier.calls.count, 1)
-        XCTAssertTrue(notifier.calls.first?.title.contains("Permission") ?? false)
-    }
-
-    func testHandlePermissionHealthHealthyNoNotification() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        state.handlePermissionHealth(HealthCheckResult(
-            screenRecording: .healthy,
-            microphone: .healthy,
-        ))
-        XCTAssertTrue(notifier.calls.isEmpty)
-    }
-
-    func testHandlePermissionHealthStoresResult() {
-        let state = AppState(notifier: RecordingNotifier())
-        let result = HealthCheckResult(
-            screenRecording: .healthy,
-            microphone: .healthy,
-        )
-        state.handlePermissionHealth(result)
-        XCTAssertEqual(state.permissionHealth, result)
-    }
-
-    func testHandlePermissionHealthDedupsRepeatedProblem() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
-        state.handlePermissionHealth(broken)
-        state.handlePermissionHealth(broken)
-        state.handlePermissionHealth(broken)
-        XCTAssertEqual(notifier.calls.count, 1, "Identical problem set should only notify once")
-    }
-
-    func testHandlePermissionHealthReNotifiesAfterRecovery() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
-        let healthy = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
-        state.handlePermissionHealth(broken) // notify #1
-        state.handlePermissionHealth(healthy) // clears dedup memory
-        state.handlePermissionHealth(broken) // notify #2
-        XCTAssertEqual(notifier.calls.count, 2)
-    }
-
-    func testHandlePermissionHealthNotifiesWhenProblemChanges() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        state.handlePermissionHealth(HealthCheckResult(screenRecording: .healthy, microphone: .broken))
-        state.handlePermissionHealth(HealthCheckResult(screenRecording: .broken, microphone: .healthy))
-        XCTAssertEqual(notifier.calls.count, 2, "Different problem sets should each trigger a notification")
-    }
-
-    func testHandlePermissionHealthAccessibilityBrokenNotifies() {
-        let notifier = RecordingNotifier()
-        let state = AppState(notifier: notifier)
-        state.handlePermissionHealth(HealthCheckResult(
-            screenRecording: .healthy,
-            microphone: .healthy,
-            accessibility: .broken,
-        ))
-        XCTAssertEqual(notifier.calls.count, 1)
-        XCTAssertTrue(notifier.calls.first?.body.contains("Accessibility") ?? false)
     }
 }
 

--- a/app/MeetingTranscriber/Tests/PermissionsControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionsControllerTests.swift
@@ -1,0 +1,119 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `PermissionsController` — the first concern-specific
+/// controller extracted from the `AppState` god-class.
+///
+/// These construct a bare `PermissionsController(notifier:)` rather than a full
+/// `AppState`, so they don't pay the AppState init cost (pipeline queue,
+/// channel-health monitors, live-transcription prewarm, and — in non-AppStore
+/// builds — the persistent-log-streamer subprocess). The injected `probe` seam
+/// also lets the debounce logic be tested without the real ~500 ms `runLive()`
+/// TCC probe, which was impossible while the call was hard-wired into AppState.
+@MainActor
+final class PermissionsControllerTests: XCTestCase {
+    // MARK: - handle: notification behaviour (moved from AppStateTests)
+
+    func testHandleBrokenSendsNotification() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        controller.handle(HealthCheckResult(screenRecording: .broken, microphone: .healthy))
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertTrue(notifier.calls.first?.title.contains("Permission") ?? false)
+    }
+
+    func testHandleHealthyNoNotification() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        controller.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
+        XCTAssertTrue(notifier.calls.isEmpty)
+    }
+
+    func testHandleStoresResult() {
+        let controller = PermissionsController(notifier: RecordingNotifier())
+        let result = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        controller.handle(result)
+        XCTAssertEqual(controller.health, result)
+    }
+
+    func testHandleDedupsRepeatedProblem() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
+        controller.handle(broken)
+        controller.handle(broken)
+        controller.handle(broken)
+        XCTAssertEqual(notifier.calls.count, 1, "Identical problem set should only notify once")
+    }
+
+    func testHandleReNotifiesAfterRecovery() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        let broken = HealthCheckResult(screenRecording: .healthy, microphone: .broken)
+        let healthy = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        controller.handle(broken) // notify #1
+        controller.handle(healthy) // clears dedup memory
+        controller.handle(broken) // notify #2
+        XCTAssertEqual(notifier.calls.count, 2)
+    }
+
+    func testHandleNotifiesWhenProblemChanges() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        controller.handle(HealthCheckResult(screenRecording: .healthy, microphone: .broken))
+        controller.handle(HealthCheckResult(screenRecording: .broken, microphone: .healthy))
+        XCTAssertEqual(notifier.calls.count, 2, "Different problem sets should each trigger a notification")
+    }
+
+    func testHandleAccessibilityBrokenNotifies() {
+        let notifier = RecordingNotifier()
+        let controller = PermissionsController(notifier: notifier)
+        controller.handle(HealthCheckResult(
+            screenRecording: .healthy,
+            microphone: .healthy,
+            accessibility: .broken,
+        ))
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertTrue(notifier.calls.first?.body.contains("Accessibility") ?? false)
+    }
+
+    // MARK: - check: probe + debounce (impossible before extraction)
+
+    func testCheckRunsProbeAndStoresHealth() async {
+        let probed = HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        let controller = PermissionsController(notifier: RecordingNotifier()) { probed }
+        await controller.check()
+        XCTAssertEqual(controller.health, probed)
+        XCTAssertNotNil(controller.lastCheckAt)
+    }
+
+    func testRepeatedCheckWithinMinimumIntervalSkipsProbe() async {
+        let counter = ProbeCounter()
+        let controller = PermissionsController(notifier: RecordingNotifier(), probe: counter.probe)
+        // First call: no prior timestamp → always runs.
+        await controller.check(minimumInterval: 9999)
+        // Second call: last check was milliseconds ago, well within 9999 s → skipped.
+        await controller.check(minimumInterval: 9999)
+        XCTAssertEqual(counter.count, 1, "Second check within the minimum interval should be debounced")
+    }
+
+    func testCheckWithNilIntervalAlwaysRunsProbe() async {
+        let counter = ProbeCounter()
+        let controller = PermissionsController(notifier: RecordingNotifier(), probe: counter.probe)
+        await controller.check()
+        await controller.check()
+        XCTAssertEqual(counter.count, 2, "A nil minimum interval must never debounce")
+    }
+}
+
+/// Counts how many times the injected probe ran. `@MainActor` to match the
+/// controller's isolation; `probe` is synchronous and gets promoted to the
+/// `() async -> HealthCheckResult` seam when passed in.
+@MainActor
+private final class ProbeCounter {
+    private(set) var count = 0
+    func probe() -> HealthCheckResult {
+        count += 1
+        return HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+    }
+}


### PR DESCRIPTION
## What

Pulls the live TCC permission-health concern out of the `AppState` god-class
into its own `@Observable @MainActor` controller. `AppState` now holds it as a
`permissions` sub-controller and composes its `health` into `currentBadge`; the
menu-bar overlay and the `didBecomeActive` re-check route through
`appState.permissions`.

This is the first slice of an incremental split of `AppState` into
concern-specific controllers. It is **behaviour-preserving** — the
`handle`/`check`/debounce logic is moved verbatim, callers are migrated 1:1,
and the full suite stays green.

## Why this slice first

`PermissionsController` is the smallest, most self-contained concern, so it is
the lowest-risk proof of the composition pattern. It also lands a concrete
testability win:

- The controller takes an injectable `probe` seam (defaulting to
  `PermissionHealthCheck.runLive`). The `didBecomeActive` debounce
  (`minimumInterval`) was **untestable** before, because the ~500 ms live TCC
  probe was hard-wired into `checkPermissions`. New tests now cover the
  debounce directly.
- The notification-dedup tests move out of `AppStateTests` and construct a bare
  `PermissionsController(notifier:)` instead of a full `AppState` — no pipeline
  queue, channel-health monitors, live-transcription prewarm, or (non-AppStore)
  persistent-log-streamer subprocess.

## Follow-up (out of scope, pre-existing)

`check()` reads `lastCheckAt`, suspends on `await probe()`, then writes
`lastCheckAt` — so two activations within the probe window can both pass the
debounce guard (an extra HAL probe; `handle()`'s own dedup still prevents a
duplicate notification). This actor-reentrancy interleaving is identical to the
pre-refactor `AppState.checkPermissions` and is not changed here. The extracted
`probe` seam now makes it cheaply testable for a dedicated hardening PR.

## Test

- `swift test --parallel` green (only machine-dependent `MenuBarIconSnapshotTests`
  differ locally; they `XCTSkipIf(isCI)`).
- `./scripts/lint.sh` clean; `./scripts/pre-push.sh` (release parity) clean.