### PR TITLE
test(app): assert manual-start threads the pid to the recorder

### DIFF
--- a/app/MeetingTranscriber/Tests/ManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/ManualRecordingTests.swift
@@ -46,6 +46,11 @@ final class ManualRecordingTests: XCTestCase {
         let (loop, mock) = makeLoop()
         try await loop.startManualRecording(pid: 1234, appName: "Chrome", title: "Meeting")
         XCTAssertTrue(mock.startCalled)
+        // Not just "was start called": the manual-start pid must actually reach
+        // the recorder (mock default is -1, so a dropped/wrong pid fails here).
+        // Full noMic/micDeviceUID threading is pinned by
+        // WatchLoopTests.testStartManualRecordingThreadsRecorderParams.
+        XCTAssertEqual(mock.capturedAppPID, 1234)
         loop.stop()
     }
 


### PR DESCRIPTION
## What

`testStartManualRecordingCallsRecorderStart` asserted only `mock.startCalled` (a bare boolean) — it never checked that the requested `pid` actually reached the recorder. A regression passing the wrong/dropped pid to `recorder.start(...)` would have kept the test green.

Adds one assertion: `XCTAssertEqual(mock.capturedAppPID, 1234)`. `MockRecorder.capturedAppPID` defaults to `-1`, so the assertion can't pass off the default — `start` must have been called with the real pid.

## Scope

This is a **one-line tightening, not a new test**. The fuller `noMic` / `micDeviceUID` threading on the manual-start path is already pinned by `WatchLoopTests.testStartManualRecordingThreadsRecorderParams` (a `/simplify` pass caught that a dedicated threading test here would duplicate it), so the change stays minimal and a cross-reference comment points there.

## Verification

Non-vacuity proven by mutation: temporarily hardcoding `appPID: 0` in `WatchLoop.startManualRecording` makes the new assertion fail; reverting restores green. `/code-review` clean; lint/format clean. No production code changed.