### PR TITLE
fix(app): cap protocol output tokens + surface truncation honestly

### DIFF
--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -18,6 +18,11 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     /// idle timer); this deadline ends it regardless. Generous by default so a
     /// legitimately long protocol isn't cut off.
     let maxTotalSeconds: TimeInterval
+    /// Output-token cap sent as `max_tokens`. Bounds a runaway/verbose
+    /// generation (the 131k-context case that ground for ~2h) by length rather
+    /// than time. Generous — a meeting protocol is well under this — and a hit
+    /// is surfaced as `protocolTruncated`, never silently presented as complete.
+    let maxOutputTokens: Int
     let session: URLSession
 
     init(
@@ -27,6 +32,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         apiKey: String? = nil,
         timeoutSeconds: TimeInterval = 600,
         maxTotalSeconds: TimeInterval = 1800,
+        maxOutputTokens: Int = 16000,
         session: URLSession = .shared,
     ) {
         self.endpoint = endpoint
@@ -35,6 +41,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         self.apiKey = apiKey
         self.timeoutSeconds = timeoutSeconds
         self.maxTotalSeconds = maxTotalSeconds
+        self.maxOutputTokens = maxOutputTokens
         self.session = session
     }
 
@@ -50,6 +57,7 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
             "model": model,
             "messages": messages,
             "stream": true,
+            "max_tokens": maxOutputTokens,
         ]
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)
@@ -126,10 +134,19 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         }
 
         var parts: [String] = []
+        var finishReason: String?
         for try await line in bytes.lines {
-            if let content = parseSSELine(line) {
-                parts.append(content)
-            }
+            guard let chunk = parseSSELine(line) else { continue }
+            if let content = chunk.content { parts.append(content) }
+            if let reason = chunk.finishReason { finishReason = reason }
+        }
+
+        // "length" = the model hit max_tokens or the context window, so the
+        // protocol is cut off mid-way. Surface it rather than save a partial as
+        // if it finished cleanly (only "stop" is a real completion).
+        guard finishReason != "length" else {
+            logger.error("openai_truncated finish_reason=length model=\(model, privacy: .public)")
+            throw ProtocolError.protocolTruncated
         }
 
         let result = parts.joined().trimmingCharacters(in: .whitespacesAndNewlines)
@@ -140,9 +157,18 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         return result
     }
 
-    /// Parse a single SSE line and extract the content delta.
-    /// Returns `nil` for non-content lines (e.g. `data: [DONE]`, empty lines, comments).
-    static func parseSSELine(_ line: String) -> String? {
+    /// One parsed SSE chunk: the content delta (if any) and the finish reason,
+    /// which is set only on the terminating chunk ("stop" = clean completion,
+    /// "length" = truncated at the output/context limit).
+    struct SSEChunk: Equatable {
+        let content: String?
+        let finishReason: String?
+    }
+
+    /// Parse a single SSE line into its content delta + finish reason. Returns
+    /// `nil` for non-data lines (`data: [DONE]`, comments, empty, unparseable)
+    /// and for chunks carrying neither a content delta nor a finish reason.
+    static func parseSSELine(_ line: String) -> SSEChunk? {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
 
         guard trimmed.hasPrefix("data: ") else { return nil }
@@ -153,12 +179,13 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
         guard let data = payload.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = obj["choices"] as? [[String: Any]],
-              let first = choices.first,
-              let delta = first["delta"] as? [String: Any],
-              let content = delta["content"] as? String
+              let first = choices.first
         else { return nil }
 
-        return content
+        let content = (first["delta"] as? [String: Any])?["content"] as? String
+        let finishReason = first["finish_reason"] as? String
+        if content == nil, finishReason == nil { return nil }
+        return SSEChunk(content: content, finishReason: finishReason)
     }
 
     /// Normalize a user-entered endpoint to the OpenAI API *base* URL (e.g.

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -194,6 +194,7 @@ enum ProtocolError: LocalizedError {
     case httpError(Int, String)
     case connectionFailed(String)
     case generationTimedOut(Int)
+    case protocolTruncated
 
     var errorDescription: String? {
         switch self {
@@ -212,6 +213,8 @@ enum ProtocolError: LocalizedError {
         case let .connectionFailed(reason): "Connection failed: \(reason)"
 
         case let .generationTimedOut(seconds): "Protocol generation timed out after \(seconds)s. The LLM endpoint is stuck or too slow — try a smaller model or shorter context."
+
+        case .protocolTruncated: "Protocol was cut off before finishing (model hit its output/context limit). Raise the limit or shorten the transcript."
         }
     }
 }

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 @testable import MeetingTranscriber
 import XCTest
 
@@ -6,7 +7,17 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
 
     func testParseSSELineExtractsContent() {
         let line = #"data: {"choices":[{"delta":{"content":"Hello"}}]}"#
-        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "Hello")
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line)?.content, "Hello")
+    }
+
+    func testParseSSELineExtractsFinishReason() {
+        let stop = #"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(stop)?.finishReason, "stop")
+        let length = #"data: {"choices":[{"delta":{},"finish_reason":"length"}]}"#
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(length)?.finishReason, "length")
+        // A content-only chunk carries no finish reason.
+        let content = #"data: {"choices":[{"delta":{"content":"x"}}]}"#
+        XCTAssertNil(OpenAIProtocolGenerator.parseSSELine(content)?.finishReason)
     }
 
     func testParseSSELineDoneReturnsNil() {
@@ -37,7 +48,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
     func testParseSSELineMultipleChoices() {
         // Should extract from first choice
         let line = #"data: {"choices":[{"delta":{"content":"A"}},{"delta":{"content":"B"}}]}"#
-        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "A")
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line)?.content, "A")
     }
 
     func testParseSSELineRoleDelta() {
@@ -48,7 +59,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
 
     func testParseSSELineEmptyContent() {
         let line = #"data: {"choices":[{"delta":{"content":""}}]}"#
-        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line), "")
+        XCTAssertEqual(OpenAIProtocolGenerator.parseSSELine(line)?.content, "")
     }
 
     // MARK: - Prompt Construction
@@ -105,7 +116,7 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
             #"data: {"choices":[{"delta":{"content":" world"}}]}"#,
             "data: [DONE]",
         ]
-        let parts = lines.compactMap { OpenAIProtocolGenerator.parseSSELine($0) }
+        let parts = lines.compactMap { OpenAIProtocolGenerator.parseSSELine($0)?.content }
         let result = parts.joined()
         XCTAssertEqual(result, "Hello world")
     }
@@ -183,6 +194,31 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         return (response, body)
     }
 
+    /// Decode the JSON request body (empty on failure). URLSession converts
+    /// `httpBody` to an `httpBodyStream` before the protocol sees it, so read
+    /// whichever is set.
+    private func requestBody(_ request: URLRequest) -> [String: Any] {
+        var data = request.httpBody
+        if data == nil, let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            var collected = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            // Drive by read result, not hasBytesAvailable (which can be false
+            // before the first read on some stream types).
+            while true {
+                let read = stream.read(&buffer, maxLength: buffer.count)
+                if read <= 0 { break }
+                collected.append(buffer, count: read)
+            }
+            data = collected
+        }
+        guard let data, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
+    }
+
     func testGenerateSuccessfulSSEStream() async throws {
         let sseBody = """
         data: {"choices":[{"delta":{"role":"assistant"}}]}
@@ -200,6 +236,55 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         let result = try await gen.generate(transcript: "Test transcript", title: "Test", diarized: false)
         XCTAssertTrue(result.contains("Protocol"))
         XCTAssertTrue(result.contains("Content here"))
+    }
+
+    func testGenerateThrowsProtocolTruncatedOnLengthFinishReason() async {
+        // The model emits content then a terminating chunk with finish_reason
+        // "length" (hit max_tokens/context). The result must NOT be presented as
+        // a clean completion.
+        let sseBody = """
+        data: {"choices":[{"delta":{"content":"# Partial protocol"}}]}
+        data: {"choices":[{"delta":{},"finish_reason":"length"}]}
+        data: [DONE]
+        """
+        MockURLProtocol.handler = { request in
+            self.mockResponse(request, body: Data(sseBody.utf8))
+        }
+        let gen = makeGenerator(session: makeMockSession())
+        do {
+            _ = try await gen.generate(transcript: "x", title: "t", diarized: false)
+            XCTFail("expected ProtocolError.protocolTruncated")
+        } catch {
+            guard case ProtocolError.protocolTruncated = error else {
+                XCTFail("expected protocolTruncated, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testGenerateSucceedsOnStopFinishReason() async throws {
+        let sseBody = """
+        data: {"choices":[{"delta":{"content":"# Done"}}]}
+        data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+        data: [DONE]
+        """
+        MockURLProtocol.handler = { request in
+            self.mockResponse(request, body: Data(sseBody.utf8))
+        }
+        let gen = makeGenerator(session: makeMockSession())
+        let result = try await gen.generate(transcript: "x", title: "t", diarized: false)
+        XCTAssertTrue(result.contains("Done"))
+    }
+
+    func testGenerateRequestIncludesMaxTokens() async throws {
+        MockURLProtocol.handler = { request in
+            let body = self.requestBody(request)
+            XCTAssertNotNil(body["max_tokens"], "request must cap output with max_tokens")
+            let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\ndata: [DONE]"
+            return self.mockResponse(request, body: Data(sse.utf8))
+        }
+        let gen = makeGenerator(session: makeMockSession())
+        _ = try await gen.generate(transcript: "x", title: "t", diarized: false)
     }
 
     func testGenerateTimesOutWhenStreamNeverCompletes() async {


### PR DESCRIPTION
Follow-up to the protocol total-deadline fix (#433). Bounds protocol generation by **length** too, and — the part you asked for — **never presents a cut-off protocol as a clean completion**.

## What

- Send `max_tokens` (default 16000) so a runaway/verbose generation (the 131k-context case that ground for ~2h) is bounded by output length, not just wall-clock.
- Parse `finish_reason` from the SSE stream (`parseSSELine` now returns `SSEChunk { content, finishReason }`). `finish_reason == "length"` = the model hit `max_tokens` **or** the context window → the protocol is truncated → throw `ProtocolError.protocolTruncated` instead of saving the partial as if it finished. Only `"stop"` (or a clean end) is a real completion.

This also closes a pre-existing gap: a context-limit truncation would previously have been accepted silently as complete.

## Why throw rather than save the partial

The whole point is that a truncated protocol must not look "done". Throwing surfaces a clear, actionable error ("hit the model's output/context limit — raise the limit or shorten the transcript") instead of persisting a half-protocol the user might mistake for complete.

## Coverage notes (best-effort by design)

Detection relies on the backend reporting `finish_reason: "length"` and honoring `max_tokens` — both hold for Ollama (the configured endpoint), which maps its done-reason to `finish_reason` and honors `max_tokens`. For any backend that neither caps nor signals, the #433 total-deadline remains the backstop. `max_completion_tokens` deliberately not also sent (avoids "both keys" rejection on strict servers).

## Testing

- `finish_reason` parsing (`stop`/`length`/absent); a length-terminated stream throws `protocolTruncated`; a stop-terminated stream succeeds; the request body carries `max_tokens` (read via `httpBodyStream`).
- `/simplify` (clean) + `/code-review` run; applied the one actionable note (drive the test body-reader by read-result, not `hasBytesAvailable`). The "discard partial" behavior is intentional per the requirement.
- The test file gains a file-level `// swiftlint:disable file_length` (matching `PipelineQueueTests`' precedent for a comprehensive suite).