### PR TITLE
feat(app): stage-timing norms — live 'longer than usual' hint + per-config Settings

### DIFF
--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -261,7 +261,7 @@ struct MenuBarView: View {
         let elapsed = pipelineQueue.activeJobElapsed
         let base = "\(job.state.label) \(formattedElapsed(elapsed))"
         guard let stage = StageKind(jobState: job.state),
-              let avg = pipelineQueue.stageAverageSeconds[stage], avg > 0 else { return base }
+              let avg = pipelineQueue.averageSeconds(forJobID: job.id, stage: stage), avg > 0 else { return base }
         let suffix = StageTimingStats.isSlowerThanUsual(elapsed: elapsed, average: avg)
             ? " · longer than usual (Ø \(formattedElapsed(avg)))"
             : " · Ø \(formattedElapsed(avg))"

--- a/app/MeetingTranscriber/Sources/MenuBarView.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarView.swift
@@ -254,13 +254,18 @@ struct MenuBarView: View {
     }
 
     /// Live elapsed for the active stage, plus the historical average ("· Ø
-    /// m:ss") when one exists, so the user can tell at a glance whether the
-    /// current run is taking longer than usual.
+    /// m:ss") when one exists, and a "longer than usual" hint once the live run
+    /// runs meaningfully past that average — so the user can tell at a glance
+    /// whether the current run is normal. Purely informational.
     private func stageProgressText(_ job: PipelineJob) -> String {
-        let base = "\(job.state.label) \(formattedElapsed(pipelineQueue.activeJobElapsed))"
+        let elapsed = pipelineQueue.activeJobElapsed
+        let base = "\(job.state.label) \(formattedElapsed(elapsed))"
         guard let stage = StageKind(jobState: job.state),
               let avg = pipelineQueue.stageAverageSeconds[stage], avg > 0 else { return base }
-        return "\(base) · Ø \(formattedElapsed(avg))"
+        let suffix = StageTimingStats.isSlowerThanUsual(elapsed: elapsed, average: avg)
+            ? " · longer than usual (Ø \(formattedElapsed(avg)))"
+            : " · Ø \(formattedElapsed(avg))"
+        return base + suffix
     }
 
     private func formattedElapsed(_ seconds: TimeInterval) -> String {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -47,10 +47,13 @@ class PipelineQueue {
     private(set) var activeJobElapsed: TimeInterval = 0
     private(set) var isProcessing = false
 
-    /// Historical average wall-clock seconds per stage (last 30 days), used by
-    /// the menu to show "live vs. typical". Refreshed from `stageTimingLog` at
-    /// launch and after each stage completes; empty until the log has data.
-    private(set) var stageAverageSeconds: [StageKind: Double] = [:]
+    /// Historical average wall-clock seconds per (stage, engine, diarizer-mode)
+    /// config (last 30 days), used by the menu to show "live vs. typical".
+    /// Keyed by full config so the menu compares a Sortformer run against
+    /// Sortformer history, not a blended offline/Sortformer average. Refreshed
+    /// from `stageTimingLog` at launch and after each stage; empty until the log
+    /// has data. Read via `averageSeconds(forJobID:stage:)`.
+    private(set) var stageAverageByConfig: [StageConfig: Double] = [:]
 
     /// When the current `.transcribing`/`.diarizing`/`.generatingProtocol` state
     /// was entered, per job — so `updateJobState` can record the state's duration
@@ -575,12 +578,24 @@ class PipelineQueue {
     }
 
     /// Concrete transcription-engine type name, the comparability tag stamped on
-    /// logged events and used to filter the menu's average to like-with-like.
+    /// logged events; also used to resolve the active config for the menu.
     private var activeEngineTag: String? {
         engine.map { String(describing: type(of: $0)) }
     }
 
-    /// Reload recent timings and recompute the per-stage average wall-clock.
+    /// The historical average for the config a job is running at a given stage —
+    /// built the same way `logStageTiming` stamps events (engine + the job's
+    /// diarizer mode), so the menu compares like-with-like. nil until that exact
+    /// config has logged data.
+    func averageSeconds(forJobID jobID: UUID, stage: StageKind) -> Double? {
+        let config = StageConfig(
+            stage: stage, engine: activeEngineTag,
+            diarizerMode: usedDiarizerMode(forJobID: jobID)?.rawValue,
+        )
+        return stageAverageByConfig[config]
+    }
+
+    /// Reload recent timings and recompute the per-config average wall-clock.
     private func refreshStageAverages() {
         Task { [weak self] in await self?.reloadStageAverages() }
     }
@@ -588,12 +603,9 @@ class PipelineQueue {
     private func reloadStageAverages() async {
         guard let stageTimingLog else { return }
         let events = await stageTimingLog.loadRecent(within: 30 * 86400)
-        // Match the menu average to the active engine so a WhisperKit run isn't
-        // compared against a Parakeet history (and vice versa). With no engine
-        // configured, fall back to the blended average.
-        let tag = activeEngineTag
-        let matched = tag == nil ? events : events.filter { $0.engine == tag }
-        stageAverageSeconds = StageTimingStats.aggregate(events: matched)
+        // Key by full config (stage + engine + diarizer-mode) so the menu
+        // resolves a like-with-like average per active job; see averageSeconds.
+        stageAverageByConfig = StageTimingStats.aggregateByConfig(events: events)
             .mapValues(\.avgWallClockSeconds)
     }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -565,13 +565,19 @@ class PipelineQueue {
         let event = StageTimingEvent(
             ts: Date(), jobID: jobID, stage: stage,
             wallClockSeconds: wallClock, audioSeconds: jobAudioSeconds[jobID] ?? 0,
-            engine: engine.map { String(describing: type(of: $0)) },
+            engine: activeEngineTag,
             diarizerMode: usedDiarizerMode(forJobID: jobID)?.rawValue,
         )
         Task { [weak self] in
             await stageTimingLog.append([event])
             await self?.reloadStageAverages()
         }
+    }
+
+    /// Concrete transcription-engine type name, the comparability tag stamped on
+    /// logged events and used to filter the menu's average to like-with-like.
+    private var activeEngineTag: String? {
+        engine.map { String(describing: type(of: $0)) }
     }
 
     /// Reload recent timings and recompute the per-stage average wall-clock.
@@ -582,7 +588,12 @@ class PipelineQueue {
     private func reloadStageAverages() async {
         guard let stageTimingLog else { return }
         let events = await stageTimingLog.loadRecent(within: 30 * 86400)
-        stageAverageSeconds = StageTimingStats.aggregate(events: events)
+        // Match the menu average to the active engine so a WhisperKit run isn't
+        // compared against a Parakeet history (and vice versa). With no engine
+        // configured, fall back to the blended average.
+        let tag = activeEngineTag
+        let matched = tag == nil ? events : events.filter { $0.engine == tag }
+        stageAverageSeconds = StageTimingStats.aggregate(events: matched)
             .mapValues(\.avgWallClockSeconds)
     }
 

--- a/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
+++ b/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
@@ -83,16 +83,18 @@ struct ProcessingStatsView: View {
     }
 
     /// "Stage · mode · engine" (mode omitted when nil, e.g. transcription);
-    /// the `…Engine` suffix is trimmed for brevity.
+    /// the trailing `Engine` suffix is trimmed for brevity.
     private func configLabel(_ config: StageConfig) -> String {
-        let engine = (config.engine ?? "unknown").replacingOccurrences(of: "Engine", with: "")
+        let raw = config.engine ?? "unknown"
+        let engine = raw.hasSuffix("Engine") ? String(raw.dropLast("Engine".count)) : raw
         var parts = [config.stage.label]
         if let mode = config.diarizerMode { parts.append(mode) }
         parts.append(engine)
         return parts.joined(separator: " · ")
     }
 
-    /// Stage order first (transcribe → diarize → protocol), then label, so rows
+    /// Stage order first (transcribe → diarize → protocol), then engine, then
+    /// mode — a total order over distinct configs (no label rebuilds), so rows
     /// are stable and grouped.
     private func orderedConfigs(
         _ aggs: [StageConfig: StageTimingStats.StageAggregate],
@@ -100,7 +102,9 @@ struct ProcessingStatsView: View {
         aggs.keys.sorted { a, b in
             let ia = StageKind.allCases.firstIndex(of: a.stage) ?? 0
             let ib = StageKind.allCases.firstIndex(of: b.stage) ?? 0
-            return ia != ib ? ia < ib : configLabel(a) < configLabel(b)
+            if ia != ib { return ia < ib }
+            if a.engine != b.engine { return (a.engine ?? "") < (b.engine ?? "") }
+            return (a.diarizerMode ?? "") < (b.diarizerMode ?? "")
         }
     }
 

--- a/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
+++ b/app/MeetingTranscriber/Sources/ProcessingStatsView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// The JSONL file remains the source of truth; this view is read-only.
 struct ProcessingStatsView: View {
     // swiftlint:disable:next discouraged_optional_collection
-    @State private var aggregates: [StageKind: StageTimingStats.StageAggregate]?
+    @State private var aggregates: [StageConfig: StageTimingStats.StageAggregate]?
     @State private var windowDays: WindowChoice = .thirty
 
     private let log: StageTimingLog
@@ -41,9 +41,9 @@ struct ProcessingStatsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(StageKind.allCases, id: \.self) { stage in
-                        if let agg = aggregates[stage] {
-                            statRow(stage, agg)
+                    ForEach(orderedConfigs(aggregates), id: \.self) { config in
+                        if let agg = aggregates[config] {
+                            statRow(config, agg)
                         }
                     }
                 }
@@ -64,8 +64,8 @@ struct ProcessingStatsView: View {
         .task(id: windowDays) { await reload() }
     }
 
-    private func statRow(_ stage: StageKind, _ agg: StageTimingStats.StageAggregate) -> some View {
-        LabeledContent(stage.label) {
+    private func statRow(_ config: StageConfig, _ agg: StageTimingStats.StageAggregate) -> some View {
+        LabeledContent(configLabel(config)) {
             HStack(spacing: 8) {
                 Text("Ø \(formattedTime(agg.avgWallClockSeconds))")
                 if let rtf = agg.avgRTF {
@@ -82,9 +82,31 @@ struct ProcessingStatsView: View {
         }
     }
 
+    /// "Stage · mode · engine" (mode omitted when nil, e.g. transcription);
+    /// the `…Engine` suffix is trimmed for brevity.
+    private func configLabel(_ config: StageConfig) -> String {
+        let engine = (config.engine ?? "unknown").replacingOccurrences(of: "Engine", with: "")
+        var parts = [config.stage.label]
+        if let mode = config.diarizerMode { parts.append(mode) }
+        parts.append(engine)
+        return parts.joined(separator: " · ")
+    }
+
+    /// Stage order first (transcribe → diarize → protocol), then label, so rows
+    /// are stable and grouped.
+    private func orderedConfigs(
+        _ aggs: [StageConfig: StageTimingStats.StageAggregate],
+    ) -> [StageConfig] {
+        aggs.keys.sorted { a, b in
+            let ia = StageKind.allCases.firstIndex(of: a.stage) ?? 0
+            let ib = StageKind.allCases.firstIndex(of: b.stage) ?? 0
+            return ia != ib ? ia < ib : configLabel(a) < configLabel(b)
+        }
+    }
+
     private func reload() async {
         let interval = TimeInterval(windowDays.rawValue * 86400)
         let events = await log.loadRecent(within: interval)
-        aggregates = StageTimingStats.aggregate(events: events)
+        aggregates = StageTimingStats.aggregateByConfig(events: events)
     }
 }

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -49,6 +49,16 @@ struct StageTimingEvent: Codable, Equatable {
     let diarizerMode: String?
 }
 
+/// Identifies one configuration whose timings are comparable. Averages only
+/// mean something within a config: a Parakeet transcription is ~10x a WhisperKit
+/// one, and a Sortformer diarization is far slower than an offline one — so the
+/// norm must be per (stage, engine, diarizer-mode).
+struct StageConfig: Hashable {
+    let stage: StageKind
+    let engine: String?
+    let diarizerMode: String?
+}
+
 enum StageTimingStats {
     /// Aggregate of one stage over a set of events. Returned keyed by stage, so
     /// the stage itself is the dictionary key, not a field here.
@@ -65,29 +75,48 @@ enum StageTimingStats {
         let avgRTF: Double?
     }
 
-    /// Group events by stage and compute per-stage count / average wall-clock /
-    /// average RTF. Events whose `audioSeconds <= 0` still count toward
-    /// `count` and `avgWallClockSeconds` but are excluded from the RTF ratio so
-    /// they neither divide by zero nor skew throughput.
+    /// Compute the count / average wall-clock / average RTF for one group of
+    /// events. Events whose `audioSeconds <= 0` still count toward `count` and
+    /// `avgWallClockSeconds` but are excluded from the RTF ratio so they neither
+    /// divide by zero nor skew throughput.
+    private static func aggregateGroup(_ events: [StageTimingEvent]) -> StageAggregate {
+        let count = events.count
+        let avgWall = events.reduce(0.0) { $0 + $1.wallClockSeconds } / Double(count)
+        let withAudio = events.filter { $0.audioSeconds > 0 }
+        let avgRTF: Double?
+        if withAudio.isEmpty {
+            avgRTF = nil
+        } else {
+            let totalWall = withAudio.reduce(0.0) { $0 + $1.wallClockSeconds }
+            let totalAudio = withAudio.reduce(0.0) { $0 + $1.audioSeconds }
+            avgRTF = totalWall / totalAudio
+        }
+        return StageAggregate(count: count, avgWallClockSeconds: avgWall, avgRTF: avgRTF)
+    }
+
+    /// Group events by stage (blending all engines/modes).
     static func aggregate(events: [StageTimingEvent]) -> [StageKind: StageAggregate] {
-        var byStage: [StageKind: [StageTimingEvent]] = [:]
-        for e in events {
-            byStage[e.stage, default: []].append(e)
-        }
-        return byStage.mapValues { stageEvents in
-            let count = stageEvents.count
-            let avgWall = stageEvents.reduce(0.0) { $0 + $1.wallClockSeconds } / Double(count)
-            let withAudio = stageEvents.filter { $0.audioSeconds > 0 }
-            let avgRTF: Double?
-            if withAudio.isEmpty {
-                avgRTF = nil
-            } else {
-                let totalWall = withAudio.reduce(0.0) { $0 + $1.wallClockSeconds }
-                let totalAudio = withAudio.reduce(0.0) { $0 + $1.audioSeconds }
-                avgRTF = totalWall / totalAudio
-            }
-            return StageAggregate(count: count, avgWallClockSeconds: avgWall, avgRTF: avgRTF)
-        }
+        Dictionary(grouping: events, by: \.stage).mapValues(aggregateGroup)
+    }
+
+    /// Group events by full (stage, engine, diarizer-mode) configuration, so the
+    /// Settings view can show comparable per-config numbers.
+    static func aggregateByConfig(events: [StageTimingEvent]) -> [StageConfig: StageAggregate] {
+        Dictionary(grouping: events) { event in
+            StageConfig(stage: event.stage, engine: event.engine, diarizerMode: event.diarizerMode)
+        }.mapValues(aggregateGroup)
+    }
+
+    /// Whether a still-running stage is taking meaningfully longer than its norm
+    /// — for an informational "longer than usual" hint, never an action.
+    /// Requires BOTH a ratio overrun AND an absolute floor, so a tiny stage
+    /// (whose average is a few seconds) doesn't trip on ordinary jitter — the
+    /// same small-denominator guard the build-perf tracker uses.
+    static func isSlowerThanUsual(
+        elapsed: Double, average: Double,
+        marginFactor: Double = 1.5, minOverrunSeconds: Double = 30,
+    ) -> Bool {
+        average > 0 && elapsed > average * marginFactor && (elapsed - average) >= minOverrunSeconds
     }
 }
 

--- a/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
+++ b/app/MeetingTranscriber/Tests/StageTimingStatsTests.swift
@@ -4,12 +4,50 @@ import XCTest
 final class StageTimingStatsTests: XCTestCase {
     private func event(
         _ stage: StageKind, wall: Double, audio: Double, ts: Date = Date(),
+        engine: String? = "parakeet", mode: String? = nil,
     ) -> StageTimingEvent {
         StageTimingEvent(
             ts: ts, jobID: UUID(), stage: stage,
             wallClockSeconds: wall, audioSeconds: audio,
-            engine: "parakeet", diarizerMode: stage == .diarizing ? "offline" : nil,
+            engine: engine, diarizerMode: mode ?? (stage == .diarizing ? "offline" : nil),
         )
+    }
+
+    // MARK: - Per-config aggregation
+
+    func testAggregateByConfigSeparatesEngineAndMode() {
+        let events = [
+            event(.diarizing, wall: 600, audio: 6000, engine: "Parakeet", mode: "offline"),
+            event(.diarizing, wall: 1200, audio: 6000, engine: "Parakeet", mode: "sortformer"),
+            event(.diarizing, wall: 300, audio: 6000, engine: "WhisperKit", mode: "offline"),
+        ]
+        let agg = StageTimingStats.aggregateByConfig(events: events)
+        XCTAssertEqual(agg.count, 3, "three distinct (stage, engine, mode) configs")
+        XCTAssertEqual(
+            agg[StageConfig(stage: .diarizing, engine: "Parakeet", diarizerMode: "offline")]?
+                .avgWallClockSeconds ?? 0, 600, accuracy: 0.001,
+        )
+        XCTAssertEqual(
+            agg[StageConfig(stage: .diarizing, engine: "Parakeet", diarizerMode: "sortformer")]?
+                .avgWallClockSeconds ?? 0, 1200, accuracy: 0.001,
+        )
+    }
+
+    // MARK: - Slower-than-usual decision
+
+    func testIsSlowerThanUsualNeedsBothRatioAndAbsoluteFloor() {
+        // Ratio (>1.5x) and overrun (>=30s) both met.
+        XCTAssertTrue(StageTimingStats.isSlowerThanUsual(elapsed: 80, average: 40))
+        // Floor is inclusive at exactly +30s (still >1.5x: 70 > 60).
+        XCTAssertTrue(StageTimingStats.isSlowerThanUsual(elapsed: 70, average: 40))
+        // Ratio met but overrun 29s < 30s floor → not flagged (tiny-stage noise).
+        XCTAssertFalse(StageTimingStats.isSlowerThanUsual(elapsed: 69, average: 40))
+        // Overrun big but ratio not met (1.25x).
+        XCTAssertFalse(StageTimingStats.isSlowerThanUsual(elapsed: 500, average: 400))
+        // Exactly 1.5x is not "more than" 1.5x.
+        XCTAssertFalse(StageTimingStats.isSlowerThanUsual(elapsed: 60, average: 40))
+        // No norm yet.
+        XCTAssertFalse(StageTimingStats.isSlowerThanUsual(elapsed: 100, average: 0))
     }
 
     // MARK: - Aggregation


### PR DESCRIPTION
Builds on the stage-timing PoC (#430): turns the recorded per-stage durations into a **norm** so the app can flag a run that's abnormally slow, and splits the Settings readout by configuration.

## What

- **Menu:** once a running stage passes its historical norm, the line reads `Diarizing… 12:30 · longer than usual (Ø 6:40)` instead of `· Ø 6:40`. The "slower than usual" check (`StageTimingStats.isSlowerThanUsual`) requires **both** a ratio (>1.5×) **and** an absolute floor (≥30s over the average), so a few-second stage never trips on jitter (same small-denominator guard as the build-perf tracker). Purely informational — never cancels or changes behaviour.
- **Settings → Speakers → Processing Stats:** rows are split per **(stage · mode · engine)** via `aggregateByConfig`, so Parakeet-offline isn't averaged with WhisperKit-Sortformer.
- The norm is **config-matched**: the menu resolves each job's exact `StageConfig` (engine + that job's diarizer mode) the same way `logStageTiming` stamps events, and looks up `stageAverageByConfig` — so a Sortformer run is compared against Sortformer history, not a blend.

## Why this matters

This pass found its own first bug in the field: a protocol-generation run sitting at **114:34 vs Ø 5:15** made an LLM hang obvious at a glance. The norm makes that proactive.

## Review

`/simplify` + `/code-review` run; both flagged that the first cut filtered the menu average by transcription-engine only (ignoring diarizer mode), which mis-compared offline vs Sortformer diarization. Fixed by keying the cache on full `StageConfig` and resolving the active job's config (final commit). Also: `configLabel` trims the trailing `Engine` suffix (not a substring replace), and `orderedConfigs` is a total order with no per-comparison string rebuild.

## Testing

- `StageTimingStatsTests`: `aggregateByConfig` separates engine+mode; `isSlowerThanUsual` boundary cases (ratio AND floor, both inclusive/exclusive edges).
- Build green, lint clean; StageTimingStats + MenuBarView suites green locally. Full suite (incl. SettingsView) runs here on CI.