### PR TITLE
fix(ci): floor build-perf slowdown alerts on absolute seconds

### DIFF
--- a/.github/workflows/build-perf-tracking.yml
+++ b/.github/workflows/build-perf-tracking.yml
@@ -13,6 +13,9 @@ on:
       alert_pct:
         description: 'Slowdown threshold (percent)'
         default: '20'
+      min_delta_seconds:
+        description: 'Slowdown threshold (absolute seconds floor)'
+        default: '10'
 
 jobs:
   track:
@@ -28,6 +31,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LIMIT: ${{ inputs.limit || '50' }}
           ALERT_PCT: ${{ inputs.alert_pct || '20' }}
+          MIN_DELTA_SECONDS: ${{ inputs.min_delta_seconds || '10' }}
           WORKFLOW: ci.yml
           BRANCH: main
         # pipefail: without it `| tee` masks the report script's exit code, so a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
         run: bash scripts/lint.sh --format-only
       - name: SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging
-      - name: Build script regression tests
-        run: bash scripts/tests/test_build_release_signing.sh
+      - name: Script regression tests
+        run: |
+          bash scripts/tests/test_build_release_signing.sh
+          bash scripts/tests/test_build_perf_report.sh
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure

--- a/scripts/build_perf_report.py
+++ b/scripts/build_perf_report.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Analyze per-job CI timings and emit a Markdown trend report.
+
+Reads a JSON-lines file of per-job timings (one record per line, with
+``job``, ``run_created`` ISO-8601 timestamp, and ``duration_seconds``) and
+prints a Markdown summary comparing each job's last-7-day median against its
+prior-28-day median. Flags any job whose recent median is more than
+``alert_pct`` percent slower than its baseline median.
+
+Exits 0 normally, 1 when at least one slowdown is detected — so the workflow
+run is visibly red in the Actions list.
+
+Usage:
+    build_perf_report.py <jobs.jsonl> <alert_pct> <branch> <workflow>
+
+The clock can be pinned via the ``SOURCE_DATE_EPOCH`` environment variable
+(seconds since the Unix epoch) for deterministic output in tests.
+"""
+
+import json
+import os
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+
+def current_time() -> datetime:
+    """Now in UTC, overridable via SOURCE_DATE_EPOCH for reproducible tests."""
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+def main() -> int:
+    path = sys.argv[1]
+    alert_pct = int(sys.argv[2])
+    branch = sys.argv[3]
+    workflow = sys.argv[4]
+
+    now = current_time()
+    recent_cutoff = now - timedelta(days=7)
+    baseline_cutoff = now - timedelta(days=35)
+
+    by_job = defaultdict(lambda: {"recent": [], "baseline": []})
+    with open(path) as f:
+        for line in f:
+            rec = json.loads(line)
+            ts = datetime.fromisoformat(rec["run_created"].replace("Z", "+00:00"))
+            if ts >= recent_cutoff:
+                by_job[rec["job"]]["recent"].append(rec["duration_seconds"])
+            elif ts >= baseline_cutoff:
+                by_job[rec["job"]]["baseline"].append(rec["duration_seconds"])
+
+    print(f"# Build Performance Tracking — `{workflow}` on `{branch}`")
+    print()
+    print(f"Generated {now:%Y-%m-%d %H:%M UTC}. Alert threshold: **>{alert_pct}%**.")
+    print()
+    print("| Job | n (last 7d) | median (7d) | n (prior 28d) | median (28d) | Δ |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: |")
+
+    slowdowns = []
+    for job, w in sorted(by_job.items()):
+        rn, bn = len(w["recent"]), len(w["baseline"])
+        rm = statistics.median(w["recent"]) if w["recent"] else 0.0
+        bm = statistics.median(w["baseline"]) if w["baseline"] else 0.0
+        if bm > 0 and rn > 0:
+            delta_pct = (rm - bm) / bm * 100
+            delta_str = f"{delta_pct:+.1f}%"
+            if delta_pct > alert_pct:
+                slowdowns.append((job, rm, bm, delta_pct))
+                delta_str = f"⚠️ {delta_str}"
+        else:
+            delta_str = "—"
+        print(f"| {job} | {rn} | {rm:.1f}s | {bn} | {bm:.1f}s | {delta_str} |")
+
+    print()
+    if slowdowns:
+        print(f"## ⚠️ {len(slowdowns)} slowdown(s) detected")
+        print()
+        for job, rm, bm, pct in slowdowns:
+            print(f"- **{job}**: {rm:.1f}s recent vs {bm:.1f}s baseline (+{pct:.1f}%)")
+        return 1
+    print("✅ No slowdowns detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_perf_report.py
+++ b/scripts/build_perf_report.py
@@ -4,14 +4,22 @@
 Reads a JSON-lines file of per-job timings (one record per line, with
 ``job``, ``run_created`` ISO-8601 timestamp, and ``duration_seconds``) and
 prints a Markdown summary comparing each job's last-7-day median against its
-prior-28-day median. Flags any job whose recent median is more than
-``alert_pct`` percent slower than its baseline median.
+prior-28-day median.
+
+A job is flagged as a slowdown only when it clears BOTH gates:
+  * relative: the median grew by more than ``alert_pct`` percent, AND
+  * absolute: the median grew by at least ``min_delta_seconds`` seconds.
+
+The absolute floor exists because a percentage on a tiny baseline is
+meaningless — a job that runs in ~3s jitters by a second between runs, which
+is +33% but not a real regression. Without the floor, runner scheduling
+noise on fast jobs reds the whole weekly cron.
 
 Exits 0 normally, 1 when at least one slowdown is detected — so the workflow
 run is visibly red in the Actions list.
 
 Usage:
-    build_perf_report.py <jobs.jsonl> <alert_pct> <branch> <workflow>
+    build_perf_report.py <jobs.jsonl> <alert_pct> <branch> <workflow> <min_delta_seconds>
 
 The clock can be pinned via the ``SOURCE_DATE_EPOCH`` environment variable
 (seconds since the Unix epoch) for deterministic output in tests.
@@ -38,6 +46,7 @@ def main() -> int:
     alert_pct = int(sys.argv[2])
     branch = sys.argv[3]
     workflow = sys.argv[4]
+    min_delta_seconds = float(sys.argv[5])
 
     now = current_time()
     recent_cutoff = now - timedelta(days=7)
@@ -55,7 +64,10 @@ def main() -> int:
 
     print(f"# Build Performance Tracking — `{workflow}` on `{branch}`")
     print()
-    print(f"Generated {now:%Y-%m-%d %H:%M UTC}. Alert threshold: **>{alert_pct}%**.")
+    print(
+        f"Generated {now:%Y-%m-%d %H:%M UTC}. "
+        f"Alert threshold: **>{alert_pct}%** and **≥{min_delta_seconds:g}s** absolute."
+    )
     print()
     print("| Job | n (last 7d) | median (7d) | n (prior 28d) | median (28d) | Δ |")
     print("| --- | ---: | ---: | ---: | ---: | ---: |")
@@ -68,7 +80,7 @@ def main() -> int:
         if bm > 0 and rn > 0:
             delta_pct = (rm - bm) / bm * 100
             delta_str = f"{delta_pct:+.1f}%"
-            if delta_pct > alert_pct:
+            if delta_pct > alert_pct and (rm - bm) >= min_delta_seconds:
                 slowdowns.append((job, rm, bm, delta_pct))
                 delta_str = f"⚠️ {delta_str}"
         else:

--- a/scripts/build_perf_report.sh
+++ b/scripts/build_perf_report.sh
@@ -9,10 +9,11 @@
 # workflow run is visibly red in the Actions list.
 #
 # Inputs (env vars):
-#   WORKFLOW   default: ci.yml
-#   BRANCH     default: main
-#   LIMIT      default: 50
-#   ALERT_PCT  default: 20
+#   WORKFLOW           default: ci.yml
+#   BRANCH             default: main
+#   LIMIT              default: 50
+#   ALERT_PCT          default: 20
+#   MIN_DELTA_SECONDS  default: 10  (absolute floor; see build_perf_report.py)
 #
 # Requires: gh, jq, python3 (all preinstalled on GitHub-hosted runners).
 
@@ -24,6 +25,7 @@ WORKFLOW="${WORKFLOW:-ci.yml}"
 BRANCH="${BRANCH:-main}"
 LIMIT="${LIMIT:-50}"
 ALERT_PCT="${ALERT_PCT:-20}"
+MIN_DELTA_SECONDS="${MIN_DELTA_SECONDS:-10}"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -74,4 +76,8 @@ while IFS=$'\t' read -r run_id created_at; do
 done < <(jq -r '.[] | "\(.databaseId)\t\(.createdAt)"' "$WORK/runs.json")
 echo "::endgroup::" >&2
 
-python3 "$SCRIPT_DIR/build_perf_report.py" "$WORK/jobs.jsonl" "$ALERT_PCT" "$BRANCH" "$WORKFLOW"
+# Keep this the terminal command and unwrapped (no if/||/pipe): the report
+# module exits 1 on a detected slowdown, and `set -e` + this being the last
+# command is what propagates that exit 1 out to the workflow step.
+python3 "$SCRIPT_DIR/build_perf_report.py" \
+    "$WORK/jobs.jsonl" "$ALERT_PCT" "$BRANCH" "$WORKFLOW" "$MIN_DELTA_SECONDS"

--- a/scripts/build_perf_report.sh
+++ b/scripts/build_perf_report.sh
@@ -18,6 +18,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 WORKFLOW="${WORKFLOW:-ci.yml}"
 BRANCH="${BRANCH:-main}"
 LIMIT="${LIMIT:-50}"
@@ -72,54 +74,4 @@ while IFS=$'\t' read -r run_id created_at; do
 done < <(jq -r '.[] | "\(.databaseId)\t\(.createdAt)"' "$WORK/runs.json")
 echo "::endgroup::" >&2
 
-python3 - "$WORK/jobs.jsonl" "$ALERT_PCT" "$BRANCH" "$WORKFLOW" <<'PY'
-import json, statistics, sys
-from collections import defaultdict
-from datetime import datetime, timedelta, timezone
-
-path, alert_pct, branch, workflow = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
-now = datetime.now(timezone.utc)
-recent_cutoff = now - timedelta(days=7)
-baseline_cutoff = now - timedelta(days=35)
-
-by_job = defaultdict(lambda: {"recent": [], "baseline": []})
-with open(path) as f:
-    for line in f:
-        rec = json.loads(line)
-        ts = datetime.fromisoformat(rec["run_created"].replace("Z", "+00:00"))
-        if ts >= recent_cutoff:
-            by_job[rec["job"]]["recent"].append(rec["duration_seconds"])
-        elif ts >= baseline_cutoff:
-            by_job[rec["job"]]["baseline"].append(rec["duration_seconds"])
-
-print(f"# Build Performance Tracking — `{workflow}` on `{branch}`")
-print()
-print(f"Generated {now:%Y-%m-%d %H:%M UTC}. Alert threshold: **>{alert_pct}%**.")
-print()
-print("| Job | n (last 7d) | median (7d) | n (prior 28d) | median (28d) | Δ |")
-print("| --- | ---: | ---: | ---: | ---: | ---: |")
-
-slowdowns = []
-for job, w in sorted(by_job.items()):
-    rn, bn = len(w["recent"]), len(w["baseline"])
-    rm = statistics.median(w["recent"]) if w["recent"] else 0.0
-    bm = statistics.median(w["baseline"]) if w["baseline"] else 0.0
-    if bm > 0 and rn > 0:
-        delta_pct = (rm - bm) / bm * 100
-        delta_str = f"{delta_pct:+.1f}%"
-        if delta_pct > alert_pct:
-            slowdowns.append((job, rm, bm, delta_pct))
-            delta_str = f"⚠️ {delta_str}"
-    else:
-        delta_str = "—"
-    print(f"| {job} | {rn} | {rm:.1f}s | {bn} | {bm:.1f}s | {delta_str} |")
-
-print()
-if slowdowns:
-    print(f"## ⚠️ {len(slowdowns)} slowdown(s) detected")
-    print()
-    for job, rm, bm, pct in slowdowns:
-        print(f"- **{job}**: {rm:.1f}s recent vs {bm:.1f}s baseline (+{pct:.1f}%)")
-    sys.exit(1)
-print("✅ No slowdowns detected.")
-PY
+python3 "$SCRIPT_DIR/build_perf_report.py" "$WORK/jobs.jsonl" "$ALERT_PCT" "$BRANCH" "$WORKFLOW"

--- a/scripts/tests/test_build_perf_report.sh
+++ b/scripts/tests/test_build_perf_report.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Regression test for scripts/build_perf_report.py slowdown gating.
+#
+# Bug history:
+#   The slowdown gate flagged any job whose median grew >ALERT_PCT%, with no
+#   absolute floor. A job that runs in ~3s jitters by a second between runs
+#   (+33%) and reddened the whole weekly Build Performance Tracking cron —
+#   GitHub Actions run 27532027974 went red on "changes: 4.0s vs 3.0s
+#   (+33.3%)". Fixed by also requiring a minimum absolute seconds delta.
+#
+# Feeds the analysis module fixture timings with a pinned clock
+# (SOURCE_DATE_EPOCH) and asserts on its exit code + output.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+REPORT_PY="$REPO_ROOT/scripts/build_perf_report.py"
+
+# Pinned clock: fixture timestamps are placed relative to this (2026-06-15T12:00:00Z).
+NOW_EPOCH=1781524800
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$name"; then printf 'PASS\n'; else printf 'FAIL\n'; FAILED=1; fi
+}
+
+# write_fixture <file> <job> <baseline_seconds> <recent_seconds>
+# Emits 5 baseline-window + 5 recent-window records for one job.
+write_fixture() {
+    local file="$1"
+    NOW_EPOCH="$NOW_EPOCH" JOB="$2" BASE_S="$3" RECENT_S="$4" \
+        python3 - "$file" <<'PY'
+import json, os, sys
+from datetime import datetime, timedelta, timezone
+now = datetime.fromtimestamp(int(os.environ["NOW_EPOCH"]), tz=timezone.utc)
+recent = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")   # in last-7d window
+base = (now - timedelta(days=21)).isoformat().replace("+00:00", "Z")    # in prior-28d window
+job = os.environ["JOB"]
+samples = [(base, float(os.environ["BASE_S"]))] * 5 + [(recent, float(os.environ["RECENT_S"]))] * 5
+with open(sys.argv[1], "w") as f:
+    for ts, dur in samples:
+        f.write(json.dumps({"run_id": "x", "run_created": ts, "job": job, "duration_seconds": dur}) + "\n")
+PY
+}
+
+# run_report <fixture> <floor_seconds> -> sets REPORT_OUT, REPORT_RC
+run_report() {
+    REPORT_OUT=$(SOURCE_DATE_EPOCH="$NOW_EPOCH" python3 "$REPORT_PY" "$1" 20 main ci.yml "$2")
+    REPORT_RC=$?
+}
+
+test_subfloor_jitter_does_not_alert() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx" changes 3.0 4.0            # +33%, but only +1s absolute
+    run_report "$fx" 10
+    if [ "$REPORT_RC" -ne 0 ]; then
+        echo; echo "  expected exit 0 (sub-floor jitter), got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    if printf '%s' "$REPORT_OUT" | grep -q "slowdown(s) detected"; then
+        echo; echo "  sub-floor jitter was reported as a slowdown"; echo "$REPORT_OUT"; return 1
+    fi
+    return 0
+}
+
+test_real_regression_alerts() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx" test 300.0 400.0           # +33%, +100s absolute
+    run_report "$fx" 10
+    if [ "$REPORT_RC" -ne 1 ]; then
+        echo; echo "  expected exit 1 (real regression), got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    if ! printf '%s' "$REPORT_OUT" | grep -q "1 slowdown(s) detected"; then
+        echo; echo "  real regression not reported as a slowdown"; echo "$REPORT_OUT"; return 1
+    fi
+    return 0
+}
+
+test_floor_boundary_is_inclusive() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    # +10s exactly at a 10s floor must alert (gate is >=).
+    write_fixture "$fx" boundary 30.0 40.0
+    run_report "$fx" 10
+    if [ "$REPORT_RC" -ne 1 ]; then
+        echo; echo "  +10s at floor 10 should alert (>=), got exit $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    # +9s just under the floor must not alert.
+    write_fixture "$fx" boundary 30.0 39.0
+    run_report "$fx" 10
+    if [ "$REPORT_RC" -ne 0 ]; then
+        echo; echo "  +9s under floor 10 should not alert, got exit $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    return 0
+}
+
+run_test test_subfloor_jitter_does_not_alert
+run_test test_real_regression_alerts
+run_test test_floor_boundary_is_inclusive
+
+exit "$FAILED"


### PR DESCRIPTION
## Problem

The weekly **Build Performance Tracking** cron went red — [run 27532027974](https://github.com/pasrom/meeting-transcriber/actions/runs/27532027974). The only "slowdown" it flagged:

> **changes**: 4.0s recent vs 3.0s baseline (+33.3%)

The `changes` job is the paths-filter that just decides which lanes run; it finishes in ~3s. A one-second jitter (3s → 4s) is +33%, so the percent-only gate flagged it and reddened the entire cron. A percentage on a few-second baseline measures runner scheduling noise, not a real regression.

## Fix

Require a slowdown to clear **both** gates:
- relative: median grew by more than `ALERT_PCT`% (unchanged), **and**
- absolute: median grew by at least `MIN_DELTA_SECONDS` (new, default **10s**, env-configurable + exposed as a `workflow_dispatch` input).

The big jobs this tracker actually targets (test lanes at ~400–490s) have 20% thresholds of 80–98s, far above the floor, so their detection is unaffected — the floor only ever binds on the fast jobs whose percentages are noise. The sub-floor percentage is still printed in the table for transparency; it just no longer triggers a warning or a non-zero exit.

With this change the failing run's scenario exits 0 (only `changes` was flagged, +1s < 10s), while a genuine +100s regression still alerts.

## Structure

1. **`refactor(ci)`** — extract the inline Python heredoc out of `build_perf_report.sh` into a standalone, testable `scripts/build_perf_report.py` (behavior-preserving; adds a `SOURCE_DATE_EPOCH` clock seam so tests can pin "now" deterministically).
2. **`fix(ci)`** — add the absolute-seconds floor + a regression test `scripts/tests/test_build_perf_report.sh` (wired into `ci.yml` alongside the existing build-script test) + the new `workflow_dispatch` input.

## Testing

`scripts/tests/test_build_perf_report.sh` (red→green verified; mutation-proven — removing the floor re-reddens the first and third cases):
- a sub-floor jitter (3s → 4s, +33%) does **not** alert,
- a real +100s regression **does** alert,
- the floor boundary is inclusive (+10s at a 10s floor alerts; +9s does not).