### PR TITLE
ci: sweep this-run recording orphans in the silent-recording e2e

### DIFF
--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -264,20 +264,10 @@ on_exit() {
         # abort the trap before the artifact sweep below runs.
         quit_running_app || true
         # The lane's recordings are measurement garbage, and quitting the app
-        # mid-grace orphans raw temps: the NEXT run's app crash-recovers a
-        # stale temp into a garbage job, and an errored recovery job is
-        # re-enqueued on every launch (it never enters
-        # processed_recordings.json). Delete everything this run created;
-        # pre-existing files are older than the marker and stay untouched.
-        # GUARDED to CI via $GITHUB_ACTIONS (same pattern as the queue-snapshot
-        # reset): dev and prod app share the recordings dir on a developer
-        # machine, so a local sweep could catch a real recording made during
-        # the run. Locally the orphans are harmless -- the next app launch
-        # recovers them.
-        if [ "${GITHUB_ACTIONS:-}" = "true" ] \
-            && [ -n "${RUN_START_MARKER:-}" ] && [ -d "$REC_DIR" ]; then
-            find "$REC_DIR" -type f -newer "$RUN_START_MARKER" -delete 2>/dev/null || true
-        fi
+        # mid-grace orphans raw temps. Sweep this run's artifacts so the next
+        # run's app doesn't crash-recover a stale temp into a garbage job (the
+        # rationale + the CI guard live in sweep_run_artifacts).
+        sweep_run_artifacts "$REC_DIR" "$RUN_START_MARKER"
     fi
     rm -f "${RUN_START_MARKER:-}" 2>/dev/null || true
 }

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -65,6 +65,10 @@ MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
 # `--no-build` rather than rebuilt in debug mode.
 SIM="$ROOT/tools/meeting-simulator/.build/release/meeting-simulator"
 BUNDLE_ID="com.meetingtranscriber.dev"
+REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
+# Anchor for the EXIT-trap artifact sweep: created before any recording, so
+# every file this run produces is newer than it (see sweep_run_artifacts).
+RUN_START_MARKER="$(mktemp "${TMPDIR:-/tmp}/e2e-silent-rec-start.XXXXXX")"
 
 # Defaults to restore after the test — empty string means "key wasn't set".
 SAVED_AUTOWATCH=""
@@ -78,6 +82,10 @@ cleanup() {
     if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
         kill -9 "$APP_PID" 2>/dev/null || true
     fi
+    # The app was kill -9'd mid-recording above, orphaning a raw temp; sweep
+    # this run's artifacts so the next run doesn't crash-recover a stale temp.
+    sweep_run_artifacts "$REC_DIR" "$RUN_START_MARKER"
+    rm -f "${RUN_START_MARKER:-}" 2>/dev/null || true
     # Restore defaults to whatever they were before we ran (or delete the
     # keys if they didn't exist).
     restore_bool_default  "$BUNDLE_ID" autoWatch                       "$SAVED_AUTOWATCH"

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -198,3 +198,21 @@ restore_float_default() {
         /usr/bin/defaults delete "$bundle" "$key" 2>/dev/null || true
     fi
 }
+
+# Delete the recording artifacts THIS run created — every file under `rec_dir`
+# newer than `marker` (create the marker before the run starts recording).
+# Killing the app mid-recording orphans a raw temp; the next run's app
+# crash-recovers it into a garbage job that, once errored, never enters
+# processed_recordings.json and so re-enqueues on every launch.
+#
+# GUARDED to CI via $GITHUB_ACTIONS (never set in a developer's shell): dev and
+# prod share the recordings dir on a developer machine, so a local sweep could
+# delete a real recording made during the run. Locally the orphans are harmless
+# — the next app launch recovers them. `-newer` leaves pre-existing files alone.
+sweep_run_artifacts() {
+    local rec_dir="$1"
+    local marker="$2"
+    if [ "${GITHUB_ACTIONS:-}" = "true" ] && [ -n "$marker" ] && [ -d "$rec_dir" ]; then
+        find "$rec_dir" -type f -newer "$marker" -delete 2>/dev/null || true
+    fi
+}


### PR DESCRIPTION
## Problem

`e2e-silent-recording.sh` kills the app with `kill -9` mid-recording, orphaning a raw `*_app16k_raw.tmp` (+ mic `.wav`) in the recordings dir — and never swept them. On CI the next run's app crash-recovers that stale temp into a garbage "Recovered Recording" job; once it errors it never enters `processed_recordings.json`, so it re-enqueues on every launch and can race the crash-recovery e2e lane red (that lane can't ignore recovered jobs — its own expected job *is* a recovered one).

## Fix

`e2e-cpu-load.sh` already does a marker-bounded, `$GITHUB_ACTIONS`-gated sweep of its own run artifacts. Extract it into a shared `sweep_run_artifacts` helper in `lib/e2e-helpers.sh` and call it from both scripts (closes the deferred "marker-cleanup in shared e2e-helpers" item):

- **e2e-cpu-load.sh** — behavior-identical (the inline gated `find` → the helper).
- **e2e-silent-recording.sh** — now anchors a run-start marker and sweeps its own artifacts in the EXIT trap.

Guarded to CI (`$GITHUB_ACTIONS`) so a developer's real recordings (dev + prod share the recordings dir) are never deleted; `-newer` leaves pre-existing files untouched.

## Verification

`shellcheck -x` clean on `e2e-cpu-load.sh`; the new lines in `e2e-silent-recording.sh` are clean (only the cosmetic SC1091 source-follow info). The pre-existing SC2148 on the sourced helper lib is unrelated.