### PR TITLE
feat(app): per-stage processing duration metrics (avg + live-vs-typical)

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -189,6 +189,10 @@ struct MeetingTranscriberApp: App {
                 // the same `recognition_log.jsonl` file. Fallback only fires in the
                 // test-only PipelineQueue init that intentionally leaves it nil.
                 recognitionStatsLog: appState.pipeline.queue.recognitionStatsLog ?? RecognitionStatsLog(),
+                // Same actor instance the pipeline writes to, so both writers
+                // serialise on stage_timing.jsonl. Fallback fires only in the
+                // test-only PipelineQueue init that leaves it nil.
+                stageTimingLog: appState.pipeline.queue.stageTimingLog ?? StageTimingLog(),
                 enrollmentDiarizerFactory: { FluidDiarizer(mode: appState.settings.diarizerMode) },
                 namingDialogActive: appState.pipeline.queue.pendingSpeakerNaming != nil,
                 pipelineBusy: appState.pipeline.queue.isProcessing,

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -254,11 +254,7 @@ struct MenuBarView: View {
     }
 
     private func formattedElapsed(_ seconds: TimeInterval) -> String {
-        let total = Int(seconds)
-        if total < 60 {
-            return "\(total)s"
-        }
-        return "\(total / 60):\(String(format: "%02d", total % 60))"
+        StageTimingStats.formatDuration(seconds)
     }
 
     private func jobColor(_ job: PipelineJob) -> Color {

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -264,7 +264,7 @@ struct MenuBarView: View {
     }
 
     private func formattedElapsed(_ seconds: TimeInterval) -> String {
-        StageTimingStats.formatDuration(seconds)
+        formattedTime(seconds)
     }
 
     private func jobColor(_ job: PipelineJob) -> Color {

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -237,7 +237,7 @@ struct MenuBarView: View {
     private func jobStateLabel(_ job: PipelineJob) -> some View {
         Group {
             if [.transcribing, .diarizing, .generatingProtocol].contains(job.state) {
-                Text("\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))")
+                Text(stageProgressText(job))
                     .foregroundStyle(.secondary)
             } else if job.state == .error, let msg = job.error {
                 Text(msg)
@@ -251,6 +251,16 @@ struct MenuBarView: View {
             }
         }
         .font(.caption2)
+    }
+
+    /// Live elapsed for the active stage, plus the historical average ("· Ø
+    /// m:ss") when one exists, so the user can tell at a glance whether the
+    /// current run is taking longer than usual.
+    private func stageProgressText(_ job: PipelineJob) -> String {
+        let base = "\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))"
+        guard let stage = StageKind(jobState: job.state),
+              let avg = pipelineQueue.stageAverageSeconds[stage], avg > 0 else { return base }
+        return "\(base) · Ø \(formattedElapsed(avg))"
     }
 
     private func formattedElapsed(_ seconds: TimeInterval) -> String {

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -87,6 +87,7 @@ final class PipelineController {
             speakerMatcherFactory: { SpeakerMatcher() },
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),
+            stageTimingLog: StageTimingLog(),
         )
         q.loadSnapshot()
         // Fire-and-forget: dir scan + per-file attr probes run off-main so app

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -30,6 +30,10 @@ class PipelineQueue {
     /// tests leave it nil unless they explicitly want to assert on the log.
     let recognitionStatsLog: RecognitionStatsLog?
 
+    /// nil disables per-stage timing capture. AppState injects a real instance;
+    /// tests leave it nil unless asserting on the log.
+    let stageTimingLog: StageTimingLog?
+
     let completedJobLifetime: TimeInterval
 
     /// Disk persistence for speaker-naming sidecars (keyed by per-job slug).
@@ -42,6 +46,20 @@ class PipelineQueue {
     /// Elapsed seconds since the current pipeline stage started.
     private(set) var activeJobElapsed: TimeInterval = 0
     private(set) var isProcessing = false
+
+    /// Historical average wall-clock seconds per stage (last 30 days), used by
+    /// the menu to show "live vs. typical". Refreshed from `stageTimingLog` at
+    /// launch and after each stage completes; empty until the log has data.
+    private(set) var stageAverageSeconds: [StageKind: Double] = [:]
+
+    /// When the current `.transcribing`/`.diarizing`/`.generatingProtocol` state
+    /// was entered, per job — so `updateJobState` can record the state's duration
+    /// on exit (keyed by job to stay correct if transitions ever interleave).
+    private var stageStartByJob: [UUID: ContinuousClock.Instant] = [:]
+    /// Audio length (seconds) each job processed, captured when transcription
+    /// completes, so stage durations can be normalised into an RTF.
+    private var jobAudioSeconds: [UUID: Double] = [:]
+
     private var elapsedTimer: Task<Void, Never>?
     private var processTask: Task<Void, Never>?
     private var cancelledJobIDs = Set<UUID>()
@@ -281,6 +299,7 @@ class PipelineQueue {
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
         self.recognitionStatsLog = nil
+        self.stageTimingLog = nil
         self.completedJobLifetime = completedJobLifetime
         self.namingStore = SpeakerNamingStore(outputDir: nil)
     }
@@ -344,6 +363,7 @@ class PipelineQueue {
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
         recognitionStatsLog: RecognitionStatsLog? = nil,
+        stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
@@ -367,8 +387,10 @@ class PipelineQueue {
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig
         self.recognitionStatsLog = recognitionStatsLog
+        self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.namingStore = SpeakerNamingStore(outputDir: outputDir)
+        refreshStageAverages()
     }
 
     var activeJobs: [PipelineJob] {
@@ -420,6 +442,8 @@ class PipelineQueue {
             markProcessed(mixPath: jobs[index].mixPath)
             jobs.remove(at: index)
         }
+        stageStartByJob.removeValue(forKey: id)
+        jobAudioSeconds.removeValue(forKey: id)
         saveSnapshot()
     }
 
@@ -458,6 +482,7 @@ class PipelineQueue {
         let oldState = jobs[index].state
         jobs[index].state = newState
         if let error { jobs[index].error = error }
+        recordStageTransition(from: oldState, to: newState, jobID: id)
         appendLog(jobID: id, event: "state_change", from: oldState, to: newState)
         saveSnapshot()
         onJobStateChange?(jobs[index], oldState, newState)
@@ -498,6 +523,49 @@ class PipelineQueue {
     private func stopElapsedTimer() {
         elapsedTimer?.cancel()
         elapsedTimer = nil
+    }
+
+    // MARK: - Stage timing metrics
+
+    /// On every state change: if we left a timed stage, log its wall-clock
+    /// duration; if we entered one, stamp its start. Measuring per-state means
+    /// the recorded duration matches exactly what the menu's elapsed timer shows
+    /// and excludes the speaker-naming pause (see `StageKind(jobState:)`).
+    private func recordStageTransition(from oldState: JobState, to newState: JobState, jobID: UUID) {
+        if let leaving = StageKind(jobState: oldState), let start = stageStartByJob.removeValue(forKey: jobID) {
+            let elapsed = ContinuousClock.now - start
+            let seconds = Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+            logStageTiming(stage: leaving, wallClock: seconds, jobID: jobID)
+        }
+        if StageKind(jobState: newState) != nil {
+            stageStartByJob[jobID] = ContinuousClock.now
+        }
+    }
+
+    /// Append one stage-timing event (fire-and-forget) and refresh the cached
+    /// averages so the menu reflects the new data point.
+    private func logStageTiming(stage: StageKind, wallClock: Double, jobID: UUID) {
+        guard let stageTimingLog else { return }
+        let event = StageTimingEvent(
+            ts: Date(), jobID: jobID, stage: stage,
+            wallClockSeconds: wallClock, audioSeconds: jobAudioSeconds[jobID] ?? 0,
+            engine: engine.map { String(describing: type(of: $0)) },
+            diarizerMode: usedDiarizerMode(forJobID: jobID)?.rawValue,
+        )
+        Task { await stageTimingLog.append([event]) }
+        refreshStageAverages()
+    }
+
+    /// Reload recent timings and recompute the per-stage average wall-clock.
+    private func refreshStageAverages() {
+        guard let stageTimingLog else { return }
+        Task { [weak self] in
+            let events = await stageTimingLog.loadRecent(within: 30 * 86400)
+            let averages = StageTimingStats.aggregate(events: events)
+                .mapValues(\.avgWallClockSeconds)
+            self?.stageAverageSeconds = averages
+        }
     }
 
     // MARK: - Processing
@@ -727,6 +795,9 @@ class PipelineQueue {
 
         let segCount = cachedSegments?.count ?? 0
         let totalSecs = cachedSegments?.last?.end ?? 0
+        // Stash for stage-timing RTF: diarization/protocol of this job process
+        // the same audio length.
+        jobAudioSeconds[ctx.jobID] = totalSecs
         logger.info(
             "[\(ctx.shortID, privacy: .public)] transcription_complete segments=\(segCount, privacy: .public) duration=\(totalSecs, privacy: .public)s",
         )

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -284,6 +284,7 @@ class PipelineQueue {
         logDir: URL? = nil,
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
+        stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
@@ -299,7 +300,7 @@ class PipelineQueue {
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
         self.recognitionStatsLog = nil
-        self.stageTimingLog = nil
+        self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.namingStore = SpeakerNamingStore(outputDir: nil)
     }
@@ -453,6 +454,11 @@ class PipelineQueue {
         guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
         let state = jobs[index].state
         let slug = jobs[index].namingSlug
+        // cancelJob removes the job directly (not via removeJob) and skips the
+        // normal terminal transition, so reap the stage-timing bookkeeping here
+        // too — otherwise a job cancelled mid-stage leaks these entries.
+        stageStartByJob.removeValue(forKey: id)
+        jobAudioSeconds.removeValue(forKey: id)
         switch state {
         case .waiting:
             jobs.remove(at: index)
@@ -532,6 +538,10 @@ class PipelineQueue {
     /// the recorded duration matches exactly what the menu's elapsed timer shows
     /// and excludes the speaker-naming pause (see `StageKind(jobState:)`).
     private func recordStageTransition(from oldState: JobState, to newState: JobState, jobID: UUID) {
+        // A same-state "transition" (e.g. the inline speaker-count rerun re-enters
+        // .diarizing while already .diarizing) is not a stage boundary — ignore it
+        // so it neither logs a partial event nor resets the start.
+        guard oldState != newState else { return }
         if let leaving = StageKind(jobState: oldState), let start = stageStartByJob.removeValue(forKey: jobID) {
             let elapsed = ContinuousClock.now - start
             let seconds = Double(elapsed.components.seconds)
@@ -543,29 +553,37 @@ class PipelineQueue {
         }
     }
 
-    /// Append one stage-timing event (fire-and-forget) and refresh the cached
-    /// averages so the menu reflects the new data point.
+    /// Append one stage-timing event, then refresh the cached averages from the
+    /// log so the menu reflects the new data point. Append and reload run in one
+    /// Task so the reload is ordered strictly after the append (no race that
+    /// could miss the just-logged event).
     private func logStageTiming(stage: StageKind, wallClock: Double, jobID: UUID) {
         guard let stageTimingLog else { return }
+        // audioSeconds is 0 for stages with no known audio length (e.g. a late
+        // re-diarization with no transcription this session); aggregate() then
+        // excludes it from the RTF but still counts its wall-clock.
         let event = StageTimingEvent(
             ts: Date(), jobID: jobID, stage: stage,
             wallClockSeconds: wallClock, audioSeconds: jobAudioSeconds[jobID] ?? 0,
             engine: engine.map { String(describing: type(of: $0)) },
             diarizerMode: usedDiarizerMode(forJobID: jobID)?.rawValue,
         )
-        Task { await stageTimingLog.append([event]) }
-        refreshStageAverages()
+        Task { [weak self] in
+            await stageTimingLog.append([event])
+            await self?.reloadStageAverages()
+        }
     }
 
     /// Reload recent timings and recompute the per-stage average wall-clock.
     private func refreshStageAverages() {
+        Task { [weak self] in await self?.reloadStageAverages() }
+    }
+
+    private func reloadStageAverages() async {
         guard let stageTimingLog else { return }
-        Task { [weak self] in
-            let events = await stageTimingLog.loadRecent(within: 30 * 86400)
-            let averages = StageTimingStats.aggregate(events: events)
-                .mapValues(\.avgWallClockSeconds)
-            self?.stageAverageSeconds = averages
-        }
+        let events = await stageTimingLog.loadRecent(within: 30 * 86400)
+        stageAverageSeconds = StageTimingStats.aggregate(events: events)
+            .mapValues(\.avgWallClockSeconds)
     }
 
     // MARK: - Processing

--- a/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
+++ b/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
@@ -17,8 +17,13 @@ struct ProcessingStatsView: View {
 
     enum WindowChoice: Int, CaseIterable, Identifiable {
         case seven = 7, thirty = 30, ninety = 90
-        var id: Int { rawValue }
-        var label: String { "Last \(rawValue) days" }
+        var id: Int {
+            rawValue
+        }
+
+        var label: String {
+            "Last \(rawValue) days"
+        }
     }
 
     var body: some View {

--- a/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
+++ b/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
@@ -43,7 +43,7 @@ struct ProcessingStatsView: View {
                 } else {
                     ForEach(StageKind.allCases, id: \.self) { stage in
                         if let agg = aggregates[stage] {
-                            statRow(agg)
+                            statRow(stage, agg)
                         }
                     }
                 }
@@ -64,10 +64,10 @@ struct ProcessingStatsView: View {
         .task(id: windowDays) { await reload() }
     }
 
-    private func statRow(_ agg: StageTimingStats.StageAggregate) -> some View {
-        LabeledContent(agg.stage.label) {
+    private func statRow(_ stage: StageKind, _ agg: StageTimingStats.StageAggregate) -> some View {
+        LabeledContent(stage.label) {
             HStack(spacing: 8) {
-                Text("Ø \(StageTimingStats.formatDuration(agg.avgWallClockSeconds))")
+                Text("Ø \(formattedTime(agg.avgWallClockSeconds))")
                 if let rtf = agg.avgRTF {
                     // RTF is processing-seconds per audio-second; ×60 reads as
                     // "processing seconds per minute of audio" — the intuitive form.

--- a/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
+++ b/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
@@ -1,0 +1,85 @@
+import AppKit
+import SwiftUI
+
+/// Surfaces average per-stage processing durations from `stage_timing.jsonl` so
+/// the user can tell whether a long-running transcription/diarization is normal.
+/// The JSONL file remains the source of truth; this view is read-only.
+struct ProcessingStatsView: View {
+    // swiftlint:disable:next discouraged_optional_collection
+    @State private var aggregates: [StageKind: StageTimingStats.StageAggregate]?
+    @State private var windowDays: WindowChoice = .thirty
+
+    private let log: StageTimingLog
+
+    init(log: StageTimingLog) {
+        self.log = log
+    }
+
+    enum WindowChoice: Int, CaseIterable, Identifiable {
+        case seven = 7, thirty = 30, ninety = 90
+        var id: Int { rawValue }
+        var label: String { "Last \(rawValue) days" }
+    }
+
+    var body: some View {
+        Section("Processing Stats") {
+            Picker("Window", selection: $windowDays) {
+                ForEach(WindowChoice.allCases) { choice in
+                    Text(choice.label).tag(choice)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if let aggregates {
+                if aggregates.isEmpty {
+                    Text("No data yet — process a meeting to start collecting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(StageKind.allCases, id: \.self) { stage in
+                        if let agg = aggregates[stage] {
+                            statRow(agg)
+                        }
+                    }
+                }
+            } else {
+                ProgressView().frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            HStack {
+                Button("Open Log Folder") {
+                    NSWorkspace.shared.activateFileViewerSelecting([StageTimingLog.defaultPath])
+                }
+                Spacer()
+                Button("Reload") {
+                    Task { await reload() }
+                }
+            }
+        }
+        .task(id: windowDays) { await reload() }
+    }
+
+    private func statRow(_ agg: StageTimingStats.StageAggregate) -> some View {
+        LabeledContent(agg.stage.label) {
+            HStack(spacing: 8) {
+                Text("Ø \(StageTimingStats.formatDuration(agg.avgWallClockSeconds))")
+                if let rtf = agg.avgRTF {
+                    // RTF is processing-seconds per audio-second; ×60 reads as
+                    // "processing seconds per minute of audio" — the intuitive form.
+                    Text(String(format: "%.1f s/audio-min", rtf * 60))
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+                Text("(n=\(agg.count))")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private func reload() async {
+        let interval = TimeInterval(windowDays.rawValue * 86400)
+        let events = await log.loadRecent(within: interval)
+        aggregates = StageTimingStats.aggregate(events: events)
+    }
+}

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -10,6 +10,7 @@ private struct KnownVoicesSheetItem: Identifiable {
 struct SpeakersSettingsView: View {
     @Bindable var settings: AppSettings
     var recognitionStatsLog: RecognitionStatsLog
+    var stageTimingLog: StageTimingLog
     var enrollmentDiarizerFactory: (() -> any DiarizationProvider)?
     var namingDialogActive: Bool
     var pipelineBusy: Bool
@@ -77,6 +78,8 @@ struct SpeakersSettingsView: View {
             }
 
             RecognitionStatsView(log: recognitionStatsLog)
+
+            ProcessingStatsView(log: stageTimingLog)
         }
         .formStyle(.grouped)
         .sheet(item: $knownVoicesSheet) { item in

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -9,6 +9,9 @@ struct SettingsView: View {
     /// Required: the same actor instance the pipeline writes to, so the Stats
     /// tab and the pipeline don't race two writers on `recognition_log.jsonl`.
     var recognitionStatsLog: RecognitionStatsLog
+    /// Same actor instance the pipeline writes to, so the Processing Stats tab
+    /// and the pipeline don't race two writers on `stage_timing.jsonl`.
+    var stageTimingLog: StageTimingLog
     /// Factory for the voice-enrollment diarizer. nil → enroll button hidden.
     var enrollmentDiarizerFactory: (() -> any DiarizationProvider)?
     /// True when a meeting is currently waiting on a naming dialog. We gate
@@ -66,6 +69,7 @@ struct SettingsView: View {
             SpeakersSettingsView(
                 settings: settings,
                 recognitionStatsLog: recognitionStatsLog,
+                stageTimingLog: stageTimingLog,
                 enrollmentDiarizerFactory: enrollmentDiarizerFactory,
                 namingDialogActive: namingDialogActive,
                 pipelineBusy: pipelineBusy,

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -3,11 +3,13 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "StageTimingStats")
 
-/// A pipeline stage whose wall-clock duration we track. Raw values match the
-/// corresponding `JobState` cases so the menu can look an average up by state.
+/// A pipeline stage whose wall-clock duration we track. The raw values are the
+/// `stage_timing.jsonl` wire contract; map from a `JobState` via the
+/// `init?(jobState:)` below.
 enum StageKind: String, Codable, CaseIterable {
     case transcribing
     case diarizing
+    // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
     case generatingProtocol
 
     var label: String {

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -63,6 +63,15 @@ enum StageTimingStats {
         let avgRTF: Double?
     }
 
+    /// Format a duration as `m:ss` (or `Ns` under a minute) for compact display
+    /// in the menu and Settings. Shared so the live elapsed timer and the
+    /// historical average render identically.
+    static func formatDuration(_ seconds: Double) -> String {
+        let total = Int(seconds)
+        if total < 60 { return "\(total)s" }
+        return "\(total / 60):\(String(format: "%02d", total % 60))"
+    }
+
     /// Group events by stage and compute per-stage count / average wall-clock /
     /// average RTF. Events whose `audioSeconds <= 0` still count toward
     /// `count` and `avgWallClockSeconds` but are excluded from the RTF ratio so

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -17,6 +17,19 @@ enum StageKind: String, Codable, CaseIterable {
         case .generatingProtocol: "Protocol"
         }
     }
+
+    /// The timed stage a `JobState` corresponds to, or nil for non-timed states
+    /// (`.waiting`, `.speakerNamingPending`, `.done`, `.error`). The speaker-
+    /// naming wait is its own state, so its human-paced duration is never
+    /// attributed to diarization.
+    init?(jobState: JobState) {
+        switch jobState {
+        case .transcribing: self = .transcribing
+        case .diarizing: self = .diarizing
+        case .generatingProtocol: self = .generatingProtocol
+        default: return nil
+        }
+    }
 }
 
 /// One row in the JSONL stage-timing log: how long a single pipeline stage of a

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -1,0 +1,144 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "StageTimingStats")
+
+/// A pipeline stage whose wall-clock duration we track. Raw values match the
+/// corresponding `JobState` cases so the menu can look an average up by state.
+enum StageKind: String, Codable, CaseIterable {
+    case transcribing
+    case diarizing
+    case generatingProtocol
+
+    var label: String {
+        switch self {
+        case .transcribing: "Transcribing"
+        case .diarizing: "Diarizing"
+        case .generatingProtocol: "Protocol"
+        }
+    }
+}
+
+/// One row in the JSONL stage-timing log: how long a single pipeline stage of a
+/// single job took, plus the audio length it processed so a real-time factor is
+/// derivable. `engine` / `diarizerMode` are context tags that make averages
+/// comparable (a Sortformer diarization is not the same cost as an offline one).
+struct StageTimingEvent: Codable, Equatable {
+    let ts: Date
+    let jobID: UUID
+    let stage: StageKind
+    let wallClockSeconds: Double
+    /// Seconds of audio the stage processed (last segment end). 0 when unknown.
+    let audioSeconds: Double
+    let engine: String?
+    let diarizerMode: String?
+}
+
+enum StageTimingStats {
+    /// Aggregate of one stage over a set of events.
+    struct StageAggregate: Equatable {
+        let stage: StageKind
+        let count: Int
+        /// Mean wall-clock duration — the intuitive "how long does it usually
+        /// take" number shown in the menu and Settings.
+        let avgWallClockSeconds: Double
+        /// Average real-time factor = processing-seconds per second of audio,
+        /// computed as a ratio of totals (sum of wall-clock over sum of audio)
+        /// so a long meeting weighs more than a short one — the right basis for
+        /// "how long will THIS meeting take". `nil` when no event carried a
+        /// positive audio duration (can't normalise).
+        let avgRTF: Double?
+    }
+
+    /// Group events by stage and compute per-stage count / average wall-clock /
+    /// average RTF. Events whose `audioSeconds <= 0` still count toward
+    /// `count` and `avgWallClockSeconds` but are excluded from the RTF ratio so
+    /// they neither divide by zero nor skew throughput.
+    static func aggregate(events: [StageTimingEvent]) -> [StageKind: StageAggregate] {
+        var byStage: [StageKind: [StageTimingEvent]] = [:]
+        for e in events {
+            byStage[e.stage, default: []].append(e)
+        }
+        return byStage.mapValues { stageEvents in
+            let count = stageEvents.count
+            let avgWall = stageEvents.reduce(0.0) { $0 + $1.wallClockSeconds } / Double(count)
+            let withAudio = stageEvents.filter { $0.audioSeconds > 0 }
+            let avgRTF: Double?
+            if withAudio.isEmpty {
+                avgRTF = nil
+            } else {
+                let totalWall = withAudio.reduce(0.0) { $0 + $1.wallClockSeconds }
+                let totalAudio = withAudio.reduce(0.0) { $0 + $1.audioSeconds }
+                avgRTF = totalWall / totalAudio
+            }
+            return StageAggregate(
+                stage: stageEvents[0].stage, count: count,
+                avgWallClockSeconds: avgWall, avgRTF: avgRTF,
+            )
+        }
+    }
+}
+
+/// Append-only JSONL writer for stage-timing events. One file per app install,
+/// owner-readable (chmod 0600 on first creation). Production callers use the
+/// no-arg `init()`; tests pass an explicit `path:` to avoid polluting the real
+/// log. Mirrors `RecognitionStatsLog`.
+actor StageTimingLog {
+    static let defaultPath = AppPaths.dataDir.appendingPathComponent("stage_timing.jsonl")
+
+    private let path: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(path: URL = StageTimingLog.defaultPath) {
+        self.path = path
+        self.encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func append(_ events: [StageTimingEvent]) {
+        guard !events.isEmpty else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: path.deletingLastPathComponent(), withIntermediateDirectories: true,
+            )
+
+            if !FileManager.default.fileExists(atPath: path.path) {
+                FileManager.default.createFile(
+                    atPath: path.path, contents: nil,
+                    attributes: [.posixPermissions: 0o600],
+                )
+            }
+
+            let handle = try FileHandle(forWritingTo: path)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            for event in events {
+                let line = try encoder.encode(event) + Data([0x0A])
+                try handle.write(contentsOf: line)
+            }
+            try handle.synchronize()
+        } catch {
+            logger.error("Failed to append stage-timing events: \(error.localizedDescription)")
+        }
+    }
+
+    /// Load events with `ts` within the last `interval` seconds. Skips lines that
+    /// fail to decode (forward-compat for future schema changes).
+    func loadRecent(within interval: TimeInterval, now: Date = Date()) -> [StageTimingEvent] {
+        guard let data = try? Data(contentsOf: path),
+              let text = String(data: data, encoding: .utf8) else { return [] }
+        let cutoff = now.addingTimeInterval(-interval)
+        var out: [StageTimingEvent] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let lineData = line.data(using: .utf8),
+                  let event = try? decoder.decode(StageTimingEvent.self, from: lineData),
+                  event.ts >= cutoff else { continue }
+            out.append(event)
+        }
+        return out
+    }
+}

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -50,9 +50,9 @@ struct StageTimingEvent: Codable, Equatable {
 }
 
 enum StageTimingStats {
-    /// Aggregate of one stage over a set of events.
+    /// Aggregate of one stage over a set of events. Returned keyed by stage, so
+    /// the stage itself is the dictionary key, not a field here.
     struct StageAggregate: Equatable {
-        let stage: StageKind
         let count: Int
         /// Mean wall-clock duration — the intuitive "how long does it usually
         /// take" number shown in the menu and Settings.
@@ -63,15 +63,6 @@ enum StageTimingStats {
         /// "how long will THIS meeting take". `nil` when no event carried a
         /// positive audio duration (can't normalise).
         let avgRTF: Double?
-    }
-
-    /// Format a duration as `m:ss` (or `Ns` under a minute) for compact display
-    /// in the menu and Settings. Shared so the live elapsed timer and the
-    /// historical average render identically.
-    static func formatDuration(_ seconds: Double) -> String {
-        let total = Int(seconds)
-        if total < 60 { return "\(total)s" }
-        return "\(total / 60):\(String(format: "%02d", total % 60))"
     }
 
     /// Group events by stage and compute per-stage count / average wall-clock /
@@ -95,10 +86,7 @@ enum StageTimingStats {
                 let totalAudio = withAudio.reduce(0.0) { $0 + $1.audioSeconds }
                 avgRTF = totalWall / totalAudio
             }
-            return StageAggregate(
-                stage: stageEvents[0].stage, count: count,
-                avgWallClockSeconds: avgWall, avgRTF: avgRTF,
-            )
+            return StageAggregate(count: count, avgWallClockSeconds: avgWall, avgRTF: avgRTF)
         }
     }
 }

--- a/app/MeetingTranscriber/Tests/PipelineQueueStageTimingTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueStageTimingTests.swift
@@ -1,0 +1,57 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class PipelineQueueStageTimingTests: XCTestCase {
+    private func makeJob() -> PipelineJob {
+        PipelineJob(
+            meetingTitle: "Test Meeting",
+            appName: "Microsoft Teams",
+            mixPath: URL(fileURLWithPath: "/tmp/mix.wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+    }
+
+    /// Drives the state machine through the timed stages plus a `.diarizing`
+    /// self-transition (the inline speaker-count rerun) and the naming pause,
+    /// asserting the log records exactly one event per real stage: the naming
+    /// wait is excluded and the self-transition is not double-counted.
+    func testCapturesOneEventPerStageExcludingNamingAndSelfTransition() async throws {
+        let logDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pq_stage_timing_\(UUID())")
+        try FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: logDir) }
+        let logPath = logDir.appendingPathComponent("stage_timing.jsonl")
+        let log = StageTimingLog(path: logPath)
+        let queue = PipelineQueue(logDir: logDir, stageTimingLog: log)
+
+        let job = makeJob()
+        queue.insertJobForTesting(job)
+
+        queue.updateJobState(id: job.id, to: .transcribing)
+        queue.updateJobState(id: job.id, to: .diarizing)
+        queue.updateJobState(id: job.id, to: .diarizing) // inline rerun self-transition: must not re-log
+        queue.updateJobState(id: job.id, to: .speakerNamingPending) // leaves .diarizing -> logs diarizing
+        queue.updateJobState(id: job.id, to: .generatingProtocol) // naming pause not timed -> no event
+        queue.updateJobState(id: job.id, to: .done) // leaves protocol -> logs protocol
+
+        // Appends run in a per-stage Task; poll until they land.
+        var events: [StageTimingEvent] = []
+        for _ in 0 ..< 200 {
+            events = await log.loadRecent(within: 30 * 86400)
+            if events.count >= 3 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(events.count, 3, "one event per real stage; naming pause + self-transition excluded")
+        XCTAssertEqual(
+            Set(events.map(\.stage)), [.transcribing, .diarizing, .generatingProtocol],
+        )
+        XCTAssertEqual(
+            events.count { $0.stage == .diarizing }, 1,
+            "the .diarizing self-transition must not produce a second diarizing event",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -51,6 +51,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
             qwen3Engine: qwen3,
             updateChecker: updateChecker,
             recognitionStatsLog: RecognitionStatsLog(),
+            stageTimingLog: StageTimingLog(),
         )
     }
 
@@ -85,6 +86,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         SpeakersSettingsView(
             settings: settings ?? makeSettings(),
             recognitionStatsLog: RecognitionStatsLog(),
+            stageTimingLog: StageTimingLog(),
             enrollmentDiarizerFactory: nil,
             namingDialogActive: false,
             pipelineBusy: false,

--- a/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
@@ -64,17 +64,6 @@ final class StageTimingStatsTests: XCTestCase {
         XCTAssertTrue(StageTimingStats.aggregate(events: []).isEmpty)
     }
 
-    // MARK: - Duration formatting
-
-    func testFormatDuration() {
-        XCTAssertEqual(StageTimingStats.formatDuration(0), "0s")
-        XCTAssertEqual(StageTimingStats.formatDuration(45), "45s")
-        XCTAssertEqual(StageTimingStats.formatDuration(59.9), "59s")
-        XCTAssertEqual(StageTimingStats.formatDuration(60), "1:00")
-        XCTAssertEqual(StageTimingStats.formatDuration(530), "8:50")
-        XCTAssertEqual(StageTimingStats.formatDuration(3725), "62:05")
-    }
-
     // MARK: - JobState → StageKind mapping
 
     func testStageKindMapsOnlyTimedStates() {

--- a/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
@@ -64,6 +64,17 @@ final class StageTimingStatsTests: XCTestCase {
         XCTAssertTrue(StageTimingStats.aggregate(events: []).isEmpty)
     }
 
+    // MARK: - Duration formatting
+
+    func testFormatDuration() {
+        XCTAssertEqual(StageTimingStats.formatDuration(0), "0s")
+        XCTAssertEqual(StageTimingStats.formatDuration(45), "45s")
+        XCTAssertEqual(StageTimingStats.formatDuration(59.9), "59s")
+        XCTAssertEqual(StageTimingStats.formatDuration(60), "1:00")
+        XCTAssertEqual(StageTimingStats.formatDuration(530), "8:50")
+        XCTAssertEqual(StageTimingStats.formatDuration(3725), "62:05")
+    }
+
     // MARK: - JobState → StageKind mapping
 
     func testStageKindMapsOnlyTimedStates() {

--- a/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
@@ -1,0 +1,87 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class StageTimingStatsTests: XCTestCase {
+    private func event(
+        _ stage: StageKind, wall: Double, audio: Double, ts: Date = Date(),
+    ) -> StageTimingEvent {
+        StageTimingEvent(
+            ts: ts, jobID: UUID(), stage: stage,
+            wallClockSeconds: wall, audioSeconds: audio,
+            engine: "parakeet", diarizerMode: stage == .diarizing ? "offline" : nil,
+        )
+    }
+
+    // MARK: - Aggregation
+
+    func testAggregateGroupsByStageAndAveragesWallClock() {
+        let events = [
+            event(.diarizing, wall: 600, audio: 6000),
+            event(.diarizing, wall: 400, audio: 4000),
+            event(.transcribing, wall: 120, audio: 6000),
+        ]
+        let agg = StageTimingStats.aggregate(events: events)
+
+        XCTAssertEqual(agg[.diarizing]?.count, 2)
+        XCTAssertEqual(agg[.diarizing]?.avgWallClockSeconds ?? 0, 500, accuracy: 0.001)
+        XCTAssertEqual(agg[.transcribing]?.count, 1)
+        XCTAssertEqual(agg[.transcribing]?.avgWallClockSeconds ?? 0, 120, accuracy: 0.001)
+    }
+
+    func testAvgRTFIsRatioOfTotalsNotMeanOfRatios() {
+        // Throughput across the whole corpus: sum(wall)/sum(audio), so a long
+        // meeting weighs more than a short one. (600+400)/(6000+4000) = 0.1.
+        let events = [
+            event(.diarizing, wall: 600, audio: 6000),
+            event(.diarizing, wall: 400, audio: 4000),
+        ]
+        let agg = StageTimingStats.aggregate(events: events)
+        XCTAssertEqual(agg[.diarizing]?.avgRTF ?? -1, 0.1, accuracy: 0.0001)
+    }
+
+    func testAvgRTFNilWhenNoPositiveAudio() {
+        // A stage whose events all report 0s of audio can't be normalised.
+        let events = [event(.transcribing, wall: 30, audio: 0)]
+        let agg = StageTimingStats.aggregate(events: events)
+        XCTAssertEqual(agg[.transcribing]?.count, 1)
+        XCTAssertNil(agg[.transcribing]?.avgRTF)
+    }
+
+    func testAvgRTFSkipsZeroAudioEventsButKeepsCount() {
+        // A zero-audio outlier must not poison the RTF (no divide-by-zero, not
+        // counted in the throughput) yet still counts toward avgWallClock/count.
+        let events = [
+            event(.diarizing, wall: 500, audio: 5000),
+            event(.diarizing, wall: 999, audio: 0),
+        ]
+        let agg = StageTimingStats.aggregate(events: events)
+        XCTAssertEqual(agg[.diarizing]?.count, 2)
+        XCTAssertEqual(agg[.diarizing]?.avgRTF ?? -1, 0.1, accuracy: 0.0001)
+        XCTAssertEqual(agg[.diarizing]?.avgWallClockSeconds ?? 0, 749.5, accuracy: 0.001)
+    }
+
+    func testAggregateEmptyForNoEvents() {
+        XCTAssertTrue(StageTimingStats.aggregate(events: []).isEmpty)
+    }
+
+    // MARK: - Log round-trip + window filtering
+
+    func testLogAppendThenLoadRecentRoundTrips() async {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stage_timing_test_\(UUID()).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let log = StageTimingLog(path: tmp)
+
+        // Whole-second timestamp: the log encodes ts as ISO-8601 (second
+        // precision), so a fractional `now` would not round-trip Equatable.
+        let now = Date(timeIntervalSince1970: 1_781_500_000)
+        let fresh = event(.diarizing, wall: 300, audio: 3000, ts: now)
+        let stale = event(.diarizing, wall: 300, audio: 3000, ts: now.addingTimeInterval(-100 * 86400))
+        await log.append([fresh])
+        await log.append([stale])
+
+        let loaded = await log.loadRecent(within: 30 * 86400, now: now)
+        XCTAssertEqual(loaded.count, 1, "only the in-window event should load")
+        XCTAssertEqual(loaded.first, fresh)
+    }
+}

--- a/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
@@ -64,6 +64,23 @@ final class StageTimingStatsTests: XCTestCase {
         XCTAssertTrue(StageTimingStats.aggregate(events: []).isEmpty)
     }
 
+    // MARK: - JobState → StageKind mapping
+
+    func testStageKindMapsOnlyTimedStates() {
+        XCTAssertEqual(StageKind(jobState: .transcribing), .transcribing)
+        XCTAssertEqual(StageKind(jobState: .diarizing), .diarizing)
+        XCTAssertEqual(StageKind(jobState: .generatingProtocol), .generatingProtocol)
+    }
+
+    func testStageKindExcludesNamingAndTerminalStates() {
+        // The naming wait is human-paced and must never be attributed to a
+        // stage; waiting/done/error aren't compute either.
+        XCTAssertNil(StageKind(jobState: .speakerNamingPending))
+        XCTAssertNil(StageKind(jobState: .waiting))
+        XCTAssertNil(StageKind(jobState: .done))
+        XCTAssertNil(StageKind(jobState: .error))
+    }
+
     // MARK: - Log round-trip + window filtering
 
     func testLogAppendThenLoadRecentRoundTrips() async {


### PR DESCRIPTION
## Why

When a long meeting sits at "Diarizing… 8:50", there was no way to tell whether that's normal — the menu shows live elapsed but there's no baseline to compare against. This adds per-stage duration tracking and surfaces the average, so "is this taking longer than usual?" is answerable.

## What

- **Capture:** `PipelineQueue` records the wall-clock duration of each timed stage (transcription / diarization / protocol) per job, plus the audio length processed, appended to `stage_timing.jsonl` (an append-only owner-only JSONL, mirroring `recognition_log.jsonl`). Durations are measured per *job-state* via the `updateJobState` hook, so the recorded number matches exactly what the menu's elapsed timer shows and the human-paced speaker-naming pause (`.speakerNamingPending`) is never counted as diarization.
- **Settings → Speakers → Processing Stats:** read-only per-stage average duration + average RTF (processing seconds per audio-minute) + sample count, over a 7/30/90-day window.
- **Menu:** the active-stage line gains the historical average next to the live timer, e.g. `Diarizing… 8:50 · Ø 6:40`. Omitted until the log has data, so a fresh install renders exactly as before.

RTF is a ratio of totals (Σ wall-clock / Σ audio) so a long meeting weighs more than a short one — the right basis for estimating the current meeting. The intuitive average duration drives the menu; both are shown in Settings.

## Notes / limitations (PoC scope)

- The average blends engines/diarizer modes; each event carries `engine`/`diarizerMode` tags for later per-config splitting, but the displayed average is not yet filtered by them.
- A late re-diarization with no transcription this session logs `audioSeconds = 0`; that point is excluded from RTF (still counted toward the duration average) rather than mis-attributed.
- The log is append-only with no rotation, matching the existing recognition log; the 30-day read window bounds what's aggregated.

## Testing

- `StageTimingStatsTests`: aggregation (avg duration, RTF as ratio-of-totals, zero-audio excluded from RTF but counted), the `JobState → StageKind` mapping (naming/terminal states excluded), and a log append/loadRecent round-trip with window filtering.
- `PipelineQueueStageTimingTests`: drives the state machine through the timed stages plus a `.diarizing` self-transition (inline rerun) and the naming pause, asserting exactly one event per real stage — mutation-proven (removing the self-transition guard yields 4 events / 2 diarizing).
- Full suite green (excluding the pre-existing local-only `MenuBarIconSnapshotTests` flakes, which pass on CI's renderer).