### PR TITLE
refactor(app): feed live captions through bounded per-channel AsyncStreams

### DIFF
--- a/app/MeetingTranscriber/Sources/EouStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/EouStreamingCaptionSession.swift
@@ -107,19 +107,6 @@ actor EouStreamingCaptionSession: LiveCaptionPipeline {
     /// another actor, so we install lazily on first ingest).
     private var callbacksInstalled = false
 
-    /// Captured buffers awaiting processing, oldest first. `ingest` appends here
-    /// SYNCHRONOUSLY (before any `await`) and a single active drain consumes them
-    /// FIFO — that synchronous enqueue is what pins ring/manager ordering even
-    /// when the production driver spawns one unstructured `Task` per buffer.
-    private var pendingBuffers: [[Float]] = []
-    /// True while a drain pass owns `pendingBuffers`. A second `ingest` (or
-    /// `flush`) that arrives mid-drain only enqueues + returns; the active pass
-    /// re-checks the queue each iteration and consumes what was appended. Without
-    /// this, two interleaved drains would fork the ring/manager sample order and
-    /// invalidate the EOU-ms → ring-slice mapping. Mirrors
-    /// `StreamingTranscriber.isDrainingInput`.
-    private var isIngesting = false
-
     private let collector = CallbackCollector()
 
     /// 16 kHz: 1 ms == 16 samples (fixed; the whole live path is 16 kHz mono).
@@ -146,35 +133,43 @@ actor EouStreamingCaptionSession: LiveCaptionPipeline {
     /// (`LiveTranscriptionController` / `MicCaptureHandler`) normalizes both
     /// channels to that shape, same guard as `StreamingTranscriber.ingest`.
     ///
-    /// The production driver spawns one unstructured `Task` per captured buffer,
-    /// so several `ingest` calls can interleave at this actor's suspension
-    /// points. Enqueue synchronously here (before any `await`) and let a single
-    /// drain pass consume the queue FIFO, so ring order == manager feed order
-    /// regardless of which task wins the actor next.
+    /// Calls are serialized by the driver (one ingest at a time, in capture
+    /// order — see the `LiveCaptionPipeline` contract), which is what keeps
+    /// ring order == manager feed order and the EOU-ms → ring-slice mapping
+    /// valid without any re-entrancy machinery here.
     func ingest(_ buffer: LiveAudioBuffer) async {
         guard buffer.channelCount == 1, buffer.sampleRate == 16000 else { return }
-        pendingBuffers.append(buffer.samples)
-        await drainPending()
+        await installCallbacksIfNeeded()
+        guard let pcm = Self.makeBuffer(buffer.samples) else { return }
+
+        do {
+            // Advance the ring + counter only AFTER the manager accepts the
+            // samples, so a thrown appendAudio can't leave the ring ahead of
+            // the manager and permanently skew the ms timeline. A
+            // processBufferedAudio failure after a successful append is
+            // benign — the manager already holds the samples.
+            try await asr.appendAudio(pcm)
+            ring.append(buffer.samples)
+            ingestedSamples += buffer.samples.count
+            try await asr.processBufferedAudio()
+        } catch {
+            // Never throw out of ingest — log and move on. Transcript text is
+            // never logged; only the (public) channel label and the error.
+            logger.warning("[\(self.channelLabel, privacy: .public)] ingest error: \(error)")
+            return
+        }
+
+        await drainCollector()
     }
 
-    /// Recording stopped — flush any pending input as captions, commit the
-    /// trailing utterance via `finish()` (whose return value carries the
-    /// transcript), then reset all state so a subsequent recording starts clean.
-    /// Idempotent: a second flush (or a flush before any ingest) emits nothing
-    /// and never calls `finish()` again, because the reset zeroes
-    /// `ingestedSamples` and empties the queue.
+    /// Recording stopped — commit the trailing utterance via `finish()`
+    /// (whose return value carries the transcript), then reset all state so a
+    /// subsequent recording starts clean. The driver retires the channel feed
+    /// before flushing, so every buffer delivered before the stop has already
+    /// been ingested when this runs. Idempotent: a second flush (or a flush
+    /// before any ingest) emits nothing and never calls `finish()` again,
+    /// because the reset zeroes `ingestedSamples`.
     func flush() async {
-        // An ingest may be mid-drain (suspended at appendAudio /
-        // processBufferedAudio). Wait for it to finish, then drain anything that
-        // accumulated meanwhile — including audio the recorder delivered in the
-        // last beat before stop — so the tail isn't dropped by stop-timing.
-        while isIngesting {
-            await Task.yield()
-        }
-        if !pendingBuffers.isEmpty {
-            await drainPending()
-        }
-
         guard ingestedSamples > 0 else { return }
 
         do {
@@ -195,42 +190,6 @@ actor EouStreamingCaptionSession: LiveCaptionPipeline {
         lastEouMs = 0
         lastFinalizedPrefix = ""
         ingestedSamples = 0
-    }
-
-    /// Single-flight drain of `pendingBuffers`: feeds each queued buffer through
-    /// ring → manager → callback drain, one at a time. The first caller owns the
-    /// pass; concurrent callers only enqueued and returned, and this loop picks
-    /// up whatever they appended. `isIngesting` is the serialization gate.
-    private func drainPending() async {
-        if isIngesting { return }
-        isIngesting = true
-        defer { isIngesting = false }
-
-        await installCallbacksIfNeeded()
-
-        while !pendingBuffers.isEmpty {
-            let samples = pendingBuffers.removeFirst()
-            guard let pcm = Self.makeBuffer(samples) else { continue }
-
-            do {
-                // Advance the ring + counter only AFTER the manager accepts the
-                // samples, so a thrown appendAudio can't leave the ring ahead of
-                // the manager and permanently skew the ms timeline. A
-                // processBufferedAudio failure after a successful append is
-                // benign — the manager already holds the samples.
-                try await asr.appendAudio(pcm)
-                ring.append(samples)
-                ingestedSamples += samples.count
-                try await asr.processBufferedAudio()
-            } catch {
-                // Never throw out of ingest — log and move on. Transcript text is
-                // never logged; only the (public) channel label and the error.
-                logger.warning("[\(self.channelLabel, privacy: .public)] ingest error: \(error)")
-                continue
-            }
-
-            await drainCollector()
-        }
     }
 
     // MARK: - Callbacks

--- a/app/MeetingTranscriber/Sources/LiveAudioResampler.swift
+++ b/app/MeetingTranscriber/Sources/LiveAudioResampler.swift
@@ -17,11 +17,13 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LiveAud
 /// internal resampling state persists across chunks (no boundary clicks).
 /// A format change mid-session rebuilds the converter and logs a warning.
 ///
-/// Used by `LiveTranscriptionController` to bridge the app-audio sink
-/// (typically 48 kHz interleaved stereo from `CATapDescription`) into the
-/// engine-friendly shape. The mic sink already runs through
-/// `MicCaptureHandler`'s own converter and arrives 16 kHz mono — it
-/// bypasses this resampler entirely.
+/// Used by `LiveTranscriptionController`'s app-channel feed. App buffers
+/// normally arrive already capture-time resampled to 16 kHz mono (via
+/// `AppAudioCapture`'s `StreamingMonoResampler`) and short-circuit through
+/// unchanged; real conversion only happens on the resampler-nil fallback
+/// path, where raw device-rate buffers (e.g. 48 kHz interleaved stereo)
+/// come through. The mic sink runs through `MicCaptureHandler`'s own
+/// converter and bypasses this resampler entirely.
 final class LiveAudioResampler {
     private var converter: AVAudioConverter?
     private var inputFormat: AVAudioFormat?

--- a/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionPipeline.swift
@@ -6,8 +6,15 @@ import AudioTapLib
 /// Extracted as a seam so a second strategy (e.g. a native streaming ASR
 /// backend) can slot in alongside the VAD-driven `StreamingTranscriber`
 /// without `LiveTranscriptionController` knowing which concrete strategy it
-/// holds. Behavior of the existing path is unchanged — `StreamingTranscriber`
-/// already exposed `ingest(_:)` with this exact shape.
+/// holds.
+///
+/// **Serialization contract:** the driver serializes all calls.
+/// `LiveTranscriptionController` feeds each pipeline from a single bounded
+/// `AsyncStream` consumer, so `ingest` runs one-at-a-time in capture order,
+/// and `flush` runs only after the feed is retired (every delivered buffer
+/// already ingested). Implementations may rely on this — no interleaved
+/// `ingest`/`flush` callers, no re-entrancy guards needed. Tests driving a
+/// pipeline directly must call sequentially (`await` each call).
 protocol LiveCaptionPipeline: Actor {
     func ingest(_ buffer: LiveAudioBuffer) async
     /// Recording stopped — flush any pending utterance as a final.

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -74,27 +74,11 @@ final class LiveTranscriptionController {
     private var micPipeline: (any LiveCaptionPipeline)?
     private var appPipeline: (any LiveCaptionPipeline)?
 
-    /// Bounded per-channel feed capacity, in buffers. Capture delivers
-    /// roughly 10–50 buffers/s per channel, so this is tens of seconds of
-    /// headroom — far more than a healthy pipeline ever queues, but a hard
-    /// bound when inference stalls: the stream then drops the OLDEST buffers
-    /// (captions degrade toward the newest audio instead of memory growing
-    /// without limit). Also sized so the fixture-driven E2E tests, which
-    /// feed ~375 buffers much faster than real time, fit without drops.
-    private static let feedCapacity = 512
-
-    /// Cross-thread continuation slots the sink closures yield into. The
-    /// audio callback thread yields under the lock; the main actor swaps
-    /// the continuation per recording (`bindFeeds` / `retireFeeds`). A nil
-    /// slot — before the first bind, or after a flush — drops the buffer,
-    /// matching the recorder lifecycle (nothing should be fed outside a
-    /// recording).
-    private let micFeedSlot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
-    private let appFeedSlot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
-    /// Single consumer task per channel feed — the serialization that makes
-    /// `LiveCaptionPipeline.ingest` calls ordered by construction.
-    private var micFeedConsumer: Task<Void, Never>?
-    private var appFeedConsumer: Task<Void, Never>?
+    /// One bounded feed per channel (see `CaptionChannelFeed`). The feeds
+    /// are (re)armed per recording via `bindFeeds()` and retired by
+    /// `flush()`/`retireFeeds()`.
+    private let micFeed = CaptionChannelFeed()
+    private let appFeed = CaptionChannelFeed()
     /// True once `prepare()` resolved the active strategy to the EOU sessions.
     /// `prepareForNextRecording()` keeps those sessions (already flushed clean at
     /// stop, reloading their models would be wasteful) and only rebuilds the
@@ -119,12 +103,7 @@ final class LiveTranscriptionController {
     /// thread; the closure yields into the channel's bounded feed and returns
     /// immediately — no task spawn, no actor hop on the audio thread.
     var micSink: LiveAudioSink {
-        let slot = micFeedSlot
-        return { buffer in
-            slot.withLock { continuation in
-                _ = continuation?.yield(buffer)
-            }
-        }
+        micFeed.sink
     }
 
     /// App-channel live sink. Hand this to `DualSourceRecorder.appLiveSink`
@@ -134,12 +113,7 @@ final class LiveTranscriptionController {
     /// runs them through `LiveAudioResampler`, which passes 16 kHz mono
     /// through unchanged.
     var appSink: LiveAudioSink {
-        let slot = appFeedSlot
-        return { buffer in
-            slot.withLock { continuation in
-                _ = continuation?.yield(buffer)
-            }
-        }
+        appFeed.sink
     }
 
     /// `verboseDiagnostics` stays the LAST parameter so a trailing closure binds
@@ -340,62 +314,24 @@ final class LiveTranscriptionController {
     /// the deterministic "all pre-stop audio is in the pipelines" barrier
     /// that `flush()` and a rebind rely on.
     private func retireFeeds() async {
-        micFeedSlot.withLock { slot in
-            slot?.finish()
-            slot = nil
-        }
-        appFeedSlot.withLock { slot in
-            slot?.finish()
-            slot = nil
-        }
-        if let consumer = micFeedConsumer { await consumer.value }
-        if let consumer = appFeedConsumer { await consumer.value }
-        micFeedConsumer = nil
-        appFeedConsumer = nil
+        await micFeed.retire()
+        await appFeed.retire()
     }
 
     /// (Re)arm one bounded feed per built pipeline, retiring any previous
-    /// feeds first so exactly one consumer per channel exists at all times —
-    /// that single consumer is what makes ingest ordering a property of the
-    /// channel rather than of scheduler luck.
+    /// feeds first (also for channels whose pipeline is nil, so no stale
+    /// consumer survives a build-less reset). The app feed's consumer runs a
+    /// fresh `LiveAudioResampler` per recording, replacing the old shared
+    /// instance + per-recording reset.
     private func bindFeeds() async {
         await retireFeeds()
         if let micPipeline {
-            micFeedConsumer = Self.makeFeed(into: micPipeline, slot: micFeedSlot, resampling: false)
+            await micFeed.bind(to: micPipeline)
         }
         if let appPipeline {
-            appFeedConsumer = Self.makeFeed(into: appPipeline, slot: appFeedSlot, resampling: true)
-        }
-    }
-
-    /// Build one channel feed: a bounded `AsyncStream` whose continuation is
-    /// installed into `slot` (for the sink closure) plus a single detached
-    /// consumer task that ingests buffers in arrival order. `resampling`
-    /// routes app-channel buffers through a fresh `LiveAudioResampler`
-    /// (confined to the consumer task, fresh per feed == per recording).
-    /// `static` so the consumer captures only the pipeline + stream, never
-    /// the controller.
-    private static func makeFeed(
-        into pipeline: any LiveCaptionPipeline,
-        slot: OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>,
-        resampling: Bool,
-    ) -> Task<Void, Never> {
-        let (stream, continuation) = AsyncStream.makeStream(
-            of: LiveAudioBuffer.self,
-            bufferingPolicy: .bufferingNewest(feedCapacity),
-        )
-        slot.withLock { $0 = continuation }
-        return Task.detached(priority: .userInitiated) {
-            if resampling {
+            await appFeed.bind(to: appPipeline) {
                 let resampler = LiveAudioResampler()
-                for await buffer in stream {
-                    guard let normalized = resampler.resample(buffer) else { continue }
-                    await pipeline.ingest(normalized)
-                }
-            } else {
-                for await buffer in stream {
-                    await pipeline.ingest(buffer)
-                }
+                return { resampler.resample($0) }
             }
         }
     }
@@ -469,6 +405,88 @@ final class LiveTranscriptionController {
                 }
             }
         }
+    }
+}
+
+/// One channel's bounded sink → pipeline feed: an `AsyncStream` whose
+/// continuation lives in a lock-guarded slot (the audio callback yields into
+/// it synchronously) plus a single detached consumer task that ingests into
+/// the channel's `LiveCaptionPipeline` in arrival order. Owning slot and
+/// consumer in one type keeps the invariant "exactly one consumer per slot;
+/// retire before rebind" in one place instead of mirrored per channel.
+///
+/// A nil slot — before the first `bind`, or after `retire` — drops yielded
+/// buffers, which is correct in every such window: there is either no
+/// recording, no pipeline yet (EOU models still loading), or the recording
+/// just stopped.
+@MainActor
+private final class CaptionChannelFeed {
+    /// Per-buffer normalization run inside the consumer task. Returning nil
+    /// drops the buffer.
+    typealias Transform = (LiveAudioBuffer) -> LiveAudioBuffer?
+
+    /// Bounded feed capacity, in buffers. Capture delivers roughly 10–50
+    /// buffers/s per channel, so this is tens of seconds of headroom — far
+    /// more than a healthy pipeline ever queues, but a hard bound when
+    /// inference stalls: the stream then drops the OLDEST buffers (captions
+    /// degrade toward the newest audio instead of memory growing without
+    /// limit). Also sized so the fixture-driven E2E tests, which feed ~375
+    /// buffers much faster than real time, fit without drops.
+    private static let capacity = 512
+
+    /// Cross-thread continuation slot the sink closure yields into. The
+    /// audio callback thread yields under the lock; the main actor swaps the
+    /// continuation per recording (`bind` / `retire`).
+    private let slot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
+    /// Single consumer task — the serialization that makes
+    /// `LiveCaptionPipeline.ingest` calls ordered by construction.
+    private var consumer: Task<Void, Never>?
+
+    /// Sink closure for the recorder: yields into the currently-armed stream
+    /// and returns immediately — no task spawn, no actor hop on the audio
+    /// thread. Captures only the slot, never the feed or its owner.
+    var sink: LiveAudioSink {
+        let slot = slot
+        return { buffer in
+            slot.withLock { continuation in
+                _ = continuation?.yield(buffer)
+            }
+        }
+    }
+
+    /// Arm a fresh feed into `pipeline`, retiring any previous one first so
+    /// exactly one consumer exists. `makeTransform` is invoked inside the
+    /// consumer task, so a stateful non-Sendable transform (the app channel's
+    /// `LiveAudioResampler`) stays confined to it — and is fresh per feed ==
+    /// per recording.
+    func bind(
+        to pipeline: any LiveCaptionPipeline,
+        makeTransform: @escaping @Sendable () -> Transform = { \.self },
+    ) async {
+        await retire()
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: LiveAudioBuffer.self,
+            bufferingPolicy: .bufferingNewest(Self.capacity),
+        )
+        slot.withLock { $0 = continuation }
+        consumer = Task.detached(priority: .userInitiated) {
+            let transform = makeTransform()
+            for await buffer in stream {
+                guard let normalized = transform(buffer) else { continue }
+                await pipeline.ingest(normalized)
+            }
+        }
+    }
+
+    /// Stop accepting sink deliveries, then await the consumer so every
+    /// buffer already delivered is ingested. Idempotent.
+    func retire() async {
+        slot.withLock { continuation in
+            continuation?.finish()
+            continuation = nil
+        }
+        if let consumer { await consumer.value }
+        consumer = nil
     }
 }
 

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -427,12 +427,14 @@ private final class CaptionChannelFeed {
 
     /// Bounded feed capacity, in buffers. Capture delivers roughly 10–50
     /// buffers/s per channel, so this is tens of seconds of headroom — far
-    /// more than a healthy pipeline ever queues, but a hard bound when
-    /// inference stalls: the stream then drops the OLDEST buffers (captions
-    /// degrade toward the newest audio instead of memory growing without
-    /// limit). Also sized so the fixture-driven E2E tests, which feed ~375
-    /// buffers much faster than real time, fit without drops.
-    private static let capacity = 512
+    /// more than a healthy pipeline ever queues in real time, but a hard
+    /// bound when inference stalls: the stream then drops the OLDEST buffers
+    /// (captions degrade toward the newest audio instead of memory growing
+    /// without limit). Sized to hold the ENTIRE 49.8 s E2E fixture (623 ×
+    /// 80 ms chunks, burst at ~40× real time by `LiveTranscriptionE2ETests`)
+    /// even if the consumer is parked in a slow first inference on the
+    /// CPU-only CI runner — those tests rely on lossless delivery.
+    private static let capacity = 1024
 
     /// Cross-thread continuation slot the sink closure yields into. The
     /// audio callback thread yields under the lock; the main actor swaps the
@@ -440,7 +442,30 @@ private final class CaptionChannelFeed {
     private let slot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
     /// Single consumer task — the serialization that makes
     /// `LiveCaptionPipeline.ingest` calls ordered by construction.
-    private var consumer: Task<Void, Never>?
+    /// Lock-boxed (not a plain var) for two reasons: `deinit` is nonisolated
+    /// and must be able to cancel it, and `retire()` must take exactly the
+    /// task it will await so a concurrent rebind's fresh consumer can never
+    /// be clobbered by `retire()`'s post-await cleanup.
+    private let consumerBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+
+    /// The owner can be dropped mid-recording (`LiveTranscriptionCoordinator`
+    /// nils the controller on a settings change) while the recorder still
+    /// holds the sink closure — which captures only the slot storage, not the
+    /// feed. Without this, the armed stream and its consumer would keep
+    /// running inference for the rest of the recording with every result
+    /// discarded (the event sink's weak controller is gone). Cancel stops the
+    /// consumer at the next buffer boundary; finishing the slot stops new
+    /// deliveries immediately.
+    deinit {
+        consumerBox.withLock { task in
+            task?.cancel()
+            task = nil
+        }
+        slot.withLock { continuation in
+            continuation?.finish()
+            continuation = nil
+        }
+    }
 
     /// Sink closure for the recorder: yields into the currently-armed stream
     /// and returns immediately — no task spawn, no actor hop on the audio
@@ -469,24 +494,31 @@ private final class CaptionChannelFeed {
             bufferingPolicy: .bufferingNewest(Self.capacity),
         )
         slot.withLock { $0 = continuation }
-        consumer = Task.detached(priority: .userInitiated) {
+        let consumer = Task.detached(priority: .userInitiated) {
             let transform = makeTransform()
             for await buffer in stream {
                 guard let normalized = transform(buffer) else { continue }
                 await pipeline.ingest(normalized)
             }
         }
+        consumerBox.withLock { $0 = consumer }
     }
 
     /// Stop accepting sink deliveries, then await the consumer so every
-    /// buffer already delivered is ingested. Idempotent.
+    /// buffer already delivered is ingested. Idempotent. Takes the task out
+    /// of the box BEFORE awaiting — a rebind that interleaves at the await
+    /// installs its fresh consumer into the (now empty) box, untouched by
+    /// this call's cleanup.
     func retire() async {
         slot.withLock { continuation in
             continuation?.finish()
             continuation = nil
         }
-        if let consumer { await consumer.value }
-        consumer = nil
+        let retiring = consumerBox.withLock { task -> Task<Void, Never>? in
+            defer { task = nil }
+            return task
+        }
+        if let retiring { await retiring.value }
     }
 }
 

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -1,31 +1,40 @@
 import AudioTapLib
 import FluidAudio
 import Foundation
-import os.log
+import os
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LiveTranscription")
 
-/// PoC controller that wires `StreamingTranscriber` actors to both audio
-/// sinks of a `DualSourceRecorder`. Logs partial/final captions via os_log
-/// on subsystem `com.meetingtranscriber.app`, category `LiveTranscription`,
-/// and feeds them into the observable `LiveCaptionsState` that backs the
-/// caption-bar overlay.
+/// Wires the per-channel caption pipelines to both audio sinks of a
+/// `DualSourceRecorder`. Logs partial/final captions via os_log on subsystem
+/// `com.meetingtranscriber.app`, category `LiveTranscription`, and feeds them
+/// into the observable `LiveCaptionsState` that backs the caption-bar overlay.
 ///
-/// PoC scope:
-///   - mic + app channels supported. App-channel buffers (typically 48 kHz
-///     interleaved stereo from `CATapDescription`) are downsampled to
-///     16 kHz mono via `LiveAudioResampler` before reaching the engine.
-///     Mic buffers arrive 16 kHz mono already (post-`MicCaptureHandler`
-///     resample) and pass through unchanged.
+/// Scope:
+///   - mic + app channels supported. Buffers normally arrive 16 kHz mono
+///     from capture-time resampling (mic via `MicCaptureHandler`, app via
+///     `AppAudioCapture`'s `StreamingMonoResampler`); the app feed still runs
+///     `LiveAudioResampler` for the resampler-nil fallback path, where raw
+///     device-rate buffers come through (16 kHz mono passes through unchanged).
 ///   - one engine instance shared by both channels (Parakeet today —
 ///     other engines fall back to `TranscriptionError.streamingNotSupported`).
 ///
+/// Dataflow: each channel is a bounded `AsyncStream<LiveAudioBuffer>` feed.
+/// The sink closure yields into the stream synchronously on the audio
+/// callback thread; a single detached consumer task per channel ingests into
+/// that channel's `LiveCaptionPipeline`. Ordering (single consumer → FIFO)
+/// and backpressure (bounded buffer, newest win) are properties of the
+/// channel — pipelines never see interleaved `ingest` calls.
+///
 /// Lifecycle:
-///   1. `prepare()` warms the engine + VAD model.
+///   1. `prepare()` warms the engine + VAD model, builds the pipelines, and
+///      arms the feeds.
 ///   2. Caller installs `micSink` and `appSink` on the recorder before
 ///      `recorder.start(...)`.
-///   3. `prepareForNextRecording()` clears accumulated state between recordings (keeps models
-///      loaded — re-creating the streaming actors + resampler is cheap).
+///   3. `flush()` retires the feeds (draining everything already delivered)
+///      and flushes the pipelines; `prepareForNextRecording()` re-arms fresh
+///      feeds between recordings (keeps models loaded — re-creating the
+///      streaming actors + feeds is cheap).
 @MainActor
 final class LiveTranscriptionController {
     /// Builds the `EouStreamingAsrManaging` backend for one channel's English
@@ -64,7 +73,28 @@ final class LiveTranscriptionController {
     private let verboseDiagnostics: () -> Bool
     private var micPipeline: (any LiveCaptionPipeline)?
     private var appPipeline: (any LiveCaptionPipeline)?
-    private var appResampler = LiveAudioResampler()
+
+    /// Bounded per-channel feed capacity, in buffers. Capture delivers
+    /// roughly 10–50 buffers/s per channel, so this is tens of seconds of
+    /// headroom — far more than a healthy pipeline ever queues, but a hard
+    /// bound when inference stalls: the stream then drops the OLDEST buffers
+    /// (captions degrade toward the newest audio instead of memory growing
+    /// without limit). Also sized so the fixture-driven E2E tests, which
+    /// feed ~375 buffers much faster than real time, fit without drops.
+    private static let feedCapacity = 512
+
+    /// Cross-thread continuation slots the sink closures yield into. The
+    /// audio callback thread yields under the lock; the main actor swaps
+    /// the continuation per recording (`bindFeeds` / `retireFeeds`). A nil
+    /// slot — before the first bind, or after a flush — drops the buffer,
+    /// matching the recorder lifecycle (nothing should be fed outside a
+    /// recording).
+    private let micFeedSlot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
+    private let appFeedSlot = OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>(initialState: nil)
+    /// Single consumer task per channel feed — the serialization that makes
+    /// `LiveCaptionPipeline.ingest` calls ordered by construction.
+    private var micFeedConsumer: Task<Void, Never>?
+    private var appFeedConsumer: Task<Void, Never>?
     /// True once `prepare()` resolved the active strategy to the EOU sessions.
     /// `prepareForNextRecording()` keeps those sessions (already flushed clean at
     /// stop, reloading their models would be wasteful) and only rebuilds the
@@ -86,23 +116,29 @@ final class LiveTranscriptionController {
 
     /// Mic-channel live sink. Hand this to `DualSourceRecorder.micLiveSink`
     /// before `recorder.start(...)`. Buffers arrive on the AVAudioEngine tap
-    /// thread; the closure hops onto an actor task and returns immediately.
+    /// thread; the closure yields into the channel's bounded feed and returns
+    /// immediately — no task spawn, no actor hop on the audio thread.
     var micSink: LiveAudioSink {
-        { [weak self] buffer in
-            guard let self else { return }
-            Task { await self.handleMicBuffer(buffer) }
+        let slot = micFeedSlot
+        return { buffer in
+            slot.withLock { continuation in
+                _ = continuation?.yield(buffer)
+            }
         }
     }
 
     /// App-channel live sink. Hand this to `DualSourceRecorder.appLiveSink`
     /// before `recorder.start(...)`. Buffers arrive on the CATap IOProc
-    /// thread at the device's native rate (typically 48 kHz stereo) — the
-    /// closure dispatches onto the actor, where `LiveAudioResampler` brings
-    /// them to 16 kHz mono before the streaming transcriber sees them.
+    /// thread, normally already capture-time resampled to 16 kHz mono (raw
+    /// device rate only on the resampler-nil fallback) — the feed's consumer
+    /// runs them through `LiveAudioResampler`, which passes 16 kHz mono
+    /// through unchanged.
     var appSink: LiveAudioSink {
-        { [weak self] buffer in
-            guard let self else { return }
-            Task { await self.handleAppBuffer(buffer) }
+        let slot = appFeedSlot
+        return { buffer in
+            slot.withLock { continuation in
+                _ = continuation?.yield(buffer)
+            }
         }
     }
 
@@ -154,6 +190,11 @@ final class LiveTranscriptionController {
         await prewarmSpeakerMatcher()
         if micPipeline == nil, appPipeline == nil {
             await buildPipelines()
+            // Arm the feeds here too (not only in `prepareForNextRecording()`)
+            // so the late-resolution ordering — recording already running,
+            // EOU models finishing their first-use load — connects the sinks
+            // mid-recording instead of staying dark until the next one.
+            await bindFeeds()
         }
         strategyResolved = true
         if verboseDiagnostics() {
@@ -220,12 +261,17 @@ final class LiveTranscriptionController {
         }
     }
 
-    /// Recording stopped — flush both channel pipelines so any pending
-    /// tail utterance (speech that was still in progress when the recorder
-    /// stopped, so VAD never emitted a `speechEnd`) is committed as a final.
-    /// Must run at STOP time, before the next recording's
-    /// `prepareForNextRecording()` clears caption state. Awaits both channels
-    /// concurrently.
+    /// Recording stopped — retire the feeds, then flush both channel
+    /// pipelines so any pending tail utterance (speech that was still in
+    /// progress when the recorder stopped, so VAD never emitted a
+    /// `speechEnd`) is committed as a final. Must run at STOP time, before
+    /// the next recording's `prepareForNextRecording()` clears caption state.
+    ///
+    /// Retiring first is the completeness barrier: it stops accepting new
+    /// deliveries and drains everything the recorder already handed over
+    /// into the pipelines, so the pipeline flush below sees the full tail
+    /// instead of racing buffers still in flight. Awaits both channels
+    /// concurrently afterwards.
     ///
     /// The work is wrapped in a stored `pendingFlush` Task so the next
     /// recording's `prepareForNextRecording()` can await it: a kept EOU session
@@ -236,6 +282,7 @@ final class LiveTranscriptionController {
     func flush() async {
         let task = Task { [weak self] in
             guard let self else { return }
+            await self.retireFeeds()
             async let mic: Void? = self.micPipeline?.flush()
             async let app: Void? = self.appPipeline?.flush()
             _ = await (mic, app)
@@ -248,18 +295,26 @@ final class LiveTranscriptionController {
     /// stop-time `flush()` FIRST so a kept EOU session is fully drained before
     /// the new recording reuses it — otherwise the late flush and the new
     /// recording's ingests interleave on the same actor. Keeps engine + VAD
-    /// models loaded; re-creating the re-transcribe actors + resampler is cheap.
+    /// models loaded; re-creating the re-transcribe actors + feeds is cheap.
     ///
     /// Construction is single-owner and branches on the CONFIG flag, not the
     /// resolved strategy, so a reset-before-`prepare()` ordering doesn't build
     /// the wrong pipelines:
     ///   - EOU resolved (English streaming live): keep the sessions (each was
-    ///     drained by its own `flush()`); just clear resampler + captions.
+    ///     drained by its own `flush()`); just re-arm feeds + clear captions.
     ///   - English opt-in but not yet resolved: build nothing — let the pending
-    ///     `prepare()` own EOU/fallback construction.
+    ///     `prepare()` own EOU/fallback construction. With no pipelines there
+    ///     are no feeds either, so sink deliveries are dropped — deliberate:
+    ///     blocking here until the EOU models load (cold first-use download
+    ///     can take ~20 s) would delay recorder.start() and lose actual
+    ///     meeting audio, which is far worse than missing the first caption.
     ///   - Otherwise (re-transcribe path, default OR post-EOU-failure fallback):
     ///     rebuild the cheap re-transcribe actors so no stale VAD/transcriber
     ///     state carries across recordings.
+    ///
+    /// `bindFeeds()` re-arms one fresh feed per existing pipeline (the app
+    /// feed gets a fresh `LiveAudioResampler`, replacing the old per-recording
+    /// reset of a shared instance).
     func prepareForNextRecording() async {
         await pendingFlush?.value
         pendingFlush = nil
@@ -268,19 +323,80 @@ final class LiveTranscriptionController {
             // EOU sessions kept (already drained by flush()).
         } else if englishStreaming, !strategyResolved {
             // EOU opted-in but prepare() hasn't resolved yet → defer to
-            // prepare(). Buffers arriving before it finishes are dropped by
-            // the nil-pipeline guards in handleMic/AppBuffer — deliberate:
-            // blocking here until the EOU models load (cold first-use download
-            // can take ~20 s) would delay recorder.start() and lose actual
-            // meeting audio, which is far worse than missing the first caption.
+            // prepare(), which also arms the feeds once it built the pipelines.
         } else if let engine {
             micPipeline = makeReTranscribePipeline(channel: .mic, engine: engine)
             appPipeline = makeReTranscribePipeline(channel: .app, engine: engine)
         }
-        appResampler = LiveAudioResampler()
+        await bindFeeds()
         captions.clear()
         if verboseDiagnostics() {
             logger.info("Live transcription reset for new recording")
+        }
+    }
+
+    /// Retire both channel feeds: stop accepting sink deliveries, then await
+    /// the consumers so every buffer already delivered is ingested. This is
+    /// the deterministic "all pre-stop audio is in the pipelines" barrier
+    /// that `flush()` and a rebind rely on.
+    private func retireFeeds() async {
+        micFeedSlot.withLock { slot in
+            slot?.finish()
+            slot = nil
+        }
+        appFeedSlot.withLock { slot in
+            slot?.finish()
+            slot = nil
+        }
+        if let consumer = micFeedConsumer { await consumer.value }
+        if let consumer = appFeedConsumer { await consumer.value }
+        micFeedConsumer = nil
+        appFeedConsumer = nil
+    }
+
+    /// (Re)arm one bounded feed per built pipeline, retiring any previous
+    /// feeds first so exactly one consumer per channel exists at all times —
+    /// that single consumer is what makes ingest ordering a property of the
+    /// channel rather than of scheduler luck.
+    private func bindFeeds() async {
+        await retireFeeds()
+        if let micPipeline {
+            micFeedConsumer = Self.makeFeed(into: micPipeline, slot: micFeedSlot, resampling: false)
+        }
+        if let appPipeline {
+            appFeedConsumer = Self.makeFeed(into: appPipeline, slot: appFeedSlot, resampling: true)
+        }
+    }
+
+    /// Build one channel feed: a bounded `AsyncStream` whose continuation is
+    /// installed into `slot` (for the sink closure) plus a single detached
+    /// consumer task that ingests buffers in arrival order. `resampling`
+    /// routes app-channel buffers through a fresh `LiveAudioResampler`
+    /// (confined to the consumer task, fresh per feed == per recording).
+    /// `static` so the consumer captures only the pipeline + stream, never
+    /// the controller.
+    private static func makeFeed(
+        into pipeline: any LiveCaptionPipeline,
+        slot: OSAllocatedUnfairLock<AsyncStream<LiveAudioBuffer>.Continuation?>,
+        resampling: Bool,
+    ) -> Task<Void, Never> {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: LiveAudioBuffer.self,
+            bufferingPolicy: .bufferingNewest(feedCapacity),
+        )
+        slot.withLock { $0 = continuation }
+        return Task.detached(priority: .userInitiated) {
+            if resampling {
+                let resampler = LiveAudioResampler()
+                for await buffer in stream {
+                    guard let normalized = resampler.resample(buffer) else { continue }
+                    await pipeline.ingest(normalized)
+                }
+            } else {
+                for await buffer in stream {
+                    await pipeline.ingest(buffer)
+                }
+            }
         }
     }
 
@@ -353,18 +469,6 @@ final class LiveTranscriptionController {
                 }
             }
         }
-    }
-
-    private func handleMicBuffer(_ buffer: LiveAudioBuffer) async {
-        guard let micPipeline else { return }
-        await micPipeline.ingest(buffer)
-    }
-
-    private func handleAppBuffer(_ buffer: LiveAudioBuffer) async {
-        guard let appPipeline,
-              let normalized = appResampler.resample(buffer)
-        else { return }
-        await appPipeline.ingest(normalized)
     }
 }
 

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -6,19 +6,19 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Streami
 
 /// Live transcription for a single audio channel (mic or app).
 ///
-/// PoC scope: ingests 16 kHz mono Float32 buffers (matches `MicCaptureHandler`
+/// Ingests 16 kHz mono Float32 buffers (matches `MicCaptureHandler`
 /// post-resample output), feeds them through `FluidVAD` in streaming mode,
 /// and calls `engine.transcribeSamples` once per ~800 ms while speaking
 /// (partial) and once per detected speech end / 5 s force-flush (final).
 ///
-/// Both mic and app channels are supported. App-channel buffers (typically
-/// interleaved 48 kHz stereo from `CATapDescription`) are downmixed and
-/// resampled to 16 kHz mono upstream in `LiveTranscriptionController` (via
-/// `LiveAudioResampler`) before they reach `ingest`, so this actor always
-/// sees the 16 kHz mono format described above.
+/// Both mic and app channels are supported. App-channel buffers are
+/// normalized to 16 kHz mono upstream (capture-time resampling, plus
+/// `LiveAudioResampler` in the controller's feed for the fallback path)
+/// before they reach `ingest`, so this actor always sees that format.
 ///
 /// Conforms to `LiveCaptionPipeline` — the VAD-driven strategy behind that
-/// seam. `ingest(_:)` is the protocol requirement.
+/// seam. Calls are serialized by the driver (see the protocol contract), so
+/// `ingest`/`flush` never interleave and need no re-entrancy guards.
 actor StreamingTranscriber: LiveCaptionPipeline {
     enum Event {
         case partial(String)
@@ -46,11 +46,6 @@ actor StreamingTranscriber: LiveCaptionPipeline {
     private var isSpeaking = false
     private var lastPartialAt: Date = .distantPast
     private let onEvent: EventSink
-    /// True while a `drainChunks()` pass owns the input accumulator. The actor
-    /// suspends at the VAD and transcribe awaits, so a second caller (another
-    /// `ingest` Task or `flush`) can interleave; without this guard two drain
-    /// loops would fork the VAD stream state and process chunks out of order.
-    private var isDrainingInput = false
 
     /// Silero v6 chunk size at 16 kHz — what FluidVAD expects per call.
     private static let chunkSize = 4096
@@ -97,24 +92,15 @@ actor StreamingTranscriber: LiveCaptionPipeline {
     /// a clean idle state (the controller recreates pipelines per recording, so
     /// this is belt-and-suspenders against any reuse).
     func flush() async {
-        // Ingestion may still be mid-drain (the actor suspends at the VAD and
-        // partial-transcribe awaits) — wait for the active pass to finish and
-        // process any input that accumulated meanwhile, so audio the recorder
-        // already delivered before the stop isn't dropped by stop-timing.
-        while isDrainingInput {
-            await Task.yield()
-        }
+        // The driver retires the channel feed before flushing, so every
+        // buffer delivered before the stop has already been ingested — only
+        // a sub-chunk remainder can still sit in the accumulator.
         if !inputAccumulator.isEmpty { await drainChunks() }
         await commitFinal()
         isSpeaking = false
     }
 
     private func drainChunks() async {
-        // Single-pass guard: the active drain re-checks the accumulator every
-        // iteration, so anything appended while it runs is consumed by it.
-        if isDrainingInput { return }
-        isDrainingInput = true
-        defer { isDrainingInput = false }
         if vadState == nil {
             do {
                 vadState = try await vad.makeStreamState()

--- a/app/MeetingTranscriber/Tests/EouStreamingCaptionSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/EouStreamingCaptionSessionTests.swift
@@ -34,9 +34,6 @@ final class EouStreamingCaptionSessionTests: XCTestCase {
         // Recorded inputs.
         private(set) var appendedFrameLengths: [Int] = []
         private(set) var appendedFormats: [(sampleRate: Double, channels: AVAudioChannelCount, isFloat: Bool)] = []
-        /// First sample of each appended buffer, in arrival order. Lets the
-        /// concurrency test compare the manager's feed order against the ring.
-        private(set) var appendedFirstSamples: [Float] = []
         private(set) var resetCount = 0
         private(set) var finishCount = 0
         private(set) var loadModelsCount = 0
@@ -50,18 +47,12 @@ final class EouStreamingCaptionSessionTests: XCTestCase {
         private var finishReturn = ""
         /// Error thrown by `loadModels()` (for the prepare()-rethrows test).
         private var loadModelsError: (any Error)?
-        /// When true, `processBufferedAudio()` yields the actor mid-call so
-        /// overlapping ingest tasks get a real suspension window to interleave at
-        /// — without it the concurrency regression test can't bite.
-        private var suspendOnProcess = false
         /// When true, each `processBufferedAudio()` call fires ONE EOU whose
         /// transcript is the accumulated word list `w0 w1 … wK` (K = call index)
         /// and whose timestamp grows by `autoEouStepMs`. Because the manager's
         /// transcript grows across utterances, the session must prefix-strip each
-        /// EOU against the previous one to recover the single new word — a process
-        /// that only works if `handleEou`'s prefix/cursor updates are SERIALIZED.
-        /// Driven entirely by manager-call order, so it's deterministic under
-        /// interleaved ingest tasks.
+        /// EOU against the previous one to recover the single new word — pinning
+        /// that prefix + cursor advance stay in lockstep across utterances.
         private var autoEou = false
         private var autoEouWords: [String] = []
         private var autoEouStepMs = 0
@@ -87,10 +78,6 @@ final class EouStreamingCaptionSessionTests: XCTestCase {
             loadModelsError = error
         }
 
-        func setSuspendOnProcess(_ value: Bool) {
-            suspendOnProcess = value
-        }
-
         func enableAutoEou(words: [String], stepMs: Int) {
             autoEou = true
             autoEouWords = words
@@ -114,26 +101,17 @@ final class EouStreamingCaptionSessionTests: XCTestCase {
                 format.channelCount,
                 format.commonFormat == .pcmFormatFloat32,
             ))
-            if let channel = buffer.floatChannelData, buffer.frameLength > 0 {
-                appendedFirstSamples.append(channel[0][0])
-            }
         }
 
-        func processBufferedAudio() async {
-            if suspendOnProcess { await Task.yield() }
-
+        func processBufferedAudio() {
             if autoEou, autoEouCallCount < autoEouWords.count {
                 // Build the accumulated transcript w0..wK and the matching growing
                 // EOU timestamp, mirroring the real manager (which appends the EOU
-                // ms and fires the callback together). A second yield AFTER
-                // mutating the manager-side accumulators but BEFORE the callback
-                // widens the window for a racing pass to corrupt the session's
-                // prefix/cursor if `handleEou` isn't serialized.
+                // ms and fires the callback together).
                 let k = autoEouCallCount
                 autoEouCallCount += 1
                 let transcript = autoEouWords[0 ... k].joined(separator: " ")
                 eouTimestampsMs.append((k + 1) * autoEouStepMs)
-                if suspendOnProcess { await Task.yield() }
                 eouCallback?(transcript)
                 return
             }
@@ -432,72 +410,34 @@ final class EouStreamingCaptionSessionTests: XCTestCase {
         XCTAssertEqual(loadCount, 1)
     }
 
-    // MARK: - Concurrency regression
+    // MARK: - Sequential multi-EOU integrity
 
-    /// The production driver spawns one unstructured `Task` per captured buffer,
-    /// so many `ingest()` calls can interleave at the session's suspension
-    /// points (`appendAudio`, `processBufferedAudio`, `getEouTimestampsMs`,
-    /// drain). The session's `isIngesting` single-flight guard must collapse them
-    /// into ONE drain pass that handles each EOU and updates the prefix/cursor
-    /// (`lastFinalizedPrefix`, `lastEouMs`) atomically. Without it, two passes
-    /// run `handleEou` concurrently: each reads `getEouTimestampsMs().last` and
-    /// strips against `lastFinalizedPrefix` interleaved with the other's write,
-    /// so deltas and audio slices come out wrong, duplicated, or empty.
-    ///
-    /// Setup: N tasks each ingest one 1600-sample ramp block. The mock fires one
-    /// auto-EOU per process call — accumulated transcript `w0 w1 … wK` with a
-    /// timestamp growing by 100 ms (1600 samples) per call — and yields twice to
-    /// force interleaving. Serialized, the session must emit exactly the words
-    /// `w0, w1, …, w(N-1)` IN ORDER, each carrying its own contiguous
-    /// `[k*1600, (k+1)*1600)` audio slice. The word order pins the manager call
-    /// order, and the per-final slice pins that the cursor advanced in lockstep.
-    func testConcurrentIngestSerializesEouFinalization() async {
-        let taskCount = 32
+    /// Sequential ingest of N ramp blocks, one auto-EOU per process call —
+    /// the session must emit exactly the words `w0 … w(N-1)` in order, each
+    /// carrying its contiguous `[k*1600, (k+1)*1600)` ring slice. Pins that
+    /// prefix stripping and the `lastEouMs` cursor advance in lockstep across
+    /// many utterances. (The driver serializes `ingest` calls by contract —
+    /// see `LiveCaptionPipeline` — ordering under rapid sink delivery is
+    /// pinned at that boundary by `LiveCaptionFeedTests`.)
+    func testSequentialMultiEouAdvancesPrefixAndCursorInLockstep() async {
+        let utterances = 32
         let segment = 1600 // 100 ms at 16 kHz; matches the 100 ms EOU step.
-        let words = (0 ..< taskCount).map { "w\($0)" }
+        let words = (0 ..< utterances).map { "w\($0)" }
         let asr = MockEouStreamingAsrManaging()
-        await asr.setSuspendOnProcess(true)
         await asr.enableAutoEou(words: words, stepMs: segment / Self.samplesPerMs)
         let recorder = EventRecorder()
         let session = makeSession(asr: asr, recorder: recorder)
 
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0 ..< taskCount {
-                let buffer = rampBuffer(base: i * segment, count: segment)
-                group.addTask { await session.ingest(buffer) }
-            }
-            await group.waitForAll()
+        for i in 0 ..< utterances {
+            await session.ingest(rampBuffer(base: i * segment, count: segment))
         }
 
         let finals = recorder.finals
-        // One single-word final per EOU, in manager-call order — proves prefix
-        // stripping ran serialized (a race drops finals, doubles words, or
-        // empties deltas). The mock assigns words by call order and the session
-        // emits one final per EOU in drain order, which equals call order.
         XCTAssertEqual(finals.map(\.text), words, "EOU finals must be the words in order, one per utterance")
-
-        // Each final carries exactly one segment-sized slice; consecutive slices
-        // are adjacent in the ring (the k-th EOU slices the k-th ring block), so
-        // concatenated they tile [0, N*segment) with no gap/overlap — proving
-        // `lastEouMs` advanced exactly one step per serialized EOU. Ring block
-        // order is the (nondeterministic) buffer arrival order, so we assert
-        // every segment appears once and each block is internally contiguous,
-        // not a fixed sequence.
-        for final in finals {
-            XCTAssertEqual(final.audio.count, segment, "each EOU slices exactly one buffer's worth of ring")
+        for (k, final) in finals.enumerated() {
+            let expected = (k * segment ..< (k + 1) * segment).map { Float($0) }
+            XCTAssertEqual(final.audio, expected, "the k-th EOU must slice exactly the k-th ring block")
         }
-        let reconstructed = finals.flatMap(\.audio)
-        XCTAssertEqual(reconstructed.count, taskCount * segment, "slices must tile the ring with no gap/overlap")
-        for blockStart in stride(from: 0, to: reconstructed.count, by: segment) {
-            let base = reconstructed[blockStart]
-            let block = Array(reconstructed[blockStart ..< blockStart + segment])
-            XCTAssertEqual(block, (0 ..< segment).map { base + Float($0) }, "a buffer's samples must stay contiguous")
-        }
-        let bases = Set(stride(from: 0, to: reconstructed.count, by: segment).map { reconstructed[$0] })
-        XCTAssertEqual(
-            bases, Set((0 ..< taskCount).map { Float($0 * segment) }),
-            "every buffer must be sliced exactly once across the EOU finals",
-        )
     }
 
     private static let samplesPerMs = 16

--- a/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
@@ -146,6 +146,40 @@ final class LiveCaptionFeedTests: XCTestCase {
         )
     }
 
+    // MARK: - 5. Dropping the controller stops the feed
+
+    /// The coordinator drops the controller on a settings change
+    /// (`controller = nil`), possibly mid-recording, while the recorder still
+    /// holds the sink closures. The feed must die with its owner: no further
+    /// deliveries may reach the pipeline (and no orphaned consumer may keep
+    /// burning inference on discarded results). The old Task-per-buffer sinks
+    /// got this via `[weak self]`; the slot-capturing sinks need the feed's
+    /// deinit to cancel the consumer and finish the stream.
+    func testDroppingControllerStopsTheFeed() async {
+        let factory = ChannelMockFactory()
+        var controller: LiveTranscriptionController? = makeController(factory: factory)
+        await controller?.prepare()
+        guard let sink = controller?.micSink else {
+            XCTFail("controller must vend a mic sink after prepare()")
+            return
+        }
+
+        sink(buffer(value: 1))
+        await waitFor { await factory.mic.appendedFirstSamples.count == 1 }
+        let before = await factory.mic.appendedFirstSamples.count
+        XCTAssertEqual(before, 1, "the armed feed must deliver while the controller is alive")
+
+        controller = nil // settings change: coordinator rebuilds the controller
+
+        sink(buffer(value: 2))
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let after = await factory.mic.appendedFirstSamples.count
+        XCTAssertEqual(
+            after, before,
+            "a dropped controller must stop its feed — no further buffers may reach the pipeline",
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeController(factory: ChannelMockFactory) -> LiveTranscriptionController {

--- a/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
@@ -113,7 +113,7 @@ final class LiveCaptionFeedTests: XCTestCase {
         // contiguous run — proving drops happened at the old end only.
         let tail = Array(appended.dropFirst())
         if let first = tail.first {
-            let expected = stride(from: first, through: Float(total - 1), by: 1).map(\.self)
+            let expected = Array(stride(from: first, through: Float(total - 1), by: 1))
             XCTAssertEqual(tail, expected, "kept buffers must be the newest contiguous run, in order")
         } else {
             XCTFail("at least the newest buffers must have been ingested after release")
@@ -138,11 +138,7 @@ final class LiveCaptionFeedTests: XCTestCase {
         await controller.prepareForNextRecording()
         controller.micSink(buffer(value: 7))
 
-        let deadline = ContinuousClock.now + .seconds(5)
-        while await factory.mic.appendedFirstSamples.count == before,
-              ContinuousClock.now < deadline {
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
+        await waitFor { await factory.mic.appendedFirstSamples.count > before }
         let appended = await factory.mic.appendedFirstSamples
         XCTAssertEqual(
             appended.last, 7,
@@ -200,7 +196,6 @@ private final class ChannelMockFactory {
 private actor MockFeedAsrManager: EouStreamingAsrManaging {
     private(set) var appendedFirstSamples: [Float] = []
     private(set) var appendedCountAtFinish = -1
-    private(set) var finishCount = 0
 
     private var blockNextProcess = false
     private var processContinuation: CheckedContinuation<Void, Never>?
@@ -244,7 +239,6 @@ private actor MockFeedAsrManager: EouStreamingAsrManaging {
     }
 
     func finish() -> String {
-        finishCount += 1
         appendedCountAtFinish = appendedFirstSamples.count
         return ""
     }

--- a/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
@@ -1,0 +1,260 @@
+import AudioTapLib
+@preconcurrency import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+/// Contract pins for the per-channel caption feed in
+/// `LiveTranscriptionController`: the sink → pipeline handoff must deliver
+/// buffers **in order**, process **everything delivered before `flush()`**
+/// before the pipeline's flush runs, drop deliveries **after** flush, and
+/// bound its buffering when the pipeline stalls (newest buffers win).
+///
+/// These properties used to be approximated inside the pipeline actors with
+/// re-entrancy guards (the production driver spawned one unstructured `Task`
+/// per buffer, so ordering and stop-completeness were scheduler luck). They
+/// are now properties of the channel itself — one bounded `AsyncStream` per
+/// channel with a single consumer — and this suite pins them at the boundary
+/// where the recorder hands buffers over.
+///
+/// Observation point: the English-streaming path with a mock EOU manager —
+/// every `ingest` lands as exactly one `appendAudio` on the manager, and
+/// `flush()` lands as `finish()`, so append order/count vs. finish position
+/// reads the feed's behavior without touching pipeline internals.
+///
+/// All scenarios share one `@MainActor` class; no CoreML, no fixtures —
+/// fully deterministic.
+@MainActor
+final class LiveCaptionFeedTests: XCTestCase {
+    // MARK: - 1. Ordering + completeness before flush
+
+    /// Every buffer handed to the sink before `flush()` must reach the
+    /// pipeline, in delivery order, BEFORE the pipeline's flush runs. With
+    /// the old Task-per-buffer handoff, sink deliveries still sitting in
+    /// unstarted tasks when `flush()` ran were finalized late or lost.
+    func testFlushProcessesEveryBufferDeliveredBeforeItInOrder() async {
+        let factory = ChannelMockFactory()
+        let controller = makeController(factory: factory)
+        await controller.prepare()
+
+        let count = 200
+        for i in 0 ..< count {
+            controller.micSink(buffer(value: Float(i)))
+        }
+        await controller.flush()
+
+        let appended = await factory.mic.appendedFirstSamples
+        XCTAssertEqual(
+            appended, (0 ..< count).map(Float.init),
+            "every pre-flush buffer must reach the pipeline, in delivery order",
+        )
+        let atFinish = await factory.mic.appendedCountAtFinish
+        XCTAssertEqual(
+            atFinish, count,
+            "the pipeline flush must run only after every delivered buffer was ingested",
+        )
+    }
+
+    // MARK: - 2. Post-flush deliveries are dropped
+
+    /// After `flush()` the recording is over — a straggler buffer from the
+    /// stopping recorder must not be ingested into the flushed pipeline.
+    func testSinkDeliveriesAfterFlushAreDropped() async {
+        let factory = ChannelMockFactory()
+        let controller = makeController(factory: factory)
+        await controller.prepare()
+
+        controller.micSink(buffer(value: 1))
+        await controller.flush()
+        let before = await factory.mic.appendedFirstSamples.count
+
+        controller.micSink(buffer(value: 99))
+        // Give a (hypothetical) stray ingest hop ample time to land.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let after = await factory.mic.appendedFirstSamples.count
+        XCTAssertEqual(
+            after, before,
+            "a buffer delivered after flush() must be dropped, not ingested into the flushed pipeline",
+        )
+    }
+
+    // MARK: - 3. Bounded buffering under a stalled pipeline
+
+    /// When the pipeline stalls (slow inference), the feed must NOT queue
+    /// unboundedly — it keeps the newest buffers and drops the oldest, so a
+    /// stall degrades captions instead of growing memory without limit.
+    func testStalledPipelineBoundsBufferingAndKeepsNewest() async {
+        let factory = ChannelMockFactory()
+        let controller = makeController(factory: factory)
+        await controller.prepare()
+
+        // Park the pipeline inside its first ingest, then pile up deliveries.
+        await factory.mic.setBlockNextProcess(true)
+        controller.micSink(buffer(value: 0))
+        await factory.mic.waitUntilBlocked()
+
+        let total = 2000
+        for i in 1 ..< total {
+            controller.micSink(buffer(value: Float(i)))
+        }
+        await factory.mic.releaseProcess()
+        await controller.flush()
+
+        let appended = await factory.mic.appendedFirstSamples
+        XCTAssertLessThan(
+            appended.count, total,
+            "a stalled pipeline must drop buffers instead of queueing without bound",
+        )
+        XCTAssertEqual(
+            appended.last, Float(total - 1),
+            "the newest delivery must survive the drop (oldest are discarded first)",
+        )
+        // Beyond the first (parked) buffer, the survivors must be the newest
+        // contiguous run — proving drops happened at the old end only.
+        let tail = Array(appended.dropFirst())
+        if let first = tail.first {
+            let expected = stride(from: first, through: Float(total - 1), by: 1).map(\.self)
+            XCTAssertEqual(tail, expected, "kept buffers must be the newest contiguous run, in order")
+        } else {
+            XCTFail("at least the newest buffers must have been ingested after release")
+        }
+    }
+
+    // MARK: - 4. Feed rebinds for the next recording
+
+    /// `flush()` retires the feed; `prepareForNextRecording()` must arm a
+    /// fresh one so the next recording's sink deliveries flow again (the EOU
+    /// sessions are kept across recordings, so this pins the re-arm, not a
+    /// rebuild).
+    func testFeedRebindsForNextRecording() async {
+        let factory = ChannelMockFactory()
+        let controller = makeController(factory: factory)
+        await controller.prepare()
+
+        controller.micSink(buffer(value: 1))
+        await controller.flush()
+        let before = await factory.mic.appendedFirstSamples.count
+
+        await controller.prepareForNextRecording()
+        controller.micSink(buffer(value: 7))
+
+        let deadline = ContinuousClock.now + .seconds(5)
+        while await factory.mic.appendedFirstSamples.count == before,
+              ContinuousClock.now < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let appended = await factory.mic.appendedFirstSamples
+        XCTAssertEqual(
+            appended.last, 7,
+            "after prepareForNextRecording() the sink must feed the (kept) pipeline again",
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeController(factory: ChannelMockFactory) -> LiveTranscriptionController {
+        let eouFactory: LiveTranscriptionController.EouSessionFactory = { factory.make() }
+        return LiveTranscriptionController(
+            engine: nil,
+            vad: FluidVAD(threshold: 0.5),
+            captions: LiveCaptionsState(),
+            speakerMatcher: FakeLiveSpeakerMatcher(),
+            englishStreaming: true,
+            eouSessionFactory: eouFactory,
+        )
+    }
+
+    /// A 16-sample 16 kHz mono buffer whose samples all carry `value` so the
+    /// mock can identify it by its first sample.
+    private func buffer(value: Float) -> LiveAudioBuffer {
+        LiveAudioBuffer(
+            samples: [Float](repeating: value, count: 16),
+            channelCount: 1,
+            sampleRate: 16000,
+            hostTime: 0,
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+/// Hands the mic mock to the first factory call and the app mock to the
+/// second — matching `buildEnglishStreamingPipelines`' construction order.
+@MainActor
+private final class ChannelMockFactory {
+    let mic = MockFeedAsrManager()
+    let app = MockFeedAsrManager()
+    private var calls = 0
+
+    func make() -> any EouStreamingAsrManaging {
+        calls += 1
+        return calls == 1 ? mic : app
+    }
+}
+
+/// EOU-manager mock that records the first sample of every `appendAudio`
+/// buffer (the feed tests tag each buffer with a distinct constant value) and
+/// the append count at the moment `finish()` runs. `processBufferedAudio()`
+/// can park once on a gate so a test can pile deliveries onto a stalled
+/// pipeline deterministically.
+private actor MockFeedAsrManager: EouStreamingAsrManaging {
+    private(set) var appendedFirstSamples: [Float] = []
+    private(set) var appendedCountAtFinish = -1
+    private(set) var finishCount = 0
+
+    private var blockNextProcess = false
+    private var processContinuation: CheckedContinuation<Void, Never>?
+    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func setBlockNextProcess(_ value: Bool) {
+        blockNextProcess = value
+    }
+
+    /// Suspends until `processBufferedAudio()` has actually parked.
+    func waitUntilBlocked() async {
+        if processContinuation != nil { return }
+        await withCheckedContinuation { blockedWaiters.append($0) }
+    }
+
+    func releaseProcess() {
+        processContinuation?.resume()
+        processContinuation = nil
+    }
+
+    // MARK: EouStreamingAsrManaging
+
+    func loadModels() {}
+
+    func appendAudio(_ buffer: AVAudioPCMBuffer) {
+        if let channel = buffer.floatChannelData, buffer.frameLength > 0 {
+            appendedFirstSamples.append(channel[0][0])
+        }
+    }
+
+    func processBufferedAudio() async {
+        guard blockNextProcess else { return }
+        blockNextProcess = false
+        await withCheckedContinuation { continuation in
+            processContinuation = continuation
+            for waiter in blockedWaiters {
+                waiter.resume()
+            }
+            blockedWaiters.removeAll()
+        }
+    }
+
+    func finish() -> String {
+        finishCount += 1
+        appendedCountAtFinish = appendedFirstSamples.count
+        return ""
+    }
+
+    func reset() {}
+
+    func setPartialCallback(_: @Sendable (String) -> Void) {}
+    func setEouCallback(_: @Sendable (String) -> Void) {}
+
+    func getEouTimestampsMs() -> [Int] {
+        []
+    }
+}

--- a/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionPipelineTests.swift
@@ -175,10 +175,10 @@ final class LiveCaptionPipelineTests: XCTestCase {
     }
 
     /// Controller-level: `flush()` must reach the APP channel too, mirroring the
-    /// mic-channel test above. App buffers normally arrive 48 kHz stereo and are
-    /// resampled by `LiveAudioResampler`; here the input is already 16 kHz mono
-    /// (the resampler short-circuits and passes it through unchanged), isolating
-    /// the controller's `appSink` → `handleAppBuffer` → `appPipeline` fan-out.
+    /// mic-channel test above. App buffers pass through `LiveAudioResampler` in
+    /// the feed's consumer; here the input is already 16 kHz mono (the resampler
+    /// short-circuits and passes it through unchanged), isolating the
+    /// controller's `appSink` → app feed → `appPipeline` fan-out.
     /// Pins the `async let` symmetry in `LiveTranscriptionController.flush()` —
     /// a regression that only flushed the mic pipeline would leave this empty.
     func testControllerFlushDeliversPendingAppChannelFinal() async throws {

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -150,7 +150,6 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
 
     // MARK: - generate() via MockURLProtocol
 
-    // swiftlint:disable:next force_unwrapping
     private static let testEndpoint = URL(string: "http://test.local/v1/chat/completions")!
     private static let okSSE = "data: {\"choices\":[{\"delta\":{\"content\":\"OK\"}}]}\ndata: [DONE]\n"
 

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -52,6 +52,20 @@ extension XCTestCase {
             await Task.yield()
         }
     }
+
+    /// Async-condition overload for conditions that must `await` (e.g. reading
+    /// actor-isolated test-double state). Polls with a short sleep instead of
+    /// a bare yield so the awaited actor gets real scheduling windows.
+    @MainActor
+    func waitFor(
+        _ condition: () async -> Bool,
+        timeout: Duration = .seconds(5),
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while await !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
 }
 
 // MARK: - Fixture URL Helper

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -40,7 +40,6 @@ struct RPCClient {
     }()
 
     // Hardcoded literal — URL(string:) cannot fail on a constant valid URL.
-    // swiftlint:disable:next force_unwrapping
     static let defaultBaseURL = URL(string: "http://127.0.0.1:9876")!
 
     /// Per-request timeout. Without this the CLI hangs forever against a


### PR DESCRIPTION
## What

Replaces the live-captions audio handoff — previously one unstructured `Task` per captured buffer, relayed through the main actor — with one bounded `AsyncStream<LiveAudioBuffer>` per channel. The sink closure yields synchronously on the audio callback thread; a single detached consumer task per channel ingests into that channel's `LiveCaptionPipeline`. A new private `CaptionChannelFeed` type owns the continuation slot, the consumer, and the lifecycle invariant ("exactly one consumer per slot; retire before rebind").

## Why

Unstructured tasks carry no FIFO guarantee, so ingest ordering and stop-completeness were scheduler luck — the new regression test reproduces real out-of-order ingestion against the old code (`…10, 12, 13, 11, 14…`), and buffers still sitting in unstarted tasks when `flush()` ran were finalized late or lost. There was also no backpressure: a stalled pipeline accumulated buffers without bound.

With the stream, these become properties of the channel:
- **Ordering** — single consumer → FIFO by construction
- **Completeness** — `flush()` retires the feed (finish + await consumer) before flushing pipelines, so the recorder's full tail is always committed
- **Backpressure** — `.bufferingNewest(1024)`: a stalled pipeline drops the *oldest* buffers; captions degrade toward live audio instead of memory growing without limit
- **Owner lifetime** — the feed's `deinit` cancels its consumer, so dropping the controller (settings change mid-recording) stops caption inference immediately, matching the old weak-self sink behavior

This deletes the compensation machinery the old driver forced into both pipeline actors: `StreamingTranscriber.isDrainingInput`, `EouStreamingCaptionSession.pendingBuffers`/`isIngesting` single-flight drains, and the `Task.yield()` spin-waits in both `flush()` implementations. The serialization contract now lives on the `LiveCaptionPipeline` protocol. The app channel's `LiveAudioResampler` moves into the consumer task (fresh per recording by construction) and runs off the main actor.

## Tests

- New `LiveCaptionFeedTests` pin the contract at the sink boundary: delivery order, completeness-before-flush, post-flush drop, bounded buffering (newest survive), feed re-arm across recordings, and feed death on controller drop. The order/completeness/bounding/owner-drop tests fail against the old implementation.
- The old direct-concurrent-ingest regression test pinned the now-deleted in-actor guard; replaced by a sequential multi-EOU lockstep test (prefix + cursor advance), since serialization is now the driver's contract.
- Full suite: 1975 tests green, parallel. Lint + release-build parity clean.