### PR TITLE
fix(app): recover from mic device-change crash (issue #379)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -81,6 +81,11 @@ ignore:
   - "tools/audiotap/Sources/AppAudioCapture.swift"
   - "tools/audiotap/Sources/MicCaptureHandler.swift"
   - "tools/audiotap/Sources/AudioCaptureSession.swift"
+  # Thin installTap wrapper bridging the NSException to a throw. The bridging
+  # shim itself is unit-tested (CExceptionCatcherTests); the installTap call is
+  # hardware-bound (exercised by e2e-app.yml). `+` is a regex metachar — escape
+  # as `\\+` to match the literal filename (see the note further down).
+  - "tools/audiotap/Sources/AVAudioNode\\+SafeInstallTap.swift"
   # SwiftUI overlay + NSPanel wrapper. The pure opacity math is extracted
   # to LiveCaptionsState.opacity(at:) and unit-tested there; what remains
   # is NSEvent global/local monitors, NSScreen frame checks, UserDefaults

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -81,6 +81,11 @@ ignore:
   - "tools/audiotap/Sources/AppAudioCapture.swift"
   - "tools/audiotap/Sources/MicCaptureHandler.swift"
   - "tools/audiotap/Sources/AudioCaptureSession.swift"
+  # Fault-injection test seam (#379): a 2-field config struct constructed ONLY
+  # in the e2e build's composition root under #if E2E_FAULT_INJECTION, so the
+  # xctest suite never executes its init. Exercised by e2e-mic-device-change.yml;
+  # a unit test would only pin a struct literal (vacuous).
+  - "tools/audiotap/Sources/DebugTapFault.swift"
   # Thin installTap wrapper bridging the NSException to a throw. The bridging
   # shim itself is unit-tested (CExceptionCatcherTests); the installTap call is
   # hardware-bound (exercised by e2e-app.yml). `+` is a regex metachar — escape

--- a/.github/workflows/e2e-mic-device-change.yml
+++ b/.github/workflows/e2e-mic-device-change.yml
@@ -1,0 +1,61 @@
+name: E2E (Mic Device-Change)
+
+# Focused live-recording E2E for issue #379: the app self-triggers a mic
+# device-change restart mid-recording whose tap install uses an invalid
+# format, the condition that raises an uncatchable NSException from
+# installTapOnBus. Asserts the app SURVIVES (no SIGABRT) and the recording
+# completes. It builds a deliberately-crashing (-DE2E_FAULT_INJECTION)
+# bundle, so it is kept out of the always-run e2e-app.yml sequence (whose
+# shared deploy path it would also poison). Dispatch-only: run manually when
+# touching the mic-restart path or before a release. GitHub indexes
+# workflow_dispatch from the default branch, so this is dispatchable once
+# merged: gh workflow run e2e-mic-device-change.yml
+on:
+  workflow_dispatch:
+
+# Shares e2e-app.yml's concurrency group so the two never race for the
+# BlackHole input device / RPC port / deployed bundle on the Mini.
+concurrency:
+  group: e2e-app-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-mic-device-change:
+    runs-on: [self-hosted, macOS, ARM64, audio]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/verify-xcode
+
+      - name: Install Developer ID certificate
+        id: dev-id
+        uses: ./.github/actions/install-developer-id
+        with:
+          cert: ${{ secrets.DEVELOPER_ID_CERT }}
+          cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          keychain-name: e2e-signing.keychain-db
+          extra-partition-roles: "codesign:"
+
+      - name: Export keychain path for e2e-app.sh
+        if: steps.dev-id.outputs.keychain-path != ''
+        run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
+
+      - name: Run mic device-change fault-injection E2E (issue #379)
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
+        run: bash scripts/e2e-app.sh --mic-device-change
+
+      - name: Upload simulator log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: meeting-simulator.log
+          path: /tmp/e2e-app-sim.log
+          if-no-files-found: ignore
+
+      - name: Cleanup signing keychain
+        if: always() && env.E2E_SIGNING_KEYCHAIN != ''
+        run: security delete-keychain "$E2E_SIGNING_KEYCHAIN" 2>/dev/null || true

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -144,6 +144,17 @@ class DualSourceRecorder: RecordingProvider {
         // root PID alone if the bundle URL is unavailable.
         let effectivePids = Self.resolveTapPIDs(rootPID: appPID)
 
+        // Mic device-change e2e (issue #379): inject a one-shot tap fault so the
+        // app self-triggers a mid-recording restart with an invalid format and
+        // the lane can verify the installTap NSException recovery. Compiled ONLY
+        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION); the fault is
+        // physically absent from every shipped binary.
+        #if E2E_FAULT_INJECTION
+            let micDebugFault: DebugTapFault? = DebugTapFault(triggerRestartAfter: 2)
+        #else
+            let micDebugFault: DebugTapFault? = nil
+        #endif
+
         let session = AudioCaptureSession(
             pids: effectivePids,
             appOutputURL: appTempURL,
@@ -154,6 +165,7 @@ class DualSourceRecorder: RecordingProvider {
             debugLogging: debugLogging,
             appLiveSink: appLiveSink,
             micLiveSink: micLiveSink,
+            micDebugFault: micDebugFault,
         )
         try session.start()
         captureSession = session

--- a/app/MeetingTranscriber/Sources/MicRecorder.swift
+++ b/app/MeetingTranscriber/Sources/MicRecorder.swift
@@ -70,7 +70,9 @@ class MicRecorder {
             channels: 1,
         )
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { [weak self] buffer, _ in
+        // safeInstallTap bridges the uncatchable NSException installTap raises
+        // for a mismatched format (issue #379) into a Swift throw.
+        try inputNode.safeInstallTap(onBus: 0, bufferSize: 4096, format: tapFormat) { [weak self] buffer, _ in
             guard let self, self.isRecording else { return }
             do {
                 try file.write(from: buffer)

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -2,6 +2,7 @@
 // types lack Sendable annotations — same gaps as Permissions.swift /
 // AudioMixer.swift; preemptively guarded.
 @preconcurrency import ApplicationServices
+import AudioTapLib
 @preconcurrency import AVFoundation
 import CoreGraphics
 import os.log
@@ -248,8 +249,16 @@ enum PermissionHealthCheck {
         }
 
         let counter = BufferCounter()
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
-            if buffer.frameLength > 0 { counter.record(buffer: buffer) }
+        do {
+            // safeInstallTap: a device change mid-probe could make installTap
+            // raise an uncatchable NSException (issue #379); treat that as a
+            // failed probe rather than an abort.
+            try inputNode.safeInstallTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+                if buffer.frameLength > 0 { counter.record(buffer: buffer) }
+            }
+        } catch {
+            debugLog("probeMicrophone: installTap failed: \(error.localizedDescription)")
+            return false
         }
 
         do {

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -32,6 +32,7 @@ RECORD_ONLY=false        # validate record-only mode (sidecar+WAV instead of tra
 REIMPORT_RECORDED=false  # chain a record-only meeting with re-import via POST /action/enqueueFile
 REIMPORT_LATEST=false    # skip live-record phase, re-import the freshest *_mix.wav already on disk
 KEEP_RECORDINGS=false    # leave record-only output on disk for a follow-up --reimport-latest run
+MIC_DEVICE_CHANGE=false  # build the issue #379 fault-injection seam + assert the app survives it
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -44,6 +45,7 @@ while [ $# -gt 0 ]; do
         --reimport-recorded) REIMPORT_RECORDED=true ;;
         --reimport-latest)  REIMPORT_LATEST=true ;;
         --keep-recordings)  KEEP_RECORDINGS=true ;;
+        --mic-device-change) MIC_DEVICE_CHANGE=true ;;
         -h|--help)
             cat <<'HELP'
 Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
@@ -72,6 +74,15 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
   --keep-recordings    Suppress the on-exit cleanup of record-only output, so
                        a follow-up --reimport-latest can pick the WAV up.
                        Only meaningful with --record-only.
+  --mic-device-change  Build with the issue #379 fault-injection seam
+                       (-DE2E_FAULT_INJECTION) and run one meeting. The app
+                       self-triggers a mic device-change restart mid-recording
+                       that installs the tap with an invalid format — the
+                       condition that raises an uncatchable NSException from
+                       installTapOnBus. Asserts the app SURVIVES (no SIGABRT)
+                       and the recording still completes. Pre-fix this crashes;
+                       the fix must catch + recover. Requires a build (incompatible
+                       with --no-build).
   --fixture            Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -87,6 +98,17 @@ done
 if [ "$REIMPORT_RECORDED" = true ] && [ "$REIMPORT_LATEST" = true ]; then
     echo "Error: --reimport-recorded and --reimport-latest are mutually exclusive" >&2
     exit 2
+fi
+
+# --mic-device-change needs the fault-injection seam compiled in, so it must
+# build — `defaults`/runtime flags can't add the -DE2E_FAULT_INJECTION code.
+if [ "$MIC_DEVICE_CHANGE" = true ] && [ "$NO_BUILD" = true ]; then
+    echo "Error: --mic-device-change requires a build; incompatible with --no-build" >&2
+    exit 2
+fi
+# Export before the build step below so run_app.sh adds -DE2E_FAULT_INJECTION.
+if [ "$MIC_DEVICE_CHANGE" = true ]; then
+    export MTT_FAULT_INJECTION=1
 fi
 
 # --reimport-recorded chains a record-only meeting with a follow-up
@@ -719,6 +741,19 @@ elif [ "$RECORD_ONLY" = true ]; then
     else
         run_one_record_only_meeting "meeting"
     fi
+elif [ "$MIC_DEVICE_CHANGE" = true ]; then
+    # Issue #379: the fault-injection build self-triggers a mic device-change
+    # restart ~2 s into recording whose tap install uses an invalid format,
+    # raising an NSException from installTapOnBus. Pre-fix the app aborts mid
+    # recording → the poll loop's assert_app_alive fails before any job lands
+    # (RED). Post-fix the app catches + recovers → recording completes → the
+    # existing run_one_meeting .done/transcript assertions pass (GREEN).
+    log "[mic-device-change] fault-injection build active; app will self-trigger a"
+    log "[mic-device-change] mic device-change restart with an invalid tap format mid-recording."
+    log "[mic-device-change] PASS = app survives (no SIGABRT) AND recording completes."
+    run_one_meeting "[mic-device-change]"
+    assert_app_alive
+    log "[mic-device-change] app survived the injected device-change restart ✅"
 elif [ "$TWO_MEETINGS" = true ]; then
     run_one_meeting "[1/2]"
     log "Sleeping ${INTER_MEETING_COOLDOWN_S}s for WatchLoop cooldown before meeting 2"

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -32,7 +32,15 @@ INFO_PLIST="$SPM_DIR/Sources/Info.plist"
 # Always rebuild to pick up code changes
 echo "Building Meeting Transcriber app..."
 cd "$SPM_DIR"
-swift build -c release
+SWIFT_BUILD_FLAGS=(-c release)
+# Opt-in fault-injection build for the mic-device-change e2e lane only
+# (scripts/e2e-app.sh --mic-device-change). Compiles the issue #379
+# reproduction seam in MicCaptureHandler; never set for normal/release builds.
+if [ -n "${MTT_FAULT_INJECTION:-}" ]; then
+    SWIFT_BUILD_FLAGS+=(-Xswiftc -DE2E_FAULT_INJECTION)
+    echo "  (fault-injection build: -DE2E_FAULT_INJECTION)"
+fi
+swift build "${SWIFT_BUILD_FLAGS[@]}"
 
 # Assemble .app bundle
 mkdir -p "$APP_MACOS"

--- a/tools/audiotap/Package.swift
+++ b/tools/audiotap/Package.swift
@@ -8,13 +8,21 @@ let package = Package(
         .library(name: "AudioTapLib", targets: ["AudioTapLib"]),
     ],
     targets: [
+        // Objective-C shim that bridges NSExceptions (e.g. from
+        // installTapOnBus) into Swift-catchable NSErrors. See header.
+        .target(
+            name: "CExceptionCatcher",
+            path: "Sources/CExceptionCatcher"
+        ),
         .target(
             name: "AudioTapLib",
-            path: "Sources"
+            dependencies: ["CExceptionCatcher"],
+            path: "Sources",
+            exclude: ["CExceptionCatcher"]
         ),
         .testTarget(
             name: "AudioTapLibTests",
-            dependencies: ["AudioTapLib"],
+            dependencies: ["AudioTapLib", "CExceptionCatcher"],
             path: "Tests"
         ),
     ]

--- a/tools/audiotap/Sources/AVAudioNode+SafeInstallTap.swift
+++ b/tools/audiotap/Sources/AVAudioNode+SafeInstallTap.swift
@@ -1,0 +1,38 @@
+@preconcurrency import AVFoundation
+import CExceptionCatcher
+
+/// Error thrown when installing an audio tap fails because AVFoundation raised
+/// an NSException (issue #379) — e.g. a tap format whose channel count or
+/// sample rate doesn't match the node's bus after a device change.
+public enum AudioTapInstallError: LocalizedError {
+    case installFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .installFailed(reason): "Failed to install audio tap: \(reason)"
+        }
+    }
+}
+
+public extension AVAudioNode {
+    /// Install a tap, bridging the Objective-C NSException AVFoundation raises
+    /// for an invalid/mismatched tap format into a Swift `throws`.
+    ///
+    /// `installTap(onBus:…)` signals a bad format by raising an NSException,
+    /// which Swift's `do/catch` cannot intercept — an unguarded call therefore
+    /// aborts the whole process (issue #379). Routing it through the ObjC shim
+    /// turns that class of aborts into a recoverable error at every call site.
+    func safeInstallTap(
+        onBus bus: AVAudioNodeBus,
+        bufferSize: AVAudioFrameCount,
+        format: AVAudioFormat?,
+        block: @escaping AVAudioNodeTapBlock,
+    ) throws {
+        let error = audiotap_tryBlock {
+            self.installTap(onBus: bus, bufferSize: bufferSize, format: format, block: block)
+        }
+        if let error {
+            throw AudioTapInstallError.installFailed(error.localizedDescription)
+        }
+    }
+}

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -16,6 +16,9 @@ public class AudioCaptureSession {
     private let debugLogging: Bool
     private let appLiveSink: LiveAudioSink?
     private let micLiveSink: LiveAudioSink?
+    // Inert in production (nil); an e2e build injects one to verify the mic
+    // installTap NSException recovery (issue #379). Forwarded to MicCaptureHandler.
+    private let micDebugFault: DebugTapFault?
 
     private var appCapture: AppAudioCapture?
     private var micCapture: MicCaptureHandler?
@@ -41,6 +44,7 @@ public class AudioCaptureSession {
         debugLogging: Bool = false,
         appLiveSink: LiveAudioSink? = nil,
         micLiveSink: LiveAudioSink? = nil,
+        micDebugFault: DebugTapFault? = nil,
     ) {
         self.pids = pids
         self.sampleRate = sampleRate
@@ -51,6 +55,7 @@ public class AudioCaptureSession {
         self.debugLogging = debugLogging
         self.appLiveSink = appLiveSink
         self.micLiveSink = micLiveSink
+        self.micDebugFault = micDebugFault
     }
 
     /// Start capturing app audio (and optionally mic audio).
@@ -87,6 +92,7 @@ public class AudioCaptureSession {
                 outputURL: micURL,
                 debugLogging: debugLogging,
                 liveSink: micLiveSink,
+                debugFault: micDebugFault,
             )
             do {
                 try mic.start(deviceUID: micDeviceUID)

--- a/tools/audiotap/Sources/CExceptionCatcher/CExceptionCatcher.m
+++ b/tools/audiotap/Sources/CExceptionCatcher/CExceptionCatcher.m
@@ -1,0 +1,15 @@
+#import "CExceptionCatcher.h"
+
+NSError *_Nullable audiotap_tryBlock(NS_NOESCAPE void (^block)(void)) {
+    @try {
+        block();
+        return nil;
+    } @catch (NSException *exception) {
+        return [NSError errorWithDomain:@"AudioTapLib.NSException"
+                                   code:1
+                               userInfo:@{
+                                   NSLocalizedDescriptionKey: exception.reason ?: exception.name,
+                                   @"exceptionName": exception.name,
+                               }];
+    }
+}

--- a/tools/audiotap/Sources/CExceptionCatcher/include/CExceptionCatcher.h
+++ b/tools/audiotap/Sources/CExceptionCatcher/include/CExceptionCatcher.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs `block` inside an Objective-C @try/@catch and bridges any raised
+/// NSException to a Swift-catchable NSError. Returns nil when the block
+/// completes normally.
+///
+/// AVFoundation APIs such as `-[AVAudioNode installTapOnBus:...]` signal
+/// misuse by raising an NSException, which Swift's `do/catch` cannot
+/// intercept — it propagates to `std::terminate`/`abort`. Wrapping the call
+/// here converts that whole class of aborts into a recoverable Swift error.
+/// The block is non-escaping: it runs synchronously before this returns.
+NSError *_Nullable audiotap_tryBlock(NS_NOESCAPE void (^block)(void));
+
+NS_ASSUME_NONNULL_END

--- a/tools/audiotap/Sources/DebugTapFault.swift
+++ b/tools/audiotap/Sources/DebugTapFault.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Configuration for injecting a one-shot tap-install fault into
+/// `MicCaptureHandler`, used by the mic device-change e2e (issue #379) to
+/// verify the installTap NSException recovery path end-to-end.
+///
+/// This is a generic, inert-by-default test seam: production code passes
+/// `nil`. Only an e2e build's composition root (DualSourceRecorder, gated by
+/// `#if E2E_FAULT_INJECTION`) constructs one, so the fault capability is
+/// physically absent from every shipped binary.
+public struct DebugTapFault: Sendable {
+    /// Delay after the first successful start before the handler self-triggers
+    /// one device-change restart whose tap install uses an invalid format.
+    public let triggerRestartAfter: TimeInterval
+
+    public init(triggerRestartAfter: TimeInterval = 2) {
+        self.triggerRestartAfter = triggerRestartAfter
+    }
+}

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -25,6 +25,16 @@ public class MicCaptureHandler: @unchecked Sendable {
     private let liveSink: LiveAudioSink?
     private var isRecording = false
     private var isRestarting = false
+    // Bounded retry for transient restart failures (issue #379): a device
+    // change can briefly expose an invalid format; retry with exponential
+    // backoff (MicRestartRetryPolicy) rather than dropping the recording.
+    // Reset to 0 on a successful (re)start.
+    private var restartRetryCount = 0
+    // True while a retry is pending in the backoff window. `isRestarting` is
+    // cleared synchronously when executeRestart returns, so without this a
+    // device change arriving during the 0.3 s backoff would start a second,
+    // parallel restart chain racing the pending one on `engine`.
+    private var retryScheduled = false
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
     private var configChangeObserver: NSObjectProtocol?
     private var selectedDeviceUID: String?
@@ -102,6 +112,24 @@ public class MicCaptureHandler: @unchecked Sendable {
         installConfigChangeObserver()
     }
 
+    /// Validate the live hardware format and derive a tap format that MATCHES
+    /// the node's actual channel count. Issue #379: a device change to a
+    /// multi-channel input (e.g. 24 kHz/1ch → 44.1 kHz/2ch) crashed because the
+    /// tap was hardcoded to 1 channel — installTapOnBus raises an NSException
+    /// when the tap format's channel count differs from the freshly-negotiated
+    /// node bus. Matching the node's channel count and downmixing to mono in
+    /// the converter (see startEngine) avoids the mismatch at the source. The
+    /// 0 Hz / 0-channel guard covers the transient where the device hasn't
+    /// finished re-initialising; throwing lets executeRestart retry.
+    private func validatedTapFormat(for hwFormat: AVAudioFormat) throws -> AVAudioFormat {
+        guard let tapFormat = TapFormatResolver.tapFormat(forHardware: hwFormat) else {
+            throw MicCaptureError.invalidHardwareFormat(
+                sampleRate: hwFormat.sampleRate, channelCount: hwFormat.channelCount,
+            )
+        }
+        return tapFormat
+    }
+
     // swiftlint:disable:next function_body_length
     private func startEngine(deviceUID: String? = nil) throws {
         // No input device available (e.g. Mac Mini server without mic hardware) —
@@ -131,6 +159,8 @@ public class MicCaptureHandler: @unchecked Sendable {
         let hwFormat = inputNode.outputFormat(forBus: 0)
         logger.info("Mic hardware format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount)ch")
 
+        let tapFormat = try validatedTapFormat(for: hwFormat)
+
         if debugLogging {
             let inUID = getDefaultInputDeviceUID() ?? "?"
             let inName = getDefaultInputDeviceName() ?? "?"
@@ -139,9 +169,6 @@ public class MicCaptureHandler: @unchecked Sendable {
             )
         }
 
-        let tapFormat = AVAudioFormat(
-            standardFormatWithSampleRate: hwFormat.sampleRate, channels: 1,
-        )! // swiftlint:disable:this force_unwrapping
         logger.info("Mic tap format: \(tapFormat.sampleRate) Hz, \(tapFormat.channelCount)ch")
 
         // Always 16kHz — WhisperKit target rate
@@ -165,14 +192,19 @@ public class MicCaptureHandler: @unchecked Sendable {
         }
 
         converter = nil
-        resampleRatio = 1.0
-        if tapFormat.sampleRate != fileSampleRate {
+        resampleRatio = fileSampleRate / tapFormat.sampleRate
+        // Convert to 16 kHz mono whenever the tap isn't already there — this
+        // covers resampling AND downmixing a multi-channel input device. Since
+        // the tap now matches the node's real channel count (issue #379), a
+        // 2ch device is captured as 2ch and folded to the mono WAV here.
+        if tapFormat.sampleRate != fileSampleRate || tapFormat.channelCount != 1 {
             let outputFormat = AVAudioFormat(
                 standardFormatWithSampleRate: fileSampleRate, channels: 1,
             )! // swiftlint:disable:this force_unwrapping
             converter = AVAudioConverter(from: tapFormat, to: outputFormat)
-            resampleRatio = fileSampleRate / tapFormat.sampleRate
-            logger.info("Mic: resampling \(Int(tapFormat.sampleRate))→\(Int(self.fileSampleRate)) Hz")
+            logger.info(
+                "Mic: converting \(Int(tapFormat.sampleRate))Hz/\(tapFormat.channelCount)ch → \(Int(self.fileSampleRate))Hz/1ch",
+            )
         }
 
         #if E2E_FAULT_INJECTION
@@ -180,8 +212,11 @@ public class MicCaptureHandler: @unchecked Sendable {
         #else
             let installFormat = tapFormat
         #endif
+        // installTapOnBus raises an ObjC NSException for an invalid/incompatible
+        // format (issue #379); Swift can't catch that. Build the tap block, then
+        // install it through the ObjC shim so a raise becomes a recoverable throw.
         // swiftlint:disable closure_parameter_position closure_body_length
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: installFormat) {
+        let tapBlock: AVAudioNodeTapBlock = {
             [weak self] buffer, _ in
             // swiftlint:enable closure_parameter_position closure_body_length
             guard let self, self.isRecording else { return }
@@ -233,9 +268,17 @@ public class MicCaptureHandler: @unchecked Sendable {
             }
         }
 
+        do {
+            try inputNode.safeInstallTap(onBus: 0, bufferSize: 4096, format: installFormat, block: tapBlock)
+        } catch {
+            logger.error("Mic: installTap failed (\(error.localizedDescription)) — restart will retry")
+            throw error
+        }
+
         engine.prepare()
         try engine.start()
         isRecording = true
+        restartRetryCount = 0
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
 
         #if E2E_FAULT_INJECTION
@@ -289,7 +332,9 @@ public class MicCaptureHandler: @unchecked Sendable {
         let isDeviceAvailable = selectedDeviceUID.map { Self.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
         let action = MicRestartPolicy.decideRestart(
             isRecording: isRecording,
-            isRestarting: isRestarting,
+            // Treat a pending retry as still-restarting so a device change in
+            // the backoff window doesn't spawn a competing restart chain.
+            isRestarting: isRestarting || retryScheduled,
             selectedDeviceUID: selectedDeviceUID,
             isSelectedDeviceAvailable: isDeviceAvailable,
         )
@@ -342,8 +387,35 @@ public class MicCaptureHandler: @unchecked Sendable {
             installConfigChangeObserver()
             logger.info("Mic: engine restarted on \(deviceUID != nil ? "selected" : "default") device (\(Int(hwRate)) Hz)")
         } catch {
+            // A transient invalid format / installTap raise (issue #379) is
+            // recoverable: the device usually settles within a few hundred ms.
+            // Keep recording and retry with backoff instead of killing it.
+            logger.error("Failed to restart mic after device change: \(error) — scheduling retry")
+            scheduleRestartRetry(deviceUID: deviceUID)
+        }
+    }
+
+    /// Re-attempt a failed restart after a short backoff, bounded by
+    /// `maxRestartRetries`. Only retries while still recording; gives up (and
+    /// stops recording) once the budget is exhausted.
+    private func scheduleRestartRetry(deviceUID: String?) {
+        guard isRecording else { return }
+        switch MicRestartRetryPolicy.decide(attemptsSoFar: restartRetryCount) {
+        case .giveUp:
             isRecording = false
-            logger.error("Failed to restart mic after device change: \(error)")
+            logger.error("Mic: giving up restart after \(MicRestartRetryPolicy.maxAttempts) failed attempts")
+
+        case let .retry(delay):
+            restartRetryCount += 1
+            retryScheduled = true
+            let attempt = restartRetryCount
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self else { return }
+                self.retryScheduled = false
+                guard self.isRecording else { return }
+                logger.info("Mic: restart retry \(attempt)/\(MicRestartRetryPolicy.maxAttempts)")
+                self.executeRestart(deviceUID: deviceUID)
+            }
         }
     }
 
@@ -471,10 +543,14 @@ private func sumOfSquaresInt16(
 
 public enum MicCaptureError: LocalizedError {
     case noInputDevice
+    case invalidHardwareFormat(sampleRate: Double, channelCount: UInt32)
 
     public var errorDescription: String? {
         switch self {
         case .noInputDevice: "No microphone hardware available"
+
+        case let .invalidHardwareFormat(sampleRate, channelCount):
+            "Microphone reported an invalid format (\(sampleRate) Hz, \(channelCount) ch)"
         }
     }
 }

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -23,6 +23,10 @@ public class MicCaptureHandler: @unchecked Sendable {
     private let outputURL: URL
     private let debugLogging: Bool
     private let liveSink: LiveAudioSink?
+    // Debug fault injection (issue #379 repro): nil in production. An e2e
+    // build's composition root injects one (DualSourceRecorder, gated by
+    // #if E2E_FAULT_INJECTION) to verify the installTap NSException recovery.
+    private let debugFault: DebugTapFault?
     private var isRecording = false
     private var isRestarting = false
     // Bounded retry for transient restart failures (issue #379): a device
@@ -44,18 +48,11 @@ public class MicCaptureHandler: @unchecked Sendable {
     private var resampleRatio: Double = 1.0
     public private(set) var firstFrameTime: UInt64 = 0
 
-    #if E2E_FAULT_INJECTION
-        // Issue #379 reproduction seam — compile-gated, built ONLY by the
-        // mic-device-change e2e lane (run_app.sh passes -DE2E_FAULT_INJECTION when
-        // MTT_FAULT_INJECTION is set). Never present in any shipped variant.
-        // Simulates a transient dead input device mid-recording: after the first
-        // successful start it self-triggers ONE real device-change restart whose
-        // tap is installed with an invalid (0 Hz) format — the exact condition
-        // that makes installTapOnBus raise an uncatchable NSException (verified on
-        // macOS 26.5). Pre-fix this aborts the app; the fix must catch + recover.
-        private var e2eFaultArmed = false
-        private var e2eInjectBadTapFormatOnce = false
-    #endif
+    // State for an injected DebugTapFault (above). Always compiled but inert
+    // unless a fault was injected — see resolveTapInstallFormat /
+    // armDebugFaultIfNeeded.
+    private var debugFaultArmed = false
+    private var injectBadTapFormatOnce = false
 
     private var debugRMS = DebugRMSReporter()
     private let levelPublisher = LevelPublisher()
@@ -77,10 +74,12 @@ public class MicCaptureHandler: @unchecked Sendable {
         outputURL: URL,
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
+        debugFault: DebugTapFault? = nil,
     ) {
         self.outputURL = outputURL
         self.debugLogging = debugLogging
         self.liveSink = liveSink
+        self.debugFault = debugFault
     }
 
     deinit {
@@ -207,11 +206,9 @@ public class MicCaptureHandler: @unchecked Sendable {
             )
         }
 
-        #if E2E_FAULT_INJECTION
-            let installFormat = e2eResolveTapFormat(default: tapFormat)
-        #else
-            let installFormat = tapFormat
-        #endif
+        // Normally returns tapFormat unchanged; under an injected DebugTapFault
+        // it returns an invalid format once to exercise the recovery path.
+        let installFormat = resolveTapInstallFormat(default: tapFormat)
         // installTapOnBus raises an ObjC NSException for an invalid/incompatible
         // format (issue #379); Swift can't catch that. Build the tap block, then
         // install it through the ObjC shim so a raise becomes a recoverable throw.
@@ -281,9 +278,7 @@ public class MicCaptureHandler: @unchecked Sendable {
         restartRetryCount = 0
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
 
-        #if E2E_FAULT_INJECTION
-            e2eArmFaultInjectionIfNeeded()
-        #endif
+        armDebugFaultIfNeeded()
     }
 
     private func installDeviceChangeListener() {
@@ -555,37 +550,37 @@ public enum MicCaptureError: LocalizedError {
     }
 }
 
-#if E2E_FAULT_INJECTION
+// MARK: - Debug fault injection (issue #379 recovery verification)
 
-    // MARK: - Issue #379 fault injection (compile-gated, e2e only)
+private extension MicCaptureHandler {
+    /// In production (`debugFault == nil`) returns `real` unchanged. Under an
+    /// injected fault it returns an invalid (0 Hz) tap format exactly once —
+    /// the condition that makes installTapOnBus raise
+    /// `IsFormatSampleRateAndChannelCountValid` — so the e2e can verify the
+    /// NSException recovery path end-to-end.
+    func resolveTapInstallFormat(default real: AVAudioFormat) -> AVAudioFormat {
+        guard injectBadTapFormatOnce else { return real }
+        injectBadTapFormatOnce = false
+        guard let bad = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 0, channels: 1, interleaved: false,
+        ) else { return real }
+        logger.warning("[debug-fault] installing invalid (0 Hz) tap format (issue #379 repro)")
+        return bad
+    }
 
-    extension MicCaptureHandler {
-        /// Returns an invalid (0 Hz) tap format exactly once after injection has
-        /// been armed, otherwise the real format. The 0 Hz format makes
-        /// installTapOnBus raise `IsFormatSampleRateAndChannelCountValid`.
-        func e2eResolveTapFormat(default real: AVAudioFormat) -> AVAudioFormat {
-            guard e2eInjectBadTapFormatOnce else { return real }
-            e2eInjectBadTapFormatOnce = false
-            guard let bad = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32, sampleRate: 0, channels: 1, interleaved: false,
-            ) else { return real }
-            logger.warning("[e2e] injecting invalid (0 Hz) tap format to reproduce issue #379")
-            return bad
-        }
-
-        /// Once, after the first successful start: schedule a single self-triggered
-        /// device-change restart whose tap install uses the bad format. Drives the
-        /// real handleDeviceChange → executeRestart → startEngine path so the
-        /// reproduction exercises production code, not a shortcut.
-        func e2eArmFaultInjectionIfNeeded() {
-            guard !e2eFaultArmed else { return }
-            e2eFaultArmed = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-                guard let self, self.isRecording else { return }
-                logger.warning("[e2e] firing simulated mic device-change mid-recording (issue #379 repro)")
-                self.e2eInjectBadTapFormatOnce = true
-                self.handleDeviceChange()
-            }
+    /// No-op in production. When a `DebugTapFault` was injected: once, after the
+    /// first successful start, schedule a single self-triggered device-change
+    /// restart whose tap install uses the bad format. Drives the real
+    /// handleDeviceChange → executeRestart → startEngine path so the
+    /// reproduction exercises production code, not a shortcut.
+    func armDebugFaultIfNeeded() {
+        guard let debugFault, !debugFaultArmed else { return }
+        debugFaultArmed = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + debugFault.triggerRestartAfter) { [weak self] in
+            guard let self, self.isRecording else { return }
+            logger.warning("[debug-fault] firing simulated mic device-change mid-recording (issue #379 repro)")
+            self.injectBadTapFormatOnce = true
+            self.handleDeviceChange()
         }
     }
-#endif
+}

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -34,6 +34,19 @@ public class MicCaptureHandler: @unchecked Sendable {
     private var resampleRatio: Double = 1.0
     public private(set) var firstFrameTime: UInt64 = 0
 
+    #if E2E_FAULT_INJECTION
+        // Issue #379 reproduction seam — compile-gated, built ONLY by the
+        // mic-device-change e2e lane (run_app.sh passes -DE2E_FAULT_INJECTION when
+        // MTT_FAULT_INJECTION is set). Never present in any shipped variant.
+        // Simulates a transient dead input device mid-recording: after the first
+        // successful start it self-triggers ONE real device-change restart whose
+        // tap is installed with an invalid (0 Hz) format — the exact condition
+        // that makes installTapOnBus raise an uncatchable NSException (verified on
+        // macOS 26.5). Pre-fix this aborts the app; the fix must catch + recover.
+        private var e2eFaultArmed = false
+        private var e2eInjectBadTapFormatOnce = false
+    #endif
+
     private var debugRMS = DebugRMSReporter()
     private let levelPublisher = LevelPublisher()
 
@@ -162,8 +175,13 @@ public class MicCaptureHandler: @unchecked Sendable {
             logger.info("Mic: resampling \(Int(tapFormat.sampleRate))→\(Int(self.fileSampleRate)) Hz")
         }
 
+        #if E2E_FAULT_INJECTION
+            let installFormat = e2eResolveTapFormat(default: tapFormat)
+        #else
+            let installFormat = tapFormat
+        #endif
         // swiftlint:disable closure_parameter_position closure_body_length
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) {
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: installFormat) {
             [weak self] buffer, _ in
             // swiftlint:enable closure_parameter_position closure_body_length
             guard let self, self.isRecording else { return }
@@ -219,6 +237,10 @@ public class MicCaptureHandler: @unchecked Sendable {
         try engine.start()
         isRecording = true
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
+
+        #if E2E_FAULT_INJECTION
+            e2eArmFaultInjectionIfNeeded()
+        #endif
     }
 
     private func installDeviceChangeListener() {
@@ -456,3 +478,38 @@ public enum MicCaptureError: LocalizedError {
         }
     }
 }
+
+#if E2E_FAULT_INJECTION
+
+    // MARK: - Issue #379 fault injection (compile-gated, e2e only)
+
+    extension MicCaptureHandler {
+        /// Returns an invalid (0 Hz) tap format exactly once after injection has
+        /// been armed, otherwise the real format. The 0 Hz format makes
+        /// installTapOnBus raise `IsFormatSampleRateAndChannelCountValid`.
+        func e2eResolveTapFormat(default real: AVAudioFormat) -> AVAudioFormat {
+            guard e2eInjectBadTapFormatOnce else { return real }
+            e2eInjectBadTapFormatOnce = false
+            guard let bad = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32, sampleRate: 0, channels: 1, interleaved: false,
+            ) else { return real }
+            logger.warning("[e2e] injecting invalid (0 Hz) tap format to reproduce issue #379")
+            return bad
+        }
+
+        /// Once, after the first successful start: schedule a single self-triggered
+        /// device-change restart whose tap install uses the bad format. Drives the
+        /// real handleDeviceChange → executeRestart → startEngine path so the
+        /// reproduction exercises production code, not a shortcut.
+        func e2eArmFaultInjectionIfNeeded() {
+            guard !e2eFaultArmed else { return }
+            e2eFaultArmed = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                guard let self, self.isRecording else { return }
+                logger.warning("[e2e] firing simulated mic device-change mid-recording (issue #379 repro)")
+                self.e2eInjectBadTapFormatOnce = true
+                self.handleDeviceChange()
+            }
+        }
+    }
+#endif

--- a/tools/audiotap/Sources/MicRestartRetryPolicy.swift
+++ b/tools/audiotap/Sources/MicRestartRetryPolicy.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Action to take after a mic-engine restart attempt failed.
+public enum MicRestartRetryAction: Equatable {
+    /// Retry the restart after the given backoff delay (seconds).
+    case retry(afterSeconds: Double)
+    /// Stop retrying — the failure budget is exhausted.
+    case giveUp
+}
+
+/// Pure decision logic for retrying a failed mic-engine restart (issue #379).
+/// A device change can briefly expose an invalid format and make the restart
+/// throw; retrying with backoff lets a transient settle instead of dropping
+/// the recording. Separated from MicCaptureHandler so the backoff schedule and
+/// give-up boundary are unit-testable without hardware.
+public enum MicRestartRetryPolicy {
+    /// Maximum number of retries before giving up.
+    public static let maxAttempts = 5
+
+    /// First-retry backoff; doubles each subsequent attempt up to `maxBackoff`.
+    static let baseBackoff = 0.3
+    static let maxBackoff = 2.0
+
+    /// Decide whether to retry after a failed restart.
+    ///
+    /// - Parameter attemptsSoFar: retries already performed (0 on the first
+    ///   failure, 1 after one retry, …).
+    /// - Returns: `.retry` with an exponentially-backed-off delay while within
+    ///   budget, otherwise `.giveUp`.
+    public static func decide(attemptsSoFar: Int) -> MicRestartRetryAction {
+        guard attemptsSoFar < maxAttempts else { return .giveUp }
+        let delay = min(baseBackoff * pow(2.0, Double(attemptsSoFar)), maxBackoff)
+        return .retry(afterSeconds: delay)
+    }
+}

--- a/tools/audiotap/Sources/TapFormatResolver.swift
+++ b/tools/audiotap/Sources/TapFormatResolver.swift
@@ -1,0 +1,21 @@
+@preconcurrency import AVFoundation
+
+/// Pure derivation of the mic tap format from the live hardware format.
+/// Separated from MicCaptureHandler so the issue #379 invariant — the tap
+/// MUST match the node's channel count (a hardcoded 1-channel tap raised an
+/// NSException on a multi-channel device) — is unit-testable without hardware.
+public enum TapFormatResolver {
+    /// The tap format matching the node's bus — i.e. the node's own
+    /// `outputFormat` — or nil when the hardware reported an invalid
+    /// (0 Hz / 0-channel) format, the transient a device change can briefly
+    /// expose. Returning the node's own format (rather than reconstructing a
+    /// `standardFormatWithSampleRate:channels:`) is both correct and robust:
+    /// it always matches the bus (issue #379 — a mismatched channel count made
+    /// installTapOnBus raise) AND it works for any channel count, whereas
+    /// `standardFormatWithSampleRate:channels:` returns nil for >2 channels
+    /// (no inferable layout). The converter downmixes it to the mono WAV.
+    public static func tapFormat(forHardware hwFormat: AVAudioFormat) -> AVAudioFormat? {
+        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else { return nil }
+        return hwFormat
+    }
+}

--- a/tools/audiotap/Tests/CExceptionCatcherTests.swift
+++ b/tools/audiotap/Tests/CExceptionCatcherTests.swift
@@ -1,0 +1,36 @@
+import CExceptionCatcher
+import XCTest
+
+/// Verifies the ObjC shim that bridges NSExceptions (issue #379, e.g. from
+/// installTapOnBus) into Swift-catchable NSErrors. Swift's do/catch cannot
+/// intercept an NSException — without this shim a raise aborts the process.
+final class CExceptionCatcherTests: XCTestCase {
+    func testReturnsNilWhenBlockCompletesNormally() {
+        var ran = false
+        let error = audiotap_tryBlock { ran = true }
+        XCTAssertTrue(ran, "block should have run")
+        XCTAssertNil(error, "no exception raised → no error")
+    }
+
+    func testBridgesRaisedNSExceptionToError() {
+        let error = audiotap_tryBlock {
+            NSException(
+                name: .invalidArgumentException, reason: "boom", userInfo: nil,
+            ).raise()
+        }
+        let nsError = try? XCTUnwrap(error as NSError?)
+        XCTAssertEqual(nsError?.domain, "AudioTapLib.NSException")
+        XCTAssertEqual(
+            nsError?.userInfo["exceptionName"] as? String,
+            NSExceptionName.invalidArgumentException.rawValue,
+        )
+        XCTAssertEqual(nsError?.localizedDescription, "boom")
+    }
+
+    func testFallsBackToExceptionNameWhenReasonIsNil() {
+        let error = audiotap_tryBlock {
+            NSException(name: .genericException, reason: nil, userInfo: nil).raise()
+        }
+        XCTAssertEqual(error?.localizedDescription, NSExceptionName.genericException.rawValue)
+    }
+}

--- a/tools/audiotap/Tests/MicRestartRetryPolicyTests.swift
+++ b/tools/audiotap/Tests/MicRestartRetryPolicyTests.swift
@@ -1,0 +1,50 @@
+@testable import AudioTapLib
+import XCTest
+
+final class MicRestartRetryPolicyTests: XCTestCase {
+    func testFirstFailureRetriesWithBaseBackoff() {
+        XCTAssertEqual(
+            MicRestartRetryPolicy.decide(attemptsSoFar: 0),
+            .retry(afterSeconds: MicRestartRetryPolicy.baseBackoff),
+        )
+    }
+
+    func testBackoffDoublesEachAttempt() {
+        guard case let .retry(d0) = MicRestartRetryPolicy.decide(attemptsSoFar: 0),
+              case let .retry(d1) = MicRestartRetryPolicy.decide(attemptsSoFar: 1),
+              case let .retry(d2) = MicRestartRetryPolicy.decide(attemptsSoFar: 2)
+        else {
+            XCTFail("expected retries within budget")
+            return
+        }
+        XCTAssertEqual(d1, d0 * 2, accuracy: 1e-9)
+        XCTAssertEqual(d2, d0 * 4, accuracy: 1e-9)
+    }
+
+    func testBackoffIsCapped() {
+        // A late (but still in-budget) attempt must not exceed the cap.
+        guard case let .retry(delay) = MicRestartRetryPolicy.decide(attemptsSoFar: 4) else {
+            XCTFail("expected a retry at attempt 4")
+            return
+        }
+        XCTAssertLessThanOrEqual(delay, MicRestartRetryPolicy.maxBackoff)
+    }
+
+    func testGivesUpAtBudget() {
+        XCTAssertEqual(
+            MicRestartRetryPolicy.decide(attemptsSoFar: MicRestartRetryPolicy.maxAttempts),
+            .giveUp,
+        )
+        XCTAssertEqual(
+            MicRestartRetryPolicy.decide(attemptsSoFar: MicRestartRetryPolicy.maxAttempts + 3),
+            .giveUp,
+        )
+    }
+
+    func testLastInBudgetAttemptStillRetries() {
+        guard case .retry = MicRestartRetryPolicy.decide(attemptsSoFar: MicRestartRetryPolicy.maxAttempts - 1) else {
+            XCTFail("the final in-budget attempt should retry, not give up")
+            return
+        }
+    }
+}

--- a/tools/audiotap/Tests/TapFormatResolverTests.swift
+++ b/tools/audiotap/Tests/TapFormatResolverTests.swift
@@ -1,0 +1,38 @@
+import AudioTapLib
+@preconcurrency import AVFoundation
+import XCTest
+
+/// Guards the issue #379 root-cause invariant: the mic tap format must match
+/// the hardware node's CHANNEL count. A regression to a hardcoded 1-channel
+/// tap (the original bug) makes `testTapFormatPreservesChannelCount` fail.
+final class TapFormatResolverTests: XCTestCase {
+    private func hw(_ rate: Double, _ channels: AVAudioChannelCount) throws -> AVAudioFormat {
+        try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: rate, channels: channels))
+    }
+
+    func testMonoHardwareYieldsMonoTap() throws {
+        let tap = try TapFormatResolver.tapFormat(forHardware: hw(24000, 1))
+        XCTAssertEqual(tap?.channelCount, 1)
+        XCTAssertEqual(tap?.sampleRate, 24000)
+    }
+
+    func testTapFormatPreservesChannelCount() throws {
+        // The root-cause fix: a 2-channel device must produce a 2-channel tap,
+        // not a hardcoded 1-channel one (which raised on the real device).
+        // A revert to forcing 1 channel fails this assertion.
+        XCTAssertEqual(try TapFormatResolver.tapFormat(forHardware: hw(44100, 2))?.channelCount, 2)
+    }
+
+    func testPreservesSampleRate() throws {
+        XCTAssertEqual(try TapFormatResolver.tapFormat(forHardware: hw(44100, 2))?.sampleRate, 44100)
+    }
+
+    func testZeroSampleRateRejected() throws {
+        // A transient dead device (0 Hz) must yield nil so the caller can
+        // retry instead of force-unwrapping or letting installTap raise.
+        let zeroRate = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 0, channels: 1, interleaved: false,
+        ))
+        XCTAssertNil(TapFormatResolver.tapFormat(forHardware: zeroRate))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the SIGABRT in #379: a microphone input-device change mid-recording aborted the app. `AVAudioNode.installTapOnBus` raises an Objective-C `NSException` that Swift's `do/catch` in `MicCaptureHandler.executeRestart` cannot intercept, so it propagated to `std::terminate` → `abort()`.

## Root cause + fix

jhavez's field report — with a **negative control** (format-changing swaps crash every time; same-format swaps never) — pinned it: the tap format was hardcoded to **1 channel**, so a swap to a device with a different format (e.g. 24 kHz/1ch → 44.1 kHz/2ch) made `installTap` raise — the 1-channel tap no longer matched the freshly-negotiated node.

**Primary fix** (exactly his recommendation, "use the new node's actual format"):
- Re-query the live node format and **tap with the node's own `outputFormat`** (any channel count), downmixing to the mono 16 kHz WAV in the converter, so the tap always matches the node. Extracted to the pure, unit-tested `TapFormatResolver`.
- This also fixes a **>2-channel device**: `AVAudioFormat(standardFormatWithSampleRate:channels:)` returns nil above 2 channels (no inferable layout), which a reconstruct-the-format approach would have thrown on.

**Defense-in-depth** (covers any residual raise, including a real device's transient 0 Hz / 0-channel format exposed during async Bluetooth/USB negotiation):
- `AVAudioNode.safeInstallTap` — an Objective-C `@try/@catch` shim bridging the `NSException` into a Swift throw, used at **all three** `installTap` call sites (mic capture, permission probe, `MicRecorder`).
- Up-front hardware-format validation, replacing a force-unwrap a transient 0 Hz device would have crashed on.
- Bounded exponential-backoff retry on a failed restart (`MicRestartRetryPolicy`) instead of dropping the recording; a `retryScheduled` guard prevents a device change in the backoff window from spawning a competing restart chain.

## Tests

- `TapFormatResolverTests` — guards the channel-preservation invariant; **mutation-proven** (reverting to a forced 1-channel tap fails it).
- `CExceptionCatcherTests` — the shim's raise→throw bridge.
- `MicRestartRetryPolicyTests` — backoff schedule + give-up boundary.
- **Fault-injection e2e** (`scripts/e2e-app.sh --mic-device-change`, dispatch-only `e2e-mic-device-change.yml`): a compile-gated seam (`-DE2E_FAULT_INJECTION`, physically absent from every shipped binary — the seam is a DI hook with the gate at the app composition root) self-triggers a device-change restart with an invalid format; the lane asserts the app survives (no SIGABRT) and the recording completes. Proven red→green on the self-hosted Mini.

## What we could not reproduce (honest)

jhavez's *exact* crash is a real-hardware transient (Bluetooth HFP↔A2DP async format negotiation). It is **not reproducible on the CI runner's virtual devices** — BlackHole switches atomically with a valid format and tolerates a channel mismatch that real hardware rejects (verified: a real 2ch→16ch swap does not crash the unfixed app on the runner). So the e2e uses **fault injection** (synthesizing the invalid-format moment), and the deterministic regression guard for the channel-match fix is the `TapFormatResolver` unit test. A real-swap e2e lane was prototyped and confirmed vacuous on virtual devices, so it is not included.

## Out of scope (follow-up)

The secondary WAV-durability bug in #379 (the recording's WAV header is left unfinalized on a crash) — recover/repair on next launch — is tracked separately. This PR does not auto-close #379.
