### PR TITLE
ci: skip app build and tests for landing-site-only changes

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,5 +1,7 @@
 # Shared dorny/paths-filter definitions. Referenced by ci.yml and release.yml
-# so docs-only PRs reliably skip both the test matrix and the DMG build.
+# so docs- and landing-site-only PRs reliably skip both the test matrix and the
+# DMG build. The site/ tree is the GitHub Pages landing page; it deploys via its
+# own pages.yml workflow and never affects the app build or tests.
 #
 # Use with `predicate-quantifier: every` — with the v4 default `some`, the
 # `**` catch-all alone marks every file as matched and the `!…` negations
@@ -9,5 +11,6 @@ code:
   - '!*.md'
   - '!**/*.md'
   - '!docs/**'
+  - '!site/**'
   - '!LICENSE'
   - '!.gitignore'


### PR DESCRIPTION
The `site/` landing page deploys through its own `pages.yml` workflow and never touches the Swift app — yet the recent favicon PR (#382), which only changed `site/`, still ran the full `lint` / `analyze` / `test (homebrew|appstore)` matrix plus the `build (homebrew|appstore)` DMG jobs. That's because `site/` matched the shared `code` paths-filter in `.github/filters.yml`.

This adds `!site/**` to that filter — the same mechanism that already short-circuits docs-only PRs.

How it behaves:
- **Site-only PR** → `code=false` → the gated jobs in `ci.yml` (`lint`, `analyze`, `test`, `audiotap-coverage`) and `release.yml` (`build`) are skipped. Skipped required checks count as success in branch protection, so the PR stays mergeable without spinning up the build.
- **PR touching app code (with or without site changes)** → at least one changed file still matches `code` → `code=true` → full CI runs as before.

This PR itself touches `.github/`, so it runs the full suite — which confirms the gate still fires for non-site changes. The skip path will be exercised by the next site-only PR.