### PR TITLE
ci(e2e): collect cpu-load trend data nightly

### DIFF
--- a/.github/workflows/e2e-cpu-load.yml
+++ b/.github/workflows/e2e-cpu-load.yml
@@ -6,12 +6,17 @@ name: E2E (CPU Load)
 # gates only a generous idle-CPU catastrophe bound — real thresholds get
 # derived from trend data later (see the RESULT artifact).
 #
-# Dispatch-only for now: the lane is in its measure-and-log phase. A nightly
-# cron + threshold gate comes once run-to-run variance is known.
-# Runner prerequisites: scripts/setup-self-hosted-runner.sh.
+# Measure-and-log phase: the nightly cron collects one RESULT artifact per
+# day to establish run-to-run variance; a threshold gate comes once that
+# variance is known. Runner prerequisites: scripts/setup-self-hosted-runner.sh.
 
 on:
   workflow_dispatch:
+  schedule:
+    # 05:15 UTC — offset from quality-and-safety (03:00) and e2e-app
+    # (04:30, ~22 min) so the audio runner is quiet when measurement
+    # starts and concurrent failures stay easy to tell apart.
+    - cron: '15 5 * * *'
 
 # Mutates host state (deploys the bundle, plays audio through the
 # speakers) and needs an otherwise-quiet app process for honest numbers —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E — fixture-based xctest on self-hosted Mac (dispatch + main push)
   e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly)
-  e2e-cpu-load.yml         # E2E — idle + in-meeting CPU/RAM measurement of the deployed app (dispatch-only, RESULT artifact for trends)
+  e2e-cpu-load.yml         # E2E — idle + in-meeting CPU/RAM measurement of the deployed app (dispatch + nightly trend cron, RESULT artifact)
   appstore.yml             # App Store variant smoke test: build + launch-check (main push + nightly + dispatch)
   build-perf-tracking.yml  # Weekly build performance trend analysis (flags regressions vs 28-day baseline)
   quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch)


### PR DESCRIPTION
Adds the nightly cron (05:15 UTC) to the CPU-load measurement lane that #390 shipped dispatch-only.

One RESULT artifact per night (idle / recording / live-captions window averages) establishes the run-to-run variance that the future threshold gate will be derived from — per the staged plan, thresholds come from measured spread, not guesses.

Schedule is offset from quality-and-safety (03:00) and the ~22-min e2e-app nightly (04:30) so the audio runner is quiet when measurement starts.