### PR TITLE
fix(app): skip recently-modified WAVs in the launch repair scan

### DIFF
--- a/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
+++ b/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
@@ -62,14 +62,25 @@ enum WavHeaderRepair {
     /// Scans `dir` (non-recursively) for `*.wav` files and repairs any with an
     /// unfinalized header. Returns the number actually repaired. Called at
     /// launch to rescue recordings whose writer was killed mid-stream (#379).
+    ///
+    /// `minAge` skips a WAV still being written by an in-progress recording
+    /// (recent mtime). A live track legitimately has a zero data size until it
+    /// closes; stamping a partial size now would erase that 0-size signature,
+    /// so a later crash of the same file could never be recovered (the `==0`
+    /// guard in `repairIfNeeded` would reject it). The launch queue-build Task
+    /// can fire right as a watch-started recording begins, so the window is
+    /// real. Same guard as `recoverCrashedRecordings` / `cleanupTempFiles`.
     @discardableResult
-    static func repairUnfinalized(in dir: URL) -> Int {
+    static func repairUnfinalized(in dir: URL, minAge: TimeInterval = 30) -> Int {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: dir, includingPropertiesForKeys: nil,
         ) else { return 0 }
+        let cutoff = Date().addingTimeInterval(-minAge)
         var repaired = 0
         for url in entries where url.pathExtension.lowercased() == "wav" {
+            if let mtime = (try? fm.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date,
+               mtime > cutoff { continue }
             if (try? repairIfNeeded(at: url)) == true { repaired += 1 }
         }
         return repaired

--- a/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
+++ b/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
@@ -120,10 +120,33 @@ final class WavHeaderRepairTests: XCTestCase {
 
         XCTAssertEqual(readableFrames(brokenURL), 0, "broken WAV starts unreadable")
 
-        let count = WavHeaderRepair.repairUnfinalized(in: dir)
+        // minAge: 0 disables the live-file guard so this freshly-written
+        // fixture exercises the repair logic itself (the guard has its own test).
+        let count = WavHeaderRepair.repairUnfinalized(in: dir, minAge: 0)
 
         XCTAssertEqual(count, 1, "only the one unfinalized WAV should be repaired")
         XCTAssertGreaterThan(readableFrames(brokenURL), 0, "the crashed WAV is readable after the dir pass")
         XCTAssertEqual(try Data(contentsOf: validURL), validBefore, "a finalized WAV must be left unchanged")
+    }
+
+    func testRepairUnfinalizedSkipsRecentlyModifiedWavs() throws {
+        // A WAV still being written by a live recording legitimately has a zero
+        // data size. The launch scan must not "repair" it: stamping a partial
+        // size now erases the 0-size signature, so a later crash of the same
+        // file could never be recovered (the ==0 guard would reject it).
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wavrepairfresh-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let liveURL = dir.appendingPathComponent("inprogress_mic.wav")
+        _ = try writeFinalizedWav(seconds: 0.4, at: liveURL)
+        try corruptHeader(at: liveURL) // unfinalized + just written → recent mtime
+
+        // Default 30 s guard: a file modified moments ago is treated as live.
+        let count = WavHeaderRepair.repairUnfinalized(in: dir)
+
+        XCTAssertEqual(count, 0, "a recently-modified (possibly live) WAV must be skipped")
+        XCTAssertEqual(readableFrames(liveURL), 0, "the live WAV's header must be left untouched")
     }
 }


### PR DESCRIPTION
## Problem

`WavHeaderRepair.repairUnfinalized` scans every `*.wav` in the recordings dir at launch with **no age guard** — unlike its siblings `recoverCrashedRecordings` and `cleanupTempFiles`, which both skip files younger than 30s.

The launch queue-build `Task` can fire right as a watch-started recording begins writing, so the scan can hit a **live** mic track. A live track legitimately has a **zero data size** until it closes. "Repairing" it stamps the current partial size into the header, erasing the 0-size signature — so if that same recording later crashes, the `== 0` guard in `repairIfNeeded` refuses to repair it and crash-recovery mixes a **truncated** mic track.

Narrow window, but the asymmetry to the siblings is real.

## Fix

Add the same `minAge` (30s mtime) guard the siblings use. Production uses the default; a recently-modified WAV is treated as possibly-live and skipped.

## Test

- New `testRepairUnfinalizedSkipsRecentlyModifiedWavs`: a freshly-written unfinalized WAV is left untouched (RED before the guard — it was repaired).
- The existing scan test opts out with `minAge: 0` so it still exercises the repair logic on its fresh fixtures.

Full `WavHeaderRepairTests` green (5/5), lint clean.