### PR TITLE
fix(app): bound OpenAI protocol generation with a hard total deadline

### DIFF
--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -9,7 +9,15 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     let model: String
     let apiKey: String?
     let language: String
+    /// Idle timeout (`URLRequest.timeoutInterval`): max time *between* received
+    /// bytes. Catches a fully-stalled connection, but does NOT bound total time —
+    /// a slow-but-trickling stream resets it on every byte. See `maxTotalSeconds`.
     let timeoutSeconds: TimeInterval
+    /// Hard wall-clock cap for the whole generation. `timeoutSeconds` alone lets
+    /// a struggling LLM that trickles tokens run for hours (each byte resets the
+    /// idle timer); this deadline ends it regardless. Generous by default so a
+    /// legitimately long protocol isn't cut off.
+    let maxTotalSeconds: TimeInterval
     let session: URLSession
 
     init(
@@ -18,6 +26,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         language: String,
         apiKey: String? = nil,
         timeoutSeconds: TimeInterval = 600,
+        maxTotalSeconds: TimeInterval = 1800,
         session: URLSession = .shared,
     ) {
         self.endpoint = endpoint
@@ -25,6 +34,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         self.language = language
         self.apiKey = apiKey
         self.timeoutSeconds = timeoutSeconds
+        self.maxTotalSeconds = maxTotalSeconds
         self.session = session
     }
 
@@ -58,12 +68,41 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
 
         logger.info("Generating protocol via OpenAI-compatible API (\(model))...")
 
+        // Race the streaming consume against a hard total deadline: the idle
+        // timeout above can't end a stream that keeps trickling bytes, so a
+        // struggling endpoint would otherwise hang the pipeline indefinitely.
+        // Capture only immutable Sendable locals so the task closure is safe.
+        let session = self.session
+        let model = self.model
+        let deadline = maxTotalSeconds
+        let finalRequest = request
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await Self.streamProtocol(session: session, request: finalRequest, requestURL: requestURL, model: model)
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+                throw ProtocolError.generationTimedOut(Int(deadline))
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw ProtocolError.connectionFailed("No response")
+            }
+            return result
+        }
+    }
+
+    /// Open the streaming request and accumulate the SSE content deltas. Static
+    /// so the deadline race captures only Sendable locals, not `self`.
+    private static func streamProtocol(
+        session: URLSession, request: URLRequest, requestURL: URL, model: String,
+    ) async throws -> String {
         let (bytes, response): (URLSession.AsyncBytes, URLResponse)
         do {
             (bytes, response) = try await session.bytes(for: request)
         } catch {
             logger.error(
-                "openai_connection_failed endpoint=\(requestURL.absoluteString, privacy: .public) model=\(self.model, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
+                "openai_connection_failed endpoint=\(requestURL.absoluteString, privacy: .public) model=\(model, privacy: .public) error=\(error.localizedDescription, privacy: .public)",
             )
             throw ProtocolError.connectionFailed(error.localizedDescription)
         }
@@ -178,12 +217,5 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         } catch {
             return .failure(ProtocolError.connectionFailed(error.localizedDescription))
         }
-    }
-}
-
-// Private instance helper that delegates to the static method
-private extension OpenAIProtocolGenerator {
-    func parseSSELine(_ line: String) -> String? {
-        Self.parseSSELine(line)
     }
 }

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -193,6 +193,7 @@ enum ProtocolError: LocalizedError {
     case emptyProtocol
     case httpError(Int, String)
     case connectionFailed(String)
+    case generationTimedOut(Int)
 
     var errorDescription: String? {
         switch self {
@@ -209,6 +210,8 @@ enum ProtocolError: LocalizedError {
         case let .httpError(code, body): "HTTP \(code)\(body.isEmpty ? "" : ": \(body)")"
 
         case let .connectionFailed(reason): "Connection failed: \(reason)"
+
+        case let .generationTimedOut(seconds): "Protocol generation timed out after \(seconds)s. The LLM endpoint is stuck or too slow — try a smaller model or shorter context."
         }
     }
 }

--- a/app/MeetingTranscriber/Tests/MockURLProtocol.swift
+++ b/app/MeetingTranscriber/Tests/MockURLProtocol.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Test URL-loading shim: route a `URLSession` through this (set
+/// `configuration.protocolClasses = [MockURLProtocol.self]`) and drive responses
+/// via the static handlers. Set the relevant handler before the request and
+/// clear all of them in tearDown.
+final class MockURLProtocol: URLProtocol {
+    // URLSession serialises protocol callbacks per task; the handler is set
+    // before the request is started and cleared in tearDown. No real race.
+    nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+    // When set, the request fails at the transport layer with this error
+    // (mirrors a connection refused / DNS failure / dropped socket). Takes
+    // precedence over `handler` so the generator's catch path is exercised.
+    nonisolated(unsafe) static var errorHandler: ((URLRequest) -> any Error)?
+    // When set, delivers a NON-HTTP `URLResponse` (takes precedence over
+    // `handler`) so the generator's `response as? HTTPURLResponse` guard fails.
+    nonisolated(unsafe) static var rawResponseHandler: ((URLRequest) -> (URLResponse, Data))?
+    // When set, delivers the response + data but NEVER finishes loading —
+    // simulates a stream that trickles/stalls forever (the struggling-LLM case),
+    // so the generator's total-deadline can be exercised.
+    nonisolated(unsafe) static var hangHandler: ((URLRequest) -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        if let errorHandler = Self.errorHandler {
+            client?.urlProtocol(self, didFailWithError: errorHandler(request))
+            return
+        }
+        if let rawResponseHandler = Self.rawResponseHandler {
+            let (response, data) = rawResponseHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        if let hangHandler = Self.hangHandler {
+            let (response, data) = hangHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            // Intentionally never finish — the stream stalls; only a total
+            // deadline (not the idle timeout) can end this.
+            return
+        }
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -157,6 +157,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         MockURLProtocol.handler = nil
         MockURLProtocol.errorHandler = nil
         MockURLProtocol.rawResponseHandler = nil
+        MockURLProtocol.hangHandler = nil
         super.tearDown()
     }
 
@@ -199,6 +200,35 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         let result = try await gen.generate(transcript: "Test transcript", title: "Test", diarized: false)
         XCTAssertTrue(result.contains("Protocol"))
         XCTAssertTrue(result.contains("Content here"))
+    }
+
+    func testGenerateTimesOutWhenStreamNeverCompletes() async {
+        // Endpoint delivers a chunk then stalls forever (the struggling-LLM
+        // case). request.timeoutInterval is an idle timeout and would never fire
+        // here once bytes arrive; only the total deadline can end it.
+        MockURLProtocol.hangHandler = { request in
+            // swiftlint:disable:next force_unwrapping
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n"
+            return (response, Data(chunk.utf8))
+        }
+        let gen = OpenAIProtocolGenerator(
+            endpoint: Self.testEndpoint,
+            model: "test-model",
+            language: "German",
+            apiKey: nil,
+            maxTotalSeconds: 0.3,
+            session: makeMockSession(),
+        )
+        do {
+            _ = try await gen.generate(transcript: "x", title: "t", diarized: false)
+            XCTFail("expected a total-deadline timeout")
+        } catch {
+            guard case ProtocolError.generationTimedOut = error else {
+                XCTFail("expected ProtocolError.generationTimedOut, got \(error)")
+                return
+            }
+        }
     }
 
     func testGenerateSetsAuthorizationHeader() async throws {
@@ -529,51 +559,4 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         XCTAssertTrue(result.contains("Ä Ö Ü ß"))
         XCTAssertTrue(result.contains("\"quotes\""))
     }
-}
-
-// MARK: - MockURLProtocol
-
-private final class MockURLProtocol: URLProtocol {
-    // URLSession serialises protocol callbacks per task; the handler is set
-    // before the request is started and cleared in tearDown. No real race.
-    nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
-    // When set, the request fails at the transport layer with this error
-    // (mirrors a connection refused / DNS failure / dropped socket). Takes
-    // precedence over `handler` so the generator's catch path is exercised.
-    nonisolated(unsafe) static var errorHandler: ((URLRequest) -> any Error)?
-    // When set, delivers a NON-HTTP `URLResponse` (takes precedence over
-    // `handler`) so the generator's `response as? HTTPURLResponse` guard fails.
-    nonisolated(unsafe) static var rawResponseHandler: ((URLRequest) -> (URLResponse, Data))?
-
-    override static func canInit(with _: URLRequest) -> Bool {
-        true
-    }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        if let errorHandler = Self.errorHandler {
-            client?.urlProtocol(self, didFailWithError: errorHandler(request))
-            return
-        }
-        if let rawResponseHandler = Self.rawResponseHandler {
-            let (response, data) = rawResponseHandler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-            return
-        }
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        let (response, data) = handler(request)
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
-    }
-
-    override func stopLoading() {}
 }


### PR DESCRIPTION
## Problem (observed in the field)

A protocol-generation run was sitting at **`Generating Protocol… 114:34`** against a ~5-min historical norm — the LLM step had effectively hung the pipeline for nearly two hours.

Root cause: the only guard was `request.timeoutInterval` (600s), which is an **idle** timeout — the max time *between* received bytes. The request streams (`stream: true`), so a struggling endpoint (here: a local `glm-4.7-flash` with a 131k context window) that trickles a token every few seconds resets the idle timer on every byte and **never** times out. The default `.shared` session's `timeoutIntervalForResource` is 7 days, so nothing capped total time.

## Fix

Add `maxTotalSeconds` (default **1800s**) and race the streaming consume against it with a task group: whichever child finishes first wins; if the deadline child fires it throws `ProtocolError.generationTimedOut` and `cancelAll()` tears down the consume task (closing the connection). `timeoutSeconds` stays as the idle timeout for a fully-dead connection. The streaming body is extracted into a `static streamProtocol` so the race captures only Sendable locals (not `self`).

Chose the task-group race over `URLSessionConfiguration.timeoutIntervalForResource` deliberately: the session is injected and defaults to `.shared` (whose config must not be mutated), and the race yields a typed, actionable error (`generationTimedOut` → "try a smaller model or shorter context") instead of an opaque `URLError(.timedOut)`.

## Testing

`testGenerateTimesOutWhenStreamNeverCompletes`: a stream that delivers a chunk then never finishes (new `MockURLProtocol.hangHandler`) now fails with `generationTimedOut` in ~0.3s instead of hanging forever. All existing OpenAI generator tests stay green. `MockURLProtocol` moved to its own test file (keeps the test file under the line limit).

## Review

`/simplify` + `/code-review` run. Both confirmed the task-group semantics (first-finisher wins, real errors propagate un-masked, cancellation closes the socket) and the altitude choice. One real finding fixed: making `streamProtocol` static orphaned a private `parseSSELine` helper (the static call binds to the static method) — deleted, so `swiftlint analyze --strict`'s `unused_declaration` stays clean.