### PR TITLE
refactor(app): move mergeDualSourceSegments to DiarizationProcess

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -32,10 +32,48 @@ protocol DiarizationProvider: Sendable {
 /// Speaker assignment utilities.
 enum DiarizationProcess {
     /// Speaker tag carried by app/remote-audio segments in a dual-source mix.
-    /// Written by `TranscribingEngine.mergeDualSourceSegments` and read back
-    /// here when splitting cached segments per track — both sides must agree,
-    /// so the literal lives in one place.
+    /// Written by `mergeDualSourceSegments` and read back here when splitting
+    /// cached segments per track — both sides must agree, so the literal lives
+    /// in one place.
     static let remoteSpeakerLabel = "Remote"
+
+    /// Label and merge pre-transcribed app/mic segments by timestamp: app
+    /// segments become `remoteSpeakerLabel`, mic segments take `micLabel`, the
+    /// mic track is shifted by `micDelay`, and the result is sorted by start
+    /// time. Pure timestamp math over transcript segments — lives here next to
+    /// the diarization assignment that reads `remoteSpeakerLabel` back, rather
+    /// than on the engine protocol (the engine doesn't care about speaker tags).
+    static func mergeDualSourceSegments(
+        appSegments: [TimestampedSegment],
+        micSegments: [TimestampedSegment],
+        micDelay: TimeInterval = 0,
+        micLabel: String = "Me",
+    ) -> [TimestampedSegment] {
+        var app = appSegments
+        var mic = micSegments
+
+        if micDelay != 0 {
+            mic = mic.map { seg in
+                TimestampedSegment(
+                    start: seg.start + micDelay,
+                    end: seg.end + micDelay,
+                    text: seg.text,
+                    speaker: seg.speaker,
+                )
+            }
+        }
+
+        for i in app.indices {
+            app[i].speaker = remoteSpeakerLabel
+        }
+        for i in mic.indices {
+            mic[i].speaker = micLabel
+        }
+
+        var result = app + mic
+        result.sort { $0.start < $1.start }
+        return result
+    }
 
     /// Assign speaker labels to transcript segments by maximum temporal overlap.
     /// Uses `autoNames` to replace raw labels (e.g. "SPEAKER_0") with human names.
@@ -91,7 +129,7 @@ enum DiarizationProcess {
     /// track's diarization onto a different timeline. Used to bring the mic
     /// track's diarization onto the app/canonical timeline by `+micDelay`, so it
     /// aligns with the mic transcript segments — which
-    /// `TranscribingEngine.mergeDualSourceSegments` already shifts by the same
+    /// `mergeDualSourceSegments` already shifts by the same
     /// `+micDelay`. Without this the two are offset and overlap-based speaker
     /// assignment mislabels mic-side segments. `speakingTimes` (durations),
     /// `autoNames`, and `embeddings` are timeline-independent, so they pass

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -685,7 +685,7 @@ class PipelineQueue {
             let micSegments = try await engine.transcribeSegments(audioPath: mic16k)
 
             // Merge dual-source segments
-            let segments = engine.mergeDualSourceSegments(
+            let segments = DiarizationProcess.mergeDualSourceSegments(
                 appSegments: appSegments,
                 micSegments: micSegments,
                 micDelay: ctx.micDelay,

--- a/app/MeetingTranscriber/Sources/TranscribingEngine.swift
+++ b/app/MeetingTranscriber/Sources/TranscribingEngine.swift
@@ -38,38 +38,3 @@ extension TranscribingEngine {
 protocol StreamingTranscribingEngine: TranscribingEngine {
     func transcribeSamples(_ samples: [Float]) async throws -> String
 }
-
-extension TranscribingEngine {
-    /// Label and merge pre-transcribed app/mic segments by timestamp.
-    func mergeDualSourceSegments(
-        appSegments: [TimestampedSegment],
-        micSegments: [TimestampedSegment],
-        micDelay: TimeInterval = 0,
-        micLabel: String = "Me",
-    ) -> [TimestampedSegment] {
-        var app = appSegments
-        var mic = micSegments
-
-        if micDelay != 0 {
-            mic = mic.map { seg in
-                TimestampedSegment(
-                    start: seg.start + micDelay,
-                    end: seg.end + micDelay,
-                    text: seg.text,
-                    speaker: seg.speaker,
-                )
-            }
-        }
-
-        for i in app.indices {
-            app[i].speaker = DiarizationProcess.remoteSpeakerLabel
-        }
-        for i in mic.indices {
-            mic[i].speaker = micLabel
-        }
-
-        var result = app + mic
-        result.sort { $0.start < $1.start }
-        return result
-    }
-}

--- a/app/MeetingTranscriber/Tests/DiarizationMergeDualSourceTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationMergeDualSourceTests.swift
@@ -1,12 +1,10 @@
 @testable import MeetingTranscriber
 import XCTest
 
-@MainActor
-final class TranscribingEngineTests: XCTestCase {
-    private func makeEngine() -> WhisperKitEngine {
-        WhisperKitEngine()
-    }
-
+/// Tests for `DiarizationProcess.mergeDualSourceSegments` — labelling + merging
+/// pre-transcribed app/mic segments by timestamp. Pure static logic; no engine
+/// needed (it used to live on the engine protocol).
+final class DiarizationMergeDualSourceTests: XCTestCase {
     // MARK: - Speaker Labels
 
     func testLabelsAppSegmentsAsRemote() {
@@ -14,7 +12,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 0, end: 5, text: "Hello"),
             TimestampedSegment(start: 5, end: 10, text: "World"),
         ]
-        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
 
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result.allSatisfy { $0.speaker == "Remote" })
@@ -25,7 +23,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 0, end: 5, text: "Hello"),
             TimestampedSegment(start: 5, end: 10, text: "World"),
         ]
-        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
 
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result.allSatisfy { $0.speaker == "Me" })
@@ -35,7 +33,7 @@ final class TranscribingEngineTests: XCTestCase {
         let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
         let micSegs = [TimestampedSegment(start: 1, end: 6, text: "Mic")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: appSegs, micSegments: micSegs, micLabel: "Alice",
         )
 
@@ -55,7 +53,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 6, end: 9, text: "Third"),
         ]
 
-        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
 
         XCTAssertEqual(result.map(\.text), ["First", "Second", "Third", "Fourth"])
         XCTAssertEqual(result.map(\.start), [0, 3, 6, 10])
@@ -71,7 +69,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 9, end: 12, text: "M2"),
         ]
 
-        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
 
         XCTAssertEqual(result.map(\.text), ["A1", "M1", "A2", "M2"])
         XCTAssertEqual(result.map(\.speaker), ["Remote", "Me", "Remote", "Me"])
@@ -83,7 +81,7 @@ final class TranscribingEngineTests: XCTestCase {
         let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
         let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: appSegs, micSegments: micSegs, micDelay: 3.0,
         )
 
@@ -96,7 +94,7 @@ final class TranscribingEngineTests: XCTestCase {
         let appSegs = [TimestampedSegment(start: 5, end: 10, text: "App")]
         let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: appSegs, micSegments: micSegs, micDelay: 2.0,
         )
 
@@ -108,7 +106,7 @@ final class TranscribingEngineTests: XCTestCase {
     func testZeroMicDelayDoesNotModifyTimestamps() {
         let micSegs = [TimestampedSegment(start: 3, end: 8, text: "Mic")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: [], micSegments: micSegs, micDelay: 0,
         )
 
@@ -120,7 +118,7 @@ final class TranscribingEngineTests: XCTestCase {
         let appSegs = [TimestampedSegment(start: 5, end: 10, text: "App")]
         let micSegs = [TimestampedSegment(start: 7, end: 12, text: "Mic")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: appSegs, micSegments: micSegs, micDelay: -2.0,
         )
 
@@ -137,7 +135,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 5, end: 10, text: "Mic2"),
         ]
 
-        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: [], micSegments: micSegs)
 
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result.allSatisfy { $0.speaker == "Me" })
@@ -150,7 +148,7 @@ final class TranscribingEngineTests: XCTestCase {
             TimestampedSegment(start: 5, end: 10, text: "App2"),
         ]
 
-        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: appSegs, micSegments: [])
 
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result.allSatisfy { $0.speaker == "Remote" })
@@ -158,7 +156,7 @@ final class TranscribingEngineTests: XCTestCase {
     }
 
     func testBothEmptyReturnsEmptyResult() {
-        let result = makeEngine().mergeDualSourceSegments(appSegments: [], micSegments: [])
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: [], micSegments: [])
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -168,7 +166,7 @@ final class TranscribingEngineTests: XCTestCase {
         let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from the app side")]
         let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from the mic side")]
 
-        let result = makeEngine().mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
+        let result = DiarizationProcess.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
 
         XCTAssertEqual(result[0].text, "Hello from the app side")
         XCTAssertEqual(result[1].text, "Hello from the mic side")
@@ -177,7 +175,7 @@ final class TranscribingEngineTests: XCTestCase {
     func testPreservesTextWithMicDelay() {
         let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Delayed mic text")]
 
-        let result = makeEngine().mergeDualSourceSegments(
+        let result = DiarizationProcess.mergeDualSourceSegments(
             appSegments: [], micSegments: micSegs, micDelay: 10.0,
         )
 

--- a/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetEngineTests.swift
@@ -55,61 +55,6 @@ final class ParakeetEngineTests: XCTestCase {
         }
     }
 
-    // MARK: - MergeDualSourceSegments (protocol extension on TranscribingEngine)
-
-    func testMergeDualSourceSegmentsLabelsAndSorts() {
-        let engine = ParakeetEngine()
-
-        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from app")]
-        let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from mic")]
-
-        let result = engine.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
-
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].speaker, "Remote")
-        XCTAssertEqual(result[0].text, "Hello from app")
-        XCTAssertEqual(result[1].speaker, "Me")
-        XCTAssertEqual(result[1].text, "Hello from mic")
-    }
-
-    func testMergeDualSourceSegmentsAppliesMicDelay() {
-        let engine = ParakeetEngine()
-
-        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
-        let micSegs = [TimestampedSegment(start: 0, end: 5, text: "Mic")]
-
-        let result = engine.mergeDualSourceSegments(
-            appSegments: appSegs, micSegments: micSegs, micDelay: 3.0,
-        )
-
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].text, "App")
-        XCTAssertEqual(result[0].start, 0)
-        XCTAssertEqual(result[1].text, "Mic")
-        XCTAssertEqual(result[1].start, 3.0)
-        XCTAssertEqual(result[1].end, 8.0)
-    }
-
-    func testMergeDualSourceSegmentsEmptyInputs() {
-        let engine = ParakeetEngine()
-
-        let result = engine.mergeDualSourceSegments(appSegments: [], micSegments: [])
-        XCTAssertTrue(result.isEmpty)
-    }
-
-    func testMergeDualSourceSegmentsCustomMicLabel() {
-        let engine = ParakeetEngine()
-
-        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "App")]
-        let micSegs = [TimestampedSegment(start: 1, end: 6, text: "Mic")]
-
-        let result = engine.mergeDualSourceSegments(
-            appSegments: appSegs, micSegments: micSegs, micLabel: "Alice",
-        )
-
-        XCTAssertEqual(result[1].speaker, "Alice")
-    }
-
     // MARK: - Load Model State Transitions
 
     func testLoadModelTransitionsToLoaded() async {

--- a/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/Qwen3AsrEngineTests.swift
@@ -76,24 +76,6 @@ final class Qwen3AsrEngineTests: XCTestCase {
         }
     }
 
-    // MARK: - MergeDualSourceSegments (protocol extension)
-
-    func testMergeDualSourceSegmentsLabelsAndSorts() {
-        guard #available(macOS 15, *) else { return }
-        let engine = Qwen3AsrEngine()
-
-        let appSegs = [TimestampedSegment(start: 0, end: 5, text: "Hello from app")]
-        let micSegs = [TimestampedSegment(start: 2, end: 7, text: "Hello from mic")]
-
-        let result = engine.mergeDualSourceSegments(appSegments: appSegs, micSegments: micSegs)
-
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].speaker, "Remote")
-        XCTAssertEqual(result[0].text, "Hello from app")
-        XCTAssertEqual(result[1].speaker, "Me")
-        XCTAssertEqual(result[1].text, "Hello from mic")
-    }
-
     // MARK: - Load Model State Transitions
 
     func testLoadModelTransitionsToLoaded() async {


### PR DESCRIPTION
Small layering cleanup (architecture-review follow-up).

`mergeDualSourceSegments` was a default method on the `TranscribingEngine` protocol extension, but it's pure timestamp math: it labels app segments with `DiarizationProcess.remoteSpeakerLabel`, tags the mic track with `micLabel`, shifts the mic track by `micDelay`, and sorts by start time. That coupled the engine layer to the diarization layer's speaker-tag namespace — and no engine overrode it or cared about speaker tags.

Move it to `DiarizationProcess` as a `static func` (next to the assignment code that reads `remoteSpeakerLabel` back), and call it from `PipelineQueue.transcribe()` directly. The body is moved verbatim — behaviour is identical (same labels, same sort, same micDelay shift).

## Tests
`TranscribingEngineTests` existed only to exercise this method through a throwaway `WhisperKitEngine`; it's renamed to `DiarizationMergeDualSourceTests` and retargeted at `DiarizationProcess` directly (git tracks it as a rename). The duplicate per-engine merge tests in `ParakeetEngineTests`/`Qwen3AsrEngineTests` (which only re-tested the shared inherited default, nothing engine-specific) are dropped as redundant. All 14 behaviour cases (labels, sorting, micDelay incl. negative, empty inputs, text preservation) are preserved.

## Verification
- Full suite green excluding `MenuBarIconSnapshotTests` (pre-existing local pixel-rendering mismatches — they pass in CI; no rendering surface here).
- Release-build parity check green.
- Combined code-review + simplify pass: clean behaviour-preserving move, coverage intact, no leftover empty extension, no hidden callers.