### PR TITLE
feat(app): recover crashed recordings by re-mixing the raw temp (issue #379 durability, part 3)

### DIFF
--- a/.github/workflows/e2e-crash-recovery.yml
+++ b/.github/workflows/e2e-crash-recovery.yml
@@ -1,0 +1,63 @@
+name: E2E (Crash Recovery)
+
+# Focused live-recording E2E for issue #379 part 3: start a meeting, wait until
+# the recorder is writing its raw app temp, SIGKILL the app mid-recording (no
+# stop() — the raw _app_raw.tmp + unfinalized _mic.wav survive, no _mix.wav),
+# then relaunch and assert the orphan is re-mixed into a readable _mix.wav and a
+# pipeline job reaches done. Pre-fix the launch cleanup deletes the temp first →
+# no recovery (RED); the fix re-mixes it (GREEN).
+#
+# Kept out of the always-run e2e-app.yml sequence: it SIGKILLs + relaunches the
+# shared bundle mid-run, which would disrupt the other lanes. Dispatch-only: run
+# manually when touching the recovery / recorder-teardown path or before a
+# release. GitHub indexes workflow_dispatch from the default branch, so this is
+# dispatchable once merged: gh workflow run e2e-crash-recovery.yml
+on:
+  workflow_dispatch:
+
+# Shares e2e-app.yml's concurrency group so the two never race for the
+# BlackHole input device / RPC port / deployed bundle on the Mini.
+concurrency:
+  group: e2e-app-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-crash-recovery:
+    runs-on: [self-hosted, macOS, ARM64, audio]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/verify-xcode
+
+      - name: Install Developer ID certificate
+        id: dev-id
+        uses: ./.github/actions/install-developer-id
+        with:
+          cert: ${{ secrets.DEVELOPER_ID_CERT }}
+          cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          keychain-name: e2e-signing.keychain-db
+          extra-partition-roles: "codesign:"
+
+      - name: Export keychain path for e2e-app.sh
+        if: steps.dev-id.outputs.keychain-path != ''
+        run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
+
+      - name: Run crash-recovery E2E (issue #379 part 3)
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
+        run: bash scripts/e2e-app.sh --crash-recovery
+
+      - name: Upload simulator log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: meeting-simulator.log
+          path: /tmp/e2e-app-sim.log
+          if-no-files-found: ignore
+
+      - name: Cleanup signing keychain
+        if: always() && env.E2E_SIGNING_KEYCHAIN != ''
+        run: security delete-keychain "$E2E_SIGNING_KEYCHAIN" 2>/dev/null || true

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -81,31 +81,141 @@ class DualSourceRecorder: RecordingProvider {
         return captureSession?.micLevelDBFS ?? -120
     }
 
-    private let recordRate = 48000
+    /// Default app-audio capture format. Static so crash recovery — which has
+    /// no live capture session to read the actual format from — can reconstruct
+    /// the `buildRecording` input. When a mic track survives, `buildRecording`
+    /// cross-checks the rate from its duration; an app-only crash falls back to
+    /// this requested rate (a renegotiated device could then be mis-rated, but
+    /// the audio is recovered, not lost).
+    nonisolated static let defaultRecordRate = 48000
+    nonisolated static let defaultAppChannels = 2
+
+    private let recordRate = DualSourceRecorder.defaultRecordRate
     private let targetRate = AudioConstants.targetSampleRate
-    private let appChannels = 2
+    private let appChannels = DualSourceRecorder.defaultAppChannels
 
     /// Recordings directory.
     static var recordingsDir: URL {
         AppPaths.recordingsDir
     }
 
-    /// Suffix on the merged-output WAV file, used by downstream code (the
-    /// record-only sidecar writer) to recover the recording basename.
-    static let mixFilenameSuffix = RecordingFileSuffix.mix
-
-    /// Remove leftover `*_app_raw.tmp` files from a previous crash.
-    static func cleanupTempFiles(recordingsDir: URL = AppPaths.recordingsDir) {
+    /// Remove leftover `*_app_raw.tmp` files a previous crash left behind. Run
+    /// AFTER `recoverCrashedRecordings` (which consumes the recoverable ones via
+    /// `buildRecording`) so a rescuable recording isn't deleted before it's
+    /// re-mixed — only genuinely unusable temps (e.g. 0-byte) remain to delete.
+    ///
+    /// `minAge` skips a temp still being written by an in-progress recording
+    /// (recent mtime). This runs in the launch queue-build Task, which a
+    /// watch-start fires immediately before the loop may begin a new recording;
+    /// without the guard an unconditional delete could race a live temp and
+    /// silently drop its app track. Same guard as `recoverCrashedRecordings`.
+    nonisolated static func cleanupTempFiles(
+        recordingsDir: URL = AppPaths.recordingsDir,
+        minAge: TimeInterval = 30,
+    ) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: recordingsDir,
             includingPropertiesForKeys: nil,
         ) else { return }
+        let cutoff = Date().addingTimeInterval(-minAge)
 
-        for file in entries where file.lastPathComponent.hasSuffix("_app_raw.tmp") {
+        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.appRaw) {
+            if let mtime = (try? fm.attributesOfItem(atPath: file.path)[.modificationDate]) as? Date,
+               mtime > cutoff { continue }
             try? fm.removeItem(at: file)
             logger.info("Removed orphaned temp file: \(file.lastPathComponent)")
         }
+    }
+
+    // MARK: - Crash recovery (#379 durability, part 3)
+
+    /// Stems of recordings whose writer was killed mid-capture: a leftover
+    /// `_app_raw.tmp` with no matching `_mix.wav`. In the normal flow
+    /// `buildRecording` deletes the `.tmp` once the mix exists, so a surviving
+    /// `.tmp` means `stop()` never ran. Pure — operates on filenames only.
+    nonisolated static func crashedRecordingStems(in filenames: [String]) -> [String] {
+        let mixStems = Set(filenames.compactMap { name -> String? in
+            name.hasSuffix(RecordingFileSuffix.mix)
+                ? String(name.dropLast(RecordingFileSuffix.mix.count)) : nil
+        })
+        var seen = Set<String>()
+        var stems: [String] = []
+        for name in filenames where name.hasSuffix(RecordingFileSuffix.appRaw) {
+            let stem = String(name.dropLast(RecordingFileSuffix.appRaw.count))
+            guard !mixStems.contains(stem), seen.insert(stem).inserted else { continue }
+            stems.append(stem)
+        }
+        return stems
+    }
+
+    /// Re-mix one crashed recording's surviving raw app track (+ mic, if
+    /// present) into a `_mix.wav`, reusing the normal `buildRecording` path. The
+    /// mic WAV header is repaired first (a crash leaves it unfinalized). The
+    /// per-track `micDelay` is unrecoverable after a crash, so the tracks are
+    /// mixed from their file starts — a sub-100 ms drift vs. a clean recording,
+    /// an acceptable cost to rescue audio that would otherwise be lost.
+    @discardableResult
+    nonisolated static func recoverCrashedRecording(stem: String, in recDir: URL) throws -> URL {
+        let appTmp = recDir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+        let micWav = recDir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        let hasMic = FileManager.default.fileExists(atPath: micWav.path)
+        if hasMic { _ = try? WavHeaderRepair.repairIfNeeded(at: micWav) }
+
+        let result = AudioCaptureResult(
+            appAudioFileURL: appTmp,
+            micAudioFileURL: hasMic ? micWav : nil,
+            actualSampleRate: defaultRecordRate,
+            actualChannels: defaultAppChannels,
+            micDelay: 0,
+        )
+        let recording = try buildRecording(
+            from: result,
+            recordingsDir: recDir,
+            timestamp: stem,
+            recordingStart: 0,
+            format: CaptureFormat(
+                requestedChannels: defaultAppChannels,
+                requestedRate: defaultRecordRate,
+                targetRate: AudioConstants.targetSampleRate,
+            ),
+        )
+        return recording.mixPath
+    }
+
+    /// Scan `dir` for crashed recordings (see `crashedRecordingStems`) and
+    /// re-mix each. Returns the count recovered; ones that can't be re-mixed
+    /// (e.g. a 0-byte temp) are left for `cleanupTempFiles`. Runs from the
+    /// launch queue-build (the first watch-start / enqueue), before
+    /// `recoverOrphanedRecordings` enqueues the recovered `_mix.wav`.
+    ///
+    /// `minAge` skips a `.tmp` still being written by an in-progress recording
+    /// (its mtime is recent; a crashed recording's temp predates the relaunch
+    /// gap). The queue-build Task that calls this is fired by a watch-start
+    /// immediately before the loop may begin a new recording, so the guard is
+    /// load-bearing — not cosmetic.
+    @discardableResult
+    nonisolated static func recoverCrashedRecordings(
+        in dir: URL = AppPaths.recordingsDir,
+        minAge: TimeInterval = 30,
+    ) -> Int {
+        let fm = FileManager.default
+        let names = (try? fm.contentsOfDirectory(atPath: dir.path)) ?? []
+        let cutoff = Date().addingTimeInterval(-minAge)
+        var recovered = 0
+        for stem in crashedRecordingStems(in: names) {
+            let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+            if let mtime = (try? fm.attributesOfItem(atPath: appTmp.path)[.modificationDate]) as? Date,
+               mtime > cutoff { continue }
+            do {
+                let mix = try recoverCrashedRecording(stem: stem, in: dir)
+                logger.info("Recovered crashed recording: \(mix.lastPathComponent)")
+                recovered += 1
+            } catch {
+                logger.warning("Could not recover crashed recording \(stem): \(error.localizedDescription)")
+            }
+        }
+        return recovered
     }
 
     /// Optional live-buffer sinks installed by an external live transcription
@@ -134,7 +244,7 @@ class DualSourceRecorder: RecordingProvider {
         startTimestamp = ts
 
         // ── AudioTapLib capture session ──
-        let appTempURL = recDir.appendingPathComponent("\(ts)_app_raw.tmp")
+        let appTempURL = recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.appRaw)")
         let micURL: URL? = noMic ? nil : recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mic)")
 
         // Electron/WebView2 apps (Teams 2.x, Slack, Discord) render call
@@ -214,7 +324,7 @@ class DualSourceRecorder: RecordingProvider {
     /// + resample the app track, load the mic track, then mix or fall back to a
     /// single track. Pure file-processing — no capture session, no `@available`
     /// gate — so it is unit-testable with fixture files.
-    static func buildRecording( // swiftlint:disable:this function_body_length
+    nonisolated static func buildRecording( // swiftlint:disable:this function_body_length
         from captureResult: AudioCaptureResult,
         recordingsDir recDir: URL,
         timestamp ts: String,
@@ -314,7 +424,7 @@ class DualSourceRecorder: RecordingProvider {
         // ── Mix via AudioMixer ──
         // Both app and mic are already at 16kHz at this point.
         let mixRate = format.targetRate
-        let mixPath = recDir.appendingPathComponent("\(ts)\(Self.mixFilenameSuffix)")
+        let mixPath = recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mix)")
 
         if let app = appPath, let mic = micPath {
             // Delegate mute masking, echo suppression, delay alignment, and mixing
@@ -361,7 +471,7 @@ class DualSourceRecorder: RecordingProvider {
     }
 
     /// Downmix interleaved multi-channel audio to mono. Passthrough if already mono.
-    static func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
+    nonisolated static func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
         guard channels >= 2, samples.count >= channels else { return samples }
         let n = samples.count - (samples.count % channels)
         var mono = [Float](repeating: 0, count: n / channels)
@@ -379,7 +489,7 @@ class DualSourceRecorder: RecordingProvider {
     /// Cross-check the device-reported sample rate against raw file size and mic duration.
     /// Returns the corrected rate (snapped to standard), or the device rate if cross-check
     /// is unavailable or agrees.
-    static func crossCheckAppRate(
+    nonisolated static func crossCheckAppRate(
         deviceRate: Int,
         appRawBytes: Int,
         appChannels: Int,

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -53,7 +53,10 @@ struct MeetingTranscriberApp: App {
     init() {
         AppPaths.migrateIfNeeded()
         NotificationManager.shared.setUp()
-        DualSourceRecorder.cleanupTempFiles()
+        // Temp-file cleanup moved into the queue-build recovery flow
+        // (`PipelineController.makeQueue`): a crashed `_app_raw.tmp` must be
+        // re-mixed by `recoverCrashedRecordings` BEFORE it's cleaned up, so the
+        // delete can no longer run first here (issue #379).
         let suppressAutoWatch = ProcessInfo.processInfo.environment["MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH"] == "1"
         // Auto-watch: schedule on main run loop after app finishes launching.
         // E2E drivers that force channel-health flags via env var also set

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -93,14 +93,20 @@ final class PipelineController {
         // startup (and the first call to `enqueueFiles`) isn't blocked by a slow
         // filesystem. Recovered jobs appear in `queue.jobs` once the scan returns.
         Task {
-            // Rescue recordings whose writer was killed mid-stream: repair any
-            // unfinalized WAV headers (#379) before the orphan scan, so the
-            // audio is readable again. Detached so the dir scan + per-file
-            // header rewrites run off-main and don't block startup (same reason
-            // the orphan scan below offloads its own filesystem work).
+            // Rescue recordings whose writer was killed mid-stream (#379), then
+            // hand off to the orphan scan which enqueues the results. Detached
+            // so the dir scans + per-file rewrites/re-mixes run off-main and
+            // don't block startup (same reason the orphan scan offloads its own
+            // filesystem work). Order matters:
+            //   1. repair unfinalized WAV headers so a crashed mic track reads,
+            //   2. re-mix crashed recordings (raw app .tmp + mic) into a _mix.wav,
+            //   3. delete any temp the re-mix couldn't use.
             await Task.detached(priority: .utility) {
                 let repaired = WavHeaderRepair.repairUnfinalized(in: AppPaths.recordingsDir)
                 if repaired > 0 { logger.info("Repaired \(repaired) unfinalized recording(s) on launch") }
+                let recovered = DualSourceRecorder.recoverCrashedRecordings()
+                if recovered > 0 { logger.info("Recovered \(recovered) crashed recording(s) on launch") }
+                DualSourceRecorder.cleanupTempFiles()
             }.value
             await q.recoverOrphanedRecordings()
         }

--- a/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
+++ b/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
@@ -6,6 +6,11 @@ enum RecordingFileSuffix {
     static let app = "_app.wav"
     static let mic = "_mic.wav"
 
+    /// Raw interleaved-float32 app-audio temp file written live during capture
+    /// and consumed by `buildRecording` at `stop()`. A leftover one means the
+    /// writer was killed mid-recording (crash) — see `recoverCrashedRecordings`.
+    static let appRaw = "_app_raw.tmp"
+
     static let all: [String] = [mix, app, mic]
 
     static func stripSuffix(from filename: String) -> (stem: String, suffix: String)? {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -28,11 +28,27 @@ final class DualSourceRecorderTests: XCTestCase {
         let wavFile = tmpDir.appendingPathComponent("20260311_100000_mix.wav")
         try Data("tmp".utf8).write(to: tmpFile)
         try Data("wav".utf8).write(to: wavFile)
+        // A leftover crash temp is older than the in-progress guard.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: tmpFile.path,
+        )
 
         DualSourceRecorder.cleanupTempFiles(recordingsDir: tmpDir)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: tmpFile.path), "tmp file should be removed")
         XCTAssertTrue(FileManager.default.fileExists(atPath: wavFile.path), "wav file should be kept")
+    }
+
+    func testCleanupKeepsInProgressTmp() throws {
+        let tmpDir = try makeTempDirectory(prefix: "cleanup_inprogress")
+        // A freshly-written temp (recent mtime) is an in-progress recording,
+        // not a crash leftover — cleanup must leave it for the live recorder.
+        let tmpFile = tmpDir.appendingPathComponent("20260311_100000_app_raw.tmp")
+        try Data("tmp".utf8).write(to: tmpFile)
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: tmpDir)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tmpFile.path), "a fresh in-progress temp must be kept")
     }
 
     func testCleanupNonexistentDirIsNoOp() {
@@ -164,6 +180,12 @@ final class DualSourceRecorderTests: XCTestCase {
         let wav1 = tmpDir.appendingPathComponent("20260311_100000_mix.wav")
         for file in [tmp1, tmp2, wav1] {
             try Data("x".utf8).write(to: file)
+        }
+        // Both temps are stale crash leftovers (older than the in-progress guard).
+        for tmp in [tmp1, tmp2] {
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: tmp.path,
+            )
         }
 
         DualSourceRecorder.cleanupTempFiles(recordingsDir: tmpDir)
@@ -452,5 +474,68 @@ final class DualSourceRecorderTests: XCTestCase {
 
         XCTAssertNotNil(result.appPath, "rate mismatch should still produce an app track")
         XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
+    }
+
+    // MARK: - Crash recovery (#379 durability, part 3)
+
+    /// Only a `_app_raw.tmp` with no matching `_mix.wav` is a crash orphan:
+    /// one that already has a mix was processed, and a lone `_mic.wav` (no
+    /// raw app temp) isn't an app-track orphan.
+    func testCrashedRecordingStemsDetectsTmpWithoutMix() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_app_raw.tmp", // crashed: temp, no mix
+            "20260311_100000_mic.wav",
+            "20260311_110000_app_raw.tmp", // already processed: temp + mix
+            "20260311_110000_mix.wav",
+            "20260311_120000_mic.wav", // mic only, no temp → not an app orphan
+            "notes.txt",
+        ])
+        XCTAssertEqual(stems, ["20260311_100000"])
+    }
+
+    /// A crashed recording (surviving raw app `.tmp` + mic WAV, no mix) is
+    /// re-mixed into a readable `_mix.wav` and the raw temp is consumed.
+    func testRecoverCrashedRecordingsRemixesOrphanedRawAppAndMic() throws {
+        let dir = try makeTempDirectory(prefix: "crash_recover")
+        let stem = "20260311_140000"
+        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        // 1 s of 48 kHz interleaved stereo — the surviving raw app track.
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        // A crashed recording's temp predates the relaunch — backdate it past
+        // the in-progress guard.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
+        )
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 1, "the crashed recording should be recovered")
+        let mix = dir.appendingPathComponent(stem + "_mix.wav")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mix.path), "a mix should be produced")
+        XCTAssertGreaterThan(
+            try AudioMixer.loadAudioFileAsFloat32(url: mix).count, 0,
+            "the recovered mix should contain audio",
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: appTmp.path), "the raw temp should be consumed")
+    }
+
+    /// A freshly-written `.tmp` (recent mtime) looks like an in-progress
+    /// recording, not a crash — recovery must leave it untouched.
+    func testRecoverCrashedRecordingsSkipsInProgressTemp() throws {
+        let dir = try makeTempDirectory(prefix: "crash_inprogress")
+        let stem = "20260311_150000"
+        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 0, "an in-progress (fresh) temp must not be recovered")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appTmp.path), "the temp must be left untouched")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent(stem + "_mix.wav").path),
+            "no mix should be produced for an in-progress temp",
+        )
     }
 }

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -33,6 +33,7 @@ REIMPORT_RECORDED=false  # chain a record-only meeting with re-import via POST /
 REIMPORT_LATEST=false    # skip live-record phase, re-import the freshest *_mix.wav already on disk
 KEEP_RECORDINGS=false    # leave record-only output on disk for a follow-up --reimport-latest run
 MIC_DEVICE_CHANGE=false  # build the issue #379 fault-injection seam + assert the app survives it
+CRASH_RECOVERY=false     # kill mid-recording + assert the orphan is re-mixed on relaunch (issue #379 part 3)
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -46,6 +47,7 @@ while [ $# -gt 0 ]; do
         --reimport-latest)  REIMPORT_LATEST=true ;;
         --keep-recordings)  KEEP_RECORDINGS=true ;;
         --mic-device-change) MIC_DEVICE_CHANGE=true ;;
+        --crash-recovery)   CRASH_RECOVERY=true ;;
         -h|--help)
             cat <<'HELP'
 Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
@@ -83,6 +85,13 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
                        and the recording still completes. Pre-fix this crashes;
                        the fix must catch + recover. Requires a build (incompatible
                        with --no-build).
+  --crash-recovery     Issue #379 part 3: start a meeting, wait until the
+                       recorder is writing its raw app temp, then SIGKILL the
+                       app mid-recording (no stop() -> the raw _app_raw.tmp +
+                       unfinalized _mic.wav survive, no _mix.wav). Relaunch and
+                       assert the orphan is re-mixed into a readable _mix.wav and
+                       the temp consumed. Pre-fix the launch cleanup deletes the
+                       temp -> no recovery (RED); the fix re-mixes it (GREEN).
   --fixture            Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -391,6 +400,13 @@ on_exit() {
     if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
         _delete_dev_default diarizerMode
     fi
+    # Crash-recovery: remove only THIS run's recording artifacts (the exact
+    # stem we created). Stem-targeted, so it never touches pre-existing user
+    # recordings. See feedback memory `no_destructive_fs_on_real_dirs`.
+    if [ "$CRASH_RECOVERY" = true ] && [ -n "${CRASH_STEM:-}" ]; then
+        rm -f "$CRASH_RECORDINGS/${CRASH_STEM}"* 2>/dev/null || true
+        [ -n "${CRASH_MARKER:-}" ] && rm -f "$CRASH_MARKER"
+    fi
 }
 trap on_exit EXIT INT TERM
 
@@ -695,6 +711,94 @@ run_one_reimport() {
 
 LAST_RECORDED_MIX_PATH=""
 
+# Issue #379 part 3 — crash recovery. Record via the live stack, SIGKILL the
+# app mid-recording so `stop()` never runs (the raw `_app_raw.tmp` + unfinalized
+# `_mic.wav` survive, no `_mix.wav`), then relaunch and assert the orphan is
+# re-mixed into a readable `_mix.wav` and the temp consumed. Pre-fix the launch
+# cleanup deletes the temp first → no recovery (RED); the fix re-mixes it (GREEN).
+#
+# Live temps go to AppPaths.recordingsDir (Application Support), NOT the
+# record-only Downloads dir — recovery scans the same path.
+CRASH_RECORDINGS="$HOME/Library/Application Support/MeetingTranscriber/recordings"
+CRASH_MARKER=""
+CRASH_STEM=""
+run_crash_recovery() {
+    local label="[crash-recovery]"
+    mkdir -p "$CRASH_RECORDINGS"
+    CRASH_MARKER="/tmp/e2e-crash-recovery-marker.$$"
+    rm -f "$CRASH_MARKER"; touch "$CRASH_MARKER"
+
+    # Baseline the pre-crash lastJob now (RPC is already up from launch). The
+    # recovered recording gets a fresh job id after relaunch, so this stable
+    # baseline can never equal the recovered job — avoids a race where recovery
+    # enqueues before we could sample a post-relaunch baseline.
+    PRE_LAST_JOB_ID="$(rpc /state | jq -r '.lastJob.jobID // empty')"
+    log "$label: pre-crash baseline lastJob.jobID=${PRE_LAST_JOB_ID:-<none>}"
+
+    # 1. Start a meeting so the app begins recording.
+    log "$label: starting meeting-simulator -> $SIMULATOR_FIXTURE"
+    "$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" >/tmp/e2e-app-sim.log 2>&1 &
+    SIM_PID=$!
+
+    # 2. Wait until the recorder is writing the raw app temp (recording active).
+    local orphan_tmp=""
+    _crash_tmp_appeared() {
+        orphan_tmp="$(find "$CRASH_RECORDINGS" -maxdepth 1 -name '*_app_raw.tmp' -newer "$CRASH_MARKER" -print 2>/dev/null | head -1)"
+        [ -n "$orphan_tmp" ]
+    }
+    log "$label: waiting for an active recording (*_app_raw.tmp)"
+    poll_until 40 1 _crash_tmp_appeared || fail "$label: no *_app_raw.tmp appeared — recording never started"
+    sleep 3   # let a little audio accumulate before the kill
+
+    CRASH_STEM="$(basename "$orphan_tmp")"; CRASH_STEM="${CRASH_STEM%_app_raw.tmp}"
+    local stem="$CRASH_STEM"
+    log "$label: recording active, orphan stem=$stem"
+
+    # 3. Simulate a crash: SIGKILL the app (no stop() → temp survives, no mix).
+    #    Kill the simulator too so the relaunch sees no active meeting — the
+    #    only recording that can surface post-relaunch is the recovered one.
+    log "$label: SIGKILL the app mid-recording (simulating a crash)"
+    pkill -KILL -f "MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" 2>/dev/null || true
+    [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
+    SIM_PID=""
+    sleep 2
+
+    # 4. Verify the crashed-orphan state on disk.
+    [ -f "$CRASH_RECORDINGS/${stem}_app_raw.tmp" ] || fail "$label: orphan ${stem}_app_raw.tmp did not survive the crash"
+    [ ! -f "$CRASH_RECORDINGS/${stem}_mix.wav" ] || fail "$label: a _mix.wav exists — stop() ran, this wasn't a crash"
+    log "$label: confirmed crashed state (raw temp present, no mix)"
+
+    # 5. Backdate the orphan past recovery's in-progress guard (a real
+    #    crash→relaunch gap is minutes; keeps the e2e fast + deterministic).
+    local old; old="$(date -v-5M +%Y%m%d%H%M.%S)"
+    touch -t "$old" "$CRASH_RECORDINGS/${stem}_app_raw.tmp"
+    [ -f "$CRASH_RECORDINGS/${stem}_mic.wav" ] && touch -t "$old" "$CRASH_RECORDINGS/${stem}_mic.wav" || true
+
+    # 6. Relaunch — recovery runs at the launch queue-build.
+    log "$label: relaunching $DEV_BUNDLE_DEPLOY"
+    open "$DEV_BUNDLE_DEPLOY"
+    poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready || fail "$label: RPC did not come back after relaunch"
+    log "$label: RPC back up after relaunch"
+
+    # 7. Assert recovery: the orphan is re-mixed into a readable _mix.wav and
+    #    the raw temp is consumed. This is the crisp red/green signal.
+    log "$label: waiting for the recovered ${stem}_mix.wav (timeout 90s)"
+    _crash_mix_appeared() { [ -f "$CRASH_RECORDINGS/${stem}_mix.wav" ]; }
+    poll_until 90 2 _crash_mix_appeared \
+        || fail "$label: orphan NOT recovered — no ${stem}_mix.wav after relaunch (recovery missing, or the temp was deleted by launch cleanup)"
+    local mix_size
+    mix_size="$(wc -c <"$CRASH_RECORDINGS/${stem}_mix.wav" | tr -d ' ')"
+    [ "$mix_size" -gt 65536 ] || fail "$label: recovered mix suspiciously small: $mix_size bytes (expected > 64 KB)"
+    [ ! -f "$CRASH_RECORDINGS/${stem}_app_raw.tmp" ] || fail "$label: raw temp not consumed after recovery"
+    log "$label: recovered ${stem}_mix.wav ($mix_size bytes), raw temp consumed ✅"
+
+    # 8. Full chain: the recovered mix is enqueued by recoverOrphanedRecordings
+    #    → assert a new pipeline job reaches done.
+    _poll_for_new_lastjob_terminal "$label"
+    [ "$POLL_LJ_STATE" = "done" ] || fail "$label: recovered job state=$POLL_LJ_STATE, expected done"
+    log "$label: recovered recording transcribed (lastJob done) ✅"
+}
+
 if [ "$REIMPORT_LATEST" = true ]; then
     # Skip the live-record phase and reuse a WAV produced by an earlier
     # `--record-only --keep-recordings` run on this host. Picks the
@@ -754,6 +858,8 @@ elif [ "$MIC_DEVICE_CHANGE" = true ]; then
     run_one_meeting "[mic-device-change]"
     assert_app_alive
     log "[mic-device-change] app survived the injected device-change restart ✅"
+elif [ "$CRASH_RECOVERY" = true ]; then
+    run_crash_recovery
 elif [ "$TWO_MEETINGS" = true ]; then
     run_one_meeting "[1/2]"
     log "Sleeping ${INTER_MEETING_COOLDOWN_S}s for WatchLoop cooldown before meeting 2"


### PR DESCRIPTION
## Problem

Follow-up to #384 (issue #379 durability). Parts 1+2 made a crashed recording's
mic WAV *readable* again, but the recording still wasn't *recovered*:

- A crash mid-recording leaves the app/remote track as a **headerless
  `<stem>_app_raw.tmp`** (consumed into the mix only at `stop()`, which never
  ran) and an unfinalized `<stem>_mic.wav`, with **no `_mix.wav`**.
- `DualSourceRecorder.cleanupTempFiles()` deleted that `.tmp` at launch before
  anything could use it — so the remote half of the call was lost, and a lone
  `_mic.wav` is never enqueued by the mix-centric `recoverOrphanedRecordings`.

## Fix

Recover the whole recording by reusing the existing mix path:

- **`crashedRecordingStems(in:)`** (pure) — a `_app_raw.tmp` with no `_mix.wav`
  sibling is a crash orphan (the normal flow deletes the temp once the mix
  exists, so a surviving temp means `stop()` never ran).
- **`recoverCrashedRecording(stem:in:)`** — repairs the mic header (part 1) and
  re-mixes the raw app track + mic into a `_mix.wav` by synthesizing
  `buildRecording`'s `AudioCaptureResult` from the default capture format. No
  mix logic duplicated.
- **`recoverCrashedRecordings(in:minAge:)`** — runs in the launch queue-build
  Task, after the header repair and before `recoverOrphanedRecordings` enqueues
  the result. Skips temps still being written by an in-progress recording
  (recent mtime).
- `cleanupTempFiles` moved out of the early synchronous `App.init` into that
  same off-main flow, **after** recovery, and gained the same `minAge` guard so
  it can't race a live recording's temp. `buildRecording` + its pure helpers are
  `nonisolated` so recovery runs off the main actor.

### Known limitation

The per-track `micDelay` is unrecoverable after a crash, so app + mic are mixed
from their file starts — a sub-100 ms drift vs. a clean recording. Acceptable to
rescue audio that would otherwise be lost.

## Tests

- Unit (TDD, mutation-proven): pure stem detection; a re-mix integration test
  (raw temp + mic → readable mix, temp consumed); an in-progress-temp guard
  test; updated cleanup tests pin the new age guard (stale temp removed, fresh
  temp kept).
- **`scripts/e2e-app.sh --crash-recovery`** + the dispatch-only
  `e2e-crash-recovery.yml` workflow — full production crash path on the
  self-hosted Mac: record → SIGKILL mid-recording → relaunch → assert the orphan
  is re-mixed into a readable `_mix.wav`, the temp consumed, and a pipeline job
  reaches done. Pre-fix the launch cleanup deletes the temp → RED; the fix
  re-mixes it → GREEN.

## Verification

- Full app suite green (parallel); recovery tests mutation-proven (stub
  `crashedRecordingStems` → []; the detection + re-mix tests fail, the
  in-progress-guard test stays green)
- Release-parity build green (`swift build -c release`)
- Lint/format clean
- **Mac mini crash-recovery e2e — RED confirmed**: ran `--crash-recovery`
  against the deployed pre-Stage-3 build; the orphan was *not* recovered (no
  `_mix.wav` after relaunch), exit 1 — the lane catches the missing recovery on
  the real crash path.
- The live **GREEN** on the Mini runs via the new dispatch workflow once merged
  (it needs the Developer-ID signing identity CI imports — a self-signed SSH
  build can't complete the Microphone-access gate that precedes the recovery
  trigger, so the live recording can't start under it).
