### PR TITLE
fix(app): repair unfinalized recordings on launch (issue #379 durability)

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Observation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PipelineController")
 
 // MARK: - PipelineController
 
@@ -89,7 +92,18 @@ final class PipelineController {
         // Fire-and-forget: dir scan + per-file attr probes run off-main so app
         // startup (and the first call to `enqueueFiles`) isn't blocked by a slow
         // filesystem. Recovered jobs appear in `queue.jobs` once the scan returns.
-        Task { await q.recoverOrphanedRecordings() }
+        Task {
+            // Rescue recordings whose writer was killed mid-stream: repair any
+            // unfinalized WAV headers (#379) before the orphan scan, so the
+            // audio is readable again. Detached so the dir scan + per-file
+            // header rewrites run off-main and don't block startup (same reason
+            // the orphan scan below offloads its own filesystem work).
+            await Task.detached(priority: .utility) {
+                let repaired = WavHeaderRepair.repairUnfinalized(in: AppPaths.recordingsDir)
+                if repaired > 0 { logger.info("Repaired \(repaired) unfinalized recording(s) on launch") }
+            }.value
+            await q.recoverOrphanedRecordings()
+        }
         q.refreshKnownSpeakerNames()
         return q
     }

--- a/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
+++ b/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Repairs an unfinalized WAV — one whose `RIFF`/`data` chunk sizes were left
+/// at placeholder values because the writer was killed before it closed the
+/// file (issue #379 secondary bug: a crash mid-recording leaves the header
+/// unfinalized, so the file reads as 0 frames even though the PCM is intact).
+/// Rewrites the two size fields from the actual on-disk size so the audio is
+/// readable again.
+enum WavHeaderRepair {
+    /// Repairs `url` if its header looks unfinalized. Returns true if it
+    /// rewrote the file, false if the header was already valid (or the file
+    /// isn't a WAV we can repair). Operates at the byte level, so it works even
+    /// when AVAudioFile can't open the corrupted file.
+    @discardableResult
+    static func repairIfNeeded(at url: URL) throws -> Bool {
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+
+        let fileSize = try Int(handle.seekToEnd())
+        guard fileSize >= 12 else { return false }
+
+        try handle.seek(toOffset: 0)
+        guard let riffHeader = try handle.read(upToCount: 12), riffHeader.count == 12,
+              isFourCC(riffHeader, 0, "RIFF"), isFourCC(riffHeader, 8, "WAVE")
+        else { return false }
+
+        // Walk the chunk list (JUNK, fmt, …) by id+size until the `data` chunk.
+        // We stop AT `data` before trusting its (possibly zero) size, so an
+        // unfinalized data size doesn't derail the walk.
+        var offset = 12
+        var dataChunkOffset: Int?
+        while offset + 8 <= fileSize {
+            try handle.seek(toOffset: UInt64(offset))
+            guard let chunk = try handle.read(upToCount: 8), chunk.count == 8 else { break }
+            if isFourCC(chunk, 0, "data") { dataChunkOffset = offset; break }
+            let size = Int(u32(chunk, 4))
+            offset += 8 + size + (size & 1) // chunks are padded to an even length
+        }
+        guard let dataOffset = dataChunkOffset else { return false }
+
+        let pcmStart = dataOffset + 8
+        let actualDataSize = fileSize - pcmStart
+        guard actualDataSize > 0, actualDataSize <= Int(UInt32.max) else { return false }
+        let correctRiffSize = fileSize - 8
+
+        try handle.seek(toOffset: UInt64(dataOffset + 4))
+        let declaredDataSize = try Int(u32(handle.read(upToCount: 4) ?? Data(), 0))
+
+        // Only the unfinalized signature (data size left at 0 by a killed
+        // writer) is safe to repair. A non-zero size means the writer finalized
+        // the file — don't second-guess it (it may have trailing chunks that
+        // would make a filesize-derived size wrong, corrupting a valid file).
+        guard declaredDataSize == 0 else { return false }
+
+        try handle.seek(toOffset: UInt64(dataOffset + 4))
+        try handle.write(contentsOf: leBytes(UInt32(actualDataSize)))
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: leBytes(UInt32(correctRiffSize)))
+        return true
+    }
+
+    private static func isFourCC(_ data: Data, _ offset: Int, _ cc: String) -> Bool {
+        let start = data.startIndex + offset
+        return data[start ..< start + 4].elementsEqual(cc.utf8)
+    }
+
+    private static func u32(_ data: Data, _ offset: Int) -> UInt32 {
+        // WAV chunk sizes are little-endian; arm64/x86_64 are little-endian, so
+        // an unaligned native load yields the value directly.
+        data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) }
+    }
+
+    private static func leBytes(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.littleEndian) { Data($0) }
+    }
+}

--- a/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
+++ b/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
@@ -59,6 +59,22 @@ enum WavHeaderRepair {
         return true
     }
 
+    /// Scans `dir` (non-recursively) for `*.wav` files and repairs any with an
+    /// unfinalized header. Returns the number actually repaired. Called at
+    /// launch to rescue recordings whose writer was killed mid-stream (#379).
+    @discardableResult
+    static func repairUnfinalized(in dir: URL) -> Int {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil,
+        ) else { return 0 }
+        var repaired = 0
+        for url in entries where url.pathExtension.lowercased() == "wav" {
+            if (try? repairIfNeeded(at: url)) == true { repaired += 1 }
+        }
+        return repaired
+    }
+
     private static func isFourCC(_ data: Data, _ offset: Int, _ cc: String) -> Bool {
         let start = data.startIndex + offset
         return data[start ..< start + 4].elementsEqual(cc.utf8)

--- a/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
+++ b/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
@@ -17,8 +17,8 @@ final class WavHeaderRepairTests: XCTestCase {
     /// Writes a real 16 kHz mono Int16 WAV via AVAudioFile and returns its URL
     /// + finalized frame count. The AVAudioFile closes (finalizes the header)
     /// when it goes out of scope at the end of this function.
-    private func writeFinalizedWav(seconds: Double) throws -> (url: URL, frames: AVAudioFramePosition) {
-        let url = tempURL()
+    private func writeFinalizedWav(seconds: Double, at target: URL? = nil) throws -> (url: URL, frames: AVAudioFramePosition) {
+        let url = target ?? tempURL()
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: 16000.0,
@@ -102,5 +102,28 @@ final class WavHeaderRepairTests: XCTestCase {
         let repaired = try WavHeaderRepair.repairIfNeeded(at: url)
         XCTAssertFalse(repaired, "a non-WAV file must not be touched")
         XCTAssertEqual(try Data(contentsOf: url), junk, "a non-WAV file must be left unchanged")
+    }
+
+    func testRepairUnfinalizedScansDirAndFixesOnlyBrokenWavs() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wavrepairdir-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let brokenURL = dir.appendingPathComponent("crashed_mic.wav")
+        _ = try writeFinalizedWav(seconds: 0.4, at: brokenURL)
+        try corruptHeader(at: brokenURL)
+        let validURL = dir.appendingPathComponent("clean_mix.wav")
+        _ = try writeFinalizedWav(seconds: 0.4, at: validURL)
+        let validBefore = try Data(contentsOf: validURL)
+        try Data("junk".utf8).write(to: dir.appendingPathComponent("notes.txt"))
+
+        XCTAssertEqual(readableFrames(brokenURL), 0, "broken WAV starts unreadable")
+
+        let count = WavHeaderRepair.repairUnfinalized(in: dir)
+
+        XCTAssertEqual(count, 1, "only the one unfinalized WAV should be repaired")
+        XCTAssertGreaterThan(readableFrames(brokenURL), 0, "the crashed WAV is readable after the dir pass")
+        XCTAssertEqual(try Data(contentsOf: validURL), validBefore, "a finalized WAV must be left unchanged")
     }
 }

--- a/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
+++ b/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
@@ -1,0 +1,106 @@
+@preconcurrency import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+/// Issue #379 secondary bug: a crash mid-recording leaves the WAV header
+/// unfinalized (`data` size = 0, `RIFF` size = placeholder), so the file reads
+/// as 0 frames even though the PCM is intact. These tests write a real WAV via
+/// AVAudioFile (the app's exact format, incl. the JUNK chunk), corrupt the two
+/// size fields to mimic the crash, and assert `WavHeaderRepair` makes it
+/// readable again. Fully deterministic — pure byte structure, no hardware.
+final class WavHeaderRepairTests: XCTestCase {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("wavrepair-\(UUID().uuidString).wav")
+    }
+
+    /// Writes a real 16 kHz mono Int16 WAV via AVAudioFile and returns its URL
+    /// + finalized frame count. The AVAudioFile closes (finalizes the header)
+    /// when it goes out of scope at the end of this function.
+    private func writeFinalizedWav(seconds: Double) throws -> (url: URL, frames: AVAudioFramePosition) {
+        let url = tempURL()
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 16000.0,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        let frames = AVAudioFrameCount(16000.0 * seconds)
+        let length: AVAudioFramePosition
+        do {
+            let file = try AVAudioFile(forWriting: url, settings: settings)
+            let buffer = try XCTUnwrap(
+                AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frames),
+            )
+            buffer.frameLength = frames
+            if let ch = buffer.floatChannelData {
+                for i in 0 ..< Int(frames) {
+                    ch[0][i] = Float(i % 100) / 100.0
+                }
+            }
+            try file.write(from: buffer)
+            length = file.length
+        } // `file` deallocs here → header finalized on disk
+        return (url, length)
+    }
+
+    /// Mimic the crash: zero the `data` chunk size and set the `RIFF` size to a
+    /// placeholder. Locates the `data` marker by search (the crafted PCM ramp
+    /// never contains the ASCII "data"), independent of WavHeaderRepair's parse.
+    private func corruptHeader(at url: URL) throws {
+        var data = try Data(contentsOf: url)
+        let dataMarker = Data("data".utf8)
+        let r = try XCTUnwrap(data.range(of: dataMarker), "no data chunk found")
+        let sizeOffset = r.upperBound
+        data.replaceSubrange(sizeOffset ..< sizeOffset + 4, with: [0, 0, 0, 0]) // data size = 0
+        data.replaceSubrange(4 ..< 8, with: [4, 0, 0, 0]) // RIFF size = placeholder
+        try data.write(to: url)
+    }
+
+    /// Frames AVAudioFile can read, or 0 if it can't even open the file — an
+    /// unfinalized header may make AVAudioFile throw rather than report 0 frames.
+    private func readableFrames(_ url: URL) -> AVAudioFramePosition {
+        (try? AVAudioFile(forReading: url))?.length ?? 0
+    }
+
+    func testRepairsUnfinalizedWavSoItReadsAgain() throws {
+        let (url, _) = try writeFinalizedWav(seconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: url) }
+        // Baseline against the finalized file's READ-BACK length (the true
+        // on-disk frame count the repair must restore), not the write-side
+        // file.length.
+        let originalFrames = readableFrames(url)
+        XCTAssertGreaterThan(originalFrames, 0, "baseline WAV should have frames")
+
+        try corruptHeader(at: url)
+        XCTAssertEqual(readableFrames(url), 0, "corruption should make the file unreadable/empty (the bug)")
+
+        let repaired = try WavHeaderRepair.repairIfNeeded(at: url)
+        XCTAssertTrue(repaired, "should report it repaired an unfinalized file")
+        XCTAssertEqual(readableFrames(url), originalFrames, "repaired file should read the original frames")
+    }
+
+    func testLeavesAlreadyFinalizedWavUntouched() throws {
+        let (url, _) = try writeFinalizedWav(seconds: 0.3)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let before = try Data(contentsOf: url)
+
+        let repaired = try WavHeaderRepair.repairIfNeeded(at: url)
+        XCTAssertFalse(repaired, "a finalized WAV must not be reported as repaired")
+        XCTAssertEqual(try Data(contentsOf: url), before, "a finalized WAV must be left byte-for-byte unchanged")
+    }
+
+    func testIgnoresNonWavFile() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let junk = Data("not a wav file at all, just some bytes".utf8)
+        try junk.write(to: url)
+
+        let repaired = try WavHeaderRepair.repairIfNeeded(at: url)
+        XCTAssertFalse(repaired, "a non-WAV file must not be touched")
+        XCTAssertEqual(try Data(contentsOf: url), junk, "a non-WAV file must be left unchanged")
+    }
+}


### PR DESCRIPTION
## Problem

Issue #379 had two bugs. The crash itself (uncatchable `installTapOnBus`
NSException on a mic device change) was fixed in #381. This PR fixes the
**secondary** bug surfaced in the same report: a crash mid-recording leaves the
mic WAV's header **unfinalized**.

`AVAudioFile` only writes the real `RIFF`/`data` chunk sizes when it closes
(on `stop()`/dealloc). If the writer is killed first, the header keeps its
placeholder values — `data` chunk size `0`, `RIFF` size a placeholder — so the
file reads as **0 frames** even though the PCM is fully intact. `afinfo`
reports `0.000000 s` and the recording looks empty. The reporter recovered
~22 min of audio by hand-rewriting those two size fields.

## Fix

- **`WavHeaderRepair.repairIfNeeded(at:)`** — walks the RIFF chunk list to find
  the `data` chunk (robust to the ~4 KB `JUNK` alignment chunk `AVAudioFile`
  writes), and **only when the `data` size is `0`** (the unfinalized signature)
  rewrites the `data` + `RIFF` sizes from the actual on-disk file size. A
  validly-finalized file (non-zero `data` size) is never touched. Byte-level, so
  it repairs files `AVAudioFile` can't even open.
- **`WavHeaderRepair.repairUnfinalized(in:)`** — scans the recordings dir for
  `*.wav` and repairs any unfinalized header. `PipelineController` runs it at
  launch (in a detached utility task, off the main actor) before
  `recoverOrphanedRecordings`.

## Scope

Readability only — this makes a crashed recording's audio openable again
(automating the manual recovery). It does **not** re-process the recording: a
crash leaves no mix file, so re-mixing app + mic and re-transcribing a recovered
recording is a separate follow-up.

## Tests

TDD, fully deterministic (pure byte structure, no hardware):

- write a real `AVAudioFile` WAV → corrupt the size fields to mimic the crash →
  assert it reads 0 frames → assert the repair restores the original frame count
- a finalized WAV is left byte-for-byte unchanged
- a non-WAV file is left untouched
- the dir scan repairs only the broken WAV (`count == 1`), leaves the finalized
  one unchanged

## Verification

- Full app suite green (1880 tests, parallel)
- Release-parity build green (`swift build -c release`)
- Lint/format clean
