### PR TITLE
refactor(app): extract WatchingController from AppState

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import AppKit
 import Foundation
 import Observation
@@ -17,7 +16,7 @@ protocol AppNotifying {
 // MARK: - AppState
 
 /// Observable ViewModel that composes the app's concern-specific controllers
-/// (`pipeline`, `permissions`, `channelHealth`, `liveTranscription`,
+/// (`watching`, `pipeline`, `permissions`, `channelHealth`, `liveTranscription`,
 /// `rpcController`) and exposes the derived UI properties (badge, status label)
 /// the menu-bar scene binds to. It wires the controllers together rather than
 /// owning their state — new concern state belongs in a controller, not here.
@@ -45,9 +44,15 @@ final class AppState {
 
     // MARK: - State
 
-    var watchLoop: WatchLoop?
     var updateChecker: UpdateChecker
     var selectedNamingJobID: UUID?
+
+    /// Watching / recording lifecycle concern (the active `WatchLoop`, the
+    /// auto-detect toggle, manual recording start/stop, the recorder factory,
+    /// and the state-change handler), extracted into its own controller. It
+    /// holds the sibling controllers it reaches across; AppState's derived UI
+    /// properties read its `watchLoop`.
+    let watching: WatchingController
 
     /// Post-processing pipeline concern (the `PipelineQueue` instance, its
     /// wiring from settings + active engine, job-state notifications, and the
@@ -62,8 +67,8 @@ final class AppState {
 
     /// Per-channel + symmetric-silence detection that drives the menu-bar
     /// red-tint indicators while recording. Extracted into its own controller;
-    /// `attachStateChangeHandler` wires its `start()` / `stop()` to `WatchLoop`
-    /// state transitions, and the menu-bar icon + RPC snapshot read its flags.
+    /// `WatchingController` wires its `start()` / `stop()` to `WatchLoop` state
+    /// transitions, and the menu-bar icon + RPC snapshot read its flags.
     let channelHealth: ChannelHealthController
 
     /// Observable state for the live caption overlay. Always present (the
@@ -74,7 +79,8 @@ final class AppState {
 
     /// Live-transcription controller lifecycle (lazy creation against the active
     /// engine, pre-warm, per-recording sink installation), extracted into its own
-    /// coordinator. `makeRecorderFactory` delegates sink installation to it.
+    /// coordinator. `WatchingController`'s recorder factory delegates sink
+    /// installation to it.
     let liveTranscription: LiveTranscriptionCoordinator
 
     #if !APPSTORE
@@ -162,26 +168,20 @@ final class AppState {
             engineSupportsLive: { [settings] in settings.transcriptionEngine.supportsLiveTranscription },
             verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
         )
+        self.watching = WatchingController(
+            settings: settings,
+            notifier: notifier,
+            pipeline: pipeline,
+            channelHealth: channelHealth,
+            permissions: permissions,
+            liveTranscription: liveTranscription,
+        )
 
         #if !APPSTORE
             // Not trailing-closure: `isEnabled` is the first param (the other two
             // have defaults), so a trailing closure would bind to `rotateToken`.
             // swiftlint:disable:next trailing_closure
             self.rpcController = RPCServerController(isEnabled: { [settings] in settings.debugRPCEnabled })
-
-            // E2E hook: force a per-channel flag on at launch so a driver
-            // script can assert the menu-bar red-tint pipeline end-to-end
-            // without orchestrating real audio. Only honoured in non-AppStore
-            // builds and only when explicitly enabled via env var. The driver
-            // is also expected to set `MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1`
-            // so an auto-watch state transition doesn't clear the flag at +3 s
-            // through the regular `channelHealth.stop()` path.
-            let env = ProcessInfo.processInfo.environment
-            channelHealth.applyForcedFlagsForE2E(
-                micSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT"] == "1",
-                appSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_APP_SILENT"] == "1",
-                recordingSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT"] == "1",
-            )
         #endif
 
         // Bring engines in line with the current settings up front so the
@@ -194,8 +194,13 @@ final class AppState {
         // `[weak self]` engine closure is valid). The pipeline is rebuilt
         // lazily on the first watch/enqueue, never during init.
         pipeline.activate { [weak self] in self?.activeTranscriptionEngine }
+        // Wire the up-front engine-sync hook the watch-start path runs before
+        // the first transcription (engine concern still owned by AppState).
+        watching.activate { [weak self] in self?.syncLanguageSettings() }
 
         #if !APPSTORE
+            applyForcedChannelFlagsFromEnvironment()
+
             // Launch gate (env var OR setting) + the settings observer now live
             // in RPCServerController.activate; AppState only supplies the wired
             // server. The closure is set here (post stored-property init) so it
@@ -236,6 +241,22 @@ final class AppState {
         func stopPersistentLogStreamer() {
             persistentLogStreamer?.stop()
             persistentLogStreamer = nil
+        }
+
+        /// E2E hook: force a per-channel silence flag on at launch so a driver
+        /// script can assert the menu-bar red-tint pipeline end-to-end without
+        /// orchestrating real audio. Only honoured in non-AppStore builds and
+        /// only when explicitly enabled via env var. The driver is also expected
+        /// to set `MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1` so an auto-watch
+        /// state transition doesn't clear the flag at +3 s through the regular
+        /// `channelHealth.stop()` path.
+        private func applyForcedChannelFlagsFromEnvironment() {
+            let env = ProcessInfo.processInfo.environment
+            channelHealth.applyForcedFlagsForE2E(
+                micSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_MIC_SILENT"] == "1",
+                appSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_APP_SILENT"] == "1",
+                recordingSilent: env["MEETINGTRANSCRIBER_DEBUG_FORCE_RECORDING_SILENT"] == "1",
+            )
         }
     #endif
 
@@ -305,8 +326,11 @@ final class AppState {
 
     // MARK: - Derived properties
 
+    /// Whether the auto-detect watch loop is active (not a manual recording).
+    /// Delegates to `watching`; exposed here as a single-member accessor so the
+    /// menu-bar body that reads `appState.isWatching` stays cheap to type-check.
     var isWatching: Bool {
-        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
+        watching.isWatching
     }
 
     /// True when the caption-bar overlay should be visible: live transcription
@@ -315,14 +339,15 @@ final class AppState {
     var shouldShowLiveCaptions: Bool {
         settings.liveTranscriptionEnabled
             && settings.transcriptionEngine.supportsLiveTranscription
-            && watchLoop?.state == .recording
+            && watching.watchLoop?.state == .recording
     }
 
     var currentBadge: BadgeKind {
-        BadgeKind.compute(
-            watchLoopActive: watchLoop?.isActive == true,
-            watchLoopState: watchLoop?.state ?? .idle,
-            transcriberState: watchLoop?.transcriberState ?? .idle,
+        let loop = watching.watchLoop
+        return BadgeKind.compute(
+            watchLoopActive: loop?.isActive == true,
+            watchLoopState: loop?.state ?? .idle,
+            transcriberState: loop?.transcriberState ?? .idle,
             activeJobState: pipeline.queue.activeJobs.first?.state,
             updateAvailable: updateChecker.availableUpdate != nil,
             permissionProblem: permissions.health?.isHealthy == false,
@@ -330,7 +355,7 @@ final class AppState {
     }
 
     var currentStateLabel: String {
-        if let loop = watchLoop, loop.isActive {
+        if let loop = watching.watchLoop, loop.isActive {
             return loop.transcriberState.label
         }
         return "Idle"
@@ -358,6 +383,13 @@ final class AppState {
         !pipeline.queue.pendingSpeakerNamingJobs.isEmpty
     }
 
+    /// Whether the active loop is a manual recording (vs. auto-detect). Drives
+    /// the menu-bar "Stop Recording" item; hoisted to a single-member accessor
+    /// so the body reading it through `watching.watchLoop` stays cheap.
+    var isManualRecording: Bool {
+        watching.watchLoop?.isManualRecording == true
+    }
+
     /// Menu-bar **top-half** red tint: mic channel silent, OR both channels
     /// silent (`recordingSilentActive` paints both halves). Hoisted out of the
     /// menu-bar body for the same type-check-budget reason as
@@ -376,7 +408,7 @@ final class AppState {
     private static let isoFormatter = ISO8601DateFormatter()
 
     var currentStatus: TranscriberStatus? {
-        guard let loop = watchLoop, loop.isActive else { return nil }
+        guard let loop = watching.watchLoop, loop.isActive else { return nil }
 
         let meeting: MeetingInfo? = if let manual = loop.manualRecordingInfo {
             MeetingInfo(
@@ -405,154 +437,6 @@ final class AppState {
             audioPath: nil,
             pid: Int(ProcessInfo.processInfo.processIdentifier),
         )
-    }
-
-    // MARK: - Live transcription factory
-
-    /// Build the `recorderFactory` closure for `WatchLoop`. Returns a fresh
-    /// `DualSourceRecorder` on each invocation; when `liveTranscriptionEnabled`
-    /// is on AND the active engine supports `transcribeSamples`, also installs
-    /// mic + app live sinks that pipe captured buffers to the
-    /// `LiveTranscriptionController`. PoC scope — see
-    /// `LiveTranscriptionController` doc for what's logged.
-    private func makeRecorderFactory() -> @MainActor () -> any RecordingProvider {
-        { [weak self] in
-            let recorder = DualSourceRecorder()
-            self?.liveTranscription.attachSinks(to: recorder)
-            return recorder
-        }
-    }
-
-    // MARK: - Start / Stop
-
-    func toggleWatching() {
-        if let loop = watchLoop, loop.isManualRecording { return }
-        if let loop = watchLoop, loop.isActive {
-            loop.stop()
-            watchLoop = nil
-        } else {
-            Task { @MainActor in
-                _ = await Permissions.ensureMicrophoneAccess()
-
-                syncLanguageSettings()
-                pipeline.rebuild()
-
-                let detector: any MeetingDetecting = PowerAssertionDetector()
-
-                let loop = WatchLoop(
-                    detector: detector,
-                    recorderFactory: makeRecorderFactory(),
-                    pipelineQueue: pipeline.queue,
-                    pollInterval: settings.pollInterval,
-                    endGracePeriod: settings.endGrace,
-                    noMic: settings.noMic,
-                    micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                    verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
-                    recordOnly: { [settings] in settings.recordOnly },
-                    recordOnlyDestination: { [settings] in
-                        .production(parent: settings.effectiveOutputDir)
-                    },
-                    notifier: notifier,
-                )
-
-                attachStateChangeHandler(to: loop, notifyOnRecording: true)
-
-                if let health = permissions.health {
-                    loop.permissionChecker = { health }
-                }
-
-                watchLoop = loop
-                loop.start()
-            }
-        }
-    }
-
-    func startManualRecording(pid: pid_t, appName: String, title: String) {
-        // Stop auto-watch if active
-        if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
-            loop.stop()
-            watchLoop = nil
-        }
-
-        Task { @MainActor in
-            _ = await Permissions.ensureMicrophoneAccess()
-
-            pipeline.ensureQueue()
-
-            let loop = WatchLoop(
-                recorderFactory: makeRecorderFactory(),
-                pipelineQueue: pipeline.queue,
-                pollInterval: settings.pollInterval,
-                noMic: settings.noMic,
-                micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
-                recordOnly: { [settings] in settings.recordOnly },
-                recordOnlyDestination: { [settings] in
-                    .production(parent: settings.effectiveOutputDir)
-                },
-                notifier: notifier,
-            )
-            watchLoop = loop
-
-            // Wire channel-health monitoring + error notification on state
-            // transitions — same hook the auto-detect path installs, so the
-            // red-tint indicator and asymmetric-silence notification work
-            // for manual recordings too.
-            attachStateChangeHandler(to: loop, notifyOnRecording: false)
-
-            // Use cached health check result instead of live probe
-            if let health = permissions.health {
-                loop.permissionChecker = { health }
-            }
-
-            do {
-                try await loop.startManualRecording(pid: pid, appName: appName, title: title)
-                notifier.notify(
-                    title: "Manual Recording",
-                    body: "Recording: \(title)",
-                )
-            } catch {
-                notifier.notify(title: "Error", body: error.localizedDescription)
-                watchLoop = nil
-            }
-        }
-    }
-
-    func stopManualRecording() {
-        watchLoop?.stopManualRecording()
-        watchLoop = nil
-    }
-
-    // MARK: - Channel Health Monitor
-
-    /// Attaches the state-change callback that drives channel-health monitoring
-    /// and post-`.error` notifications. Shared between the auto-detect path
-    /// (`toggleWatching`) and the manual-recording path (`startManualRecording`)
-    /// so the red-tint indicator + asymmetric-silence notification fire in both.
-    /// `notifyOnRecording` only fires "Meeting Detected" notifications for the
-    /// auto-detect path; manual recording emits its own start notification.
-    private func attachStateChangeHandler(to loop: WatchLoop, notifyOnRecording: Bool) {
-        loop.onStateChange = { [weak self, weak loop, notifier] _, newState in
-            switch newState {
-            case .recording:
-                if notifyOnRecording, let meeting = loop?.currentMeeting {
-                    notifier.notify(
-                        title: "Meeting Detected",
-                        body: "Recording: \(meeting.windowTitle)",
-                    )
-                }
-                self?.channelHealth.start { [weak self] in self?.watchLoop?.activeRecorder }
-
-            case .error:
-                if let err = loop?.lastError {
-                    notifier.notify(title: "Error", body: err)
-                }
-                self?.channelHealth.stop()
-
-            default:
-                self?.channelHealth.stop()
-            }
-        }
     }
 
     // MARK: - Engine Settings

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -76,10 +76,10 @@ struct MeetingTranscriberApp: App {
                 isWatching: appState.isWatching,
                 pipelineQueue: appState.pipelineQueue,
                 updateChecker: appState.updateChecker,
-                onStartStop: appState.toggleWatching,
+                onStartStop: { appState.watching.toggleWatching() },
                 onRecordApp: { bringWindowToFront(id: "record-app") },
-                onStopManualRecording: appState.watchLoop?.isManualRecording == true ? {
-                    appState.stopManualRecording()
+                onStopManualRecording: appState.isManualRecording ? {
+                    appState.watching.stopManualRecording()
                 } : nil,
                 onOpenLastProtocol: openLastProtocol,
                 onOpenProtocol: { url in NSWorkspace.shared.open(url) },
@@ -111,7 +111,7 @@ struct MeetingTranscriberApp: App {
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
                 if !appState.isWatching {
-                    appState.toggleWatching()
+                    appState.watching.toggleWatching()
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
@@ -211,7 +211,7 @@ struct MeetingTranscriberApp: App {
         Window("Record App", id: "record-app") {
             AppPickerView(
                 onStartRecording: { pid, appName, title in
-                    appState.startManualRecording(pid: pid, appName: appName, title: title)
+                    appState.watching.startManualRecording(pid: pid, appName: appName, title: title)
                     closeWindow(id: "record-app")
                 },
                 onCancel: { closeWindow(id: "record-app") },
@@ -332,7 +332,7 @@ struct MeetingTranscriberApp: App {
     }
 
     private func quit() {
-        appState.watchLoop?.stop()
+        appState.watching.watchLoop?.stop()
         NSApplication.shared.terminate(nil)
     }
 

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Observation
+
+// MARK: - WatchingController
+
+/// Owns the watching / recording lifecycle: the active `WatchLoop`, the
+/// auto-detect toggle, manual recording start/stop, the per-recording recorder
+/// factory (which installs live-transcription sinks), and the state-change
+/// handler that drives channel-health monitoring + error notifications.
+///
+/// Extracted from `AppState` as a concern-specific controller (see the AppState
+/// god-class split). Unlike the earlier leaf controllers, watching is a hub: it
+/// reaches across the already-extracted siblings — `pipeline` (to rebuild/ensure
+/// the queue and pass it to the loop), `channelHealth` (start/stop on state
+/// transitions), `permissions` (seed the loop's permission checker), and
+/// `liveTranscription` (attach live sinks to each recorder). It holds those
+/// siblings as direct references (not an `AppState` back-reference) since they
+/// are all constructed before this controller in `AppState.init`.
+///
+/// Testability seams: `ensureMicAccess` + `makeDetector` are injectable (default
+/// to the production `Permissions.ensureMicrophoneAccess` / `PowerAssertionDetector`)
+/// so `toggleWatching` can be exercised without real TCC or IOKit. `syncEngines`
+/// is wired post-init via `activate(syncEngines:)` because it calls back into
+/// AppState's engine-sync (an engine concern not yet extracted) and must capture
+/// `self` after stored-property init — the same post-init wiring idiom the other
+/// controllers use.
+@Observable
+@MainActor
+final class WatchingController {
+    var watchLoop: WatchLoop?
+
+    private let settings: AppSettings
+    private let notifier: any AppNotifying
+    private let pipeline: PipelineController
+    private let channelHealth: ChannelHealthController
+    private let permissions: PermissionsController
+    private let liveTranscription: LiveTranscriptionCoordinator
+
+    /// Microphone-access gate. Injectable so tests skip the real TCC prompt; the
+    /// return value is intentionally ignored (the loop is created regardless, and
+    /// surfaces a permission problem through its own `permissionChecker`).
+    private let ensureMicAccess: () async -> Bool
+
+    /// Meeting detector factory for the auto-detect path. Injectable so tests can
+    /// supply a deterministic detector instead of the IOKit-backed
+    /// `PowerAssertionDetector`.
+    private let makeDetector: () -> any MeetingDetecting
+
+    /// Engine-sync hook, wired by `activate`. Calls back into AppState's
+    /// `syncLanguageSettings` (an engine concern not yet extracted); nil until
+    /// `activate` runs, in which case the up-front sync is skipped (the reactive
+    /// `observeEngineSettings` observer still keeps engines in line).
+    private var syncEngines: (() -> Void)?
+
+    init(
+        settings: AppSettings,
+        notifier: any AppNotifying,
+        pipeline: PipelineController,
+        channelHealth: ChannelHealthController,
+        permissions: PermissionsController,
+        liveTranscription: LiveTranscriptionCoordinator,
+        ensureMicAccess: @escaping () async -> Bool = { await Permissions.ensureMicrophoneAccess() },
+        makeDetector: @escaping () -> any MeetingDetecting = { PowerAssertionDetector() },
+    ) {
+        self.settings = settings
+        self.notifier = notifier
+        self.pipeline = pipeline
+        self.channelHealth = channelHealth
+        self.permissions = permissions
+        self.liveTranscription = liveTranscription
+        self.ensureMicAccess = ensureMicAccess
+        self.makeDetector = makeDetector
+    }
+
+    /// Wire the engine-sync hook. Called once from `AppState.init` after its
+    /// stored-property init, where the `[weak self]` AppState closure is valid.
+    func activate(syncEngines: @escaping () -> Void) {
+        self.syncEngines = syncEngines
+    }
+
+    // MARK: - Derived
+
+    var isWatching: Bool {
+        watchLoop?.isActive == true && watchLoop?.isManualRecording == false
+    }
+
+    // MARK: - Start / Stop
+
+    func toggleWatching() {
+        if let loop = watchLoop, loop.isManualRecording { return }
+        if let loop = watchLoop, loop.isActive {
+            loop.stop()
+            watchLoop = nil
+        } else {
+            Task { @MainActor in
+                _ = await ensureMicAccess()
+
+                syncEngines?()
+                pipeline.rebuild()
+
+                let detector = makeDetector()
+
+                let loop = WatchLoop(
+                    detector: detector,
+                    recorderFactory: makeRecorderFactory(),
+                    pipelineQueue: pipeline.queue,
+                    pollInterval: settings.pollInterval,
+                    endGracePeriod: settings.endGrace,
+                    noMic: settings.noMic,
+                    micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+                    verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
+                    recordOnly: { [settings] in settings.recordOnly },
+                    recordOnlyDestination: { [settings] in
+                        .production(parent: settings.effectiveOutputDir)
+                    },
+                    notifier: notifier,
+                )
+
+                attachStateChangeHandler(to: loop, notifyOnRecording: true)
+
+                if let health = permissions.health {
+                    loop.permissionChecker = { health }
+                }
+
+                watchLoop = loop
+                loop.start()
+            }
+        }
+    }
+
+    func startManualRecording(pid: pid_t, appName: String, title: String) {
+        // Stop auto-watch if active
+        if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
+            loop.stop()
+            watchLoop = nil
+        }
+
+        Task { @MainActor in
+            _ = await ensureMicAccess()
+
+            pipeline.ensureQueue()
+
+            let loop = WatchLoop(
+                recorderFactory: makeRecorderFactory(),
+                pipelineQueue: pipeline.queue,
+                pollInterval: settings.pollInterval,
+                noMic: settings.noMic,
+                micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+                verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
+                recordOnly: { [settings] in settings.recordOnly },
+                recordOnlyDestination: { [settings] in
+                    .production(parent: settings.effectiveOutputDir)
+                },
+                notifier: notifier,
+            )
+            watchLoop = loop
+
+            // Wire channel-health monitoring + error notification on state
+            // transitions — same hook the auto-detect path installs, so the
+            // red-tint indicator and asymmetric-silence notification work
+            // for manual recordings too.
+            attachStateChangeHandler(to: loop, notifyOnRecording: false)
+
+            // Use cached health check result instead of live probe
+            if let health = permissions.health {
+                loop.permissionChecker = { health }
+            }
+
+            do {
+                try await loop.startManualRecording(pid: pid, appName: appName, title: title)
+                notifier.notify(
+                    title: "Manual Recording",
+                    body: "Recording: \(title)",
+                )
+            } catch {
+                notifier.notify(title: "Error", body: error.localizedDescription)
+                watchLoop = nil
+            }
+        }
+    }
+
+    func stopManualRecording() {
+        watchLoop?.stopManualRecording()
+        watchLoop = nil
+    }
+
+    // MARK: - Recorder factory
+
+    /// Build the `recorderFactory` closure for `WatchLoop`. Returns a fresh
+    /// `DualSourceRecorder` on each invocation; when live transcription is on AND
+    /// the active engine supports `transcribeSamples`, the coordinator installs
+    /// mic + app live sinks that pipe captured buffers to the
+    /// `LiveTranscriptionController`.
+    private func makeRecorderFactory() -> @MainActor () -> any RecordingProvider {
+        { [weak self] in
+            let recorder = DualSourceRecorder()
+            self?.liveTranscription.attachSinks(to: recorder)
+            return recorder
+        }
+    }
+
+    // MARK: - State-change handler
+
+    /// Attaches the state-change callback that drives channel-health monitoring
+    /// and post-`.error` notifications. Shared between the auto-detect path
+    /// (`toggleWatching`) and the manual-recording path (`startManualRecording`)
+    /// so the red-tint indicator + asymmetric-silence notification fire in both.
+    /// `notifyOnRecording` only fires "Meeting Detected" notifications for the
+    /// auto-detect path; manual recording emits its own start notification.
+    private func attachStateChangeHandler(to loop: WatchLoop, notifyOnRecording: Bool) {
+        loop.onStateChange = { [weak self, weak loop, notifier] _, newState in
+            switch newState {
+            case .recording:
+                if notifyOnRecording, let meeting = loop?.currentMeeting {
+                    notifier.notify(
+                        title: "Meeting Detected",
+                        body: "Recording: \(meeting.windowTitle)",
+                    )
+                }
+                self?.channelHealth.start { [weak self] in self?.watchLoop?.activeRecorder }
+
+            case .error:
+                if let err = loop?.lastError {
+                    notifier.notify(title: "Error", body: err)
+                }
+                self?.channelHealth.stop()
+
+            default:
+                self?.channelHealth.stop()
+            }
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -85,7 +85,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testIsWatchingTrueWhenLoopActiveNotManual() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertTrue(state.isWatching)
@@ -94,7 +94,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testIsWatchingFalseWhenLoopNotStarted() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         // loop not started → isActive == false
         XCTAssertFalse(state.isWatching)
     }
@@ -102,7 +102,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testIsWatchingFalseWhenManualRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertFalse(state.isWatching)
@@ -113,7 +113,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStateLabelWatchingWhenLoopActive() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertEqual(state.currentStateLabel, "Watching for Meetings...")
@@ -122,7 +122,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStateLabelRecordingWhenManualRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertEqual(state.currentStateLabel, "Recording")
@@ -131,10 +131,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStateLabelIdleWhenLoopStopped() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         loop.stop()
-        state.watchLoop = nil
+        state.watching.watchLoop = nil
         XCTAssertEqual(state.currentStateLabel, "Idle")
     }
 
@@ -143,14 +143,14 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStatusNilWhenLoopNotStarted() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         XCTAssertNil(state.currentStatus)
     }
 
     func testCurrentStatusNotNilWhenLoopActive() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertNotNil(state.currentStatus)
@@ -159,7 +159,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStatusStateMatchesLoopTranscriberState() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertEqual(state.currentStatus?.state, .watching)
@@ -168,7 +168,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStatusDetailMatchesLoopDetail() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertEqual(state.currentStatus?.detail, "Polling for meetings...")
@@ -177,7 +177,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStatusMeetingNilWhenNoActiveMeeting() {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         loop.start()
         defer { loop.stop() }
         XCTAssertNil(state.currentStatus?.meeting)
@@ -186,7 +186,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentStatusMeetingFromManualRecordingInfo() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
         defer { loop.stop() }
         let status = try XCTUnwrap(state.currentStatus)
@@ -213,7 +213,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testCurrentBadgeRecordingWhenLoopRecording() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
         XCTAssertEqual(state.currentBadge, .recording)
@@ -225,26 +225,26 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
         loop.start()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         XCTAssertTrue(state.isWatching)
 
-        state.toggleWatching()
+        state.watching.toggleWatching()
 
-        XCTAssertNil(state.watchLoop)
+        XCTAssertNil(state.watching.watchLoop)
         XCTAssertFalse(state.isWatching)
     }
 
     func testToggleWatchingWhileManualRecordingIsNoOp() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         defer { loop.stop() }
 
-        state.toggleWatching() // must be a no-op
+        state.watching.toggleWatching() // must be a no-op
 
-        XCTAssertNotNil(state.watchLoop)
-        XCTAssertEqual(state.watchLoop?.isManualRecording, true)
+        XCTAssertNotNil(state.watching.watchLoop)
+        XCTAssertEqual(state.watching.watchLoop?.isManualRecording, true)
     }
 
     // MARK: - toggleWatching: start path (async)
@@ -255,22 +255,22 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testToggleWatchingCreatesWatchLoop() async {
         let (state, _) = makeState()
-        addTeardownBlock { state.watchLoop?.stop() }
+        addTeardownBlock { state.watching.watchLoop?.stop() }
 
-        state.toggleWatching()
-        await waitFor(state.watchLoop != nil)
+        state.watching.toggleWatching()
+        await waitFor(state.watching.watchLoop != nil)
 
-        XCTAssertNotNil(state.watchLoop)
+        XCTAssertNotNil(state.watching.watchLoop)
     }
 
     func testToggleWatchingMakesLoopActive() async {
         let (state, _) = makeState()
-        addTeardownBlock { state.watchLoop?.stop() }
+        addTeardownBlock { state.watching.watchLoop?.stop() }
 
-        state.toggleWatching()
-        await waitFor(state.watchLoop?.isActive == true)
+        state.watching.toggleWatching()
+        await waitFor(state.watching.watchLoop?.isActive == true)
 
-        XCTAssertEqual(state.watchLoop?.isActive, true)
+        XCTAssertEqual(state.watching.watchLoop?.isActive, true)
     }
 
     // MARK: - stopManualRecording
@@ -278,18 +278,18 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testStopManualRecordingClearsWatchLoop() async throws {
         let (state, _) = makeState()
         let (loop, _) = makeTestWatchLoop()
-        state.watchLoop = loop
+        state.watching.watchLoop = loop
         try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
 
-        state.stopManualRecording()
+        state.watching.stopManualRecording()
 
-        XCTAssertNil(state.watchLoop)
+        XCTAssertNil(state.watching.watchLoop)
     }
 
     func testStopManualRecordingWhenNoLoopIsNoOp() {
         let (state, _) = makeState()
-        state.stopManualRecording() // must not crash
-        XCTAssertNil(state.watchLoop)
+        state.watching.stopManualRecording() // must not crash
+        XCTAssertNil(state.watching.watchLoop)
     }
 
     // MARK: - enqueueFiles
@@ -601,9 +601,9 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testStartManualRecordingSendsNotification() async {
         let (state, notifier) = makeState()
         state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
-        addTeardownBlock { state.watchLoop?.stop() }
+        addTeardownBlock { state.watching.watchLoop?.stop() }
 
-        state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        state.watching.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
         // Success → "Manual Recording" / hardware unavailable → "Error"
         await waitFor(!notifier.calls.isEmpty)
 
@@ -618,10 +618,10 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
         let (existingLoop, _) = makeTestWatchLoop()
         existingLoop.start()
-        state.watchLoop = existingLoop
+        state.watching.watchLoop = existingLoop
         XCTAssertTrue(existingLoop.isActive)
 
-        state.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        state.watching.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
         await waitFor(!existingLoop.isActive)
 
         XCTAssertFalse(existingLoop.isActive, "Existing auto-watch loop should be stopped")

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionGatingTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionGatingTests.swift
@@ -77,7 +77,7 @@ final class LiveTranscriptionGatingTests: XCTestCase {
         settings.liveTranscriptionEnabled = true
         let state = AppState(settings: settings)
         // No watch loop has been started → recording state is unreachable
-        XCTAssertNil(state.watchLoop)
+        XCTAssertNil(state.watching.watchLoop)
         XCTAssertFalse(state.shouldShowLiveCaptions)
     }
 
@@ -85,7 +85,7 @@ final class LiveTranscriptionGatingTests: XCTestCase {
         settings.transcriptionEngine = .whisperKit
         settings.liveTranscriptionEnabled = true
         let state = AppState(settings: settings)
-        XCTAssertNil(state.watchLoop)
+        XCTAssertNil(state.watching.watchLoop)
         XCTAssertFalse(state.shouldShowLiveCaptions)
     }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -171,7 +171,7 @@ func makeSilentDetector() -> MeetingDetector {
 }
 
 /// Creates a WatchLoop backed by a MockRecorder and a silent detector.
-/// Assign the returned loop to `appState.watchLoop` in tests that need
+/// Assign the returned loop to `appState.watching.watchLoop` in tests that need
 /// an active loop without calling toggleWatching() (which requires Permissions).
 @MainActor
 func makeTestWatchLoop(

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -1,0 +1,153 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `WatchingController` exercised on a bare controller (no full
+/// `AppState`), focusing on the genuinely-new injection seams the extraction
+/// enables: `ensureMicAccess` and `makeDetector`. Before the split,
+/// `toggleWatching` hard-wired `Permissions.ensureMicrophoneAccess()` +
+/// `PowerAssertionDetector()`, so neither the mic-access gate nor the detector
+/// wiring was reachable in a unit test without real TCC / IOKit.
+@MainActor
+final class WatchingControllerTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "WatchingControllerTests")
+    }
+
+    override func tearDown() async throws {
+        if let tmpDir { try? FileManager.default.removeItem(at: tmpDir) }
+        try await super.tearDown()
+    }
+
+    /// Builds a `WatchingController` wired to real (but inert) sibling
+    /// controllers and the supplied seams. The pipeline gets a queue on an
+    /// isolated `logDir` so `rebuild()` touches no production path, and the
+    /// default detector never matches a window so no recording starts.
+    private func makeController(
+        ensureMicAccess: @escaping () async -> Bool = { true },
+        makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
+    ) -> WatchingController {
+        let settings = AppSettings()
+        let notifier = RecordingNotifier()
+        let pipeline = PipelineController(settings: settings, notifier: notifier)
+        pipeline.queue = PipelineQueue(logDir: tmpDir)
+        let channelHealth = ChannelHealthController(
+            notifier: notifier,
+            debounceSeconds: { 0 },
+            indicatorEnabled: { false },
+        )
+        let permissions = PermissionsController(notifier: notifier)
+        let liveTranscription = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { false },
+            engineSupportsLive: { false },
+            verboseDiagnostics: { false },
+        )
+        return WatchingController(
+            settings: settings,
+            notifier: notifier,
+            pipeline: pipeline,
+            channelHealth: channelHealth,
+            permissions: permissions,
+            liveTranscription: liveTranscription,
+            ensureMicAccess: ensureMicAccess,
+            makeDetector: makeDetector,
+        )
+    }
+
+    // MARK: - ensureMicAccess seam
+
+    func testToggleWatchingAwaitsInjectedMicAccess() async {
+        var micAccessCalled = false
+        // Not trailing-closure: a trailing closure binds to the last param
+        // (`makeDetector`), not `ensureMicAccess`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            micAccessCalled = true
+            return true
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(micAccessCalled)
+
+        XCTAssertTrue(micAccessCalled, "toggleWatching must await the injected mic-access gate")
+    }
+
+    func testStartManualRecordingAwaitsInjectedMicAccess() async {
+        var micAccessCalled = false
+        // Not trailing-closure: a trailing closure binds to the last param
+        // (`makeDetector`), not `ensureMicAccess`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            micAccessCalled = true
+            return true
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        await waitFor(micAccessCalled)
+
+        XCTAssertTrue(micAccessCalled, "startManualRecording must await the injected mic-access gate")
+    }
+
+    // MARK: - makeDetector seam
+
+    func testToggleWatchingUsesInjectedDetectorFactory() async {
+        var detectorMade = false
+        // Not trailing-closure: with `ensureMicAccess` defaulted before it, a
+        // trailing closure binds to `ensureMicAccess` (→ `Bool`), not `makeDetector`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(makeDetector: {
+            detectorMade = true
+            return makeSilentDetector()
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(detectorMade)
+
+        XCTAssertTrue(detectorMade, "toggleWatching must build its detector via the injected factory")
+    }
+
+    // MARK: - Toggle / stop lifecycle
+
+    func testToggleWatchingCreatesLoopThenSecondToggleStops() async {
+        let controller = makeController()
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(controller.watchLoop?.isActive == true)
+        XCTAssertEqual(controller.watchLoop?.isActive, true, "first toggle should start an active loop")
+
+        controller.toggleWatching()
+        XCTAssertNil(controller.watchLoop, "second toggle should stop and clear the loop")
+    }
+
+    func testToggleWatchingNoOpWhileManualRecording() async throws {
+        let controller = makeController()
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+
+        controller.toggleWatching() // must be a no-op while a manual recording is live
+
+        XCTAssertNotNil(controller.watchLoop)
+        XCTAssertEqual(controller.watchLoop?.isManualRecording, true)
+    }
+
+    func testStopManualRecordingClearsLoop() async throws {
+        let controller = makeController()
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Meeting")
+
+        controller.stopManualRecording()
+
+        XCTAssertNil(controller.watchLoop)
+    }
+}

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -18,7 +18,7 @@ Native SwiftUI menu bar application that orchestrates meeting detection, recordi
                                            │ owns
                 ┌──────────────────────────▼───────────────────────┐
                 │            AppState (@Observable @MainActor)     │
-                │   watchLoop, pipelineQueue, settings, engines    │
+                │   concern controllers, settings, engines         │
                 └────────┬─────────────────────────────────┬───────┘
                          │                                 │ optional
                          │                                 │ (#if !APPSTORE


### PR DESCRIPTION
## What

Extracts the **watching / recording lifecycle** out of the `AppState`
god-class into its own `@Observable @MainActor WatchingController`:

- the active `WatchLoop`,
- the auto-detect toggle (`toggleWatching`),
- manual recording start/stop,
- the per-recording recorder factory (which installs live-transcription sinks),
- the state-change handler that drives channel-health monitoring + error notifications.

Unlike the earlier leaf controllers, watching is a **hub** — it reaches across
the already-extracted siblings (`pipeline`, `channelHealth`, `permissions`,
`liveTranscription`), which it holds as direct references (no `AppState`
back-reference) since they are all constructed before it in `AppState.init`.
The earlier `PipelineController` extraction was the prerequisite: giving the
queue a single owner dissolved the reassignment knot that made this cut
impossible before.

`AppState` keeps the derived UI properties (`currentBadge` / `currentStatus` /
`currentStateLabel` / `isWatching` / `shouldShowLiveCaptions`), now reading
`watching.watchLoop`, plus single-member hoisted accessors (`isWatching` /
`isManualRecording`) so the menu-bar body stays under the type-check budget.

`AppState` shrank ~115 lines and **dropped its `file_length` suppression**; the
E2E forced-channel-flags hook moved to a named method to keep `init` under the
body-length limit.

## Testability

`ensureMicAccess` + `makeDetector` are injectable (defaulting to
`Permissions.ensureMicrophoneAccess` / `PowerAssertionDetector`) so
`toggleWatching` can be exercised without real TCC or IOKit. New
`WatchingControllerTests` assert both seams (toggle + manual-record await the
mic-access gate; toggle builds its detector via the injected factory) plus
toggle/stop lifecycle on a bare controller — paths that hard-wired the
production deps before the split and so were unreachable in a unit test.
Non-vacuity proven by bypassing each seam → the tests go red.

## Verification

Full suite green (1860 tests), lint + swiftlint-analyze clean, release-mode
parity build passes, APPSTORE variant builds. Byte-preserving extraction (moved
method bodies are verbatim).