### PR TITLE
refactor(app): unify engine loadModel dedup via shared SingleFlight

### DIFF
--- a/app/MeetingTranscriber/Sources/FluidVAD.swift
+++ b/app/MeetingTranscriber/Sources/FluidVAD.swift
@@ -121,7 +121,8 @@ final class FluidVAD: @unchecked Sendable {
     /// and trigger duplicate CoreML compiles of the Silero model.
     ///
     /// On failure the shared `Task` is dropped so the next call retries
-    /// from scratch (mirrors `ParakeetEngine.loadModel()`). An awaiter
+    /// from scratch (the same clear-on-failure invariant `SingleFlight`
+    /// documents for the engine loaders). An awaiter
     /// being cancelled only cancels its own `await`; the underlying load
     /// continues so other awaiters still receive the manager.
     private func ensureManager() async throws -> VadManager {

--- a/app/MeetingTranscriber/Sources/LiveSpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/LiveSpeakerMatcher.swift
@@ -23,10 +23,10 @@ protocol LiveSpeakerMatching: Sendable {
 /// dialog gets recognised live without retraining.
 ///
 /// Off-MainActor (actor isolation) so the CoreML inference doesn't stall
-/// the UI. `prepare()` is idempotent and deduped via a single-flight task
-/// in the same shape as `WhisperKitEngine.loadModel()` /
-/// `ParakeetEngine.loadModel()` / `FluidVAD.ensureManager()` — second
-/// caller awaits the first's work.
+/// the UI. `prepare()` is idempotent and deduped via a single-flight task —
+/// concurrent callers await the first's work. This is the typed/throwing
+/// variant (like `FluidVAD.ensureManager()`); the engines' simpler
+/// non-throwing `loadModel()` dedup is factored into `SingleFlight`.
 ///
 /// **Vector-space note:** Both the batch path
 /// (`FluidDiarizer.extractSortformerEmbeddings`) and this live path load

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -35,7 +35,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
     }
 
     private var asrManager: AsrManager?
-    private var loadingTask: Task<Void, Never>?
+    private let modelLoad = SingleFlight()
 
     // CTC vocabulary boosting state
     private struct VocabularyBooster {
@@ -50,12 +50,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
     private var currentVocabularyPath: String = ""
 
     func loadModel() async {
-        if let existing = loadingTask {
-            await existing.value
-            return
-        }
-
-        let task = Task {
+        await modelLoad.run { [self] in
             modelState = .downloading
             downloadProgress = 0
             do {
@@ -80,10 +75,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
                 modelState = .unloaded
                 downloadProgress = 0
             }
-            loadingTask = nil
         }
-        loadingTask = task
-        await task.value
     }
 
     private func ensureModel() async throws {

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -23,15 +23,10 @@ final class Qwen3AsrEngine: TranscribingEngine {
     var language: String?
 
     private var asrManager: Qwen3AsrManager?
-    private var loadingTask: Task<Void, Never>?
+    private let modelLoad = SingleFlight()
 
     func loadModel() async {
-        if let existing = loadingTask {
-            await existing.value
-            return
-        }
-
-        let task = Task {
+        await modelLoad.run { [self] in
             modelState = .downloading
             downloadProgress = 0
             do {
@@ -51,10 +46,7 @@ final class Qwen3AsrEngine: TranscribingEngine {
                 modelState = .unloaded
                 downloadProgress = 0
             }
-            loadingTask = nil
         }
-        loadingTask = task
-        await task.value
     }
 
     private func ensureModel() async throws {

--- a/app/MeetingTranscriber/Sources/SingleFlight.swift
+++ b/app/MeetingTranscriber/Sources/SingleFlight.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Single-flight coordinator: runs an idempotent async operation at most once
+/// concurrently. The first caller kicks off the work; callers that arrive while
+/// it is in flight await the same run instead of starting their own. Once the
+/// run finishes the coordinator re-arms, so a later call starts fresh.
+///
+/// This is the shared scaffolding behind the three ASR engines' `loadModel()`
+/// dedup (WhisperKit / Parakeet / Qwen3), which otherwise repeated the same
+/// `loadingTask` machinery verbatim. The body owns its own error handling and
+/// state transitions; this type only owns the dedup.
+///
+/// The in-flight `Task` is cleared once the body returns — on every path, since
+/// the body is non-throwing and handles its own failures — so a failed load
+/// doesn't latch a poisoned task that replays the failure to every future
+/// caller (see [[feedback-single-flight-clear-loadingtask-on-failure]]).
+@MainActor
+final class SingleFlight {
+    private var task: Task<Void, Never>?
+
+    /// Run `body`, deduplicating against any run already in flight. Returns once
+    /// the run this call observed (its own, or the one it joined) has finished.
+    func run(_ body: @escaping @MainActor () async -> Void) async {
+        if let existing = task {
+            await existing.value
+            return
+        }
+        let task = Task { @MainActor in
+            await body()
+            self.task = nil
+        }
+        self.task = task
+        await task.value
+    }
+}

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -47,16 +47,10 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
     /// Transcription progress (0.0–1.0) based on WhisperKit's 30s window processing.
     private(set) var transcriptionProgress: Double = 0
     private var pipe: WhisperKit?
-    private var loadingTask: Task<Void, Never>?
+    private let modelLoad = SingleFlight()
 
     func loadModel() async {
-        // Deduplicate concurrent loads
-        if let existing = loadingTask {
-            await existing.value
-            return
-        }
-
-        let task = Task {
+        await modelLoad.run { [self] in
             modelState = .downloading
             downloadProgress = 0
             do {
@@ -84,10 +78,7 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
                 modelState = .unloaded
                 downloadProgress = 0
             }
-            loadingTask = nil
         }
-        loadingTask = task
-        await task.value
     }
 
     /// Ensure model is loaded, loading it if necessary.

--- a/app/MeetingTranscriber/Tests/SingleFlightTests.swift
+++ b/app/MeetingTranscriber/Tests/SingleFlightTests.swift
@@ -1,0 +1,55 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for the `SingleFlight` concurrency primitive that the three ASR
+/// engines share for `loadModel()` deduplication. These pin the dedup +
+/// re-arm invariants directly with trivial in-memory bodies — no model loads,
+/// so they run in the fast (non-E2E) suite.
+@MainActor
+final class SingleFlightTests: XCTestCase {
+    /// Concurrent callers must run the body exactly once: the second caller
+    /// awaits the in-flight run instead of starting its own. The first body is
+    /// parked on a continuation so the second call provably overlaps it; a
+    /// non-deduping implementation would run the body twice (count 2).
+    func test_concurrentCallers_runBodyOnce() async {
+        let flight = SingleFlight()
+        var runCount = 0
+        let started = expectation(description: "first body entered")
+        var release: (() -> Void)?
+
+        let first = Task { @MainActor in
+            await flight.run {
+                runCount += 1
+                started.fulfill()
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    release = { cont.resume() }
+                }
+            }
+        }
+        await fulfillment(of: [started], timeout: 2)
+
+        // The first body is parked with the flight's task set. A second call
+        // must dedup onto it and never run its own body.
+        let second = Task { @MainActor in
+            await flight.run { runCount += 1 }
+        }
+        await Task.yield() // let `second` reach its `await existing.value`
+        release?()
+        await first.value
+        await second.value
+
+        XCTAssertEqual(runCount, 1)
+    }
+
+    /// After a run completes the flight must re-arm: a subsequent call runs the
+    /// body again rather than latching onto the finished task. This is the
+    /// clear-on-finish invariant — a latched task would replay its result and
+    /// the second body would never run (count stays 1).
+    func test_sequentialCallers_rerunBody() async {
+        let flight = SingleFlight()
+        var runCount = 0
+        await flight.run { runCount += 1 }
+        await flight.run { runCount += 1 }
+        XCTAssertEqual(runCount, 2)
+    }
+}


### PR DESCRIPTION
## What

WhisperKit, Parakeet, and Qwen3 each repeated the same single-flight `loadModel()` scaffolding verbatim — a private `loadingTask`, a dedup guard that awaits an in-flight load, and a clear-on-finish that re-arms for the next call. This extracts that machinery into a small `SingleFlight` coordinator, so each engine's `loadModel()` supplies only its own download/load body and state transitions.

```
Sources/SingleFlight.swift  | +35   (new primitive)
Sources/{WhisperKit,Parakeet,Qwen3Asr}Engine.swift  | −31 / +6 total
Tests/SingleFlightTests.swift  | +55  (new)
```

## Why it's safe

Byte-equivalent in ordering and semantics to the inline code it replaces: the dedup check, store, clear-on-finish, and await are preserved exactly. The clear runs on **every** path — the load bodies are non-throwing and handle their own failures — so a failed load never latches a poisoned task that replays the error to every future caller.

The seam is closure-based on purpose: it keeps each engine's `private(set)` `modelState`/`downloadProgress` writes in the engine's own scope. A protocol-extension `loadModel` default would have required widening that visibility, which the codebase avoids.

## Scope

`FluidVAD.ensureManager()` and `LiveSpeakerMatcher.prepare()` keep their own loaders — those are typed, throwing, result-caching single-flights of a different shape, and folding them into a `Void`/`Never` primitive would over-generalize it. Their now-stale cross-references to the engine `loadModel()`s are re-pointed at `SingleFlight`.

## Tests

New `SingleFlightTests` pin the two invariants directly with trivial in-memory bodies (no model loads, fast suite):
- **dedup** — concurrent callers run the body exactly once (second awaits the in-flight run),
- **re-arm** — sequential callers re-run the body (the clear-on-finish isn't a latch).

Both are non-vacuous (each fails against the obvious wrong implementation). The pre-existing per-engine concurrent-load tests and the full suite stay green.