### PR TITLE
fix(app): make the requested speaker count actually force that many speakers

### DIFF
--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -273,7 +273,12 @@ struct FluidOfflineProcessor: OfflineDiarizationProcessing {
     static func makeConfig(tuning: OfflineDiarizerTuning, numSpeakers: Int?) -> OfflineDiarizerConfig {
         var config = tuning.apply(to: OfflineDiarizerConfig())
         if let n = numSpeakers, n > 0 {
-            config = config.withSpeakers(min: 1, max: n)
+            // Force EXACTLY n, not merely cap at n. FluidAudio only re-clusters
+            // when the natural detection falls outside the speaker bounds, so a
+            // cap-only constraint left an under-detected count untouched — the
+            // "Expected Speakers" setting and the naming dialog's "Wrong count?"
+            // re-run were silent no-ops whenever the detector found ≤ n.
+            config = config.withSpeakers(exactly: n)
         }
         return config
     }

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -218,7 +218,7 @@ private struct TuningKnob {
         step: 0.05,
         format: "%.2f",
         suffix: "",
-        help: "Euclidean distance threshold for clustering speaker embeddings. Lower values split speakers more aggressively.",
+        help: "Cosine-similarity threshold for merging speaker embeddings. Higher values split speakers more aggressively (more speakers detected).",
     )
 
     static let warmStartFa = Self(

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -106,6 +106,12 @@ struct SpeakersSettingsView: View {
                     .font(.caption)
                 }
                 expectedSpeakersRow
+                Label(
+                    "Auto detects the count; a fixed value forces exactly that many speakers (and over-splits a smaller meeting).",
+                    systemImage: "info.circle",
+                )
+                .foregroundStyle(.secondary)
+                .font(.caption)
                 if settings.diarizerMode == .offline {
                     experimentalTuningDisclosure
                 }

--- a/app/MeetingTranscriber/Tests/FluidDiarizerTuningTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidDiarizerTuningTests.swift
@@ -86,12 +86,13 @@ final class FluidDiarizerTuningTests: XCTestCase {
         XCTAssertNil(config.clustering.maxSpeakers)
     }
 
-    func testMakeConfigAppliesSpeakerConstraints() {
+    func testMakeConfigForcesExactSpeakerCount() {
+        // Forced exact (numSpeakers), not a cap — see makeConfig for why.
         let config = FluidOfflineProcessor.makeConfig(tuning: .defaults, numSpeakers: 4)
 
-        XCTAssertEqual(config.clustering.minSpeakers, 1)
-        XCTAssertEqual(config.clustering.maxSpeakers, 4)
-        XCTAssertNil(config.clustering.numSpeakers)
+        XCTAssertEqual(config.clustering.numSpeakers, 4)
+        XCTAssertNil(config.clustering.minSpeakers)
+        XCTAssertNil(config.clustering.maxSpeakers)
     }
 
     func testMakeConfigIgnoresZeroOrNegativeSpeakerCount() {


### PR DESCRIPTION
## Problem

Meetings were diarized to too few speakers (often collapsing to 2), and the usual recovery — re-running with a higher speaker count via the naming dialog's **Wrong count?** stepper — had no effect.

Root cause: a requested count `n` (from **Expected Speakers** or the re-run dialog) was applied as `withSpeakers(min: 1, max: n)`. FluidAudio's offline diarizer only re-clusters (via K-Means) when the natural AHC/VBx detection falls **outside** `[minSpeakers, maxSpeakers]`. With `min: 1`, a recording that auto-detected 2 speakers is already inside `[1, n]`, so nothing happens — the count acted as a ceiling but never a floor. The re-run was a silent no-op whenever the detector found `<= n`.

In a dual-track recording this surfaces as exactly "2 speakers": the app/remote track collapses to one cluster and the mic track contributes one, so a remote meeting with several participants shows up as 2.

**Verified on a real recording** (a daily standup's app track, re-diarized locally): auto-detect → 2 speakers; old `min:1,max:6` forced-6 → **still 2** (the no-op); `withSpeakers(exactly: 6)` → **6**.

## Fix

- **`FluidOfflineProcessor.makeConfig`** — use FluidAudio's purpose-built `config.withSpeakers(exactly: n)` so a requested count is the exact target (its `min:max:` overload doc literally says "Use `withSpeakers(exactly:)` for exact count"). K-Means is then forced to split up to the requested number. `n > numEmbeddings` is clamped by FluidAudio; `0`/Auto is unchanged (existing `n > 0` guard).
- **Cluster-threshold help text** — the Experimental Diarization Tuning help called the knob a "Euclidean distance threshold" and said "Lower values split speakers more aggressively." Both are wrong: FluidAudio treats the value as a cosine **similarity** (`distance = sqrt(2 − 2·sim)`; clusters merge when their distance is below the cut), so a **higher** threshold merges less and yields **more** speakers. Verified empirically against the offline diarizer on real audio: `0.4→1, 0.5→2, 0.6→3, 0.7→5` speakers. The old text pushed users to lower it — the opposite of the intent when too few are detected.
- **"Expected Speakers" caption** — that row changed from a soft cap to an exact target, so it now carries a one-line help caption (it previously had none) explaining the exact-count behavior and its over-split trade-off on smaller meetings.

## Trade-off

Forcing exactly `n` can over-split a meeting that genuinely has fewer than `n` distinguishable voices — but that is the explicit intent when a user types a number into **Wrong count?** or sets a non-zero **Expected Speakers**. `0`/Auto keeps pure auto-detect. The global setting and the re-run intentionally share one path (a single exact-count knob); splitting them (global = cap, re-run = exact) would thread a flag through `DiarizationProvider.run → prepare → makeConfig` and the mock — deferred as not worth it for a rarely-hit case.

## Test

`testMakeConfigForcesExactSpeakerCount` asserts `numSpeakers == n` with `min`/`max` nil (mutation-proven: fails against the old `min: 1`). Full app suite green; lint clean.