### PR TITLE
fix(app): accept OpenAI base URL, not only full chat-completions URL

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -344,6 +344,11 @@ final class AppSettings {
         }
     #endif
 
+    /// Default OpenAI-compatible endpoint — Ollama's base URL. Both the base
+    /// form (`.../v1`) and a full chat-completions URL are accepted on read
+    /// (see `OpenAIProtocolGenerator.apiBaseURL`); the base form is canonical.
+    static let defaultOpenAIEndpoint = "http://localhost:11434/v1"
+
     var openAIEndpoint: String {
         didSet { defaults.set(openAIEndpoint, forKey: "openAIEndpoint") }
     }
@@ -504,7 +509,7 @@ final class AppSettings {
         protocolLanguage = defaults.string(forKey: "protocolLanguage") ?? "German"
 
         openAIEndpoint = defaults.object(forKey: "openAIEndpoint") as? String
-            ?? "http://localhost:11434/v1/chat/completions"
+            ?? Self.defaultOpenAIEndpoint
         openAIModel = defaults.object(forKey: "openAIModel") as? String ?? "llama3.1"
 
         // Migrate legacy "audioDebugLogging" key (renamed to "verboseDiagnostics" 2026-05-04).

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -44,7 +44,10 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)
 
-        var request = URLRequest(url: endpoint)
+        let requestURL = Self.apiBaseURL(from: endpoint)
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions")
+        var request = URLRequest(url: requestURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let apiKey, !apiKey.isEmpty {
@@ -60,13 +63,13 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
             (bytes, response) = try await session.bytes(for: request)
         } catch {
             logger.error(
-                "openai_connection_failed endpoint=\(self.endpoint.absoluteString, privacy: .public) model=\(self.model, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
+                "openai_connection_failed endpoint=\(requestURL.absoluteString, privacy: .public) model=\(self.model, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
             )
             throw ProtocolError.connectionFailed(error.localizedDescription)
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            logger.error("openai_invalid_response endpoint=\(self.endpoint.absoluteString, privacy: .public)")
+            logger.error("openai_invalid_response endpoint=\(requestURL.absoluteString, privacy: .public)")
             throw ProtocolError.connectionFailed("Invalid response")
         }
 
@@ -78,7 +81,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
                 if errorBody.count > 500 { break }
             }
             logger.error(
-                "openai_http_error status=\(httpResponse.statusCode, privacy: .public) endpoint=\(self.endpoint.absoluteString, privacy: .public) body=\(errorBody, privacy: .public)",
+                "openai_http_error status=\(httpResponse.statusCode, privacy: .public) endpoint=\(requestURL.absoluteString, privacy: .public) body=\(errorBody, privacy: .public)",
             )
             throw ProtocolError.httpError(httpResponse.statusCode, errorBody)
         }
@@ -119,17 +122,34 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         return content
     }
 
+    /// Normalize a user-entered endpoint to the OpenAI API *base* URL (e.g.
+    /// `http://host/v1`), from which the concrete `/chat/completions` and
+    /// `/models` paths are derived.
+    ///
+    /// Accepts both conventions so no existing configuration breaks:
+    ///   - base URL:          `http://host/v1`                  → `http://host/v1`
+    ///   - full endpoint URL: `http://host/v1/chat/completions` → `http://host/v1`
+    ///
+    /// The OpenAI ecosystem (and LM Studio's own UI) presents the base URL,
+    /// while this app historically shipped the full chat-completions URL as its
+    /// default — collapsing both to the same base means either works.
+    static func apiBaseURL(from endpoint: URL) -> URL {
+        guard endpoint.lastPathComponent == "completions" else { return endpoint }
+        let chat = endpoint.deletingLastPathComponent()
+        guard chat.lastPathComponent == "chat" else { return endpoint }
+        return chat.deletingLastPathComponent()
+    }
+
     /// Test connection to the API by querying available models.
     /// Returns model names on success.
     static func testConnection(endpoint: String, model _: String, apiKey: String?, session: URLSession = .shared) async -> Result<[String], any Error> {
-        // Derive models endpoint from chat completions endpoint
-        guard let chatURL = URL(string: endpoint) else {
+        // Accept either the API base URL (.../v1) or the full chat-completions
+        // URL (.../v1/chat/completions); both resolve to the same base + /models.
+        guard let entered = URL(string: endpoint) else {
             return .failure(ProtocolError.connectionFailed("Invalid endpoint URL"))
         }
 
-        // Navigate from .../v1/chat/completions to .../v1/models
-        let baseURL = chatURL.deletingLastPathComponent().deletingLastPathComponent()
-        let modelsURL = baseURL.appendingPathComponent("models")
+        let modelsURL = apiBaseURL(from: entered).appendingPathComponent("models")
 
         var request = URLRequest(url: modelsURL)
         request.httpMethod = "GET"

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -127,7 +127,7 @@ final class PipelineController {
             OpenAIProtocolGenerator(
                 endpoint: URL(string: settings.openAIEndpoint)
                     // swiftlint:disable:next force_unwrapping
-                    ?? URL(string: "http://localhost:11434/v1/chat/completions")!,
+                    ?? URL(string: AppSettings.defaultOpenAIEndpoint)!,
                 model: settings.openAIModel,
                 language: settings.protocolLanguage,
                 apiKey: settings.openAIAPIKey.isEmpty ? nil : settings.openAIAPIKey,

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -135,8 +135,11 @@ struct OutputSettingsView: View {
     private var openAIConfigView: some View { // swiftlint:disable:this attributes
         VStack(alignment: .leading, spacing: 4) {
             Text("Endpoint")
-            TextField("", text: $settings.openAIEndpoint)
+            TextField("http://localhost:1234/v1", text: $settings.openAIEndpoint)
                 .textFieldStyle(.roundedBorder)
+            Text("Base URL (e.g. http://localhost:1234/v1) or full chat-completions URL — both work.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
 
         if !availableModels.isEmpty {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -208,7 +208,7 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testOpenAIEndpointDefault() {
-        XCTAssertEqual(settings.openAIEndpoint, "http://localhost:11434/v1/chat/completions")
+        XCTAssertEqual(settings.openAIEndpoint, "http://localhost:11434/v1")
     }
 
     func testOpenAIModelDefault() {

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -1,7 +1,7 @@
 @testable import MeetingTranscriber
 import XCTest
 
-final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle
+final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this balanced_xctest_lifecycle type_body_length
     // MARK: - SSE Line Parsing
 
     func testParseSSELineExtractsContent() {
@@ -415,6 +415,61 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         if case .failure = result { /* expected */ } else {
             XCTFail("Expected failure for empty endpoint")
         }
+    }
+
+    // MARK: - Endpoint Base-URL Handling (issue #363)
+
+    func testTestConnectionDerivesModelsURLFromBaseURL() async {
+        // Issue #363: the OpenAI ecosystem convention (and LM Studio's own UI)
+        // is to enter the *base URL* ".../v1". Fetch Models must then hit
+        // ".../v1/models", NOT ".../models" (which 404s on LM Studio).
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                "http://test.local/v1/models",
+                "base URL '/v1' must resolve to '/v1/models', not '/models'",
+            )
+            return self.mockResponse(request, body: Data(#"{"data":[]}"#.utf8))
+        }
+
+        let result = await OpenAIProtocolGenerator.testConnection(
+            endpoint: "http://test.local/v1",
+            model: "test",
+            apiKey: nil,
+            session: makeMockSession(),
+        )
+        // Non-vacuity: prove the request was actually issued (handler reached),
+        // so the in-handler URL assertion above is not skipped.
+        guard case .success = result else {
+            XCTFail("Expected the models request to be issued, got \(result)")
+            return
+        }
+    }
+
+    func testGeneratePostsToChatCompletionsFromBaseURL() async throws {
+        // Issue #363: with the base URL ".../v1", generate() must POST to
+        // ".../v1/chat/completions", not to ".../v1" itself (which 404s and
+        // makes summarization fail).
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                "http://test.local/v1/chat/completions",
+                "base URL '/v1' must POST to '/v1/chat/completions'",
+            )
+            return self.mockResponse(request, body: Data(Self.okSSE.utf8))
+        }
+
+        let gen = try OpenAIProtocolGenerator(
+            endpoint: XCTUnwrap(URL(string: "http://test.local/v1")),
+            model: "test-model",
+            language: "German",
+            session: makeMockSession(),
+        )
+        // Non-vacuity: the "OK" body is only reachable through the mock, so a
+        // matching result proves the request was issued and the in-handler URL
+        // assertion above actually ran.
+        let result = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
+        XCTAssertEqual(result, "OK")
     }
 
     // MARK: - Full Protocol Roundtrip


### PR DESCRIPTION
## Problem

The OpenAI-compatible endpoint field required the *full* chat-completions URL (`…/v1/chat/completions`). Users following the standard OpenAI / LM Studio convention enter the **base URL** (`…/v1`) — which broke silently:

- **Fetch Models** requested `/models` instead of `/v1/models` (two `deletingLastPathComponent()` calls overshot to the host root).
- **Protocol generation** POSTed to `/v1` instead of `/v1/chat/completions` → 404, summarization failed.

Reported in #363.

## Fix

- Add `OpenAIProtocolGenerator.apiBaseURL(from:)` that normalizes any entered endpoint to the API base, then derive `/chat/completions` (generate) and `/models` (testConnection) from it. Both conventions — base URL and full chat-completions URL — collapse to the same base, so existing configurations produce **byte-identical** request URLs; only the previously-broken base-URL form changes behavior.
- Error logs now reference the actual request URL rather than the configured value (they diverge for base-URL inputs).
- Default endpoint changed to the base form `http://localhost:11434/v1` to match the convention; a shared `AppSettings.defaultOpenAIEndpoint` constant removes the duplicated literal.
- Settings field gains a placeholder + hint noting both forms work.

## Tests

- Two regression tests assert the resulting request URLs for a base-URL input (`…/v1/models` and `…/v1/chat/completions`), each non-vacuous (a result assertion proves the request was actually issued through the mock).
- Full suite green (1861 tests), lint clean.

Closes #363