### PR TITLE
refactor(app): extract RPCServerController from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -69,9 +69,11 @@ final class AppState { // swiftlint:disable:this type_body_length
     let liveTranscription: LiveTranscriptionCoordinator
 
     #if !APPSTORE
-        /// Lazy-started debug RPC server. Only constructed if the env var is
-        /// set — otherwise `nil` and zero overhead.
-        var debugRPCServer: DebugRPCServer?
+        /// Debug RPC server lifecycle (launch gate, settings-driven start/stop,
+        /// token rotation), extracted into its own controller. `AppState` supplies
+        /// the wired server via `buildDebugRPCServer()` and keeps the state
+        /// projection (`rpcStateSnapshot`) + speaker-DB actions.
+        let rpcController: RPCServerController
 
         /// Background `log stream` subprocess that mirrors our subsystems to
         /// `~/Library/Logs/MeetingTranscriber/diagnostics-YYYY-MM-DD.log`.
@@ -153,6 +155,11 @@ final class AppState { // swiftlint:disable:this type_body_length
         )
 
         #if !APPSTORE
+            // Not trailing-closure: `isEnabled` is the first param (the other two
+            // have defaults), so a trailing closure would bind to `rotateToken`.
+            // swiftlint:disable:next trailing_closure
+            self.rpcController = RPCServerController(isEnabled: { [settings] in settings.debugRPCEnabled })
+
             // E2E hook: force a per-channel flag on at launch so a driver
             // script can assert the menu-bar red-tint pipeline end-to-end
             // without orchestrating real audio. Only honoured in non-AppStore
@@ -176,14 +183,11 @@ final class AppState { // swiftlint:disable:this type_body_length
         liveTranscription.beginPrewarm { [weak self] in self?.activeTranscriptionEngine }
 
         #if !APPSTORE
-            // Env var force-enables at launch only — preserves back-compat with
-            // scripts/test_rpc.sh and CI. After init, settings.debugRPCEnabled
-            // is the sole driver, so toggling off mid-session works even when
-            // the env var was set at launch.
-            if DebugRPCServer.enabled || settings.debugRPCEnabled {
-                startDebugRPCServer()
-            }
-            observeDebugRPCSetting()
+            // Launch gate (env var OR setting) + the settings observer now live
+            // in RPCServerController.activate; AppState only supplies the wired
+            // server. The closure is set here (post stored-property init) so it
+            // can capture self.
+            rpcController.activate { [weak self] in self?.buildDebugRPCServer() }
 
             PersistentDiagnosticLog.cleanup()
             do {
@@ -223,25 +227,10 @@ final class AppState { // swiftlint:disable:this type_body_length
     #endif
 
     #if !APPSTORE
-        /// Reconcile the debug RPC server with the current setting.
-        ///
-        /// Called only from the settings-driven `observeDebugRPCSetting` path
-        /// (init has its own gate). On a toggle off → on we rotate the bearer
-        /// token before starting the listener: that way any token an attacker
-        /// scraped while the server was previously running is invalidated by
-        /// the act of turning it off and on again — the same gesture a user
-        /// already performs to "reset" the feature.
-        func applyDebugRPCSetting() {
-            if settings.debugRPCEnabled, debugRPCServer == nil {
-                DebugRPCServer.rotateToken()
-                startDebugRPCServer()
-            } else if !settings.debugRPCEnabled, let server = debugRPCServer {
-                server.stop()
-                debugRPCServer = nil
-            }
-        }
-
-        private func startDebugRPCServer() {
+        /// Build a fully-wired debug RPC server (state snapshot + speaker-DB
+        /// actions + skip-naming + file-enqueue closures). `RPCServerController`
+        /// owns when to start/stop it; this just constructs it.
+        func buildDebugRPCServer() -> DebugRPCServer {
             let snapshot: () -> RPCStateSnapshot = { [weak self] in
                 self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
             }
@@ -273,30 +262,13 @@ final class AppState { // swiftlint:disable:this type_body_length
             let enqueueFilesRPC: ([URL]) -> Int = { [weak self] urls in
                 self?.enqueueExistingFiles(urls) ?? 0
             }
-            let server = DebugRPCServer(
+            return DebugRPCServer(
                 snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
                 skipNaming: skipNaming,
                 enqueueFile: enqueueFile,
                 enqueueFiles: enqueueFilesRPC,
             )
-            server.start()
-            debugRPCServer = server
-        }
-
-        /// `withObservationTracking` is one-shot — re-arm after each fire so
-        /// the AppState reacts to every toggle of `settings.debugRPCEnabled`,
-        /// not just the first one.
-        private func observeDebugRPCSetting() {
-            withObservationTracking {
-                _ = settings.debugRPCEnabled
-            } onChange: { [weak self] in
-                Task { @MainActor in
-                    guard let self else { return }
-                    self.applyDebugRPCSetting()
-                    self.observeDebugRPCSetting()
-                }
-            }
         }
     #endif
 
@@ -638,7 +610,7 @@ final class AppState { // swiftlint:disable:this type_body_length
 
     /// `withObservationTracking` is one-shot — re-arm after each fire so the
     /// AppState reacts to every settings change, not just the first one.
-    /// Mirrors the `observeDebugRPCSetting` pattern.
+    /// Same self-re-arming pattern the concern controllers use for their observers.
     private func observeEngineSettings() {
         withObservationTracking {
             _ = settings.transcriptionEngine

--- a/app/MeetingTranscriber/Sources/RPCServerController.swift
+++ b/app/MeetingTranscriber/Sources/RPCServerController.swift
@@ -1,0 +1,101 @@
+#if !APPSTORE
+    import Foundation
+    import Observation
+
+    // MARK: - RPCServing
+
+    /// The slice of `DebugRPCServer` the controller drives. A protocol so the
+    /// lifecycle (start/stop/token-rotation reconciliation) is testable against a
+    /// spy without binding a real socket. `@MainActor` to match `DebugRPCServer`'s
+    /// isolation (and the controller's) — the whole lifecycle runs on the main actor.
+    @MainActor
+    protocol RPCServing: AnyObject {
+        func start()
+        func stop()
+    }
+
+    extension DebugRPCServer: RPCServing {}
+
+    // MARK: - RPCServerController
+
+    /// Owns the debug RPC server's lifecycle: the launch-time enable gate, the
+    /// settings-driven start/stop, and the security token rotation on re-enable.
+    ///
+    /// Extracted from `AppState` as a concern-specific controller (see the AppState
+    /// god-class split). `AppState` keeps the state projection (`rpcStateSnapshot`)
+    /// and the speaker-DB actions (both used by tests + reading the whole AppState);
+    /// it supplies a fully-wired server via the `makeServer` closure passed to
+    /// `activate()` (a post-init context, so the closure can capture AppState).
+    ///
+    /// Whole file is `#if !APPSTORE` — the sandboxed App Store build has no RPC server.
+    @MainActor
+    final class RPCServerController {
+        private(set) var server: (any RPCServing)?
+
+        private let isEnabled: () -> Bool
+        private let envForceEnabled: () -> Bool
+        private let rotateToken: () -> Void
+        private var makeServer: (() -> (any RPCServing)?)?
+
+        init(
+            isEnabled: @escaping () -> Bool,
+            envForceEnabled: @escaping () -> Bool = { DebugRPCServer.enabled },
+            rotateToken: @escaping () -> Void = { _ = DebugRPCServer.rotateToken() },
+        ) {
+            self.isEnabled = isEnabled
+            self.envForceEnabled = envForceEnabled
+            self.rotateToken = rotateToken
+        }
+
+        /// Wire the server factory, run the launch-time enable gate, and arm the
+        /// settings observer. Called once from `AppState.init`.
+        ///
+        /// Launch gate: the env var force-enables OR the persisted setting is on.
+        /// No token rotation here — that's intentional, preserving back-compat with
+        /// `scripts/test_rpc.sh` + CI which set the env var at launch. After init,
+        /// the setting is the sole driver via `apply()`, so toggling off mid-session
+        /// works even when the env var was set at launch.
+        func activate(makeServer: @escaping () -> (any RPCServing)?) {
+            self.makeServer = makeServer
+            if envForceEnabled() || isEnabled() {
+                start()
+            }
+            observe()
+        }
+
+        /// Reconcile the server with the current setting (the toggle path). On a
+        /// toggle off → on we rotate the bearer token before starting the listener:
+        /// any token scraped while the server was previously running is invalidated
+        /// by the act of turning it off and on again — the same gesture a user
+        /// already performs to "reset" the feature.
+        func apply() {
+            if isEnabled(), server == nil {
+                rotateToken()
+                start()
+            } else if !isEnabled(), let server {
+                server.stop()
+                self.server = nil
+            }
+        }
+
+        private func start() {
+            guard let server = makeServer?() else { return }
+            server.start()
+            self.server = server
+        }
+
+        /// `withObservationTracking` is one-shot — re-arm after each fire so the
+        /// controller reacts to every toggle of the enable setting, not just the first.
+        private func observe() {
+            withObservationTracking {
+                _ = isEnabled()
+            } onChange: { [weak self] in
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.apply()
+                    self.observe()
+                }
+            }
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/RPCServerControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCServerControllerTests.swift
@@ -1,0 +1,100 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Unit tests for `RPCServerController`'s lifecycle — the launch gate, the
+    /// settings-driven start/stop, and the security token rotation on re-enable.
+    ///
+    /// Drives the controller against a spy `RPCServing` + injected enable/rotate
+    /// closures, so the lifecycle (previously buried in `AppState` as private
+    /// methods, covered only by the real-socket integration test) is testable
+    /// without binding a socket.
+    @MainActor
+    final class RPCServerControllerTests: XCTestCase {
+        private final class SpyServer: RPCServing {
+            var startCount = 0
+            var stopCount = 0
+            func start() {
+                startCount += 1
+            }
+
+            func stop() {
+                stopCount += 1
+            }
+        }
+
+        func testActivateStartsWhenEnvForcedWithoutTokenRotation() {
+            let spy = SpyServer()
+            var rotations = 0
+            let controller = RPCServerController(
+                isEnabled: { false },
+                envForceEnabled: { true },
+                rotateToken: { rotations += 1 },
+            )
+            controller.activate { spy }
+            XCTAssertEqual(spy.startCount, 1, "env-forced launch should start the server")
+            XCTAssertEqual(rotations, 0, "the launch gate must NOT rotate the token")
+            XCTAssertNotNil(controller.server)
+        }
+
+        func testActivateDoesNotStartWhenDisabledAndNotForced() {
+            let spy = SpyServer()
+            let controller = RPCServerController(
+                isEnabled: { false },
+                envForceEnabled: { false },
+                rotateToken: {},
+            )
+            controller.activate { spy }
+            XCTAssertEqual(spy.startCount, 0)
+            XCTAssertNil(controller.server)
+        }
+
+        func testApplyRotatesTokenAndStartsOnEnable() {
+            let spy = SpyServer()
+            var enabled = false
+            var rotations = 0
+            let controller = RPCServerController(
+                isEnabled: { enabled },
+                envForceEnabled: { false },
+                rotateToken: { rotations += 1 },
+            )
+            controller.activate { spy } // disabled → no start
+            XCTAssertEqual(spy.startCount, 0)
+
+            enabled = true
+            controller.apply() // off → on: rotate the bearer token, then start
+            XCTAssertEqual(rotations, 1, "off→on must rotate the bearer token")
+            XCTAssertEqual(spy.startCount, 1)
+            XCTAssertNotNil(controller.server)
+        }
+
+        func testApplyStopsOnDisable() {
+            let spy = SpyServer()
+            var enabled = true
+            let controller = RPCServerController(
+                isEnabled: { enabled },
+                envForceEnabled: { true },
+                rotateToken: {},
+            )
+            controller.activate { spy } // forced → started
+            XCTAssertEqual(spy.startCount, 1)
+
+            enabled = false
+            controller.apply() // on → off: stop + drop
+            XCTAssertEqual(spy.stopCount, 1)
+            XCTAssertNil(controller.server)
+        }
+
+        func testApplyIsNoOpWhenAlreadyRunning() {
+            let spy = SpyServer()
+            let controller = RPCServerController(
+                isEnabled: { true },
+                envForceEnabled: { true },
+                rotateToken: {},
+            )
+            controller.activate { spy } // started (count 1)
+            controller.apply() // still enabled + server != nil → no restart
+            XCTAssertEqual(spy.startCount, 1, "apply while already running must not restart")
+        }
+    }
+#endif


### PR DESCRIPTION
## What

Pulls the debug RPC server's **lifecycle** out of the `AppState` god-class into
its own `@MainActor` controller: the launch-time enable gate (env var OR
setting), the settings-driven start/stop, and the security bearer-token rotation
on re-enable. Whole file is `#if !APPSTORE` (no RPC server in the sandboxed App
Store build).

Fourth slice of the incremental `AppState` concern-split (after Permissions /
ChannelHealth / LiveTranscription).

## Split

`AppState` keeps what genuinely belongs to it:
- `rpcStateSnapshot()` — projects the **entire** AppState (pipeline, speaker DB,
  engines, channel-health flags, live captions); can't move, and ~20 test call
  sites use it directly.
- `makeSpeakerDBActions()` — the speaker-DB action closures.
- a new `buildDebugRPCServer()` that wires those into a ready-to-start server.

The controller owns only the lifecycle and is handed the wired server via the
`makeServer` closure passed to `activate()` (a post-init context, so it can
capture `self` — same pattern as the prior slices' `start`/`beginPrewarm`).

## Testability win

A small `RPCServing` protocol (`start`/`stop`, which `DebugRPCServer` already
satisfies) lets the lifecycle be tested against a spy **without binding a real
socket**. `RPCServerControllerTests` pins the launch gate, enable/disable
start-stop, the no-restart-when-already-running case, and crucially the **off→on
token rotation** (non-vacuity proven by disabling the rotation and watching the
test fail). `envForceEnabled` / `rotateToken` are injected closures with
production defaults (`DebugRPCServer.enabled` / `.rotateToken()`) so production
callers pass only `isEnabled`.

## Behaviour-preserving

The launch gate, toggle reconciliation, token rotation, and the 5 server-wiring
closures are moved verbatim; only their owner changes. The settings observer
reads the same `debugRPCEnabled` key (through the `isEnabled` closure;
`withObservationTracking` tracks accesses made inside the closure).

## Test

- `swift test --parallel` green (1846; incl. `DebugRPCServerIntegrationTests`
  which exercise the real server over sockets, + the 5 new lifecycle tests).
- `./scripts/test_rpc.sh` reached `✓ listening on :9876` on a clean run —
  confirms the `activate → buildDebugRPCServer → start` wiring binds the real
  dev server end-to-end.
- `./scripts/lint.sh` clean; `./scripts/pre-push.sh` (release parity) clean;
  APPStore variant (`-Xswiftc -DAPPSTORE`) builds clean.