### PR TITLE
refactor(app): extract SpeakerNamingStore from PipelineQueue

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -32,6 +32,10 @@ class PipelineQueue {
 
     let completedJobLifetime: TimeInterval
 
+    /// Disk persistence for speaker-naming sidecars (keyed by per-job slug).
+    /// Pure I/O over `outputDir`; see `SpeakerNamingStore`.
+    private let namingStore: SpeakerNamingStore
+
     /// Cached FluidVAD instance — reused across jobs to avoid model reload.
     private var vad: FluidVAD?
 
@@ -109,16 +113,11 @@ class PipelineQueue {
         return speakerNamingDataByJob[firstPendingJob.id]
     }
 
-    /// Filesystem slug for a job's persisted artefacts (`<slug>_naming.json`,
-    /// `<slug>_16k.wav`, `<slug>_segments.json`, mix/app/mic WAVs). Embedding
-    /// the job's short-id keeps two back-to-back same-title meetings (e.g. a
-    /// recurring "Daily Standup") from clobbering each other on disk and
-    /// confusing snapshot rebuild — without it both jobs would resolve to the
-    /// same `<title>_naming.json` and the second save would overwrite the
-    /// first, then both UUIDs would map to the survivor.
+    /// Filesystem slug for a job's persisted artefacts. Thin alias for
+    /// `SpeakerNamingStore.slug` — kept so existing call sites (`processNext`,
+    /// tests) don't have to reach into the store for a pure helper.
     static func namingSlug(title: String, jobID: UUID) -> String {
-        let titleSlug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
-        return "\(titleSlug)_\(PipelineJob.shortID(for: jobID))"
+        SpeakerNamingStore.slug(title: title, jobID: jobID)
     }
 
     /// Returns naming data for a specific job ID, or the first pending job as fallback.
@@ -283,6 +282,7 @@ class PipelineQueue {
         self.vadConfig = nil
         self.recognitionStatsLog = nil
         self.completedJobLifetime = completedJobLifetime
+        self.namingStore = SpeakerNamingStore(outputDir: nil)
     }
 
     // MARK: - Known speaker names (issue #155)
@@ -368,6 +368,7 @@ class PipelineQueue {
         self.vadConfig = vadConfig
         self.recognitionStatsLog = recognitionStatsLog
         self.completedJobLifetime = completedJobLifetime
+        self.namingStore = SpeakerNamingStore(outputDir: outputDir)
     }
 
     var activeJobs: [PipelineJob] {
@@ -1377,50 +1378,17 @@ class PipelineQueue {
 
     // MARK: - Speaker Naming Persistence
 
-    func saveNamingData(_ data: SpeakerNamingData, slug: String) {
-        guard let outputDir else { return }
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        try? FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
-        let path = recordingsDir.appendingPathComponent("\(slug)_naming.json")
+    /// Persist naming data via `namingStore`, surfacing a per-job warning on
+    /// failure (the store stays I/O-only; the queue owns the job-state side
+    /// effect). A silent failure would mean late-confirm won't work after a
+    /// restart, so make it visible: log + warning on the job.
+    private func saveNamingData(_ data: SpeakerNamingData, slug: String) {
         do {
-            // FluidAudio embeddings can contain NaN/Inf for short or silent
-            // segments. Default JSON encoder rejects them — use the string
-            // round-trip strategy so the data still makes it to disk.
-            let encoder = JSONEncoder()
-            encoder.nonConformingFloatEncodingStrategy = .convertToString(
-                positiveInfinity: "Infinity",
-                negativeInfinity: "-Infinity",
-                nan: "NaN",
-            )
-            let json = try encoder.encode(data)
-            try json.write(to: path, options: .atomic)
-            // Carries per-speaker voice embeddings — restrict to owner-only.
-            try FileManager.default.restrictToOwner(path)
+            try namingStore.save(data, slug: slug)
         } catch {
-            // Silent failure here means late-confirm won't work after a
-            // restart. Make it visible: log + warning on the job.
             logger.error("Failed to save naming data: \(error.localizedDescription)")
             addWarning(id: data.jobID, "Late re-confirm unavailable — naming data could not be persisted")
         }
-    }
-
-    func loadNamingData(slug: String) -> SpeakerNamingData? {
-        guard let outputDir else { return nil }
-        let path = outputDir.appendingPathComponent("recordings/\(slug)_naming.json")
-        guard let json = try? Data(contentsOf: path) else { return nil }
-        let decoder = JSONDecoder()
-        decoder.nonConformingFloatDecodingStrategy = .convertFromString(
-            positiveInfinity: "Infinity",
-            negativeInfinity: "-Infinity",
-            nan: "NaN",
-        )
-        return try? decoder.decode(SpeakerNamingData.self, from: json)
-    }
-
-    func deleteNamingData(slug: String?) {
-        guard let slug, let outputDir else { return }
-        let path = outputDir.appendingPathComponent("recordings/\(slug)_naming.json")
-        try? FileManager.default.removeItem(at: path)
     }
 
     /// Remove all naming-related data for a job: RAM caches, disk JSON, and
@@ -1430,19 +1398,8 @@ class PipelineQueue {
         speakerNamingDataByJob.removeValue(forKey: jobID)
         stashedSuggestedAtDialog.removeValue(forKey: jobID)
         stashedTopCandidates.removeValue(forKey: jobID)
-        deleteNamingData(slug: slug)
-        cleanupSidecarFiles(slug: slug)
-    }
-
-    /// Delete 16kHz audio and segment sidecar files for a slug.
-    func cleanupSidecarFiles(slug: String?) {
-        guard let slug, let outputDir else { return }
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        let suffixes = ["_16k.wav", "_app_16k.wav", "_mic_16k.wav", "_segments.json"]
-        for suffix in suffixes {
-            let path = recordingsDir.appendingPathComponent("\(slug)\(suffix)")
-            try? FileManager.default.removeItem(at: path)
-        }
+        namingStore.deleteNamingJSON(slug: slug)
+        namingStore.cleanupSidecarFiles(slug: slug)
     }
 
     /// Auto-resolve pending naming items older than maxAge (default: 24h).
@@ -1547,7 +1504,7 @@ class PipelineQueue {
 
         // Rebuild speaker naming cache from disk for .speakerNamingPending jobs
         for job in jobs where job.state == .speakerNamingPending {
-            if let slug = job.namingSlug, let data = loadNamingData(slug: slug) {
+            if let slug = job.namingSlug, let data = namingStore.load(slug: slug) {
                 speakerNamingDataByJob[job.id] = data
             } else {
                 // Naming data lost — transition to done

--- a/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Disk persistence for a job's speaker-naming sidecars, keyed by a per-job
+/// `slug`. Pure I/O over a single `outputDir` (the protocol output folder) —
+/// it holds no queue/job state, so naming-persistence behaviour can be
+/// unit-tested without constructing a `PipelineQueue`. Extracted from
+/// `PipelineQueue` as the first step of unbundling its speaker-naming concern.
+///
+/// Sidecar layout under `<outputDir>/recordings/`:
+/// - `<slug>_naming.json`  — the `SpeakerNamingData` payload (owner-only)
+/// - `<slug>_16k.wav`, `<slug>_app_16k.wav`, `<slug>_mic_16k.wav` — audio for re-diarization
+/// - `<slug>_segments.json` — cached transcript segments for late re-assignment
+struct SpeakerNamingStore {
+    /// Protocol output directory; the `recordings/` subfolder holds the
+    /// sidecars. `nil` disables all I/O (skeleton queues / tests without an
+    /// output dir) — every method is then a no-op.
+    let outputDir: URL?
+
+    /// Filesystem slug for a job's persisted artefacts. Embeds the job's
+    /// short-id so two back-to-back same-title meetings (e.g. a recurring
+    /// "Daily Standup") can't clobber each other on disk and confuse snapshot
+    /// rebuild — without it both jobs would resolve to the same
+    /// `<title>_naming.json` and the second save would overwrite the first,
+    /// then both UUIDs would map to the survivor.
+    static func slug(title: String, jobID: UUID) -> String {
+        let titleSlug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
+        return "\(titleSlug)_\(PipelineJob.shortID(for: jobID))"
+    }
+
+    private var recordingsDir: URL? {
+        outputDir?.appendingPathComponent("recordings")
+    }
+
+    // FluidAudio embeddings can contain NaN/Inf for short or silent segments.
+    // The default JSON coders reject non-conforming floats — encode/decode them
+    // as these string tokens instead. The encode and decode token sets MUST
+    // match for embeddings to round-trip, so build both from one place.
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.nonConformingFloatEncodingStrategy = .convertToString(
+            positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN",
+        )
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+            positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN",
+        )
+        return decoder
+    }
+
+    /// Persist naming data as `<slug>_naming.json`. Throws on encode/write
+    /// failure so the caller can surface a job warning — the store itself stays
+    /// I/O-only and queue-state-free. No-op when `outputDir` is `nil`.
+    func save(_ data: PipelineQueue.SpeakerNamingData, slug: String) throws {
+        guard let recordingsDir else { return }
+        try? FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let path = recordingsDir.appendingPathComponent("\(slug)_naming.json")
+        let json = try Self.makeEncoder().encode(data)
+        try json.write(to: path, options: .atomic)
+        // Carries per-speaker voice embeddings — restrict to owner-only.
+        try FileManager.default.restrictToOwner(path)
+    }
+
+    func load(slug: String) -> PipelineQueue.SpeakerNamingData? {
+        guard let recordingsDir else { return nil }
+        let path = recordingsDir.appendingPathComponent("\(slug)_naming.json")
+        guard let json = try? Data(contentsOf: path) else { return nil }
+        return try? Self.makeDecoder().decode(PipelineQueue.SpeakerNamingData.self, from: json)
+    }
+
+    /// Delete only the `<slug>_naming.json` sidecar. Audio/segment sidecars are
+    /// the concern of `cleanupSidecarFiles`.
+    func deleteNamingJSON(slug: String?) {
+        guard let slug, let recordingsDir else { return }
+        try? FileManager.default.removeItem(at: recordingsDir.appendingPathComponent("\(slug)_naming.json"))
+    }
+
+    /// Delete the 16 kHz audio and segment sidecar files for a slug.
+    func cleanupSidecarFiles(slug: String?) {
+        guard let slug, let recordingsDir else { return }
+        let suffixes = ["_16k.wav", "_app_16k.wav", "_mic_16k.wav", "_segments.json"]
+        for suffix in suffixes {
+            try? FileManager.default.removeItem(at: recordingsDir.appendingPathComponent("\(slug)\(suffix)"))
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2427,36 +2427,6 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(queue.jobs.first?.state, .speakerNamingPending)
     }
 
-    func testCleanupSidecarFilesDeletesPersistedFiles() throws {
-        let outputDir = tmpDir.appendingPathComponent("output")
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
-
-        let slug = "test_cleanup"
-        for suffix in ["_16k.wav", "_segments.json", "_naming.json"] {
-            try Data([0]).write(to: recordingsDir.appendingPathComponent("\(slug)\(suffix)"))
-        }
-
-        let localQueue = PipelineQueue(
-            engine: MockEngine(),
-            diarizationFactory: { MockDiarization() },
-            protocolGeneratorFactory: { nil },
-            outputDir: outputDir,
-            logDir: self.tmpDir,
-        )
-
-        localQueue.cleanupSidecarFiles(slug: slug)
-        localQueue.deleteNamingData(slug: slug)
-
-        for suffix in ["_16k.wav", "_segments.json", "_naming.json"] {
-            let path = recordingsDir.appendingPathComponent("\(slug)\(suffix)")
-            XCTAssertFalse(
-                FileManager.default.fileExists(atPath: path.path),
-                "\(suffix) should be deleted",
-            )
-        }
-    }
-
     // MARK: - knownSpeakerNames cache (issue #155)
 
     //
@@ -2579,63 +2549,5 @@ final class PipelineQueueTests: XCTestCase {
             slug.lowercased().contains("daily") && slug.lowercased().contains("standup"),
             "Slug should still encode the title for human-readable filenames",
         )
-    }
-
-    /// End-to-end: two same-title jobs save naming data to disk via the
-    /// real `saveNamingData(_:slug:)` path and produce distinct files. The
-    /// pure-function slug tests above prove the helper is collision-free;
-    /// this test proves the helper is actually wired into the persistence
-    /// path (catches a future refactor that bypasses `namingSlug`).
-    func test_sameTitleJobsWriteDistinctNamingFiles() throws {
-        let outputDir = try XCTUnwrap(tmpDir)
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
-
-        let mockEngine = MockEngine()
-        let queueWithOutput = PipelineQueue(
-            engine: mockEngine,
-            diarizationFactory: { MockDiarization() },
-            protocolGeneratorFactory: { nil },
-            outputDir: outputDir,
-            logDir: tmpDir,
-            diarizeEnabled: false,
-        )
-
-        let title = "Daily Standup"
-        let job1ID = UUID()
-        let job2ID = UUID()
-        let slug1 = PipelineQueue.namingSlug(title: title, jobID: job1ID)
-        let slug2 = PipelineQueue.namingSlug(title: title, jobID: job2ID)
-
-        let data1 = PipelineQueue.SpeakerNamingData(
-            jobID: job1ID, meetingTitle: title,
-            mapping: ["SPEAKER_0": "Alice"], speakingTimes: [:], embeddings: [:],
-            audioPath: nil, segments: [], participants: [], isDualSource: false,
-        )
-        let data2 = PipelineQueue.SpeakerNamingData(
-            jobID: job2ID, meetingTitle: title,
-            mapping: ["SPEAKER_0": "Bob"], speakingTimes: [:], embeddings: [:],
-            audioPath: nil, segments: [], participants: [], isDualSource: false,
-        )
-
-        queueWithOutput.saveNamingData(data1, slug: slug1)
-        queueWithOutput.saveNamingData(data2, slug: slug2)
-
-        let path1 = recordingsDir.appendingPathComponent("\(slug1)_naming.json")
-        let path2 = recordingsDir.appendingPathComponent("\(slug2)_naming.json")
-
-        XCTAssertNotEqual(
-            path1.lastPathComponent, path2.lastPathComponent,
-            "Same-title jobs must produce distinct on-disk filenames",
-        )
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path1.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path2.path))
-
-        // Each file resolves back to its own job's mapping — survivor's
-        // data isn't shadowing the other.
-        let loaded1 = queueWithOutput.loadNamingData(slug: slug1)
-        let loaded2 = queueWithOutput.loadNamingData(slug: slug2)
-        XCTAssertEqual(loaded1?.mapping["SPEAKER_0"], "Alice")
-        XCTAssertEqual(loaded2?.mapping["SPEAKER_0"], "Bob")
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
@@ -105,6 +105,25 @@ final class SpeakerNamingStoreTests: XCTestCase {
         XCTAssertNil(store.load(slug: "does_not_exist"))
     }
 
+    /// Two same-title jobs resolve to distinct slugs and so write coexisting
+    /// sidecars — the survivor's data never shadows the other. Guards the
+    /// no-clobber property end-to-end through the real save/load path.
+    func test_distinctSlugs_writeCoexistingLoadableFiles() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let title = "Daily Standup"
+        let id1 = UUID()
+        let id2 = UUID()
+        let slug1 = SpeakerNamingStore.slug(title: title, jobID: id1)
+        let slug2 = SpeakerNamingStore.slug(title: title, jobID: id2)
+
+        try store.save(makeData(jobID: id1, title: title, mapping: ["SPEAKER_0": "Alice"]), slug: slug1)
+        try store.save(makeData(jobID: id2, title: title, mapping: ["SPEAKER_0": "Bob"]), slug: slug2)
+
+        XCTAssertNotEqual(slug1, slug2)
+        XCTAssertEqual(store.load(slug: slug1)?.mapping["SPEAKER_0"], "Alice")
+        XCTAssertEqual(store.load(slug: slug2)?.mapping["SPEAKER_0"], "Bob")
+    }
+
     func test_save_nilOutputDir_isNoOp() throws {
         let store = SpeakerNamingStore(outputDir: nil)
         // Must neither throw nor crash; load is correspondingly nil.

--- a/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
@@ -1,0 +1,164 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `SpeakerNamingStore` — the naming-sidecar persistence layer
+/// extracted from `PipelineQueue`. These exercise the disk I/O directly,
+/// without constructing a whole `PipelineQueue`, which is the point of the
+/// extraction.
+final class SpeakerNamingStoreTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    private var tmpDir: URL!
+    // swiftlint:enable implicitly_unwrapped_optional
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "speaker_naming_store_test")
+    }
+
+    override func tearDown() async throws {
+        if let tmpDir { try? FileManager.default.removeItem(at: tmpDir) }
+        try await super.tearDown()
+    }
+
+    private func makeData(
+        jobID: UUID = UUID(),
+        title: String = "Standup",
+        mapping: [String: String] = ["SPEAKER_0": "Alice"],
+        embeddings: [String: [Float]] = ["SPEAKER_0": [0.1, 0.2]],
+    ) -> PipelineQueue.SpeakerNamingData {
+        PipelineQueue.SpeakerNamingData(
+            jobID: jobID, meetingTitle: title,
+            mapping: mapping, speakingTimes: ["SPEAKER_0": 60],
+            embeddings: embeddings, audioPath: nil,
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            participants: [], isDualSource: false,
+        )
+    }
+
+    // MARK: - slug
+
+    func test_slug_differsForSameTitleDifferentJobs() {
+        let slug1 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID())
+        let slug2 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID())
+        XCTAssertNotEqual(slug1, slug2)
+    }
+
+    func test_slug_isDeterministicForSameJob() {
+        let id = UUID()
+        XCTAssertEqual(
+            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id),
+            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id),
+        )
+    }
+
+    func test_slug_embedsTitleAndShortID() {
+        let id = UUID()
+        let slug = SpeakerNamingStore.slug(title: "Daily Standup", jobID: id)
+        XCTAssertTrue(slug.contains(PipelineJob.shortID(for: id)))
+        XCTAssertTrue(slug.lowercased().contains("daily") && slug.lowercased().contains("standup"))
+    }
+
+    // MARK: - save / load round-trip
+
+    func test_saveThenLoad_roundTripsMapping() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let id = UUID()
+        let slug = SpeakerNamingStore.slug(title: "Standup", jobID: id)
+        try store.save(makeData(jobID: id, mapping: ["SPEAKER_0": "Alice"]), slug: slug)
+
+        let loaded = try XCTUnwrap(store.load(slug: slug))
+        XCTAssertEqual(loaded.mapping["SPEAKER_0"], "Alice")
+        XCTAssertEqual(loaded.jobID, id)
+    }
+
+    /// FluidAudio embeddings can contain NaN/Inf for short/silent segments.
+    /// The store must use the string round-trip float strategy so the sidecar
+    /// still persists — a plain JSONEncoder rejects non-conforming floats.
+    func test_saveThenLoad_survivesNonConformingFloats() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let slug = "nan_test"
+        try store.save(makeData(embeddings: ["SPEAKER_0": [.nan, .infinity, -.infinity, 0.5]]), slug: slug)
+
+        let loaded = try XCTUnwrap(store.load(slug: slug))
+        let emb = try XCTUnwrap(loaded.embeddings["SPEAKER_0"])
+        XCTAssertEqual(emb.count, 4)
+        XCTAssertTrue(emb[0].isNaN)
+        XCTAssertEqual(emb[1], .infinity)
+        XCTAssertEqual(emb[2], -.infinity)
+        XCTAssertEqual(emb[3], 0.5)
+    }
+
+    func test_save_writesOwnerOnlyPermissions() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let slug = "perm_test"
+        try store.save(makeData(), slug: slug)
+
+        let path = tmpDir.appendingPathComponent("recordings/\(slug)_naming.json")
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: path.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600, "Naming sidecar carries voice embeddings — must be owner-only")
+    }
+
+    func test_load_missingFile_returnsNil() {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        XCTAssertNil(store.load(slug: "does_not_exist"))
+    }
+
+    func test_save_nilOutputDir_isNoOp() throws {
+        let store = SpeakerNamingStore(outputDir: nil)
+        // Must neither throw nor crash; load is correspondingly nil.
+        try store.save(makeData(), slug: "any")
+        XCTAssertNil(store.load(slug: "any"))
+    }
+
+    // MARK: - delete / cleanup
+
+    func test_deleteNamingJSON_removesOnlyTheNamingFile() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let slug = "del_test"
+        for suffix in ["_naming.json", "_16k.wav"] {
+            try Data([0]).write(to: recordingsDir.appendingPathComponent("\(slug)\(suffix)"))
+        }
+
+        store.deleteNamingJSON(slug: slug)
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: recordingsDir.appendingPathComponent("\(slug)_naming.json").path,
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: recordingsDir.appendingPathComponent("\(slug)_16k.wav").path,
+        ), "deleteNamingJSON must not touch audio sidecars")
+    }
+
+    func test_cleanupSidecarFiles_removesAudioAndSegmentSidecars() throws {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        let slug = "cleanup_test"
+        let suffixes = ["_16k.wav", "_app_16k.wav", "_mic_16k.wav", "_segments.json"]
+        for suffix in suffixes {
+            try Data([0]).write(to: recordingsDir.appendingPathComponent("\(slug)\(suffix)"))
+        }
+
+        store.cleanupSidecarFiles(slug: slug)
+
+        for suffix in suffixes {
+            XCTAssertFalse(
+                FileManager.default.fileExists(
+                    atPath: recordingsDir.appendingPathComponent("\(slug)\(suffix)").path,
+                ),
+                "\(suffix) should be deleted",
+            )
+        }
+    }
+
+    func test_cleanupSidecarFiles_nilSlug_isNoOp() {
+        let store = SpeakerNamingStore(outputDir: tmpDir)
+        // Must not throw or crash.
+        store.cleanupSidecarFiles(slug: nil)
+        store.deleteNamingJSON(slug: nil)
+    }
+}


### PR DESCRIPTION
## What

Extracts the naming-sidecar disk persistence out of `PipelineQueue` into a new standalone value type, `SpeakerNamingStore`.

This is the first step of unbundling `PipelineQueue`'s speaker-naming concern, which the recent architecture review flagged as the file's largest concentration of structural debt (the stage executor is well-decomposed, but the naming session, recovery ledger, and logging still live in the same ~1900-line type, behind two lint suppressions, and naming behaviour can only be tested by constructing a whole queue).

`SpeakerNamingStore` owns only what is genuinely pure I/O over an output directory:

- the per-job `slug` helper
- `save(_:slug:)` (throwing), `load(slug:)`
- `deleteNamingJSON(slug:)`, `cleanupSidecarFiles(slug:)`

`PipelineQueue` now holds a `namingStore` and delegates to it. `namingSlug` stays as a thin alias to `SpeakerNamingStore.slug` so existing call sites are untouched. `saveNamingData` becomes a small private wrapper that delegates to the store and surfaces the existing per-job warning on a thrown failure — the store stays I/O-only and queue-state-free, the queue keeps the side effect that needs job state.

## Why this slice

The store is the one boundary in the naming session that needs no back-reference to the queue, so it can be lifted as a value type and unit-tested on its own. That directly removes the "must build a whole queue to test naming I/O" problem and gives the larger follow-up (the data cache + late-diarization paths, which do talk back to the queue) a clean seam to build on — without opening up that back-reference machinery in one big change to the most critical file in the app.

## Behaviour

Unchanged. Same slug scheme, same non-conforming-float JSON strategy (NaN/Inf embeddings still round-trip), same owner-only sidecar permissions, same warning on save failure, same nil-output-dir no-op. The old `load`/`delete` used a single `"recordings/<slug>_naming.json"` path component; the store composes `recordings` + filename separately — both resolve to the same file URL, and a test asserts the owner-only file written by the new save path is found at the old-style path.

## Tests

- New `SpeakerNamingStoreTests` (12 tests): slug determinism/uniqueness, save→load round-trip, NaN/Inf survival (mutation-proven: neutralising the float strategy turns it red), owner-only permissions, missing-file/nil-output-dir no-ops, delete-only-the-json vs cleanup-the-audio split, two same-title jobs writing coexisting loadable files.
- Two `PipelineQueueTests` cases that constructed a whole queue just to exercise the I/O are dropped; the new store tests cover the same properties directly.
- Full suite green; release-build parity check green.