### PR TITLE
test(app): cover LiveTranscriptionCoordinator sink-attach gate

### DIFF
--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -34,17 +34,41 @@ final class LiveTranscriptionCoordinator {
     private let liveEnabled: () -> Bool
     private let engineSupportsLive: () -> Bool
     private let verboseDiagnostics: () -> Bool
+    private let makeController: ControllerFactory
+
+    /// Builds the streaming controller for an already-resolved engine. Injectable
+    /// so tests can supply a controller with mock collaborators (no model load);
+    /// the default builds the real one. Takes `captions` + `verboseDiagnostics` as
+    /// parameters (rather than capturing `self`) so the default can be a `static`
+    /// function with no init-ordering dependency.
+    typealias ControllerFactory = @MainActor (
+        any StreamingTranscribingEngine, LiveCaptionsState, @escaping () -> Bool,
+    ) -> LiveTranscriptionController
 
     init(
         captions: LiveCaptionsState,
         liveEnabled: @escaping () -> Bool,
         engineSupportsLive: @escaping () -> Bool,
         verboseDiagnostics: @escaping () -> Bool,
+        makeController: @escaping ControllerFactory = LiveTranscriptionCoordinator.makeDefaultController,
     ) {
         self.captions = captions
         self.liveEnabled = liveEnabled
         self.engineSupportsLive = engineSupportsLive
         self.verboseDiagnostics = verboseDiagnostics
+        self.makeController = makeController
+    }
+
+    private static func makeDefaultController(
+        engine: any StreamingTranscribingEngine,
+        captions: LiveCaptionsState,
+        verboseDiagnostics: @escaping () -> Bool,
+    ) -> LiveTranscriptionController {
+        LiveTranscriptionController(
+            engine: engine,
+            vad: FluidVAD(threshold: 0.5),
+            captions: captions,
+        ) { verboseDiagnostics() }
     }
 
     /// Wire the active-engine source, then do the initial pre-warm + arm the
@@ -116,11 +140,7 @@ final class LiveTranscriptionCoordinator {
         else {
             return nil
         }
-        let controller = LiveTranscriptionController(
-            engine: streamingEngine,
-            vad: FluidVAD(threshold: 0.5),
-            captions: captions,
-        ) { [verboseDiagnostics] in verboseDiagnostics() }
+        let controller = makeController(streamingEngine, captions, verboseDiagnostics)
         self.controller = controller
         Task { @MainActor in await controller.prepare() }
         return controller

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -1,0 +1,87 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `LiveTranscriptionCoordinator.attachSinks`'s gate — that live
+/// sinks are installed on the recorder IFF the toggle is on AND the active engine
+/// supports streaming.
+///
+/// This gating was previously buried in `AppState.makeRecorderFactory` (a private
+/// closure) and only reachable via live recording / E2E. The `makeController`
+/// injection seam lets a test supply a controller built with mock collaborators
+/// (`MockStreamingEngine` + `FakeLiveSpeakerMatcher`) so `prepare()` loads no
+/// models — making the gate testable in isolation.
+///
+/// Non-vacuity: the two "skip" tests build the controller with the gate OPEN
+/// (so it's cached), then flip the gate CLOSED before `attachSinks`. The sinks
+/// stay nil *because of the gate*, not because no controller exists — removing
+/// the gate would install them (proven by temporarily deleting the guard).
+@MainActor
+final class LiveTranscriptionCoordinatorTests: XCTestCase {
+    /// Builds a controller with mock collaborators — `prepare()` is a no-op
+    /// (mock engine `loadModel`, fake matcher `prepare`), so no model loads.
+    private func mockControllerFactory() -> LiveTranscriptionCoordinator.ControllerFactory {
+        { engine, captions, verboseDiagnostics in
+            LiveTranscriptionController(
+                engine: engine,
+                vad: FluidVAD(threshold: 0.5),
+                captions: captions,
+                speakerMatcher: FakeLiveSpeakerMatcher(),
+            ) { verboseDiagnostics() }
+        }
+    }
+
+    func testAttachSinksInstallsWhenGateOpenAndControllerReady() {
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { true },
+            engineSupportsLive: { true },
+            verboseDiagnostics: { false },
+            makeController: mockControllerFactory(),
+        )
+        coordinator.beginPrewarm { MockStreamingEngine() }
+
+        let recorder = DualSourceRecorder()
+        coordinator.attachSinks(to: recorder)
+
+        XCTAssertNotNil(recorder.micLiveSink, "gate open + controller ready should install the mic sink")
+        XCTAssertNotNil(recorder.appLiveSink, "gate open + controller ready should install the app sink")
+    }
+
+    func testAttachSinksSkipsWhenLiveDisabledEvenWithControllerReady() {
+        var enabled = true
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { enabled },
+            engineSupportsLive: { true },
+            verboseDiagnostics: { false },
+            makeController: mockControllerFactory(),
+        )
+        coordinator.beginPrewarm { MockStreamingEngine() } // gate open → controller cached
+        enabled = false
+
+        let recorder = DualSourceRecorder()
+        coordinator.attachSinks(to: recorder)
+
+        XCTAssertNil(recorder.micLiveSink, "live disabled must skip sink install even with a cached controller")
+        XCTAssertNil(recorder.appLiveSink)
+    }
+
+    func testAttachSinksSkipsWhenEngineUnsupportedEvenWithControllerReady() {
+        var supportsLive = true
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { true },
+            engineSupportsLive: { supportsLive },
+            verboseDiagnostics: { false },
+            makeController: mockControllerFactory(),
+        )
+        coordinator.beginPrewarm { MockStreamingEngine() } // gate open → controller cached
+        supportsLive = false
+
+        let recorder = DualSourceRecorder()
+        coordinator.attachSinks(to: recorder)
+
+        XCTAssertNil(recorder.micLiveSink, "unsupported engine must skip sink install even with a cached controller")
+        XCTAssertNil(recorder.appLiveSink)
+    }
+}


### PR DESCRIPTION
## What

Closes the test-coverage follow-up from the `LiveTranscriptionCoordinator`
extraction. That slice shipped byte-preserving but with **no unit coverage** for
the sink-attach gate (live-transcription toggle AND engine-supports-streaming) —
the gate had lived as a private closure in `AppState.makeRecorderFactory`,
reachable only via live recording / E2E, and a real controller can't be built in
a unit test without loading the WeSpeaker model (heavy / CoreML-cache-race-prone
under parallel xctest).

## How

Adds a `makeController` injection seam to `LiveTranscriptionCoordinator`: a
`ControllerFactory` typealias + an init param defaulting to a `static
makeDefaultController` (parameters, not `self` capture, so no init-ordering
coupling). `ensureController` calls it instead of inline-building. The default is
byte-equivalent to the old inline build — zero production change. The seam
mirrors the prior controllers' injection pattern (probe / makeServer /
speakerMatcherFactory).

Three tests inject a factory that returns a controller with mock collaborators
(`MockStreamingEngine` + `FakeLiveSpeakerMatcher`) whose `prepare()` loads
nothing:
- gate open + controller ready → both sinks installed
- live-disabled → skip (even with a cached controller)
- engine-unsupported → skip (even with a cached controller)

**Non-vacuity**: the two skip tests build the controller with the gate OPEN (so
it's cached), then flip the gate closed before `attachSinks`. They fail if the
guard is removed — proven by deleting the `liveEnabled()` guard and watching them
go red (then reverting). They are NOT vacuous on a nil controller.

## Test

- `swift test --parallel` green (1849; +3 new).
- `./scripts/lint.sh` clean; `./scripts/pre-push.sh` (release parity) clean.