### PR TITLE
test(app): pin StoredSpeaker.id Identifiable contract

### DIFF
--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -38,6 +38,22 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(SpeakerMatcher.cosineDistance(a, b), 1, accuracy: 0.001)
     }
 
+    // MARK: - StoredSpeaker model
+
+    /// `StoredSpeaker.id` (its `Identifiable` conformance) is the speaker's
+    /// `name`. `KnownVoicesView`'s list diffing and the rename/merge UI key off
+    /// this, so a refactor that switched `id` to a synthesized UUID would break
+    /// list identity across DB reloads without any other test noticing.
+    func testIdentifiableIDIsName() {
+        // Two distinct names so the assertions catch a constant-return `id` (e.g.
+        // a hardcoded string) as well as a synthesized-UUID `id` — a single
+        // fixture name would let a `return name`-vs-`return "Alice"` mutant pass.
+        let alice = StoredSpeaker(name: "Alice", embeddings: [[1, 0, 0]])
+        let bob = StoredSpeaker(name: "Bob", embeddings: [[0, 1, 0]])
+        XCTAssertEqual(alice.id, "Alice")
+        XCTAssertEqual(bob.id, "Bob")
+    }
+
     // MARK: - Match
 
     func testMatchEmptyDB() {


### PR DESCRIPTION
## What

Adds one unit test pinning `StoredSpeaker.id` — its `Identifiable` conformance, which returns `name`.

## Why

`id` was the single uncovered line in an otherwise 100%-covered pure model. `KnownVoicesView`'s list diffing and the rename/merge UI key off this `id`; a refactor that switched it to a synthesized UUID would silently break list identity across DB reloads with no test noticing.

The test uses two distinct fixture names (`Alice`/`Bob`) and asserts each `id` against its literal name, so it catches a constant-return `id` as well as a UUID one — a single fixture name would let a `return name` vs `return "Alice"` mutant pass. Verified non-vacuous by mutation (both a UUID-style and a constant-return mutant fail the test).

No production change.