### PR TITLE
ci: label fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,7 +1,20 @@
 name: Auto-label PRs
 
+# Uses pull_request_target (not pull_request) so labeling also works on PRs
+# opened from forks. Under pull_request, a fork PR gets a read-only
+# GITHUB_TOKEN regardless of the permissions block below, so addLabels fails
+# with 403 "Resource not accessible by integration". pull_request_target runs
+# in the base-repo context with a token that honors the declared permissions.
+#
+# SAFETY: this is only safe because the job never checks out or executes the
+# PR's code. It reads the PR title from the event payload as data (via
+# context.payload, not a `${{ }}` interpolation) and applies a label from a
+# fixed allowlist. Do NOT add an `actions/checkout` of the PR head followed by
+# build/run steps here, and do NOT interpolate PR-controlled fields (title,
+# body, branch name) via `${{ }}` into a script/run block — either would expose
+# the writable token to untrusted fork input.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
## Problem

The **Auto-label PRs** workflow fails on PRs opened from a fork. PR #403 (from a fork) failed its `label` job with:

```
POST /repos/pasrom/meeting-transcriber/issues/403/labels - 403
RequestError [HttpError]: Resource not accessible by integration
```

Under the `pull_request` trigger, GitHub hands PRs from forks a **read-only** `GITHUB_TOKEN` regardless of the workflow's `permissions:` block (the block can only *reduce* permissions, never grant write to a fork-PR token). So `github.rest.issues.addLabels` is rejected with 403. Same-repo PRs are unaffected because their token is writable.

## Fix

Switch the trigger from `pull_request` to `pull_request_target`. It runs in the **base-repo** context with a token that honors the declared `pull-requests: write` permission, so labeling works for fork PRs too.

## Why this stays safe

`pull_request_target` is only dangerous when a workflow checks out and **executes** the PR's (untrusted) code with the privileged token. This job does neither:

- **No `actions/checkout`** and no build/run of PR code — the classic "pwn request" vector is absent.
- The workflow always runs the **base-branch (`main`) version** of itself, so a fork PR cannot alter what it does.
- The only attacker-controlled input is the PR title, read as **data** via `context.payload.pull_request.title` (not a `${{ }}` interpolation into the script), and only used for a regex match against a **fixed label allowlist**.

Worst case from a malicious title: a cosmetic mislabel from the allowlist. No secret access, no code execution.

A comment in the workflow documents these constraints so the safe pattern isn't regressed (no PR-head checkout, no `${{ }}` of PR-controlled fields).

## Note

`pull_request_target` always uses the workflow from `main`, so this takes effect for PRs opened/edited **after** merge. Existing open fork PRs (incl. #403) can be labeled manually once, or re-labeled by a title edit after merge.