### PR TITLE
fix(app): debug RPC server listener lifecycle + orphaned log-streamer reaper

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -176,6 +176,14 @@ final class AppState {
             rpcController.activate { [weak self] in self?.buildDebugRPCServer() }
 
             PersistentDiagnosticLog.cleanup()
+            // Reap any `log stream` children orphaned by a previous crash/SIGKILL
+            // (re-parented to launchd) so they can't accumulate across launches.
+            // Off the main thread: it shells out to `ps` + waitUntilExit(), which
+            // would otherwise stall launch proportional to the process-table size.
+            // The reap is deliberately NOT ordered before `startForToday()` — an
+            // orphan surviving a few extra ms is benign next to blocking launch,
+            // and the new streamer is matched by parent pid so it's never reaped.
+            Task.detached(priority: .utility) { PersistentDiagnosticLog.reapOrphans() }
             do {
                 self.persistentLogStreamer = try PersistentDiagnosticLog.startForToday()
             } catch {

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -177,14 +177,25 @@
                     port: port,
                 )
                 let listener = try NWListener(using: params)
+                // Assign BEFORE wiring the handlers + starting so the handlers can
+                // reach the listener through `self.listener` instead of capturing
+                // the local `listener` strongly. Capturing it strongly would form a
+                // `listener → stateUpdateHandler → listener` self-cycle: a
+                // `DebugRPCServer` dropped without `stop()` (e.g. the controller
+                // overwriting `self.server` with a fresh instance) would then leave
+                // a handler-less listener squatting the LISTEN socket — connections
+                // get accepted but `self?` is nil, so they are never serviced. That
+                // is exactly the observed CLOSE_WAIT wedge. With only `[weak self]`
+                // captured, dropping the server releases its strong ref to the
+                // listener and ARC reclaims it.
+                self.listener = listener
                 listener.newConnectionHandler = { [weak self] connection in
                     Task { @MainActor in self?.handle(connection) }
                 }
                 listener.stateUpdateHandler = { [weak self] state in
                     switch state {
                     case .ready:
-                        guard let self else { return }
-                        Task { @MainActor in self.boundPort = listener.port?.rawValue }
+                        Task { @MainActor in self?.boundPort = self?.listener?.port?.rawValue }
 
                     case let .failed(error):
                         // Without this, a post-start bind failure (e.g. the
@@ -195,13 +206,16 @@
                         // even let a doomed listener log nothing while the
                         // kernel routes connections to the dead twin.
                         logger.error("DebugRPCServer listener failed: \(error.localizedDescription, privacy: .public)")
+                        // Tear THIS instance's listener down so a doomed bind never
+                        // lingers holding the socket. Scoped to `self?.stop()` — it
+                        // can never touch another server's listener.
+                        Task { @MainActor in self?.stop() }
 
                     default:
                         break
                     }
                 }
                 listener.start(queue: .main)
-                self.listener = listener
                 logger.info("DebugRPCServer listening on 127.0.0.1:\(self.port.rawValue, privacy: .public)")
             } catch {
                 logger.error("DebugRPCServer failed to start: \(error.localizedDescription)")
@@ -210,9 +224,27 @@
 
         /// Cancel the listener and free the port. Idempotent.
         func stop() {
+            // Sever the handlers before dropping the reference. The handlers only
+            // capture `[weak self]` (no self-cycle — see `start()`), but a callback
+            // can still be in flight on `.main` after `cancel()`; clearing them
+            // first guarantees a stopped instance does nothing further.
+            listener?.stateUpdateHandler = nil
+            listener?.newConnectionHandler = nil
             listener?.cancel()
             listener = nil
             boundPort = nil
+        }
+
+        /// Releasing the last strong reference to an NWListener does NOT close its
+        /// socket — only `cancel()` does. The field hit exactly this: the launch
+        /// double-start path overwrites the controller's `self.server`, dropping a
+        /// started instance without `stop()`. Without an explicit cancel the kernel
+        /// keeps the LISTEN socket on the port, blocking the survivor from re-binding
+        /// and accumulating unserviced connections. Cancelling here guarantees the
+        /// socket is reclaimed however the instance is torn down. `NWListener.cancel()`
+        /// is thread-safe, so calling it from `deinit` (nonisolated) is sound.
+        deinit {
+            listener?.cancel()
         }
 
         // MARK: - Connection handling

--- a/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
+++ b/app/MeetingTranscriber/Sources/PersistentDiagnosticLog.swift
@@ -95,6 +95,42 @@ enum PersistentDiagnosticLog {
         return name.range(of: pattern, options: .regularExpression) != nil
     }
 
+    /// The `log stream` predicate that uniquely identifies a streamer we spawned.
+    /// Shared by the `Streamer` argument list and the orphan reaper so the two
+    /// can never drift — the reaper kills only processes whose command line
+    /// carries this exact marker, never an unrelated `log stream` a user started.
+    static let streamPredicate = "subsystem CONTAINS 'com.meetingtranscriber'"
+
+    /// Path of the `log` binary we spawn. Reused by the reaper's command match.
+    static let logExecutablePath = "/usr/bin/log"
+
+    /// PURE: from a snapshot of the process table, pick the pids of orphaned
+    /// `log stream` subprocesses WE spawned that survived a crash/SIGKILL and
+    /// were re-parented to launchd (PID 1). Matching is deliberately narrow:
+    ///
+    /// - the command must invoke our exact `log` executable, AND
+    /// - the command must carry our `streamPredicate` marker (so a user's own
+    ///   unrelated `log stream` is never touched), AND
+    /// - the parent must be PID 1 (re-parented orphan — a live streamer of a
+    ///   *running* sibling instance still has that instance as its parent and
+    ///   is left alone), AND
+    /// - the pid is not our own (defence-in-depth; our process isn't `log`
+    ///   anyway, but never reap self).
+    ///
+    /// `command` is the full argv string as `ps -axo command=` renders it.
+    static func orphanPids(
+        processTable: [(pid: Int32, ppid: Int32, command: String)],
+        ownPid: Int32,
+    ) -> [Int32] {
+        processTable.compactMap { entry in
+            guard entry.ppid == 1 else { return nil }
+            guard entry.pid != ownPid else { return nil }
+            guard entry.command.contains(logExecutablePath) else { return nil }
+            guard entry.command.contains(streamPredicate) else { return nil }
+            return entry.pid
+        }
+    }
+
     #if !APPSTORE
         /// Convenience: open today's log file as the stream target. Returns the
         /// running streamer so the caller can stop it on app shutdown.
@@ -103,6 +139,68 @@ enum PersistentDiagnosticLog {
             let streamer = try Streamer()
             try streamer.start()
             return streamer
+        }
+
+        /// Effect shell for the orphan reaper. Snapshots the process table via
+        /// `ps`, runs the pure `orphanPids` filter, and SIGTERMs each match.
+        ///
+        /// Why this exists: a crash / SIGKILL of the app leaves the `log stream`
+        /// subprocess alive — `stop()`/`deinit` never run — and launchd re-parents
+        /// it to PID 1. Successive launches stack up these orphans (one machine
+        /// had five, the oldest days old), each holding a unified-log subscription.
+        /// Call this at launch BEFORE starting a fresh streamer so the count can't
+        /// grow without bound.
+        ///
+        /// SIGTERM is enough: `log stream` exits cleanly on it. No escalation —
+        /// a process wedged hard enough to ignore TERM is rare and not worth the
+        /// complexity here. Best-effort: a `ps` failure is logged and ignored.
+        static func reapOrphans() {
+            let victims = orphanPids(processTable: snapshotProcessTable(), ownPid: getpid())
+            for pid in victims {
+                logger.info("reaping orphaned log stream pid=\(pid, privacy: .public)")
+                kill(pid, SIGTERM)
+            }
+        }
+
+        /// Run `ps -axo pid=,ppid=,command=` and parse it into the tuple shape
+        /// `orphanPids` consumes. Returns an empty table if `ps` can't be run or
+        /// read — best-effort, so a `ps` failure simply reaps nothing. The `=`
+        /// suffixes suppress the header row; the first two fields are numeric,
+        /// the remainder (which can contain spaces) is the command.
+        private static func snapshotProcessTable() -> [(pid: Int32, ppid: Int32, command: String)] {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+            proc.arguments = ["-axo", "pid=,ppid=,command="]
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError = Pipe()
+            do {
+                try proc.run()
+            } catch {
+                logger.error("reap_orphans_ps_failed error=\(error.localizedDescription, privacy: .public)")
+                return []
+            }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            proc.waitUntilExit()
+            guard let text = String(data: data, encoding: .utf8) else { return [] }
+            return parseProcessTable(text)
+        }
+
+        /// PURE: parse `ps -axo pid=,ppid=,command=` output into tuples. Each line
+        /// is `<pid> <ppid> <command…>`; the command can contain spaces so only
+        /// the first two whitespace-delimited fields are split off. Malformed or
+        /// blank lines are skipped.
+        static func parseProcessTable(_ text: String) -> [(pid: Int32, ppid: Int32, command: String)] {
+            text.split(separator: "\n").compactMap { rawLine in
+                let line = rawLine.trimmingCharacters(in: .whitespaces)
+                guard !line.isEmpty else { return nil }
+                let parts = line.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+                guard parts.count == 3,
+                      let pid = Int32(parts[0]),
+                      let ppid = Int32(parts[1])
+                else { return nil }
+                return (pid: pid, ppid: ppid, command: String(parts[2]))
+            }
         }
     #endif
 
@@ -190,10 +288,10 @@ enum PersistentDiagnosticLog {
                 logDirectory: URL = PersistentDiagnosticLog.logDirectory,
                 now: @escaping () -> Date = { Date() },
                 restartPolicy: RestartPolicy = .default,
-                logExecutable: URL = URL(fileURLWithPath: "/usr/bin/log"),
+                logExecutable: URL = URL(fileURLWithPath: PersistentDiagnosticLog.logExecutablePath),
                 logArguments: [String] = [
                     "stream",
-                    "--predicate", "subsystem CONTAINS 'com.meetingtranscriber'",
+                    "--predicate", PersistentDiagnosticLog.streamPredicate,
                     "--style", "syslog",
                     "--info",
                 ],

--- a/app/MeetingTranscriber/Sources/RPCServerController.swift
+++ b/app/MeetingTranscriber/Sources/RPCServerController.swift
@@ -79,6 +79,15 @@
         }
 
         private func start() {
+            // Single-flight: never build/start a second server while one is live.
+            // Two start signals race at launch — the gate in `activate()` and the
+            // observer's `onChange` — and the field hit a third, cross-instance
+            // path (SwiftUI re-evaluating the `@State` default that constructs
+            // `AppState`). Without this guard a second `makeServer()` overwrites
+            // `self.server`, dropping the last strong ref to the live instance #1
+            // while instance #2 fails to bind the already-held port. The toggle-off
+            // path that stops + nils `server` re-opens this gate as intended.
+            guard server == nil else { return }
             guard let server = makeServer?() else { return }
             server.start()
             self.server = server

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -274,6 +274,104 @@
             XCTAssertEqual(received, 2)
         }
 
+        // MARK: - Listener lifecycle: don't-break-the-survivor + no leak on drop
+
+        /// Construct + start a server pinned to a specific port and wait until it
+        /// reports `boundPort`. Caller owns the returned strong ref (so the leak
+        /// test can drop it deliberately). Does NOT store into `self.server`.
+        private func startServerPinned(port: UInt16) async throws -> DebugRPCServer {
+            let server = DebugRPCServer(port: port, token: Self.testToken) { .empty }
+            server.start()
+            for _ in 0 ..< 50 {
+                if server.boundPort != nil { return server }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            throw XCTestError(.timeoutWhileWaiting)
+        }
+
+        private func healthzStatus(port: UInt16) async -> Int? {
+            guard let url = URL(string: "http://127.0.0.1:\(port)/healthz") else { return nil }
+            var req = URLRequest(url: url)
+            req.timeoutInterval = 2
+            req.setValue("Bearer \(Self.testToken)", forHTTPHeaderField: "Authorization")
+            guard let (_, response) = try? await URLSession.shared.data(for: req) else { return nil }
+            return (response as? HTTPURLResponse)?.statusCode
+        }
+
+        /// A second server whose bind collides with a live server must NOT damage
+        /// the survivor: server A keeps serving after server B's bind fails. Pins
+        /// the controller's reference-overwrite hazard at the socket layer — a
+        /// doomed instance #2 may never disturb the live instance #1.
+        func testCollidingSecondServerDoesNotBreakSurvivor() async throws {
+            let serverA = try await startServerPinned(port: 0)
+            let portA = try XCTUnwrap(serverA.boundPort)
+            let before = await healthzStatus(port: portA)
+            XCTAssertEqual(before, 200, "server A should serve before the collision")
+
+            // B pinned to A's port → its bind fails (Address already in use). The
+            // failure path must confine itself to B's own listener.
+            let serverB = DebugRPCServer(port: portA, token: Self.testToken) { .empty }
+            serverB.start()
+
+            // Re-assert the survivor invariant repeatedly instead of sleeping a
+            // fixed interval (CI-flaky on a loaded runner). B can never reach
+            // `.ready` while A holds the port, so `boundPort` stays nil throughout;
+            // A must answer 200 on every probe, so a transient mid-failure
+            // regression surfaces, not just the end state. ~10 probes (each a real
+            // healthz roundtrip + 50 ms step) span well past B's async bind-fail.
+            for _ in 0 ..< 10 {
+                let aStatus = await healthzStatus(port: portA)
+                XCTAssertEqual(aStatus, 200, "server A must keep serving while B's bind fails")
+                XCTAssertNil(serverB.boundPort, "B's colliding bind must never reach .ready")
+                try await Task.sleep(for: .milliseconds(50))
+            }
+
+            serverA.stop()
+            serverB.stop()
+        }
+
+        /// The wedge: a started server dropped WITHOUT `stop()` (the controller
+        /// overwriting `self.server` with a fresh instance dealloc'd #1) must not
+        /// leave its listener squatting the port. With the old `listener →
+        /// stateUpdateHandler → listener` self-cycle the listener outlived the
+        /// dealloc'd server, kept the LISTEN socket, and accepted connections that
+        /// `self?` (now nil) never serviced. We assert the inverse: after dropping
+        /// the only strong ref, a FRESH server can bind the same port and serve.
+        func testDroppingServerWithoutStopReleasesPort() async throws {
+            var first: DebugRPCServer? = try await startServerPinned(port: 0)
+            let port = try XCTUnwrap(first?.boundPort)
+            let firstStatus = await healthzStatus(port: port)
+            XCTAssertEqual(firstStatus, 200, "first server should serve")
+
+            // Drop the only strong reference WITHOUT stop() — models the controller
+            // overwriting `self.server`. ARC must reclaim the listener (no cycle).
+            first = nil
+
+            // Poll the observable end-condition — a FRESH server can bind + serve
+            // the same port — instead of a fixed sleep waiting for dealloc+cancel
+            // to settle (CI-flaky on a loaded runner). Each attempt waits for the
+            // candidate to reach `.ready` (or times out) before retrying; if the
+            // old listener leaked and squatted the socket, every attempt fails and
+            // the loop exhausts its ~5 s budget. The successful candidate is kept
+            // and stopped once; failed candidates are released between attempts.
+            var served = false
+            for _ in 0 ..< 25 {
+                if let candidate = try? await startServerPinned(port: port) {
+                    let status = await healthzStatus(port: port)
+                    candidate.stop()
+                    if status == 200 {
+                        served = true
+                        break
+                    }
+                }
+                try await Task.sleep(for: .milliseconds(50))
+            }
+            XCTAssertTrue(
+                served,
+                "a fresh server must bind + serve the port the dropped one held",
+            )
+        }
+
         // MARK: - M6: Host header allowlist (raw-socket)
 
         /// `URLRequest.setValue(_:forHTTPHeaderField: "Host")` is silently

--- a/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PersistentDiagnosticLogTests.swift
@@ -126,6 +126,116 @@ final class PersistentDiagnosticLogTests: XCTestCase {
         PersistentDiagnosticLog.cleanup(in: bogus, retentionDays: 30)
     }
 
+    // MARK: - Orphan reaper (pure matching)
+
+    // The reaper machinery (`parseProcessTable`, `reapOrphans`, …) is `#if
+    // !APPSTORE` in the source — `Process`/`ps` are forbidden under sandbox —
+    // so these tests are guarded too. `orphanPids` happens to be unguarded, but
+    // keeping all reaper tests together under one guard avoids a split that
+    // would re-break the appstore build the next time a test moves.
+    #if !APPSTORE
+        /// A `log stream` we spawned (our predicate marker), re-parented to PID 1,
+        /// is reaped.
+        func test_orphanPids_matchesOurReparentedStreamer() {
+            let cmd = "/usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber' --style syslog --info"
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 4242, ppid: 1, command: cmd),
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [4242])
+        }
+
+        /// A streamer still owned by a *running* sibling instance (ppid != 1) is a
+        /// live child, not an orphan — leave it alone.
+        func test_orphanPids_skipsLiveChildOfRunningParent() {
+            let cmd = "/usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber' --style syslog --info"
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 4242, ppid: 777, command: cmd), // parent alive
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [])
+        }
+
+        /// An unrelated `log stream` the user started for a different subsystem must
+        /// never be reaped — matching keys on OUR predicate marker.
+        func test_orphanPids_skipsUnrelatedLogStream() {
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 4242, ppid: 1, command: "/usr/bin/log stream --predicate subsystem CONTAINS 'com.apple.network' --style syslog"),
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [])
+        }
+
+        /// A non-`log` process whose argv happens to mention our predicate (e.g. a
+        /// grep over logs) is not our streamer — the `/usr/bin/log` executable match
+        /// excludes it.
+        func test_orphanPids_skipsNonLogProcessMentioningPredicate() {
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 4242, ppid: 1, command: "grep subsystem CONTAINS 'com.meetingtranscriber' somefile"),
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [])
+        }
+
+        /// Never reap ourselves even if the row otherwise matches (defence-in-depth).
+        func test_orphanPids_neverReapsOwnPid() {
+            let cmd = "/usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber'"
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 99, ppid: 1, command: cmd),
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [])
+        }
+
+        /// Several rows at once: only the orphaned, predicate-matching `log` rows
+        /// come back, preserving order.
+        func test_orphanPids_returnsAllMatchingOrphans() {
+            let ourCmd = "/usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber' --style syslog --info"
+            let table: [(pid: Int32, ppid: Int32, command: String)] = [
+                (pid: 10, ppid: 1, command: ourCmd), // orphan ✓
+                (pid: 11, ppid: 1, command: "/usr/bin/log stream --predicate subsystem CONTAINS 'com.apple.foo'"), // unrelated ✗
+                (pid: 12, ppid: 500, command: ourCmd), // live child ✗
+                (pid: 13, ppid: 1, command: ourCmd), // orphan ✓
+            ]
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: table, ownPid: 99), [10, 13])
+        }
+
+        // MARK: - Orphan reaper (process-table parsing)
+
+        /// Parses the `ps -axo pid=,ppid=,command=` shape, keeping spaces inside the
+        /// command field intact.
+        func test_parseProcessTable_parsesPidPpidAndSpacedCommand() {
+            let text = """
+              501     1 /usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber'
+              777   501 /Applications/Foo.app/Contents/MacOS/Foo --flag value
+            """
+            let rows = PersistentDiagnosticLog.parseProcessTable(text)
+            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows[0].pid, 501)
+            XCTAssertEqual(rows[0].ppid, 1)
+            XCTAssertEqual(rows[0].command, "/usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber'")
+            XCTAssertEqual(rows[1].pid, 777)
+            XCTAssertEqual(rows[1].ppid, 501)
+            XCTAssertEqual(rows[1].command, "/Applications/Foo.app/Contents/MacOS/Foo --flag value")
+        }
+
+        /// Blank and malformed lines (missing a command field) are skipped, not
+        /// treated as a process.
+        func test_parseProcessTable_skipsBlankAndMalformedLines() {
+            let text = "\n  501     1 /usr/bin/log stream\n\nnotanumber 1 cmd\n  601 2\n"
+            let rows = PersistentDiagnosticLog.parseProcessTable(text)
+            XCTAssertEqual(rows.count, 1)
+            XCTAssertEqual(rows[0].pid, 501)
+            XCTAssertEqual(rows[0].command, "/usr/bin/log stream")
+        }
+
+        /// End-to-end of the pure pair: real `ps`-style text → parse → orphan filter.
+        func test_parseThenOrphanPids_endToEnd() {
+            let text = """
+              900     1 /usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber' --style syslog --info
+              901   900 /usr/bin/log stream --predicate subsystem CONTAINS 'com.meetingtranscriber'
+            """
+            let rows = PersistentDiagnosticLog.parseProcessTable(text)
+            // 900 is the orphan (ppid 1); 901's parent (900) is alive → live child.
+            XCTAssertEqual(PersistentDiagnosticLog.orphanPids(processTable: rows, ownPid: 99), [900])
+        }
+    #endif
+
     // MARK: - Streamer day-rotation
 
     #if !APPSTORE


### PR DESCRIPTION
## What

Two debug-infrastructure fixes, both observed live during manual testing on a development machine:

1. **Debug RPC server could end up bound-but-dead.** Dropping a started `DebugRPCServer` without calling `stop()` (e.g. when a redundant start signal overwrites the controller's reference) leaked its `NWListener`: the state/connection handlers captured the listener strongly, so the LISTEN socket stayed open and kept accepting TCP connections — but with the server instance gone, no handler ever serviced them. Clients saw connects that never get answered (server-side `CLOSE_WAIT` sockets with unread bytes piling up), and any later instance failed to bind with `Address already in use`.
2. **Diagnostic log streamers survived crashes and accumulated.** `PersistentDiagnosticLog`'s `/usr/bin/log stream` subprocess is re-parented to PID 1 when the app crashes or is killed — the machine where this was found had five orphans, the oldest two days old, each holding a unified-log streaming session.

## How

**RPC server lifecycle (defense in depth):**
- Handlers now reach the listener through `self.listener` instead of capturing it strongly — releasing the server releases the listener.
- `deinit` cancels the listener (releasing an `NWListener` does *not* close its socket; only `cancel()` does).
- The `.failed` state path stops its own listener; `stop()` severs handlers before cancelling.
- `RPCServerController.start()` is single-flight (`guard server == nil`) so redundant start signals can't create a second instance in the first place.

**Orphan reaper:** at launch, `PersistentDiagnosticLog.reapOrphans()` (dispatched off the main thread) SIGTERMs `/usr/bin/log` processes that match our exact stream predicate **and** are re-parented to PID 1. The matching is a pure function over a `ps` snapshot — it can never match a live child of a running instance (any variant), an unrelated `log stream`, or the current process.

## Testing

- New integration test (real sockets): dropping a started server without `stop()` must release the port — **fails against the previous code** (the leaked listener squats the port), passes now. A second test pins the survivor property: a bind-collision loser never disturbs the serving instance (asserted via repeated live round-trips, no fixed sleeps).
- Reaper matching: 9 pure unit tests (predicate, ppid, own-pid, unrelated-process filters), mutation-proven (weakening the filter fails 4 of them).
- Full suite green incl. TSan-relevant suites; lint clean; release-build parity clean.

## Notes

- The reaper's snapshot→kill window is the standard `ps`-based-reaper caveat (PID reuse in a microsecond window); SIGTERM + the four-condition match keep the blast radius negligible.
- A related crash observed only when **two different app instances** record and stop simultaneously is tracked separately in #400 (CoreAudio-internal, no app frames).
