### PR TITLE
refactor(app): extract ChannelHealthController from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -31,11 +31,7 @@
                 pendingNamingJobs: pendingJobs,
                 engines: enginesSnapshot(),
                 lastJob: lastFinishedJobSnapshot(),
-                channelHealth: .init(
-                    micSilent: micSilentActive,
-                    appSilent: appSilentActive,
-                    recordingSilent: recordingSilentActive,
-                ),
+                channelHealth: channelHealthSnapshot(),
                 liveCaptions: liveCaptionsSnapshot(),
             )
         }
@@ -49,6 +45,18 @@
                 hypothesisMic: liveCaptions.hypothesisMic,
                 hypothesisApp: liveCaptions.hypothesisApp,
                 recentFinals: liveCaptions.recentFinals,
+            )
+        }
+
+        /// Snapshot the channel-health flags. Extracted into a helper (rather
+        /// than inlined in `rpcStateSnapshot`'s already-large literal) because
+        /// reading the three `channelHealth.*` flags through the sub-controller
+        /// inside that expression pushed its type-check over the 300 ms budget.
+        private func channelHealthSnapshot() -> RPCStateSnapshot.ChannelHealth {
+            RPCStateSnapshot.ChannelHealth(
+                micSilent: channelHealth.micSilentActive,
+                appSilent: channelHealth.appSilentActive,
+                recordingSilent: channelHealth.recordingSilentActive,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -51,38 +51,11 @@ final class AppState { // swiftlint:disable:this type_body_length
     /// `currentBadge` composes its `health` into the `.error` state.
     let permissions: PermissionsController
 
-    /// True while the **mic** channel is silent and the app channel is carrying
-    /// speech continuously for `settings.asymmetricSilenceWarningSeconds`. Drives
-    /// the menu-bar **top-half** red tint. Latches until the dead channel recovers
-    /// (or recording stops). At most one of `micSilentActive` / `appSilentActive`
-    /// is true at a time — the monitor's channel-switch path resets when roles flip.
-    var micSilentActive: Bool = false
-
-    /// True while the **app-audio** channel is silent and the mic is carrying
-    /// speech continuously for `settings.asymmetricSilenceWarningSeconds`. Drives
-    /// the menu-bar **bottom-half** red tint.
-    var appSilentActive: Bool = false
-
-    /// True while **both** capture channels have been below the silence
-    /// threshold continuously for `settings.asymmetricSilenceWarningSeconds`
-    /// — the failure mode `ChannelHealthMonitor` intentionally ignores
-    /// (symmetric silence). Drives the menu-bar **full red** waveform
-    /// (both halves tinted simultaneously).
-    var recordingSilentActive: Bool = false
-
-    /// Pure state machine driven by the 10-Hz level poll while recording. Lives
-    /// here (not on WatchLoop) so its lifecycle outlasts a single recording —
-    /// observers of `micSilentActive` / `appSilentActive` keep their identity across the
-    /// detect → record → process state churn.
-    @ObservationIgnored private var channelHealthMonitor = ChannelHealthMonitor()
-
-    /// Sibling monitor that catches the symmetric-silence case
-    /// `ChannelHealthMonitor` intentionally skips. Shares the same
-    /// debounce threshold; lifecycle managed alongside the channel-health
-    /// monitor in `startChannelHealthMonitoring` / `stopChannelHealthMonitoring`.
-    @ObservationIgnored private var silentRecordingMonitor = SilentRecordingMonitor()
-
-    @ObservationIgnored private var levelMonitorTask: Task<Void, Never>?
+    /// Per-channel + symmetric-silence detection that drives the menu-bar
+    /// red-tint indicators while recording. Extracted into its own controller;
+    /// `attachStateChangeHandler` wires its `start()` / `stop()` to `WatchLoop`
+    /// state transitions, and the menu-bar icon + RPC snapshot read its flags.
+    let channelHealth: ChannelHealthController
 
     /// PoC live-transcription controller. Lazily created on first recording
     /// start where `settings.liveTranscriptionEnabled` is true AND the active
@@ -168,11 +141,10 @@ final class AppState { // swiftlint:disable:this type_body_length
         self.permissions = PermissionsController(notifier: notifier)
         self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
         self.pipelineQueue = PipelineQueue()
-        self.channelHealthMonitor = ChannelHealthMonitor(
-            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
-        )
-        self.silentRecordingMonitor = SilentRecordingMonitor(
-            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
+        self.channelHealth = ChannelHealthController(
+            notifier: notifier,
+            debounceSeconds: { [settings] in settings.asymmetricSilenceWarningSeconds },
+            indicatorEnabled: { [settings] in settings.perChannelIndicatorEnabled },
         )
 
         #if !APPSTORE
@@ -182,17 +154,13 @@ final class AppState { // swiftlint:disable:this type_body_length
             // builds and only when explicitly enabled via env var. The driver
             // is also expected to set `MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1`
             // so an auto-watch state transition doesn't clear the flag at +3 s
-            // through the regular `stopChannelHealthMonitoring()` path.
+            // through the regular `channelHealth.stop()` path.
             let env = ProcessInfo.processInfo.environment
-            if env["MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT"] == "1" {
-                micSilentActive = true
-            }
-            if env["MEETINGTRANSCRIBER_DEBUG_FORCE_APP_SILENT"] == "1" {
-                appSilentActive = true
-            }
-            if env["MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT"] == "1" {
-                recordingSilentActive = true
-            }
+            channelHealth.applyForcedFlagsForE2E(
+                micSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT"] == "1",
+                appSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_APP_SILENT"] == "1",
+                recordingSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT"] == "1",
+            )
         #endif
 
         // Bring engines in line with the current settings up front so the
@@ -385,6 +353,21 @@ final class AppState { // swiftlint:disable:this type_body_length
     /// named `Bool` property keeps the body cheap.
     var hasPermissionProblem: Bool {
         permissions.health?.isHealthy == false
+    }
+
+    /// Menu-bar **top-half** red tint: mic channel silent, OR both channels
+    /// silent (`recordingSilentActive` paints both halves). Hoisted out of the
+    /// menu-bar body for the same type-check-budget reason as
+    /// `hasPermissionProblem` — reading two `channelHealth.*` flags through the
+    /// sub-controller inline is more than the body can afford on slow CI.
+    var micSilentOverlay: Bool {
+        channelHealth.micSilentActive || channelHealth.recordingSilentActive
+    }
+
+    /// Menu-bar **bottom-half** red tint: app-audio channel silent, OR both
+    /// channels silent. See `micSilentOverlay`.
+    var appSilentOverlay: Bool {
+        channelHealth.appSilentActive || channelHealth.recordingSilentActive
     }
 
     private static let isoFormatter = ISO8601DateFormatter()
@@ -646,141 +629,18 @@ final class AppState { // swiftlint:disable:this type_body_length
                         body: "Recording: \(meeting.windowTitle)",
                     )
                 }
-                self?.startChannelHealthMonitoring()
+                self?.channelHealth.start { [weak self] in self?.watchLoop?.activeRecorder }
 
             case .error:
                 if let err = loop?.lastError {
                     notifier.notify(title: "Error", body: err)
                 }
-                self?.stopChannelHealthMonitoring()
+                self?.channelHealth.stop()
 
             default:
-                self?.stopChannelHealthMonitoring()
+                self?.channelHealth.stop()
             }
         }
-    }
-
-    /// Rebuilds `channelHealthMonitor` with the current settings-driven debounce.
-    /// Called from `startChannelHealthMonitoring` and exposed as a test seam so
-    /// `ChannelHealthIntegrationTests` can simulate the "user changed threshold
-    /// between recordings" path without spinning up the polling Task.
-    func simulateStartChannelHealthMonitoringForTests() {
-        rebuildChannelHealthMonitor()
-    }
-
-    private func rebuildChannelHealthMonitor() {
-        channelHealthMonitor = ChannelHealthMonitor(
-            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
-        )
-        silentRecordingMonitor = SilentRecordingMonitor(
-            debounceSeconds: settings.asymmetricSilenceWarningSeconds,
-        )
-    }
-
-    /// Starts a ~10 Hz polling task that feeds the active recorder's per-channel
-    /// levels into `channelHealthMonitor` and flips `micSilentActive` /
-    /// `appSilentActive` based on the resulting events. Idempotent: calling while already running
-    /// is a no-op. Skips entirely when the master toggle is off.
-    private func startChannelHealthMonitoring() {
-        guard settings.perChannelIndicatorEnabled else { return }
-        guard levelMonitorTask == nil else { return }
-        rebuildChannelHealthMonitor()
-        levelMonitorTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { return }
-                self.tickChannelHealth()
-                try? await Task.sleep(for: .milliseconds(100))
-            }
-        }
-    }
-
-    private func tickChannelHealth() {
-        guard let recorder = watchLoop?.activeRecorder else { return }
-        applyChannelHealthTick(recorder: recorder, now: Date())
-    }
-
-    /// Internal test seam: drives one polling tick against an arbitrary
-    /// recorder + clock. Production code uses `tickChannelHealth()` which
-    /// reads the active recorder + wall clock.
-    @discardableResult
-    func applyChannelHealthTick(
-        recorder: any RecordingProvider,
-        now: Date,
-    ) -> ChannelHealthEvent? {
-        let mic = recorder.micLevelDBFS
-        let app = recorder.appLevelDBFS
-
-        let event = channelHealthMonitor.update(micDBFS: mic, appDBFS: app, now: now)
-        switch event {
-        case let .started(channel, _):
-            switch channel {
-            case .mic:
-                micSilentActive = true
-                appSilentActive = false
-
-            case .app:
-                appSilentActive = true
-                micSilentActive = false
-            }
-            notifier.notify(
-                title: "Capture Channel Silent",
-                body: Self.asymmetricSilenceMessage(for: channel),
-            )
-
-        case .recovered:
-            micSilentActive = false
-            appSilentActive = false
-
-        case .none:
-            break
-        }
-
-        let silentEvent = silentRecordingMonitor.update(micDBFS: mic, appDBFS: app, now: now)
-        switch silentEvent {
-        case .started:
-            recordingSilentActive = true
-            notifier.notify(
-                title: "Recording Appears Silent",
-                body: Self.silentRecordingMessage,
-            )
-
-        case .recovered:
-            recordingSilentActive = false
-
-        case .none:
-            break
-        }
-
-        return event
-    }
-
-    nonisolated static func asymmetricSilenceMessage(for channel: AudioChannel) -> String {
-        switch channel {
-        case .app:
-            "The app-audio channel went silent while the mic is still carrying audio. "
-                + "Check the meeting app's audio settings or system audio permission."
-
-        case .mic:
-            "The microphone went silent while the app audio is still recording. "
-                + "Check the mic device, mute state, or microphone permission."
-        }
-    }
-
-    nonisolated static let silentRecordingMessage: String =
-        "Both capture channels have been silent since the recording started. "
-            + "Check the audio routing — the meeting app may have claimed the mic "
-            + "in exclusive mode (e.g. AirPods HFP), or the system input device may be muted."
-
-    /// Stops the polling task and resets the monitor + UI flag. Called when
-    /// recording ends or an error transition happens.
-    private func stopChannelHealthMonitoring() {
-        levelMonitorTask?.cancel()
-        levelMonitorTask = nil
-        channelHealthMonitor.reset()
-        silentRecordingMonitor.reset()
-        micSilentActive = false
-        appSilentActive = false
-        recordingSilentActive = false
     }
 
     // MARK: - Pipeline

--- a/app/MeetingTranscriber/Sources/ChannelHealthController.swift
+++ b/app/MeetingTranscriber/Sources/ChannelHealthController.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Observation
+
+// MARK: - ChannelHealthController
+
+/// Owns the per-channel + symmetric-silence detection that drives the menu-bar
+/// red-tint indicators while recording.
+///
+/// Extracted from `AppState` as a concern-specific controller (see the AppState
+/// god-class split). `AppState` holds it as a sub-controller, wires `start()` /
+/// `stop()` to `WatchLoop` state transitions, and exposes the observable flags
+/// to the menu-bar icon + RPC snapshot.
+///
+/// Two sibling state machines run off one 10 Hz poll:
+/// - `ChannelHealthMonitor` — asymmetric silence (one channel dead while the
+///   other carries speech), drives `micSilentActive` / `appSilentActive`.
+/// - `SilentRecordingMonitor` — symmetric silence (both channels dead), the case
+///   the asymmetric monitor intentionally ignores, drives `recordingSilentActive`.
+///
+/// The `debounceSeconds` / `indicatorEnabled` closures read live from settings;
+/// `recorderProvider` is passed to `start()` (not stored at init) so the
+/// controller never holds an `AppState` back-reference. This keeps the polling
+/// + notification logic testable against a mock recorder without a `WatchLoop`.
+@Observable
+@MainActor
+final class ChannelHealthController {
+    /// True while the **mic** channel is silent and the app channel is carrying
+    /// speech continuously for the debounce window. Drives the menu-bar
+    /// **top-half** red tint. Latches until the dead channel recovers (or
+    /// recording stops). At most one of `micSilentActive` / `appSilentActive`
+    /// is true at a time — the monitor's channel-switch path resets when roles flip.
+    private(set) var micSilentActive: Bool = false
+
+    /// True while the **app-audio** channel is silent and the mic is carrying
+    /// speech continuously for the debounce window. Drives the menu-bar
+    /// **bottom-half** red tint.
+    private(set) var appSilentActive: Bool = false
+
+    /// True while **both** capture channels have been below the silence
+    /// threshold continuously for the debounce window — the failure mode
+    /// `ChannelHealthMonitor` intentionally ignores (symmetric silence). Drives
+    /// the menu-bar **full red** waveform (both halves tinted simultaneously).
+    private(set) var recordingSilentActive: Bool = false
+
+    /// Pure state machine driven by the 10-Hz level poll while recording. Lives
+    /// here (not on WatchLoop) so its lifecycle outlasts a single recording —
+    /// observers of `micSilentActive` / `appSilentActive` keep their identity across the
+    /// detect → record → process state churn.
+    @ObservationIgnored private var channelHealthMonitor: ChannelHealthMonitor
+
+    /// Sibling monitor that catches the symmetric-silence case
+    /// `ChannelHealthMonitor` intentionally skips. Shares the same
+    /// debounce threshold; lifecycle managed alongside the channel-health
+    /// monitor in `start` / `stop`.
+    @ObservationIgnored private var silentRecordingMonitor: SilentRecordingMonitor
+
+    @ObservationIgnored private var levelMonitorTask: Task<Void, Never>?
+
+    private let notifier: any AppNotifying
+    private let debounceSeconds: () -> TimeInterval
+    private let indicatorEnabled: () -> Bool
+
+    init(
+        notifier: any AppNotifying,
+        debounceSeconds: @escaping () -> TimeInterval,
+        indicatorEnabled: @escaping () -> Bool,
+    ) {
+        self.notifier = notifier
+        self.debounceSeconds = debounceSeconds
+        self.indicatorEnabled = indicatorEnabled
+        self.channelHealthMonitor = ChannelHealthMonitor(debounceSeconds: debounceSeconds())
+        self.silentRecordingMonitor = SilentRecordingMonitor(debounceSeconds: debounceSeconds())
+    }
+
+    /// Starts a ~10 Hz polling task that feeds the active recorder's per-channel
+    /// levels into the monitors and flips the observable flags based on the
+    /// resulting events. Idempotent: calling while already running is a no-op.
+    /// Skips entirely when the master toggle is off.
+    ///
+    /// `recorderProvider` is supplied by the caller (it resolves the live
+    /// `WatchLoop.activeRecorder`) so the controller stays free of an AppState
+    /// back-reference. A tick where it returns nil is skipped, not fatal.
+    func start(recorderProvider: @escaping @MainActor () -> (any RecordingProvider)?) {
+        guard indicatorEnabled() else { return }
+        guard levelMonitorTask == nil else { return }
+        rebuild()
+        levelMonitorTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                if let recorder = recorderProvider() {
+                    self.applyTick(recorder: recorder, now: Date())
+                }
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        }
+    }
+
+    /// Stops the polling task and resets the monitors + UI flags. Called when
+    /// recording ends or an error transition happens.
+    func stop() {
+        levelMonitorTask?.cancel()
+        levelMonitorTask = nil
+        channelHealthMonitor.reset()
+        silentRecordingMonitor.reset()
+        micSilentActive = false
+        appSilentActive = false
+        recordingSilentActive = false
+    }
+
+    /// Rebuilds both monitors with the current settings-driven debounce. Also
+    /// exposed as a test seam so the "user changed threshold between recordings"
+    /// path can be simulated without spinning up the polling Task.
+    func simulateStartForTests() {
+        rebuild()
+    }
+
+    #if !APPSTORE
+        /// E2E hook: force the red-tint flags at launch so a driver script can
+        /// assert the menu-bar pipeline end-to-end without orchestrating real
+        /// audio. Keeps the flags `private(set)` for normal operation — only
+        /// `AppState.init`'s env-var path calls this. See that call site for the
+        /// `MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH` interaction.
+        func applyForcedFlagsForE2E(micSilent: Bool, appSilent: Bool, recordingSilent: Bool) {
+            micSilentActive = micSilent
+            appSilentActive = appSilent
+            recordingSilentActive = recordingSilent
+        }
+    #endif
+
+    private func rebuild() {
+        channelHealthMonitor = ChannelHealthMonitor(debounceSeconds: debounceSeconds())
+        silentRecordingMonitor = SilentRecordingMonitor(debounceSeconds: debounceSeconds())
+    }
+
+    /// Internal test seam: drives one polling tick against an arbitrary
+    /// recorder + clock. Production code's polling task calls this with the
+    /// active recorder + wall clock.
+    @discardableResult
+    func applyTick(
+        recorder: any RecordingProvider,
+        now: Date,
+    ) -> ChannelHealthEvent? {
+        let mic = recorder.micLevelDBFS
+        let app = recorder.appLevelDBFS
+
+        let event = channelHealthMonitor.update(micDBFS: mic, appDBFS: app, now: now)
+        switch event {
+        case let .started(channel, _):
+            switch channel {
+            case .mic:
+                micSilentActive = true
+                appSilentActive = false
+
+            case .app:
+                appSilentActive = true
+                micSilentActive = false
+            }
+            notifier.notify(
+                title: "Capture Channel Silent",
+                body: Self.asymmetricSilenceMessage(for: channel),
+            )
+
+        case .recovered:
+            micSilentActive = false
+            appSilentActive = false
+
+        case .none:
+            break
+        }
+
+        let silentEvent = silentRecordingMonitor.update(micDBFS: mic, appDBFS: app, now: now)
+        switch silentEvent {
+        case .started:
+            recordingSilentActive = true
+            notifier.notify(
+                title: "Recording Appears Silent",
+                body: Self.silentRecordingMessage,
+            )
+
+        case .recovered:
+            recordingSilentActive = false
+
+        case .none:
+            break
+        }
+
+        return event
+    }
+
+    nonisolated static func asymmetricSilenceMessage(for channel: AudioChannel) -> String {
+        switch channel {
+        case .app:
+            "The app-audio channel went silent while the mic is still carrying audio. "
+                + "Check the meeting app's audio settings or system audio permission."
+
+        case .mic:
+            "The microphone went silent while the app audio is still recording. "
+                + "Check the mic device, mute state, or microphone permission."
+        }
+    }
+
+    nonisolated static let silentRecordingMessage: String =
+        "Both capture channels have been silent since the recording started. "
+            + "Check the audio routing — the meeting app may have claimed the mic "
+            + "in exclusive mode (e.g. AirPods HFP), or the system input device may be muted."
+}

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -59,7 +59,7 @@ struct MeetingTranscriberApp: App {
         // E2E drivers that force channel-health flags via env var also set
         // `MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1` so a +3 s
         // `toggleWatching` doesn't reset the forced flag through the
-        // normal `stopChannelHealthMonitoring()` path.
+        // normal `channelHealth.stop()` path.
         if (CommandLine.arguments.contains("--auto-watch")
             || UserDefaults.standard.bool(forKey: "autoWatch"))
             && !suppressAutoWatch {
@@ -102,10 +102,11 @@ struct MeetingTranscriberApp: App {
                     badge: appState.currentBadge,
                     permissionOverlay: appState.hasPermissionProblem,
                     recordOnlyOverlay: appState.settings.recordOnly,
-                    // `recordingSilentActive` paints both halves; OR'd in here so
-                    // MenuBarIcon only needs the two per-channel overlay inputs.
-                    micSilentOverlay: appState.micSilentActive || appState.recordingSilentActive,
-                    appSilentOverlay: appState.appSilentActive || appState.recordingSilentActive,
+                    // `recordingSilentActive` paints both halves; folded into the
+                    // hoisted overlay props so MenuBarIcon only needs the two
+                    // per-channel overlay inputs.
+                    micSilentOverlay: appState.micSilentOverlay,
+                    appSilentOverlay: appState.appSilentOverlay,
                 )
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -80,20 +80,6 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertNil(state.currentStatus)
     }
 
-    func testAsymmetricSilenceInactiveByDefault() {
-        let (state, _) = makeState()
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
-    }
-
-    func testAsymmetricSilenceMessageDistinguishesChannel() {
-        let appMessage = AppState.asymmetricSilenceMessage(for: .app)
-        let micMessage = AppState.asymmetricSilenceMessage(for: .mic)
-        XCTAssertNotEqual(appMessage, micMessage)
-        XCTAssertTrue(appMessage.lowercased().contains("app-audio"))
-        XCTAssertTrue(micMessage.lowercased().contains("microphone"))
-    }
-
     // MARK: - isWatching
 
     func testIsWatchingTrueWhenLoopActiveNotManual() {

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -1,10 +1,15 @@
 @testable import MeetingTranscriber
 import XCTest
 
-/// Integration test of the AppState polling-tick path: drives `applyChannelHealthTick`
-/// against a mock recorder with controllable per-channel levels and verifies the
-/// observable flags + notification side-effects line up with the
+/// Integration test of the `ChannelHealthController` polling-tick path: drives
+/// `applyTick` against a mock recorder with controllable per-channel levels and
+/// verifies the observable flags + notification side-effects line up with the
 /// `ChannelHealthMonitor` events.
+///
+/// Constructs a bare `ChannelHealthController` (not a full `AppState`) — the
+/// controller was extracted from AppState precisely so this concern is testable
+/// in isolation, against settings closures + a mock recorder, without a
+/// `WatchLoop` or the rest of the app.
 ///
 /// Covers the production scenario "user mutes their mic while the meeting app's
 /// audio continues to play other participants" — the mic input goes to -120 dBFS,
@@ -14,7 +19,7 @@ import XCTest
 final class ChannelHealthIntegrationTests: XCTestCase {
     private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
 
-    private func makeState() -> (AppState, MockRecorder, RecordingNotifier, AppSettings) {
+    private func makeController() -> (ChannelHealthController, MockRecorder, RecordingNotifier, AppSettings) {
         let suite = "ChannelHealthIntegrationTests-\(getpid())-\(UUID().uuidString)"
         // swiftlint:disable:next force_unwrapping
         let defaults = UserDefaults(suiteName: suite)!
@@ -24,51 +29,71 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         settings.asymmetricSilenceWarningSeconds = 30
 
         let notifier = RecordingNotifier()
-        let state = AppState(settings: settings, notifier: notifier)
+        // Settings-backed closures mirror production: `simulateStartForTests()`
+        // rebuilds the monitors from the live `asymmetricSilenceWarningSeconds`.
+        let controller = ChannelHealthController(
+            notifier: notifier,
+            debounceSeconds: { settings.asymmetricSilenceWarningSeconds },
+            indicatorEnabled: { settings.perChannelIndicatorEnabled },
+        )
         let recorder = MockRecorder()
-        // AppState reads recorder via watchLoop?.activeRecorder. Skipping the
-        // WatchLoop construction in the test — the `applyChannelHealthTick`
-        // overload takes the recorder directly.
-        return (state, recorder, notifier, settings)
+        return (controller, recorder, notifier, settings)
+    }
+
+    // MARK: - Defaults
+
+    func testFlagsInactiveByDefault() {
+        let (controller, _, _, _) = makeController()
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
+        XCTAssertFalse(controller.recordingSilentActive)
+    }
+
+    func testAsymmetricSilenceMessageDistinguishesChannel() {
+        let appMessage = ChannelHealthController.asymmetricSilenceMessage(for: .app)
+        let micMessage = ChannelHealthController.asymmetricSilenceMessage(for: .mic)
+        XCTAssertNotEqual(appMessage, micMessage)
+        XCTAssertTrue(appMessage.lowercased().contains("app-audio"))
+        XCTAssertTrue(micMessage.lowercased().contains("microphone"))
     }
 
     // MARK: - Production scenario: user mutes their mic mid-meeting
 
     func testMutedMicWithAppSpeechFiresMicSilent() {
-        let (state, recorder, notifier, _) = makeState()
-        // Initialize monitor with the same debounce as production startChannelHealthMonitoring.
+        let (controller, recorder, notifier, _) = makeController()
+        // Initialize monitor with the same debounce as production start().
         // (The test bypasses the polling task; we still need a fresh monitor.)
-        state.applyChannelHealthTick(recorder: recorder, now: t0) // warmup tick
+        controller.applyTick(recorder: recorder, now: t0) // warmup tick
 
         recorder.micLevelDBFS = -80 // muted
         recorder.appLevelDBFS = -25 // other participants speaking
 
         // Before debounce elapses: nothing fires
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 0)
 
         // At debounce boundary: mic-silent fires
-        let event = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        let event = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
         XCTAssertEqual(event, .started(channel: .mic, quietSince: t0))
-        XCTAssertTrue(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertTrue(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertEqual(notifier.calls[0].title, "Capture Channel Silent")
         XCTAssertTrue(notifier.calls[0].body.lowercased().contains("microphone"))
     }
 
     func testMutedAppAudioWithMicSpeechFiresAppSilent() {
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         recorder.micLevelDBFS = -25 // user speaking
         recorder.appLevelDBFS = -80 // app audio dead (e.g. dropped CATapDescription)
 
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        let event = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        let event = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
         XCTAssertEqual(event, .started(channel: .app, quietSince: t0))
-        XCTAssertTrue(state.appSilentActive)
-        XCTAssertFalse(state.micSilentActive)
+        XCTAssertTrue(controller.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertTrue(notifier.calls[0].body.lowercased().contains("app-audio"))
     }
@@ -76,36 +101,36 @@ final class ChannelHealthIntegrationTests: XCTestCase {
     // MARK: - Latch + recovery
 
     func testStartedFiresExactlyOncePerEpisode() {
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -25
 
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30)) // .started
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30)) // .started
         XCTAssertEqual(notifier.calls.count, 1)
 
         // Subsequent ticks while the episode is latched must not re-fire.
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(40))
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(120))
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(40))
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(120))
         XCTAssertEqual(notifier.calls.count, 1, "notifier must fire exactly once per episode")
-        XCTAssertTrue(state.micSilentActive)
+        XCTAssertTrue(controller.micSilentActive)
     }
 
     func testRecoveryClearsBothFlags() {
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -25
 
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30)) // .started
-        XCTAssertTrue(state.micSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30)) // .started
+        XCTAssertTrue(controller.micSilentActive)
 
         // Mic comes back online (user unmutes).
         recorder.micLevelDBFS = -25
-        let event = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(40))
+        let event = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(40))
         XCTAssertEqual(event, .recovered(channel: .mic))
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
         // Recovery doesn't fire a notification today — only .started does.
         XCTAssertEqual(notifier.calls.count, 1)
     }
@@ -113,30 +138,30 @@ final class ChannelHealthIntegrationTests: XCTestCase {
     // MARK: - Channel switch mid-episode
 
     func testChannelSwitchClearsOldFlagBeforeNewFires() {
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         // Phase 1: mic silent, app speaking — start tracking mic
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -25
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30)) // mic .started
-        XCTAssertTrue(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30)) // mic .started
+        XCTAssertTrue(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
 
         // Phase 2: roles flip — mic recovers AND app dies. Monitor's channel-switch path resets.
         recorder.micLevelDBFS = -25
         recorder.appLevelDBFS = -80
         // Right at the swap: not asymmetric in the same direction → monitor returns to clean state.
         // Both flags clear via `.recovered`.
-        let recovery = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(35))
+        let recovery = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(35))
         XCTAssertEqual(recovery, .recovered(channel: .mic))
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
 
         // Phase 3: app stays dead, mic stays alive — new episode tracks app
-        let event = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(65))
+        let event = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(65))
         XCTAssertEqual(event, .started(channel: .app, quietSince: t0.addingTimeInterval(35)))
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertTrue(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertTrue(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 2)
         XCTAssertTrue(notifier.calls[1].body.lowercased().contains("app-audio"))
     }
@@ -144,14 +169,14 @@ final class ChannelHealthIntegrationTests: XCTestCase {
     // MARK: - Symmetric cases never fire
 
     func testBothChannelsActiveDoesNotFire() {
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         recorder.micLevelDBFS = -25
         recorder.appLevelDBFS = -25
         for offset in stride(from: 0.0, through: 30.0, by: 1.0) {
-            _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(offset))
+            _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(offset))
         }
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 0)
     }
 
@@ -160,14 +185,14 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         // (its job is one-side-dead detection). The sibling
         // `SilentRecordingMonitor` *does* fire on this case — see
         // `testBothChannelsSilentFiresRecordingSilentAfterDebounce`.
-        let (state, recorder, _, _) = makeState()
+        let (controller, recorder, _, _) = makeController()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -80
         for offset in stride(from: 0.0, through: 30.0, by: 1.0) {
-            _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(offset))
+            _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(offset))
         }
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
     }
 
     // MARK: - Silent-recording (symmetric silence) detection
@@ -179,59 +204,59 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         // `SilentRecordingMonitor` shares the same debounce as
         // `ChannelHealthMonitor` and fires `recordingSilentActive` plus
         // a notification.
-        let (state, recorder, notifier, _) = makeState()
+        let (controller, recorder, notifier, _) = makeController()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -80
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        XCTAssertFalse(state.recordingSilentActive)
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
-        XCTAssertTrue(state.recordingSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        XCTAssertFalse(controller.recordingSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        XCTAssertTrue(controller.recordingSilentActive)
         // Asymmetric flags stay clear — semantics distinct from the
         // mic/app-silent path.
-        XCTAssertFalse(state.micSilentActive)
-        XCTAssertFalse(state.appSilentActive)
+        XCTAssertFalse(controller.micSilentActive)
+        XCTAssertFalse(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertEqual(notifier.calls[0].title, "Recording Appears Silent")
     }
 
     func testRecordingSilentRecoversWhenAnyChannelReturnsToSpeech() {
-        let (state, recorder, _, _) = makeState()
+        let (controller, recorder, _, _) = makeController()
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -80
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(30))
-        XCTAssertTrue(state.recordingSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        XCTAssertTrue(controller.recordingSilentActive)
 
         recorder.micLevelDBFS = -25
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(35))
-        XCTAssertFalse(state.recordingSilentActive)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(35))
+        XCTAssertFalse(controller.recordingSilentActive)
     }
 
     // MARK: - Settings re-init across recordings
 
     func testThresholdChangeBetweenRecordingsTakesEffectOnNextStart() {
-        let (state, recorder, _, settings) = makeState()
+        let (controller, recorder, _, settings) = makeController()
         // First recording uses the initial 30 s debounce; warm-up tick.
         recorder.micLevelDBFS = -80
         recorder.appLevelDBFS = -25
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0)
         XCTAssertNil(
-            state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(20)),
+            controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(20)),
             "20s under initial 30s debounce should not fire yet",
         )
 
-        // User stops watching → would normally call stopChannelHealthMonitoring,
-        // then bumps the threshold up to 60s before starting again.
+        // User stops watching → would normally call stop(), then bumps the
+        // threshold up to 60s before starting again.
         settings.asymmetricSilenceWarningSeconds = 60
-        state.simulateStartChannelHealthMonitoringForTests()
+        controller.simulateStartForTests()
 
         // Replay the same asymmetric levels — but now 30s should NOT be enough.
-        _ = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(100))
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(100))
         XCTAssertNil(
-            state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(140)),
+            controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(140)),
             "40s under new 60s debounce should not fire — proves the monitor picked up the new threshold",
         )
-        let event = state.applyChannelHealthTick(recorder: recorder, now: t0.addingTimeInterval(160))
+        let event = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(160))
         XCTAssertEqual(
             event,
             .started(channel: .mic, quietSince: t0.addingTimeInterval(100)),


### PR DESCRIPTION
## What

Pulls the per-channel + symmetric-silence detection out of the `AppState`
god-class into its own `@Observable @MainActor` controller. The controller
owns the two pure state machines (`ChannelHealthMonitor` +
`SilentRecordingMonitor`), the 10 Hz polling task, the three red-tint flags,
and the notification logic. `AppState` holds it as a `channelHealth`
sub-controller and wires its `start()` / `stop()` to `WatchLoop` state
transitions via `attachStateChangeHandler`.

Second slice of the incremental `AppState` concern-split (after
`PermissionsController`). Net: ~136 lines leave `AppState`.

## Design

- `debounceSeconds` / `indicatorEnabled` are settings-backed closures (capture
  the settings object, no `self`), so the controller is constructed in
  `AppState.init` without an AppState back-reference.
- The active recorder is supplied via the closure passed to `start()` (a
  post-init context where `[weak self]` is valid) rather than stored at init —
  so the polling + notification path is testable against a mock recorder
  without a `WatchLoop`.
- The three flags are `private(set)`; the `#if !APPSTORE` E2E force-flag path
  goes through an explicit `applyForcedFlagsForE2E(...)` method (keeps the
  encapsulation consistent with `PermissionsController.health`).

## Behaviour-preserving

The detection logic, debounce, latch/recovery, channel-switch, and the env-var
E2E force-flags are moved verbatim. The menu-bar overlay and RPC snapshot read
the same flags through the controller. `ChannelHealthIntegrationTests` now
construct a bare controller instead of a full `AppState`; the message +
default-flag assertions move out of `AppStateTests` with them.

The two menu-bar overlay booleans and the RPC channel-health snapshot are
hoisted into named helpers (`AppState.micSilentOverlay` / `appSilentOverlay` /
`AppState+RPC.channelHealthSnapshot`) so the sub-controller indirection doesn't
push those SwiftUI/snapshot expressions over the 300 ms type-check budget on
slower CI runners.

## Test

- `swift test --parallel` green (only machine-dependent `MenuBarIconSnapshotTests`
  differ locally; they `XCTSkipIf(isCI)`).
- `./scripts/lint.sh` clean; `./scripts/pre-push.sh` (release parity) clean.