### PR TITLE
refactor(app): own EngineModelState + skip diarization without per-utterance timestamps

### DIFF
--- a/app/MeetingTranscriber/Sources/EngineModelState.swift
+++ b/app/MeetingTranscriber/Sources/EngineModelState.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// App-owned model lifecycle state for a `TranscribingEngine`, decoupled from
+/// any ASR vendor's enum. WhisperKit ships its own `ModelState`; mapping to
+/// this type at the engine boundary keeps the protocol — and the
+/// FluidAudio-backed engines (Parakeet, Qwen3) — from importing WhisperKit
+/// just to report status.
+///
+/// The case names are the RPC wire contract: `String(describing:).lowercased()`
+/// must keep producing "unloaded"/"downloading"/"loading"/"loaded".
+/// `scripts/e2e-cpu-load.sh` waits for `modelState == "loaded"` to know preload
+/// finished, and `RPCEngineStateTests` pins the spelling.
+enum EngineModelState: Equatable {
+    case unloaded
+    case downloading
+    case loading
+    case loaded
+}

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -1,7 +1,6 @@
 import FluidAudio
 import Foundation
 import os.log
-import WhisperKit
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "ParakeetEngine")
 
@@ -13,7 +12,7 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Parakee
 @MainActor
 @Observable
 final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
-    private(set) var modelState: ModelState = .unloaded
+    private(set) var modelState: EngineModelState = .unloaded
     private(set) var downloadProgress: Double = 0
     private(set) var transcriptionProgress: Double = 0
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -746,6 +746,19 @@ class PipelineQueue {
         var finalTranscript = transcription.transcript
 
         guard diarizeEnabled, let diarizationFactory else { return finalTranscript }
+        // An engine without per-utterance timestamps (Qwen3 emits a single
+        // whole-recording segment) can't be diarized — assignSpeakers would
+        // collapse the entire meeting onto one speaker. Skip it and tell the
+        // user why. Dual-source transcripts keep their per-track Remote/mic
+        // labels (set in transcribe()); single-source stays unlabeled.
+        guard engine.providesTimestamps else {
+            logger.info("[\(ctx.shortID, privacy: .public)] diarization_skipped_no_timestamps")
+            addWarning(
+                id: ctx.jobID,
+                "Speaker diarization needs per-utterance timestamps, which the selected transcription engine doesn't produce — speakers not labeled",
+            )
+            return finalTranscript
+        }
         let diarizeProcess = diarizationFactory()
         guard diarizeProcess.isAvailable else {
             logger.info("[\(ctx.shortID, privacy: .public)] diarization_skipped")

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -1,7 +1,6 @@
 import FluidAudio
 import Foundation
 import os.log
-import WhisperKit
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Qwen3AsrEngine")
 
@@ -14,7 +13,7 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Qwen3As
 @MainActor
 @Observable
 final class Qwen3AsrEngine: TranscribingEngine {
-    private(set) var modelState: ModelState = .unloaded
+    private(set) var modelState: EngineModelState = .unloaded
     private(set) var downloadProgress: Double = 0
     private(set) var transcriptionProgress: Double = 0
 

--- a/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
+++ b/app/MeetingTranscriber/Sources/Qwen3AsrEngine.swift
@@ -17,6 +17,11 @@ final class Qwen3AsrEngine: TranscribingEngine {
     private(set) var downloadProgress: Double = 0
     private(set) var transcriptionProgress: Double = 0
 
+    /// Qwen3 emits a single segment spanning the whole recording (no
+    /// per-utterance timestamps), so diarization can't assign speakers per
+    /// utterance — the pipeline skips it. See `TranscribingEngine`.
+    let providesTimestamps = false
+
     /// Language hint for transcription (ISO 639-1 code, e.g. "de", "en").
     /// nil = auto-detect.
     var language: String?

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -102,7 +102,7 @@
             /// `nil` on macOS <15 where `Qwen3AsrEngine` isn't available.
             let qwen3: Qwen3?
 
-            // `modelState` (stringified `ModelState`, e.g. "unloaded"/"loaded")
+            // `modelState` (stringified `EngineModelState`, e.g. "unloaded"/"loaded")
             // lets driver scripts wait for model preload before measuring —
             // pipeline state tracks jobs, not loads (used by e2e-cpu-load.sh).
 

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -167,7 +167,7 @@ struct TranscriptionSettingsView: View {
                 .foregroundStyle(.green)
                 .font(.caption)
 
-        case .unloaded, .unloading:
+        case .unloaded:
             Button("Load Model") {
                 if settings.transcriptionEngine == .whisperKit {
                     whisperKitEngine.modelVariant = settings.whisperKitModel
@@ -177,14 +177,6 @@ struct TranscriptionSettingsView: View {
                     qe.language = settings.qwen3LanguageOrNil
                 }
                 Task { await engine.loadModel() }
-            }
-
-        case .prewarming, .prewarmed, .downloaded:
-            HStack {
-                ProgressView().controlSize(.small)
-                Text("Preparing model...")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/TranscribingEngine.swift
+++ b/app/MeetingTranscriber/Sources/TranscribingEngine.swift
@@ -7,8 +7,23 @@ protocol TranscribingEngine: AnyObject {
     var downloadProgress: Double { get }
     var transcriptionProgress: Double { get } // swiftlint:disable:this unused_declaration
 
+    /// Whether `transcribeSegments` returns per-utterance timestamps fine-grained
+    /// enough to drive speaker diarization. WhisperKit and Parakeet do (default
+    /// `true`); Qwen3 emits a single segment spanning the whole recording, so
+    /// diarization would collapse the meeting onto one speaker — it returns
+    /// `false` and the pipeline skips diarization with a warning.
+    var providesTimestamps: Bool { get }
+
     func loadModel() async
     func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment]
+}
+
+extension TranscribingEngine {
+    /// Most engines produce per-utterance timestamps; only the exceptions
+    /// override this.
+    var providesTimestamps: Bool {
+        true
+    }
 }
 
 /// Engines that can transcribe an already-decoded `[Float]` buffer of

--- a/app/MeetingTranscriber/Sources/TranscribingEngine.swift
+++ b/app/MeetingTranscriber/Sources/TranscribingEngine.swift
@@ -1,10 +1,9 @@
 import Foundation
-import WhisperKit
 
 /// Common interface for transcription engine implementations (WhisperKit, Parakeet, …).
 @MainActor
 protocol TranscribingEngine: AnyObject {
-    var modelState: ModelState { get }
+    var modelState: EngineModelState { get }
     var downloadProgress: Double { get }
     var transcriptionProgress: Double { get } // swiftlint:disable:this unused_declaration
 

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -42,7 +42,7 @@ extension TimestampedSegment {
 final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
     var modelVariant = "openai_whisper-large-v3-v20240930_turbo"
     var language: String?
-    private(set) var modelState: ModelState = .unloaded
+    private(set) var modelState: EngineModelState = .unloaded
     private(set) var downloadProgress: Double = 0
     /// Transcription progress (0.0–1.0) based on WhisperKit's 30s window processing.
     private(set) var transcriptionProgress: Double = 0

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionControllerTests.swift
@@ -1,5 +1,4 @@
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 /// Behaviour invariants around the `verboseDiagnostics` gate on
@@ -122,7 +121,7 @@ private final class VerboseCounter {
 /// without loading the real Parakeet/WhisperKit CoreML models.
 @MainActor
 final class MockStreamingEngine: StreamingTranscribingEngine {
-    var modelState: ModelState = .loaded
+    var modelState: EngineModelState = .loaded
     var downloadProgress: Double = 1.0
     var transcriptionProgress: Double = 1.0
     var transcribeCallCount = 0

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -1,5 +1,4 @@
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 /// Unit tests for `LiveTranscriptionCoordinator.attachSinks`'s gate — that live
@@ -129,7 +128,7 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
 /// build a controller with a nil streaming engine.
 @MainActor
 private final class NonStreamingEngine: TranscribingEngine {
-    var modelState: ModelState = .loaded
+    var modelState: EngineModelState = .loaded
     var downloadProgress: Double = 1.0
     var transcriptionProgress: Double = 1.0
     func loadModel() {}

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionEnglishStreamingTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionEnglishStreamingTests.swift
@@ -1,7 +1,6 @@
 import AudioTapLib
 @preconcurrency import AVFoundation
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 /// Behaviour pins for the English low-latency streaming path on
@@ -39,7 +38,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
     /// Tracks whether the engine's `loadModel()` ran — the tell that the
     /// re-transcribe path was built (the EOU path skips it entirely).
     private final class LoadTrackingEngine: StreamingTranscribingEngine {
-        var modelState: ModelState = .loaded
+        var modelState: EngineModelState = .loaded
         var downloadProgress: Double = 1.0
         var transcriptionProgress: Double = 1.0
         private(set) var loadModelCount = 0

--- a/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
@@ -1,5 +1,4 @@
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 @MainActor
@@ -121,7 +120,7 @@ final class ParakeetEngineTests: XCTestCase {
 
         // Model loads successfully from cached CoreML files, or fails and resets to .unloaded.
         // Either way it must not be stuck in .downloading or .loading.
-        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        let terminalStates: [EngineModelState] = [.loaded, .unloaded]
         XCTAssertTrue(
             terminalStates.contains(engine.modelState),
             "Model state should be terminal (.loaded or .unloaded), got: \(engine.modelState)",
@@ -150,7 +149,7 @@ final class ParakeetEngineTests: XCTestCase {
         _ = await (load1, load2)
 
         // Both complete without crash; state is terminal
-        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        let terminalStates: [EngineModelState] = [.loaded, .unloaded]
         XCTAssertTrue(
             terminalStates.contains(engine.modelState),
             "Model state should be terminal after concurrent loads, got: \(engine.modelState)",

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -846,6 +846,37 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// An engine that doesn't produce per-utterance timestamps (Qwen3 emits one
+    /// segment for the whole recording) must skip diarization entirely — running
+    /// it would collapse the meeting onto a single speaker — and warn the user.
+    func testDiarizeSkippedWhenEngineLacksTimestamps() async throws {
+        let engine = MockEngine()
+        engine.providesTimestamps = false
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 30, text: "Whole meeting in one segment")]
+        let diar = MockDiarization()
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        q.enqueue(PipelineJob(
+            meetingTitle: "NoTimestamps", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        ))
+        await q.processNext()
+
+        XCTAssertEqual(diar.runCount, 0, "diarization must not run for a timestamp-less engine")
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        XCTAssertTrue(
+            transcript.contains("Whole meeting in one segment"),
+            "transcript should pass through unlabeled — got: \(transcript)",
+        )
+        let warnings = q.jobs.first?.warnings ?? []
+        XCTAssertTrue(
+            warnings.contains { $0.contains("per-utterance timestamps") },
+            "expected a timestamp-capability warning — got: \(warnings)",
+        )
+    }
+
     func testDiarizeDualTrackLabelsBothTracks() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]

--- a/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
@@ -1,5 +1,4 @@
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 @MainActor
@@ -106,7 +105,7 @@ final class Qwen3AsrEngineTests: XCTestCase {
 
         // Model loads successfully from cached CoreML files, or fails and resets to .unloaded.
         // Either way it must not be stuck in .downloading or .loading.
-        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        let terminalStates: [EngineModelState] = [.loaded, .unloaded]
         XCTAssertTrue(
             terminalStates.contains(engine.modelState),
             "Model state should be terminal (.loaded or .unloaded), got: \(engine.modelState)",
@@ -123,7 +122,7 @@ final class Qwen3AsrEngineTests: XCTestCase {
         _ = await (load1, load2)
 
         // Both complete without crash; state is terminal
-        let terminalStates: [ModelState] = [.loaded, .unloaded]
+        let terminalStates: [EngineModelState] = [.loaded, .unloaded]
         XCTAssertTrue(
             terminalStates.contains(engine.modelState),
             "Model state should be terminal after concurrent loads, got: \(engine.modelState)",

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -1,6 +1,5 @@
 #if !APPSTORE
     @testable import MeetingTranscriber
-    import WhisperKit
     import XCTest
 
     /// Verifies that `rpcStateSnapshot()` exposes the live engine state so
@@ -103,11 +102,11 @@
         func test_modelStateWireFormat_pinsDescriptionContract() {
             // e2e-cpu-load.sh string-matches `.modelState == "loaded"` to know
             // when model preload is done. The wire value is
-            // `String(describing: ModelState).lowercased()` — pin that mapping
+            // `String(describing: EngineModelState).lowercased()` — pin that mapping
             // here so a WhisperKit upgrade changing the enum's description
             // breaks THIS test, not silently the e2e runner's settle gate.
-            XCTAssertEqual(String(describing: ModelState.loaded).lowercased(), "loaded")
-            XCTAssertEqual(String(describing: ModelState.unloaded).lowercased(), "unloaded")
+            XCTAssertEqual(String(describing: EngineModelState.loaded).lowercased(), "loaded")
+            XCTAssertEqual(String(describing: EngineModelState.unloaded).lowercased(), "unloaded")
         }
 
         func test_snapshot_whisperLanguageNil_surfacesAsNil() {

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -1,7 +1,6 @@
 @preconcurrency import AVFoundation
 import Foundation
 @testable import MeetingTranscriber
-import WhisperKit
 import XCTest
 
 // MARK: - Temp-Directory / Temp-File Helpers
@@ -403,7 +402,7 @@ class MockProtocolGen: ProtocolGenerating {
 /// Mock transcription engine for pipeline tests.
 @MainActor
 class MockEngine: TranscribingEngine {
-    var modelState: ModelState = .loaded
+    var modelState: EngineModelState = .loaded
     var downloadProgress: Double = 1.0
     var transcriptionProgress: Double = 1.0
     var segmentsToReturn: [TimestampedSegment] = []

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -405,6 +405,7 @@ class MockEngine: TranscribingEngine {
     var modelState: EngineModelState = .loaded
     var downloadProgress: Double = 1.0
     var transcriptionProgress: Double = 1.0
+    var providesTimestamps = true
     var segmentsToReturn: [TimestampedSegment] = []
     var transcribeCallCount = 0
     var shouldThrow = false


### PR DESCRIPTION
Two related engine-protocol changes (one commit each).

## 1. Own `EngineModelState`, drop the WhisperKit vendor leak

`TranscribingEngine.modelState` was WhisperKit's `ModelState` enum, so the two FluidAudio-backed engines (Parakeet, Qwen3) imported WhisperKit *solely* to report status, and every downstream consumer (RPC snapshot, Settings UI) coupled to the vendor enum.

This introduces an app-owned `EngineModelState` (`unloaded`/`downloading`/`loading`/`loaded` — the four states the engines actually emit) and switches the protocol + all three engines to it. WhisperKitEngine keeps importing WhisperKit (it uses `WhisperKit`, `WhisperKitConfig`, `DecodingOptions`); the protocol, Parakeet, Qwen3, and eight test files no longer need the import.

**Wire format unchanged:** `AppState+RPC` still emits `String(describing: modelState).lowercased()`, and the new enum's case names keep producing `"unloaded"`/`"loaded"`/etc. — `RPCEngineStateTests` pins that and `e2e-cpu-load.sh` waits on `modelState == "loaded"`. The Settings status switch drops its dead `.prewarming`/`.prewarmed`/`.downloaded`/`.unloading` branches (WhisperKit-internal states the engines never set), becoming exhaustive on the four real states.

## 2. Skip diarization for engines without per-utterance timestamps

Qwen3 emits a single `TimestampedSegment` spanning the whole recording. With diarization enabled, `assignSpeakers` matched that one segment to whichever diarized speaker had the most overlap — silently collapsing the entire meeting onto one speaker, with no warning, after running the diarization model for nothing.

Adds a `providesTimestamps` capability to `TranscribingEngine` (default `true` via a protocol extension; Qwen3 returns `false`) and guards `diarize()` on it: a timestamp-less engine skips diarization and adds a job warning. Dual-source transcripts keep their per-track Remote/mic labels from `transcribe()`; single-source stays honestly unlabeled instead of wrongly single-speaker. The Qwen3 single-segment behaviour is confirmed from the engine code (`return [TimestampedSegment(start: 0, end: duration, …)]`).

TDD: the new test drives a job through a timestamp-less mock engine and asserts the diarizer is never invoked and the warning is present (red before the guard — diarization ran and labeled — green after).

## Verification
- Full suite green excluding `MenuBarIconSnapshotTests` (those 5 are pre-existing pixel-rendering mismatches on this machine — they fail identically on clean `origin/main` here and pass in CI; the change has no rendering surface).
- Release-build parity check green.