### PR TITLE
perf(app): forward resampled 16k audio to the app live sink

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture+LiveSink.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+LiveSink.swift
@@ -6,9 +6,28 @@ import Foundation
 /// `AppAudioCapture+PIDTranslation.swift`.
 @available(macOS 14.2, *)
 extension AppAudioCapture {
+    /// Hand already-resampled 16 kHz mono samples to the optional live sink —
+    /// the same data `writeCapturedBuffer` writes to the file fd. The normal
+    /// path: forwarding the resampled buffer means the app side doesn't resample
+    /// a second time (`LiveAudioResampler` short-circuits 16 kHz mono). Gap-fill
+    /// silence is deliberately excluded; only the buffer's real samples flow
+    /// here. Short-circuits when no sink is installed.
+    func forwardToLiveSink(monoSamples: [Float]) {
+        guard let sink = liveSink, !monoSamples.isEmpty else { return }
+        sink(LiveAudioBuffer(
+            samples: monoSamples,
+            channelCount: 1,
+            sampleRate: Int(speechSampleRate),
+            hostTime: mach_absolute_time(),
+        ))
+    }
+
     /// Copy the interleaved float32 IOProc buffer into `[Float]` and hand it
-    /// to the optional live sink. Short-circuits when no sink is installed so
-    /// the batch-only path stays allocation-free.
+    /// to the optional live sink at the raw device rate/channels. Fallback only:
+    /// used when no resampler was built (`writeCapturedBuffer`'s `resampler ==
+    /// nil` branch), so the live path still gets audio it can resample itself.
+    /// Short-circuits when no sink is installed so the batch-only path stays
+    /// allocation-free.
     func forwardToLiveSink(data: UnsafeMutableRawPointer, byteCount: Int) {
         guard let sink = liveSink else { return }
         let sampleCount = byteCount / MemoryLayout<Float>.size

--- a/tools/audiotap/Sources/AppAudioCapture+Resampling.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+Resampling.swift
@@ -31,30 +31,50 @@ public extension AppAudioCapture {
     }
 
     /// Resample + downmix one interleaved CATap buffer to 16 kHz mono and write
-    /// it to `fd`, rebuilding the converter on a mid-recording rate change. The
-    /// resampler buffers internally, so a buffer that yields no output yet
-    /// (converter priming) is simply not written — its samples emerge on a later
-    /// call, no data lost. Falls back to the raw native-rate write only if no
-    /// resampler was built (not expected for a 16 kHz target). `hostTicks` is the
-    /// buffer's hardware presentation time, used to fill device-restart gaps with
-    /// silence so the track stays aligned to wall-clock. Runs on `writeQueue`.
+    /// it to `fd`, also forwarding the resampled buffer to the live sink. The
+    /// converter is rebuilt on a mid-recording rate change. The resampler buffers
+    /// internally, so a buffer that yields no output yet (converter priming) is
+    /// simply not written — its samples emerge on a later call, no data lost.
+    /// Falls back to the raw native-rate write *and* raw-format live-sink forward
+    /// only if no resampler was built (not expected for a 16 kHz target).
+    /// `hostTicks` is the buffer's hardware presentation time, used to fill
+    /// device-restart gaps with silence so the track stays aligned to wall-clock.
+    /// Runs on `writeQueue`.
     internal func writeCapturedBuffer(
         fd: Int32, data: UnsafeMutableRawPointer, byteCount: Int, hostTicks: UInt64,
     ) {
-        guard let resampler else {
+        guard resampler != nil else {
             writeAllToFileHandle(fd, data, count: byteCount)
+            forwardToLiveSink(data: data, byteCount: byteCount)
             return
         }
         let floatCount = byteCount / MemoryLayout<Float>.size
         let interleaved = Array(UnsafeBufferPointer(
             start: data.assumingMemoryBound(to: Float.self), count: floatCount,
         ))
+        resampleForwardAndWrite(
+            fd: fd, interleaved: interleaved,
+            inputRate: actualSampleRate, inputChannels: max(actualChannels, 1),
+            hostTicks: hostTicks,
+        )
+    }
+
+    /// Core of `writeCapturedBuffer`, parameterised on the input rate/channels so
+    /// it's drivable without a live CATap. Resamples to 16 kHz mono, fills any
+    /// device-restart gap with silence (file only — the live path doesn't need
+    /// gap-fill), writes the resampled samples to `fd`, and forwards those same
+    /// samples to the live sink. Caller guarantees `resampler != nil`.
+    internal func resampleForwardAndWrite(
+        fd: Int32, interleaved: [Float], inputRate: Int, inputChannels: Int, hostTicks: UInt64,
+    ) {
+        guard let resampler else { return }
         let mono16k = resampler.process(
-            interleaved, inputRate: actualSampleRate, inputChannels: max(actualChannels, 1),
+            interleaved, inputRate: inputRate, inputChannels: inputChannels,
         )
         guard !mono16k.isEmpty else { return }
         fillTimelineGap(fd: fd, hostTicks: hostTicks, outputFrames: mono16k.count)
         Self.writeFloats(mono16k, to: fd)
+        forwardToLiveSink(monoSamples: mono16k)
     }
 
     /// Write silence for a device-restart gap before this buffer's audio, so the

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -414,9 +414,10 @@ public class AppAudioCapture: @unchecked Sendable {
             // to 16 kHz mono AT CAPTURE (writeCapturedBuffer, +Resampling),
             // rebuilding the converter on a mid-recording rate change so a
             // device swap can't time-warp the file the way a single post-hoc
-            // resample did (issue #379 follow-up). RMS/level/live-sink stay on
-            // the raw buffer below — the live path has its own rate-adaptive
-            // resampler.
+            // resample did (issue #379 follow-up). The live sink is fed the SAME
+            // resampled 16 kHz mono buffer from inside writeCapturedBuffer, so
+            // the app doesn't resample a second time. RMS/level still read the
+            // raw buffer below.
             guard let data = abl.mBuffers.mData else { return }
             let byteCount = Int(abl.mBuffers.mDataByteSize)
             let hostTicks = Self.hostTicks(from: inInputTime)
@@ -425,7 +426,6 @@ public class AppAudioCapture: @unchecked Sendable {
             self.accumulateDebugRMS(data: data, byteCount: byteCount)
             self.publishCurrentLevel()
             self.maybeReportDebugRMS()
-            self.forwardToLiveSink(data: data, byteCount: byteCount)
         }
 
         guard ioProcStatus == noErr, let validProcID = newProcID else {

--- a/tools/audiotap/Tests/AppAudioCaptureLiveSinkTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureLiveSinkTests.swift
@@ -152,4 +152,44 @@ final class AppAudioCaptureLiveSinkTests: XCTestCase {
         }
         XCTAssertEqual(recorder.buffers[0].channelCount, 1, "must clamp to 1")
     }
+
+    // MARK: - Resampled forward (the normal capture-write path)
+
+    /// The seam PR-1 changes: the resampled 16 kHz mono buffer that
+    /// `writeCapturedBuffer` writes to the file fd is the SAME buffer handed to
+    /// the live sink. Feeds one second of 48 kHz interleaved stereo through the
+    /// real converter and asserts the sink received 16 kHz mono — so the app
+    /// side never resamples a second time. `resampleForwardAndWrite` is the
+    /// parameterised core of `writeCapturedBuffer` (drivable without a live
+    /// CATap, which can't set `actualSampleRate`).
+    func test_resampleForwardAndWrite_forwardsResampled16kMonoToSink() {
+        let recorder = SinkRecorder()
+        let capture = makeCapture(sampleRate: 48000, channels: 2) { recorder.sink($0) }
+
+        // 1 s of 48 kHz interleaved stereo, L=0.4 R=0.6 → mono average 0.5.
+        var stereo = [Float]()
+        stereo.reserveCapacity(48000 * 2)
+        for _ in 0 ..< 48000 {
+            stereo.append(0.4)
+            stereo.append(0.6)
+        }
+
+        capture.resampleForwardAndWrite(
+            fd: devNullFD, interleaved: stereo,
+            inputRate: 48000, inputChannels: 2, hostTicks: mach_absolute_time(),
+        )
+
+        XCTAssertEqual(recorder.buffers.count, 1, "sink must receive exactly the one resampled buffer")
+        let delivered = recorder.buffers[0]
+        XCTAssertEqual(delivered.sampleRate, 16000, "sink must get 16 kHz, not the raw 48 kHz device rate")
+        XCTAssertEqual(delivered.channelCount, 1, "sink must get mono, not the raw 2-channel stereo")
+        // 48 k stereo (96000 interleaved samples) → ~16000 mono. Allow converter
+        // priming slop, matching StreamingMonoResamplerTests' ±300 tolerance.
+        XCTAssertEqual(
+            delivered.samples.count, 16000, accuracy: 300,
+            "1 s of 48 kHz stereo → ~16000 mono samples (≈ input frames / 3)",
+        )
+        let mid = delivered.samples[delivered.samples.count / 2]
+        XCTAssertEqual(mid, 0.5, accuracy: 0.05, "stereo must downmix to the channel average")
+    }
 }


### PR DESCRIPTION
## Problem

Since capture-time resampling landed (#392), the CATap IOProc already produces 16 kHz mono app audio for the file write — but the live-captions sink still received the raw device-rate stereo buffer, which the app then resampled a **second** time in `LiveAudioResampler`. One conversion of the same audio per buffer is enough.

## Fix

Live-sink forwarding moves to the post-resample point: the sink now receives the same 16 kHz mono samples that go to the file. Raw-format forwarding remains only on the no-resampler fallback path (mirroring the file-write fallback), and the timeline gap-fill silence stays file-only — the sink gets real audio exclusively. The app-side `LiveAudioResampler` already short-circuits 16 kHz mono input, so it now acts as a zero-cost pass-through safety net.

On the realtime path this also allocates less than before: the mono buffer already exists for the file write and is reused for the sink, where the raw path previously made a dedicated copy.

## Tests

- New `AppAudioCaptureLiveSinkTests`: 1 s of 48 kHz interleaved stereo through the real converter must reach the sink as 16 kHz mono with the expected sample count and downmix average (0.4/0.6 → 0.5). Mutation-verified: removing the forward fails the test with `0 != 1` received buffers.
- Full AudioTapLib suite + release-build parity green; lint clean.
