### PR TITLE
ci(e2e-mic-device-change): run nightly + restore canonical bundle (issue #379)

### DIFF
--- a/.github/workflows/e2e-mic-device-change.yml
+++ b/.github/workflows/e2e-mic-device-change.yml
@@ -4,14 +4,31 @@ name: E2E (Mic Device-Change)
 # device-change restart mid-recording whose tap install uses an invalid
 # format, the condition that raises an uncatchable NSException from
 # installTapOnBus. Asserts the app SURVIVES (no SIGABRT) and the recording
-# completes. It builds a deliberately-crashing (-DE2E_FAULT_INJECTION)
-# bundle, so it is kept out of the always-run e2e-app.yml sequence (whose
-# shared deploy path it would also poison). Dispatch-only: run manually when
-# touching the mic-restart path or before a release. GitHub indexes
-# workflow_dispatch from the default branch, so this is dispatchable once
-# merged: gh workflow run e2e-mic-device-change.yml
+# completes.
+#
+# It builds a deliberately-crashing (-DE2E_FAULT_INJECTION) bundle, which is
+# why it stays a SEPARATE workflow rather than a lane inside e2e-app.yml: that
+# fault build would poison e2e-app's shared deploy path. Two things keep it
+# safe to run on a schedule:
+#   1. It's its own isolated job (serialized against e2e-app via the shared
+#      concurrency group below), and e2e-app rebuilds the canonical bundle at
+#      its own first step — so the fault bundle never leaks into an e2e-app run.
+#   2. The always() "Restore canonical bundle" step below runs
+#      `e2e-app.sh --redeploy-only` to rebuild + redeploy the non-fault bundle
+#      at the shared path, so a later `--no-build` dispatch (e.g.
+#      e2e-crash-recovery.yml) can't accidentally run against the fault build.
+#
+# Runs nightly + on manual dispatch. The core crash is already guarded on every
+# CI run by the TapFormatResolver mutation test + safeInstallTap shim; this is
+# the end-to-end belt-and-suspenders. GitHub indexes workflow_dispatch from the
+# default branch: gh workflow run e2e-mic-device-change.yml
 on:
   workflow_dispatch:
+  schedule:
+    # 05:30 UTC = 07:30 CEST. Offset an hour past e2e-app.yml's 04:30 cron so
+    # the two don't queue behind each other on the shared concurrency group and
+    # are easy to tell apart in `gh run list`.
+    - cron: '30 5 * * *'
 
 # Shares e2e-app.yml's concurrency group so the two never race for the
 # BlackHole input device / RPC port / deployed bundle on the Mini.
@@ -22,7 +39,11 @@ concurrency:
 jobs:
   e2e-mic-device-change:
     runs-on: [self-hosted, macOS, ARM64, audio]
-    timeout-minutes: 15
+    # Fault run (~5 min, 10 min step cap) + the always() "Restore canonical
+    # bundle" rebuild (~3 min, 5 min step cap) + setup. 20 gives the restore
+    # step honest room even if the fault run burns its full step budget — it
+    # MUST be able to finish so the shared bundle is left clean.
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +63,7 @@ jobs:
         if: steps.dev-id.outputs.keychain-path != ''
         run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
 
-      - name: Run mic device-change fault-injection E2E (issue #379)
+      - name: "Run mic device-change fault-injection E2E (issue #379)"
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         timeout-minutes: 10
@@ -55,6 +76,20 @@ jobs:
           name: meeting-simulator.log
           path: /tmp/e2e-app-sim.log
           if-no-files-found: ignore
+
+      # Restore a clean (non-fault-injection) bundle at the shared deploy path.
+      # The run above leaves the deliberately-crashing build deployed; without
+      # this, a later `--no-build` dispatch (e2e-crash-recovery.yml, or a manual
+      # e2e-app.sh --no-build) would silently run against the fault build.
+      # always() so it restores the bundle whether the fault test passed or
+      # failed. Must precede the keychain cleanup below — it re-signs the
+      # rebuilt bundle with the same Developer ID + keychain.
+      - name: Restore canonical bundle
+        if: always()
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 5
+        run: bash scripts/e2e-app.sh --redeploy-only
 
       - name: Cleanup signing keychain
         if: always() && env.E2E_SIGNING_KEYCHAIN != ''

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -34,6 +34,7 @@ REIMPORT_LATEST=false    # skip live-record phase, re-import the freshest *_mix.
 KEEP_RECORDINGS=false    # leave record-only output on disk for a follow-up --reimport-latest run
 MIC_DEVICE_CHANGE=false  # build the issue #379 fault-injection seam + assert the app survives it
 CRASH_RECOVERY=false     # kill mid-recording + assert the orphan is recovered into the pipeline on relaunch (issue #379 part 3)
+REDEPLOY_ONLY=false      # rebuild + redeploy the canonical (non-fault) bundle and exit — restores a clean bundle after --mic-device-change
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -48,6 +49,7 @@ while [ $# -gt 0 ]; do
         --keep-recordings)  KEEP_RECORDINGS=true ;;
         --mic-device-change) MIC_DEVICE_CHANGE=true ;;
         --crash-recovery)   CRASH_RECOVERY=true ;;
+        --redeploy-only)    REDEPLOY_ONLY=true ;;
         -h|--help)
             cat <<'HELP'
 Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
@@ -94,6 +96,13 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
                        pipeline consumes it into its workdir within seconds).
                        Pre-fix the launch cleanup deletes the temp -> no
                        recovery (RED); the fix re-mixes + enqueues it (GREEN).
+  --redeploy-only      Rebuild + redeploy the canonical (non-fault-injection)
+                       bundle to ~/Applications/MeetingTranscriber-Dev.app and
+                       exit without launching or running a meeting. Used as an
+                       always() cleanup after --mic-device-change to restore a
+                       clean bundle (that run leaves a deliberately-crashing
+                       fault-injection build deployed). Requires a build
+                       (incompatible with --no-build and --mic-device-change).
   --fixture            Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -115,6 +124,16 @@ fi
 # build — `defaults`/runtime flags can't add the -DE2E_FAULT_INJECTION code.
 if [ "$MIC_DEVICE_CHANGE" = true ] && [ "$NO_BUILD" = true ]; then
     echo "Error: --mic-device-change requires a build; incompatible with --no-build" >&2
+    exit 2
+fi
+# --redeploy-only rebuilds the canonical bundle, so it must build (not --no-build)
+# and must NOT carry the fault-injection seam it exists to clean up.
+if [ "$REDEPLOY_ONLY" = true ] && [ "$NO_BUILD" = true ]; then
+    echo "Error: --redeploy-only rebuilds the bundle; incompatible with --no-build" >&2
+    exit 2
+fi
+if [ "$REDEPLOY_ONLY" = true ] && [ "$MIC_DEVICE_CHANGE" = true ]; then
+    echo "Error: --redeploy-only restores the canonical bundle; incompatible with --mic-device-change" >&2
     exit 2
 fi
 # Export before the build step below so run_app.sh adds -DE2E_FAULT_INJECTION.
@@ -272,6 +291,15 @@ else
             "$DEV_BUNDLE_DEPLOY" >/dev/null \
             || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
     fi
+fi
+
+# --redeploy-only stops here: the canonical bundle is rebuilt + deployed +
+# signed above, which is the whole job. Don't launch, don't run a meeting.
+# This is the always() cleanup the --mic-device-change workflow runs to leave
+# a clean (non-fault-injection) bundle at the shared deploy path.
+if [ "$REDEPLOY_ONLY" = true ]; then
+    log "Redeployed the canonical (non-fault-injection) bundle to $DEV_BUNDLE_DEPLOY; exiting (--redeploy-only)"
+    exit 0
 fi
 
 if [ ! -x "$SIMULATOR_BIN" ]; then


### PR DESCRIPTION
## What

Wire the issue #379 installTap-NSException fault-injection e2e (`e2e-mic-device-change.yml`, PR #381's regression) into **automatic** regression via a **nightly cron** (05:30 UTC). Previously dispatch-only.

Two commits:
1. **`ci(e2e-app)`** — add a `--redeploy-only` mode to `e2e-app.sh`: rebuild + redeploy the canonical (non-fault) bundle to the shared deploy path, then exit before launch. Reuses the existing build/deploy/sign block. Guarded incompatible with `--no-build` and `--mic-device-change`.
2. **`ci(e2e-mic-device-change)`** — add `schedule: '30 5 * * *'`, an `always()` "Restore canonical bundle" cleanup step, job timeout `15 → 20`, and quote the truncated run-step name.

## Why nightly + a separate workflow (not an e2e-app.yml lane)

Unlike the crash-recovery lane (#387, reuses the normal bundle via `--no-build`), this one builds a **deliberately-crashing `-DE2E_FAULT_INJECTION` bundle**. That can't be a lane inside `e2e-app.yml` — it would poison the shared deploy path the other `--no-build` lanes rely on. So it stays a separate, isolated job (serialized against e2e-app via the shared concurrency group), now triggered nightly.

## The poison-window fix

The `always()` **Restore canonical bundle** step runs `e2e-app.sh --redeploy-only` afterward to leave a clean bundle at the shared path — so a later `--no-build` consumer (`e2e-crash-recovery.yml`, or a manual `e2e-app.sh --no-build`) can't silently run against the fault build. This also fixes a **latent footgun**: every prior *manual* dispatch of this workflow left the fault bundle deployed.

## Note on coverage altitude

The core crash is already guarded on **every CI run** by `TapFormatResolverTests.testTapFormatPreservesChannelCount` (the mutation-proven unit test) + the `safeInstallTap` shim tests. This nightly e2e is the end-to-end belt-and-suspenders on top of that.

## Verification

- `bash -n scripts/e2e-app.sh` clean; both `--redeploy-only` guards fire (exit 2) before any build; `--help` renders the new flag.
- YAML parses; `actionlint` clean on the changed lines (only the pre-existing `audio` custom-runner-label warning on the untouched `runs-on:` line).
- Cron offset (05:30) vs e2e-app's 04:30 avoids queueing on the shared concurrency group; scheduled runs use `refs/heads/main` so the group key is stable.
- The live nightly run can only be confirmed once it fires (or via `gh workflow run e2e-mic-device-change.yml` after merge — `workflow_dispatch` indexes from the default branch).