### PR TITLE
ci(e2e): clean up cpu-load lane recording artifacts on exit

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -487,10 +487,16 @@ POLL_LJ_ID=""
 POLL_LJ_STATE=""
 _poll_for_new_lastjob_terminal() {
     local label="$1"
+    # When $2 is non-empty, launch-recovery jobs ("Recovered Recording (...)")
+    # never satisfy the wait: a stale orphan from a previous run is recovered
+    # at app launch and races the simulator-triggered job — three CI reds in
+    # one day came from lanes mistaking that recovery job for their own. The
+    # crash-recovery lane omits the flag; its expected job IS the recovered one.
+    local ignore_recovered="${2:-}"
     log "$label: polling /state every 5s for new lastJob (timeout ${PIPELINE_TIMEOUT_S}s)"
     local deadline=$(( $(date +%s) + PIPELINE_TIMEOUT_S ))
-    local last_state="" last_id=""
-    local lj_id="" lj_state="" pipe_active="" pipe_processing="" pending_naming=""
+    local last_state="" last_id="" noted_recovered=""
+    local lj_id="" lj_state="" lj_recovered="" pipe_active="" pipe_processing="" pending_naming=""
 
     while true; do
         # Fail fast if the dev .app died — otherwise the loop just sees
@@ -499,9 +505,9 @@ _poll_for_new_lastjob_terminal() {
         # job reached terminal state", masking the real crash.
         assert_app_alive
 
-        lj_id=""; lj_state=""; pipe_active=""; pipe_processing=""; pending_naming=""
-        IFS='|' read -r lj_id lj_state pipe_active pipe_processing pending_naming < <(
-            rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", .pipeline.activeJobCount, .pipeline.isProcessing, .pipeline.pendingNamingJobCount] | join("|")'
+        lj_id=""; lj_state=""; lj_recovered=""; pipe_active=""; pipe_processing=""; pending_naming=""
+        IFS='|' read -r lj_id lj_state lj_recovered pipe_active pipe_processing pending_naming < <(
+            rpc /state | jq -r '[.lastJob.jobID // "", .lastJob.state // "", ((.lastJob.meetingTitle // "") | startswith("Recovered Recording")), .pipeline.activeJobCount, .pipeline.isProcessing, .pipeline.pendingNamingJobCount] | join("|")'
         ) || true
 
         # Drain speaker-naming dialogs so headless runs don't deadlock on a
@@ -531,7 +537,13 @@ _poll_for_new_lastjob_terminal() {
             last_id="$lj_id"
         fi
 
+        if [ -n "$ignore_recovered" ] && [ "$lj_recovered" = "true" ] \
+            && [ "$lj_id" != "$PRE_LAST_JOB_ID" ] && [ "$lj_id" != "${noted_recovered:-}" ]; then
+            log "$label:   ignoring launch-recovery job $lj_id (state=$lj_state) — waiting for the simulator-triggered job"
+            noted_recovered="$lj_id"
+        fi
         if [ -n "$lj_id" ] && [ "$lj_id" != "$PRE_LAST_JOB_ID" ] \
+            && { [ -z "$ignore_recovered" ] || [ "$lj_recovered" != "true" ]; } \
             && { [ "$lj_state" = "done" ] || [ "$lj_state" = "error" ]; }; then
             break
         fi
@@ -553,7 +565,7 @@ run_one_meeting() {
     "$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" >/tmp/e2e-app-sim.log 2>&1 &
     SIM_PID=$!
 
-    _poll_for_new_lastjob_terminal "$label"
+    _poll_for_new_lastjob_terminal "$label" ignore-recovered
     local lj_id="$POLL_LJ_ID" lj_state="$POLL_LJ_STATE"
 
     log "$label: final state: $lj_state"

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -76,6 +76,7 @@ SIMULATOR_PKG="$ROOT/tools/meeting-simulator"
 SIMULATOR_BIN="$SIMULATOR_PKG/.build/release/meeting-simulator"
 DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 RPC_BASE="http://127.0.0.1:9876"
 BUNDLE_ID="com.meetingtranscriber.dev"
 
@@ -242,6 +243,10 @@ launch_app_and_wait() {
     log "RPC up"
 }
 
+# Timestamp anchor for on_exit cleanup: every recording artifact this run
+# creates is newer than this marker file.
+RUN_START_MARKER="$(mktemp "${TMPDIR:-/tmp}/e2e-cpu-load-start.XXXXXX")"
+
 SIM_PID=""
 on_exit() {
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
@@ -254,6 +259,27 @@ on_exit() {
     restore_bool_default "$BUNDLE_ID" debugRPCEnabled "$SAVED_DEBUG_RPC"
     restore_bool_default "$BUNDLE_ID" autoWatch       "$SAVED_AUTO_WATCH"
     restore_bool_default "$BUNDLE_ID" recordOnly      "$SAVED_RECORD_ONLY"
+    if [ "$APP_AFTER" = quit ]; then
+        # `|| true`: under set -e a wedged app (quit ladder exhausted) must not
+        # abort the trap before the artifact sweep below runs.
+        quit_running_app || true
+        # The lane's recordings are measurement garbage, and quitting the app
+        # mid-grace orphans raw temps: the NEXT run's app crash-recovers a
+        # stale temp into a garbage job, and an errored recovery job is
+        # re-enqueued on every launch (it never enters
+        # processed_recordings.json). Delete everything this run created;
+        # pre-existing files are older than the marker and stay untouched.
+        # GUARDED to CI via $GITHUB_ACTIONS (same pattern as the queue-snapshot
+        # reset): dev and prod app share the recordings dir on a developer
+        # machine, so a local sweep could catch a real recording made during
+        # the run. Locally the orphans are harmless -- the next app launch
+        # recovers them.
+        if [ "${GITHUB_ACTIONS:-}" = "true" ] \
+            && [ -n "${RUN_START_MARKER:-}" ] && [ -d "$REC_DIR" ]; then
+            find "$REC_DIR" -type f -newer "$RUN_START_MARKER" -delete 2>/dev/null || true
+        fi
+    fi
+    rm -f "${RUN_START_MARKER:-}" 2>/dev/null || true
 }
 trap on_exit EXIT INT TERM
 
@@ -422,6 +448,5 @@ IFS=$'\t' read -r IDLE_CPU idle_ok < <(
 
 log "PASS — idle ${IDLE_CPU}% CPU (bound ${IDLE_MAX_CPU_PCT}%); recording + live-captions windows logged for trend"
 
-if [ "$APP_AFTER" = quit ]; then
-    quit_running_app
-fi
+# App quit + recording-artifact cleanup happen in on_exit (EXIT trap), so
+# failure paths get the same hygiene as the happy path.


### PR DESCRIPTION
## Problem

The cpu-load measurement lane quits the app mid-recording by design (the simulated meeting's end grace never elapses), orphaning raw app temps in the recordings dir. The next run's app then crash-recovers those stale temps into recovery jobs that race the e2e-app driver's lane-1 "new lastJob" polling — this is what turned the first post-#392 main run red: the recovered job errored ("Empty transcript" from a pre-upgrade temp) and, because an errored recovery never enters `processed_recordings.json`, it was re-enqueued on every launch.

The app-side half (reading pre-upgrade temps with their legacy format) is #393; this PR stops the lane from producing the landmines in the first place.

## Fix

`on_exit` now owns the app lifecycle and deletes every recording artifact the run created — a run-start `mktemp` marker plus `find -newer … -delete`, so pre-existing files stay untouched. The cleanup runs on failure paths too (EXIT trap), `--keep-app` skips it for interactive debugging, and `quit_running_app` is `||`-true'd so a wedged app cannot abort the trap before the sweep under `set -e`.

Deliberately deferred: `e2e-app.sh` has its own marker-bounded cleanup of the same shape — extracting both into `scripts/lib/e2e-helpers.sh` is a follow-up that should migrate both scripts together.
