### PR TITLE
chore: gitignore Claude Code local settings and in-repo worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ tools/audiotap/.build/
 # Git worktrees
 .worktrees/
 
+# Claude Code: per-machine settings + in-repo worktrees (never tracked).
+# A shared .claude/settings.json stays trackable by design.
+.claude/settings.local.json
+.claude/worktrees/
+
 # Python
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Problem

`.claude/` was not ignored — `git check-ignore .claude/settings.local.json` returned empty — so the per-machine settings file and the live worktree checkouts under `.claude/worktrees/` could be staged/committed by accident. The existing `.worktrees/` rule only matches a top-level dir, not the nested `.claude/worktrees/`.

## Fix

Ignore the two per-machine paths specifically rather than blanket-ignoring `.claude/`, so a shared `.claude/settings.json` stays trackable by design:

```
.claude/settings.local.json
.claude/worktrees/
```

Nothing under `.claude/` is currently tracked, so no `git rm --cached` is needed.

## Verification

```
$ git check-ignore -v .claude/settings.local.json .claude/worktrees/foo
.gitignore:19:.claude/settings.local.json   .claude/settings.local.json
.gitignore:20:.claude/worktrees/            .claude/worktrees/foo
$ git check-ignore .claude/settings.json    # → empty (shared config stays trackable)
```