### PR TITLE
fix(app): guard toggleWatching against a re-entrant start

### DIFF
--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -29,6 +29,12 @@ import Observation
 final class WatchingController {
     var watchLoop: WatchLoop?
 
+    /// Non-nil while `toggleWatching`'s async start is in flight — it awaits mic
+    /// access before `watchLoop` is assigned, so without this a second toggle in
+    /// that window would launch a duplicate start. Cleared when the start task
+    /// finishes.
+    private var startTask: Task<Void, Never>?
+
     private let settings: AppSettings
     private let notifier: any AppNotifying
     private let pipeline: PipelineController
@@ -92,7 +98,13 @@ final class WatchingController {
             loop.stop()
             watchLoop = nil
         } else {
-            Task { @MainActor in
+            // The start is async — mic access is awaited before `watchLoop` is
+            // assigned — so a second toggle in that window would otherwise launch
+            // a duplicate WatchLoop and rebuild the queue twice. Ignore it while
+            // a start is already in flight.
+            guard startTask == nil else { return }
+            startTask = Task { @MainActor in
+                defer { startTask = nil }
                 _ = await ensureMicAccess()
 
                 syncEngines?()

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -127,6 +127,30 @@ final class WatchingControllerTests: XCTestCase {
         XCTAssertNil(controller.watchLoop, "second toggle should stop and clear the loop")
     }
 
+    func testReentrantToggleWhileStartingStartsOnlyOneLoop() async {
+        // The start path is async: it awaits mic access before it assigns
+        // `watchLoop`. A second toggle fired in that window sees `watchLoop ==
+        // nil` and, without a guard, launches a *second* start — duplicating the
+        // queue rebuild and leaving an orphan WatchLoop running. The mic-access
+        // gate counts starts: a re-entrant toggle must not trip it twice.
+        var startAttempts = 0
+        // Not trailing-closure: a trailing closure binds to the last param
+        // (`makeDetector`), not `ensureMicAccess`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            startAttempts += 1
+            return true
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        // Two toggles back-to-back, before the first start can finish.
+        controller.toggleWatching()
+        controller.toggleWatching()
+
+        await waitFor(controller.watchLoop != nil)
+        XCTAssertEqual(startAttempts, 1, "a re-entrant toggle during start must not launch a second WatchLoop")
+    }
+
     func testToggleWatchingNoOpWhileManualRecording() async throws {
         let controller = makeController()
         let (loop, _) = makeTestWatchLoop()


### PR DESCRIPTION
## Problem

`toggleWatching`'s start path is async — it `await`s microphone access **before** it assigns `watchLoop`. A second toggle fired in that window (a fast double-click, or a programmatic re-toggle) sees `watchLoop == nil`, falls through the same `else` branch, and launches a **second** start:

- `pipeline.rebuild()` runs twice → two live `PipelineQueue`s, each launching its own crash-recovery scan and racing snapshot writes;
- a second `WatchLoop` is created, started, and then orphaned (the second `watchLoop = loop` wins; the first keeps polling).

## Fix

Track the in-flight start in a `startTask` and ignore a toggle while one is running. Cleared via `defer` when the start finishes, so a later toggle still hits the stop branch. One guard fixes both the duplicate-queue (R5a) and orphan-WatchLoop (R5b) paths at their shared root — the re-entrant start — rather than hardening each downstream.

## Test

`testReentrantToggleWhileStartingStartsOnlyOneLoop` fires two back-to-back toggles before the first start can finish and asserts the injected mic-access gate trips **exactly once** (RED before the guard: it tripped twice). Full `WatchingControllerTests` green (7/7), lint clean.