### PR TITLE
refactor(app): extract LiveTranscriptionCoordinator from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -57,17 +57,16 @@ final class AppState { // swiftlint:disable:this type_body_length
     /// state transitions, and the menu-bar icon + RPC snapshot read its flags.
     let channelHealth: ChannelHealthController
 
-    /// PoC live-transcription controller. Lazily created on first recording
-    /// start where `settings.liveTranscriptionEnabled` is true AND the active
-    /// engine is Parakeet (other engines silently no-op via
-    /// `TranscriptionError.streamingNotSupported`). Kept across recordings so
-    /// engine + VAD models stay warm.
-    @ObservationIgnored private var liveTranscriptionController: LiveTranscriptionController?
-
     /// Observable state for the live caption overlay. Always present (the
     /// `LiveCaptionsOverlay` window observes this); content is only populated
-    /// when live transcription is on AND a recording is active.
+    /// when live transcription is on AND a recording is active. Owned here (read
+    /// by the overlay window + RPC snapshot) and injected into `liveTranscription`.
     let liveCaptions: LiveCaptionsState = .init()
+
+    /// Live-transcription controller lifecycle (lazy creation against the active
+    /// engine, pre-warm, per-recording sink installation), extracted into its own
+    /// coordinator. `makeRecorderFactory` delegates sink installation to it.
+    let liveTranscription: LiveTranscriptionCoordinator
 
     #if !APPSTORE
         /// Lazy-started debug RPC server. Only constructed if the env var is
@@ -146,6 +145,12 @@ final class AppState { // swiftlint:disable:this type_body_length
             debounceSeconds: { [settings] in settings.asymmetricSilenceWarningSeconds },
             indicatorEnabled: { [settings] in settings.perChannelIndicatorEnabled },
         )
+        self.liveTranscription = LiveTranscriptionCoordinator(
+            captions: liveCaptions,
+            liveEnabled: { [settings] in settings.liveTranscriptionEnabled },
+            engineSupportsLive: { [settings] in settings.transcriptionEngine.supportsLiveTranscription },
+            verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
+        )
 
         #if !APPSTORE
             // E2E hook: force a per-channel flag on at launch so a driver
@@ -168,7 +173,7 @@ final class AppState { // swiftlint:disable:this type_body_length
         // start observing for runtime changes.
         syncLanguageSettings()
         observeEngineSettings()
-        setupLiveTranscriptionPrewarm()
+        liveTranscription.beginPrewarm { [weak self] in self?.activeTranscriptionEngine }
 
         #if !APPSTORE
             // Env var force-enables at launch only — preserves back-compat with
@@ -415,46 +420,9 @@ final class AppState { // swiftlint:disable:this type_body_length
     private func makeRecorderFactory() -> @MainActor () -> any RecordingProvider {
         { [weak self] in
             let recorder = DualSourceRecorder()
-            guard let self else { return recorder }
-            if self.settings.liveTranscriptionEnabled,
-               self.settings.transcriptionEngine.supportsLiveTranscription,
-               let controller = self.ensureLiveTranscriptionController() {
-                controller.reset()
-                recorder.micLiveSink = controller.micSink
-                recorder.appLiveSink = controller.appSink
-            }
+            self?.liveTranscription.attachSinks(to: recorder)
             return recorder
         }
-    }
-
-    /// Lazily create + warm the live transcription controller against the
-    /// currently-active engine. Safe to call repeatedly — `prepare()` is
-    /// idempotent (engines dedupe concurrent `loadModel` calls). When the
-    /// transcription-engine setting changes, the controller is invalidated
-    /// via `observeEngineSettings` so the next call rebuilds against the
-    /// new engine.
-    ///
-    /// Returns nil when the active engine doesn't conform to
-    /// `StreamingTranscribingEngine` — the static equivalent of the
-    /// `supportsLiveTranscription` enum-level gate. Both `prewarm…` and
-    /// `makeRecorderFactory` callers already check that gate before
-    /// invoking this, so a nil return here only happens if a regression
-    /// breaks one of those guards.
-    private func ensureLiveTranscriptionController() -> LiveTranscriptionController? {
-        if let existing = liveTranscriptionController { return existing }
-        guard let streamingEngine = activeTranscriptionEngine as? any StreamingTranscribingEngine else {
-            return nil
-        }
-        let controller = LiveTranscriptionController(
-            engine: streamingEngine,
-            vad: FluidVAD(threshold: 0.5),
-            captions: liveCaptions,
-        ) { [weak self] in
-            self?.settings.verboseDiagnostics ?? false
-        }
-        liveTranscriptionController = controller
-        Task { @MainActor in await controller.prepare() }
-        return controller
     }
 
     // MARK: - Start / Stop
@@ -683,53 +651,6 @@ final class AppState { // swiftlint:disable:this type_body_length
                 guard let self else { return }
                 self.syncLanguageSettings()
                 self.observeEngineSettings()
-            }
-        }
-    }
-
-    /// Eagerly load the FluidVAD + Parakeet models when the live-transcription
-    /// toggle flips on (or is already on at launch with the right engine), so
-    /// the first utterance after the recorder starts doesn't pay the cold-load
-    /// cost (a few seconds for the first call to `engine.loadModel()` + VAD
-    /// init). No-op when the conditions aren't met. Idempotent — the engines
-    /// dedupe concurrent `loadModel` calls.
-    private func prewarmLiveTranscriptionIfEligible() {
-        guard settings.liveTranscriptionEnabled,
-              settings.transcriptionEngine.supportsLiveTranscription
-        else { return }
-        _ = ensureLiveTranscriptionController()
-    }
-
-    /// Initial pre-warm of the live-transcription controller (when enabled +
-    /// the active engine supports streaming) plus a re-arming
-    /// `withObservationTracking` watcher on `liveTranscriptionEnabled` and
-    /// `transcriptionEngine`. On every change, drop the cached controller so
-    /// the next `ensureLiveTranscriptionController()` call rebuilds against
-    /// the (possibly new) `activeTranscriptionEngine` and re-warms the right
-    /// engine.
-    ///
-    /// Engine changes take effect on the **next** recording. Switching the
-    /// engine mid-recording deallocates the controller (its sinks capture
-    /// `[weak self]`), buffers from the running recorder no longer reach any
-    /// engine, and the live overlay goes silent until the recording stops and
-    /// a new one starts. Live mid-recording engine swap is a deferred follow-up
-    /// — see PR #318 limitations.
-    ///
-    /// Combined into a single method (rather than two init-body calls) so the
-    /// AppState init's type-check stays under the 300 ms `expression_type_check`
-    /// lint budget. Same recurring flake as `feedback_local_verify_before_push`
-    /// — the compiler's constraint solver gets slower with every method call
-    /// inside a long initializer.
-    private func setupLiveTranscriptionPrewarm() {
-        prewarmLiveTranscriptionIfEligible()
-        withObservationTracking {
-            _ = settings.liveTranscriptionEnabled
-            _ = settings.transcriptionEngine
-        } onChange: { [weak self] in
-            Task { @MainActor in
-                guard let self else { return }
-                self.liveTranscriptionController = nil
-                self.setupLiveTranscriptionPrewarm()
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Observation
+
+// MARK: - LiveTranscriptionCoordinator
+
+/// Owns the live-transcription controller lifecycle: lazy creation against the
+/// active engine, the pre-warm + re-arm observer, and installing the per-channel
+/// live sinks onto a recorder.
+///
+/// Extracted from `AppState` as a concern-specific controller (see the AppState
+/// god-class split). `AppState` keeps the shared `LiveCaptionsState` (read by the
+/// caption-overlay window + RPC snapshot) and injects it here; the coordinator
+/// only owns the streaming `LiveTranscriptionController` and its warm-up.
+///
+/// The active engine is supplied via `beginPrewarm(engineProvider:)` (called from
+/// `AppState.init` after stored-property init, where the `[weak self]` engine
+/// closure is valid) rather than captured at construction — so the coordinator
+/// never holds an AppState back-reference. `liveEnabled` / `engineSupportsLive` /
+/// `verboseDiagnostics` are settings-backed closures.
+///
+/// Not `@Observable` — it exposes no observable state (it drives the controller
+/// + captions imperatively). It still uses `withObservationTracking` internally
+/// to watch the settings keys, which works regardless of this type's annotation.
+@MainActor
+final class LiveTranscriptionCoordinator {
+    private var controller: LiveTranscriptionController?
+
+    /// Source of the currently-active engine. Set by `beginPrewarm`; nil before
+    /// then (so `ensureController` safely no-ops if called early). Captures the
+    /// owner weakly, so it returns nil once the owner is gone.
+    private var engineProvider: (() -> (any TranscribingEngine)?)?
+
+    private let captions: LiveCaptionsState
+    private let liveEnabled: () -> Bool
+    private let engineSupportsLive: () -> Bool
+    private let verboseDiagnostics: () -> Bool
+
+    init(
+        captions: LiveCaptionsState,
+        liveEnabled: @escaping () -> Bool,
+        engineSupportsLive: @escaping () -> Bool,
+        verboseDiagnostics: @escaping () -> Bool,
+    ) {
+        self.captions = captions
+        self.liveEnabled = liveEnabled
+        self.engineSupportsLive = engineSupportsLive
+        self.verboseDiagnostics = verboseDiagnostics
+    }
+
+    /// Wire the active-engine source, then do the initial pre-warm + arm the
+    /// re-warm observer. Called once from `AppState.init`.
+    ///
+    /// Combined into a single entry point (rather than separate prewarm + observe
+    /// calls in the AppState init body) to keep that init's type-check under the
+    /// 300 ms budget — the compiler's constraint solver slows with every method
+    /// call inside a long initializer.
+    func beginPrewarm(engineProvider: @escaping () -> (any TranscribingEngine)?) {
+        self.engineProvider = engineProvider
+        prewarmAndObserve()
+    }
+
+    /// Install mic + app live sinks onto `recorder` when live transcription is on
+    /// AND the active engine supports streaming. No-op otherwise — the recorder
+    /// records normally with no live overlay. Called by `AppState`'s recorder
+    /// factory on each recording start.
+    func attachSinks(to recorder: DualSourceRecorder) {
+        guard liveEnabled(), engineSupportsLive(), let controller = ensureController() else { return }
+        controller.reset()
+        recorder.micLiveSink = controller.micSink
+        recorder.appLiveSink = controller.appSink
+    }
+
+    /// Eagerly load the VAD + engine models when the toggle is on (or already on
+    /// at launch with a streaming engine) so the first utterance after the
+    /// recorder starts doesn't pay the cold-load cost. Plus a re-arming
+    /// `withObservationTracking` watcher on the toggle + engine setting: on every
+    /// change, drop the cached controller so the next `ensureController()` rebuilds
+    /// against the (possibly new) active engine and re-warms it.
+    ///
+    /// Engine changes take effect on the **next** recording. Switching the engine
+    /// mid-recording deallocates the controller, buffers from the running recorder
+    /// no longer reach any engine, and the live overlay goes silent until the next
+    /// recording. Live mid-recording engine swap is a deferred follow-up.
+    private func prewarmAndObserve() {
+        prewarmIfEligible()
+        withObservationTracking {
+            // Touch the underlying settings via the gate closures so the change
+            // tracker observes `liveTranscriptionEnabled` + `transcriptionEngine`.
+            _ = liveEnabled()
+            _ = engineSupportsLive()
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.controller = nil
+                self.prewarmAndObserve()
+            }
+        }
+    }
+
+    private func prewarmIfEligible() {
+        guard liveEnabled(), engineSupportsLive() else { return }
+        _ = ensureController()
+    }
+
+    /// Lazily create + warm the controller against the active engine. Idempotent
+    /// — `prepare()` dedupes concurrent `loadModel` calls.
+    ///
+    /// Returns nil when no engine source is wired yet, or the active engine
+    /// doesn't conform to `StreamingTranscribingEngine` (the static equivalent of
+    /// the `supportsLiveTranscription` gate). Callers already check that gate, so
+    /// a nil return only happens if a regression breaks one of those guards.
+    private func ensureController() -> LiveTranscriptionController? {
+        if let existing = controller { return existing }
+        guard let engine = engineProvider?(),
+              let streamingEngine = engine as? any StreamingTranscribingEngine
+        else {
+            return nil
+        }
+        let controller = LiveTranscriptionController(
+            engine: streamingEngine,
+            vad: FluidVAD(threshold: 0.5),
+            captions: captions,
+        ) { [verboseDiagnostics] in verboseDiagnostics() }
+        self.controller = controller
+        Task { @MainActor in await controller.prepare() }
+        return controller
+    }
+}


### PR DESCRIPTION
## What

Pulls the live-transcription controller lifecycle out of the `AppState`
god-class into its own `@MainActor` coordinator: lazy creation of the streaming
`LiveTranscriptionController` against the active engine, the pre-warm + re-arm
observer, and per-recording live-sink installation. `AppState`'s recorder
factory now delegates sink installation to it.

Third slice of the incremental `AppState` concern-split (after
`PermissionsController` + `ChannelHealthController`). `AppState` shrinks ~80 lines.

## Minimal blast radius

`AppState` KEEPS the shared `LiveCaptionsState` (read by the caption-overlay
window + RPC snapshot) and `shouldShowLiveCaptions` (reads `watchLoop`),
injecting `liveCaptions` into the coordinator. So this slice touches **no tests,
no RPC, no menu-bar code** — only `AppState.swift` changes (+ the new file).

## Design (mirrors the prior slices)

- The active engine is supplied via `beginPrewarm(engineProvider:)` (called post
  stored-property init, where the `[weak self]` engine closure is valid) rather
  than captured at construction — so the coordinator holds no `AppState`
  back-reference. `liveEnabled` / `engineSupportsLive` / `verboseDiagnostics`
  are settings-backed closures.
- Not `@Observable` — it exposes no observable state (drives the controller +
  captions imperatively). It still uses `withObservationTracking` internally to
  watch the toggle + engine settings keys.

## Behaviour-preserving

The gating, lazy-build, pre-warm, and engine-switch invalidation logic is moved
verbatim. The observer reads the same two settings keys
(`liveTranscriptionEnabled` + `transcriptionEngine`) through the gate closures;
verified that `withObservationTracking` re-fires identically when an observable
property is read through a closure (so the engine-switch → drop-controller path
is preserved). The injected `LiveCaptionsState` is the same instance the overlay
window + RPC read, so captions still populate the visible overlay.

## Test

- `swift test --parallel` green (only machine-dependent `MenuBarIconSnapshotTests`
  differ locally; they `XCTSkipIf(isCI)`).
- `./scripts/lint.sh` clean; `./scripts/pre-push.sh` (release parity) clean.