### PR TITLE
chore(build): drop swiftlint disables made superfluous by 0.63.3

### DIFF
--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -150,7 +150,6 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
 
     // MARK: - generate() via MockURLProtocol
 
-    // swiftlint:disable:next force_unwrapping
     private static let testEndpoint = URL(string: "http://test.local/v1/chat/completions")!
     private static let okSSE = "data: {\"choices\":[{\"delta\":{\"content\":\"OK\"}}]}\ndata: [DONE]\n"
 

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -40,7 +40,6 @@ struct RPCClient {
     }()
 
     // Hardcoded literal — URL(string:) cannot fail on a constant valid URL.
-    // swiftlint:disable:next force_unwrapping
     static let defaultBaseURL = URL(string: "http://127.0.0.1:9876")!
 
     /// Per-request timeout. Without this the CLI hangs forever against a


### PR DESCRIPTION
## What

Removes two `swiftlint:disable:next force_unwrapping` directives (in `tools/mt-cli/Sources/RPCClient.swift` and `Tests/OpenAIProtocolGeneratorTests.swift`).

## Why

SwiftLint 0.63.3 — which the GitHub CI runners now pull via brew — no longer flags force-unwrapping `URL(string:)` with a constant literal. That turns these two previously-required directives into `superfluous_disable_command` errors, so the lint job goes red on every CI run (first observed on #424, which doesn't touch either file).

Verified locally against SwiftLint 0.63.3: 0 violations across all 294 files.