### PR TITLE
feat(app): per-job status readback for local automation API (#431)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     PipelineSnapshot.swift  # Pure I/O helpers for persisting pipeline queue jobs to disk (atomic rename)
     SnapshotWriterActor.swift  # Actor isolating pipeline queue snapshot writes (prevents main-actor stalls)
     PipelineController.swift  # @Observable controller owning PipelineQueue lifecycle (wired by AppState)
+    TerminalJobStore.swift  # Durable finished-job records (id→state+paths) so the /v1/jobs/<id> automation readback survives the in-memory done-job reaping
+    JobStatusDTO.swift      # Wire shape for GET /v1/jobs/<id> (live job or persisted terminal record)
     LiveTranscriptionController.swift # Wires StreamingTranscriber to both DualSourceRecorder sinks (mic + app), feeds LiveCaptionsState (PoC)
     LiveTranscriptionCoordinator.swift # @Observable coordinator: builds + arms LiveTranscriptionController, feeds LiveCaptionsState
     ProtocolGenerator.swift   # Shared protocol utilities: prompts, file I/O, ProtocolError
@@ -105,6 +107,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     String+LogRedaction.swift # String extensions: .pseudonymized and .redactedName for log privacy
     DebugRPCServer.swift   # Localhost HTTP RPC for shell-driven inspection (#if !APPSTORE, env-gated by MEETINGTRANSCRIBER_DEBUG_RPC=1)
     DebugRPCServer+Metrics.swift # GET /metrics handler (line-cap split from DebugRPCServer.route)
+    DebugRPCServer+V1.swift # /v1/jobs automation-API routing (line-cap split from DebugRPCServer.route)
     HTTPRequest.swift      # HTTP/1.1 request parsing for DebugRPCServer (line-cap split)
     HTTPResponse.swift     # HTTP/1.1 response serialization for DebugRPCServer (line-cap split)
     RPCStateSnapshot.swift # JSON-serializable RPC state snapshot (#if !APPSTORE)

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -272,12 +272,23 @@ final class AppState {
             let enqueueFilesRPC: ([URL]) -> Int = { [weak self] urls in
                 self?.pipeline.enqueueExistingFiles(urls) ?? 0
             }
+            // `/v1/jobs` automation surface: enqueue returning the created job
+            // IDs, and per-job status lookup (live job or persisted terminal
+            // record) so a headless client can poll a specific job.
+            let enqueueReturningIDs: ([URL]) -> [UUID] = { [weak self] urls in
+                self?.pipeline.enqueueExistingFilesReturningIDs(urls) ?? []
+            }
+            let jobStatus: (UUID) -> JobStatusDTO? = { [weak self] id in
+                self?.pipeline.jobStatus(forID: id)
+            }
             return DebugRPCServer(
                 snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
                 skipNaming: skipNaming,
                 enqueueFile: enqueueFile,
                 enqueueFiles: enqueueFilesRPC,
+                enqueueReturningIDs: enqueueReturningIDs,
+                jobStatus: jobStatus,
             )
         }
     #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -1,0 +1,35 @@
+#if !APPSTORE
+    import Foundation
+
+    /// `/v1` automation-API routing, line-cap split from `DebugRPCServer.route`.
+    extension DebugRPCServer {
+        /// Route the versioned automation surface. `POST /v1/jobs` enqueues the
+        /// given file paths and returns the created job IDs; `GET /v1/jobs/<id>`
+        /// returns a job's status (live or persisted terminal record). The query
+        /// string is already stripped from `path` by the caller.
+        func routeV1(_ request: HTTPRequest, path: String) -> HTTPResponse {
+            switch (request.method, path) {
+            case ("POST", "/v1/jobs"):
+                guard let p = try? JSONDecoder().decode(EnqueueFilesPayload.self, from: request.body),
+                      !p.paths.isEmpty
+                else { return HTTPResponse.badRequest() }
+                let ids = enqueueReturningIDs(p.paths.map { URL(fileURLWithPath: $0) })
+                guard let body = try? JSONEncoder().encode(["jobIDs": ids.map(\.uuidString)]) else {
+                    return HTTPResponse.badRequest()
+                }
+                return HTTPResponse.ok(body: body, contentType: "application/json")
+
+            case ("GET", _) where path.hasPrefix("/v1/jobs/"):
+                let idString = String(path.dropFirst("/v1/jobs/".count))
+                guard let uuid = UUID(uuidString: idString), let dto = jobStatus(uuid) else {
+                    return HTTPResponse.notFound()
+                }
+                guard let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
+                return HTTPResponse.ok(body: body, contentType: "application/json")
+
+            default:
+                return HTTPResponse.notFound()
+            }
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -82,6 +82,13 @@
         /// Multi-file counterpart for paired-import testing. Returns the number
         /// of URLs that existed on disk and were forwarded to `enqueueFiles`.
         private let enqueueFiles: ([URL]) -> Int
+        /// `POST /v1/jobs` entry point — enqueues the existing files and returns
+        /// the created job IDs so an automation client can poll each one.
+        /// Internal (not private) so the `DebugRPCServer+V1` extension can reach it.
+        let enqueueReturningIDs: ([URL]) -> [UUID]
+        /// `GET /v1/jobs/<id>` lookup — current status of a job (live or a
+        /// persisted terminal record), or nil → 404.
+        let jobStatus: (UUID) -> JobStatusDTO?
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -100,6 +107,8 @@
             skipNaming: @escaping () -> Void = {},
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
+            enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
+            jobStatus: @escaping (UUID) -> JobStatusDTO? = { _ in nil },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -108,6 +117,8 @@
             self.skipNaming = skipNaming
             self.enqueueFile = enqueueFile
             self.enqueueFiles = enqueueFiles
+            self.enqueueReturningIDs = enqueueReturningIDs
+            self.jobStatus = jobStatus
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -285,8 +296,10 @@
 
         // MARK: - Routing
 
-        // swiftlint:disable:next cyclomatic_complexity
-        func route(_ request: HTTPRequest) async -> HTTPResponse {
+        /// Origin / Host / bearer-token pre-checks shared by every route.
+        /// Returns a rejection response (403/401) when a check fails, or nil
+        /// when the request may proceed.
+        private func rejectionForFailedGuards(_ request: HTTPRequest) -> HTTPResponse? {
             if let origin = request.headers["origin"], !origin.isEmpty, origin != "null" {
                 return HTTPResponse.forbidden()
             }
@@ -297,6 +310,21 @@
             let provided = request.headers["authorization"] ?? ""
             guard Self.constantTimeEquals(provided, expectedAuth) else {
                 return HTTPResponse.unauthorized()
+            }
+            return nil
+        }
+
+        // swiftlint:disable:next cyclomatic_complexity
+        func route(_ request: HTTPRequest) async -> HTTPResponse {
+            if let rejection = rejectionForFailedGuards(request) { return rejection }
+
+            // Versioned automation API — kept off the debug `/action/*` surface
+            // so it can carry a stability contract independent of the debug
+            // endpoints. Routed before the legacy switch. Strip any query string
+            // so `/v1/jobs/<id>?x=1` still resolves the id rather than 404ing.
+            let v1Path = String(request.path.prefix { $0 != "?" })
+            if v1Path == "/v1/jobs" || v1Path.hasPrefix("/v1/jobs/") {
+                return routeV1(request, path: v1Path)
             }
 
             switch (request.method, request.path) {
@@ -431,7 +459,8 @@
             let path: String
         }
 
-        private struct EnqueueFilesPayload: Decodable {
+        // Internal (not private) so the `DebugRPCServer+V1` extension can decode it.
+        struct EnqueueFilesPayload: Decodable {
             let paths: [String]
         }
 

--- a/app/MeetingTranscriber/Sources/JobStatusDTO.swift
+++ b/app/MeetingTranscriber/Sources/JobStatusDTO.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A job's status plus its result paths, for either a live (in-flight) job or a
+/// finished job already reaped from the queue. Served by `GET /v1/jobs/<id>` and
+/// persisted in `TerminalJobStore` (the wire shape and the stored shape are the
+/// same; if they ever need to diverge, split then).
+struct JobStatusDTO: Codable, Equatable {
+    let jobID: String
+    let state: JobState
+    let meetingTitle: String
+    let transcriptPath: String?
+    let protocolPath: String?
+    let error: String?
+    let warnings: [String]
+}
+
+extension JobStatusDTO {
+    /// Map a live pipeline job to its status shape (URL paths flattened to
+    /// strings). Single source of the job→status mapping, shared by the live
+    /// `GET /v1/jobs/<id>` lookup and the terminal-record persistence.
+    init(job: PipelineJob) {
+        self.init(
+            jobID: job.id.uuidString,
+            state: job.state,
+            meetingTitle: job.meetingTitle,
+            transcriptPath: job.transcriptPath?.path,
+            protocolPath: job.protocolPath?.path,
+            error: job.error,
+            warnings: job.warnings,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -34,15 +34,21 @@ final class PipelineController {
     private let settings: AppSettings
     private let notifier: any AppNotifying
 
+    /// Durable finished-job record store, shared across queue rebuilds and read
+    /// by `jobStatus(forID:)` for the automation API. Test-injectable.
+    let terminalJobStore: TerminalJobStore
+
     /// Source of the currently-active engine. Set by `activate`; nil before then
     /// (so `makeQueue()` safely returns the current queue if called early — only
     /// reachable at process teardown, since `rebuild`/`ensureQueue` are driven by
     /// user actions while `AppState` is alive). Captures the owner weakly.
     private var engineProvider: (() -> (any TranscribingEngine)?)?
 
-    init(settings: AppSettings, notifier: any AppNotifying) {
+    init(settings: AppSettings, notifier: any AppNotifying, terminalJobStore: TerminalJobStore? = nil) {
         self.settings = settings
         self.notifier = notifier
+        self.terminalJobStore = terminalJobStore
+            ?? TerminalJobStore(path: AppPaths.ipcDir.appendingPathComponent("terminal_jobs.json"))
         self.queue = PipelineQueue()
     }
 
@@ -88,6 +94,7 @@ final class PipelineController {
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),
             stageTimingLog: StageTimingLog(),
+            terminalJobStore: terminalJobStore,
         )
         q.loadSnapshot()
         // Fire-and-forget: dir scan + per-file attr probes run off-main so app
@@ -179,8 +186,13 @@ final class PipelineController {
 
     // MARK: - File enqueue
 
-    /// Filters `urls` to files that currently exist on disk, forwards them to
-    /// `enqueueFiles`, and returns the existing count. RPC-friendly entry point.
+    /// Filters `urls` to files that currently exist on disk, enqueues them, and
+    /// returns the count of files that existed. RPC-friendly entry point.
+    ///
+    /// NOTE: this is the count of *files that existed*, not jobs created — a
+    /// paired `_app` + `_mic` import collapses two files into one job. The
+    /// `/action/enqueueFiles` response contract is the file count, so this must
+    /// not be derived from `enqueueExistingFilesReturningIDs(_:).count`.
     @discardableResult
     func enqueueExistingFiles(_ urls: [URL]) -> Int {
         let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
@@ -189,10 +201,23 @@ final class PipelineController {
         return existing.count
     }
 
-    func enqueueFiles(_ urls: [URL]) {
+    /// Like `enqueueExistingFiles` but returns the created job IDs so an
+    /// automation client can poll each job's status. `[]` when no URL exists on
+    /// disk. Distinct from the file count above: paired imports yield fewer IDs
+    /// than files.
+    @discardableResult
+    func enqueueExistingFilesReturningIDs(_ urls: [URL]) -> [UUID] {
+        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !existing.isEmpty else { return [] }
+        return enqueueFiles(existing)
+    }
+
+    @discardableResult
+    func enqueueFiles(_ urls: [URL]) -> [UUID] {
         ensureQueue()
 
         let resolution = PairedRecordingResolver.resolve(urls: urls)
+        var ids: [UUID] = []
 
         for group in resolution.paired {
             let sidecar = RecordingSidecar.read(
@@ -213,6 +238,7 @@ final class PipelineController {
                 mixPath: group.mix, appPath: group.app, micPath: group.mic,
                 micDelay: micDelay, participants: participants,
             )
+            ids.append(job.id)
             queue.enqueue(job)
         }
 
@@ -226,7 +252,22 @@ final class PipelineController {
                 micPath: nil,
                 micDelay: 0,
             )
+            ids.append(job.id)
             queue.enqueue(job)
         }
+
+        return ids
+    }
+
+    // MARK: - Job status
+
+    /// Current status of a job for the automation API: the live job if it's
+    /// still in the queue, otherwise the persisted terminal record once the
+    /// queue has reaped it, otherwise nil (unknown ID → the RPC layer 404s).
+    func jobStatus(forID id: UUID) -> JobStatusDTO? {
+        if let job = queue.jobs.first(where: { $0.id == id }) {
+            return JobStatusDTO(job: job)
+        }
+        return terminalJobStore.lookup(jobID: id)
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -40,6 +40,10 @@ class PipelineQueue {
     /// Pure I/O over `outputDir`; see `SpeakerNamingStore`.
     private let namingStore: SpeakerNamingStore
 
+    /// Durable store of finished-job records for the automation API readback.
+    /// nil (default) disables it; production injects one, tests opt in.
+    let terminalJobStore: TerminalJobStore?
+
     /// Cached FluidVAD instance — reused across jobs to avoid model reload.
     private var vad: FluidVAD?
 
@@ -289,6 +293,7 @@ class PipelineQueue {
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
+        terminalJobStore: TerminalJobStore? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.engine = nil
@@ -306,6 +311,7 @@ class PipelineQueue {
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.namingStore = SpeakerNamingStore(outputDir: nil)
+        self.terminalJobStore = terminalJobStore
     }
 
     // MARK: - Known speaker names (issue #155)
@@ -369,6 +375,7 @@ class PipelineQueue {
         recognitionStatsLog: RecognitionStatsLog? = nil,
         stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
+        terminalJobStore: TerminalJobStore? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.engine = engine
@@ -394,6 +401,7 @@ class PipelineQueue {
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.namingStore = SpeakerNamingStore(outputDir: outputDir)
+        self.terminalJobStore = terminalJobStore
         refreshStageAverages()
     }
 
@@ -498,6 +506,7 @@ class PipelineQueue {
 
         if newState == .done || newState == .error {
             markProcessed(mixPath: jobs[index].mixPath)
+            recordTerminalJob(jobs[index])
         }
         if newState == .done {
             Task { [weak self] in
@@ -505,6 +514,13 @@ class PipelineQueue {
                 self?.removeJob(id: id)
             }
         }
+    }
+
+    /// Persist a durable terminal-state record so the automation API can read
+    /// back a finished job's outcome even after `completedJobLifetime` removes
+    /// it from the in-memory list. No-op when no store is wired.
+    private func recordTerminalJob(_ job: PipelineJob) {
+        terminalJobStore?.record(JobStatusDTO(job: job))
     }
 
     func addWarning(id: UUID, _ message: String) {

--- a/app/MeetingTranscriber/Sources/TerminalJobStore.swift
+++ b/app/MeetingTranscriber/Sources/TerminalJobStore.swift
@@ -1,0 +1,87 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "TerminalJobStore")
+
+/// File-backed store of recent finished-job statuses, keyed by jobID with a
+/// bounded FIFO so it can't grow without limit.
+///
+/// `PipelineQueue` removes `.done` jobs from its in-memory list after
+/// `completedJobLifetime` (default 60s). An automation client polling slower
+/// than that would then get a 404 and lose the transcript/protocol paths. This
+/// store outlives the reaping (and an app restart) so `GET /v1/jobs/<id>` stays
+/// answerable. Only finished (`.done`/`.error`) jobs are ever recorded; the
+/// element type is the same `JobStatusDTO` served on the wire.
+///
+/// Writes are atomic (staging file + `replaceItemAt`, mirroring
+/// `PipelineSnapshot`) and owner-only; reads happen on `init`.
+@MainActor
+final class TerminalJobStore {
+    private let path: URL
+    private let cap: Int
+    private(set) var records: [JobStatusDTO]
+
+    init(path: URL, cap: Int = 200) {
+        self.path = path
+        self.cap = cap
+        self.records = Self.load(from: path)
+    }
+
+    /// Pure: drop any record with the same jobID, append the new one, and keep
+    /// only the most recent `cap` entries.
+    nonisolated static func upserting(
+        _ records: [JobStatusDTO], with rec: JobStatusDTO, cap: Int,
+    ) -> [JobStatusDTO] {
+        var next = records.filter { $0.jobID != rec.jobID }
+        next.append(rec)
+        if next.count > cap {
+            next = Array(next.suffix(cap))
+        }
+        return next
+    }
+
+    /// Upsert `rec` and persist. Best-effort: a write failure is logged but
+    /// never throws into the pipeline (the job itself already succeeded).
+    func record(_ rec: JobStatusDTO) {
+        records = Self.upserting(records, with: rec, cap: cap)
+        save()
+    }
+
+    func lookup(jobID: UUID) -> JobStatusDTO? {
+        records.last { $0.jobID == jobID.uuidString }
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        do {
+            let data = try JSONEncoder().encode(records)
+            let staging = path.deletingLastPathComponent()
+                .appendingPathComponent(path.lastPathComponent + ".tmp")
+            try FileManager.default.createDirectory(
+                at: path.deletingLastPathComponent(), withIntermediateDirectories: true,
+            )
+            try data.write(to: staging)
+            _ = try FileManager.default.replaceItemAt(path, withItemAt: staging)
+            // Records carry meeting titles + output paths — keep owner-only,
+            // matching the other sensitive-JSON writers (SpeakerMatcher,
+            // RecordingSidecar).
+            try? FileManager.default.restrictToOwner(path)
+        } catch {
+            logger.error("Failed to persist terminal job records: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Load records from `path`, returning `[]` on a missing or unreadable file
+    /// (a corrupt store must never block startup or readback).
+    private static func load(from path: URL) -> [JobStatusDTO] {
+        guard FileManager.default.fileExists(atPath: path.path) else { return [] }
+        do {
+            let data = try Data(contentsOf: path)
+            return try JSONDecoder().decode([JobStatusDTO].self, from: data)
+        } catch {
+            logger.error("Failed to load terminal job records: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -387,6 +387,17 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertEqual(state.pipeline.queue.jobs[0].mixPath?.lastPathComponent, "present.wav")
     }
 
+    #if !APPSTORE
+        func testBuildDebugRPCServerReturnsWiredServer() {
+            let (state, _) = makeState()
+            // Exercises buildDebugRPCServer's wiring, including the /v1 automation
+            // closures (enqueueReturningIDs + jobStatus). Construction does not
+            // start a listener, so boundPort is nil until start() is called.
+            let server = state.buildDebugRPCServer()
+            XCTAssertNil(server.boundPort)
+        }
+    #endif
+
     func testEnqueueFilesAppPlusMicWithoutMixHasNilMixPath() {
         // No `_mix.wav` in selection — job carries nil mixPath; the pipeline
         // mixes app+mic into the workdir cache on the fly, no persistent mix

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -31,6 +31,8 @@
             snapshot: RPCStateSnapshot = .empty,
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
+            enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
+            jobStatus: @escaping (UUID) -> JobStatusDTO? = { _ in nil },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
@@ -38,6 +40,8 @@
                 snapshot: { snapshot },
                 enqueueFile: enqueueFile,
                 enqueueFiles: enqueueFiles,
+                enqueueReturningIDs: enqueueReturningIDs,
+                jobStatus: jobStatus,
             )
             self.server = server
             server.start()
@@ -370,6 +374,89 @@
                 served,
                 "a fresh server must bind + serve the port the dropped one held",
             )
+        }
+
+        // MARK: - /v1/jobs
+
+        func testV1JobStatusReturnsJSON() async throws {
+            let id = UUID()
+            let dto = JobStatusDTO(
+                jobID: id.uuidString, state: .done, meetingTitle: "Synced Call",
+                transcriptPath: "/out/call.txt", protocolPath: "/out/call.md",
+                error: nil, warnings: ["Mic track diarization failed"],
+            )
+            let lookup: (UUID) -> JobStatusDTO? = { $0 == id ? dto : nil }
+            let base = try await startServer(jobStatus: lookup)
+
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/jobs/\(id.uuidString)"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(JobStatusDTO.self, from: data)
+            XCTAssertEqual(decoded.state, .done)
+            XCTAssertEqual(decoded.transcriptPath, "/out/call.txt")
+            XCTAssertEqual(decoded.protocolPath, "/out/call.md")
+            // Also exercises the full status contract round-trip (error + warnings),
+            // which the live job-status response carries.
+            XCTAssertNil(decoded.error)
+            XCTAssertEqual(decoded.warnings, ["Mic track diarization failed"])
+        }
+
+        func testV1JobStatusUnknownIDReturns404() async throws {
+            // Default jobStatus closure already returns nil for every ID.
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/jobs/\(UUID().uuidString)"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1JobStatusIgnoresQueryString() async throws {
+            let id = UUID()
+            let dto = JobStatusDTO(
+                jobID: id.uuidString, state: .done, meetingTitle: "Q",
+                transcriptPath: nil, protocolPath: nil, error: nil, warnings: [],
+            )
+            let lookup: (UUID) -> JobStatusDTO? = { $0 == id ? dto : nil }
+            let base = try await startServer(jobStatus: lookup)
+
+            let url = try XCTUnwrap(URL(string: "\(base.absoluteString)/v1/jobs/\(id.uuidString)?wait=1"))
+            let (_, response) = try await URLSession.shared.data(for: request("GET", url, headers: authHeader))
+            XCTAssertEqual(
+                (response as? HTTPURLResponse)?.statusCode, 200,
+                "A query string must not turn a valid job ID into a 404",
+            )
+        }
+
+        func testV1JobStatusMalformedIDReturns404() async throws {
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/jobs/not-a-uuid"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1EnqueueReturnsJobIDs() async throws {
+            struct EnqueueResult: Decodable { let jobIDs: [String] }
+            let ids = [UUID(), UUID()]
+            let enqueue: ([URL]) -> [UUID] = { _ in ids }
+            let base = try await startServer(enqueueReturningIDs: enqueue)
+
+            var req = request("POST", base.appendingPathComponent("v1/jobs"), headers: authHeader)
+            req.httpBody = Data(#"{"paths":["/inbox/a.wav","/inbox/b.wav"]}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(EnqueueResult.self, from: data)
+            XCTAssertEqual(decoded.jobIDs, ids.map(\.uuidString))
+        }
+
+        func testV1EnqueueEmptyPathsReturns400() async throws {
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("v1/jobs"), headers: authHeader)
+            req.httpBody = Data(#"{"paths":[]}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
         }
 
         // MARK: - M6: Host header allowlist (raw-socket)

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -88,4 +88,81 @@ final class PipelineControllerTests: XCTestCase {
         XCTAssertEqual(pc.queue.jobs.count, 1)
         XCTAssertEqual(pc.queue.jobs[0].meetingTitle, "sprint-review")
     }
+
+    func testEnqueueFilesReturnsCreatedJobIDs() {
+        let pc = makeWiredController()
+
+        let ids = pc.enqueueFiles([URL(fileURLWithPath: "/tmp/sprint-review.wav")])
+
+        XCTAssertEqual(ids, pc.queue.jobs.map(\.id), "Returned IDs must match the enqueued jobs")
+    }
+
+    func testEnqueueExistingFilesReturningIDsFiltersMissingFiles() {
+        let pc = makeWiredController()
+        let existing = tmpDir.appendingPathComponent("real-meeting.wav")
+        FileManager.default.createFile(atPath: existing.path, contents: Data("RIFF".utf8))
+        let missing = URL(fileURLWithPath: "/tmp/no-such-file-\(UUID().uuidString).wav")
+
+        let ids = pc.enqueueExistingFilesReturningIDs([existing, missing])
+
+        XCTAssertEqual(ids.count, 1, "Only the file that exists on disk is enqueued")
+        XCTAssertEqual(ids, pc.queue.jobs.map(\.id))
+    }
+
+    func testEnqueueExistingFilesCountsExistingFilesNotCollapsedJobs() {
+        let pc = makeWiredController()
+        // A paired _app + _mic recording collapses into ONE job, but the
+        // documented `enqueued` count is the number of files that existed.
+        let app = tmpDir.appendingPathComponent("standup_app.wav")
+        let mic = tmpDir.appendingPathComponent("standup_mic.wav")
+        FileManager.default.createFile(atPath: app.path, contents: Data("RIFF".utf8))
+        FileManager.default.createFile(atPath: mic.path, contents: Data("RIFF".utf8))
+
+        let count = pc.enqueueExistingFiles([app, mic])
+
+        XCTAssertEqual(count, 2, "Count reflects files that existed on disk, not collapsed jobs")
+        XCTAssertEqual(pc.queue.jobs.count, 1, "Paired _app + _mic collapse into a single job")
+    }
+
+    // MARK: - jobStatus
+
+    func testJobStatusReturnsLiveJob() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier(), terminalJobStore: store)
+        pc.queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Live Sync", appName: "File",
+            mixPath: URL(fileURLWithPath: "/tmp/x.wav"), appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.transcriptPath = URL(fileURLWithPath: "/out/x.txt")
+        pc.queue.insertJobForTesting(job)
+
+        let dto = pc.jobStatus(forID: job.id)
+
+        XCTAssertEqual(dto?.state, .waiting)
+        XCTAssertEqual(dto?.meetingTitle, "Live Sync")
+        XCTAssertEqual(dto?.transcriptPath, "/out/x.txt")
+    }
+
+    func testJobStatusFallsBackToTerminalStore() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier(), terminalJobStore: store)
+        let id = UUID()
+        store.record(JobStatusDTO(
+            jobID: id.uuidString, state: .done, meetingTitle: "Reaped",
+            transcriptPath: "/out/r.txt", protocolPath: nil, error: nil, warnings: [],
+        ))
+
+        let dto = pc.jobStatus(forID: id)
+
+        XCTAssertEqual(dto?.state, .done, "Must read back a job already reaped from the queue")
+        XCTAssertEqual(dto?.meetingTitle, "Reaped")
+        XCTAssertEqual(dto?.transcriptPath, "/out/r.txt")
+    }
+
+    func testJobStatusUnknownReturnsNil() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier(), terminalJobStore: store)
+        XCTAssertNil(pc.jobStatus(forID: UUID()))
+    }
 }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -68,6 +68,49 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertLessThan(elapsed, 0.05, "saveSnapshot returned in \(elapsed)s — should be near-instant")
     }
 
+    // MARK: - Terminal job record (durable readback)
+
+    func testTerminalRecordWrittenOnDone() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let q = PipelineQueue(logDir: tmpDir, terminalJobStore: store)
+        var job = makeJob(title: "Synced Call")
+        job.transcriptPath = URL(fileURLWithPath: "/out/call.txt")
+        job.protocolPath = URL(fileURLWithPath: "/out/call.md")
+        q.insertJobForTesting(job)
+
+        q.updateJobState(id: job.id, to: .done)
+
+        let rec = store.lookup(jobID: job.id)
+        XCTAssertEqual(rec?.state, .done)
+        XCTAssertEqual(rec?.meetingTitle, "Synced Call")
+        XCTAssertEqual(rec?.transcriptPath, "/out/call.txt")
+        XCTAssertEqual(rec?.protocolPath, "/out/call.md")
+    }
+
+    func testTerminalRecordWrittenOnError() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let q = PipelineQueue(logDir: tmpDir, terminalJobStore: store)
+        let job = makeJob()
+        q.insertJobForTesting(job)
+
+        q.updateJobState(id: job.id, to: .error, error: "Empty transcript")
+
+        let rec = store.lookup(jobID: job.id)
+        XCTAssertEqual(rec?.state, .error)
+        XCTAssertEqual(rec?.error, "Empty transcript")
+    }
+
+    func testNoTerminalRecordForNonTerminalState() {
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let q = PipelineQueue(logDir: tmpDir, terminalJobStore: store)
+        let job = makeJob()
+        q.insertJobForTesting(job)
+
+        q.updateJobState(id: job.id, to: .transcribing)
+
+        XCTAssertNil(store.lookup(jobID: job.id), "Only terminal states should be recorded")
+    }
+
     func testConsecutiveSnapshotsPersistLastStateOnDisk() async throws {
         // Coalescing: a burst of saves must collapse to a single write of
         // the final state, never an interleaved earlier snapshot.

--- a/app/MeetingTranscriber/Tests/TerminalJobStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/TerminalJobStoreTests.swift
@@ -1,0 +1,130 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class TerminalJobStoreTests: XCTestCase {
+    private func record(
+        id: UUID = UUID(),
+        state: JobState = .done,
+        title: String = "Meeting",
+        transcript: String? = nil,
+        proto: String? = nil,
+    ) -> JobStatusDTO {
+        JobStatusDTO(
+            jobID: id.uuidString,
+            state: state,
+            meetingTitle: title,
+            transcriptPath: transcript,
+            protocolPath: proto,
+            error: nil,
+            warnings: [],
+        )
+    }
+
+    // MARK: - Pure upsert/cap logic
+
+    func testUpsertAppendsNewRecord() {
+        let a = record(title: "A")
+        let result = TerminalJobStore.upserting([], with: a, cap: 10)
+        XCTAssertEqual(result, [a])
+    }
+
+    func testUpsertReplacesRecordWithSameJobID() {
+        let id = UUID()
+        let first = record(id: id, title: "Stale")
+        let updated = record(id: id, title: "Fresh")
+        let result = TerminalJobStore.upserting([first], with: updated, cap: 10)
+        XCTAssertEqual(result, [updated], "Same jobID must replace, not duplicate")
+    }
+
+    func testUpsertCapsToMostRecent() {
+        var records: [JobStatusDTO] = []
+        let kept = (0 ..< 5).map { record(title: "job-\($0)") }
+        for r in kept {
+            records = TerminalJobStore.upserting(records, with: r, cap: 3)
+        }
+        XCTAssertEqual(records.count, 3)
+        XCTAssertEqual(records.map(\.meetingTitle), ["job-2", "job-3", "job-4"])
+    }
+
+    // MARK: - File roundtrip + durability
+
+    func testRecordThenLookupReturnsRecord() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tjs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = UUID()
+        let store = TerminalJobStore(path: dir.appendingPathComponent("terminal_jobs.json"))
+        store.record(record(id: id, transcript: "/out/t.txt", proto: "/out/p.md"))
+
+        let found = store.lookup(jobID: id)
+        XCTAssertEqual(found?.transcriptPath, "/out/t.txt")
+        XCTAssertEqual(found?.protocolPath, "/out/p.md")
+    }
+
+    func testLookupUnknownReturnsNil() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tjs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = TerminalJobStore(path: dir.appendingPathComponent("terminal_jobs.json"))
+        XCTAssertNil(store.lookup(jobID: UUID()))
+    }
+
+    func testRecordSurvivesReload() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tjs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("terminal_jobs.json")
+        let id = UUID()
+        let writer = TerminalJobStore(path: path)
+        writer.record(record(id: id, title: "Persisted"))
+
+        // A fresh store reading the same path must see the persisted record,
+        // proving readback survives the in-memory job reaping (the #431 bug).
+        let reader = TerminalJobStore(path: path)
+        XCTAssertEqual(reader.lookup(jobID: id)?.meetingTitle, "Persisted")
+    }
+
+    func testLoadFromCorruptFileReturnsEmpty() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tjs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let path = dir.appendingPathComponent("terminal_jobs.json")
+        try Data("not valid json {".utf8).write(to: path)
+
+        // A corrupt store must never block startup or readback — it loads empty.
+        let store = TerminalJobStore(path: path)
+        XCTAssertTrue(store.records.isEmpty)
+        XCTAssertNil(store.lookup(jobID: UUID()))
+    }
+
+    func testRecordKeptInMemoryWhenPersistenceFails() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tjs-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Parent path is a FILE, so createDirectory/write inside save() throws and
+        // hits its best-effort catch — the just-finished job must still be held in
+        // memory rather than lost to a persistence error.
+        let blocker = dir.appendingPathComponent("blocker")
+        try Data("x".utf8).write(to: blocker)
+        let store = TerminalJobStore(path: blocker.appendingPathComponent("nested/terminal_jobs.json"))
+
+        let id = UUID()
+        store.record(record(id: id, title: "Unwritable"))
+
+        XCTAssertEqual(
+            store.lookup(jobID: id)?.meetingTitle, "Unwritable",
+            "record is retained in memory even when persistence fails",
+        )
+    }
+}


### PR DESCRIPTION
## What

First slice toward a local automation HTTP API for headless / agent-driven use (issue #431). It builds out the per-job status readback that an external client needs to submit a recording and poll it to completion, on top of the embedded local server the app already has.

## Why

For a headless setup, the app already had the inbound plumbing (the local server can enqueue a file into the pipeline), but two things were missing for a client to actually drive it end to end:

1. No way to get the **per-job** id back from an enqueue, only the most-recent finished job was visible.
2. Finished jobs are removed from the in-memory list after `completedJobLifetime` (60s), so a client polling slower than that would get a 404 and lose the transcript/protocol paths.

## Changes

- **`TerminalJobStore`** — durable, bounded, jobID-keyed FIFO of finished-job records, persisted atomically and reloaded on launch. Survives both the 60s reaping and an app restart. Pure upsert/cap logic is unit-tested independently of the file I/O.
- **`PipelineQueue`** writes a terminal record on every `.done`/`.error` transition (opt-in via an injected store; default nil keeps existing behaviour).
- **Enqueue returns job IDs** — `enqueueFiles` now returns the created `[UUID]`; `enqueueExistingFilesReturningIDs` exposes the same for the existence-filtered entry point.
- **`PipelineController.jobStatus(forID:)`** — returns a live job, else the persisted terminal record, else nil.
- **New `/v1/jobs` endpoints** on the local server: `POST /v1/jobs` (enqueue, returns job IDs) and `GET /v1/jobs/<id>` (status as `JobStatusDTO`). Routed before the existing debug endpoints, behind the same localhost + bearer-token + Origin checks (which were extracted into a shared guard helper).

## Out of scope (follow-ups)

Speaker-naming over the API, a one-call blocking endpoint, idempotency keys, MCP/CLI fronts, docs, and a watch-folder ingest are intentionally deferred to keep this slice reviewable.

## Tests

- 18 new tests added test-first (TerminalJobStore, PipelineController, PipelineQueue, and real-socket `/v1` integration tests).
- Full debug suite green except `MenuBarIconSnapshotTests`, which are golden-image comparisons that also fail on `main` in this environment (unrelated to this change).
- Release build parity (Homebrew) and App Store variant both compile; lint clean.
