### PR TITLE
chore(docs): serve landing page from custom domain meetingtranscriber.app

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+meetingtranscriber.app

--- a/site/index.html
+++ b/site/index.html
@@ -8,8 +8,8 @@
 <meta property="og:title" content="Meeting Transcriber">
 <meta property="og:description" content="Meeting notes that stay on your Mac. Free and open source.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://pasrom.github.io/meeting-transcriber/">
-<meta property="og:image" content="https://pasrom.github.io/meeting-transcriber/assets/social-preview.png">
+<meta property="og:url" content="https://meetingtranscriber.app/">
+<meta property="og:image" content="https://meetingtranscriber.app/assets/social-preview.png">
 <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
Connects the landing page to the newly registered apex domain **meetingtranscriber.app**.

- Adds `site/CNAME` so the custom domain survives every Actions-based Pages redeploy (with the `build_type: workflow` source there is no branch for GitHub to auto-manage the CNAME, so it must live in the published artifact).
- Points `og:url` / `og:image` at the canonical domain so link previews unfurl from the live host.

DNS A/AAAA records still need to be added at the registrar; HTTPS cert provisioning + "Enforce HTTPS" follow once DNS propagates.