### PR TITLE
fix(app): shift dual-track mic diarization by micDelay to match transcript

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -87,6 +87,27 @@ enum DiarizationProcess {
 
     // MARK: - Dual-Track Diarization
 
+    /// Shift every segment's `start`/`end` by `offset` seconds, moving a
+    /// track's diarization onto a different timeline. Used to bring the mic
+    /// track's diarization onto the app/canonical timeline by `+micDelay`, so it
+    /// aligns with the mic transcript segments — which
+    /// `TranscribingEngine.mergeDualSourceSegments` already shifts by the same
+    /// `+micDelay`. Without this the two are offset and overlap-based speaker
+    /// assignment mislabels mic-side segments. `speakingTimes` (durations),
+    /// `autoNames`, and `embeddings` are timeline-independent, so they pass
+    /// through unchanged. A zero offset is a no-op (returns the input verbatim).
+    static func shiftSegments(_ result: DiarizationResult, by offset: TimeInterval) -> DiarizationResult {
+        guard offset != 0 else { return result }
+        return DiarizationResult(
+            segments: result.segments.map { seg in
+                DiarizationResult.Segment(start: seg.start + offset, end: seg.end + offset, speaker: seg.speaker)
+            },
+            speakingTimes: result.speakingTimes,
+            autoNames: result.autoNames,
+            embeddings: result.embeddings,
+        )
+    }
+
     /// Merge two separate diarization results (app + mic) into one,
     /// prefixing speaker IDs with `R_` (remote/app) and `M_` (mic/local).
     static func mergeDualTrackDiarization(

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -843,6 +843,7 @@ class PipelineQueue {
             tracks: (
                 app: workDir.appendingPathComponent("app_16k.wav"),
                 mic: workDir.appendingPathComponent("mic_16k.wav"),
+                micDelay: ctx.micDelay,
             ),
             speakerCount: speakerCount, title: ctx.title, jobID: ctx.jobID,
         )
@@ -858,7 +859,7 @@ class PipelineQueue {
     /// between them.
     private func runDualTrackDiarization(
         diarizeProcess: any DiarizationProvider,
-        tracks: (app: URL, mic: URL),
+        tracks: (app: URL, mic: URL, micDelay: TimeInterval),
         speakerCount: Int?, title: String, jobID: UUID,
     ) async throws -> DiarizationRun {
         let appDiarization = try await diarizeProcess.run(
@@ -866,11 +867,15 @@ class PipelineQueue {
         )
         var micDiarization: DiarizationResult?
         do {
-            micDiarization = try await diarizeProcess.run(
+            let rawMic = try await diarizeProcess.run(
                 audioPath: tracks.mic,
                 numSpeakers: nil, // auto-detect local speakers
                 meetingTitle: title,
             )
+            // Shift the mic diarization onto the app/canonical timeline so it
+            // aligns with the mic transcript segments, which
+            // `mergeDualSourceSegments` already shifted by `+micDelay`.
+            micDiarization = DiarizationProcess.shiftSegments(rawMic, by: tracks.micDelay)
         } catch {
             logger.warning(
                 "[\(PipelineJob.shortID(for: jobID), privacy: .public)] mic_diarization_failed error=\(error.localizedDescription, privacy: .public) — falling back to app-only diarization",
@@ -1269,7 +1274,7 @@ class PipelineQueue {
             let title = jobs[jobIndex].meetingTitle
             let diarization = try await runLateDiarization(
                 diarizer: diarizeProcess,
-                recording: (dir: recordingsDir, slug: slug, jobID: jobID),
+                recording: (dir: recordingsDir, slug: slug, jobID: jobID, micDelay: jobs[jobIndex].micDelay),
                 isDualSource: namingData.isDualSource,
                 speakerCount: speakerCount, title: title,
             )
@@ -1310,12 +1315,12 @@ class PipelineQueue {
     /// keep its function body under the lint cap.
     private func runLateDiarization(
         diarizer: any DiarizationProvider,
-        recording: (dir: URL, slug: String, jobID: UUID),
+        recording: (dir: URL, slug: String, jobID: UUID, micDelay: TimeInterval),
         isDualSource: Bool,
         speakerCount: Int,
         title: String,
     ) async throws -> DiarizationResult {
-        let (recordingsDir, slug, jobID) = recording
+        let (recordingsDir, slug, jobID, micDelay) = recording
         if isDualSource {
             // Mirror the batch path's mic-fail fallback (via the shared helper):
             // a silent/failing mic track must degrade to the unprefixed app-only
@@ -1326,6 +1331,7 @@ class PipelineQueue {
                 tracks: (
                     app: recordingsDir.appendingPathComponent("\(slug)_app_16k.wav"),
                     mic: recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav"),
+                    micDelay: micDelay,
                 ),
                 speakerCount: speakerCount, title: title, jobID: jobID,
             )

--- a/app/MeetingTranscriber/Tests/DiarizationShiftSegmentsTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationShiftSegmentsTests.swift
@@ -1,0 +1,52 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `DiarizationProcess.shiftSegments` — the pure timeline shift
+/// that moves the mic track's diarization onto the app/canonical timeline by
+/// `+micDelay` so it aligns with the mic transcript segments (which
+/// `mergeDualSourceSegments` already shifts). Lives in its own file because
+/// `DiarizationProcessTests` is already at the file-length limit.
+final class DiarizationShiftSegmentsTests: XCTestCase {
+    func testShiftSegments_offsetsStartAndEndPreservingMetadata() {
+        let result = DiarizationResult(
+            segments: [
+                .init(start: 1, end: 3, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 8, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 2, "SPEAKER_1": 3],
+            autoNames: ["SPEAKER_0": "Ann"],
+            embeddings: ["SPEAKER_0": [0.1, 0.2]],
+        )
+
+        let shifted = DiarizationProcess.shiftSegments(result, by: 10)
+
+        // Every segment moves by +offset; speaker tags unchanged.
+        XCTAssertEqual(shifted.segments.map(\.start), [11, 15])
+        XCTAssertEqual(shifted.segments.map(\.end), [13, 18])
+        XCTAssertEqual(shifted.segments.map(\.speaker), ["SPEAKER_0", "SPEAKER_1"])
+        // Timeline-independent fields pass through unchanged.
+        XCTAssertEqual(shifted.speakingTimes, ["SPEAKER_0": 2, "SPEAKER_1": 3])
+        XCTAssertEqual(shifted.autoNames, ["SPEAKER_0": "Ann"])
+        XCTAssertEqual(shifted.embeddings?["SPEAKER_0"], [0.1, 0.2])
+    }
+
+    func testShiftSegments_negativeOffset() {
+        let result = DiarizationResult(
+            segments: [.init(start: 5, end: 8, speaker: "SPEAKER_0")],
+            speakingTimes: [:], autoNames: [:], embeddings: nil,
+        )
+        let shifted = DiarizationProcess.shiftSegments(result, by: -2)
+        XCTAssertEqual(shifted.segments.map(\.start), [3])
+        XCTAssertEqual(shifted.segments.map(\.end), [6])
+    }
+
+    func testShiftSegments_zeroOffsetReturnsUnchanged() {
+        let result = DiarizationResult(
+            segments: [.init(start: 1, end: 3, speaker: "SPEAKER_0")],
+            speakingTimes: [:], autoNames: [:], embeddings: nil,
+        )
+        let shifted = DiarizationProcess.shiftSegments(result, by: 0)
+        XCTAssertEqual(shifted.segments.map(\.start), [1])
+        XCTAssertEqual(shifted.segments.map(\.end), [3])
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -805,7 +805,7 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
-    private func makeDualSourceJob(title: String) throws -> PipelineJob {
+    private func makeDualSourceJob(title: String, micDelay: TimeInterval = 0) throws -> PipelineJob {
         let audioPath = try createTestAudioFile(in: tmpDir)
         let appPath = tmpDir.appendingPathComponent("app_audio.wav")
         let micPath = tmpDir.appendingPathComponent("mic_audio.wav")
@@ -815,7 +815,7 @@ final class PipelineQueueTests: XCTestCase {
         try FileManager.default.copyItem(at: audioPath, to: micPath)
         return PipelineJob(
             meetingTitle: title, appName: "Teams",
-            mixPath: audioPath, appPath: appPath, micPath: micPath, micDelay: 0,
+            mixPath: audioPath, appPath: appPath, micPath: micPath, micDelay: micDelay,
         )
     }
 
@@ -916,6 +916,47 @@ final class PipelineQueueTests: XCTestCase {
             warnings.contains { $0.contains("Mic track diarization failed") },
             "mic-fail fallback should add a warning — got: \(warnings)",
         )
+    }
+
+    /// Dual-track diarization must shift the mic track's diarization by
+    /// `micDelay` so it lands on the same (app/canonical) timeline as the mic
+    /// transcript segments — which `mergeDualSourceSegments` already shifted by
+    /// `+micDelay`. Without the shift, the diarization and transcript are offset
+    /// by `micDelay` and `assignSpeakers` overlaps the wrong diarization segment,
+    /// mislabeling mic-side speakers (only visible with ≥2 mic speakers; a single
+    /// mic speaker is masked by the nearest-gap fallback).
+    func testDiarizeDualTrackShiftsMicDiarizationByMicDelay() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "MICWORD")]
+        let diar = MockDiarization()
+        // Mic-timeline diarization: the utterance's true speaker is SPEAKER_0
+        // (Bob), who speaks at raw [0,5]. SPEAKER_1 (Carol) speaks later at
+        // [100,105]. The pipeline shifts the mic transcript by +micDelay (100s)
+        // to [100,105]; the mic diarization must be shifted to match, else
+        // [100,105] overlaps SPEAKER_1 and the utterance is mislabeled Carol.
+        diar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 100, end: 105, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5],
+            autoNames: ["SPEAKER_0": "Bob", "SPEAKER_1": "Carol"],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        try q.enqueue(makeDualSourceJob(title: "MicDelay", micDelay: 100))
+        await q.processNext()
+
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        // The mic utterance's true speaker is Bob; Carol only surfaces if the
+        // mic diarization wasn't shifted to match the +micDelay transcript shift.
+        XCTAssertFalse(
+            transcript.contains("Carol"),
+            "mic diarization must be shifted by micDelay to align with the shifted mic transcript — got: \(transcript)",
+        )
+        XCTAssertTrue(transcript.contains("Bob"), "mic utterance should be labeled Bob — got: \(transcript)")
     }
 
     /// A user can set the Mic Speaker Name to "Remote" — the same literal used


### PR DESCRIPTION
## The bug

Dual-track recordings diarize the **app** and **mic** tracks separately, then merge. But only the **transcript** path applied the mic-vs-app capture offset (`micDelay`):

- `mergeDualSourceSegments` shifts the mic **transcript** segments `+micDelay` onto the app/canonical timeline.
- The mic **diarization** stayed on the raw mic timeline.

`labeledTranscript` then overlaps the (shifted) mic transcript against the (unshifted) mic diarization — so `assignSpeakers` matches the wrong diarization segment and **mislabels mic-side speakers**.

**Impact:** visible when the mic track has **≥2 speakers** (shared mic / conference room); a single mic speaker is masked by the nearest-gap fallback. Magnitude scales with `micDelay`. Single-source is unaffected (`AudioMixer.mix` shifts the samples, so transcript + diarization share one timeline).

## The fix

Shift the mic diarization `+micDelay` at the source in `runDualTrackDiarization` (the shared batch + late-rerun helper) via a new pure `DiarizationProcess.shiftSegments` — symmetric to the existing transcript shift, and matching the audio-mixing convention (`AudioMixer.mix` prepends `micDelay` of silence to the mic). This aligns:
- `run.mic` — used by `labelSegments(.dualTrack)` for label assignment (the actual bug),
- `combined` — used for the naming-dialog audio seek into the mix.

`speakingTimes` / `autoNames` / `embeddings` are timeline-independent and pass through unchanged; a zero offset is a no-op. `micDelay` is threaded through the existing `tracks` (batch) and `recording` (late) tuples to stay within the parameter-count limit.

## Tests

- **Regression (pipeline-level, non-vacuous):** `testDiarizeDualTrackShiftsMicDiarizationByMicDelay` — a dual-source job with `micDelay=100` and a 2-speaker mic diarization (`Bob@[0,5]`, `Carol@[100,105]`). The mic utterance's true speaker is Bob; without the shift it mislabels as Carol. Verified red before the fix, green after.
- **Pure helper:** `DiarizationShiftSegmentsTests` — offset arithmetic, metadata pass-through, negative + zero offsets.

Full suite green (except the env-sensitive `MenuBarIconSnapshotTests`); lint/format clean; release-parity + APPSTORE builds clean.