### PR TITLE
ci(e2e-app): run crash-recovery e2e as always-run final lane (issue #379)

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -35,12 +35,13 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, audio]
     # Three transcript lanes (transcript, record-only, reimport) at
     # ~4–6 min each → ~14 min observed. Plus channel-health (~30 s),
-    # silent-recording (~45 s), live-captions (~2 min) → ~17 min wall.
-    # 25 min job budget gives honest margin; each lane has its own
+    # silent-recording (~45 s), live-captions (~2 min), crash-recovery
+    # (~5 min: record → kill → relaunch → recover → transcribe) → ~22 min
+    # wall. 32 min job budget gives honest margin; each lane has its own
     # step-timeout below so a hang in lane N surfaces as `timed_out`
     # on that step (not as an opaque job-level `cancelled`). See
     # docs/plans/.local/open/2026-05-11-job-timeout-visibility.md.
-    timeout-minutes: 25
+    timeout-minutes: 32
 
     steps:
       - uses: actions/checkout@v6
@@ -221,6 +222,23 @@ jobs:
           name: live-captions-simulator.log
           path: /tmp/e2e-live-captions-sim.log
           if-no-files-found: ignore
+
+      # Crash-recovery lane (issue #379 part 3, PR #385/#386): start a meeting,
+      # SIGKILL the app mid-recording (no stop() → orphaned _app_raw.tmp +
+      # unfinalized _mic.wav, no _mix.wav survive), relaunch, and assert the
+      # launch recovery re-mixes the orphan into the pipeline and a job reaches
+      # done. Reverting the recovery wiring in DualSourceRecorder/PipelineController
+      # makes this fail (the orphan is deleted by launch cleanup, no job lands).
+      # Same dispatch-only driver as e2e-crash-recovery.yml, wired here as an
+      # always-run regression guard. Kept LAST among the test lanes: it
+      # SIGKILLs + relaunches the shared bundle, so running it after every
+      # other lane means that teardown can't disrupt them. `--no-build` reuses
+      # the bundle the first lane built + signed.
+      - name: "Run crash-recovery E2E (issue #379 part 3)"
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 10
+        run: bash scripts/e2e-app.sh --no-build --crash-recovery
 
       # Best-effort: capture the simulator's stdout for post-mortem if
       # the driver failed before tearing it down.


### PR DESCRIPTION
## What

Wire the issue #379 crash-recovery E2E into the always-run `e2e-app` job as its **final** test lane, so the recovery path gets an automatic regression guard on every main push + nightly run — not just manual dispatch.

```yaml
- name: "Run crash-recovery E2E (issue #379 part 3)"
  env:
    DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
  timeout-minutes: 10
  run: bash scripts/e2e-app.sh --no-build --crash-recovery
```

## Why

The crash-recovery driver previously lived only in the dispatch-only `e2e-crash-recovery.yml`. That gave us a proven red→green lane (recovery re-mixes a crashed `_app_raw.tmp` orphan into the pipeline) but no guard that fires automatically when someone touches the recovery / recorder-teardown path. This closes that gap.

## Placement & cost

- **Last among the test lanes by design.** The lane SIGKILLs + relaunches the shared dev bundle; running it after every other lane means that teardown can't disrupt them. Each lane is a separate `e2e-app.sh` process (`quit_running_app` → relaunch → its own CI pipeline-queue reset), so there's no cross-lane state leakage into the recovery assertion.
- `--no-build` reuses the bundle the first lane built + signed.
- Job timeout bumped **25 → 32 min**: the new lane adds ~5 min (record → kill → relaunch → recover → transcribe), pushing wall time to ~22 min; 32 keeps the same honest margin the prior budget had.

## Regression value

Reverting the recovery wiring in `DualSourceRecorder`/`PipelineController` makes this lane fail: the orphaned `_app_raw.tmp` is deleted by launch cleanup and no pipeline job lands. The lane asserts a *new* recovered job (distinct from the pre-crash baseline) reaches `done`, so a broken recovery can't false-pass.

The standalone `e2e-crash-recovery.yml` stays as-is — still useful for dispatching the recovery lane in isolation without the ~17 min of preceding lanes.

## Verification

- YAML parses; `actionlint` clean on the added lines (the only finding is the pre-existing `audio` custom-runner-label warning on the untouched `runs-on:` line).
- The `--no-build --crash-recovery` driver itself was already proven red→green on the Mac mini (RED = pre-fix app, orphan not recovered; GREEN = current main via `e2e-crash-recovery.yml` dispatch).