### PR TITLE
fix(app): keep recordings rate- and wall-clock-correct across mid-session device changes

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -18,10 +18,12 @@ struct RecordingResult {
     let recordingStart: TimeInterval // ProcessInfo.systemUptime
 }
 
-/// The recorder's declared capture format, passed to `buildRecording` so the
-/// processing logic stays free of instance state (and unit-testable).
-/// `requested*` are what we asked the device for (used to flag a USB/Bluetooth
-/// renegotiation in the logs); `targetRate` is the rate we resample/mix to.
+/// The format `buildRecording` should expect the app track to arrive in, passed
+/// explicitly so the processing logic stays free of instance state (and
+/// unit-testable). `requested*` describe the file the capture session is
+/// expected to produce — 16 kHz mono since `AppAudioCapture` resamples in the
+/// IOProc — so a logged mismatch flags the unexpected fallback/legacy path, not
+/// routine device renegotiation. `targetRate` is the rate we resample/mix to.
 struct CaptureFormat {
     let requestedChannels: Int
     let requestedRate: Int
@@ -81,12 +83,11 @@ class DualSourceRecorder: RecordingProvider {
         return captureSession?.micLevelDBFS ?? -120
     }
 
-    /// Default app-audio capture format. Static so crash recovery — which has
-    /// no live capture session to read the actual format from — can reconstruct
-    /// the `buildRecording` input. When a mic track survives, `buildRecording`
-    /// cross-checks the rate from its duration; an app-only crash falls back to
-    /// this requested rate (a renegotiated device could then be mis-rated, but
-    /// the audio is recovered, not lost).
+    /// Requested app-audio capture format (what the CATap aggregate device is
+    /// asked for). The device may renegotiate to another rate/channel count
+    /// mid-session; `AppAudioCapture` resamples every buffer to 16 kHz mono in
+    /// the IOProc regardless, so the written file — and crash recovery — are
+    /// always at the speech target rate, not this one.
     nonisolated static let defaultRecordRate = 48000
     nonisolated static let defaultAppChannels = 2
 
@@ -149,12 +150,15 @@ class DualSourceRecorder: RecordingProvider {
         return stems
     }
 
-    /// Re-mix one crashed recording's surviving raw app track (+ mic, if
-    /// present) into a `_mix.wav`, reusing the normal `buildRecording` path. The
-    /// mic WAV header is repaired first (a crash leaves it unfinalized). The
-    /// per-track `micDelay` is unrecoverable after a crash, so the tracks are
-    /// mixed from their file starts — a sub-100 ms drift vs. a clean recording,
-    /// an acceptable cost to rescue audio that would otherwise be lost.
+    /// Re-mix one crashed recording's surviving app track (+ mic, if present)
+    /// into a `_mix.wav`, reusing the normal `buildRecording` path. The app temp
+    /// is already 16 kHz mono float — `AppAudioCapture` resamples in the IOProc
+    /// (issue #379 follow-up) — so recovery reads it at the speech target rate,
+    /// not the device capture rate. The mic WAV header is repaired first (a
+    /// crash leaves it unfinalized). The per-track `micDelay` is unrecoverable
+    /// after a crash, so the tracks are mixed from their file starts — a
+    /// sub-100 ms drift vs. a clean recording, an acceptable cost to rescue
+    /// audio that would otherwise be lost.
     @discardableResult
     nonisolated static func recoverCrashedRecording(stem: String, in recDir: URL) throws -> URL {
         let appTmp = recDir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
@@ -162,11 +166,12 @@ class DualSourceRecorder: RecordingProvider {
         let hasMic = FileManager.default.fileExists(atPath: micWav.path)
         if hasMic { _ = try? WavHeaderRepair.repairIfNeeded(at: micWav) }
 
+        let recoveredRate = AudioConstants.targetSampleRate
         let result = AudioCaptureResult(
             appAudioFileURL: appTmp,
             micAudioFileURL: hasMic ? micWav : nil,
-            actualSampleRate: defaultRecordRate,
-            actualChannels: defaultAppChannels,
+            actualSampleRate: recoveredRate,
+            actualChannels: 1,
             micDelay: 0,
         )
         let recording = try buildRecording(
@@ -175,9 +180,9 @@ class DualSourceRecorder: RecordingProvider {
             timestamp: stem,
             recordingStart: 0,
             format: CaptureFormat(
-                requestedChannels: defaultAppChannels,
-                requestedRate: defaultRecordRate,
-                targetRate: AudioConstants.targetSampleRate,
+                requestedChannels: 1,
+                requestedRate: recoveredRate,
+                targetRate: recoveredRate,
             ),
         )
         return recording.mixPath
@@ -310,12 +315,16 @@ class DualSourceRecorder: RecordingProvider {
         let ts = startTimestamp ?? Self.timestamp()
         startTimestamp = nil
 
+        // The capture session writes 16 kHz mono (in-IOProc resample), so that —
+        // not the device-facing recordRate/appChannels — is the expected file
+        // format; a buildRecording mismatch warning then means the resampler
+        // fallback wrote raw native-rate audio.
         return try Self.buildRecording(
             from: captureResult,
             recordingsDir: Self.recordingsDir,
             timestamp: ts,
             recordingStart: recordingStart,
-            format: CaptureFormat(requestedChannels: appChannels, requestedRate: recordRate, targetRate: targetRate),
+            format: CaptureFormat(requestedChannels: 1, requestedRate: targetRate, targetRate: targetRate),
         )
     }
 
@@ -347,13 +356,21 @@ class DualSourceRecorder: RecordingProvider {
             nil
         }
 
-        let actualRate = crossCheckAppRate(
-            deviceRate: captureResult.actualSampleRate,
-            appRawBytes: appRawBytes,
-            appChannels: actualChannels,
-            micDurationSeconds: micDuration,
-            micDelay: micDelay,
-        )
+        // A temp already at the target rate (the in-IOProc resampler's output)
+        // has no rate left to second-guess — the duration heuristic could only
+        // mis-correct it (e.g. a mic that died mid-recording shortens the
+        // reference duration and would re-warp a healthy 16 kHz track). The
+        // cross-check still guards the fallback/legacy path where the temp is
+        // raw device-rate audio.
+        let actualRate = captureResult.actualSampleRate == format.targetRate
+            ? captureResult.actualSampleRate
+            : crossCheckAppRate(
+                deviceRate: captureResult.actualSampleRate,
+                appRawBytes: appRawBytes,
+                appChannels: actualChannels,
+                micDurationSeconds: micDuration,
+                micDelay: micDelay,
+            )
 
         if micDelay != 0 {
             logger.info("Mic delay: \(micDelay)s")
@@ -470,20 +487,11 @@ class DualSourceRecorder: RecordingProvider {
         return enumerated.contains(rootPID) ? enumerated : [rootPID] + enumerated
     }
 
-    /// Downmix interleaved multi-channel audio to mono. Passthrough if already mono.
+    /// Downmix interleaved multi-channel audio to mono. Passthrough if already
+    /// mono. Delegates to the AudioTapLib implementation so the averaging logic
+    /// lives once (the capture-time resampler uses the same function).
     nonisolated static func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
-        guard channels >= 2, samples.count >= channels else { return samples }
-        let n = samples.count - (samples.count % channels)
-        var mono = [Float](repeating: 0, count: n / channels)
-        let scale = 1.0 / Float(channels)
-        for i in 0 ..< mono.count {
-            var sum: Float = 0
-            for ch in 0 ..< channels {
-                sum += samples[i * channels + ch]
-            }
-            mono[i] = sum * scale
-        }
-        return mono
+        AudioTapLib.downmixToMono(samples, channels: channels)
     }
 
     /// Cross-check the device-reported sample rate against raw file size and mic duration.

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
@@ -1,0 +1,71 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// Crash-recovery coverage for `DualSourceRecorder` (#379 durability, part 3).
+/// Split from `DualSourceRecorderTests` to keep that class under the
+/// type-body-length lint cap.
+@MainActor
+final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
+    /// Only a `_app_raw.tmp` with no matching `_mix.wav` is a crash orphan:
+    /// one that already has a mix was processed, and a lone `_mic.wav` (no
+    /// raw app temp) isn't an app-track orphan.
+    func testCrashedRecordingStemsDetectsTmpWithoutMix() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_app_raw.tmp", // crashed: temp, no mix
+            "20260311_100000_mic.wav",
+            "20260311_110000_app_raw.tmp", // already processed: temp + mix
+            "20260311_110000_mix.wav",
+            "20260311_120000_mic.wav", // mic only, no temp → not an app orphan
+            "notes.txt",
+        ])
+        XCTAssertEqual(stems, ["20260311_100000"])
+    }
+
+    /// A crashed recording (surviving raw app `.tmp` + mic WAV, no mix) is
+    /// re-mixed into a readable `_mix.wav` and the raw temp is consumed.
+    func testRecoverCrashedRecordingsRemixesOrphanedRawAppAndMic() throws {
+        let dir = try makeTempDirectory(prefix: "crash_recover")
+        let stem = "20260311_140000"
+        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        // 2 s of 16 kHz mono float — the surviving app track (AppAudioCapture
+        // resamples to 16 kHz mono in the IOProc, so the temp is already there).
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000 * 2), to: appTmp)
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        // A crashed recording's temp predates the relaunch — backdate it past
+        // the in-progress guard.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
+        )
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 1, "the crashed recording should be recovered")
+        let mix = dir.appendingPathComponent(stem + "_mix.wav")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mix.path), "a mix should be produced")
+        XCTAssertGreaterThan(
+            try AudioMixer.loadAudioFileAsFloat32(url: mix).count, 0,
+            "the recovered mix should contain audio",
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: appTmp.path), "the raw temp should be consumed")
+    }
+
+    /// A freshly-written `.tmp` (recent mtime) looks like an in-progress
+    /// recording, not a crash — recovery must leave it untouched.
+    func testRecoverCrashedRecordingsSkipsInProgressTemp() throws {
+        let dir = try makeTempDirectory(prefix: "crash_inprogress")
+        let stem = "20260311_150000"
+        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 0, "an in-progress (fresh) temp must not be recovered")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appTmp.path), "the temp must be left untouched")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent(stem + "_mix.wav").path),
+            "no mix should be produced for an in-progress temp",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -476,66 +476,37 @@ final class DualSourceRecorderTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
     }
 
-    // MARK: - Crash recovery (#379 durability, part 3)
+    /// An app temp already at the target rate must be trusted — the
+    /// mic-duration rate heuristic must not re-warp it. Scenario: the mic died
+    /// mid-recording (restart retries exhausted), so the mic track is much
+    /// shorter than the app track; inferring the app rate from that short
+    /// reference would override 16 kHz with a bogus higher rate and time-warp
+    /// a healthy track.
+    func testBuildRecordingTrustsTargetRateAppTempOverMicDurationInference() throws {
+        let dir = try makeTempDirectory(prefix: "build_trust16k")
+        let appTmp = dir.appendingPathComponent("20260311_180000_app_raw.tmp")
+        // 10 s of 16 kHz mono app audio, but only 4 s of mic.
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000 * 10), to: appTmp)
+        let micWav = dir.appendingPathComponent("20260311_180000_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000 * 4), sampleRate: 16000, url: micWav)
 
-    /// Only a `_app_raw.tmp` with no matching `_mix.wav` is a crash orphan:
-    /// one that already has a mix was processed, and a lone `_mic.wav` (no
-    /// raw app temp) isn't an app-track orphan.
-    func testCrashedRecordingStemsDetectsTmpWithoutMix() {
-        let stems = DualSourceRecorder.crashedRecordingStems(in: [
-            "20260311_100000_app_raw.tmp", // crashed: temp, no mix
-            "20260311_100000_mic.wav",
-            "20260311_110000_app_raw.tmp", // already processed: temp + mix
-            "20260311_110000_mix.wav",
-            "20260311_120000_mic.wav", // mic only, no temp → not an app orphan
-            "notes.txt",
-        ])
-        XCTAssertEqual(stems, ["20260311_100000"])
-    }
-
-    /// A crashed recording (surviving raw app `.tmp` + mic WAV, no mix) is
-    /// re-mixed into a readable `_mix.wav` and the raw temp is consumed.
-    func testRecoverCrashedRecordingsRemixesOrphanedRawAppAndMic() throws {
-        let dir = try makeTempDirectory(prefix: "crash_recover")
-        let stem = "20260311_140000"
-        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
-        // 1 s of 48 kHz interleaved stereo — the surviving raw app track.
-        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
-        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
-        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
-        // A crashed recording's temp predates the relaunch — backdate it past
-        // the in-progress guard.
-        try FileManager.default.setAttributes(
-            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
+        let result = try DualSourceRecorder.buildRecording(
+            from: AudioCaptureResult(
+                appAudioFileURL: appTmp, micAudioFileURL: micWav,
+                actualSampleRate: 16000, actualChannels: 1, micDelay: 0,
+            ),
+            recordingsDir: dir, timestamp: "20260311_180000", recordingStart: 1000,
+            format: CaptureFormat(requestedChannels: 1, requestedRate: 16000, targetRate: 16000),
         )
 
-        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
-
-        XCTAssertEqual(count, 1, "the crashed recording should be recovered")
-        let mix = dir.appendingPathComponent(stem + "_mix.wav")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: mix.path), "a mix should be produced")
-        XCTAssertGreaterThan(
-            try AudioMixer.loadAudioFileAsFloat32(url: mix).count, 0,
-            "the recovered mix should contain audio",
-        )
-        XCTAssertFalse(FileManager.default.fileExists(atPath: appTmp.path), "the raw temp should be consumed")
-    }
-
-    /// A freshly-written `.tmp` (recent mtime) looks like an in-progress
-    /// recording, not a crash — recovery must leave it untouched.
-    func testRecoverCrashedRecordingsSkipsInProgressTemp() throws {
-        let dir = try makeTempDirectory(prefix: "crash_inprogress")
-        let stem = "20260311_150000"
-        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
-        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
-
-        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
-
-        XCTAssertEqual(count, 0, "an in-progress (fresh) temp must not be recovered")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: appTmp.path), "the temp must be left untouched")
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: dir.appendingPathComponent(stem + "_mix.wav").path),
-            "no mix should be produced for an in-progress temp",
+        let appPath = try XCTUnwrap(result.appPath)
+        let out = try AudioMixer.loadAudioFileAsFloat32(url: appPath)
+        XCTAssertEqual(
+            out.count, 160_000, accuracy: 800,
+            "a target-rate temp must keep its duration regardless of mic length",
         )
     }
+
+    // Crash-recovery coverage (#379 durability, part 3) lives in
+    // DualSourceRecorderCrashRecoveryTests.swift (type-body-length cap).
 }

--- a/tools/audiotap/Sources/AppAudioCapture+Resampling.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+Resampling.swift
@@ -1,0 +1,80 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+
+/// Capture-time resampling for `AppAudioCapture`. Folds each CATap buffer to
+/// 16 kHz mono before the file write (issue #379 follow-up) so a mid-recording
+/// output-device rate change can't time-warp the track the way a single
+/// post-hoc resample did. Extracted to a sibling file so `AppAudioCapture.swift`
+/// stays under the 600-line lint cap — same pattern as
+/// `AppAudioCapture+LiveSink.swift`.
+@available(macOS 14.2, *)
+public extension AppAudioCapture {
+    /// Format of the data actually written to the output fd: 16 kHz mono when
+    /// the resampler is active (the normal case), else the raw device input
+    /// (`actualSampleRate`/`actualChannels`) as a fallback. Read by
+    /// `AudioCaptureSession` to describe the produced file.
+    var outputSampleRate: Int {
+        resampler != nil ? Int(speechSampleRate) : actualSampleRate
+    }
+
+    var outputChannels: Int {
+        resampler != nil ? 1 : actualChannels
+    }
+
+    /// The buffer's hardware presentation time in mach ticks, for wall-clock
+    /// gap-filling. Falls back to the callback clock if the IOProc didn't mark
+    /// the host time valid.
+    internal static func hostTicks(from time: UnsafePointer<AudioTimeStamp>) -> UInt64 {
+        let stamp = time.pointee
+        return stamp.mFlags.contains(.hostTimeValid) ? stamp.mHostTime : mach_absolute_time()
+    }
+
+    /// Resample + downmix one interleaved CATap buffer to 16 kHz mono and write
+    /// it to `fd`, rebuilding the converter on a mid-recording rate change. The
+    /// resampler buffers internally, so a buffer that yields no output yet
+    /// (converter priming) is simply not written — its samples emerge on a later
+    /// call, no data lost. Falls back to the raw native-rate write only if no
+    /// resampler was built (not expected for a 16 kHz target). `hostTicks` is the
+    /// buffer's hardware presentation time, used to fill device-restart gaps with
+    /// silence so the track stays aligned to wall-clock. Runs on `writeQueue`.
+    internal func writeCapturedBuffer(
+        fd: Int32, data: UnsafeMutableRawPointer, byteCount: Int, hostTicks: UInt64,
+    ) {
+        guard let resampler else {
+            writeAllToFileHandle(fd, data, count: byteCount)
+            return
+        }
+        let floatCount = byteCount / MemoryLayout<Float>.size
+        let interleaved = Array(UnsafeBufferPointer(
+            start: data.assumingMemoryBound(to: Float.self), count: floatCount,
+        ))
+        let mono16k = resampler.process(
+            interleaved, inputRate: actualSampleRate, inputChannels: max(actualChannels, 1),
+        )
+        guard !mono16k.isEmpty else { return }
+        fillTimelineGap(fd: fd, hostTicks: hostTicks, outputFrames: mono16k.count)
+        Self.writeFloats(mono16k, to: fd)
+    }
+
+    /// Write silence for a device-restart gap before this buffer's audio, so the
+    /// app track stays aligned to wall-clock (issue #379 follow-up). Mirrors
+    /// `MicCaptureHandler.fillTimelineGap`; the `TimelineAnchor` self-anchors on
+    /// the first buffer and is never reset, so only a real gap produces silence.
+    private func fillTimelineGap(fd: Int32, hostTicks: UInt64, outputFrames: Int) {
+        let silence = timelineAnchor.silenceFramesBefore(
+            hostSeconds: machTicksToSeconds(hostTicks), frameCount: outputFrames,
+        )
+        guard silence > 0 else { return }
+        Self.writeFloats([Float](repeating: 0, count: silence), to: fd)
+    }
+
+    /// Write a float buffer's raw bytes to `fd` in one POSIX write loop.
+    private static func writeFloats(_ samples: [Float], to fd: Int32) {
+        samples.withUnsafeBytes { raw in
+            if let base = raw.baseAddress {
+                writeAllToFileHandle(fd, base, count: raw.count)
+            }
+        }
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture+TapError.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+TapError.swift
@@ -1,0 +1,30 @@
+import CoreAudio
+import Foundation
+
+/// Tap-creation error mapping for `AppAudioCapture`. Extracted to a sibling file
+/// so `AppAudioCapture.swift` stays under the 600-line lint cap — same pattern
+/// as `AppAudioCapture+LiveSink.swift`.
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    /// Translates an `AudioHardwareCreateProcessTap` OSStatus to a human hint.
+    /// Exposed `internal` for unit tests.
+    static func describeTapError(_ status: OSStatus) -> String {
+        switch status {
+        case -12988:
+            "OSStatus -12988: likely missing permission. " +
+                "Check System Settings → Privacy & Security → Screen Recording " +
+                "and enable Meeting Transcriber."
+
+        case -10851:
+            "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +
+                "the tap target may have exited before the tap was created."
+
+        case -50:
+            "OSStatus -50 (paramErr): invalid CATapDescription parameter " +
+                "(target process may not be capturable)."
+
+        default:
+            "OSStatus \(status): unrecognised — see CoreAudio headers."
+        }
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -29,6 +29,17 @@ public class AppAudioCapture: @unchecked Sendable {
     /// can drive the throttled dBFS log line.
     let debugLogging: Bool
     let liveSink: LiveAudioSink?
+    /// Resamples + downmixes each captured buffer to 16 kHz mono in the IOProc
+    /// (issue #379 follow-up — see `writeCapturedBuffer` in `+Resampling`).
+    /// `internal` (not `private`) so that cross-file extension can reach it.
+    /// `nil` only if a 16 kHz output format couldn't be built (not expected);
+    /// the write then falls back to the raw native-rate path.
+    let resampler: StreamingMonoResampler?
+    /// Wall-clock anchoring so an output-device-restart gap becomes silence in
+    /// the file instead of an under-run that drifts against the mic track (issue
+    /// #379 follow-up — see `writeCapturedBuffer` in `+Resampling`). `internal`
+    /// for that cross-file extension; touched only on `writeQueue`.
+    var timelineAnchor = TimelineAnchor(rate: Int(speechSampleRate))
     private var aggregateID = AudioObjectID(kAudioObjectUnknown)
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var procID: AudioDeviceIOProcID?
@@ -82,6 +93,9 @@ public class AppAudioCapture: @unchecked Sendable {
 
     /// Actual channel count detected from first IOProc callback.
     public private(set) var actualChannels: Int = 0
+    // `outputSampleRate` / `outputChannels` (the format actually written to the
+    // fd, 16 kHz mono after the in-IOProc resample) live in `+Resampling`.
+
     private var didLogFormat = false
     /// Pure state machine that decides when/what to dispatch on device-change events.
     private var deviceChangeCoordinator = OutputDeviceChangeCoordinator()
@@ -114,6 +128,7 @@ public class AppAudioCapture: @unchecked Sendable {
         self.channels = channels
         self.debugLogging = debugLogging
         self.liveSink = liveSink
+        resampler = StreamingMonoResampler(targetRate: Int(speechSampleRate))
     }
 
     public func start() throws {
@@ -363,7 +378,7 @@ public class AppAudioCapture: @unchecked Sendable {
         var newProcID: AudioDeviceIOProcID?
         let ioProcStatus = AudioDeviceCreateIOProcIDWithBlock(
             &newProcID, aggregateID, writeQueue,
-        ) { [weak self] _, inInputData, _, _, _ in
+        ) { [weak self] _, inInputData, inInputTime, _, _ in
             guard let self, self.isRunning else { return }
             let abl = inInputData.pointee
 
@@ -395,10 +410,17 @@ public class AppAudioCapture: @unchecked Sendable {
                 )
             }
 
-            // CATapDescription delivers interleaved float32 — write directly
+            // CATapDescription delivers interleaved float32. Resample + downmix
+            // to 16 kHz mono AT CAPTURE (writeCapturedBuffer, +Resampling),
+            // rebuilding the converter on a mid-recording rate change so a
+            // device swap can't time-warp the file the way a single post-hoc
+            // resample did (issue #379 follow-up). RMS/level/live-sink stay on
+            // the raw buffer below — the live path has its own rate-adaptive
+            // resampler.
             guard let data = abl.mBuffers.mData else { return }
             let byteCount = Int(abl.mBuffers.mDataByteSize)
-            writeAllToFileHandle(fd, data, count: byteCount)
+            let hostTicks = Self.hostTicks(from: inInputTime)
+            self.writeCapturedBuffer(fd: fd, data: data, byteCount: byteCount, hostTicks: hostTicks)
 
             self.accumulateDebugRMS(data: data, byteCount: byteCount)
             self.publishCurrentLevel()
@@ -492,28 +514,6 @@ public class AppAudioCapture: @unchecked Sendable {
             outputListenerInstalled = false
         }
         logger.info("Audio capture stopped")
-    }
-
-    /// Translates an `AudioHardwareCreateProcessTap` OSStatus to a human hint.
-    /// Exposed `internal` for unit tests.
-    static func describeTapError(_ status: OSStatus) -> String {
-        switch status {
-        case -12988:
-            "OSStatus -12988: likely missing permission. " +
-                "Check System Settings → Privacy & Security → Screen Recording " +
-                "and enable Meeting Transcriber."
-
-        case -10851:
-            "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +
-                "the tap target may have exited before the tap was created."
-
-        case -50:
-            "OSStatus -50 (paramErr): invalid CATapDescription parameter " +
-                "(target process may not be capturable)."
-
-        default:
-            "OSStatus \(status): unrecognised — see CoreAudio headers."
-        }
     }
 }
 

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -132,8 +132,10 @@ public class AudioCaptureSession {
             }
         }
 
-        let actualRate = appCapture?.actualSampleRate ?? 0
-        let actualChannels = appCapture?.actualChannels ?? 0
+        // The app file is what `AppAudioCapture` actually WROTE — 16 kHz mono
+        // after the in-IOProc resample, not the device's raw capture format.
+        let actualRate = appCapture?.outputSampleRate ?? 0
+        let actualChannels = appCapture?.outputChannels ?? 0
 
         // Close file handle
         try? appFileHandle?.close()

--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -24,6 +24,26 @@ func secondsToMachTicks(_ seconds: Double) -> UInt64 {
     return UInt64(nanos * Double(machTimebaseInfo.denom) / Double(machTimebaseInfo.numer))
 }
 
+/// Average interleaved multi-channel samples to mono. Passthrough for mono
+/// input; an incomplete trailing frame is dropped. `public` so the app module's
+/// `DualSourceRecorder` can delegate to the same implementation
+/// `StreamingMonoResampler` uses (the app depends on this library, not the
+/// other way round).
+public func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
+    guard channels >= 2, samples.count >= channels else { return samples }
+    let n = samples.count - (samples.count % channels)
+    var mono = [Float](repeating: 0, count: n / channels)
+    let scale = 1.0 / Float(channels)
+    for i in 0 ..< mono.count {
+        var sum: Float = 0
+        for ch in 0 ..< channels {
+            sum += samples[i * channels + ch]
+        }
+        mono[i] = sum * scale
+    }
+    return mono
+}
+
 /// Write all bytes to a file descriptor using POSIX write() — no Data copy, no Foundation overhead.
 func writeAllToFileHandle(_ fd: Int32, _ ptr: UnsafeRawPointer, count: Int) {
     var remaining = count

--- a/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
@@ -1,0 +1,50 @@
+@preconcurrency import AVFoundation
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "MicCaptureTimeline")
+
+/// Wall-clock gap-filling for `MicCaptureHandler`. A device-change restart drops
+/// mic audio for the teardown→rebuild gap; without compensation the WAV
+/// under-runs and drifts out of sync with the app track (issue #379 follow-up).
+/// Extracted to a sibling file so `MicCaptureHandler.swift` stays under the
+/// 600-line lint cap — same pattern as `AppAudioCapture+Resampling.swift`.
+extension MicCaptureHandler {
+    /// Write silence for the gap before `outputFrames` of real audio, so the
+    /// output file stays aligned to wall-clock. `when` is the buffer's hardware
+    /// presentation time (jitter-free); falls back to the callback clock if the
+    /// host time is invalid. The `TimelineAnchor` self-anchors on the first
+    /// buffer and bridges restart gaps (it is never reset), so steady-state
+    /// capture inserts nothing and only a real gap produces silence.
+    func fillTimelineGap(before when: AVAudioTime, outputFrames: Int) {
+        let hostTicks = when.isHostTimeValid ? when.hostTime : mach_absolute_time()
+        let hostSeconds = machTicksToSeconds(hostTicks)
+        let silence = timelineAnchor.silenceFramesBefore(
+            hostSeconds: hostSeconds, frameCount: outputFrames,
+        )
+        guard silence > 0, let outputFile else { return }
+        Self.writeSilence(frames: silence, to: outputFile)
+    }
+
+    /// Write `frames` zeroed frames to `file` in its processing format. Static
+    /// and engine-free so it is unit-testable without instantiating the handler
+    /// (whose deinit touches `AVAudioEngine.inputNode` — fatal on input-less CI
+    /// hosts, see the `noInputDevice` guard in `startEngine`).
+    static func writeSilence(frames: Int, to file: AVAudioFile) {
+        guard frames > 0, let silentBuffer = AVAudioPCMBuffer(
+            pcmFormat: file.processingFormat,
+            frameCapacity: AVAudioFrameCount(frames),
+        ) else { return }
+        silentBuffer.frameLength = AVAudioFrameCount(frames)
+        // AVAudioPCMBuffer storage isn't guaranteed zeroed — clear it.
+        if let channel = silentBuffer.floatChannelData?[0] {
+            channel.update(repeating: 0, count: frames)
+        }
+        do {
+            try file.write(from: silentBuffer)
+            logger.info("Mic: filled \(frames) silent frames for a device-restart gap")
+        } catch {
+            logger.warning("Mic timeline gap-fill write error: \(error)")
+        }
+    }
+}

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -19,7 +19,9 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// reflects that this discipline isn't expressible to the compiler.
 public class MicCaptureHandler: @unchecked Sendable {
     private var engine = AVAudioEngine()
-    private var outputFile: AVAudioFile?
+    /// `internal` (not `private`) so the cross-file `+Timeline` extension can
+    /// write gap-fill silence to it.
+    var outputFile: AVAudioFile?
     private let outputURL: URL
     private let debugLogging: Bool
     private let liveSink: LiveAudioSink?
@@ -46,6 +48,10 @@ public class MicCaptureHandler: @unchecked Sendable {
     private var converter: AVAudioConverter?
     /// Pre-computed resampling ratio (fileSampleRate / tapSampleRate), avoids division in audio callback.
     private var resampleRatio: Double = 1.0
+    /// Wall-clock anchoring so a device-restart gap becomes silence in the WAV
+    /// instead of an under-run (issue #379 follow-up — see `+Timeline`).
+    /// `internal` for that cross-file extension; survives restarts (never reset).
+    var timelineAnchor = TimelineAnchor(rate: Int(speechSampleRate))
     public private(set) var firstFrameTime: UInt64 = 0
 
     // State for an injected DebugTapFault (above). Always compiled but inert
@@ -188,6 +194,10 @@ public class MicCaptureHandler: @unchecked Sendable {
                 [.posixPermissions: 0o600],
                 ofItemAtPath: outputURL.path,
             )
+            // A fresh file gets a fresh wall-clock anchor — its accounting
+            // belongs to this file's sample stream. Restarts keep the file
+            // (and the anchor), so a restart gap is bridged with silence.
+            timelineAnchor = TimelineAnchor(rate: Int(fileSampleRate))
         }
 
         converter = nil
@@ -214,7 +224,7 @@ public class MicCaptureHandler: @unchecked Sendable {
         // install it through the ObjC shim so a raise becomes a recoverable throw.
         // swiftlint:disable closure_parameter_position closure_body_length
         let tapBlock: AVAudioNodeTapBlock = {
-            [weak self] buffer, _ in
+            [weak self] buffer, when in
             // swiftlint:enable closure_parameter_position closure_body_length
             guard let self, self.isRecording else { return }
             if self.firstFrameTime == 0 {
@@ -233,30 +243,19 @@ public class MicCaptureHandler: @unchecked Sendable {
                         frameCapacity: outputFrames,
                     ) else { return }
                     var error: NSError?
-                    // The converter input block is typed `@Sendable`, so a
-                    // captured `var Bool` would trip Swift 6's concurrent-
-                    // capture check — even though the block actually runs
-                    // synchronously while `convert(to:error:withInputFrom:)`
-                    // is on the stack. Box the flag so the closure captures
-                    // it by-reference.
-                    final class InputState: @unchecked Sendable { var consumed = false }
-                    let inputState = InputState()
+                    let feed = FeedOnce(buffer: buffer)
                     converter.convert(to: outputBuffer, error: &error) { _, outStatus in
-                        if inputState.consumed {
-                            outStatus.pointee = .noDataNow
-                            return nil
-                        }
-                        inputState.consumed = true
-                        outStatus.pointee = .haveData
-                        return buffer
+                        feed.next(outStatus)
                     }
                     if let error {
                         logger.warning("Mic resample error: \(error)")
                     } else {
+                        self.fillTimelineGap(before: when, outputFrames: Int(outputBuffer.frameLength))
                         try self.outputFile?.write(from: outputBuffer)
                         self.forwardToLiveSink(buffer: outputBuffer)
                     }
                 } else {
+                    self.fillTimelineGap(before: when, outputFrames: Int(buffer.frameLength))
                     try self.outputFile?.write(from: buffer)
                     self.forwardToLiveSink(buffer: buffer)
                 }

--- a/tools/audiotap/Sources/StreamingMonoResampler.swift
+++ b/tools/audiotap/Sources/StreamingMonoResampler.swift
@@ -1,0 +1,120 @@
+@preconcurrency import AVFoundation
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "StreamingMonoResampler")
+
+/// Converts interleaved float32 capture buffers to mono Float32 at a fixed
+/// target rate, rebuilding the underlying `AVAudioConverter` whenever the input
+/// sample rate changes.
+///
+/// A mid-recording output-device change can renegotiate the capture rate (e.g.
+/// 48 kHz → 24 kHz). Resampling every span with one rate — as the batch app
+/// path historically did — time-warps every span that wasn't at that rate
+/// (issue #379 "tape-stop" drift: a 24 kHz span played as 48 kHz comes out 2×
+/// too fast and an octave low). Converting each buffer at the rate that was live
+/// when it arrived keeps the written track at true real-time duration. Mirrors
+/// the in-callback resampling `MicCaptureHandler` already does for the mic track
+/// and the app module's `LiveAudioResampler` does for live captions.
+///
+/// Channels are folded to mono by averaging *before* the converter (matching
+/// `DualSourceRecorder.downmixToMono` — `AVAudioConverter`'s own stereo→mono
+/// keeps only channel 0), so the converter does pure rate conversion and a
+/// channel-count change across a device swap needs no special handling.
+///
+/// Not thread-safe: drive it from a single serial context (the capture IOProc's
+/// `writeQueue`).
+final class StreamingMonoResampler {
+    private let outputFormat: AVAudioFormat
+    private var converter: AVAudioConverter?
+    private var inputRate = 0
+
+    init?(targetRate: Int) {
+        guard targetRate > 0, let output = AVAudioFormat(
+            standardFormatWithSampleRate: Double(targetRate), channels: 1,
+        ) else { return nil }
+        outputFormat = output
+    }
+
+    /// Convert one interleaved buffer (`inputChannels` channels at `inputRate`)
+    /// to mono samples at the target rate. A change in `inputRate` from the
+    /// previous call rebuilds the converter so resampling state stays continuous
+    /// within a span but never carries a stale rate across a device swap.
+    /// Returns `[]` for empty input or when a converter can't be built.
+    func process(_ samples: [Float], inputRate: Int, inputChannels: Int) -> [Float] {
+        guard !samples.isEmpty, inputRate > 0, inputChannels > 0 else { return [] }
+
+        let mono = downmixToMono(samples, channels: inputChannels)
+        guard !mono.isEmpty, let converter = ensureConverter(rate: inputRate) else { return [] }
+
+        let inputFrames = AVAudioFrameCount(mono.count)
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: converter.inputFormat, frameCapacity: inputFrames)
+        else { return [] }
+        inputBuffer.frameLength = inputFrames
+        if let channel = inputBuffer.floatChannelData?[0] {
+            mono.withUnsafeBufferPointer { src in
+                if let base = src.baseAddress {
+                    channel.update(from: base, count: mono.count)
+                }
+            }
+        }
+
+        let ratio = outputFormat.sampleRate / Double(inputRate)
+        let outputCapacity = AVAudioFrameCount(Double(inputFrames) * ratio + 16)
+        guard let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFormat, frameCapacity: outputCapacity,
+        ) else { return [] }
+
+        var error: NSError?
+        let feed = FeedOnce(buffer: inputBuffer)
+        let status = converter.convert(to: outputBuffer, error: &error) { _, inStatus in
+            feed.next(inStatus)
+        }
+        if let error {
+            logger.warning("App resample error: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+        guard status != .error, outputBuffer.frameLength > 0,
+              let outPtr = outputBuffer.floatChannelData?[0] else { return [] }
+        return Array(UnsafeBufferPointer(start: outPtr, count: Int(outputBuffer.frameLength)))
+    }
+
+    private func ensureConverter(rate: Int) -> AVAudioConverter? {
+        if let converter, rate == inputRate { return converter }
+        guard let input = AVAudioFormat(
+            standardFormatWithSampleRate: Double(rate), channels: 1,
+        ), let conv = AVAudioConverter(from: input, to: outputFormat) else {
+            logger.error("Failed to build resampler for \(rate) Hz")
+            return nil
+        }
+        converter = conv
+        inputRate = rate
+        return conv
+    }
+}
+
+/// Single-shot input provider for `AVAudioConverter.convert(to:error:withInputFrom:)`.
+/// First call returns the buffer with `.haveData`; subsequent calls return
+/// `.noDataNow` so the converter stops asking. Reference-typed because the
+/// converter's input callback is `@Sendable` and would reject a mutating-var
+/// capture. `internal` — `MicCaptureHandler`'s tap converter uses the same
+/// provider (the app module's `LiveAudioResampler` keeps its own copy across
+/// the package boundary).
+final class FeedOnce: @unchecked Sendable {
+    private let buffer: AVAudioPCMBuffer
+    private var fed = false
+
+    init(buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+
+    func next(_ outStatus: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+        if fed {
+            outStatus.pointee = .noDataNow
+            return nil
+        }
+        fed = true
+        outStatus.pointee = .haveData
+        return buffer
+    }
+}

--- a/tools/audiotap/Sources/TimelineAnchor.swift
+++ b/tools/audiotap/Sources/TimelineAnchor.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Tracks an audio track's position on a wall-clock timeline anchored to its
+/// first captured buffer, so a device-change restart gap becomes silence and the
+/// track stays aligned to real time (issue #379 follow-up).
+///
+/// The capture handler feeds each buffer's *hardware* host-time (jitter-free
+/// presentation time, e.g. `AVAudioTime.hostTime` or `AudioTimeStamp.mHostTime`,
+/// converted to seconds) and its frame count; the anchor returns how many silent
+/// frames to write before that buffer. Using the hardware timestamp — not the
+/// callback wall-clock — means continuous capture inserts nothing (the timestamp
+/// advances exactly with the audio), while a restart gap, where the timestamp
+/// jumps forward, is filled precisely.
+///
+/// Survives restarts: it is anchored once on the first buffer and never reset, so
+/// the gap between the last pre-restart buffer and the first post-restart buffer
+/// is bridged automatically. Not thread-safe — drive it from the single capture
+/// callback context.
+struct TimelineAnchor {
+    let rate: Int
+    private var anchorHostSeconds: Double?
+    private var framesWritten = 0
+
+    /// Gaps beyond this are treated as a corrupt timestamp, not a real device
+    /// outage: no silence is inserted (the write would be gigabytes of zeros on
+    /// the audio thread, and `AVAudioFrameCount` traps past UInt32.max). The
+    /// anchor is absolute, so a one-off glitched buffer self-heals on the next
+    /// sane timestamp.
+    static let maxGapSeconds: Double = 600
+
+    init(rate: Int) {
+        self.rate = rate
+    }
+
+    /// Silent frames to insert before a buffer that presents at `hostSeconds`
+    /// carrying `frameCount` frames, to keep the written stream aligned to
+    /// wall-clock. The first call sets the anchor and inserts nothing. Never
+    /// negative — an early/jittered timestamp just appends.
+    mutating func silenceFramesBefore(hostSeconds: Double, frameCount: Int) -> Int {
+        guard let anchor = anchorHostSeconds else {
+            anchorHostSeconds = hostSeconds
+            framesWritten = frameCount
+            return 0
+        }
+        let expected = Int(((hostSeconds - anchor) * Double(rate)).rounded())
+        let silence = max(0, expected - framesWritten)
+        guard silence <= Int(Self.maxGapSeconds * Double(rate)) else {
+            framesWritten += frameCount
+            return 0
+        }
+        framesWritten += silence + frameCount
+        return silence
+    }
+}

--- a/tools/audiotap/Tests/AppAudioCaptureResamplingTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureResamplingTests.swift
@@ -1,0 +1,41 @@
+@testable import AudioTapLib
+import CoreAudio
+import XCTest
+
+/// Pins the parts of the capture-time resampling contract that are testable
+/// without a live CATap: the written-file format `AudioCaptureSession` relies
+/// on, and the host-time extraction feeding the timeline anchor. The IOProc
+/// write path itself is hardware-bound.
+@available(macOS 14.2, *)
+final class AppAudioCaptureResamplingTests: XCTestCase {
+    func testOutputFormatIsSpeechRateMono() {
+        // AudioCaptureSession reports this as the produced file's format —
+        // buildRecording trusts it (and skips the rate cross-check on it).
+        let capture = AppAudioCapture(pids: [], outputFileDescriptor: -1)
+        XCTAssertEqual(capture.outputSampleRate, Int(speechSampleRate))
+        XCTAssertEqual(capture.outputChannels, 1)
+    }
+
+    func testHostTicksUsesValidHostTime() {
+        var stamp = AudioTimeStamp()
+        stamp.mHostTime = 12345
+        stamp.mFlags = .hostTimeValid
+
+        let ticks = withUnsafePointer(to: stamp) { AppAudioCapture.hostTicks(from: $0) }
+
+        XCTAssertEqual(ticks, 12345, "a valid presentation timestamp must be used as-is")
+    }
+
+    func testHostTicksFallsBackToCallbackClockWhenInvalid() {
+        var stamp = AudioTimeStamp()
+        stamp.mHostTime = 12345 // present but NOT marked valid
+
+        let before = mach_absolute_time()
+        let ticks = withUnsafePointer(to: stamp) { AppAudioCapture.hostTicks(from: $0) }
+
+        XCTAssertGreaterThanOrEqual(
+            ticks, before,
+            "an unmarked host time must fall back to the callback clock, not be trusted",
+        )
+    }
+}

--- a/tools/audiotap/Tests/MicCaptureHandlerTimelineTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerTimelineTests.swift
@@ -1,0 +1,64 @@
+@testable import AudioTapLib
+@preconcurrency import AVFoundation
+import XCTest
+
+/// Tests the engine-free silence writer behind the mic gap-fill. The gap
+/// *arithmetic* is covered by `TimelineAnchorTests`; this verifies the silence
+/// actually lands in the file, zeroed and at the right length. The handler
+/// itself is deliberately never instantiated — its deinit touches
+/// `AVAudioEngine.inputNode`, which is fatal on input-less CI hosts.
+final class MicCaptureHandlerTimelineTests: XCTestCase {
+    /// Mirror MicCaptureHandler.startEngine's output settings. A function
+    /// rather than a `static let` — `[String: Any]` is not Sendable, so a
+    /// shared stored value trips Swift 6 strict concurrency.
+    private func wavSettings() -> [String: Any] {
+        [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: speechSampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+    }
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mic_timeline_\(UUID().uuidString).wav")
+    }
+
+    func testWriteSilenceAppendsZeroedFrames() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Scope the writer so it finalizes the WAV header before read-back —
+        // AVAudioFile only completes the header on deallocation.
+        try autoreleasepool {
+            let file = try AVAudioFile(forWriting: url, settings: wavSettings())
+            MicCaptureHandler.writeSilence(frames: 14400, to: file)
+            XCTAssertEqual(file.length, 14400, "the gap must land in the file at full length")
+        }
+
+        // Read back and prove the frames are actual silence.
+        let reader = try AVAudioFile(forReading: url)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: reader.processingFormat, frameCapacity: 14400,
+        ))
+        try reader.read(into: buffer)
+        XCTAssertEqual(buffer.frameLength, 14400)
+        let channel = try XCTUnwrap(buffer.floatChannelData?[0])
+        let samples = UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength))
+        XCTAssertTrue(samples.allSatisfy { $0 == 0 }, "gap frames must be zeroed, not garbage")
+    }
+
+    func testWriteSilenceZeroFramesWritesNothing() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let file = try AVAudioFile(forWriting: url, settings: wavSettings())
+        MicCaptureHandler.writeSilence(frames: 0, to: file)
+
+        XCTAssertEqual(file.length, 0, "no gap, no write")
+    }
+}

--- a/tools/audiotap/Tests/StreamingMonoResamplerTests.swift
+++ b/tools/audiotap/Tests/StreamingMonoResamplerTests.swift
@@ -1,0 +1,67 @@
+@testable import AudioTapLib
+import XCTest
+
+final class StreamingMonoResamplerTests: XCTestCase {
+    // MARK: - Basic conversion
+
+    func testEmptyInputReturnsEmpty() throws {
+        let resampler = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+        XCTAssertEqual(resampler.process([], inputRate: 48000, inputChannels: 2), [])
+    }
+
+    func testDownmixesAndResamplesStereo() throws {
+        let resampler = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+        // 1 s of 48 kHz interleaved stereo, L=0.4 R=0.6 → mono average 0.5.
+        var stereo = [Float]()
+        stereo.reserveCapacity(48000 * 2)
+        for _ in 0 ..< 48000 {
+            stereo.append(0.4)
+            stereo.append(0.6)
+        }
+
+        let out = resampler.process(stereo, inputRate: 48000, inputChannels: 2)
+
+        XCTAssertEqual(out.count, 16000, accuracy: 300, "1 s of 48 kHz stereo → ~16000 mono samples")
+        let mid = out[out.count / 2]
+        XCTAssertEqual(mid, 0.5, accuracy: 0.05, "stereo must downmix to the channel average")
+    }
+
+    // MARK: - Rate change mid-stream (issue #379 follow-up: "tape-stop" drift)
+
+    /// The core of the fix. A mid-recording output-device change renegotiates
+    /// the capture rate (e.g. 48 kHz → 24 kHz). The converter MUST be rebuilt
+    /// for the new rate; a stale 48 kHz converter fed a 24 kHz span produces
+    /// only ~8000 samples (2× too fast / an octave low — the slowed, low-pitched
+    /// speaker-naming clips jhavez reported). Each span must map 1 s → 1 s.
+    func testRebuildsConverterWhenInputRateChanges() throws {
+        let resampler = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+
+        let first = resampler.process([Float](repeating: 0.5, count: 48000), inputRate: 48000, inputChannels: 1)
+        XCTAssertEqual(first.count, 16000, accuracy: 300, "1 s @48 kHz → 1 s @16 kHz")
+
+        // Device renegotiated to 24 kHz mid-recording.
+        let second = resampler.process([Float](repeating: -0.5, count: 24000), inputRate: 24000, inputChannels: 1)
+        XCTAssertEqual(
+            second.count, 16000, accuracy: 300,
+            "1 s @24 kHz must still map to 1 s @16 kHz after the converter is rebuilt",
+        )
+        XCTAssertLessThan(second.max() ?? 1, 0, "the 24 kHz span content (negative fill) must be preserved")
+    }
+
+    /// A channel-count change across a device swap (2ch → 1ch) must also rebuild
+    /// the converter rather than misread the interleaving.
+    func testRebuildsConverterWhenChannelCountChanges() throws {
+        let resampler = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+
+        let stereo = [Float](repeating: 0.5, count: 48000 * 2) // 1 s stereo
+        let firstStereo = resampler.process(stereo, inputRate: 48000, inputChannels: 2)
+        XCTAssertEqual(firstStereo.count, 16000, accuracy: 300)
+
+        let mono = [Float](repeating: 0.5, count: 48000) // 1 s mono, same rate
+        let thenMono = resampler.process(mono, inputRate: 48000, inputChannels: 1)
+        XCTAssertEqual(
+            thenMono.count, 16000, accuracy: 300,
+            "1 s of mono must still map to 1 s after a channel-count change",
+        )
+    }
+}

--- a/tools/audiotap/Tests/TimelineAnchorTests.swift
+++ b/tools/audiotap/Tests/TimelineAnchorTests.swift
@@ -1,0 +1,55 @@
+@testable import AudioTapLib
+import XCTest
+
+final class TimelineAnchorTests: XCTestCase {
+    func testFirstBufferAnchorsWithoutSilence() {
+        var anchor = TimelineAnchor(rate: 16000)
+        // The first buffer defines t=0 for the track — nothing precedes it.
+        XCTAssertEqual(anchor.silenceFramesBefore(hostSeconds: 100.0, frameCount: 1600), 0)
+    }
+
+    func testContinuousCaptureInsertsNoSilence() {
+        var anchor = TimelineAnchor(rate: 16000)
+        _ = anchor.silenceFramesBefore(hostSeconds: 100.0, frameCount: 1600) // anchor, 0.1 s written
+        // Next buffer exactly 0.1 s later carrying 0.1 s of audio → perfectly on time.
+        XCTAssertEqual(anchor.silenceFramesBefore(hostSeconds: 100.1, frameCount: 1600), 0)
+    }
+
+    /// The core of the fix. A device-change restart drops audio for the
+    /// teardown→rebuild gap; the next buffer's hardware timestamp jumps forward
+    /// by the real gap. That jump must become silence so the track stays aligned
+    /// to wall-clock instead of under-running (jhavez's −18.5 s mic drift).
+    func testRestartGapInsertsSilence() {
+        var anchor = TimelineAnchor(rate: 16000)
+        _ = anchor.silenceFramesBefore(hostSeconds: 100.0, frameCount: 1600) // written 1600
+        _ = anchor.silenceFramesBefore(hostSeconds: 100.1, frameCount: 1600) // written 3200
+        // 2.6 s restart gap: buffer arrives at t=102.7. expected = 2.7 × 16000 =
+        // 43200, written 3200 → insert 40000 silent frames before it.
+        XCTAssertEqual(anchor.silenceFramesBefore(hostSeconds: 102.7, frameCount: 1600), 40000)
+    }
+
+    /// A corrupt timestamp far in the future must not produce a giant silence
+    /// block (gigabytes of zeros on the audio thread; `AVAudioFrameCount` traps
+    /// past UInt32.max). Treated as an anomaly: nothing inserted, and the next
+    /// sane buffer self-heals against the absolute anchor.
+    func testAnomalousTimestampJumpIsNotFilled() {
+        var anchor = TimelineAnchor(rate: 16000)
+        _ = anchor.silenceFramesBefore(hostSeconds: 100.0, frameCount: 1600)
+        XCTAssertEqual(
+            anchor.silenceFramesBefore(hostSeconds: 100.0 + 7200, frameCount: 1600), 0,
+            "a 2 h timestamp jump is a corrupt clock, not a real gap",
+        )
+        XCTAssertEqual(
+            anchor.silenceFramesBefore(hostSeconds: 100.2, frameCount: 1600), 0,
+            "the next sane buffer must resume normally",
+        )
+    }
+
+    /// A timestamp slightly behind the write head (clock jitter / converter
+    /// latency wobble) must never produce negative silence — we pad, never drop.
+    func testEarlyBufferNeverNegative() {
+        var anchor = TimelineAnchor(rate: 16000)
+        _ = anchor.silenceFramesBefore(hostSeconds: 100.0, frameCount: 16000) // 1 s written
+        XCTAssertEqual(anchor.silenceFramesBefore(hostSeconds: 100.5, frameCount: 1600), 0)
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to the #379 crash fix: rc2 made mid-recording device changes survivable, which exposed that the recording pipeline assumed **one constant sample rate per track**. On a session with several rate renegotiations (24 kHz ↔ 44.1 kHz ↔ 48 kHz), the reporter measured the mic track 18.5 s short, the app track 58 s long, and speaker-naming clips playing slowed-down and octave-low ("tape-stop") for spans captured at a non-final rate.

Two root causes:

1. **App audio was written raw at the device's native rate** and resampled once, post-hoc, at a single rate in `buildRecording`. Every span not at that rate got time-warped — the mic and live-caption paths already resampled at the source and were unaffected.
2. **Device-change restarts drop audio** during the teardown→rebuild gap. Nothing compensated, so each track under-ran wall-clock by its accumulated gaps and the tracks drifted against each other.

## Fix

1. **Capture-time resampling** — `AppAudioCapture` now resamples + downmixes every IOProc buffer to 16 kHz mono (`StreamingMonoResampler`, converter rebuilt on a rate change), so the file is single-rate by construction. This brings the app batch path in line with the mic and live paths; `buildRecording`'s post-hoc resample becomes an identity pass.
2. **Wall-clock anchoring** — both capture paths anchor every buffer to its hardware presentation time (`TimelineAnchor`) and fill restart gaps with silence. Each track now tracks real time, so they stay aligned to each other (the existing `micDelay` still bridges the start offset). Implausible timestamp jumps (>10 min) are treated as clock anomalies, not gaps — no unbounded zero-blocks, no `AVAudioFrameCount` overflow trap.
3. **Consequential hardening** — `buildRecording` no longer second-guesses a temp that is already at the target rate (a mic dying mid-recording would otherwise shorten the reference duration and re-warp a healthy track); crash recovery reads the new 16 kHz mono temps; the rate/channel mismatch warnings compare against the expected file format instead of firing on every clean recording.

## Tests

- `StreamingMonoResamplerTests`: rate-change rebuild (the stale-converter case produced 8 000 instead of 16 000 frames per second of audio — the "tape-stop" mechanism), channel-count change, downmix averaging.
- `TimelineAnchorTests`: gap filling, on-time/jitter clamping, anomaly cap.
- `MicCaptureHandlerTimelineTests`: the gap silence really lands in the WAV — full length and all-zero samples, proven by read-back.
- `AppAudioCaptureResamplingTests`: the written-format contract (16 kHz mono) and host-time extraction, including the invalid-timestamp fallback.
- `DualSourceRecorderTests`: target-rate temps are never re-rated by the mic-duration heuristic; crash-recovery fixtures updated to the new temp format (moved to their own class).
- Full suites green: AudioTapLib 140, app 1 897. Remaining uncovered patch lines are the hardware-bound IOProc/tap shells and defensive error branches.

## Known trade-offs

- Converter priming/latency introduces millisecond-scale constant offsets in the anchor accounting; a rate-change rebuild can lose a few ms at the span boundary (masked as silence). Both are far below the seconds-scale drift this fixes.
- A crashed temp written by a **pre-upgrade** version (raw native-rate stereo) recovered by this version will be mis-rated — the headerless temp carries no format. Narrow window (crash → upgrade → first launch), best-effort path.
- Under disk-full/memory-pressure the gap accounting can drift relative to the file; audio writes already fail silently in that state.

## Verification

Like the #379 crash fix, the multi-rate device-change cannot be reproduced on the CI runner (the virtual audio device negotiates formats differently), so beyond the unit-tested cores this was validated live on real hardware: a 290 s recording with repeated AirPods ↔ built-in swaps went through several 44.1 kHz/2ch ↔ 48 kHz/1ch renegotiations and accumulated ~42 s of mic restart gaps (largest single gap 38.6 s, a slow Bluetooth reconnect mid-recording). All gaps were bridged with silence and the three tracks came out within 0.26 s of each other and of wall-clock — the residual being exactly the intended `micDelay` offset. The mismatch warnings stayed quiet on the clean path. Reporter confirmation with the original repro setup is still welcome on the next pre-release.

Refs #379

