### PR TITLE
refactor(app): extract PipelineController from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -4,11 +4,16 @@
     extension AppState {
         /// Build a snapshot of state for the debug RPC. Read-only.
         func rpcStateSnapshot() -> RPCStateSnapshot {
+            // Bind the queue to a local so the reads below stay single-member
+            // accesses (`q.x`) rather than going through `pipeline.queue.x` —
+            // the extra member layer in this already-large literal would push
+            // its type-check over the 300 ms budget.
+            let q = pipeline.queue
             let stored = SpeakerMatcher().loadDB()
             let recentNames = SpeakerMatcher.rankByRecency(speakers: stored)
                 .prefix(10).map(\.name)
-            let pendingJobs = pipelineQueue.pendingSpeakerNamingJobs.map { job in
-                let data = pipelineQueue.speakerNamingDataByJob[job.id]
+            let pendingJobs = q.pendingSpeakerNamingJobs.map { job in
+                let data = q.speakerNamingDataByJob[job.id]
                 return RPCStateSnapshot.PendingNaming(
                     jobID: job.id.uuidString,
                     meetingTitle: job.meetingTitle,
@@ -18,15 +23,15 @@
             }
             return RPCStateSnapshot(
                 pipeline: .init(
-                    isProcessing: pipelineQueue.isProcessing,
-                    activeJobCount: pipelineQueue.activeJobs.count,
-                    waitingJobCount: pipelineQueue.pendingJobs.count,
+                    isProcessing: q.isProcessing,
+                    activeJobCount: q.activeJobs.count,
+                    waitingJobCount: q.pendingJobs.count,
                     pendingNamingJobCount: pendingJobs.count,
                 ),
                 speakerDB: .init(
                     count: stored.count,
                     recentNames: recentNames,
-                    knownSpeakerNames: pipelineQueue.knownSpeakerNames,
+                    knownSpeakerNames: q.knownSpeakerNames,
                 ),
                 pendingNamingJobs: pendingJobs,
                 engines: enginesSnapshot(),
@@ -64,7 +69,7 @@
         /// snapshot shape. Used by E2E driver scripts to assert on outcome
         /// after triggering a meeting.
         private func lastFinishedJobSnapshot() -> RPCStateSnapshot.LastJob? {
-            guard let job = pipelineQueue.jobs.last(where: { job in
+            guard let job = pipeline.queue.jobs.last(where: { job in
                 job.state == .done || job.state == .error
             }) else {
                 return nil
@@ -123,17 +128,17 @@
                     case .noop: .noop
                     case .notFound: .notFound
                     }
-                    if outcome != .notFound { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    if outcome != .notFound { self?.pipeline.queue.refreshKnownSpeakerNames() }
                     return outcome
                 },
                 delete: { [weak self] name in
                     let removed = speakerMatcherFactory().deleteSpeaker(name: name)
-                    if removed { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    if removed { self?.pipeline.queue.refreshKnownSpeakerNames() }
                     return removed ? .ok : .notFound
                 },
                 merge: { [weak self] from, into in
                     let merged = speakerMatcherFactory().mergeSpeakers(from: from, into: into)
-                    if merged { self?.pipelineQueue.refreshKnownSpeakerNames() }
+                    if merged { self?.pipeline.queue.refreshKnownSpeakerNames() }
                     return merged ? .ok : .notFound
                 },
                 seed: { [weak self] name in
@@ -154,7 +159,7 @@
                             isSynthetic: true,
                         ))
                     }
-                    self?.pipelineQueue.refreshKnownSpeakerNames()
+                    self?.pipeline.queue.refreshKnownSpeakerNames()
                     return .ok
                 },
             )

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -16,14 +16,17 @@ protocol AppNotifying {
 
 // MARK: - AppState
 
-/// Observable ViewModel that owns all business state and derived UI properties.
+/// Observable ViewModel that composes the app's concern-specific controllers
+/// (`pipeline`, `permissions`, `channelHealth`, `liveTranscription`,
+/// `rpcController`) and exposes the derived UI properties (badge, status label)
+/// the menu-bar scene binds to. It wires the controllers together rather than
+/// owning their state — new concern state belongs in a controller, not here.
 ///
-/// Extracted from `MeetingTranscriberApp` so that:
-/// - Badge/watching logic is testable without instantiating the `@main` App struct.
-/// - `BadgeKind.compute(...)` can be called directly in tests.
+/// Extracted from `MeetingTranscriberApp` so badge/watching logic and
+/// `BadgeKind.compute(...)` are testable without the `@main` App struct.
 @Observable
 @MainActor
-final class AppState { // swiftlint:disable:this type_body_length
+final class AppState {
     // MARK: - Dependencies
 
     let settings: AppSettings
@@ -43,9 +46,15 @@ final class AppState { // swiftlint:disable:this type_body_length
     // MARK: - State
 
     var watchLoop: WatchLoop?
-    var pipelineQueue: PipelineQueue
     var updateChecker: UpdateChecker
     var selectedNamingJobID: UUID?
+
+    /// Post-processing pipeline concern (the `PipelineQueue` instance, its
+    /// wiring from settings + active engine, job-state notifications, and the
+    /// file-enqueue entry points), extracted into its own controller. Read as
+    /// `pipeline.queue` by the menu-bar UI + RPC snapshot. `AppState` supplies
+    /// the active engine via `activate(engineProvider:)` post-init.
+    let pipeline: PipelineController
 
     /// Live TCC permission-health concern, extracted into its own controller.
     /// `currentBadge` composes its `health` into the `.error` state.
@@ -141,7 +150,7 @@ final class AppState { // swiftlint:disable:this type_body_length
         self.notifier = notifier
         self.permissions = PermissionsController(notifier: notifier)
         self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
-        self.pipelineQueue = PipelineQueue()
+        self.pipeline = PipelineController(settings: settings, notifier: notifier)
         self.channelHealth = ChannelHealthController(
             notifier: notifier,
             debounceSeconds: { [settings] in settings.asymmetricSilenceWarningSeconds },
@@ -181,6 +190,10 @@ final class AppState { // swiftlint:disable:this type_body_length
         syncLanguageSettings()
         observeEngineSettings()
         liveTranscription.beginPrewarm { [weak self] in self?.activeTranscriptionEngine }
+        // Wire the active-engine source (post stored-property init so the
+        // `[weak self]` engine closure is valid). The pipeline is rebuilt
+        // lazily on the first watch/enqueue, never during init.
+        pipeline.activate { [weak self] in self?.activeTranscriptionEngine }
 
         #if !APPSTORE
             // Launch gate (env var OR setting) + the settings observer now live
@@ -244,9 +257,9 @@ final class AppState { // swiftlint:disable:this type_body_length
                     // pending list unchanged) — observed live during E2E
                     // when the data dictionary was already cleared by an
                     // earlier skip race.
-                    let pendingIDs = self.pipelineQueue.pendingSpeakerNamingJobs.map(\.id)
+                    let pendingIDs = self.pipeline.queue.pendingSpeakerNamingJobs.map(\.id)
                     for jobID in pendingIDs {
-                        self.pipelineQueue.completeSpeakerNaming(jobID: jobID, result: .skipped)
+                        self.pipeline.queue.completeSpeakerNaming(jobID: jobID, result: .skipped)
                     }
                 }
             }
@@ -256,11 +269,11 @@ final class AppState { // swiftlint:disable:this type_body_length
             // menu uses, so the import code path is identical.
             let enqueueFile: (URL) -> Bool = { [weak self] url in
                 guard let self, FileManager.default.fileExists(atPath: url.path) else { return false }
-                Task { @MainActor in self.enqueueFiles([url]) }
+                Task { @MainActor in self.pipeline.enqueueFiles([url]) }
                 return true
             }
             let enqueueFilesRPC: ([URL]) -> Int = { [weak self] urls in
-                self?.enqueueExistingFiles(urls) ?? 0
+                self?.pipeline.enqueueExistingFiles(urls) ?? 0
             }
             return DebugRPCServer(
                 snapshot: snapshot,
@@ -310,7 +323,7 @@ final class AppState { // swiftlint:disable:this type_body_length
             watchLoopActive: watchLoop?.isActive == true,
             watchLoopState: watchLoop?.state ?? .idle,
             transcriberState: watchLoop?.transcriberState ?? .idle,
-            activeJobState: pipelineQueue.activeJobs.first?.state,
+            activeJobState: pipeline.queue.activeJobs.first?.state,
             updateAvailable: updateChecker.availableUpdate != nil,
             permissionProblem: permissions.health?.isHealthy == false,
         )
@@ -330,6 +343,19 @@ final class AppState { // swiftlint:disable:this type_body_length
     /// named `Bool` property keeps the body cheap.
     var hasPermissionProblem: Bool {
         permissions.health?.isHealthy == false
+    }
+
+    /// Single-member accessors that keep the menu-bar body's type-check cheap.
+    /// Reading `pipeline.queue.…` directly in that body adds a member-resolution
+    /// layer per use that pushed its type-check over budget on slower CI runners
+    /// (the same footgun `hasPermissionProblem` / `micSilentOverlay` address).
+    /// The body reads these named props instead; the chains resolve here.
+    var pipelineQueue: PipelineQueue {
+        pipeline.queue
+    }
+
+    var hasPendingSpeakerNamingJobs: Bool {
+        !pipeline.queue.pendingSpeakerNamingJobs.isEmpty
     }
 
     /// Menu-bar **top-half** red tint: mic channel silent, OR both channels
@@ -409,14 +435,14 @@ final class AppState { // swiftlint:disable:this type_body_length
                 _ = await Permissions.ensureMicrophoneAccess()
 
                 syncLanguageSettings()
-                pipelineQueue = makePipelineQueue()
+                pipeline.rebuild()
 
                 let detector: any MeetingDetecting = PowerAssertionDetector()
 
                 let loop = WatchLoop(
                     detector: detector,
                     recorderFactory: makeRecorderFactory(),
-                    pipelineQueue: pipelineQueue,
+                    pipelineQueue: pipeline.queue,
                     pollInterval: settings.pollInterval,
                     endGracePeriod: settings.endGrace,
                     noMic: settings.noMic,
@@ -435,8 +461,6 @@ final class AppState { // swiftlint:disable:this type_body_length
                     loop.permissionChecker = { health }
                 }
 
-                configurePipelineCallbacks()
-
                 watchLoop = loop
                 loop.start()
             }
@@ -453,11 +477,11 @@ final class AppState { // swiftlint:disable:this type_body_length
         Task { @MainActor in
             _ = await Permissions.ensureMicrophoneAccess()
 
-            ensurePipelineQueue()
+            pipeline.ensureQueue()
 
             let loop = WatchLoop(
                 recorderFactory: makeRecorderFactory(),
-                pipelineQueue: pipelineQueue,
+                pipelineQueue: pipeline.queue,
                 pollInterval: settings.pollInterval,
                 noMic: settings.noMic,
                 micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
@@ -499,58 +523,6 @@ final class AppState { // swiftlint:disable:this type_body_length
         watchLoop = nil
     }
 
-    /// Filters `urls` to files that currently exist on disk, forwards them to
-    /// `enqueueFiles`, and returns the existing count. RPC-friendly entry
-    /// point; nil-callers (weak self) treat absent app as 0-enqueued.
-    @discardableResult
-    func enqueueExistingFiles(_ urls: [URL]) -> Int {
-        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
-        guard !existing.isEmpty else { return 0 }
-        enqueueFiles(existing)
-        return existing.count
-    }
-
-    func enqueueFiles(_ urls: [URL]) {
-        ensurePipelineQueue()
-
-        let resolution = PairedRecordingResolver.resolve(urls: urls)
-
-        for group in resolution.paired {
-            let sidecar = RecordingSidecar.read(
-                fromDirectory: group.directory,
-                basename: group.stem,
-            )
-            let title = sidecar?.title ?? group.stem
-            let appName = sidecar?.appName ?? "File"
-            let micDelay = sidecar?.micDelaySeconds ?? 0
-            let participants = sidecar?.participants ?? []
-
-            // For paired groups: pass `group.mix` directly (nil when only app+mic
-            // were selected — the pipeline mixes app+mic into the workdir cache
-            // on the fly, no persistent `_mix.wav` is written to the user's
-            // recordings dir).
-            let job = PipelineJob(
-                meetingTitle: title, appName: appName,
-                mixPath: group.mix, appPath: group.app, micPath: group.mic,
-                micDelay: micDelay, participants: participants,
-            )
-            pipelineQueue.enqueue(job)
-        }
-
-        for url in resolution.singletons {
-            let title = url.deletingPathExtension().lastPathComponent
-            let job = PipelineJob(
-                meetingTitle: title,
-                appName: "File",
-                mixPath: url,
-                appPath: nil,
-                micPath: nil,
-                micDelay: 0,
-            )
-            pipelineQueue.enqueue(job)
-        }
-    }
-
     // MARK: - Channel Health Monitor
 
     /// Attaches the state-change callback that drives channel-health monitoring
@@ -583,7 +555,7 @@ final class AppState { // swiftlint:disable:this type_body_length
         }
     }
 
-    // MARK: - Pipeline
+    // MARK: - Engine Settings
 
     /// Push current language/vocabulary settings into the active engine.
     /// Idempotent — each branch only writes when the value actually differs,
@@ -623,93 +595,6 @@ final class AppState { // swiftlint:disable:this type_body_length
                 guard let self else { return }
                 self.syncLanguageSettings()
                 self.observeEngineSettings()
-            }
-        }
-    }
-
-    func ensurePipelineQueue() {
-        guard pipelineQueue.engine == nil else { return }
-        pipelineQueue = makePipelineQueue()
-        configurePipelineCallbacks()
-    }
-
-    /// One-stop FluidDiarizer instantiation. Captures the current tuning
-    /// fields from settings so both the global-mode factory and the
-    /// per-job mode-override factory stay in sync. Tuning only affects
-    /// `.offline` mode, but is harmless when passed to `.sortformer`.
-    private func makeFluidDiarizer(mode: DiarizerMode) -> FluidDiarizer {
-        FluidDiarizer(
-            mode: mode,
-            tuning: OfflineDiarizerTuning(
-                clusterThreshold: settings.clusterThreshold,
-                warmStartFa: settings.warmStartFa,
-                warmStartFb: settings.warmStartFb,
-                minSegmentDurationSeconds: settings.minSegmentDurationSeconds,
-                excludeOverlap: settings.excludeOverlap,
-            ),
-        )
-    }
-
-    func makePipelineQueue() -> PipelineQueue {
-        let queue = PipelineQueue(
-            engine: activeTranscriptionEngine,
-            diarizationFactory: { [self] in makeFluidDiarizer(mode: settings.diarizerMode) },
-            diarizationFactoryWithMode: { [self] mode in makeFluidDiarizer(mode: mode) },
-            protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
-            outputDir: settings.effectiveOutputDir,
-            diarizeEnabled: settings.diarize,
-            numSpeakers: settings.numSpeakers,
-            micLabel: settings.micName,
-            speakerMatcherFactory: { SpeakerMatcher() },
-            vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
-            recognitionStatsLog: RecognitionStatsLog(),
-        )
-        queue.loadSnapshot()
-        // Fire-and-forget: dir scan + per-file attr probes run off-main so
-        // app startup (and the first call to `enqueueFiles`) isn't blocked
-        // by a slow filesystem. Recovered jobs appear in `queue.jobs` once
-        // the scan returns.
-        Task { await queue.recoverOrphanedRecordings() }
-        queue.refreshKnownSpeakerNames()
-        return queue
-    }
-
-    func makeProtocolGenerator() -> (any ProtocolGenerating)? {
-        switch settings.protocolProvider {
-        #if !APPSTORE
-            case .claudeCLI:
-                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin, language: settings.protocolLanguage)
-        #endif
-
-        case .openAICompatible:
-            OpenAIProtocolGenerator(
-                endpoint: URL(string: settings.openAIEndpoint)
-                    // swiftlint:disable:next force_unwrapping
-                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
-                model: settings.openAIModel,
-                language: settings.protocolLanguage,
-                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
-            )
-
-        case .none:
-            nil
-        }
-    }
-
-    func configurePipelineCallbacks() {
-        pipelineQueue.onJobStateChange = { [notifier] job, _, newState in
-            switch newState {
-            case .done:
-                let title = job.protocolPath != nil ? "Protocol Ready" : "Transcript Saved"
-                notifier.notify(title: title, body: job.meetingTitle)
-
-            case .error:
-                if let err = job.error {
-                    notifier.notify(title: "Error", body: err)
-                }
-
-            default:
-                break
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -87,9 +87,9 @@ struct MeetingTranscriberApp: App {
                 onOpenSettings: {
                     bringWindowToFront(id: "settings")
                 },
-                onNameSpeakers: appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty ? nil : {
+                onNameSpeakers: appState.hasPendingSpeakerNamingJobs ? {
                     bringWindowToFront(id: "speaker-naming")
-                },
+                } : nil,
                 onProcessFiles: processAudioFiles,
                 onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
                 onQuit: quit,
@@ -169,14 +169,14 @@ struct MeetingTranscriberApp: App {
             speakerNamingContent
                 .onAppear {
                     // Close restored window if no naming data available (macOS state restoration)
-                    if appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
+                    if appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty {
                         closeWindow(id: "speaker-naming")
                     }
                 }
                 // Auto-close when the pending list drains. Covers RPC-driven
                 // skip (`POST /action/skipNaming`), where the data layer
                 // transitions but the UI callback never fires.
-                .onChange(of: appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty) { _, isEmpty in
+                .onChange(of: appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty) { _, isEmpty in
                     if isEmpty {
                         closeWindow(id: "speaker-naming")
                     }
@@ -199,11 +199,11 @@ struct MeetingTranscriberApp: App {
                 // Share the pipeline's actor instance so both writers serialise on
                 // the same `recognition_log.jsonl` file. Fallback only fires in the
                 // test-only PipelineQueue init that intentionally leaves it nil.
-                recognitionStatsLog: appState.pipelineQueue.recognitionStatsLog ?? RecognitionStatsLog(),
+                recognitionStatsLog: appState.pipeline.queue.recognitionStatsLog ?? RecognitionStatsLog(),
                 enrollmentDiarizerFactory: { FluidDiarizer(mode: appState.settings.diarizerMode) },
-                namingDialogActive: appState.pipelineQueue.pendingSpeakerNaming != nil,
-                pipelineBusy: appState.pipelineQueue.isProcessing,
-                onSpeakerMutate: appState.pipelineQueue.refreshKnownSpeakerNames,
+                namingDialogActive: appState.pipeline.queue.pendingSpeakerNaming != nil,
+                pipelineBusy: appState.pipeline.queue.isProcessing,
+                onSpeakerMutate: appState.pipeline.queue.refreshKnownSpeakerNames,
             )
         }
         .windowResizability(.contentSize)
@@ -223,7 +223,7 @@ struct MeetingTranscriberApp: App {
     // MARK: - Speaker Naming Window
 
     @ViewBuilder private var speakerNamingContent: some View {
-        if let data = appState.pipelineQueue.speakerNamingData(
+        if let data = appState.pipeline.queue.speakerNamingData(
             forJobID: appState.selectedNamingJobID,
         ) {
             VStack(spacing: 0) {
@@ -237,15 +237,15 @@ struct MeetingTranscriberApp: App {
     }
 
     @ViewBuilder private var speakerNamingPicker: some View {
-        if appState.pipelineQueue.pendingSpeakerNamingJobs.count > 1 {
+        if appState.pipeline.queue.pendingSpeakerNamingJobs.count > 1 {
             Picker("Meeting", selection: Binding(
                 get: {
                     appState.selectedNamingJobID
-                        ?? appState.pipelineQueue.pendingSpeakerNamingJobs.first?.id
+                        ?? appState.pipeline.queue.pendingSpeakerNamingJobs.first?.id
                 },
                 set: { appState.selectedNamingJobID = $0 },
             )) {
-                ForEach(appState.pipelineQueue.pendingSpeakerNamingJobs) { job in
+                ForEach(appState.pipeline.queue.pendingSpeakerNamingJobs) { job in
                     Text(job.meetingTitle).tag(Optional(job.id))
                 }
             }
@@ -260,16 +260,16 @@ struct MeetingTranscriberApp: App {
     ) -> some View {
         SpeakerNamingView(
             data: data,
-            knownSpeakerNames: appState.pipelineQueue.knownSpeakerNames,
-            currentDiarizerMode: appState.pipelineQueue.usedDiarizerMode(forJobID: data.jobID)
+            knownSpeakerNames: appState.pipeline.queue.knownSpeakerNames,
+            currentDiarizerMode: appState.pipeline.queue.usedDiarizerMode(forJobID: data.jobID)
                 ?? appState.settings.diarizerMode,
         ) { result in
-            appState.pipelineQueue.completeSpeakerNaming(jobID: data.jobID, result: result)
-            if appState.pipelineQueue.pendingSpeakerNamingJobs.isEmpty {
+            appState.pipeline.queue.completeSpeakerNaming(jobID: data.jobID, result: result)
+            if appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty {
                 closeWindow(id: "speaker-naming")
             } else {
                 appState.selectedNamingJobID =
-                    appState.pipelineQueue.pendingSpeakerNamingJobs.first?.id
+                    appState.pipeline.queue.pendingSpeakerNamingJobs.first?.id
             }
         }
     }
@@ -296,11 +296,11 @@ struct MeetingTranscriberApp: App {
         panel.isAccessoryViewDisclosed = true
 
         guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
-        appState.enqueueFiles(panel.urls)
+        appState.pipeline.enqueueFiles(panel.urls)
     }
 
     private func openLastProtocol() {
-        if let job = appState.pipelineQueue.completedJobs.last,
+        if let job = appState.pipeline.queue.completedJobs.last,
            let path = job.protocolPath ?? job.transcriptPath {
             NSWorkspace.shared.open(path)
         }

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Observation
+
+// MARK: - PipelineController
+
+/// Owns the post-processing pipeline concern: the `PipelineQueue` instance, its
+/// construction from the current settings + active engine, the per-job
+/// notification callbacks, and the file-enqueue entry points.
+///
+/// Extracted from `AppState` as a concern-specific controller (see the AppState
+/// god-class split). `AppState` keeps the engine instances + the active-engine
+/// switch and supplies the active engine via `activate(engineProvider:)` (called
+/// post stored-property init, where the `[weak self]` engine closure is valid) so
+/// this controller never holds an `AppState` back-reference. `settings` +
+/// `notifier` are shared references injected at construction.
+///
+/// `@Observable` because `queue` is read by the menu-bar UI + RPC snapshot: when
+/// `rebuild()` swaps in a freshly-wired queue, the views observing `queue`
+/// through `AppState.pipeline.queue` must re-read. Nested-`@Observable`
+/// observation through `let pipeline` + this stored `var queue` is the same
+/// pattern the other extracted controllers use.
+@Observable
+@MainActor
+final class PipelineController {
+    /// The active pipeline queue. Settable so tests can swap in a queue wired to
+    /// an isolated `logDir` (byte-equivalent to the prior `AppState.pipelineQueue`
+    /// var, which was likewise publicly settable). Production mutates it only via
+    /// `rebuild()` / `ensureQueue()`.
+    var queue: PipelineQueue
+
+    private let settings: AppSettings
+    private let notifier: any AppNotifying
+
+    /// Source of the currently-active engine. Set by `activate`; nil before then
+    /// (so `makeQueue()` safely returns the current queue if called early — only
+    /// reachable at process teardown, since `rebuild`/`ensureQueue` are driven by
+    /// user actions while `AppState` is alive). Captures the owner weakly.
+    private var engineProvider: (() -> (any TranscribingEngine)?)?
+
+    init(settings: AppSettings, notifier: any AppNotifying) {
+        self.settings = settings
+        self.notifier = notifier
+        self.queue = PipelineQueue()
+    }
+
+    /// Wire the active-engine source. Called once from `AppState.init` after its
+    /// stored-property init.
+    func activate(engineProvider: @escaping () -> (any TranscribingEngine)?) {
+        self.engineProvider = engineProvider
+    }
+
+    // MARK: - Queue lifecycle
+
+    /// Rebuild the queue against the current settings + active engine and
+    /// re-install the job-state callbacks. Unconditional — the watch-start path
+    /// always rebuilds so a fresh session picks up the latest settings/engine.
+    func rebuild() {
+        queue = makeQueue()
+        configureCallbacks()
+    }
+
+    /// Rebuild only when the queue isn't already wired to an engine. The
+    /// manual-recording + file-enqueue paths call this so an already-configured
+    /// queue (e.g. one a test injected) isn't replaced.
+    func ensureQueue() {
+        guard queue.engine == nil else { return }
+        rebuild()
+    }
+
+    /// One-stop wired `PipelineQueue`: active engine from the provider, the
+    /// diarization/protocol factories, current settings, then load the persisted
+    /// snapshot + recover orphaned recordings off-main + refresh known names.
+    func makeQueue() -> PipelineQueue {
+        guard let engine = engineProvider?() else { return queue }
+        let q = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { [self] in makeFluidDiarizer(mode: settings.diarizerMode) },
+            diarizationFactoryWithMode: { [self] mode in makeFluidDiarizer(mode: mode) },
+            protocolGeneratorFactory: { [self] in makeProtocolGenerator() },
+            outputDir: settings.effectiveOutputDir,
+            diarizeEnabled: settings.diarize,
+            numSpeakers: settings.numSpeakers,
+            micLabel: settings.micName,
+            speakerMatcherFactory: { SpeakerMatcher() },
+            vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
+            recognitionStatsLog: RecognitionStatsLog(),
+        )
+        q.loadSnapshot()
+        // Fire-and-forget: dir scan + per-file attr probes run off-main so app
+        // startup (and the first call to `enqueueFiles`) isn't blocked by a slow
+        // filesystem. Recovered jobs appear in `queue.jobs` once the scan returns.
+        Task { await q.recoverOrphanedRecordings() }
+        q.refreshKnownSpeakerNames()
+        return q
+    }
+
+    /// One-stop FluidDiarizer instantiation. Captures the current tuning fields
+    /// from settings so both the global-mode factory and the per-job
+    /// mode-override factory stay in sync. Tuning only affects `.offline` mode,
+    /// but is harmless when passed to `.sortformer`.
+    private func makeFluidDiarizer(mode: DiarizerMode) -> FluidDiarizer {
+        FluidDiarizer(
+            mode: mode,
+            tuning: OfflineDiarizerTuning(
+                clusterThreshold: settings.clusterThreshold,
+                warmStartFa: settings.warmStartFa,
+                warmStartFb: settings.warmStartFb,
+                minSegmentDurationSeconds: settings.minSegmentDurationSeconds,
+                excludeOverlap: settings.excludeOverlap,
+            ),
+        )
+    }
+
+    // `makeProtocolGenerator` + `configureCallbacks` are module-internal (not
+    // `private`) to preserve the access level they had on `AppState` before this
+    // extraction — they encode real behavior (provider selection, notification
+    // routing) that is unit-tested directly, same altitude as the other wiring
+    // methods above.
+    func makeProtocolGenerator() -> (any ProtocolGenerating)? {
+        switch settings.protocolProvider {
+        #if !APPSTORE
+            case .claudeCLI:
+                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin, language: settings.protocolLanguage)
+        #endif
+
+        case .openAICompatible:
+            OpenAIProtocolGenerator(
+                endpoint: URL(string: settings.openAIEndpoint)
+                    // swiftlint:disable:next force_unwrapping
+                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
+                model: settings.openAIModel,
+                language: settings.protocolLanguage,
+                apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,
+            )
+
+        case .none:
+            nil
+        }
+    }
+
+    func configureCallbacks() {
+        queue.onJobStateChange = { [notifier] job, _, newState in
+            switch newState {
+            case .done:
+                let title = job.protocolPath != nil ? "Protocol Ready" : "Transcript Saved"
+                notifier.notify(title: title, body: job.meetingTitle)
+
+            case .error:
+                if let err = job.error {
+                    notifier.notify(title: "Error", body: err)
+                }
+
+            default:
+                break
+            }
+        }
+    }
+
+    // MARK: - File enqueue
+
+    /// Filters `urls` to files that currently exist on disk, forwards them to
+    /// `enqueueFiles`, and returns the existing count. RPC-friendly entry point.
+    @discardableResult
+    func enqueueExistingFiles(_ urls: [URL]) -> Int {
+        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !existing.isEmpty else { return 0 }
+        enqueueFiles(existing)
+        return existing.count
+    }
+
+    func enqueueFiles(_ urls: [URL]) {
+        ensureQueue()
+
+        let resolution = PairedRecordingResolver.resolve(urls: urls)
+
+        for group in resolution.paired {
+            let sidecar = RecordingSidecar.read(
+                fromDirectory: group.directory,
+                basename: group.stem,
+            )
+            let title = sidecar?.title ?? group.stem
+            let appName = sidecar?.appName ?? "File"
+            let micDelay = sidecar?.micDelaySeconds ?? 0
+            let participants = sidecar?.participants ?? []
+
+            // For paired groups: pass `group.mix` directly (nil when only app+mic
+            // were selected — the pipeline mixes app+mic into the workdir cache
+            // on the fly, no persistent `_mix.wav` is written to the user's
+            // recordings dir).
+            let job = PipelineJob(
+                meetingTitle: title, appName: appName,
+                mixPath: group.mix, appPath: group.app, micPath: group.mic,
+                micDelay: micDelay, participants: participants,
+            )
+            queue.enqueue(job)
+        }
+
+        for url in resolution.singletons {
+            let title = url.deletingPathExtension().lastPathComponent
+            let job = PipelineJob(
+                meetingTitle: title,
+                appName: "File",
+                mixPath: url,
+                appPath: nil,
+                micPath: nil,
+                micDelay: 0,
+            )
+            queue.enqueue(job)
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
@@ -161,8 +161,8 @@
         func test_snapshot_pendingNamingJobs_mapsQueueStateToRPCFields() throws {
             var job = makeJob(title: "Acme Standup")
             job.state = .speakerNamingPending
-            state.pipelineQueue.insertJobForTesting(job)
-            state.pipelineQueue.speakerNamingDataByJob[job.id] = PipelineQueue.SpeakerNamingData(
+            state.pipeline.queue.insertJobForTesting(job)
+            state.pipeline.queue.speakerNamingDataByJob[job.id] = PipelineQueue.SpeakerNamingData(
                 jobID: job.id,
                 meetingTitle: "Acme Standup",
                 mapping: ["R_0": "Alice", "R_1": "Bob"],
@@ -191,7 +191,7 @@
         func test_snapshot_pendingNamingJob_withoutData_speakerCountIsZero() throws {
             var job = makeJob(title: "Orphan")
             job.state = .speakerNamingPending
-            state.pipelineQueue.insertJobForTesting(job)
+            state.pipeline.queue.insertJobForTesting(job)
 
             let snapshot = state.rpcStateSnapshot()
 

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -24,10 +24,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)
         // Inject a PipelineQueue with mocks + the per-test isolated logDir.
-        // The engine != nil arm short-circuits `ensurePipelineQueue()` so
+        // The engine != nil arm short-circuits `pipeline.ensureQueue()` so
         // it doesn't replace our queue with one wired to the production
         // `AppPaths.ipcDir` path on the first `enqueueFiles` call.
-        state.pipelineQueue = PipelineQueue(
+        state.pipeline.queue = PipelineQueue(
             engine: MockEngine(),
             diarizationFactory: { MockDiarization() },
             protocolGeneratorFactory: { MockProtocolGen() },
@@ -43,7 +43,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     private func makeIsolatedState(logDir: URL) -> (AppState, RecordingNotifier) {
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)
-        state.pipelineQueue = PipelineQueue(logDir: logDir)
+        state.pipeline.queue = PipelineQueue(logDir: logDir)
         return (state, notifier)
     }
 
@@ -298,46 +298,46 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, _) = makeState()
         let url = URL(fileURLWithPath: "/tmp/sprint-review.wav")
 
-        state.enqueueFiles([url])
+        state.pipeline.enqueueFiles([url])
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
     }
 
     func testEnqueueFilesMultipleURLs() {
         let (state, _) = makeState()
         let urls = (1 ... 3).map { URL(fileURLWithPath: "/tmp/meeting-\($0).wav") }
 
-        state.enqueueFiles(urls)
+        state.pipeline.enqueueFiles(urls)
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 3)
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 3)
     }
 
     func testEnqueueFilesTitleFromLastPathComponent() {
         let (state, _) = makeState()
         let url = URL(fileURLWithPath: "/tmp/sprint-review.wav")
 
-        state.enqueueFiles([url])
+        state.pipeline.enqueueFiles([url])
 
-        XCTAssertEqual(state.pipelineQueue.jobs[0].meetingTitle, "sprint-review")
+        XCTAssertEqual(state.pipeline.queue.jobs[0].meetingTitle, "sprint-review")
     }
 
     func testEnqueueFilesAppNameIsFile() {
         let (state, _) = makeState()
-        state.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
-        XCTAssertEqual(state.pipelineQueue.jobs[0].appName, "File")
+        state.pipeline.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
+        XCTAssertEqual(state.pipeline.queue.jobs[0].appName, "File")
     }
 
     func testEnqueueFilesEmptyArrayIsNoOp() {
         let (state, _) = makeState()
-        state.enqueueFiles([])
-        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+        state.pipeline.enqueueFiles([])
+        XCTAssertTrue(state.pipeline.queue.jobs.isEmpty)
     }
 
     func testEnqueueFilesCreatesJobsWithNilAudioPaths() {
         let (state, _) = makeState()
-        state.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
-        XCTAssertNil(state.pipelineQueue.jobs[0].appPath)
-        XCTAssertNil(state.pipelineQueue.jobs[0].micPath)
+        state.pipeline.enqueueFiles([URL(fileURLWithPath: "/tmp/meeting.wav")])
+        XCTAssertNil(state.pipeline.queue.jobs[0].appPath)
+        XCTAssertNil(state.pipeline.queue.jobs[0].micPath)
     }
 
     func testEnqueueFilesPairsTripletAsOneDualTrackJob() {
@@ -348,10 +348,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             URL(fileURLWithPath: "/tmp/standup_mix.wav"),
         ]
 
-        state.enqueueFiles(urls)
+        state.pipeline.enqueueFiles(urls)
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
-        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
+        let job = state.pipeline.queue.jobs[0]
         XCTAssertEqual(job.mixPath?.lastPathComponent, "standup_mix.wav")
         XCTAssertEqual(job.appPath?.lastPathComponent, "standup_app.wav")
         XCTAssertEqual(job.micPath?.lastPathComponent, "standup_mic.wav")
@@ -359,8 +359,8 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testEnqueueExistingFilesEmptyArrayReturnsZero() {
         let (state, _) = makeState()
-        XCTAssertEqual(state.enqueueExistingFiles([]), 0)
-        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+        XCTAssertEqual(state.pipeline.enqueueExistingFiles([]), 0)
+        XCTAssertTrue(state.pipeline.queue.jobs.isEmpty)
     }
 
     func testEnqueueExistingFilesAllMissingReturnsZeroAndDoesNotEnqueue() {
@@ -369,8 +369,8 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             URL(fileURLWithPath: "/tmp/never-exists-\(UUID().uuidString).wav"),
             URL(fileURLWithPath: "/tmp/also-missing-\(UUID().uuidString).wav"),
         ]
-        XCTAssertEqual(state.enqueueExistingFiles(urls), 0)
-        XCTAssertTrue(state.pipelineQueue.jobs.isEmpty)
+        XCTAssertEqual(state.pipeline.enqueueExistingFiles(urls), 0)
+        XCTAssertTrue(state.pipeline.queue.jobs.isEmpty)
     }
 
     func testEnqueueExistingFilesPartialExistenceForwardsOnlyExisting() throws {
@@ -380,11 +380,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let missing = tmpDir.appendingPathComponent("absent.wav")
         try Data("RIFF".utf8).write(to: existing)
 
-        let count = state.enqueueExistingFiles([existing, missing])
+        let count = state.pipeline.enqueueExistingFiles([existing, missing])
 
         XCTAssertEqual(count, 1)
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
-        XCTAssertEqual(state.pipelineQueue.jobs[0].mixPath?.lastPathComponent, "present.wav")
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
+        XCTAssertEqual(state.pipeline.queue.jobs[0].mixPath?.lastPathComponent, "present.wav")
     }
 
     func testEnqueueFilesAppPlusMicWithoutMixHasNilMixPath() {
@@ -397,10 +397,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             URL(fileURLWithPath: "/tmp/20260311_143000_mic.wav"),
         ]
 
-        state.enqueueFiles(urls)
+        state.pipeline.enqueueFiles(urls)
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
-        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
+        let job = state.pipeline.queue.jobs[0]
         XCTAssertNil(job.mixPath, "paired without mix → nil mixPath")
         XCTAssertEqual(job.appPath?.lastPathComponent, "20260311_143000_app.wav")
         XCTAssertEqual(job.micPath?.lastPathComponent, "20260311_143000_mic.wav")
@@ -410,10 +410,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, _) = makeState()
         let urls = [URL(fileURLWithPath: "/tmp/orphan_app.wav")]
 
-        state.enqueueFiles(urls)
+        state.pipeline.enqueueFiles(urls)
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
-        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
+        let job = state.pipeline.queue.jobs[0]
         XCTAssertEqual(job.mixPath?.lastPathComponent, "orphan_app.wav")
         XCTAssertNil(job.appPath)
         XCTAssertNil(job.micPath)
@@ -428,11 +428,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             URL(fileURLWithPath: "/tmp/podcast.mp3"),
         ]
 
-        state.enqueueFiles(urls)
+        state.pipeline.enqueueFiles(urls)
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 2)
-        let paired = state.pipelineQueue.jobs.first { $0.appPath != nil }
-        let single = state.pipelineQueue.jobs.first { $0.appPath == nil }
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 2)
+        let paired = state.pipeline.queue.jobs.first { $0.appPath != nil }
+        let single = state.pipeline.queue.jobs.first { $0.appPath == nil }
         XCTAssertEqual(paired?.meetingTitle, "meeting")
         XCTAssertEqual(single?.meetingTitle, "podcast")
     }
@@ -454,65 +454,65 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             micFilename: "\(basename)_mic.wav",
         ).write(toDirectory: tmpDir, basename: basename)
 
-        state.enqueueFiles([
+        state.pipeline.enqueueFiles([
             tmpDir.appendingPathComponent("\(basename)_app.wav"),
             tmpDir.appendingPathComponent("\(basename)_mic.wav"),
             tmpDir.appendingPathComponent("\(basename)_mix.wav"),
         ])
 
-        XCTAssertEqual(state.pipelineQueue.jobs.count, 1)
-        let job = state.pipelineQueue.jobs[0]
+        XCTAssertEqual(state.pipeline.queue.jobs.count, 1)
+        let job = state.pipeline.queue.jobs[0]
         XCTAssertEqual(job.meetingTitle, "Sprint Review")
         XCTAssertEqual(job.appName, "Microsoft Teams")
         XCTAssertEqual(job.participants, ["Speaker A", "Speaker B"])
         XCTAssertEqual(job.micDelay, 0.25, accuracy: 0.0001)
     }
 
-    // MARK: - ensurePipelineQueue
+    // MARK: - pipeline.ensureQueue
 
-    func testEnsurePipelineQueueReplacesBareQueue() {
+    func testEnsureQueueReplacesBareQueue() {
         // Bare queue (no engine) — uses the no-engine init; logDir is the
         // production path but this test never enqueues so no I/O hits it.
         let notifier = RecordingNotifier()
         let state = AppState(notifier: notifier)
-        state.pipelineQueue = PipelineQueue(logDir: testLogDir)
-        XCTAssertNil(state.pipelineQueue.engine, "Precondition: fresh queue has no engine")
+        state.pipeline.queue = PipelineQueue(logDir: testLogDir)
+        XCTAssertNil(state.pipeline.queue.engine, "Precondition: fresh queue has no engine")
 
-        state.ensurePipelineQueue()
+        state.pipeline.ensureQueue()
 
-        XCTAssertNotNil(state.pipelineQueue.engine)
+        XCTAssertNotNil(state.pipeline.queue.engine)
     }
 
-    func testEnsurePipelineQueueIdempotent() {
+    func testEnsureQueueIdempotent() {
         let (state, _) = makeState()
-        state.ensurePipelineQueue()
-        let firstID = ObjectIdentifier(state.pipelineQueue)
+        state.pipeline.ensureQueue()
+        let firstID = ObjectIdentifier(state.pipeline.queue)
 
-        state.ensurePipelineQueue()
+        state.pipeline.ensureQueue()
 
-        XCTAssertEqual(ObjectIdentifier(state.pipelineQueue), firstID)
+        XCTAssertEqual(ObjectIdentifier(state.pipeline.queue), firstID)
     }
 
-    // MARK: - makePipelineQueue
+    // MARK: - pipeline.makeQueue
 
-    func testMakePipelineQueueHasEngine() {
+    func testMakeQueueHasEngine() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().engine)
+        XCTAssertNotNil(state.pipeline.makeQueue().engine)
     }
 
-    func testMakePipelineQueueHasDiarizationFactory() {
+    func testMakeQueueHasDiarizationFactory() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().diarizationFactory)
+        XCTAssertNotNil(state.pipeline.makeQueue().diarizationFactory)
     }
 
-    func testMakePipelineQueueHasProtocolGeneratorFactory() {
+    func testMakeQueueHasProtocolGeneratorFactory() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().protocolGeneratorFactory)
+        XCTAssertNotNil(state.pipeline.makeQueue().protocolGeneratorFactory)
     }
 
-    func testMakePipelineQueueSetsOutputDir() {
+    func testMakeQueueSetsOutputDir() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().outputDir)
+        XCTAssertNotNil(state.pipeline.makeQueue().outputDir)
     }
 
     // MARK: - makeProtocolGenerator
@@ -521,7 +521,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let settings = AppSettings()
         settings.protocolProvider = .openAICompatible
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.makeProtocolGenerator() is OpenAIProtocolGenerator)
+        XCTAssertTrue(state.pipeline.makeProtocolGenerator() is OpenAIProtocolGenerator)
     }
 
     #if !APPSTORE
@@ -529,7 +529,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             let settings = AppSettings()
             settings.protocolProvider = .claudeCLI
             let state = AppState(settings: settings)
-            XCTAssertTrue(state.makeProtocolGenerator() is ClaudeCLIProtocolGenerator)
+            XCTAssertTrue(state.pipeline.makeProtocolGenerator() is ClaudeCLIProtocolGenerator)
         }
     #endif
 
@@ -537,31 +537,31 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let settings = AppSettings()
         settings.protocolProvider = .none
         let state = AppState(settings: settings)
-        XCTAssertNil(state.makeProtocolGenerator())
+        XCTAssertNil(state.pipeline.makeProtocolGenerator())
     }
 
-    // MARK: - configurePipelineCallbacks
+    // MARK: - pipeline.configureCallbacks
 
-    func testConfigurePipelineCallbacksDoneFiresNotification() throws {
+    func testConfigureCallbacksDoneFiresNotification() throws {
         let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
-        state.configurePipelineCallbacks()
+        state.pipeline.configureCallbacks()
 
         var job = makeJob(title: "Sprint Review")
         job.protocolPath = URL(fileURLWithPath: "/tmp/protocol.md")
-        state.pipelineQueue.onJobStateChange?(job, .transcribing, .done)
+        state.pipeline.queue.onJobStateChange?(job, .transcribing, .done)
 
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertEqual(notifier.calls[0].title, "Protocol Ready")
         XCTAssertEqual(notifier.calls[0].body, "Sprint Review")
     }
 
-    func testConfigurePipelineCallbacksErrorFiresNotification() throws {
+    func testConfigureCallbacksErrorFiresNotification() throws {
         let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
-        state.configurePipelineCallbacks()
+        state.pipeline.configureCallbacks()
 
         var job = makeJob()
         job = PipelineJob(
@@ -574,20 +574,20 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         )
         // Simulate a job with an error string
         let errorJob = jobWithError(job, message: "Transcription failed")
-        state.pipelineQueue.onJobStateChange?(errorJob, .transcribing, .error)
+        state.pipeline.queue.onJobStateChange?(errorJob, .transcribing, .error)
 
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertEqual(notifier.calls[0].title, "Error")
         XCTAssertEqual(notifier.calls[0].body, "Transcription failed")
     }
 
-    func testConfigurePipelineCallbacksTranscribingNoNotification() throws {
+    func testConfigureCallbacksTranscribingNoNotification() throws {
         let tmpDir = try makeTempDirectory(prefix: "appstate_callbacks")
 
         let (state, notifier) = makeIsolatedState(logDir: tmpDir)
-        state.configurePipelineCallbacks()
+        state.pipeline.configureCallbacks()
 
-        state.pipelineQueue.onJobStateChange?(makeJob(), .waiting, .transcribing)
+        state.pipeline.queue.onJobStateChange?(makeJob(), .waiting, .transcribing)
 
         XCTAssertTrue(notifier.calls.isEmpty)
     }
@@ -653,22 +653,22 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
     }
 
-    func testMakePipelineQueueUsesActiveEngine() {
+    func testMakeQueueUsesActiveEngine() {
         let (state, _) = makeState()
-        XCTAssertNotNil(state.makePipelineQueue().engine, "WhisperKit engine should be set")
+        XCTAssertNotNil(state.pipeline.makeQueue().engine, "WhisperKit engine should be set")
 
         state.settings.transcriptionEngine = .parakeet
-        XCTAssertNotNil(state.makePipelineQueue().engine, "Parakeet engine should be set")
+        XCTAssertNotNil(state.pipeline.makeQueue().engine, "Parakeet engine should be set")
     }
 
-    func testEnsurePipelineQueueWithParakeet() {
+    func testEnsureQueueWithParakeet() {
         let settings = AppSettings()
         settings.transcriptionEngine = .parakeet
         let state = AppState(settings: settings)
 
-        state.ensurePipelineQueue()
+        state.pipeline.ensureQueue()
 
-        XCTAssertNotNil(state.pipelineQueue.engine)
+        XCTAssertNotNil(state.pipeline.queue.engine)
     }
 
     func testActiveTranscriptionEngineReturnsQwen3WhenSet() {
@@ -693,23 +693,23 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
     }
 
-    func testMakePipelineQueueUsesQwen3Engine() {
+    func testMakeQueueUsesQwen3Engine() {
         guard #available(macOS 15, *) else { return }
         let settings = AppSettings()
         settings.transcriptionEngine = .qwen3
         let state = AppState(settings: settings)
-        XCTAssertNotNil(state.makePipelineQueue().engine, "Qwen3 engine should be set")
+        XCTAssertNotNil(state.pipeline.makeQueue().engine, "Qwen3 engine should be set")
     }
 
-    func testEnsurePipelineQueueWithQwen3() {
+    func testEnsureQueueWithQwen3() {
         guard #available(macOS 15, *) else { return }
         let settings = AppSettings()
         settings.transcriptionEngine = .qwen3
         let state = AppState(settings: settings)
 
-        state.ensurePipelineQueue()
+        state.pipeline.ensureQueue()
 
-        XCTAssertNotNil(state.pipelineQueue.engine)
+        XCTAssertNotNil(state.pipeline.queue.engine)
     }
 
     // MARK: - Qwen3 Fallback
@@ -724,26 +724,26 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertNotNil(state.activeTranscriptionEngine)
     }
 
-    // MARK: - MakePipelineQueue Settings
+    // MARK: - makeQueue settings
 
-    func testMakePipelineQueueUsesDiarizeSettingFromSettings() {
+    func testMakeQueueUsesDiarizeSettingFromSettings() {
         let (state, _) = makeState()
         state.settings.diarize = true
-        let queue = state.makePipelineQueue()
+        let queue = state.pipeline.makeQueue()
         XCTAssertTrue(queue.diarizeEnabled)
     }
 
-    func testMakePipelineQueueUsesMicLabelFromSettings() {
+    func testMakeQueueUsesMicLabelFromSettings() {
         let (state, _) = makeState()
         state.settings.micName = "Speaker A"
-        let queue = state.makePipelineQueue()
+        let queue = state.pipeline.makeQueue()
         XCTAssertEqual(queue.micLabel, "Speaker A")
     }
 
-    func testMakePipelineQueueUsesNumSpeakersFromSettings() {
+    func testMakeQueueUsesNumSpeakersFromSettings() {
         let (state, _) = makeState()
         state.settings.numSpeakers = 4
-        let queue = state.makePipelineQueue()
+        let queue = state.pipeline.makeQueue()
         XCTAssertEqual(queue.numSpeakers, 4)
     }
 }

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -1,0 +1,91 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `PipelineController`'s queue lifecycle — exercised on a bare
+/// controller (no full `AppState`), which is the construction the extraction
+/// enables. They focus on the genuinely-new `engineProvider` seam: before the
+/// split, `makePipelineQueue` read `AppState.activeTranscriptionEngine`
+/// directly, so the "no engine source wired" path and the provider→engine
+/// wiring couldn't be exercised in isolation.
+@MainActor
+final class PipelineControllerTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "PipelineControllerTests")
+    }
+
+    override func tearDown() async throws {
+        if let tmpDir { try? FileManager.default.removeItem(at: tmpDir) }
+        try await super.tearDown()
+    }
+
+    /// A controller whose queue is already wired to a mock engine + isolated
+    /// `logDir`, so `ensureQueue()` short-circuits and no production-path I/O
+    /// is touched.
+    private func makeWiredController() -> PipelineController {
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier())
+        pc.queue = PipelineQueue(
+            engine: MockEngine(),
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { MockProtocolGen() },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+        )
+        return pc
+    }
+
+    // MARK: - engineProvider seam
+
+    func testMakeQueueReturnsCurrentQueueWhenProviderUnset() {
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier())
+        pc.queue = PipelineQueue(logDir: tmpDir)
+        let before = pc.queue
+
+        // No `activate(engineProvider:)` call → the defensive guard returns the
+        // current queue instead of building one without an engine.
+        let result = pc.makeQueue()
+
+        XCTAssertIdentical(result, before, "makeQueue must return the current queue when no engine provider is wired")
+    }
+
+    func testEnsureQueueRebuildsBareQueueUsingProviderEngine() {
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier())
+        pc.queue = PipelineQueue(logDir: tmpDir)
+        XCTAssertNil(pc.queue.engine, "Precondition: fresh queue has no engine")
+
+        let engine = MockEngine()
+        pc.activate { engine }
+        pc.ensureQueue()
+
+        XCTAssertIdentical(
+            pc.queue.engine as AnyObject, engine,
+            "ensureQueue must rebuild the bare queue with the engine the provider supplies",
+        )
+    }
+
+    func testEnsureQueueIsNoOpWhenEngineAlreadySet() {
+        let pc = makeWiredController()
+        let before = ObjectIdentifier(pc.queue)
+
+        pc.ensureQueue()
+
+        XCTAssertEqual(
+            ObjectIdentifier(pc.queue), before,
+            "ensureQueue must not replace a queue that is already wired to an engine",
+        )
+    }
+
+    // MARK: - enqueueFiles (bare controller)
+
+    func testEnqueueFilesCreatesJobOnBareController() {
+        let pc = makeWiredController()
+
+        pc.enqueueFiles([URL(fileURLWithPath: "/tmp/sprint-review.wav")])
+
+        XCTAssertEqual(pc.queue.jobs.count, 1)
+        XCTAssertEqual(pc.queue.jobs[0].meetingTitle, "sprint-review")
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2358,7 +2358,7 @@ final class PipelineQueueTests: XCTestCase {
 
     //
     // The SpeakerNamingView dialog used to call
-    // `appState.pipelineQueue.speakerMatcherFactory().allSpeakerNames()`
+    // `appState.pipeline.queue.speakerMatcherFactory().allSpeakerNames()`
     // inside the SwiftUI body getter. Each body re-eval re-constructed a
     // SpeakerMatcher (running migrateIfNeeded → file read) and re-parsed
     // the entire speakers.json (including embeddings) just to extract

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -144,7 +144,7 @@
         func test_snapshot_lastJob_skipsWaitingAndInFlightJobs() {
             let state = AppState(settings: settings)
             let waiting = makeJob(title: "in-flight")
-            state.pipelineQueue.insertJobForTesting(waiting)
+            state.pipeline.queue.insertJobForTesting(waiting)
             // .waiting is the default state on init; not finished yet.
             XCTAssertNil(state.rpcStateSnapshot().lastJob)
         }
@@ -161,8 +161,8 @@
             // Order in the array determines "last" — `last(where:)` walks
             // back-to-front. Append done first, then errored, so the latter
             // is returned.
-            state.pipelineQueue.insertJobForTesting(done)
-            state.pipelineQueue.insertJobForTesting(errored)
+            state.pipeline.queue.insertJobForTesting(done)
+            state.pipeline.queue.insertJobForTesting(errored)
 
             let snapshot = state.rpcStateSnapshot()
             let last = try XCTUnwrap(snapshot.lastJob)
@@ -181,7 +181,7 @@
             done.transcriptPath = URL(fileURLWithPath: "/tmp/transcript.md")
             done.protocolPath = URL(fileURLWithPath: "/tmp/protocol.md")
             done.warnings = ["diarization fell back to single track"]
-            state.pipelineQueue.insertJobForTesting(done)
+            state.pipeline.queue.insertJobForTesting(done)
 
             let json = try state.rpcStateSnapshot().jsonData()
             let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: json)


### PR DESCRIPTION
## What

Extracts the post-processing **pipeline** concern out of the `AppState`
god-class into its own `@Observable @MainActor PipelineController`:

- the `PipelineQueue` instance (`queue`),
- its construction from settings + the active engine (`makeQueue` / `ensureQueue` / `rebuild`),
- the job-state notification callbacks (`configureCallbacks`),
- the diarizer + protocol-generator factories,
- the file-enqueue entry points (`enqueueFiles` / `enqueueExistingFiles`).

`AppState` keeps the engine instances and supplies the active engine to the
controller via `activate(engineProvider:)` post stored-property init, so the
controller holds no `AppState` back-reference — the same post-init wiring idiom
the other extracted controllers use (`LiveTranscriptionCoordinator.beginPrewarm`,
`RPCServerController.activate`).

The queue is read as `appState.pipeline.queue` (direct sub-controller access,
matching the established altitude). The SwiftUI menu-bar body reads single-member
hoisted accessors (`pipelineQueue` / `hasPendingSpeakerNamingJobs`) to keep its
type-check under the 300 ms budget, and `rpcStateSnapshot` binds the queue to a
local for the same reason.

The class body shrank enough to **drop `AppState`'s `type_body_length`
suppression** (the file-length one stays — `AppState.swift` still holds the
`AppNotifying` protocol + `SilentNotifier` alongside the class).

## Why

This is the first of a planned sequence (PipelineController → WatchingController →
facade collapse). The watching concern (`toggleWatching` / `startManualRecording`)
reassigns the queue, which is read by ~everything — that single-owner knot is what
made watching impossible to extract cleanly. Giving the queue one owner here
dissolves it, so the next step becomes a clean cut.

## Tests

- Migrated the existing AppState pipeline tests onto the controller
  (`state.pipeline.queue`; method/MARK names track the renamed controller methods).
- New `PipelineControllerTests` cover the genuinely-new `engineProvider` seam —
  `makeQueue` returning the current queue when no provider is wired, `ensureQueue`
  rebuilding a bare queue with the provider-supplied engine, and the already-wired
  no-op. These paths read `AppState.activeTranscriptionEngine` directly before the
  split, so they were not unit-testable in isolation.

Byte-preserving extraction (moved method bodies are verbatim). Full suite green
(1854 tests), lint + swiftlint-analyze clean, release-mode parity build passes,
APPSTORE variant builds.