### PR TITLE
ci: pipefail the tee'd report/analyze steps so failures aren't masked

### DIFF
--- a/.github/workflows/build-perf-tracking.yml
+++ b/.github/workflows/build-perf-tracking.yml
@@ -30,4 +30,8 @@ jobs:
           ALERT_PCT: ${{ inputs.alert_pct || '20' }}
           WORKFLOW: ci.yml
           BRANCH: main
-        run: bash scripts/build_perf_report.sh | tee -a "$GITHUB_STEP_SUMMARY"
+        # pipefail: without it `| tee` masks the report script's exit code, so a
+        # detected slowdown (the script's exit 1) would never fail the step.
+        run: |
+          set -o pipefail
+          bash scripts/build_perf_report.sh | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         run: brew install swiftlint
       - name: Build & Analyze
         run: |
+          # pipefail: without it `xcodebuild ... | tee` masks an xcodebuild
+          # failure, leaving swiftlint analyze to pass against an empty log.
+          set -o pipefail
           cd app/MeetingTranscriber
           xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' build-for-testing 2>&1 | tee /tmp/xcodebuild.log
           cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Problem

Two workflow steps pipe a command into `tee`. Without `pipefail` the step's exit code is **tee's** (always 0), so an upstream failure is silently swallowed:

- **`build-perf-tracking.yml`** — `build_perf_report.sh` is documented to exit `1` when it detects a build slowdown vs the 28-day baseline. Piped into `tee -a "$GITHUB_STEP_SUMMARY"`, that exit code is lost, so the slowdown alert could **never** turn the step red.
- **`ci.yml` analyze job** — `xcodebuild ... 2>&1 | tee /tmp/xcodebuild.log` masked an `xcodebuild` failure, leaving `swiftlint analyze` to run against an empty/partial log and pass. The analyze job is a **required status check**, so it could go **vacuously green** on a build break.

## Fix

Add `set -o pipefail` to both steps, matching the existing precedent in `e2e-cpu-load.yml` (which already documents this exact `| tee` masking pitfall).

Behavior changes **only** when the piped command fails — green runs are unaffected.

## Verification

`actionlint` clean on both workflows.