### PR TITLE
fix(app): reject negative Content-Length in RPC request parser

### DIFF
--- a/app/MeetingTranscriber/Sources/HTTPRequest.swift
+++ b/app/MeetingTranscriber/Sources/HTTPRequest.swift
@@ -38,6 +38,10 @@
             }
 
             let contentLength = headers["content-length"].flatMap(Int.init) ?? 0
+            // Reject a negative Content-Length before it reaches the body range:
+            // `bodyStart ..< bodyStart + contentLength` would otherwise trap on
+            // `lowerBound > upperBound`, aborting the process pre-auth.
+            guard contentLength >= 0 else { return nil }
             let bodyStart = separatorRange.upperBound
             let availableBody = data.count - bodyStart
             guard availableBody >= contentLength else { return nil }

--- a/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerTests.swift
@@ -47,6 +47,15 @@
             XCTAssertNil(HTTPRequest.parse(raw))
         }
 
+        func testParseNegativeContentLengthReturnsNil() {
+            // A negative Content-Length must be rejected outright. Without a
+            // guard, `bodyStart ..< bodyStart + contentLength` builds a Range
+            // whose lowerBound exceeds its upperBound and traps — aborting the
+            // process before the origin/token checks ever run.
+            let raw = Data("GET /healthz HTTP/1.1\r\nContent-Length: -1\r\n\r\n".utf8)
+            XCTAssertNil(HTTPRequest.parse(raw))
+        }
+
         // MARK: - HTTPResponse serialization
 
         func testResponseShape() {


### PR DESCRIPTION
## Problem

A malformed `Content-Length: -1` parses to `Int(-1)`, slips past the `availableBody >= contentLength` guard (`0 >= -1` is true), then builds the body range `bodyStart ..< bodyStart + contentLength` with `lowerBound > upperBound`. Swift traps on that range and **aborts the process**.

`HTTPRequest.parse` runs in `DebugRPCServer.receive` **before** the `Origin` and bearer-token checks, so any local process could abort the app without a token.

**Scope / severity dampers:** the RPC server is dev-only (`#if !APPSTORE`), off by default, and bound to `127.0.0.1` (local processes only). Still, a pre-auth process-abort is worth closing.

## Fix

One guard — `contentLength >= 0` — placed right where `contentLength` is derived, before its only use in the body range.

## Test

`testParseNegativeContentLengthReturnsNil` reproduces the crash on the unfixed parser:

```
Fatal error: Range requires lowerBound <= upperBound   (SIGTRAP, signal code 5)
```

After the fix it returns `nil`. Full `DebugRPCServerTests` group green (57/57), lint clean.