### PR TITLE
fix(audiotap): give the mic resampler output-buffer headroom

### DIFF
--- a/tools/audiotap/Sources/Helpers.swift
+++ b/tools/audiotap/Sources/Helpers.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import CoreAudio
 import Foundation
 
@@ -42,6 +43,22 @@ public func downmixToMono(_ samples: [Float], channels: Int) -> [Float] {
         mono[i] = sum * scale
     }
     return mono
+}
+
+/// Output-buffer frame capacity for a sample-rate conversion, with a fixed
+/// headroom margin. `AVAudioConverter` retains a fractional output sample on
+/// each `convert` call; sizing the output buffer to exactly `floor(inputFrames
+/// * ratio)` strands that remainder, and it accumulates into a growing backlog
+/// the converter can never flush — the written track then under-runs wall-clock
+/// and `TimelineAnchor` papers over the deficit by injecting silence mid-speech.
+/// The `headroom` lets the converter emit its retained samples every call so no
+/// backlog builds. Single source of truth for both the mic and app capture
+/// paths. Note `floor(x + headroom) == floor(x) + headroom` for integer
+/// headroom, so this matches a `* ratio + headroom`-then-truncate form exactly.
+func resampleOutputCapacity(
+    inputFrames: AVAudioFrameCount, ratio: Double, headroom: AVAudioFrameCount = 16,
+) -> AVAudioFrameCount {
+    AVAudioFrameCount(Double(inputFrames) * ratio) + headroom
 }
 
 /// Write all bytes to a file descriptor using POSIX write() — no Data copy, no Foundation overhead.

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -235,8 +235,8 @@ public class MicCaptureHandler: @unchecked Sendable {
             self.maybeReportDebugRMS()
             do {
                 if let converter = self.converter {
-                    let outputFrames = AVAudioFrameCount(
-                        Double(buffer.frameLength) * self.resampleRatio,
+                    let outputFrames = resampleOutputCapacity(
+                        inputFrames: buffer.frameLength, ratio: self.resampleRatio,
                     )
                     guard let outputBuffer = AVAudioPCMBuffer(
                         pcmFormat: converter.outputFormat,

--- a/tools/audiotap/Sources/StreamingMonoResampler.swift
+++ b/tools/audiotap/Sources/StreamingMonoResampler.swift
@@ -60,7 +60,7 @@ final class StreamingMonoResampler {
         }
 
         let ratio = outputFormat.sampleRate / Double(inputRate)
-        let outputCapacity = AVAudioFrameCount(Double(inputFrames) * ratio + 16)
+        let outputCapacity = resampleOutputCapacity(inputFrames: inputFrames, ratio: ratio)
         guard let outputBuffer = AVAudioPCMBuffer(
             pcmFormat: outputFormat, frameCapacity: outputCapacity,
         ) else { return [] }

--- a/tools/audiotap/Tests/HelpersTests.swift
+++ b/tools/audiotap/Tests/HelpersTests.swift
@@ -47,6 +47,26 @@ final class HelpersTests: XCTestCase {
         XCTAssertEqual(speechSampleRate, 16000)
     }
 
+    // MARK: - resampleOutputCapacity
+
+    func testResampleOutputCapacityIncludesHeadroom() {
+        // 48 kHz → 16 kHz, 4096-frame input buffer: 4096 * (1/3) = 1365.33,
+        // which truncates to 1365. AVAudioConverter retains the fractional
+        // output sample each call; a floor()'d capacity strands it and the
+        // remainder accumulates into a growing backlog (→ TimelineAnchor
+        // injects silence to "catch up", drifting real audio later). The
+        // capacity must exceed the floor so the converter can flush per call.
+        let cap = resampleOutputCapacity(inputFrames: 4096, ratio: 16000.0 / 48000.0)
+        XCTAssertEqual(cap, 1365 + 16)
+        XCTAssertGreaterThan(cap, 1365, "no headroom → converter backlog → timeline drift")
+    }
+
+    func testResampleOutputCapacityIdentityRateKeepsHeadroom() {
+        // Same-rate path (ratio 1.0) still carries headroom — the converter
+        // can be primed/flushed without the capacity ever being the limiter.
+        XCTAssertEqual(resampleOutputCapacity(inputFrames: 1000, ratio: 1.0), 1016)
+    }
+
     // MARK: - writeAllToFileHandle
 
     func testWriteAllToFileHandleWritesAllBytes() throws {


### PR DESCRIPTION
## Problem

The mic capture tap sized its resample output buffer to exactly `floor(frameLength * resampleRatio)`. `AVAudioConverter` retains a fractional output sample on each `convert` call, so a floor()'d capacity **strands that remainder** — and it accumulates into a backlog the converter can never flush.

Consequence: the mic track under-runs wall-clock, and `TimelineAnchor` (which compares `expected − framesWritten`) papers over the growing deficit by injecting 1-frame silences **mid-speech**, drifting the real audio progressively later relative to the app track.

At 48 kHz the backlog grows **~0.9 s/h** — invisible to the short E2E validation window, but degrades long meetings.

The **app** capture path already added `+16` headroom inline (`StreamingMonoResampler`); only the mic path was missing it.

## Fix

Extract the capacity computation into a shared pure helper `resampleOutputCapacity(inputFrames:ratio:)` (single source of truth) and use it on **both** paths, fixing the mic side.

`floor(x + 16) == floor(x) + 16` for integer headroom, so the app path is byte-identical to before — confirmed by the existing resampler tests (146/146 green).

## Test

A mutation-proof unit test pins the headroom contract:

```swift
resampleOutputCapacity(inputFrames: 4096, ratio: 16000.0/48000.0) == 1365 + 16
```

Dropping the `+ headroom` yields `1365` and fails `>= 1381`. Lint clean.