### PR TITLE
fix(app): avoid splitting Parakeet tokens mid-word at the token cap

### DIFF
--- a/app/MeetingTranscriber/Sources/ParakeetTokenGrouping.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetTokenGrouping.swift
@@ -4,29 +4,40 @@ import Foundation
 /// Pure token-grouping logic for Parakeet ASR output.
 ///
 /// Extracted from `ParakeetEngine` so the segmentation rules (sentence-end
-/// punctuation, 20-token cap) can be unit-tested without loading a model.
+/// punctuation, soft 20-token cap) can be unit-tested without loading a model.
 enum ParakeetTokenGrouping {
-    /// Maximum tokens per segment before forcing a split — keeps segments
-    /// short enough that they remain useful for the protocol generator
-    /// even when the model emits long runs without terminal punctuation.
+    /// Target maximum tokens per segment before splitting at the next word boundary.
+    ///
+    /// The cap is soft because Parakeet can emit partial-word tokens. Splitting
+    /// immediately at the token limit can turn `normally` into `norm ally` when
+    /// segment texts are joined later.
     static let maxTokensPerSegment = 20
+
+    private static let whitespace = CharacterSet.whitespacesAndNewlines
 
     /// Group token-level timings into sentence-level `TimestampedSegment`s.
     ///
     /// Ends a segment at sentence-terminating punctuation (`. ! ?`) or
-    /// after `maxTokensPerSegment` tokens, whichever comes first. Tokens
-    /// that are blank after whitespace-trimming are skipped entirely.
+    /// after `maxTokensPerSegment` tokens once a word boundary is reached.
+    /// Tokens that are blank after whitespace-trimming are skipped entirely.
     static func groupIntoSegments(_ timings: [TokenTiming]) -> [TimestampedSegment] {
         var segments: [TimestampedSegment] = []
         var group: [TokenTiming] = []
 
-        for timing in timings {
+        for (index, timing) in timings.enumerated() {
             let token = timing.token
-            guard !token.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty else { continue }
+            guard !isBlank(token) else { continue }
             group.append(timing)
 
             let endsWithPunct = token.hasSuffix(".") || token.hasSuffix("!") || token.hasSuffix("?")
-            if endsWithPunct || group.count >= maxTokensPerSegment {
+            let nextBoundary = nextTokenBoundary(after: index, in: timings)
+            let canSplitAtTokenCap = group.count >= maxTokensPerSegment
+                && isWordBoundary(
+                    after: token,
+                    before: nextBoundary.token,
+                    hasWhitespaceSeparator: nextBoundary.hasWhitespaceSeparator,
+                )
+            if endsWithPunct || canSplitAtTokenCap {
                 if let seg = makeSegment(from: group) { segments.append(seg) }
                 group = []
             }
@@ -40,9 +51,45 @@ enum ParakeetTokenGrouping {
     /// Returns nil if `timings` is empty or yields an all-whitespace text.
     static func makeSegment(from timings: [TokenTiming]) -> TimestampedSegment? {
         guard !timings.isEmpty else { return nil }
-        let text = timings.map(\.token).joined().trimmingCharacters(in: CharacterSet.whitespaces)
+        let text = timings.map(\.token).joined().trimmingCharacters(in: whitespace)
         guard !text.isEmpty else { return nil }
         // swiftlint:disable:next force_unwrapping
         return TimestampedSegment(start: timings.first!.startTime, end: timings.last!.endTime, text: text)
+    }
+
+    private static func isBlank(_ token: String) -> Bool {
+        token.trimmingCharacters(in: whitespace).isEmpty
+    }
+
+    private static func nextTokenBoundary(
+        after index: Int,
+        in timings: [TokenTiming],
+    ) -> (token: String?, hasWhitespaceSeparator: Bool) {
+        var hasWhitespaceSeparator = false
+        var nextIndex = index + 1
+
+        while nextIndex < timings.count {
+            let token = timings[nextIndex].token
+            if isBlank(token) {
+                hasWhitespaceSeparator = hasWhitespaceSeparator
+                    || token.unicodeScalars.contains(where: whitespace.contains)
+                nextIndex += 1
+                continue
+            }
+            return (token, hasWhitespaceSeparator)
+        }
+
+        return (nil, hasWhitespaceSeparator)
+    }
+
+    private static func isWordBoundary(
+        after token: String,
+        before nextToken: String?,
+        hasWhitespaceSeparator: Bool,
+    ) -> Bool {
+        if hasWhitespaceSeparator { return true }
+        guard let nextToken else { return true }
+        return token.unicodeScalars.last.map(whitespace.contains) == true
+            || nextToken.unicodeScalars.first.map(whitespace.contains) == true
     }
 }

--- a/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
@@ -92,6 +92,22 @@ final class ParakeetTokenGroupingTests: XCTestCase {
         XCTAssertEqual(segments[1].text, "next")
     }
 
+    func testGroupIntoSegmentsSoftCapKeepsUnbrokenRunInOneSegment() {
+        // 25 non-blank tokens, no whitespace between them, no terminal
+        // punctuation. There is no safe split point, so the soft cap keeps
+        // them in a single segment even though it exceeds maxTokensPerSegment.
+        // Documents that the cap is a target, not a hard invariant — the old
+        // hard cap would have split this into two segments at the 20th token.
+        let timings = (0 ..< 25).map { i in
+            timing("x", start: Double(i), end: Double(i) + 1)
+        }
+
+        let segments = ParakeetTokenGrouping.groupIntoSegments(timings)
+
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].text, String(repeating: "x", count: 25))
+    }
+
     func testGroupIntoSegmentsSkipsBlankTokensInsideGroup() {
         // Whitespace-only tokens must not count toward the 20-cap and must
         // not appear in the joined text. They're stripped before grouping.

--- a/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetTokenGroupingTests.swift
@@ -46,7 +46,8 @@ final class ParakeetTokenGroupingTests: XCTestCase {
     }
 
     func testGroupIntoSegmentsForcesSplitAt20TokenCap() {
-        // 25 tokens with no punctuation — must split at the 20-token cap.
+        // 25 complete-word tokens with no punctuation — should split at the
+        // 20-token target because every token ends at a safe word boundary.
         let timings = (0 ..< 25).map { i in
             timing("w\(i) ", start: Double(i), end: Double(i) + 1)
         }
@@ -58,6 +59,37 @@ final class ParakeetTokenGroupingTests: XCTestCase {
         XCTAssertFalse(segments[0].text.contains("w20"))
         // Second segment: w20..w24
         XCTAssertTrue(segments[1].text.contains("w24"))
+    }
+
+    func testGroupIntoSegmentsDoesNotSplitInsideWordAtTokenCap() {
+        var timings = (0 ..< 19).map { i in
+            timing("w\(i) ", start: Double(i), end: Double(i) + 1)
+        }
+        timings.append(timing("norm", start: 19, end: 20))
+        timings.append(timing("ally", start: 20, end: 21))
+        timings.append(timing(" next", start: 21, end: 22))
+
+        let segments = ParakeetTokenGrouping.groupIntoSegments(timings)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertTrue(segments[0].text.contains("normally"))
+        XCTAssertFalse(segments[0].text.contains("norm ally"))
+        XCTAssertEqual(segments[1].text, "next")
+    }
+
+    func testGroupIntoSegmentsTreatsStandaloneWhitespaceTokenAsWordBoundaryAtCap() {
+        var timings = (0 ..< 19).map { i in
+            timing("w\(i) ", start: Double(i), end: Double(i) + 1)
+        }
+        timings.append(timing("word", start: 19, end: 20))
+        timings.append(timing(" ", start: 20, end: 20.1))
+        timings.append(timing("next", start: 20.1, end: 21))
+
+        let segments = ParakeetTokenGrouping.groupIntoSegments(timings)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertTrue(segments[0].text.contains("word"))
+        XCTAssertEqual(segments[1].text, "next")
     }
 
     func testGroupIntoSegmentsSkipsBlankTokensInsideGroup() {


### PR DESCRIPTION
## Problem

`ParakeetTokenGrouping.groupIntoSegments` turns Parakeet's token-level timings
into transcript segments, ending a segment on sentence punctuation (`.`, `!`,
`?`) or once it reaches a 20-token cap. The cap was a hard split: the segment
ended at exactly the 20th token no matter where that token sat inside a word.

Parakeet can emit a single word as several sub-word tokens (for example `norm` +
`ally`). Consecutive same-speaker segments are later concatenated with a space
during diarization (`DiarizationProcess.mergeConsecutiveSpeakers`, joined as
`"\(current.text) \(seg.text)"`), so a cap split that fell between `norm` and
`ally` surfaced in the final transcript as `norm ally` instead of `normally`.

## Fix

The 20-token cap becomes a soft target. A segment still ends immediately on
sentence punctuation, but a cap-triggered split now waits for the next word
boundary before flushing.

Boundaries are inferred from the whitespace the tokenizer already carries: a
separating whitespace-only token, a trailing space on the current token, a
leading space on the next token, or the end of the stream. Whitespace-only
tokens are skipped from the joined text (they never count toward the cap and
never appear in output) but are now honored as boundary evidence. Blank-token
detection also widens from `CharacterSet.whitespaces` to
`.whitespacesAndNewlines`, so newline-only tokens count as blank too.

The logic is factored into small helpers on the existing pure
`ParakeetTokenGrouping` type (`nextTokenBoundary`, `isWordBoundary`, `isBlank`),
so it stays unit-testable without loading a model. Grouping remains linear:
`nextTokenBoundary` only scans the blank run that immediately follows a non-blank
token, and each blank run is visited once.

## Tests

`ParakeetTokenGroupingTests`: 15 pass. New coverage for the contract:

- **Mid-word cap split.** 19 whole-word tokens then `norm` + `ally` + ` next`
  keeps `normally` intact and defers the split to the following boundary.
- **Standalone whitespace token at the cap** is honored as a boundary.
- **Unbroken run with no boundary.** 25 contiguous non-blank tokens (no
  whitespace, no punctuation) stay in one segment. This pins the new contract
  that the cap is a target, not a hard limit, and it fails against the previous
  hard-cap code (which split at the 20th token into two segments), so it guards
  the behavior rather than restating it.
- The existing whole-word cap test still splits at 20 when every token ends at a
  safe boundary, so the common case does not regress.

## Verification

- Manually verified end-to-end on real meetings: transcripts come out without
  the mid-word spacing artifacts.
- Release build of the app (`swift build -c release`) clean; test target builds
  clean.

The change is a pure function with no model dependency, so the model-heavy
suites are unaffected; CI runs the full suite and lint.

## Notes

The cap is intentionally soft with no absolute ceiling. Forcing a split after a
fixed token count would partially reintroduce the mid-word splitting this fix
removes. If a hard upper bound on segment length is ever needed for pathological
input, it should be a separate, clearly named escape hatch (for example
`hardMaxTokensPerSegment`) rather than re-hardening this cap.
