### PR TITLE
docs(ci): correct the fail-fast comment to match cancel-on-failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,11 @@ jobs:
       contents: read
       actions: write
     strategy:
-      # Both Homebrew and AppStore variants must pass; one failing leg
-      # shouldn't kill the other's diagnostic output.
+      # Both Homebrew and AppStore variants must pass. fail-fast: false NOT to
+      # keep the sibling running on failure — the `Cancel run on failure` step
+      # below cancels the whole run on any failure — but so the failing leg runs
+      # that step and names itself the culprit in the run summary, instead of
+      # being silently auto-cancelled by the matrix before it can.
       fail-fast: false
       matrix:
         variant: [homebrew, appstore]

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -54,8 +54,11 @@ jobs:
       contents: read
       actions: write
     strategy:
-      # TSan and ASan find different classes of bugs; one failing leg
-      # shouldn't kill the other's diagnostic output.
+      # TSan and ASan find different classes of bugs. fail-fast: false NOT to
+      # keep the sibling running on failure — the `Cancel run on failure` step
+      # below cancels the whole run on any failure — but so the failing leg runs
+      # that step and names itself the culprit in the run summary, instead of
+      # being silently auto-cancelled by the matrix before it can.
       fail-fast: false
       matrix:
         variant: [tsan, asan]


### PR DESCRIPTION
## Problem

The matrix `fail-fast: false` in `ci.yml` (test) and `quality-and-safety.yml` (sanitizers) carried the comment:

> one failing leg shouldn't kill the other's diagnostic output

That's not what happens. Each leg has a `Cancel run on failure` step (`if: failure()`) that cancels the **whole run** on any failure — so the sibling leg *is* killed. The comment contradicts the actual behavior.

## Fix

Correct the comment. `fail-fast: false` is still needed, but for a different reason than stated: it lets the failing leg run its `Cancel run on failure` step and **name itself the culprit** in the run summary (the matrix's built-in fail-fast would silently auto-cancel the leg first, hiding which one failed — the exact problem the cancel-on-failure action's culprit annotation was built to solve).

Comment-only — no behavior change (`actionlint` clean; the diff touches no `fail-fast`/`uses`/`run` line).