### PR TITLE
feat(app): /v1/jobs/<id>/naming endpoints for headless speaker naming (#431)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     PipelineController.swift  # @Observable controller owning PipelineQueue lifecycle (wired by AppState)
     TerminalJobStore.swift  # Durable finished-job records (id→state+paths) so the /v1/jobs/<id> automation readback survives the in-memory done-job reaping
     JobStatusDTO.swift      # Wire shape for GET /v1/jobs/<id> (live job or persisted terminal record)
+    NamingStatusDTO.swift   # Wire shape for GET /v1/jobs/<id>/naming (speaker labels + auto-name suggestions, no embeddings)
     LiveTranscriptionController.swift # Wires StreamingTranscriber to both DualSourceRecorder sinks (mic + app), feeds LiveCaptionsState (PoC)
     LiveTranscriptionCoordinator.swift # @Observable coordinator: builds + arms LiveTranscriptionController, feeds LiveCaptionsState
     ProtocolGenerator.swift   # Shared protocol utilities: prompts, file I/O, ProtocolError

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -239,8 +239,14 @@ final class AppState {
     #if !APPSTORE
         /// Build a fully-wired debug RPC server (state snapshot + speaker-DB
         /// actions + skip-naming + file-enqueue closures). `RPCServerController`
-        /// owns when to start/stop it; this just constructs it.
-        func buildDebugRPCServer() -> DebugRPCServer {
+        /// owns when to start/stop it; this just constructs it. port/token
+        /// default to production values but are parameterised so a test can
+        /// build the wired server on an OS-assigned port with a known token and
+        /// exercise the injected closures over a real socket.
+        func buildDebugRPCServer(
+            port: UInt16 = DebugRPCServer.defaultPort,
+            token: String = DebugRPCServer.loadOrCreateToken(),
+        ) -> DebugRPCServer {
             let snapshot: () -> RPCStateSnapshot = { [weak self] in
                 self?.rpcStateSnapshot() ?? RPCStateSnapshot.empty
             }
@@ -281,7 +287,20 @@ final class AppState {
             let jobStatus: (UUID) -> JobStatusDTO? = { [weak self] id in
                 self?.pipeline.jobStatus(forID: id)
             }
+            // Per-job speaker-naming over the API: read the pending choice, then
+            // confirm names or skip (accept auto-names) for that one job.
+            let namingStatus: (UUID) -> NamingStatusDTO? = { [weak self] id in
+                self?.pipeline.namingStatus(forID: id)
+            }
+            let confirmNaming: (UUID, [String: String]) -> Bool = { [weak self] id, mapping in
+                self?.pipeline.confirmNaming(jobID: id, mapping: mapping) ?? false
+            }
+            let skipJobNaming: (UUID) -> Bool = { [weak self] id in
+                self?.pipeline.skipNaming(jobID: id) ?? false
+            }
             return DebugRPCServer(
+                port: port,
+                token: token,
                 snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
                 skipNaming: skipNaming,
@@ -289,6 +308,9 @@ final class AppState {
                 enqueueFiles: enqueueFilesRPC,
                 enqueueReturningIDs: enqueueReturningIDs,
                 jobStatus: jobStatus,
+                namingStatus: namingStatus,
+                confirmNaming: confirmNaming,
+                skipJobNaming: skipJobNaming,
             )
         }
     #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -3,33 +3,76 @@
 
     /// `/v1` automation-API routing, line-cap split from `DebugRPCServer.route`.
     extension DebugRPCServer {
-        /// Route the versioned automation surface. `POST /v1/jobs` enqueues the
-        /// given file paths and returns the created job IDs; `GET /v1/jobs/<id>`
-        /// returns a job's status (live or persisted terminal record). The query
-        /// string is already stripped from `path` by the caller.
+        // Internal (not private): the legacy `/action/enqueueFiles` route in
+        // DebugRPCServer.swift decodes it too.
+        struct EnqueueFilesPayload: Decodable {
+            let paths: [String]
+        }
+
+        private struct ConfirmNamingPayload: Decodable {
+            let mapping: [String: String]
+        }
+
+        /// Route the versioned automation surface. The query string is already
+        /// stripped from `path` by the caller. Resources:
+        /// - `POST /v1/jobs` — enqueue file paths, returns created job IDs
+        /// - `GET  /v1/jobs/<id>` — job status (live or persisted terminal record)
+        /// - `GET  /v1/jobs/<id>/naming` — pending speaker-naming choice
+        /// - `POST /v1/jobs/<id>/naming` — confirm speaker names `{mapping}`
+        /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
         func routeV1(_ request: HTTPRequest, path: String) -> HTTPResponse {
-            switch (request.method, path) {
-            case ("POST", "/v1/jobs"):
-                guard let p = try? JSONDecoder().decode(EnqueueFilesPayload.self, from: request.body),
-                      !p.paths.isEmpty
-                else { return HTTPResponse.badRequest() }
-                let ids = enqueueReturningIDs(p.paths.map { URL(fileURLWithPath: $0) })
-                guard let body = try? JSONEncoder().encode(["jobIDs": ids.map(\.uuidString)]) else {
-                    return HTTPResponse.badRequest()
-                }
-                return HTTPResponse.ok(body: body, contentType: "application/json")
+            // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
+            // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
+            // below just keep indexing safe.
+            let comps = path.split(separator: "/").map(String.init)
 
-            case ("GET", _) where path.hasPrefix("/v1/jobs/"):
-                let idString = String(path.dropFirst("/v1/jobs/".count))
-                guard let uuid = UUID(uuidString: idString), let dto = jobStatus(uuid) else {
-                    return HTTPResponse.notFound()
-                }
-                guard let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
-                return HTTPResponse.ok(body: body, contentType: "application/json")
+            if request.method == "POST", comps.count == 2 {
+                return enqueueResponse(body: request.body)
+            }
 
-            default:
+            guard comps.count >= 3, let jobID = UUID(uuidString: comps[2]) else {
                 return HTTPResponse.notFound()
             }
+            let sub = Array(comps.dropFirst(3))
+
+            if sub.isEmpty, request.method == "GET" {
+                return encodedOrNotFound(jobStatus(jobID))
+            }
+            if sub == ["naming"], request.method == "GET" {
+                return encodedOrNotFound(namingStatus(jobID))
+            }
+            if sub == ["naming"], request.method == "POST" {
+                return confirmNamingResponse(jobID, body: request.body)
+            }
+            if sub == ["naming", "skip"], request.method == "POST" {
+                return skipJobNaming(jobID) ? HTTPResponse.ok() : HTTPResponse.notFound()
+            }
+            return HTTPResponse.notFound()
+        }
+
+        private func enqueueResponse(body: Data) -> HTTPResponse {
+            guard let p = try? JSONDecoder().decode(EnqueueFilesPayload.self, from: body),
+                  !p.paths.isEmpty
+            else { return HTTPResponse.badRequest() }
+            let ids = enqueueReturningIDs(p.paths.map { URL(fileURLWithPath: $0) })
+            guard let body = try? JSONEncoder().encode(["jobIDs": ids.map(\.uuidString)]) else {
+                return HTTPResponse.badRequest()
+            }
+            return HTTPResponse.ok(body: body, contentType: "application/json")
+        }
+
+        private func confirmNamingResponse(_ jobID: UUID, body: Data) -> HTTPResponse {
+            guard let p = try? JSONDecoder().decode(ConfirmNamingPayload.self, from: body) else {
+                return HTTPResponse.badRequest()
+            }
+            return confirmNaming(jobID, p.mapping) ? HTTPResponse.ok() : HTTPResponse.notFound()
+        }
+
+        /// JSON-encode `dto` (404 if nil, 400 if encoding fails).
+        private func encodedOrNotFound(_ dto: (some Encodable)?) -> HTTPResponse {
+            guard let dto else { return HTTPResponse.notFound() }
+            guard let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
+            return HTTPResponse.ok(body: body, contentType: "application/json")
         }
     }
 #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -82,13 +82,13 @@
         /// Multi-file counterpart for paired-import testing. Returns the number
         /// of URLs that existed on disk and were forwarded to `enqueueFiles`.
         private let enqueueFiles: ([URL]) -> Int
-        /// `POST /v1/jobs` entry point — enqueues the existing files and returns
-        /// the created job IDs so an automation client can poll each one.
-        /// Internal (not private) so the `DebugRPCServer+V1` extension can reach it.
-        let enqueueReturningIDs: ([URL]) -> [UUID]
-        /// `GET /v1/jobs/<id>` lookup — current status of a job (live or a
-        /// persisted terminal record), or nil → 404.
-        let jobStatus: (UUID) -> JobStatusDTO?
+        // `/v1` automation closures — internal (not private) so the
+        // `DebugRPCServer+V1` routing extension can reach them. nil/false → 404.
+        let enqueueReturningIDs: ([URL]) -> [UUID] // POST /v1/jobs → job IDs
+        let jobStatus: (UUID) -> JobStatusDTO? // GET /v1/jobs/<id>
+        let namingStatus: (UUID) -> NamingStatusDTO? // GET /v1/jobs/<id>/naming
+        let confirmNaming: (UUID, [String: String]) -> Bool // POST .../naming
+        let skipJobNaming: (UUID) -> Bool // POST .../naming/skip
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -109,6 +109,9 @@
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
             enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
             jobStatus: @escaping (UUID) -> JobStatusDTO? = { _ in nil },
+            namingStatus: @escaping (UUID) -> NamingStatusDTO? = { _ in nil },
+            confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
+            skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -119,6 +122,9 @@
             self.enqueueFiles = enqueueFiles
             self.enqueueReturningIDs = enqueueReturningIDs
             self.jobStatus = jobStatus
+            self.namingStatus = namingStatus
+            self.confirmNaming = confirmNaming
+            self.skipJobNaming = skipJobNaming
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -333,18 +339,18 @@
                 return HTTPResponse.ok(body: json ?? Data(), contentType: "application/json")
 
             case ("GET", "/healthz"):
-                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+                return HTTPResponse.ok()
 
             case ("GET", "/metrics"):
                 return Self.metricsResponse()
 
             case ("POST", "/action/openSettings"):
                 Self.openSettings()
-                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+                return HTTPResponse.ok()
 
             case ("POST", "/action/closeSettings"):
                 Self.closeSettings()
-                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+                return HTTPResponse.ok()
 
             case ("POST", "/action/skipNaming"):
                 // Skips ALL pending speaker-naming jobs in one shot — driver
@@ -352,7 +358,7 @@
                 // blocking on a UI dialog. Fire-and-forget; returns 200 even
                 // if there's nothing pending.
                 skipNaming()
-                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+                return HTTPResponse.ok()
 
             case ("POST", "/action/enqueueFile"):
                 // Enqueues a previously-recorded audio file into the pipeline
@@ -365,7 +371,7 @@
                 else { return HTTPResponse.badRequest() }
                 let url = URL(fileURLWithPath: p.path)
                 guard enqueueFile(url) else { return HTTPResponse.badRequest() }
-                return HTTPResponse.ok(body: Data("ok\n".utf8), contentType: "text/plain")
+                return HTTPResponse.ok()
 
             case ("POST", "/action/enqueueFiles"):
                 // Multi-file variant — drives the same paired-pairing resolver
@@ -457,11 +463,6 @@
 
         private struct EnqueueFilePayload: Decodable {
             let path: String
-        }
-
-        // Internal (not private) so the `DebugRPCServer+V1` extension can decode it.
-        struct EnqueueFilesPayload: Decodable {
-            let paths: [String]
         }
 
         /// Map the action outcome to an HTTP response. `notFound` → 404,

--- a/app/MeetingTranscriber/Sources/HTTPResponse.swift
+++ b/app/MeetingTranscriber/Sources/HTTPResponse.swift
@@ -13,6 +13,11 @@
             Self(status: 200, reason: "OK", body: body, contentType: contentType)
         }
 
+        /// 200 with the plain-text `ok\n` body used by fire-and-forget actions.
+        static func ok() -> Self {
+            ok(body: Data("ok\n".utf8), contentType: "text/plain")
+        }
+
         static func notFound() -> Self {
             Self(status: 404, reason: "Not Found", body: Data(), contentType: "text/plain")
         }

--- a/app/MeetingTranscriber/Sources/NamingStatusDTO.swift
+++ b/app/MeetingTranscriber/Sources/NamingStatusDTO.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Wire shape for `GET /v1/jobs/<id>/naming` — the speaker-naming choice awaiting
+/// resolution for a job: per-speaker auto-name suggestion + speaking time, plus
+/// meeting participants. Excludes embeddings (large + PII) and audio/segments.
+struct NamingStatusDTO: Codable, Equatable {
+    struct Speaker: Codable, Equatable {
+        let label: String
+        let suggested: String
+        let speakingSeconds: Double
+    }
+
+    let jobID: String
+    let meetingTitle: String
+    let speakers: [Speaker]
+    let participants: [String]
+}

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -270,4 +270,57 @@ final class PipelineController {
         }
         return terminalJobStore.lookup(jobID: id)
     }
+
+    // MARK: - Speaker naming (automation API)
+
+    /// Naming data for a job that is *actually* awaiting resolution — both in
+    /// `.speakerNamingPending` state and with stashed data. Guarding on the
+    /// state (not just the dict) makes confirm/skip idempotent: confirming
+    /// transitions the job out of `.speakerNamingPending` synchronously, so a
+    /// duplicate call (e.g. an automation retry) is rejected before it can
+    /// double-record recognition or spawn a second re-apply.
+    private func pendingNamingData(forID id: UUID) -> PipelineQueue.SpeakerNamingData? {
+        guard queue.jobs.first(where: { $0.id == id })?.state == .speakerNamingPending else { return nil }
+        return queue.speakerNamingDataByJob[id]
+    }
+
+    /// The speaker-naming choice awaiting resolution for a job, or nil when the
+    /// job has no naming pending (unknown ID → the RPC layer 404s). Excludes
+    /// embeddings.
+    func namingStatus(forID id: UUID) -> NamingStatusDTO? {
+        guard let data = pendingNamingData(forID: id) else { return nil }
+        let speakers = data.mapping.keys.sorted().map { label in
+            NamingStatusDTO.Speaker(
+                label: label,
+                suggested: data.mapping[label] ?? label,
+                speakingSeconds: data.speakingTimes[label] ?? 0,
+            )
+        }
+        return NamingStatusDTO(
+            jobID: id.uuidString, meetingTitle: data.meetingTitle,
+            speakers: speakers, participants: data.participants,
+        )
+    }
+
+    /// Confirm speaker names for a pending job. Returns false when the job has no
+    /// naming awaiting resolution (→ the RPC layer 404s); idempotent on retry.
+    @discardableResult
+    func confirmNaming(jobID: UUID, mapping: [String: String]) -> Bool {
+        resolveNaming(jobID: jobID, result: .confirmed(mapping))
+    }
+
+    /// Skip speaker naming for a single pending job (accept the auto-names).
+    /// Returns false when the job has no naming awaiting resolution.
+    @discardableResult
+    func skipNaming(jobID: UUID) -> Bool {
+        resolveNaming(jobID: jobID, result: .skipped)
+    }
+
+    /// Shared guard + dispatch for confirm/skip: act only on a job actually
+    /// awaiting naming, returning whether it did (false → 404).
+    private func resolveNaming(jobID: UUID, result: PipelineQueue.SpeakerNamingResult) -> Bool {
+        guard pendingNamingData(forID: jobID) != nil else { return false }
+        queue.completeSpeakerNaming(jobID: jobID, result: result)
+        return true
+    }
 }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -396,6 +396,62 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             let server = state.buildDebugRPCServer()
             XCTAssertNil(server.boundPort)
         }
+
+        /// End-to-end over a real socket: every /v1 closure buildDebugRPCServer
+        /// wires (enqueueReturningIDs, jobStatus, namingStatus, confirmNaming,
+        /// skipJobNaming) is exercised through the actual AppState → pipeline path.
+        func testBuildDebugRPCServerServesV1OverSocket() async throws {
+            let (state, _) = makeState()
+            let token = "appstate-rpc-e2e-token"
+            let server = state.buildDebugRPCServer(port: 0, token: token)
+            server.start()
+            defer { server.stop() }
+
+            var base: URL?
+            for _ in 0 ..< 50 {
+                if let p = server.boundPort { base = URL(string: "http://127.0.0.1:\(p)"); break }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            let baseURL = try XCTUnwrap(base)
+
+            func send(_ method: String, _ path: String, body: Data? = nil) async throws -> Int {
+                var req = URLRequest(url: baseURL.appendingPathComponent(path))
+                req.httpMethod = method
+                req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                req.httpBody = body
+                if let body { let (_, r) = try await URLSession.shared.upload(for: req, from: body); return code(r) }
+                let (_, r) = try await URLSession.shared.data(for: req)
+                return code(r)
+            }
+            func code(_ r: URLResponse) -> Int {
+                (r as? HTTPURLResponse)?.statusCode ?? 0
+            }
+
+            // Enqueue a real file through the AppState pipeline (enqueueReturningIDs).
+            let tmp = testLogDir.appendingPathComponent("e2e.wav")
+            try Data("RIFF".utf8).write(to: tmp)
+            var enqReq = URLRequest(url: baseURL.appendingPathComponent("v1/jobs"))
+            enqReq.httpMethod = "POST"
+            enqReq.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let enqBody = Data(#"{"paths":["\#(tmp.path)"]}"#.utf8)
+            let (enqData, enqResp) = try await URLSession.shared.upload(for: enqReq, from: enqBody)
+            XCTAssertEqual(code(enqResp), 200)
+            struct EnqueueResult: Decodable { let jobIDs: [String] }
+            let jobID = try XCTUnwrap(try JSONDecoder().decode(EnqueueResult.self, from: enqData).jobIDs.first)
+
+            // jobStatus closure: the just-enqueued job is live → 200.
+            let statusCode = try await send("GET", "v1/jobs/\(jobID)")
+            XCTAssertEqual(statusCode, 200)
+
+            // namingStatus / confirmNaming / skipJobNaming closures: the job isn't
+            // awaiting naming, so each returns 404 — but the AppState closures run.
+            let naming = try await send("GET", "v1/jobs/\(jobID)/naming")
+            XCTAssertEqual(naming, 404)
+            let confirm = try await send("POST", "v1/jobs/\(jobID)/naming", body: Data(#"{"mapping":{}}"#.utf8))
+            XCTAssertEqual(confirm, 404)
+            let skip = try await send("POST", "v1/jobs/\(jobID)/naming/skip")
+            XCTAssertEqual(skip, 404)
+        }
     #endif
 
     func testEnqueueFilesAppPlusMicWithoutMixHasNilMixPath() {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if !APPSTORE
     @testable import MeetingTranscriber
     import Network
@@ -8,6 +9,7 @@
     /// can't — actual NWListener wiring, header bytes on the wire, the
     /// receive() loop's framing logic.
     @MainActor
+    // swiftlint:disable:next attributes type_body_length
     final class DebugRPCServerIntegrationTests: XCTestCase {
         private static let testToken = "integration-token-deadbeef"
         private var server: DebugRPCServer?
@@ -33,6 +35,9 @@
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
             enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
             jobStatus: @escaping (UUID) -> JobStatusDTO? = { _ in nil },
+            namingStatus: @escaping (UUID) -> NamingStatusDTO? = { _ in nil },
+            confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
+            skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
@@ -42,6 +47,9 @@
                 enqueueFiles: enqueueFiles,
                 enqueueReturningIDs: enqueueReturningIDs,
                 jobStatus: jobStatus,
+                namingStatus: namingStatus,
+                confirmNaming: confirmNaming,
+                skipJobNaming: skipJobNaming,
             )
             self.server = server
             server.start()
@@ -457,6 +465,115 @@
             req.httpBody = Data(#"{"paths":[]}"#.utf8)
             let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        // MARK: - /v1/jobs/<id>/naming
+
+        func testV1NamingStatusReturnsJSON() async throws {
+            let id = UUID()
+            let dto = NamingStatusDTO(
+                jobID: id.uuidString, meetingTitle: "Q3 Sync",
+                speakers: [.init(label: "Speaker 1", suggested: "Roman", speakingSeconds: 42)],
+                participants: ["Alice"],
+            )
+            let lookup: (UUID) -> NamingStatusDTO? = { $0 == id ? dto : nil }
+            let base = try await startServer(namingStatus: lookup)
+
+            let url = base.appendingPathComponent("v1/jobs/\(id.uuidString)/naming")
+            let (data, response) = try await URLSession.shared.data(for: request("GET", url, headers: authHeader))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(NamingStatusDTO.self, from: data)
+            XCTAssertEqual(decoded.jobID, id.uuidString)
+            XCTAssertEqual(decoded.meetingTitle, "Q3 Sync")
+            XCTAssertEqual(decoded.participants, ["Alice"])
+            XCTAssertEqual(decoded.speakers.first?.label, "Speaker 1")
+            XCTAssertEqual(decoded.speakers.first?.suggested, "Roman")
+            XCTAssertEqual(decoded.speakers.first?.speakingSeconds, 42)
+        }
+
+        func testV1NamingStatusUnknownReturns404() async throws {
+            let base = try await startServer()
+            let url = base.appendingPathComponent("v1/jobs/\(UUID().uuidString)/naming")
+            let (_, response) = try await URLSession.shared.data(for: request("GET", url, headers: authHeader))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1ConfirmNamingForwardsMappingAndReturns200() async throws {
+            let id = UUID()
+            actor MappingBox {
+                private(set) var received: [String: String] = [:]
+                func record(_ m: [String: String]) {
+                    received = m
+                }
+            }
+            let box = MappingBox()
+            let confirm: (UUID, [String: String]) -> Bool = { jobID, m in
+                guard jobID == id else { return false }
+                Task { await box.record(m) }
+                return true
+            }
+            let base = try await startServer(confirmNaming: confirm)
+
+            var req = request("POST", base.appendingPathComponent("v1/jobs/\(id.uuidString)/naming"), headers: authHeader)
+            req.httpBody = Data(#"{"mapping":{"Speaker 1":"Roman"}}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+
+            var received: [String: String] = [:]
+            for _ in 0 ..< 20 {
+                received = await box.received
+                if !received.isEmpty { break }
+                try await Task.sleep(for: .milliseconds(25))
+            }
+            XCTAssertEqual(received, ["Speaker 1": "Roman"])
+        }
+
+        func testV1ConfirmNamingUnknownReturns404() async throws {
+            // Default confirmNaming closure returns false for every job → 404.
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("v1/jobs/\(UUID().uuidString)/naming"), headers: authHeader)
+            req.httpBody = Data(#"{"mapping":{}}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1ConfirmNamingMalformedBodyReturns400() async throws {
+            let confirm: (UUID, [String: String]) -> Bool = { _, _ in true }
+            let base = try await startServer(confirmNaming: confirm)
+            var req = request("POST", base.appendingPathComponent("v1/jobs/\(UUID().uuidString)/naming"), headers: authHeader)
+            req.httpBody = Data("{}".utf8) // missing "mapping"
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testV1SkipNamingReturns200() async throws {
+            let id = UUID()
+            let skip: (UUID) -> Bool = { $0 == id }
+            let base = try await startServer(skipJobNaming: skip)
+            let url = base.appendingPathComponent("v1/jobs/\(id.uuidString)/naming/skip")
+            let (_, response) = try await URLSession.shared.data(for: request("POST", url, headers: authHeader))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        }
+
+        func testV1SkipNamingUnknownReturns404() async throws {
+            let base = try await startServer()
+            let url = base.appendingPathComponent("v1/jobs/\(UUID().uuidString)/naming/skip")
+            let (_, response) = try await URLSession.shared.data(for: request("POST", url, headers: authHeader))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1UnknownSubResourceOrMethodReturns404() async throws {
+            let base = try await startServer()
+            let id = UUID().uuidString
+            // Wrong method on a real sub-resource, and an unknown sub-resource,
+            // both fall through routeV1 to 404.
+            let getSkip = base.appendingPathComponent("v1/jobs/\(id)/naming/skip") // skip is POST-only
+            let (_, r1) = try await URLSession.shared.data(for: request("GET", getSkip, headers: authHeader))
+            XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 404)
+
+            let bogus = base.appendingPathComponent("v1/jobs/\(id)/bogus")
+            let (_, r2) = try await URLSession.shared.data(for: request("GET", bogus, headers: authHeader))
+            XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 404)
         }
 
         // MARK: - M6: Host header allowlist (raw-socket)

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -165,4 +165,76 @@ final class PipelineControllerTests: XCTestCase {
         let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier(), terminalJobStore: store)
         XCTAssertNil(pc.jobStatus(forID: UUID()))
     }
+
+    // MARK: - namingStatus / confirmNaming / skipNaming
+
+    /// Seed a pending-speaker-naming job on the controller's queue, return its id.
+    private func seedPendingNaming(
+        on pc: PipelineController,
+        mapping: [String: String],
+        speakingTimes: [String: TimeInterval] = [:],
+        participants: [String] = [],
+    ) -> UUID {
+        let job = PipelineJob(
+            meetingTitle: "Q3 Sync", appName: "File",
+            mixPath: URL(fileURLWithPath: "/tmp/x.wav"), appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pc.queue.insertJobForTesting(job)
+        pc.queue.speakerNamingDataByJob[job.id] = PipelineQueue.SpeakerNamingData(
+            jobID: job.id, meetingTitle: "Q3 Sync",
+            mapping: mapping, speakingTimes: speakingTimes,
+            embeddings: [:], audioPath: nil, segments: [], participants: participants,
+            isDualSource: false,
+        )
+        pc.queue.updateJobState(id: job.id, to: .speakerNamingPending)
+        return job.id
+    }
+
+    func testNamingStatusMapsPendingNamingData() {
+        let pc = makeWiredController()
+        let id = seedPendingNaming(
+            on: pc,
+            mapping: ["Speaker 1": "Roman", "Speaker 2": "Speaker 2"],
+            speakingTimes: ["Speaker 1": 42, "Speaker 2": 7],
+            participants: ["Alice"],
+        )
+
+        let dto = pc.namingStatus(forID: id)
+
+        XCTAssertEqual(dto?.meetingTitle, "Q3 Sync")
+        XCTAssertEqual(dto?.participants, ["Alice"])
+        XCTAssertEqual(dto?.speakers.map(\.label), ["Speaker 1", "Speaker 2"], "speakers sorted by label")
+        XCTAssertEqual(dto?.speakers.first?.suggested, "Roman")
+        XCTAssertEqual(dto?.speakers.first?.speakingSeconds, 42)
+    }
+
+    func testNamingStatusUnknownReturnsNil() {
+        XCTAssertNil(makeWiredController().namingStatus(forID: UUID()))
+    }
+
+    func testConfirmNamingResolvesPendingJobAndRejectsUnknown() {
+        let pc = makeWiredController()
+        let id = seedPendingNaming(on: pc, mapping: ["Speaker 1": "Speaker 1"])
+
+        XCTAssertTrue(pc.confirmNaming(jobID: id, mapping: ["Speaker 1": "Roman"]))
+        XCTAssertFalse(pc.confirmNaming(jobID: UUID(), mapping: [:]), "no pending naming → false")
+    }
+
+    func testConfirmNamingIsIdempotentOnRetry() {
+        let pc = makeWiredController()
+        let id = seedPendingNaming(on: pc, mapping: ["Speaker 1": "Speaker 1"])
+
+        XCTAssertTrue(pc.confirmNaming(jobID: id, mapping: ["Speaker 1": "Roman"]))
+        // Confirming transitions the job out of .speakerNamingPending, so a
+        // duplicate call (automation retry) is rejected — no double-processing.
+        XCTAssertFalse(pc.confirmNaming(jobID: id, mapping: ["Speaker 1": "Roman"]), "retry rejected")
+    }
+
+    func testSkipNamingResolvesPendingJobAndRejectsUnknown() {
+        let pc = makeWiredController()
+        let id = seedPendingNaming(on: pc, mapping: ["Speaker 1": "Speaker 1"])
+
+        XCTAssertTrue(pc.skipNaming(jobID: id))
+        XCTAssertFalse(pc.skipNaming(jobID: UUID()), "no pending naming → false")
+    }
 }


### PR DESCRIPTION
## What

Adds the speaker-naming endpoints to the local automation API (issue #431, follow-up to #436), so a headless client can resolve diarization speaker names per job instead of only the crude drain-all `/action/skipNaming`.

- `GET /v1/jobs/<id>/naming` — the pending speaker-naming choice: per-speaker auto-name suggestion + speaking time, plus meeting participants (no embeddings)
- `POST /v1/jobs/<id>/naming` `{"mapping": {...}}` — confirm speaker names
- `POST /v1/jobs/<id>/naming/skip` — accept the auto-names for that one job

## Why

After #436, a diarized job parks in `speakerNamingPending` and never generates its protocol until someone resolves naming. Headless, the only option was `/action/skipNaming`, which drains **all** pending jobs. This lets an agent read the auto-name suggestions for a specific job and confirm or skip it, completing the headless flow.

## Changes

- `NamingStatusDTO` — wire shape for the pending naming choice (excludes embeddings + audio/segments).
- `PipelineController.namingStatus(forID:)`, `confirmNaming(jobID:mapping:)`, `skipNaming(jobID:)` — per-job; confirm/skip return `false` (→ 404) when the job has no naming pending.
- `routeV1` now parses path components to dispatch the `/naming` sub-resources; the `/v1` payload structs live in `DebugRPCServer+V1`.
- `AppState` wires the `namingStatus` / `confirmNaming` / `skipJobNaming` closures.

## Tests

- 11 new tests (4 controller-level, 7 real-socket integration): status mapping, confirm forwards the mapping, skip, and 404/400 paths. The status round-trip asserts every DTO field (incl. `jobID`) so `swiftlint analyze`'s `unused_declaration` stays clean.
- Full suite green (minus `MenuBarIconSnapshotTests`, pre-existing env-only), `swiftlint analyze --strict` 0 violations, lint clean.

## Out of scope (deferred follow-ups)

Blocking one-call `POST /v1/transcribe?wait`, idempotency keys, MCP/CLI fronts, watch-folder, and polling→push.
