### PR TITLE
chore: name copyright holder in MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025 pasrom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What

The `LICENSE` copyright line read `Copyright (c) 2025` with no holder. This names it `pasrom`.

## Why

- A blank holder leaves the MIT permission grant without an identifiable licensor.
- The attribution MIT requires downstream copies to retain was empty, so reuse would carry no credit.
- GitHub's license detection (`licensee`) didn't recognize the file as MIT — the repo showed no license badge and the API returned `licenseInfo = null`. Naming the holder lets it match the MIT template.

One-line change; no code impact.