### PR TITLE
fix(app): keep rpcStateSnapshot under the 300ms type-check budget

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -1,13 +1,30 @@
 #if !APPSTORE
     import Foundation
 
+    extension PipelineQueue {
+        /// Build the RPC pipeline-queue status from inside `PipelineQueue`, so the
+        /// counter reads are single-hop `self.` accesses. Constructing this
+        /// 4-field struct in `AppState.rpcStateSnapshot` from the two-hop
+        /// `pipeline.queue.…` `@Observable` chain instead blew the type-checker up
+        /// to ~100 ms (cross-type chain access + memberwise init in one body),
+        /// tripping the 300 ms `-warn-long-function-bodies` budget on loaded CI
+        /// runners. Self-access here type-checks in ~2 ms.
+        /// `pendingNamingCount` is passed in (rather than read as
+        /// `pendingSpeakerNamingJobs.count`) so the caller can reuse the count of
+        /// the `pendingNamingJobs` array it already builds — one filter pass, not two.
+        func rpcQueueStatus(pendingNamingCount: Int) -> RPCStateSnapshot.Pipeline {
+            RPCStateSnapshot.Pipeline(
+                isProcessing: isProcessing,
+                activeJobCount: activeJobs.count,
+                waitingJobCount: pendingJobs.count,
+                pendingNamingJobCount: pendingNamingCount,
+            )
+        }
+    }
+
     extension AppState {
         /// Build a snapshot of state for the debug RPC. Read-only.
         func rpcStateSnapshot() -> RPCStateSnapshot {
-            // Bind the queue to a local so the reads below stay single-member
-            // accesses (`q.x`) rather than going through `pipeline.queue.x` —
-            // the extra member layer in this already-large literal would push
-            // its type-check over the 300 ms budget.
             let q = pipeline.queue
             let stored = SpeakerMatcher().loadDB()
             let recentNames = SpeakerMatcher.rankByRecency(speakers: stored)
@@ -22,12 +39,9 @@
                 )
             }
             return RPCStateSnapshot(
-                pipeline: .init(
-                    isProcessing: q.isProcessing,
-                    activeJobCount: q.activeJobs.count,
-                    waitingJobCount: q.pendingJobs.count,
-                    pendingNamingJobCount: pendingJobs.count,
-                ),
+                // Built inside PipelineQueue (single-hop) to stay under the
+                // type-check budget — see `rpcQueueStatus`.
+                pipeline: q.rpcQueueStatus(pendingNamingCount: pendingJobs.count),
                 speakerDB: .init(
                     count: stored.count,
                     recentNames: recentNames,


### PR DESCRIPTION
## The flake

The `analyze` CI job builds with `-warn-long-function-bodies=300`. `AppState.rpcStateSnapshot()` type-checked in **~108 ms locally** and spiked to **379 ms** on a loaded CI runner — failing the build, which `cancel-on-failure` then turned into a cancelled run. It passed 2 of 3 recent main pushes (a load-dependent flake), most recently red on `6ec9c01`.

> A re-run of the affected commit went green (confirming the flake) — this PR is the durable fix so it stops recurring.

## Root cause

The cost was constructing the 4-field `RPCStateSnapshot.Pipeline` struct **from the two-hop `pipeline.queue.…` `@Observable` chain**. That cross-type chain access combined with the multi-`Int` memberwise init makes Swift's constraint solver blow up super-linearly — one such access elsewhere is ~2 ms, but the construction in this body accounted for ~90 ms of the function's total.

Confirmed by isolation (all measured via `-debug-time-function-bodies`):
- hardcoded constants (no queue access): **1.2 ms**
- one queue access + the construction: **~100 ms**
- the *same* construction from inside `PipelineQueue` (single-hop `self.`): **2.5 ms**

Things that did **not** help (measured, then reverted): helper extraction, typed-local args, plain-`Int` count properties, rewriting the `[…].contains` predicate, and renaming the type.

## Fix

Build the status inside `PipelineQueue.rpcQueueStatus(pendingNamingCount:)` (a `#if !APPSTORE` extension in the RPC file) using single-hop `self.` accesses; `rpcStateSnapshot` calls it. The function drops to **~10 ms** — comfortable margin even at the ~3.5× CI scaling.

Behavior is byte-identical: same `PipelineQueue` instance, same four field values. The caller passes its already-built pending-naming array's `.count`, so the state filter runs once (not twice).

## Verification

- Type-check budget: `rpcStateSnapshot` 108 → 10 ms; `rpcQueueStatus` 2.5 ms; **0 expressions > 50 ms** in the whole build.
- 38 RPC tests + full suite green; release + APP STORE builds clean; lint/format clean.