### PR TITLE
ci: harden against slow-runner flakes and self-masking cancellations

### DIFF
--- a/.github/actions/cancel-on-failure/action.yml
+++ b/.github/actions/cancel-on-failure/action.yml
@@ -10,9 +10,33 @@ description: >
   step-level `if`). The inner step swallows errors via continue-on-error
   so a transient gh CLI hiccup doesn't mask the original failure.
 
+  The run-level cancellation races the calling job's own conclusion:
+  the culprit job usually ends up marked `cancelled` like its victims,
+  hiding which job actually failed. The annotation + step-summary line
+  emitted before cancelling survive that repaint and name the culprit
+  in the run summary.
+
+inputs:
+  job-name:
+    description: >
+      Human-readable name of the failing job for the culprit annotation.
+      Matrix jobs should pass the expanded name (e.g. "test (appstore)")
+      because `github.job` only carries the job key.
+    required: false
+    default: ${{ github.job }}
+
 runs:
   using: "composite"
   steps:
+    - name: Name the culprit before cancelling
+      shell: bash
+      continue-on-error: true
+      run: |
+        echo "::error title=Run cancelled by failing job::'${JOB_NAME}' failed and cancelled this run — sibling jobs marked 'cancelled' are victims, not causes."
+        echo "### ⚠️ Run cancelled by failing job: \`${JOB_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+        echo "Sibling jobs marked \`cancelled\` are victims, not causes." >> "$GITHUB_STEP_SUMMARY"
+      env:
+        JOB_NAME: ${{ inputs.job-name }}
     - name: Cancel current workflow run
       shell: bash
       continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure
+        with:
+          job-name: test (${{ matrix.variant }})
 
   # AudioTapLib SPM library lives in `tools/audiotap/` and has its own
   # test suite (`tools/audiotap/Tests/`). Runs as its own top-level job

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure
+        with:
+          job-name: sanitizers (${{ matrix.variant }})
 
   quality-baseline:
     if: |

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionE2ETests.swift
@@ -166,15 +166,18 @@ final class LiveTranscriptionE2ETests: XCTestCase {
     /// the test responsive while bounding the wait if the engine emits
     /// nothing.
     ///
-    /// Default deadline is 60 s because the macos-26 CI runner is a
+    /// Default deadline is 120 s because the macos-26 CI runner is a
     /// virtualised M1 with 3 CPU cores and no ANE — Parakeet inference
     /// on CPU is ~5× slower than local M-series hardware, and parallel
     /// xctest workers loading neighbouring CoreML models compete for
     /// the same e5rt cache. Locally the poll usually returns inside 1 s
     /// on the first final, so the generous deadline is "safety net for
-    /// slow CI", not "expected wall-clock budget". Was 30 s; bumped
-    /// after a CI run hit the deadline on the app channel while the
-    /// mic channel had already produced two finals.
+    /// slow CI", not "expected wall-clock budget" — a green run exits on
+    /// the first final and never pays it. Was 30 s, then 60 s (a CI run
+    /// hit the deadline on the app channel while the mic channel had
+    /// already produced two finals); 60 s still flaked zero-finals on
+    /// both channels during a degraded runner-pool window, so doubled
+    /// again rather than chasing the pool's worst case in 30 s steps.
     ///
     /// The `channel` filter lets a single test wait for a mic-channel
     /// final and then a separate app-channel final — without the filter,
@@ -183,7 +186,7 @@ final class LiveTranscriptionE2ETests: XCTestCase {
     private func waitForFinal(
         in captions: LiveCaptionsState,
         channel: LiveCaptionChannel,
-        deadlineSeconds: Double = 60.0,
+        deadlineSeconds: Double = 120.0,
     ) async {
         let deadline = ContinuousClock.now + .seconds(deadlineSeconds)
         while await MainActor.run(body: {


### PR DESCRIPTION
## What

Two CI-reliability fixes for failure modes that hit three consecutive main-push runs today:

1. **Live-caption E2E deadline 60 s → 120 s.** `LiveTranscriptionE2ETests` (the streaming-path coverage test that deliberately runs in regular CI) expired its 60 s per-channel deadline with **zero** finals on either channel during a degraded macos-runner-pool window — the same failure mode the deadline was already bumped once for (30 → 60 s). A green run exits on the first final and never pays the deadline, so doubling it costs passing runs nothing (the test ran in 3.9 s locally after the change). Worst case is 2 × 120 s, far under the 18-min test-step timeout.
2. **`cancel-on-failure` now names the culprit.** The composite's run-level `gh run cancel` races the failing job's own conclusion, so the culprit usually ends up marked `cancelled` like its victims — today that masked first a flaked E2E deadline and then a type-check-budget miss as opaque "cancelled" runs, twice sending diagnosis down the wrong path. The action now emits an `::error` annotation and a step-summary line naming the failing job *before* cancelling; both survive the conclusion repaint. Matrix call sites (`test (homebrew|appstore)`, the sanitizer legs) pass their expanded job name since `github.job` only carries the job key; non-matrix callers keep the default.

## Testing

- E2E test green locally with the new default (early-exit path, 3.9 s).
- YAML validated; matrix variables verified against both touched workflow matrices; annotation/step-summary persistence and `continue-on-error` sequencing reviewed against GitHub Actions semantics.
- The annotation path proves itself the next time any guarded job fails — it cannot be unit-tested ahead of time, which is also why the wording is deliberately explicit about victims vs causes.
