### PR TITLE
fix(app): keep the app temp until the mix is durable so recovery can retry

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -410,7 +410,6 @@ class DualSourceRecorder: RecordingProvider {
 
         if appRawBytes > 0 {
             let raw = try Data(contentsOf: tempURL)
-            try? FileManager.default.removeItem(at: tempURL)
 
             let floatCount = raw.count / MemoryLayout<Float>.size
             var floats = [Float](repeating: 0, count: floatCount)
@@ -481,6 +480,13 @@ class DualSourceRecorder: RecordingProvider {
         }
 
         logger.info("Mix saved: \(mixPath.lastPathComponent)")
+
+        // The raw app temp is the canonical recovery source on the crash-
+        // recovery path. Drop it only now that a durable mix exists, so a
+        // failure anywhere above leaves it intact for the next recovery attempt.
+        if appRawBytes > 0 {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
 
         return RecordingResult(
             mixPath: mixPath,

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -434,6 +434,39 @@ final class DualSourceRecorderTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: result.mixPath.path))
     }
 
+    /// Crash-recovery safety: the raw app `.tmp` is the only recoverable copy
+    /// on the recovery path. If buildRecording fails *after* reading it but
+    /// *before* a durable mix exists, it must leave the temp intact so the next
+    /// recovery attempt can retry — eagerly deleting it would destroy the
+    /// recording.
+    func testBuildRecordingPreservesAppTempWhenLaterStepThrows() throws {
+        let dir = try makeTempDirectory(prefix: "build_preserve")
+        let appTmp = dir.appendingPathComponent("20260311_160000_app_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
+        // A mic file that exists and is larger than a WAV header but is not
+        // decodable audio: buildRecording clears the size guard, then
+        // AVAudioFile(forReading:) throws — failing the build after the temp
+        // has been read but before any durable mix is written.
+        let badMic = dir.appendingPathComponent("20260311_160000_mic.wav")
+        try Data(repeating: 0xFF, count: 128).write(to: badMic)
+
+        XCTAssertThrowsError(
+            try DualSourceRecorder.buildRecording(
+                from: AudioCaptureResult(
+                    appAudioFileURL: appTmp, micAudioFileURL: badMic,
+                    actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
+                ),
+                recordingsDir: dir, timestamp: "20260311_160000", recordingStart: 1000,
+                format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
+            ),
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: appTmp.path),
+            "app .tmp must survive a failed buildRecording so crash-recovery can retry",
+        )
+    }
+
     /// Captured channel count below the requested one (mono USB device) still
     /// produces a valid track — downmix is a passthrough for mono input.
     func testBuildRecordingToleratesChannelCountMismatch() throws {


### PR DESCRIPTION
## Problem

`buildRecording` read the raw app `.tmp` into memory and **immediately deleted it**, then ran several throwing steps before any durable output existed:

1. save the app WAV,
2. open the mic file (`AVAudioFile(forReading:)`, plain `try`),
3. mix / save the mix.

If any of those threw — a disk-full app WAV, an unreadable/corrupt mic file, a failed mix — the temp was already gone and no `_mix` had been written. On the **crash-recovery path** (`recoverCrashedRecordings` re-derives a recording from an orphaned temp on the next launch), that temp is the *only* surviving copy, so the recording was lost for good. It directly contradicted the recovery code's own contract.

Low probability (needs a throw between the temp read and the mix write), but the failure mode is permanent data loss.

## Fix

Defer the temp deletion until **after** the mix is durably written. A failure anywhere above now leaves the temp intact for the next recovery attempt. The happy path still consumes it (guarded by the same `appRawBytes > 0` condition as the read); the empty-temp case keeps its existing cleanup branch.

## Test

`testBuildRecordingPreservesAppTempWhenLaterStepThrows` reproduces the loss: a mid-build failure (a >44-byte but non-decodable mic file makes `AVAudioFile(forReading:)` throw) left the temp **deleted** before the fix, **preserved** after. Full `DualSourceRecorderTests` green (37/37, including the happy-path "raw .tmp is consumed" assertions); lint clean.