### PR TITLE
refactor(app): extract EngineController from AppState (final god-class split)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,8 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - `TranscribingEngine` protocol abstracts ASR backends. Three implementations: `WhisperKitEngine` (99+ languages, ~1 GB model), `ParakeetEngine` (25 EU languages, ~50 MB model, ~10× faster), and `Qwen3AsrEngine` (30 languages, ~1.75 GB model, macOS 15+).
 - `AppSettings.transcriptionEngine` enum (`.whisperKit` / `.parakeet` / `.qwen3`) selects the engine. Settings UI shows engine picker; engine-specific options hidden when not selected. `availableCases` filters by macOS version.
 - Parakeet auto-detects language (no parameter) and supports custom vocabulary via CTC boosting (`ParakeetEngine.customVocabularyPath`). WhisperKit and Qwen3 support explicit language selection.
-- `Qwen3AsrEngine` requires macOS 15+ (`@available`). Returns plain text (no timestamps) — emits single `TimestampedSegment`. Chunks audio into <=30s windows (`Qwen3AsrConfig.maxAudioSeconds`). Type-erased in AppState via `_qwen3Engine: AnyObject?` for macOS <15 compatibility.
-- `AppState.activeTranscriptionEngine` returns the selected engine, used by `PipelineQueue`.
+- `Qwen3AsrEngine` requires macOS 15+ (`@available`). Returns plain text (no timestamps) — emits single `TimestampedSegment`. Chunks audio into <=30s windows (`Qwen3AsrConfig.maxAudioSeconds`). Type-erased in `EngineController` via `_qwen3Engine: AnyObject?` for macOS <15 compatibility.
+- `EngineController` (`@MainActor`) owns the three engine instances + the active-engine selection (`activeTranscriptionEngine`, used by `PipelineQueue`) + the settings → engine language/vocabulary sync (up-front + reactive) + launch model preload. `AppState` exposes it as `engines`.
 
 **Concurrency:**
 - `WatchLoop` is `@MainActor`. Tests for this class must also be `@MainActor`.

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -92,17 +92,17 @@
         /// settings → engine propagation without running a transcription.
         private func enginesSnapshot() -> RPCStateSnapshot.Engines {
             let qwen3State: RPCStateSnapshot.Engines.Qwen3? = if #available(macOS 15, *) {
-                .init(language: qwen3Engine.language)
+                .init(language: engines.qwen3Engine.language)
             } else {
                 nil
             }
             return RPCStateSnapshot.Engines(
                 active: settings.transcriptionEngine,
                 whisperKit: .init(
-                    modelVariant: whisperKit.modelVariant,
-                    language: whisperKit.language,
+                    modelVariant: engines.whisperKit.modelVariant,
+                    language: engines.whisperKit.language,
                 ),
-                parakeet: .init(customVocabularyPath: parakeetEngine.customVocabularyPath),
+                parakeet: .init(customVocabularyPath: engines.parakeetEngine.customVocabularyPath),
                 qwen3: qwen3State,
             )
         }

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -16,10 +16,11 @@ protocol AppNotifying {
 // MARK: - AppState
 
 /// Observable ViewModel that composes the app's concern-specific controllers
-/// (`watching`, `pipeline`, `permissions`, `channelHealth`, `liveTranscription`,
-/// `rpcController`) and exposes the derived UI properties (badge, status label)
-/// the menu-bar scene binds to. It wires the controllers together rather than
-/// owning their state — new concern state belongs in a controller, not here.
+/// (`engines`, `watching`, `pipeline`, `permissions`, `channelHealth`,
+/// `liveTranscription`, `rpcController`) and exposes the derived UI properties
+/// (badge, status label) the menu-bar scene binds to. It wires the controllers
+/// together rather than owning their state — new concern state belongs in a
+/// controller, not here.
 ///
 /// Extracted from `MeetingTranscriberApp` so badge/watching logic and
 /// `BadgeKind.compute(...)` are testable without the `@main` App struct.
@@ -29,23 +30,19 @@ final class AppState {
     // MARK: - Dependencies
 
     let settings: AppSettings
-    let whisperKit: WhisperKitEngine
-    let parakeetEngine: ParakeetEngine
-    // Only created on macOS 15+ where Qwen3-ASR is available.
-    private let _qwen3Engine: AnyObject?
     private let notifier: any AppNotifying
-
-    /// Typed accessor (only callable under @available(macOS 15, *) checks).
-    @available(macOS 15, *)
-    var qwen3Engine: Qwen3AsrEngine {
-        // swiftlint:disable:next force_cast
-        _qwen3Engine as! Qwen3AsrEngine
-    }
 
     // MARK: - State
 
     var updateChecker: UpdateChecker
     var selectedNamingJobID: UUID?
+
+    /// Transcription-engine concern (the three engine instances, active-engine
+    /// selection, and settings → engine language/vocabulary sync), extracted
+    /// into its own controller. Read as `engines.activeTranscriptionEngine` by
+    /// the pipeline + live-transcription coordinators and `engines.whisperKit`
+    /// etc. by the Settings UI + RPC snapshot.
+    let engines: EngineController
 
     /// Watching / recording lifecycle concern (the active `WatchLoop`, the
     /// auto-detect toggle, manual recording start/stop, the recorder factory,
@@ -107,53 +104,28 @@ final class AppState {
         AppSettings()
     }
 
-    private static func makeWhisperKit() -> WhisperKitEngine {
-        WhisperKitEngine()
-    }
-
-    private static func makeParakeet() -> ParakeetEngine {
-        ParakeetEngine()
-    }
-
     private static func makeUpdateChecker() -> UpdateChecker {
         UpdateChecker()
-    }
-
-    @available(macOS 15, *)
-    private static func makeQwen3() -> Qwen3AsrEngine {
-        Qwen3AsrEngine()
     }
 
     // MARK: - Init
 
     init(
         settings: AppSettings = AppState.makeDefaultSettings(),
-        whisperKit: WhisperKitEngine? = nil,
-        parakeetEngine: ParakeetEngine? = nil,
-        qwen3Engine: AnyObject? = nil,
         notifier: any AppNotifying = SilentNotifier(),
         updateChecker: UpdateChecker? = nil,
     ) {
         // Dependency defaults are resolved through explicitly-typed factory
-        // helpers (above) rather than inline `?? SomeType()` expressions (and
-        // an inline `AppSettings()` default argument). Each inline
-        // `@Observable` / protocol-existential constructor forces the
-        // type-checker to re-solve the dependency's own init constraints at
-        // this call site; summed across the engine + settings dependencies
-        // that pushed this init's body-type-check time right up against the
-        // 300 ms hard limit enforced in Package.swift, where it flaked
-        // intermittently under heavy CI load. A factory with a declared
-        // return type collapses the inference here to a plain function
-        // reference. Behaviour is identical.
+        // helpers (above) rather than inline `?? SomeType()` expressions (and an
+        // inline `AppSettings()` default argument). An inline `@Observable`
+        // constructor forces the type-checker to re-solve the dependency's own
+        // init constraints at this call site, which pushed this init's
+        // body-type-check time toward the 300 ms hard limit enforced in
+        // Package.swift. A factory with a declared return type collapses the
+        // inference here to a plain function reference. Behaviour is identical.
         self.settings = settings
-        self.whisperKit = whisperKit ?? Self.makeWhisperKit()
-        self.parakeetEngine = parakeetEngine ?? Self.makeParakeet()
-        if #available(macOS 15, *) {
-            self._qwen3Engine = (qwen3Engine as? Qwen3AsrEngine) ?? Self.makeQwen3()
-        } else {
-            self._qwen3Engine = nil
-        }
         self.notifier = notifier
+        self.engines = EngineController(settings: settings)
         self.permissions = PermissionsController(notifier: notifier)
         self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
         self.pipeline = PipelineController(settings: settings, notifier: notifier)
@@ -184,19 +156,14 @@ final class AppState {
             self.rpcController = RPCServerController(isEnabled: { [settings] in settings.debugRPCEnabled })
         #endif
 
-        // Bring engines in line with the current settings up front so the
-        // first transcription doesn't run against stale defaults, then
-        // start observing for runtime changes.
-        syncLanguageSettings()
-        observeEngineSettings()
-        liveTranscription.beginPrewarm { [weak self] in self?.activeTranscriptionEngine }
-        // Wire the active-engine source (post stored-property init so the
-        // `[weak self]` engine closure is valid). The pipeline is rebuilt
-        // lazily on the first watch/enqueue, never during init.
-        pipeline.activate { [weak self] in self?.activeTranscriptionEngine }
-        // Wire the up-front engine-sync hook the watch-start path runs before
-        // the first transcription (engine concern still owned by AppState).
-        watching.activate { [weak self] in self?.syncLanguageSettings() }
+        // Wire the active-engine source + the watch-start up-front engine sync
+        // (post stored-property init so the `[weak self]` closures are valid).
+        // `EngineController` does its own up-front sync + reactive observe in its
+        // init; these hooks let the pipeline / live-transcription / watch paths
+        // reach the active engine and re-sync before the first transcription.
+        liveTranscription.beginPrewarm { [weak self] in self?.engines.activeTranscriptionEngine }
+        pipeline.activate { [weak self] in self?.engines.activeTranscriptionEngine }
+        watching.activate { [weak self] in self?.engines.syncLanguageSettings() }
 
         #if !APPSTORE
             applyForcedChannelFlagsFromEnvironment()
@@ -305,24 +272,6 @@ final class AppState {
             )
         }
     #endif
-
-    /// The active transcription engine based on the current settings.
-    var activeTranscriptionEngine: any TranscribingEngine {
-        switch settings.transcriptionEngine {
-        case .parakeet:
-            parakeetEngine
-
-        case .qwen3:
-            if #available(macOS 15, *) {
-                qwen3Engine
-            } else {
-                whisperKit // Fallback (should not happen -- UI prevents selection)
-            }
-
-        case .whisperKit:
-            whisperKit
-        }
-    }
 
     // MARK: - Derived properties
 
@@ -437,50 +386,6 @@ final class AppState {
             audioPath: nil,
             pid: Int(ProcessInfo.processInfo.processIdentifier),
         )
-    }
-
-    // MARK: - Engine Settings
-
-    /// Push current language/vocabulary settings into the active engine.
-    /// Idempotent — each branch only writes when the value actually differs,
-    /// so unchanged settings don't churn the engine's `@Observable` watchers.
-    private func syncLanguageSettings() {
-        switch settings.transcriptionEngine {
-        case .whisperKit:
-            let next = settings.whisperLanguageOrNil
-            if whisperKit.language != next { whisperKit.language = next }
-
-        case .parakeet:
-            let nextVocab = settings.customVocabularyPath
-            if parakeetEngine.customVocabularyPath != nextVocab { parakeetEngine.customVocabularyPath = nextVocab }
-            let nextLang = settings.parakeetLanguageOrNil
-            if parakeetEngine.language != nextLang { parakeetEngine.language = nextLang }
-
-        case .qwen3:
-            if #available(macOS 15, *) {
-                let next = settings.qwen3LanguageOrNil
-                if qwen3Engine.language != next { qwen3Engine.language = next }
-            }
-        }
-    }
-
-    /// `withObservationTracking` is one-shot — re-arm after each fire so the
-    /// AppState reacts to every settings change, not just the first one.
-    /// Same self-re-arming pattern the concern controllers use for their observers.
-    private func observeEngineSettings() {
-        withObservationTracking {
-            _ = settings.transcriptionEngine
-            _ = settings.whisperLanguage
-            _ = settings.customVocabularyPath
-            _ = settings.parakeetLanguage
-            _ = settings.qwen3Language
-        } onChange: { [weak self] in
-            Task { @MainActor in
-                guard let self else { return }
-                self.syncLanguageSettings()
-                self.observeEngineSettings()
-            }
-        }
     }
 }
 

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Observation
+
+// MARK: - EngineController
+
+/// Owns the transcription-engine concern: the three engine instances
+/// (`WhisperKitEngine`, `ParakeetEngine`, and — on macOS 15+ — `Qwen3AsrEngine`),
+/// the active-engine selection, and keeping each engine's language / vocabulary
+/// in line with `AppSettings` (both an up-front sync at construction and a
+/// self-rearming reactive observer for runtime changes).
+///
+/// Extracted from `AppState` as the final concern-specific controller in the
+/// god-class split. Unlike the other controllers it is fully self-contained — it
+/// needs only `settings`, so it does its up-front sync + arms its observer in its
+/// own `init` (no post-init `activate` wiring). `AppState` exposes it as
+/// `engines` and the pipeline / live-transcription coordinators read
+/// `engines.activeTranscriptionEngine`; the watch-start path calls
+/// `engines.syncLanguageSettings()` for its belt-and-suspenders up-front sync.
+///
+/// Not `@Observable` — its stored engine references are `let`s and consumers
+/// observe the engine instances themselves (each is `@Observable`), so the
+/// controller exposes no observable state of its own. It still uses
+/// `withObservationTracking` internally to watch the settings keys, which works
+/// regardless of this type's annotation (same as `LiveTranscriptionCoordinator`).
+@MainActor
+final class EngineController {
+    let whisperKit: WhisperKitEngine
+    let parakeetEngine: ParakeetEngine
+    // Only created on macOS 15+ where Qwen3-ASR is available; type-erased so the
+    // stored property is expressible on macOS 14.
+    private let _qwen3Engine: AnyObject?
+
+    private let settings: AppSettings
+
+    /// Typed accessor (only callable under `@available(macOS 15, *)` checks).
+    @available(macOS 15, *)
+    var qwen3Engine: Qwen3AsrEngine {
+        // swiftlint:disable:next force_cast
+        _qwen3Engine as! Qwen3AsrEngine
+    }
+
+    // Dependency-default factories keep `init`'s body-type-check under the 300 ms
+    // budget — an inline `@Observable` engine constructor forces the type-checker
+    // to re-solve that engine's own init constraints at this call site (the same
+    // reason AppState uses factory helpers for its defaults).
+
+    private static func makeWhisperKit() -> WhisperKitEngine {
+        WhisperKitEngine()
+    }
+
+    private static func makeParakeet() -> ParakeetEngine {
+        ParakeetEngine()
+    }
+
+    @available(macOS 15, *)
+    private static func makeQwen3() -> Qwen3AsrEngine {
+        Qwen3AsrEngine()
+    }
+
+    init(settings: AppSettings) {
+        self.settings = settings
+        self.whisperKit = Self.makeWhisperKit()
+        self.parakeetEngine = Self.makeParakeet()
+        if #available(macOS 15, *) {
+            self._qwen3Engine = Self.makeQwen3()
+        } else {
+            self._qwen3Engine = nil
+        }
+
+        // Bring engines in line with the current settings up front so the first
+        // transcription doesn't run against stale defaults, then start observing
+        // for runtime changes.
+        syncLanguageSettings()
+        observeEngineSettings()
+    }
+
+    /// The active transcription engine based on the current settings.
+    var activeTranscriptionEngine: any TranscribingEngine {
+        switch settings.transcriptionEngine {
+        case .parakeet:
+            parakeetEngine
+
+        case .qwen3:
+            if #available(macOS 15, *) {
+                qwen3Engine
+            } else {
+                whisperKit // Fallback (should not happen -- UI prevents selection)
+            }
+
+        case .whisperKit:
+            whisperKit
+        }
+    }
+
+    /// Pre-load the active engine's model (applying its settings-derived config
+    /// first) so the first transcription doesn't pay the cold-load cost. Called
+    /// from the menu-bar `.task` at launch.
+    func preloadActiveModel() async {
+        switch settings.transcriptionEngine {
+        case .whisperKit:
+            whisperKit.modelVariant = settings.whisperKitModel
+            whisperKit.language = settings.whisperLanguageOrNil
+            await whisperKit.loadModel()
+
+        case .parakeet:
+            await parakeetEngine.loadModel()
+
+        case .qwen3:
+            if #available(macOS 15, *) {
+                qwen3Engine.language = settings.qwen3LanguageOrNil
+                await qwen3Engine.loadModel()
+            }
+        }
+    }
+
+    /// Push current language/vocabulary settings into the active engine.
+    /// Idempotent — each branch only writes when the value actually differs,
+    /// so unchanged settings don't churn the engine's `@Observable` watchers.
+    func syncLanguageSettings() {
+        switch settings.transcriptionEngine {
+        case .whisperKit:
+            let next = settings.whisperLanguageOrNil
+            if whisperKit.language != next { whisperKit.language = next }
+
+        case .parakeet:
+            let nextVocab = settings.customVocabularyPath
+            if parakeetEngine.customVocabularyPath != nextVocab { parakeetEngine.customVocabularyPath = nextVocab }
+            let nextLang = settings.parakeetLanguageOrNil
+            if parakeetEngine.language != nextLang { parakeetEngine.language = nextLang }
+
+        case .qwen3:
+            if #available(macOS 15, *) {
+                let next = settings.qwen3LanguageOrNil
+                if qwen3Engine.language != next { qwen3Engine.language = next }
+            }
+        }
+    }
+
+    /// `withObservationTracking` is one-shot — re-arm after each fire so the
+    /// controller reacts to every settings change, not just the first one.
+    /// Same self-re-arming pattern the other concern controllers use.
+    private func observeEngineSettings() {
+        withObservationTracking {
+            _ = settings.transcriptionEngine
+            _ = settings.whisperLanguage
+            _ = settings.customVocabularyPath
+            _ = settings.parakeetLanguage
+            _ = settings.qwen3Language
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.syncLanguageSettings()
+                self.observeEngineSettings()
+            }
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -124,21 +124,7 @@ struct MeetingTranscriberApp: App {
                 closeWindow(id: "settings")
             }
             .task {
-                switch appState.settings.transcriptionEngine {
-                case .whisperKit:
-                    appState.whisperKit.modelVariant = appState.settings.whisperKitModel
-                    appState.whisperKit.language = appState.settings.whisperLanguageOrNil
-                    await appState.whisperKit.loadModel()
-
-                case .parakeet:
-                    await appState.parakeetEngine.loadModel()
-
-                case .qwen3:
-                    if #available(macOS 15, *) {
-                        appState.qwen3Engine.language = appState.settings.qwen3LanguageOrNil
-                        await appState.qwen3Engine.loadModel()
-                    }
-                }
+                await appState.engines.preloadActiveModel()
             }
             .task {
                 appState.updateChecker.startPeriodicChecks(settings: appState.settings)
@@ -187,11 +173,11 @@ struct MeetingTranscriberApp: App {
         Window("Settings", id: "settings") {
             SettingsView(
                 settings: appState.settings,
-                whisperKitEngine: appState.whisperKit,
-                parakeetEngine: appState.parakeetEngine,
+                whisperKitEngine: appState.engines.whisperKit,
+                parakeetEngine: appState.engines.parakeetEngine,
                 qwen3Engine: {
                     if #available(macOS 15, *) {
-                        return appState.qwen3Engine
+                        return appState.engines.qwen3Engine
                     }
                     return nil
                 }(),

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -20,10 +20,10 @@ import Observation
 /// Testability seams: `ensureMicAccess` + `makeDetector` are injectable (default
 /// to the production `Permissions.ensureMicrophoneAccess` / `PowerAssertionDetector`)
 /// so `toggleWatching` can be exercised without real TCC or IOKit. `syncEngines`
-/// is wired post-init via `activate(syncEngines:)` because it calls back into
-/// AppState's engine-sync (an engine concern not yet extracted) and must capture
-/// `self` after stored-property init — the same post-init wiring idiom the other
-/// controllers use.
+/// is wired post-init via `activate(syncEngines:)`: it bridges to
+/// `EngineController.syncLanguageSettings()` (held by `AppState`, not injected
+/// here as a sibling) and the closure must capture `self` after stored-property
+/// init — the same post-init wiring idiom the other controllers use.
 @Observable
 @MainActor
 final class WatchingController {
@@ -46,10 +46,10 @@ final class WatchingController {
     /// `PowerAssertionDetector`.
     private let makeDetector: () -> any MeetingDetecting
 
-    /// Engine-sync hook, wired by `activate`. Calls back into AppState's
-    /// `syncLanguageSettings` (an engine concern not yet extracted); nil until
-    /// `activate` runs, in which case the up-front sync is skipped (the reactive
-    /// `observeEngineSettings` observer still keeps engines in line).
+    /// Engine-sync hook, wired by `activate`. Bridges to
+    /// `EngineController.syncLanguageSettings()`; nil until `activate` runs, in
+    /// which case the up-front sync is skipped (EngineController's own reactive
+    /// observer still keeps the engines in line).
     private var syncEngines: (() -> Void)?
 
     init(

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -633,24 +633,24 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let settings = AppSettings()
         settings.transcriptionEngine = .whisperKit
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is WhisperKitEngine)
     }
 
     func testActiveTranscriptionEngineReturnsParakeetWhenSet() {
         let settings = AppSettings()
         settings.transcriptionEngine = .parakeet
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is ParakeetEngine)
     }
 
     func testActiveTranscriptionEngineSwitchesBack() {
         let settings = AppSettings()
         settings.transcriptionEngine = .parakeet
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is ParakeetEngine)
 
         settings.transcriptionEngine = .whisperKit
-        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is WhisperKitEngine)
     }
 
     func testMakeQueueUsesActiveEngine() {
@@ -676,7 +676,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let settings = AppSettings()
         settings.transcriptionEngine = .qwen3
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.activeTranscriptionEngine is Qwen3AsrEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is Qwen3AsrEngine)
     }
 
     func testActiveTranscriptionEngineSwitchesToQwen3AndBack() {
@@ -684,13 +684,13 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let settings = AppSettings()
         settings.transcriptionEngine = .whisperKit
         let state = AppState(settings: settings)
-        XCTAssertTrue(state.activeTranscriptionEngine is WhisperKitEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is WhisperKitEngine)
 
         settings.transcriptionEngine = .qwen3
-        XCTAssertTrue(state.activeTranscriptionEngine is Qwen3AsrEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is Qwen3AsrEngine)
 
         settings.transcriptionEngine = .parakeet
-        XCTAssertTrue(state.activeTranscriptionEngine is ParakeetEngine)
+        XCTAssertTrue(state.engines.activeTranscriptionEngine is ParakeetEngine)
     }
 
     func testMakeQueueUsesQwen3Engine() {
@@ -721,7 +721,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         settings.transcriptionEngine = .qwen3
         let state = AppState(settings: settings)
         // On macOS 15+: Qwen3AsrEngine; on older: WhisperKit (fallback)
-        XCTAssertNotNil(state.activeTranscriptionEngine)
+        XCTAssertNotNil(state.engines.activeTranscriptionEngine)
     }
 
     // MARK: - makeQueue settings

--- a/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
+++ b/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
@@ -5,6 +5,10 @@ import XCTest
 /// runtime, not just on app restart. The settings ↔ engine sync used to run
 /// only once when the pipeline queue was first built; later UI changes
 /// silently dropped on the floor until the next launch.
+///
+/// Exercises `EngineController` directly — the concern was extracted out of
+/// `AppState`, so these tests now construct the bare controller (no full
+/// `AppState`, no log-streamer subprocess) and assert on its engine instances.
 @MainActor
 final class EngineSettingsRuntimeSyncTests: XCTestCase {
     // swiftlint:disable:next implicitly_unwrapped_optional
@@ -33,20 +37,20 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // MARK: - Initial sync at AppState init
+    // MARK: - Initial sync at EngineController init
 
     func test_initialSync_propagatesWhisperLanguageToEngine() {
         settings.transcriptionEngine = .whisperKit
         settings.whisperLanguage = "de"
-        let state = AppState(settings: settings)
-        XCTAssertEqual(state.whisperKit.language, "de")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.whisperKit.language, "de")
     }
 
     func test_initialSync_propagatesCustomVocabularyPathToParakeet() {
         settings.transcriptionEngine = .parakeet
         settings.customVocabularyPath = "/tmp/init-vocab.txt"
-        let state = AppState(settings: settings)
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
     }
 
     // MARK: - Runtime propagation
@@ -54,24 +58,24 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
     func test_runtimeChange_whisperLanguage_propagatesToEngine() async {
         settings.transcriptionEngine = .whisperKit
         settings.whisperLanguage = "de"
-        let state = AppState(settings: settings)
-        XCTAssertEqual(state.whisperKit.language, "de")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.whisperKit.language, "de")
 
         settings.whisperLanguage = "en"
 
-        await waitFor(state.whisperKit.language == "en")
-        XCTAssertEqual(state.whisperKit.language, "en")
+        await waitFor(engines.whisperKit.language == "en")
+        XCTAssertEqual(engines.whisperKit.language, "en")
     }
 
     func test_runtimeChange_customVocabularyPath_propagatesToParakeet() async {
         settings.transcriptionEngine = .parakeet
-        let state = AppState(settings: settings)
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "")
 
         settings.customVocabularyPath = "/tmp/runtime-vocab.txt"
 
-        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/runtime-vocab.txt")
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/runtime-vocab.txt")
+        await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/runtime-vocab.txt")
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/runtime-vocab.txt")
     }
 
     func test_runtimeChange_qwen3Language_propagatesToEngine() async throws {
@@ -80,13 +84,13 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         }
         settings.transcriptionEngine = .qwen3
         settings.qwen3Language = "de"
-        let state = AppState(settings: settings)
-        XCTAssertEqual(state.qwen3Engine.language, "de")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.qwen3Engine.language, "de")
 
         settings.qwen3Language = "en"
 
-        await waitFor(state.qwen3Engine.language == "en")
-        XCTAssertEqual(state.qwen3Engine.language, "en")
+        await waitFor(engines.qwen3Engine.language == "en")
+        XCTAssertEqual(engines.qwen3Engine.language, "en")
     }
 
     // MARK: - Re-arming
@@ -96,19 +100,19 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
     /// the first change would propagate and subsequent ones silently no-op.
     func test_observation_rearmsForMultipleChanges() async {
         settings.transcriptionEngine = .parakeet
-        let state = AppState(settings: settings)
+        let engines = EngineController(settings: settings)
 
         settings.customVocabularyPath = "/tmp/v1.txt"
-        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v1.txt")
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v1.txt")
+        await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v1.txt")
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v1.txt")
 
         settings.customVocabularyPath = "/tmp/v2.txt"
-        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v2.txt")
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v2.txt")
+        await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v2.txt")
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v2.txt")
 
         settings.customVocabularyPath = "/tmp/v3.txt"
-        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/v3.txt")
-        XCTAssertEqual(state.parakeetEngine.customVocabularyPath, "/tmp/v3.txt")
+        await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v3.txt")
+        XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v3.txt")
     }
 
     // MARK: - Engine switch
@@ -120,19 +124,19 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         settings.transcriptionEngine = .whisperKit
         settings.whisperLanguage = "de"
         settings.customVocabularyPath = "/tmp/parakeet-vocab.txt"
-        let state = AppState(settings: settings)
+        let engines = EngineController(settings: settings)
 
-        XCTAssertEqual(state.whisperKit.language, "de")
+        XCTAssertEqual(engines.whisperKit.language, "de")
         XCTAssertEqual(
-            state.parakeetEngine.customVocabularyPath, "",
+            engines.parakeetEngine.customVocabularyPath, "",
             "Parakeet inactive at init — no sync expected",
         )
 
         settings.transcriptionEngine = .parakeet
 
-        await waitFor(state.parakeetEngine.customVocabularyPath == "/tmp/parakeet-vocab.txt")
+        await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/parakeet-vocab.txt")
         XCTAssertEqual(
-            state.parakeetEngine.customVocabularyPath, "/tmp/parakeet-vocab.txt",
+            engines.parakeetEngine.customVocabularyPath, "/tmp/parakeet-vocab.txt",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -43,8 +43,8 @@
         func test_snapshot_reflectsActiveEngine_whisperKit() {
             settings.transcriptionEngine = .whisperKit
             let state = AppState(settings: settings)
-            state.whisperKit.modelVariant = "openai_whisper-large-v3-v20240930_turbo"
-            state.whisperKit.language = "de"
+            state.engines.whisperKit.modelVariant = "openai_whisper-large-v3-v20240930_turbo"
+            state.engines.whisperKit.language = "de"
 
             let snapshot = state.rpcStateSnapshot()
 
@@ -59,7 +59,7 @@
         func test_snapshot_reflectsActiveEngine_parakeet() {
             settings.transcriptionEngine = .parakeet
             let state = AppState(settings: settings)
-            state.parakeetEngine.customVocabularyPath = "/tmp/parakeet-vocab.txt"
+            state.engines.parakeetEngine.customVocabularyPath = "/tmp/parakeet-vocab.txt"
 
             let snapshot = state.rpcStateSnapshot()
 
@@ -75,7 +75,7 @@
             }
             settings.transcriptionEngine = .qwen3
             let state = AppState(settings: settings)
-            state.qwen3Engine.language = "en"
+            state.engines.qwen3Engine.language = "en"
 
             let snapshot = state.rpcStateSnapshot()
 
@@ -85,7 +85,7 @@
 
         func test_snapshot_whisperLanguageNil_surfacesAsNil() {
             let state = AppState(settings: settings)
-            state.whisperKit.language = nil
+            state.engines.whisperKit.language = nil
 
             let snapshot = state.rpcStateSnapshot()
 

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -332,7 +332,7 @@ All recordings are normalized to 16kHz at capture time — no resampling needed 
 - **Language:** 30 languages via `Qwen3AsrConfig.Language` enum, selectable in Settings. `nil` = auto-detect.
 - **No timestamps:** Returns plain text — emits single `TimestampedSegment` spanning full audio duration
 - **Chunking:** Audio split into <=30s windows (`Qwen3AsrConfig.maxAudioSeconds`), results concatenated
-- **Availability:** `@available(macOS 15, *)` — type-erased via `AnyObject?` in AppState for macOS <15 compatibility
+- **Availability:** `@available(macOS 15, *)` — type-erased via `AnyObject?` in `EngineController` for macOS <15 compatibility
 
 ### Modes
 


### PR DESCRIPTION
## What

Extracts the **transcription-engine concern** out of the `AppState` god-class
into its own `@MainActor EngineController` — the final concern extraction in the
split:

- the three engine instances (`WhisperKit` / `Parakeet` / `Qwen3`, incl. the
  macOS-<15 `_qwen3Engine: AnyObject?` type-erasure),
- the active-engine selection (`activeTranscriptionEngine`),
- the settings → engine language/vocabulary sync (up-front + self-rearming
  reactive observer),
- the launch-time model preload (`preloadActiveModel()`, moved out of the
  SwiftUI scene `.task`).

`EngineController` is fully self-contained — it needs only `settings`, so it runs
its up-front sync + arms its observer in its own `init` (no post-init `activate`
wiring). It is **not `@Observable`**: its engine references are `let`s and
consumers observe the engine instances themselves, so it exposes no observable
state of its own (same rationale as `LiveTranscriptionCoordinator`).

`AppState` exposes it as `engines`; the pipeline / live-transcription
coordinators read `engines.activeTranscriptionEngine`, the watch-start path calls
`engines.syncLanguageSettings()`, and the Settings UI + RPC snapshot read
`engines.whisperKit` etc.

## Result

This completes the **AppState god-class split**. `AppState` shrank from ~997
lines to **~396** and is now a thin composer wiring seven controllers
(`engines`, `watching`, `pipeline`, `permissions`, `channelHealth`,
`liveTranscription`, `rpcController`) + `updateChecker` + `liveCaptions`, exposing
the derived UI properties the menu bar binds to. The init also dropped its unused
engine-injection parameters (no caller passed them).

## Tests

`EngineSettingsRuntimeSyncTests` now constructs a bare `EngineController(settings:)`
instead of a full `AppState` — the settings→engine sync is the controller's
concern, so the suite exercises it directly (no AppState init, no log-streamer
subprocess). The AppStateTests engine-switching / Qwen3-fallback assertions and
RPCEngineStateTests engine-state setup repoint at `state.engines.*`.

Byte-preserving extraction (moved logic is verbatim). Full suite green (1860
tests), lint + swiftlint-analyze clean, release-mode parity build passes, APPSTORE
variant builds. CLAUDE.md + the architecture sketch updated to name the new owner.