### PR TITLE
fix(app): flush pending live utterance when recording stops

### DIFF
--- a/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
@@ -1,0 +1,13 @@
+import AudioTapLib
+
+/// Per-channel live captioning strategy. Implementations turn 16 kHz mono
+/// `LiveAudioBuffer`s into partial/finalized caption events.
+///
+/// Extracted as a seam so a second strategy (e.g. a native streaming ASR
+/// backend) can slot in alongside the VAD-driven `StreamingTranscriber`
+/// without `LiveTranscriptionController` knowing which concrete strategy it
+/// holds. Behavior of the existing path is unchanged — `StreamingTranscriber`
+/// already exposed `ingest(_:)` with this exact shape.
+protocol LiveCaptionPipeline: Actor {
+    func ingest(_ buffer: LiveAudioBuffer) async
+}

--- a/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
@@ -10,4 +10,6 @@ import AudioTapLib
 /// already exposed `ingest(_:)` with this exact shape.
 protocol LiveCaptionPipeline: Actor {
     func ingest(_ buffer: LiveAudioBuffer) async
+    /// Recording stopped — flush any pending utterance as a final.
+    func flush() async
 }

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -111,6 +111,17 @@ final class LiveTranscriptionController {
         }
     }
 
+    /// Recording stopped — flush both channel pipelines so any pending
+    /// tail utterance (speech that was still in progress when the recorder
+    /// stopped, so VAD never emitted a `speechEnd`) is committed as a final.
+    /// Must run at STOP time, before the next recording's `reset()` clears
+    /// caption state. Awaits both channels concurrently.
+    func flush() async {
+        async let mic: Void? = micPipeline?.flush()
+        async let app: Void? = appPipeline?.flush()
+        _ = await (mic, app)
+    }
+
     /// Reset accumulated state for the next recording. Keeps engine + VAD
     /// models loaded — re-creating the actors + resampler is cheap.
     func reset() {

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -43,8 +43,8 @@ final class LiveTranscriptionController {
     /// from inside the `Task { @MainActor in ... }` hop in `onEvent`, so the
     /// closure never crosses an isolation boundary.
     private let verboseDiagnostics: () -> Bool
-    private var micTranscriber: StreamingTranscriber?
-    private var appTranscriber: StreamingTranscriber?
+    private var micPipeline: (any LiveCaptionPipeline)?
+    private var appPipeline: (any LiveCaptionPipeline)?
     private var appResampler = LiveAudioResampler()
 
     /// Mic-channel live sink. Hand this to `DualSourceRecorder.micLiveSink`
@@ -88,11 +88,11 @@ final class LiveTranscriptionController {
     func prepare() async {
         await engine.loadModel()
         await prewarmSpeakerMatcher()
-        if micTranscriber == nil {
-            micTranscriber = makeTranscriber(channel: .mic)
+        if micPipeline == nil {
+            micPipeline = makePipeline(channel: .mic)
         }
-        if appTranscriber == nil {
-            appTranscriber = makeTranscriber(channel: .app)
+        if appPipeline == nil {
+            appPipeline = makePipeline(channel: .app)
         }
         if verboseDiagnostics() {
             logger.info("Live transcription ready (engine: \(String(describing: type(of: self.engine)), privacy: .public))")
@@ -114,8 +114,8 @@ final class LiveTranscriptionController {
     /// Reset accumulated state for the next recording. Keeps engine + VAD
     /// models loaded — re-creating the actors + resampler is cheap.
     func reset() {
-        micTranscriber = makeTranscriber(channel: .mic)
-        appTranscriber = makeTranscriber(channel: .app)
+        micPipeline = makePipeline(channel: .mic)
+        appPipeline = makePipeline(channel: .app)
         appResampler = LiveAudioResampler()
         captions.clear()
         if verboseDiagnostics() {
@@ -123,7 +123,7 @@ final class LiveTranscriptionController {
         }
     }
 
-    private func makeTranscriber(channel: LiveCaptionChannel) -> StreamingTranscriber {
+    private func makePipeline(channel: LiveCaptionChannel) -> any LiveCaptionPipeline {
         // `EngineProxy` is `@unchecked Sendable` so the `@Sendable` closure
         // below can capture it. Safe because every call routes through the
         // engine's `@MainActor`-isolated `transcribeSamples`, which hops back
@@ -169,15 +169,15 @@ final class LiveTranscriptionController {
     }
 
     private func handleMicBuffer(_ buffer: LiveAudioBuffer) async {
-        guard let micTranscriber else { return }
-        await micTranscriber.ingest(buffer)
+        guard let micPipeline else { return }
+        await micPipeline.ingest(buffer)
     }
 
     private func handleAppBuffer(_ buffer: LiveAudioBuffer) async {
-        guard let appTranscriber,
+        guard let appPipeline,
               let normalized = appResampler.resample(buffer)
         else { return }
-        await appTranscriber.ingest(normalized)
+        await appPipeline.ingest(normalized)
     }
 }
 

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -94,6 +94,16 @@ final class LiveTranscriptionCoordinator {
         recorder.appLiveSink = controller.appSink
     }
 
+    /// Flush the live controller's pending tail utterance when recording stops.
+    /// No-op when no controller is active (live transcription off / unsupported
+    /// engine / never warmed). Called at STOP time — before any `reset()` that
+    /// clears caption state on the next recording — so the user sees the final
+    /// caption of the last utterance. Idempotent: a second call after the
+    /// pipelines already flushed finds nothing pending and emits nothing.
+    func flush() async {
+        await controller?.flush()
+    }
+
     /// Eagerly load the VAD + engine models when the toggle is on (or already on
     /// at launch with a streaming engine) so the first utterance after the
     /// recorder starts doesn't pay the cold-load cost. Plus a re-arming

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -16,7 +16,10 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Streami
 /// resampled to 16 kHz mono upstream in `LiveTranscriptionController` (via
 /// `LiveAudioResampler`) before they reach `ingest`, so this actor always
 /// sees the 16 kHz mono format described above.
-actor StreamingTranscriber {
+///
+/// Conforms to `LiveCaptionPipeline` — the VAD-driven strategy behind that
+/// seam. `ingest(_:)` is the protocol requirement.
+actor StreamingTranscriber: LiveCaptionPipeline {
     enum Event {
         case partial(String)
         /// Finalized utterance. `audio` carries the buffered 16 kHz mono

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -46,6 +46,11 @@ actor StreamingTranscriber: LiveCaptionPipeline {
     private var isSpeaking = false
     private var lastPartialAt: Date = .distantPast
     private let onEvent: EventSink
+    /// True while a `drainChunks()` pass owns the input accumulator. The actor
+    /// suspends at the VAD and transcribe awaits, so a second caller (another
+    /// `ingest` Task or `flush`) can interleave; without this guard two drain
+    /// loops would fork the VAD stream state and process chunks out of order.
+    private var isDrainingInput = false
 
     /// Silero v6 chunk size at 16 kHz — what FluidVAD expects per call.
     private static let chunkSize = 4096
@@ -78,7 +83,32 @@ actor StreamingTranscriber: LiveCaptionPipeline {
         await drainChunks()
     }
 
+    /// Recording stopped — commit any pending speech as a final so the last
+    /// utterance isn't dropped when the recorder stops mid-speech (no VAD
+    /// `speechEnd` event ever arrives for the tail). `commitFinal()` keeps the
+    /// ≥1 s `minFinalSamples` guard, so sub-second pending speech is still
+    /// dropped as noise. Reset `isSpeaking` afterwards so the actor returns to
+    /// a clean idle state (the controller recreates pipelines per recording, so
+    /// this is belt-and-suspenders against any reuse).
+    func flush() async {
+        // Ingestion may still be mid-drain (the actor suspends at the VAD and
+        // partial-transcribe awaits) — wait for the active pass to finish and
+        // process any input that accumulated meanwhile, so audio the recorder
+        // already delivered before the stop isn't dropped by stop-timing.
+        while isDrainingInput {
+            await Task.yield()
+        }
+        if !inputAccumulator.isEmpty { await drainChunks() }
+        await commitFinal()
+        isSpeaking = false
+    }
+
     private func drainChunks() async {
+        // Single-pass guard: the active drain re-checks the accumulator every
+        // iteration, so anything appended while it runs is consumed by it.
+        if isDrainingInput { return }
+        isDrainingInput = true
+        defer { isDrainingInput = false }
         if vadState == nil {
             do {
                 vadState = try await vad.makeStreamState()

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -208,7 +208,18 @@ final class WatchingController {
     /// `notifyOnRecording` only fires "Meeting Detected" notifications for the
     /// auto-detect path; manual recording emits its own start notification.
     private func attachStateChangeHandler(to loop: WatchLoop, notifyOnRecording: Bool) {
-        loop.onStateChange = { [weak self, weak loop, notifier] _, newState in
+        loop.onStateChange = { [weak self, weak loop, notifier] oldState, newState in
+            // Leaving `.recording` (natural meeting end, manual stop, or
+            // mid-recording cancel — all route through this transition) is the
+            // unified stop signal for both the auto-detect and manual paths.
+            // Flush the live pipeline here so the pending tail utterance is
+            // committed before the next recording's reset() clears state. The
+            // flush runs after `recorder.stop()` (WatchLoop stops the recorder
+            // before this transition fires); the buffered tail lives in the
+            // streaming actors, not the recorder, so it survives the stop.
+            if oldState == .recording {
+                Task { @MainActor in await self?.liveTranscription.flush() }
+            }
             switch newState {
             case .recording:
                 if notifyOnRecording, let meeting = loop?.currentMeeting {

--- a/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
@@ -1,0 +1,173 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// Coverage for the `LiveCaptionPipeline.flush()` contract: when recording
+/// stops mid-utterance (no trailing silence → no VAD `speechEnd` event), the
+/// pending speech must still be committed as a final so the user sees the
+/// last caption. Without `flush()`, that tail utterance is silently dropped.
+///
+/// Drives a real `StreamingTranscriber` through the real `FluidVAD` streaming
+/// state machine — the same wiring the production path uses. The German
+/// two-speaker fixture starts with a `speechStart` at chunk 0 and its first
+/// `speechEnd` only at ~8.4 s, so feeding a bounded prefix (a handful of
+/// 4096-sample chunks) leaves speech *buffered but not yet finalized* — the
+/// exact "recording stopped mid-utterance" condition. `flush()` then has to
+/// commit that buffer through `commitFinal()`.
+///
+/// Both test methods live in one `@MainActor` class (and the actor-level test
+/// folds its three scenarios into a single method) on purpose — under
+/// `swift test --parallel` each method runs in its own worker process, and the
+/// Silero VAD load is the dominant cost. Folding minimises VAD loads and avoids
+/// piling parallel-load pressure on the neighbouring CoreML-heavy
+/// live-transcription suites. See
+/// `feedback_coreml_e5rt_cache_race_under_parallel_xctest`.
+@MainActor
+final class LiveCaptionPipelineTests: XCTestCase {
+    /// Number of 16 kHz mono samples per VAD chunk (Silero v6).
+    private static let chunkSize = 4096
+
+    /// Actor-level: `StreamingTranscriber.flush()` commits the pending utterance
+    /// (positive) and respects the sub-1 s noise guard (negative).
+    func testFlushCommitsPendingUtteranceContract() async throws {
+        let samples = try await loadSpeechFixture()
+
+        // (1) Positive: feed ~1.3 s of speech-active prefix (5 chunks). The
+        // fixture's first speechEnd is at ~8.4 s, so no end event fires and
+        // ~20 480 samples (> the 1 s `minFinalSamples` guard) stay buffered.
+        // flush() must emit exactly one finalized event carrying that audio.
+        let speakingPrefix = Array(samples.prefix(Self.chunkSize * 5))
+        let positive = OnEventRecorder()
+        let pipeline = makePipeline(observer: positive)
+        await pipeline.ingest(buffer(speakingPrefix))
+        XCTAssertEqual(
+            positive.finals.count, 0,
+            "no speechEnd yet — nothing should be finalized before flush",
+        )
+
+        await pipeline.flush()
+
+        XCTAssertEqual(
+            positive.finals.count, 1,
+            "flush must commit the pending >1 s utterance as exactly one final",
+        )
+        XCTAssertEqual(
+            positive.finals.first?.audio.count, speakingPrefix.count,
+            "the finalized event must carry the buffered speech samples",
+        )
+
+        // (2) Negative: feed only ~0.77 s of speech-active prefix (3 chunks =
+        // 12 288 samples, below the 1 s `minFinalSamples` noise guard). flush()
+        // must drop it — sub-second pending speech is treated as noise, same
+        // as a real speechEnd would.
+        let noisePrefix = Array(samples.prefix(Self.chunkSize * 3))
+        let negative = OnEventRecorder()
+        let noisePipeline = makePipeline(observer: negative)
+        await noisePipeline.ingest(buffer(noisePrefix))
+        XCTAssertEqual(negative.finals.count, 0)
+
+        await noisePipeline.flush()
+
+        XCTAssertEqual(
+            negative.finals.count, 0,
+            "flush must NOT finalize sub-1 s pending speech (noise guard preserved)",
+        )
+    }
+
+    /// Controller-level: `LiveTranscriptionController.flush()` must propagate to
+    /// both channel pipelines so a pending tail utterance reaches
+    /// `LiveCaptionsState`. Uses `MockStreamingEngine` (no model load) + the real
+    /// `FluidVAD` + the real fixture, driving audio through `micSink` the same
+    /// way the recorder does in production.
+    ///
+    /// Non-vacuity: without `flush()` propagation the pending speech (fed
+    /// mid-utterance, no `speechEnd`) never finalises, so `recentFinals` stays
+    /// empty — the assertion only passes because flush commits it.
+    func testControllerFlushDeliversPendingFinalToCaptions() async throws {
+        let samples = try await loadSpeechFixture()
+        let captions = LiveCaptionsState()
+        let engine = MockStreamingEngine()
+        engine.samplesToTranscribe = "tail utterance"
+        let controller = LiveTranscriptionController(
+            engine: engine,
+            vad: FluidVAD(threshold: 0.5),
+            captions: captions,
+            speakerMatcher: FakeLiveSpeakerMatcher(),
+        )
+        await controller.prepare()
+
+        // Feed a >1 s speech-active prefix through the mic sink (the recorder's
+        // entry point). The sink hops onto an actor Task — wait for the partial
+        // the prefix emits as the deterministic drain signal. A fixed sleep is
+        // not enough: on a cold CI runner the first Silero load inside ingest
+        // takes seconds, the actor suspends in the VAD load (reentrancy), and
+        // an early flush() would commit an empty buffer.
+        let prefix = Array(samples.prefix(Self.chunkSize * 5))
+        controller.micSink(buffer(prefix))
+        await waitFor(!captions.hypothesisMic.isEmpty, timeout: .seconds(30))
+        XCTAssertFalse(captions.hypothesisMic.isEmpty, "ingestion must surface a partial before flushing")
+        // No speechEnd yet → nothing finalised before flush.
+        XCTAssertTrue(captions.recentFinals.isEmpty, "no final should appear before flush")
+
+        await controller.flush()
+        await waitFor(!captions.recentFinals.isEmpty, timeout: .seconds(2))
+
+        let micFinals = captions.recentFinals.filter { $0.channel == .mic }
+        XCTAssertEqual(
+            micFinals.count, 1,
+            "controller.flush() must deliver the pending mic-channel final to captions",
+        )
+        XCTAssertEqual(micFinals.first?.text, "tail utterance")
+    }
+
+    // MARK: - Helpers
+
+    private func makePipeline(observer: OnEventRecorder) -> StreamingTranscriber {
+        StreamingTranscriber(
+            channelLabel: "test",
+            vad: FluidVAD(threshold: 0.5),
+            transcribe: { samples in
+                // Non-empty so `commitFinal` reaches the `onEvent(.finalized)`
+                // emission (it skips emission on empty transcripts).
+                samples.isEmpty ? "" : "transcribed"
+            },
+            onEvent: { event in observer.record(event) },
+        )
+    }
+
+    private func buffer(_ samples: [Float]) -> LiveAudioBuffer {
+        LiveAudioBuffer(samples: samples, channelCount: 1, sampleRate: 16000, hostTime: 0)
+    }
+
+    private func loadSpeechFixture() async throws -> [Float] {
+        let url = fixtureURL("two_speakers_de.wav")
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: url.path),
+            "Test fixture not found at \(url.path)",
+        )
+        return try await loadFixtureAs16kMono(url)
+    }
+}
+
+/// Sendable, lock-protected recorder for the actor's `@Sendable` callbacks.
+private final class OnEventRecorder: @unchecked Sendable {
+    struct Final {
+        let text: String
+        let audio: [Float]
+    }
+
+    private let lock = NSLock()
+    private var _finals: [Final] = []
+
+    var finals: [Final] {
+        lock.lock(); defer { lock.unlock() }
+        return _finals
+    }
+
+    func record(_ event: StreamingTranscriber.Event) {
+        lock.lock(); defer { lock.unlock() }
+        if case let .finalized(text, audio) = event {
+            _finals.append(Final(text: text, audio: audio))
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
@@ -120,6 +120,101 @@ final class LiveCaptionPipelineTests: XCTestCase {
         XCTAssertEqual(micFinals.first?.text, "tail utterance")
     }
 
+    /// Actor-level: `flush()` after a *natural* `speechEnd` adds no new final —
+    /// the most common real stop case (user stops the recorder a beat after a
+    /// sentence finishes, so VAD already committed it). Feeds the fixture
+    /// through its first natural `speechEnd` at chunk 33; the speech-active span
+    /// is long enough that the 5 s force-flush also fires once, so the baseline
+    /// is two finals (a fixture fact, not the point). The contract pinned here is
+    /// that `flush()` commits *nothing more* once the buffer was already drained
+    /// by a real `speechEnd` — no phantom duplicate of the last utterance.
+    func testFlushAfterNaturalSpeechEndEmitsNoSecondFinal() async throws {
+        let samples = try await loadSpeechFixture()
+        // chunks 0…33 — through the fixture's first natural speechEnd (chunk 33).
+        let throughEnd = Array(samples.prefix(Self.chunkSize * 34))
+        let recorder = OnEventRecorder()
+        let pipeline = makePipeline(observer: recorder)
+        await pipeline.ingest(buffer(throughEnd))
+
+        let baseline = recorder.finals.count
+        XCTAssertGreaterThan(
+            baseline, 0,
+            "the natural speechEnd (plus the 5 s force-flush) must have committed at least one final",
+        )
+
+        await pipeline.flush()
+
+        XCTAssertEqual(
+            recorder.finals.count, baseline,
+            "flush after a natural speechEnd must add no final — the buffer was already drained",
+        )
+    }
+
+    /// Actor-level: `flush()` is idempotent. The first flush commits the pending
+    /// (>1 s) tail; `commitFinal()` reassigns `speechSamples = []`, consuming the
+    /// buffer, so a second flush finds nothing to commit. Guards against a
+    /// regression where the buffer isn't reset and the tail is emitted twice.
+    func testFlushIsIdempotent() async throws {
+        let samples = try await loadSpeechFixture()
+        // 5-chunk speech-active prefix (~1.3 s > 1 s minFinalSamples), no
+        // speechEnd yet → speech stays buffered until flush commits it.
+        let speakingPrefix = Array(samples.prefix(Self.chunkSize * 5))
+        let recorder = OnEventRecorder()
+        let pipeline = makePipeline(observer: recorder)
+        await pipeline.ingest(buffer(speakingPrefix))
+        XCTAssertEqual(recorder.finals.count, 0, "no speechEnd yet — nothing finalized before flush")
+
+        await pipeline.flush()
+        XCTAssertEqual(recorder.finals.count, 1, "first flush commits the pending tail")
+
+        await pipeline.flush()
+        XCTAssertEqual(
+            recorder.finals.count, 1,
+            "second flush is a no-op — commitFinal already consumed the buffer",
+        )
+    }
+
+    /// Controller-level: `flush()` must reach the APP channel too, mirroring the
+    /// mic-channel test above. App buffers normally arrive 48 kHz stereo and are
+    /// resampled by `LiveAudioResampler`; here the input is already 16 kHz mono
+    /// (the resampler short-circuits and passes it through unchanged), isolating
+    /// the controller's `appSink` → `handleAppBuffer` → `appPipeline` fan-out.
+    /// Pins the `async let` symmetry in `LiveTranscriptionController.flush()` —
+    /// a regression that only flushed the mic pipeline would leave this empty.
+    func testControllerFlushDeliversPendingAppChannelFinal() async throws {
+        let samples = try await loadSpeechFixture()
+        let captions = LiveCaptionsState()
+        let engine = MockStreamingEngine()
+        engine.samplesToTranscribe = "tail utterance"
+        let controller = LiveTranscriptionController(
+            engine: engine,
+            vad: FluidVAD(threshold: 0.5),
+            captions: captions,
+            speakerMatcher: FakeLiveSpeakerMatcher(),
+        )
+        await controller.prepare()
+
+        // Feed a >1 s speech-active prefix through the APP sink (the CATap entry
+        // point). Same deterministic drain signal as the mic test above: wait
+        // for the prefix's partial instead of a fixed sleep, so a cold-CI VAD
+        // load can't race flush() past the still-suspended ingestion.
+        let prefix = Array(samples.prefix(Self.chunkSize * 5))
+        controller.appSink(buffer(prefix))
+        await waitFor(!captions.hypothesisApp.isEmpty, timeout: .seconds(30))
+        XCTAssertFalse(captions.hypothesisApp.isEmpty, "ingestion must surface a partial before flushing")
+        XCTAssertTrue(captions.recentFinals.isEmpty, "no final should appear before flush")
+
+        await controller.flush()
+        await waitFor(!captions.recentFinals.isEmpty, timeout: .seconds(2))
+
+        let appFinals = captions.recentFinals.filter { $0.channel == .app }
+        XCTAssertEqual(
+            appFinals.count, 1,
+            "controller.flush() must deliver the pending app-channel final to captions",
+        )
+        XCTAssertEqual(appFinals.first?.text, "tail utterance")
+    }
+
     // MARK: - Helpers
 
     private func makePipeline(observer: OnEventRecorder) -> StreamingTranscriber {

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionControllerTests.swift
@@ -89,7 +89,7 @@ final class LiveTranscriptionControllerTests: XCTestCase {
             captions: captions,
             speakerMatcher: matcher,
         )
-        // The controller's makeTranscriber wires the matcher into the
+        // The controller's makePipeline wires the matcher into the
         // finalized branch — driving a real audio buffer through it would
         // require VAD timing. The seam test instead asserts at the
         // captions.applyFinalized level: the matcher returns the canned

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
@@ -192,14 +192,4 @@ final class LiveTranscriptionE2ETests: XCTestCase {
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
     }
-
-    /// Decode the fixture WAV into a 16 kHz mono Float32 array via the
-    /// production `AudioMixer` helpers — exercising the same load+resample
-    /// path the batch pipeline uses, so a regression in either landing on
-    /// only-test code is unlikely.
-    private func loadFixtureAs16kMono(_ url: URL) async throws -> [Float] {
-        let (raw, srcRate) = try await AudioMixer.loadAudioAsFloat32(url: url)
-        guard srcRate != 16000 else { return raw }
-        return AudioMixer.resample(raw, from: srcRate, to: 16000)
-    }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -67,6 +67,18 @@ extension XCTestCase {
     }
 }
 
+/// Decode a fixture WAV into a 16 kHz mono Float32 array via the
+/// production `AudioMixer` helpers — exercising the same load+resample
+/// path the batch pipeline uses, so a regression in either landing on
+/// only-test code is unlikely. Free function (not an XCTestCase extension)
+/// so `@MainActor`-isolated test classes can call it without sending a
+/// non-Sendable `self` across the isolation boundary.
+func loadFixtureAs16kMono(_ url: URL) async throws -> [Float] {
+    let (raw, srcRate) = try await AudioMixer.loadAudioAsFloat32(url: url)
+    guard srcRate != 16000 else { return raw }
+    return AudioMixer.resample(raw, from: srcRate, to: 16000)
+}
+
 // MARK: - E2E Opt-In Gate
 
 /// Skip in CI unless the dedicated `e2e.yml` workflow opted in via `E2E_ENABLED=1`.

--- a/tools/audiotap/Tests/AppAudioCaptureLiveSinkTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureLiveSinkTests.swift
@@ -192,4 +192,151 @@ final class AppAudioCaptureLiveSinkTests: XCTestCase {
         let mid = delivered.samples[delivered.samples.count / 2]
         XCTAssertEqual(mid, 0.5, accuracy: 0.05, "stereo must downmix to the channel average")
     }
+
+    /// THE gap-fill contract: a device-restart timeline gap is filled with
+    /// silence in the FILE only, never forwarded to the live sink. The file is
+    /// `sink samples + silence`; the sink sees only real audio. A regression
+    /// that routed gap-fill silence (or the silence-padded buffer) to the sink
+    /// would make captions transcribe a block of zeros as a phantom utterance.
+    ///
+    /// Drives `resampleForwardAndWrite` twice with 1 s of 48 kHz stereo each,
+    /// the second call's `hostTicks` 3 s after the first. The `TimelineAnchor`
+    /// self-anchors on the first call (no silence) and bridges the ~2 s gap
+    /// (3 s wall-clock minus 1 s already written) on the second.
+    func test_resampleForwardAndWrite_gapFillSilenceIsFileOnly() {
+        let recorder = SinkRecorder()
+        let capture = makeCapture(sampleRate: 48000, channels: 2) { recorder.sink($0) }
+
+        let path = NSTemporaryDirectory() + "livesink_gap_\(UUID().uuidString).f32"
+        let fd = open(path, O_CREAT | O_RDWR, 0o644)
+        XCTAssertGreaterThanOrEqual(fd, 0, "couldn't open temp file")
+        defer { close(fd); unlink(path) }
+
+        let oneSecond48kStereo = stereoFrames(count: 48000, left: 0.4, right: 0.6)
+        let t0 = mach_absolute_time()
+        capture.resampleForwardAndWrite(
+            fd: fd, interleaved: oneSecond48kStereo,
+            inputRate: 48000, inputChannels: 2, hostTicks: t0,
+        )
+        // Buffer 2 presents 3 s after t0 → ~2 s restart gap before it.
+        let t1 = t0 + secondsToMachTicks(3.0)
+        capture.resampleForwardAndWrite(
+            fd: fd, interleaved: oneSecond48kStereo,
+            inputRate: 48000, inputChannels: 2, hostTicks: t1,
+        )
+
+        // Every sink buffer is 16 kHz mono real audio…
+        XCTAssertEqual(recorder.buffers.count, 2, "two real buffers, no gap-fill buffer")
+        for buf in recorder.buffers {
+            XCTAssertEqual(buf.sampleRate, 16000)
+            XCTAssertEqual(buf.channelCount, 1)
+        }
+        let sinkSamples = recorder.buffers.reduce(0) { $0 + $1.samples.count }
+
+        // …and the file is exactly sink audio + gap-fill silence. The silence
+        // block (file − sink) must account for the ~2 s gap (allowing for
+        // converter priming slop on each span). If silence had been forwarded
+        // to the sink, this delta would collapse toward zero.
+        let fileFrames = Int(lseek(fd, 0, SEEK_END)) / MemoryLayout<Float>.size
+        let silenceFrames = fileFrames - sinkSamples
+        XCTAssertGreaterThanOrEqual(
+            silenceFrames, Int(1.5 * 16000),
+            "the ~2 s gap must reach the file as ≥1.5 s of silence (file = sink + silence)",
+        )
+        // The sink itself received none of that silence: its total is just the
+        // two real spans (~2 × 16000), well under the file total.
+        XCTAssertLessThan(
+            sinkSamples, fileFrames - Int(1.0 * 16000),
+            "sink must carry no gap-fill silence — file strictly exceeds sink by the gap",
+        )
+    }
+
+    /// HFP↔A2DP renegotiation shape: the device rate changes mid-recording
+    /// (48 kHz → 24 kHz on the same capture instance). The resampler must
+    /// rebuild its converter so each 1 s span still maps to ~1 s of 16 kHz
+    /// mono — and every forwarded sink buffer stays 16 kHz mono regardless of
+    /// the changing input rate.
+    func test_resampleForwardAndWrite_rateChangeKeepsSinkAt16kMono() {
+        let recorder = SinkRecorder()
+        let capture = makeCapture(sampleRate: 48000, channels: 2) { recorder.sink($0) }
+
+        let path = NSTemporaryDirectory() + "livesink_rate_\(UUID().uuidString).f32"
+        let fd = open(path, O_CREAT | O_RDWR, 0o644)
+        XCTAssertGreaterThanOrEqual(fd, 0, "couldn't open temp file")
+        defer { close(fd); unlink(path) }
+
+        let t0 = mach_absolute_time()
+        capture.resampleForwardAndWrite(
+            fd: fd, interleaved: stereoFrames(count: 48000, left: 0.4, right: 0.6),
+            inputRate: 48000, inputChannels: 2, hostTicks: t0,
+        )
+        // 24 kHz span, contiguous in wall-clock (t0 + 1 s) so no gap-fill —
+        // isolates the rate-change behaviour from the gap-fill path.
+        let t1 = t0 + secondsToMachTicks(1.0)
+        capture.resampleForwardAndWrite(
+            fd: fd, interleaved: stereoFrames(count: 24000, left: 0.4, right: 0.6),
+            inputRate: 24000, inputChannels: 2, hostTicks: t1,
+        )
+
+        XCTAssertEqual(recorder.buffers.count, 2)
+        for buf in recorder.buffers {
+            XCTAssertEqual(buf.sampleRate, 16000, "sink stays 16 kHz across the rate change")
+            XCTAssertEqual(buf.channelCount, 1, "sink stays mono across the rate change")
+        }
+        // Two 1 s spans → ~32000 mono samples total. A stale converter fed the
+        // 24 kHz span as 48 kHz would yield ~half that span (~8000) — far
+        // outside the ±10 % tolerance allowed for the converter rebuild/priming.
+        let sinkSamples = recorder.buffers.reduce(0) { $0 + $1.samples.count }
+        XCTAssertEqual(
+            sinkSamples, 32000, accuracy: 3200,
+            "1 s @48 kHz + 1 s @24 kHz → ~32000 mono samples after converter rebuild",
+        )
+    }
+
+    /// FIRST-buffer priming probe: a tiny first buffer (64 samples = 32 frames
+    /// of 48 kHz stereo) into a fresh capture deterministically yields exactly
+    /// one short, NON-empty resampled buffer (5 mono samples, verified across
+    /// trials). The contract this pins: the resampler never hands the live sink
+    /// an EMPTY `[Float]` — `resampleForwardAndWrite`'s `guard !mono16k.isEmpty`
+    /// plus `forwardToLiveSink(monoSamples:)`'s own non-empty guard ensure a
+    /// priming-only buffer is dropped rather than forwarded as a zero-length
+    /// caption span. (The converter does emit a few samples even for tiny input,
+    /// so we assert non-empty delivery rather than zero calls.)
+    func test_resampleForwardAndWrite_primingEmitsNoEmptyBuffer() {
+        let recorder = SinkRecorder()
+        let capture = makeCapture(sampleRate: 48000, channels: 2) { recorder.sink($0) }
+
+        let path = NSTemporaryDirectory() + "livesink_prime_\(UUID().uuidString).f32"
+        let fd = open(path, O_CREAT | O_RDWR, 0o644)
+        XCTAssertGreaterThanOrEqual(fd, 0, "couldn't open temp file")
+        defer { close(fd); unlink(path) }
+
+        let tinyFirst = stereoFrames(count: 32, left: 0.4, right: 0.6) // 64 interleaved samples
+        capture.resampleForwardAndWrite(
+            fd: fd, interleaved: tinyFirst,
+            inputRate: 48000, inputChannels: 2, hostTicks: mach_absolute_time(),
+        )
+
+        // The converter emits samples for tiny input, so the sink IS called —
+        // and what it gets must be a real, non-empty 16 kHz mono buffer.
+        XCTAssertFalse(recorder.buffers.isEmpty, "tiny input still yields a (short) resampled buffer")
+        for buf in recorder.buffers {
+            XCTAssertFalse(buf.samples.isEmpty, "the sink must never receive an empty priming buffer")
+            XCTAssertEqual(buf.sampleRate, 16000)
+            XCTAssertEqual(buf.channelCount, 1)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    /// Build `count` interleaved stereo frames with the given L/R values.
+    private func stereoFrames(count: Int, left: Float, right: Float) -> [Float] {
+        var samples = [Float]()
+        samples.reserveCapacity(count * 2)
+        for _ in 0 ..< count {
+            samples.append(left)
+            samples.append(right)
+        }
+        return samples
+    }
 }


### PR DESCRIPTION
## Problem

When a recording stops mid-utterance, the live-captions path silently drops whatever speech is still buffered: nothing ever commits the pending samples, so the last thing said in a meeting never becomes a final caption.

Separately, the live path is hard-wired to one captioning strategy (VAD-gated re-transcription), which blocks evaluating alternative strategies behind the same controller.

## Changes

Two commits:

1. **`refactor(app): extract LiveCaptionPipeline seam from StreamingTranscriber`** — a minimal per-channel `LiveCaptionPipeline: Actor` protocol; `StreamingTranscriber` is its first conformer and the controller now builds channels through a `makePipeline(channel:)` factory. Byte-for-byte behavior preserving (the event/speaker-matcher plumbing is untouched); compiles and passes tests standalone.

2. **`fix(app): flush pending live utterance when recording stops`** — `flush()` on the pipeline commits pending speech through the existing final path, keeping the ≥1 s noise guard; the controller fans out to both channels, and the watch-state handler triggers it on every transition out of `.recording` (manual stop, natural meeting end, and error paths) — after the recorder has stopped, before the next recording resets caption state.

## Tests

- Positive: >1 s of buffered speech with no VAD speech-end → `flush()` emits exactly one finalized caption carrying the buffered audio (asserted end-to-end into `LiveCaptionsState`).
- Negative: <1 s pending speech → no final (noise guard preserved).
- Mutation-proven at both levels: a no-op `flush()` and an unwired controller each fail the tests.
- Full suite, lint, and release-build parity green.

Known edge (accepted): an in-flight flush racing a fast restart can land one stale final after the new session's caption clear — cosmetic, capped by the 2-line recent-finals window, self-healing.
