### PR TITLE
fix(app): recover pre-upgrade raw temps with their legacy format

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -225,7 +225,7 @@ jobs:
           if-no-files-found: ignore
 
       # Crash-recovery lane (issue #379 part 3, PR #385/#386): start a meeting,
-      # SIGKILL the app mid-recording (no stop() → orphaned _app_raw.tmp +
+      # SIGKILL the app mid-recording (no stop() → orphaned _app16k_raw.tmp +
       # unfinalized _mic.wav, no _mix.wav survive), relaunch, and assert the
       # launch recovery re-mixes the orphan into the pipeline and a job reaches
       # done. Reverting the recovery wiring in DualSourceRecorder/PipelineController

--- a/.github/workflows/e2e-crash-recovery.yml
+++ b/.github/workflows/e2e-crash-recovery.yml
@@ -2,7 +2,7 @@ name: E2E (Crash Recovery)
 
 # Focused live-recording E2E for issue #379 part 3: start a meeting, wait until
 # the recorder is writing its raw app temp, SIGKILL the app mid-recording (no
-# stop() — the raw _app_raw.tmp + unfinalized _mic.wav survive, no _mix.wav),
+# stop() — the raw _app16k_raw.tmp + unfinalized _mic.wav survive, no _mix.wav),
 # then relaunch and assert the recovered recording enters the pipeline and a job
 # reaches done (the re-mixed _mix.wav is transient — the pipeline consumes it
 # into its workdir within seconds). Pre-fix the launch cleanup deletes the temp

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -100,10 +100,11 @@ class DualSourceRecorder: RecordingProvider {
         AppPaths.recordingsDir
     }
 
-    /// Remove leftover `*_app_raw.tmp` files a previous crash left behind. Run
-    /// AFTER `recoverCrashedRecordings` (which consumes the recoverable ones via
-    /// `buildRecording`) so a rescuable recording isn't deleted before it's
-    /// re-mixed — only genuinely unusable temps (e.g. 0-byte) remain to delete.
+    /// Remove leftover raw app temp files (current or legacy suffix) a previous
+    /// crash left behind. Run AFTER `recoverCrashedRecordings` (which consumes
+    /// the recoverable ones via `buildRecording`) so a rescuable recording isn't
+    /// deleted before it's re-mixed — only genuinely unusable temps (e.g.
+    /// 0-byte) remain to delete.
     ///
     /// `minAge` skips a temp still being written by an in-progress recording
     /// (recent mtime). This runs in the launch queue-build Task, which a
@@ -121,7 +122,7 @@ class DualSourceRecorder: RecordingProvider {
         ) else { return }
         let cutoff = Date().addingTimeInterval(-minAge)
 
-        for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.appRaw) {
+        for file in entries where RecordingFileSuffix.stripAppRaw(from: file.lastPathComponent) != nil {
             if let mtime = (try? fm.attributesOfItem(atPath: file.path)[.modificationDate]) as? Date,
                mtime > cutoff { continue }
             try? fm.removeItem(at: file)
@@ -131,10 +132,11 @@ class DualSourceRecorder: RecordingProvider {
 
     // MARK: - Crash recovery (#379 durability, part 3)
 
-    /// Stems of recordings whose writer was killed mid-capture: a leftover
-    /// `_app_raw.tmp` with no matching `_mix.wav`. In the normal flow
-    /// `buildRecording` deletes the `.tmp` once the mix exists, so a surviving
-    /// `.tmp` means `stop()` never ran. Pure — operates on filenames only.
+    /// Stems of recordings whose writer was killed mid-capture: a leftover raw
+    /// app temp (current or legacy suffix) with no matching `_mix.wav`. In the
+    /// normal flow `buildRecording` deletes the `.tmp` once the mix exists, so a
+    /// surviving `.tmp` means `stop()` never ran. Pure — operates on filenames
+    /// only.
     nonisolated static func crashedRecordingStems(in filenames: [String]) -> [String] {
         let mixStems = Set(filenames.compactMap { name -> String? in
             name.hasSuffix(RecordingFileSuffix.mix)
@@ -142,36 +144,54 @@ class DualSourceRecorder: RecordingProvider {
         })
         var seen = Set<String>()
         var stems: [String] = []
-        for name in filenames where name.hasSuffix(RecordingFileSuffix.appRaw) {
-            let stem = String(name.dropLast(RecordingFileSuffix.appRaw.count))
+        for name in filenames {
+            guard let stem = RecordingFileSuffix.stripAppRaw(from: name) else { continue }
             guard !mixStems.contains(stem), seen.insert(stem).inserted else { continue }
             stems.append(stem)
         }
         return stems
     }
 
+    /// Locate a crashed stem's surviving temp, current format first. Returns
+    /// the URL and whether it is the legacy (raw device-rate stereo) format —
+    /// the temp is headerless, so the suffix is the only format marker.
+    nonisolated private static func crashedTemp(stem: String, in dir: URL) -> (url: URL, isLegacy: Bool)? {
+        for suffix in RecordingFileSuffix.appRawAny {
+            let url = dir.appendingPathComponent(stem + suffix)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return (url, suffix == RecordingFileSuffix.legacyAppRaw)
+            }
+        }
+        return nil
+    }
+
     /// Re-mix one crashed recording's surviving app track (+ mic, if present)
-    /// into a `_mix.wav`, reusing the normal `buildRecording` path. The app temp
-    /// is already 16 kHz mono float — `AppAudioCapture` resamples in the IOProc
-    /// (issue #379 follow-up) — so recovery reads it at the speech target rate,
-    /// not the device capture rate. The mic WAV header is repaired first (a
-    /// crash leaves it unfinalized). The per-track `micDelay` is unrecoverable
-    /// after a crash, so the tracks are mixed from their file starts — a
-    /// sub-100 ms drift vs. a clean recording, an acceptable cost to rescue
-    /// audio that would otherwise be lost.
+    /// into a `_mix.wav`, reusing the normal `buildRecording` path. A current
+    /// temp is already 16 kHz mono float (`AppAudioCapture` resamples in the
+    /// IOProc) and is read at the target rate; a legacy temp from a pre-upgrade
+    /// version holds raw device-rate stereo and gets the pre-resampler
+    /// interpretation (device rate/channels + buildRecording's mic-duration
+    /// rate cross-check). The mic WAV header is repaired first (a crash leaves
+    /// it unfinalized). The per-track `micDelay` is unrecoverable after a
+    /// crash, so the tracks are mixed from their file starts — a sub-100 ms
+    /// drift vs. a clean recording, an acceptable cost to rescue audio that
+    /// would otherwise be lost.
     @discardableResult
     nonisolated static func recoverCrashedRecording(stem: String, in recDir: URL) throws -> URL {
-        let appTmp = recDir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+        guard let temp = crashedTemp(stem: stem, in: recDir) else {
+            throw RecorderError.noAudioData
+        }
         let micWav = recDir.appendingPathComponent(stem + RecordingFileSuffix.mic)
         let hasMic = FileManager.default.fileExists(atPath: micWav.path)
         if hasMic { _ = try? WavHeaderRepair.repairIfNeeded(at: micWav) }
 
-        let recoveredRate = AudioConstants.targetSampleRate
+        let rate = temp.isLegacy ? defaultRecordRate : AudioConstants.targetSampleRate
+        let channels = temp.isLegacy ? defaultAppChannels : 1
         let result = AudioCaptureResult(
-            appAudioFileURL: appTmp,
+            appAudioFileURL: temp.url,
             micAudioFileURL: hasMic ? micWav : nil,
-            actualSampleRate: recoveredRate,
-            actualChannels: 1,
+            actualSampleRate: rate,
+            actualChannels: channels,
             micDelay: 0,
         )
         let recording = try buildRecording(
@@ -180,9 +200,9 @@ class DualSourceRecorder: RecordingProvider {
             timestamp: stem,
             recordingStart: 0,
             format: CaptureFormat(
-                requestedChannels: 1,
-                requestedRate: recoveredRate,
-                targetRate: recoveredRate,
+                requestedChannels: channels,
+                requestedRate: rate,
+                targetRate: AudioConstants.targetSampleRate,
             ),
         )
         return recording.mixPath
@@ -209,8 +229,8 @@ class DualSourceRecorder: RecordingProvider {
         let cutoff = Date().addingTimeInterval(-minAge)
         var recovered = 0
         for stem in crashedRecordingStems(in: names) {
-            let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
-            if let mtime = (try? fm.attributesOfItem(atPath: appTmp.path)[.modificationDate]) as? Date,
+            guard let temp = crashedTemp(stem: stem, in: dir) else { continue }
+            if let mtime = (try? fm.attributesOfItem(atPath: temp.url.path)[.modificationDate]) as? Date,
                mtime > cutoff { continue }
             do {
                 let mix = try recoverCrashedRecording(stem: stem, in: dir)

--- a/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
+++ b/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
@@ -6,12 +6,34 @@ enum RecordingFileSuffix {
     static let app = "_app.wav"
     static let mic = "_mic.wav"
 
-    /// Raw interleaved-float32 app-audio temp file written live during capture
-    /// and consumed by `buildRecording` at `stop()`. A leftover one means the
-    /// writer was killed mid-recording (crash) — see `recoverCrashedRecordings`.
-    static let appRaw = "_app_raw.tmp"
+    /// Raw float32 app-audio temp file written live during capture (16 kHz
+    /// mono, in-IOProc resampled) and consumed by `buildRecording` at `stop()`.
+    /// A leftover one means the writer was killed mid-recording (crash) — see
+    /// `recoverCrashedRecordings`. The suffix encodes the content format: the
+    /// temp is headerless, so crash recovery across an app upgrade can only
+    /// tell formats apart by name.
+    static let appRaw = "_app16k_raw.tmp"
+
+    /// Temp suffix written by versions before the capture-time resampler: raw
+    /// interleaved float32 at the DEVICE's native rate/channels (typically
+    /// 48 kHz stereo). Never written anymore — only read by crash recovery (so
+    /// an upgrade doesn't turn a pre-upgrade crash's audio into 6×-slowed
+    /// garbage) and deleted by temp cleanup.
+    static let legacyAppRaw = "_app_raw.tmp"
+
+    /// Both raw-temp suffixes, current format first — the probe order used by
+    /// crash recovery and temp cleanup.
+    static let appRawAny: [String] = [appRaw, legacyAppRaw]
 
     static let all: [String] = [mix, app, mic]
+
+    /// Stem of a raw app temp filename (either format); nil for other files.
+    static func stripAppRaw(from filename: String) -> String? {
+        for suffix in appRawAny where filename.hasSuffix(suffix) {
+            return String(filename.dropLast(suffix.count))
+        }
+        return nil
+    }
 
     static func stripSuffix(from filename: String) -> (stem: String, suffix: String)? {
         for suffix in all where filename.hasSuffix(suffix) {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
@@ -12,7 +12,7 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
     /// raw app temp) isn't an app-track orphan.
     func testCrashedRecordingStemsDetectsTmpWithoutMix() {
         let stems = DualSourceRecorder.crashedRecordingStems(in: [
-            "20260311_100000_app_raw.tmp", // crashed: temp, no mix
+            "20260311_100000_app16k_raw.tmp", // crashed: temp, no mix
             "20260311_100000_mic.wav",
             "20260311_110000_app_raw.tmp", // already processed: temp + mix
             "20260311_110000_mix.wav",
@@ -27,7 +27,7 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
     func testRecoverCrashedRecordingsRemixesOrphanedRawAppAndMic() throws {
         let dir = try makeTempDirectory(prefix: "crash_recover")
         let stem = "20260311_140000"
-        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        let appTmp = dir.appendingPathComponent(stem + "_app16k_raw.tmp")
         // 2 s of 16 kHz mono float — the surviving app track (AppAudioCapture
         // resamples to 16 kHz mono in the IOProc, so the temp is already there).
         try writeRawFloat32([Float](repeating: 0.3, count: 16000 * 2), to: appTmp)
@@ -51,12 +51,52 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: appTmp.path), "the raw temp should be consumed")
     }
 
+    /// A pre-upgrade temp (`_app_raw.tmp`, raw device-rate stereo) must also be
+    /// detected as a crash orphan — upgrading the app must not strand audio
+    /// recorded by the previous version.
+    func testCrashedRecordingStemsDetectsLegacyTempFormat() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_app16k_raw.tmp", // current format, no mix
+            "20260311_110000_app_raw.tmp", // legacy format, no mix
+            "20260311_120000_app_raw.tmp", // legacy, already processed
+            "20260311_120000_mix.wav",
+        ])
+        XCTAssertEqual(stems.sorted(), ["20260311_100000", "20260311_110000"])
+    }
+
+    /// A legacy temp contains RAW DEVICE-RATE audio (typically 48 kHz stereo),
+    /// not the 16 kHz mono the current capture writes. Recovery must read it
+    /// with the legacy interpretation — reading 48 kHz stereo as 16 kHz mono
+    /// yields ~6× slowed channel-interleaved garbage (and an empty transcript).
+    func testRecoverLegacyTempUsesDeviceCaptureFormat() throws {
+        let dir = try makeTempDirectory(prefix: "crash_legacy")
+        let stem = "20260311_160000"
+        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        // 1 s of 48 kHz interleaved stereo — what a pre-upgrade version wrote.
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
+        )
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 1)
+        let appWav = dir.appendingPathComponent(stem + "_app.wav")
+        let samples = try AudioMixer.loadAudioFileAsFloat32(url: appWav)
+        XCTAssertEqual(
+            samples.count, 16000, accuracy: 800,
+            "1 s of legacy 48 kHz stereo must recover to 1 s at 16 kHz, not 6 s of garbage",
+        )
+    }
+
     /// A freshly-written `.tmp` (recent mtime) looks like an in-progress
     /// recording, not a crash — recovery must leave it untouched.
     func testRecoverCrashedRecordingsSkipsInProgressTemp() throws {
         let dir = try makeTempDirectory(prefix: "crash_inprogress")
         let stem = "20260311_150000"
-        let appTmp = dir.appendingPathComponent(stem + "_app_raw.tmp")
+        let appTmp = dir.appendingPathComponent(stem + "_app16k_raw.tmp")
         try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
 
         let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -89,7 +89,7 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
                        with --no-build).
   --crash-recovery     Issue #379 part 3: start a meeting, wait until the
                        recorder is writing its raw app temp, then SIGKILL the
-                       app mid-recording (no stop() -> the raw _app_raw.tmp +
+                       app mid-recording (no stop() -> the raw _app16k_raw.tmp +
                        unfinalized _mic.wav survive, no _mix.wav). Relaunch and
                        assert the recovered recording enters the pipeline and a
                        job reaches done (the re-mixed _mix.wav is transient — the
@@ -754,7 +754,7 @@ run_one_reimport() {
 LAST_RECORDED_MIX_PATH=""
 
 # Issue #379 part 3 — crash recovery. Record via the live stack, SIGKILL the
-# app mid-recording so `stop()` never runs (the raw `_app_raw.tmp` + unfinalized
+# app mid-recording so `stop()` never runs (the raw `_app16k_raw.tmp` + unfinalized
 # `_mic.wav` survive, no `_mix.wav`), then relaunch and assert the recovered
 # recording enters the pipeline and a job reaches done. The re-mixed `_mix.wav`
 # is transient (recoverOrphanedRecordings enqueues it + the pipeline consumes it
@@ -788,14 +788,14 @@ run_crash_recovery() {
     # 2. Wait until the recorder is writing the raw app temp (recording active).
     local orphan_tmp=""
     _crash_tmp_appeared() {
-        orphan_tmp="$(find "$CRASH_RECORDINGS" -maxdepth 1 -name '*_app_raw.tmp' -newer "$CRASH_MARKER" -print 2>/dev/null | head -1)"
+        orphan_tmp="$(find "$CRASH_RECORDINGS" -maxdepth 1 -name '*_app16k_raw.tmp' -newer "$CRASH_MARKER" -print 2>/dev/null | head -1)"
         [ -n "$orphan_tmp" ]
     }
-    log "$label: waiting for an active recording (*_app_raw.tmp)"
-    poll_until 40 1 _crash_tmp_appeared || fail "$label: no *_app_raw.tmp appeared — recording never started"
+    log "$label: waiting for an active recording (*_app16k_raw.tmp)"
+    poll_until 40 1 _crash_tmp_appeared || fail "$label: no *_app16k_raw.tmp appeared — recording never started"
     sleep 3   # let a little audio accumulate before the kill
 
-    CRASH_STEM="$(basename "$orphan_tmp")"; CRASH_STEM="${CRASH_STEM%_app_raw.tmp}"
+    CRASH_STEM="$(basename "$orphan_tmp")"; CRASH_STEM="${CRASH_STEM%_app16k_raw.tmp}"
     local stem="$CRASH_STEM"
     log "$label: recording active, orphan stem=$stem"
 
@@ -809,14 +809,14 @@ run_crash_recovery() {
     sleep 2
 
     # 4. Verify the crashed-orphan state on disk.
-    [ -f "$CRASH_RECORDINGS/${stem}_app_raw.tmp" ] || fail "$label: orphan ${stem}_app_raw.tmp did not survive the crash"
+    [ -f "$CRASH_RECORDINGS/${stem}_app16k_raw.tmp" ] || fail "$label: orphan ${stem}_app16k_raw.tmp did not survive the crash"
     [ ! -f "$CRASH_RECORDINGS/${stem}_mix.wav" ] || fail "$label: a _mix.wav exists — stop() ran, this wasn't a crash"
     log "$label: confirmed crashed state (raw temp present, no mix)"
 
     # 5. Backdate the orphan past recovery's in-progress guard (a real
     #    crash→relaunch gap is minutes; keeps the e2e fast + deterministic).
     local old; old="$(date -v-5M +%Y%m%d%H%M.%S)"
-    touch -t "$old" "$CRASH_RECORDINGS/${stem}_app_raw.tmp"
+    touch -t "$old" "$CRASH_RECORDINGS/${stem}_app16k_raw.tmp"
     [ -f "$CRASH_RECORDINGS/${stem}_mic.wav" ] && touch -t "$old" "$CRASH_RECORDINGS/${stem}_mic.wav" || true
 
     # 6. Relaunch — recovery runs at the launch queue-build.


### PR DESCRIPTION
## Problem

Post-merge hardening after #392. The first main run after that merge went red in the live-recording E2E: the runner held raw app temps written by the *previous* app version (raw device-rate stereo), and the upgraded app's crash recovery read them as 16 kHz mono — the temp is headerless, so it had no way to tell. The result is ~6×-slowed channel-interleaved garbage, an "Empty transcript" error job, and — because an errored recovery never enters `processed_recordings.json` — that job is re-enqueued on every launch. Any user who crashes mid-recording on an older build and then upgrades hits the same path.

## Fix

The suffix now encodes the temp format: current temps are written as `_app16k_raw.tmp`; the old `_app_raw.tmp` is never written anymore and is read by crash recovery with the pre-resampler interpretation (device rate/channels + the mic-duration rate cross-check). Temp cleanup handles both; the suffix set lives once on `RecordingFileSuffix` (`appRawAny`/`stripAppRaw`). The crash-recovery E2E lane tracks the rename — its recording-active probe greps for the suffix the live app actually writes.

The companion CI-side fix (the cpu-load lane orphaning the temps that triggered this) is split into its own PR.

## Tests

- `testRecoverLegacyTempUsesDeviceCaptureFormat`: 1 s of legacy 48 kHz stereo recovers to 1 s at 16 kHz (the unfixed path produced 6 s of garbage — the CI incident as a unit test).
- `testCrashedRecordingStemsDetectsLegacyTempFormat`: both suffixes are detected as crash orphans.
- Full suites green (app 1 899); lint clean; release-build parity passed.

Refs #379
