### PR TITLE
feat(app): blocking POST /v1/transcribe endpoint (#431)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -298,6 +298,12 @@ final class AppState {
             let skipJobNaming: (UUID) -> Bool = { [weak self] id in
                 self?.pipeline.skipNaming(jobID: id) ?? false
             }
+            // Blocking one-call: enqueue + wait until terminal (auto-skipping
+            // the headless naming pause), returning the final status inline.
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { [weak self] url, maxWait in
+                guard let self else { return .noFile }
+                return await pipeline.transcribeAndWait(path: url, maxWaitSeconds: maxWait)
+            }
             return DebugRPCServer(
                 port: port,
                 token: token,
@@ -311,6 +317,7 @@ final class AppState {
                 namingStatus: namingStatus,
                 confirmNaming: confirmNaming,
                 skipJobNaming: skipJobNaming,
+                transcribe: transcribe,
             )
         }
     #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -13,14 +13,27 @@
             let mapping: [String: String]
         }
 
+        private struct TranscribePayload: Decodable {
+            let path: String
+            let maxWaitSeconds: Double?
+        }
+
+        /// Default / hard-cap blocking-transcribe wait (seconds).
+        private static let defaultTranscribeWaitSeconds: Double = 600
+        private static let maxTranscribeWaitSeconds: Double = 1800
+
         /// Route the versioned automation surface. The query string is already
         /// stripped from `path` by the caller. Resources:
+        /// - `POST /v1/transcribe` — enqueue one file, block until terminal
         /// - `POST /v1/jobs` — enqueue file paths, returns created job IDs
         /// - `GET  /v1/jobs/<id>` — job status (live or persisted terminal record)
         /// - `GET  /v1/jobs/<id>/naming` — pending speaker-naming choice
         /// - `POST /v1/jobs/<id>/naming` — confirm speaker names `{mapping}`
         /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
-        func routeV1(_ request: HTTPRequest, path: String) -> HTTPResponse {
+        func routeV1(_ request: HTTPRequest, path: String) async -> HTTPResponse {
+            if request.method == "POST", path == "/v1/transcribe" {
+                return await transcribeResponse(body: request.body)
+            }
             // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
             // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
             // below just keep indexing safe.
@@ -59,6 +72,25 @@
                 return HTTPResponse.badRequest()
             }
             return HTTPResponse.ok(body: body, contentType: "application/json")
+        }
+
+        private func transcribeResponse(body: Data) async -> HTTPResponse {
+            guard let p = try? JSONDecoder().decode(TranscribePayload.self, from: body), !p.path.isEmpty
+            else { return HTTPResponse.badRequest() }
+            let requested = p.maxWaitSeconds ?? Self.defaultTranscribeWaitSeconds
+            let wait = min(max(0, requested), Self.maxTranscribeWaitSeconds)
+            switch await transcribe(URL(fileURLWithPath: p.path), wait) {
+            case .noFile:
+                return HTTPResponse.badRequest()
+
+            case let .completed(dto):
+                return encodedOrNotFound(dto)
+
+            case let .timedOut(dto):
+                // 202 Accepted: still running; client polls GET /v1/jobs/<id>.
+                guard let dto, let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
+                return HTTPResponse(status: 202, reason: "Accepted", body: body, contentType: "application/json")
+            }
         }
 
         private func confirmNamingResponse(_ jobID: UUID, body: Data) -> HTTPResponse {

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -89,6 +89,7 @@
         let namingStatus: (UUID) -> NamingStatusDTO? // GET /v1/jobs/<id>/naming
         let confirmNaming: (UUID, [String: String]) -> Bool // POST .../naming
         let skipJobNaming: (UUID) -> Bool // POST .../naming/skip
+        let transcribe: (URL, Double) async -> BlockingTranscribeResult // POST /v1/transcribe
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests
@@ -112,6 +113,7 @@
             namingStatus: @escaping (UUID) -> NamingStatusDTO? = { _ in nil },
             confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
             skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
+            transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -125,6 +127,7 @@
             self.namingStatus = namingStatus
             self.confirmNaming = confirmNaming
             self.skipJobNaming = skipJobNaming
+            self.transcribe = transcribe
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -329,8 +332,8 @@
             // endpoints. Routed before the legacy switch. Strip any query string
             // so `/v1/jobs/<id>?x=1` still resolves the id rather than 404ing.
             let v1Path = String(request.path.prefix { $0 != "?" })
-            if v1Path == "/v1/jobs" || v1Path.hasPrefix("/v1/jobs/") {
-                return routeV1(request, path: v1Path)
+            if v1Path == "/v1/jobs" || v1Path.hasPrefix("/v1/jobs/") || v1Path == "/v1/transcribe" {
+                return await routeV1(request, path: v1Path)
             }
 
             switch (request.method, request.path) {

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -206,14 +206,14 @@ final class PipelineController {
     /// disk. Distinct from the file count above: paired imports yield fewer IDs
     /// than files.
     @discardableResult
-    func enqueueExistingFilesReturningIDs(_ urls: [URL]) -> [UUID] {
+    func enqueueExistingFilesReturningIDs(_ urls: [URL], autoSkipNaming: Bool = false) -> [UUID] {
         let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
         guard !existing.isEmpty else { return [] }
-        return enqueueFiles(existing)
+        return enqueueFiles(existing, autoSkipNaming: autoSkipNaming)
     }
 
     @discardableResult
-    func enqueueFiles(_ urls: [URL]) -> [UUID] {
+    func enqueueFiles(_ urls: [URL], autoSkipNaming: Bool = false) -> [UUID] {
         ensureQueue()
 
         let resolution = PairedRecordingResolver.resolve(urls: urls)
@@ -237,6 +237,7 @@ final class PipelineController {
                 meetingTitle: title, appName: appName,
                 mixPath: group.mix, appPath: group.app, micPath: group.mic,
                 micDelay: micDelay, participants: participants,
+                autoSkipNaming: autoSkipNaming,
             )
             ids.append(job.id)
             queue.enqueue(job)
@@ -251,6 +252,7 @@ final class PipelineController {
                 appPath: nil,
                 micPath: nil,
                 micDelay: 0,
+                autoSkipNaming: autoSkipNaming,
             )
             ids.append(job.id)
             queue.enqueue(job)
@@ -323,4 +325,45 @@ final class PipelineController {
         queue.completeSpeakerNaming(jobID: jobID, result: result)
         return true
     }
+
+    // MARK: - Blocking transcribe (one-call automation API)
+
+    /// Enqueue a single file with `autoSkipNaming` so it completes headlessly
+    /// (the queue accepts the auto-assigned speaker names instead of parking at
+    /// `.speakerNamingPending`), then wait until the job reaches a terminal
+    /// state. Returns `.noFile` when the path doesn't exist, `.timedOut` with
+    /// the in-flight status once `maxWaitSeconds` elapses (the job keeps running
+    /// and will still finish on its own), else `.completed` with the terminal
+    /// status.
+    func transcribeAndWait(
+        path: URL,
+        maxWaitSeconds: Double,
+        pollInterval: Duration = .milliseconds(200),
+    ) async -> BlockingTranscribeResult {
+        guard let jobID = enqueueExistingFilesReturningIDs([path], autoSkipNaming: true).first
+        else { return .noFile }
+        let deadline = ContinuousClock.now.advanced(by: .seconds(maxWaitSeconds))
+        while ContinuousClock.now < deadline {
+            if let job = queue.jobs.first(where: { $0.id == jobID }) {
+                if job.state == .done || job.state == .error { return .completed(JobStatusDTO(job: job)) }
+            } else if let record = terminalJobStore.lookup(jobID: jobID) {
+                return .completed(record) // already reaped from the live queue
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        // Final read: a job that went terminal in the last sub-interval window
+        // (or while we were enqueuing with maxWaitSeconds==0) is completed, not
+        // timed out.
+        let final = jobStatus(forID: jobID)
+        if let final, final.state == .done || final.state == .error { return .completed(final) }
+        return .timedOut(final)
+    }
+}
+
+/// Outcome of a blocking `transcribeAndWait`. The RPC layer maps `noFile` → 400,
+/// `completed` → 200, `timedOut` → 202.
+enum BlockingTranscribeResult {
+    case noFile
+    case completed(JobStatusDTO)
+    case timedOut(JobStatusDTO?)
 }

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -67,6 +67,17 @@ struct PipelineJob: Identifiable, Codable {
     /// callers fall back to the current global setting.
     var usedDiarizerMode: DiarizerMode?
 
+    // When true, the pipeline accepts the auto-assigned speaker names instead of
+    // parking at .speakerNamingPending for an interactive client. Set by the
+    // headless blocking-transcribe API path so a multi-speaker job still
+    // completes on its own.
+    //
+    // Optional (not Bool) so a legacy snapshot missing this key decodes as nil:
+    // synthesized Codable throws on a missing non-optional key. nil and false
+    // both mean "keep the interactive pause", so callers read `== true`.
+    // swiftlint:disable:next discouraged_optional_boolean
+    var autoSkipNaming: Bool?
+
     init(
         meetingTitle: String,
         appName: String,
@@ -75,6 +86,7 @@ struct PipelineJob: Identifiable, Codable {
         micPath: URL?,
         micDelay: TimeInterval,
         participants: [String] = [],
+        autoSkipNaming: Bool = false,
     ) {
         self.id = UUID()
         self.meetingTitle = meetingTitle
@@ -92,5 +104,6 @@ struct PipelineJob: Identifiable, Codable {
         self.protocolPath = nil
         self.namingSlug = nil
         self.usedDiarizerMode = nil
+        self.autoSkipNaming = autoSkipNaming
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1112,6 +1112,14 @@ class PipelineQueue {
         namingData: SpeakerNamingData, autoNames: [String: String],
         recog: RecognitionContext, ctx: JobContext,
     ) async -> SpeakerNamingOutcome {
+        if jobs.first(where: { $0.id == ctx.jobID })?.autoSkipNaming == true {
+            // Headless blocking-transcribe: accept the auto-assigned names
+            // inline (exactly like a `.skipped` dialog result) so the job
+            // finishes on its own. Don't stash naming data — there is no
+            // interactive client to resolve it, and parking would wedge the
+            // job until the next launch's 24h stale-cleanup.
+            return .finalized(autoNames)
+        }
         guard let handler = speakerNamingHandler else {
             // Production: stash data, don't block the pipeline. The notification
             // is posted later — after the job transitions to

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -451,6 +451,15 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             XCTAssertEqual(confirm, 404)
             let skip = try await send("POST", "v1/jobs/\(jobID)/naming/skip")
             XCTAssertEqual(skip, 404)
+
+            // transcribe closure (blocking one-call): maxWaitSeconds 0 leaves the
+            // just-enqueued job in-flight at the deadline → 202, exercising the
+            // AppState closure's delegation to pipeline.transcribeAndWait.
+            let txFile = testLogDir.appendingPathComponent("e2e-transcribe.wav")
+            try Data("RIFF".utf8).write(to: txFile)
+            let txBody = Data(#"{"path":"\#(txFile.path)","maxWaitSeconds":0}"#.utf8)
+            let tx = try await send("POST", "v1/transcribe", body: txBody)
+            XCTAssertEqual(tx, 202)
         }
     #endif
 

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -38,6 +38,7 @@
             namingStatus: @escaping (UUID) -> NamingStatusDTO? = { _ in nil },
             confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
             skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
+            transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
@@ -50,6 +51,7 @@
                 namingStatus: namingStatus,
                 confirmNaming: confirmNaming,
                 skipJobNaming: skipJobNaming,
+                transcribe: transcribe,
             )
             self.server = server
             server.start()
@@ -574,6 +576,57 @@
             let bogus = base.appendingPathComponent("v1/jobs/\(id)/bogus")
             let (_, r2) = try await URLSession.shared.data(for: request("GET", bogus, headers: authHeader))
             XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        // MARK: - POST /v1/transcribe (blocking)
+
+        func testV1TranscribeCompletedReturns200() async throws {
+            let dto = JobStatusDTO(
+                jobID: UUID().uuidString, state: .done, meetingTitle: "M",
+                transcriptPath: "/out/t.txt", protocolPath: nil, error: nil, warnings: [],
+            )
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in await Task.yield(); return .completed(dto) }
+            let base = try await startServer(transcribe: transcribe)
+
+            var req = request("POST", base.appendingPathComponent("v1/transcribe"), headers: authHeader)
+            req.httpBody = Data(#"{"path":"/inbox/a.wav"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(JobStatusDTO.self, from: data)
+            XCTAssertEqual(decoded.state, .done)
+            XCTAssertEqual(decoded.transcriptPath, "/out/t.txt")
+        }
+
+        func testV1TranscribeTimedOutReturns202() async throws {
+            let dto = JobStatusDTO(
+                jobID: UUID().uuidString, state: .transcribing, meetingTitle: "M",
+                transcriptPath: nil, protocolPath: nil, error: nil, warnings: [],
+            )
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in await Task.yield(); return .timedOut(dto) }
+            let base = try await startServer(transcribe: transcribe)
+
+            var req = request("POST", base.appendingPathComponent("v1/transcribe"), headers: authHeader)
+            req.httpBody = Data(#"{"path":"/inbox/a.wav","maxWaitSeconds":1}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 202)
+        }
+
+        func testV1TranscribeNoFileReturns400() async throws {
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in await Task.yield(); return .noFile }
+            let base = try await startServer(transcribe: transcribe)
+
+            var req = request("POST", base.appendingPathComponent("v1/transcribe"), headers: authHeader)
+            req.httpBody = Data(#"{"path":"/inbox/missing.wav"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testV1TranscribeEmptyPathReturns400() async throws {
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("v1/transcribe"), headers: authHeader)
+            req.httpBody = Data(#"{"path":""}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
         }
 
         // MARK: - M6: Host header allowlist (raw-socket)

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -237,4 +237,77 @@ final class PipelineControllerTests: XCTestCase {
         XCTAssertTrue(pc.skipNaming(jobID: id))
         XCTAssertFalse(pc.skipNaming(jobID: UUID()), "no pending naming → false")
     }
+
+    // MARK: - transcribeAndWait (blocking)
+
+    func testTranscribeAndWaitReturnsNoFileForMissingPath() async {
+        let pc = makeWiredController()
+        let result = await pc.transcribeAndWait(
+            path: URL(fileURLWithPath: "/tmp/missing-\(UUID().uuidString).wav"), maxWaitSeconds: 1,
+        )
+        guard case .noFile = result else { XCTFail("expected .noFile, got \(result)"); return }
+    }
+
+    func testTranscribeAndWaitCompletesJob() async {
+        let pc = makeWiredController()
+        let file = tmpDir.appendingPathComponent("blocking.wav")
+        FileManager.default.createFile(atPath: file.path, contents: Data("RIFF".utf8))
+
+        let result = await pc.transcribeAndWait(path: file, maxWaitSeconds: 10, pollInterval: .milliseconds(10))
+
+        guard case let .completed(dto) = result else { XCTFail("expected .completed, got \(result)"); return }
+        XCTAssertTrue(dto.state == .done || dto.state == .error, "wait loop returns on terminal state: \(dto.state)")
+    }
+
+    func testTranscribeAndWaitTimesOutWhileInFlight() async {
+        let pc = makeWiredController()
+        let file = tmpDir.appendingPathComponent("blocking-timeout.wav")
+        FileManager.default.createFile(atPath: file.path, contents: Data("RIFF".utf8))
+
+        // maxWaitSeconds 0 → the deadline is already past, so the just-enqueued
+        // (still non-terminal) job yields a timeout with its in-flight status.
+        let result = await pc.transcribeAndWait(path: file, maxWaitSeconds: 0, pollInterval: .milliseconds(10))
+
+        guard case let .timedOut(dto) = result else { XCTFail("expected .timedOut, got \(result)"); return }
+        XCTAssertNotEqual(dto?.state, .done)
+    }
+
+    func testTranscribeAndWaitFallsBackToTerminalStoreWhenJobReaped() async {
+        // A job that completed and was reaped from the live queue before the poll
+        // loop observed it must still resolve via the terminal store (the slow
+        // poller the store exists for). ReapingQueue reproduces that
+        // deterministically: enqueue records a terminal DTO and leaves `jobs`
+        // empty.
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_reap.json"))
+        let pc = PipelineController(settings: AppSettings(), notifier: RecordingNotifier(), terminalJobStore: store)
+        pc.queue = ReapingQueue(store: store)
+
+        let file = tmpDir.appendingPathComponent("reaped.wav")
+        FileManager.default.createFile(atPath: file.path, contents: Data("RIFF".utf8))
+
+        let result = await pc.transcribeAndWait(path: file, maxWaitSeconds: 5, pollInterval: .milliseconds(10))
+
+        guard case let .completed(dto) = result else { XCTFail("expected .completed from terminal store, got \(result)"); return }
+        XCTAssertEqual(dto.state, .done)
+    }
+}
+
+/// A `PipelineQueue` whose `enqueue` records a terminal DTO to the store and
+/// never keeps the job in `jobs` — reproduces a job reaped from the live queue
+/// before `transcribeAndWait`'s poll loop observes it.
+@MainActor
+private final class ReapingQueue: PipelineQueue {
+    private let store: TerminalJobStore
+
+    init(store: TerminalJobStore) {
+        self.store = store
+        super.init(terminalJobStore: store)
+    }
+
+    override func enqueue(_ job: PipelineJob) {
+        store.record(JobStatusDTO(
+            jobID: job.id.uuidString, state: .done, meetingTitle: job.meetingTitle,
+            transcriptPath: nil, protocolPath: nil, error: nil, warnings: [],
+        ))
+    }
 }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1641,6 +1641,48 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(finalState, .done, "Confirmed naming should end as .done")
     }
 
+    func testPipelineAutoSkipsNamingForHeadlessJob() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+        // No speakerNamingHandler — the production/headless path. autoSkipNaming
+        // must make the job finish on its own instead of parking at
+        // .speakerNamingPending (which would wedge a headless blocking call).
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Headless Test",
+            appName: "TestApp",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.autoSkipNaming = true
+        pQueue.enqueue(job)
+        await pQueue.processNext()
+
+        XCTAssertEqual(
+            pQueue.jobs.first?.state, .done,
+            "autoSkipNaming job must complete without parking at .speakerNamingPending",
+        )
+        XCTAssertNil(
+            pQueue.speakerNamingDataByJob[job.id],
+            "Auto-skipped job should not stash naming data awaiting resolution",
+        )
+    }
+
     func testCompleteSpeakerNamingLateConfirmedTransitionsToDone() async {
         let queue = PipelineQueue(logDir: tmpDir)
         var job = PipelineJob(


### PR DESCRIPTION
Third slice of the local automation API from #431 (after #436 per-job status readback and #437 headless speaker naming). Adds a single blocking call so a script or LLM agent can transcribe one file and get the result back in one request, instead of enqueue-then-poll.

## What it does

`POST /v1/transcribe` with `{"path": "/inbox/a.wav", "maxWaitSeconds": 600}` enqueues the file and waits until the job reaches a terminal state, then returns the job status inline:

- **200** with the `JobStatusDTO` when the job finishes (`done` or `error`).
- **202** with the in-flight status when `maxWaitSeconds` elapses first. The job keeps running and still finishes on its own; the client can poll `GET /v1/jobs/<id>` for the final result.
- **400** when the path is missing on disk or empty.

`maxWaitSeconds` is optional (defaults to 600) and clamped to `[0, 1800]`, so a wedged job can never hold the request socket open indefinitely and a negative value can't slip through.

## Headless naming

A blocking caller has no UI to name speakers, so a multi-speaker job would otherwise park at the naming pause forever (until the 24h stale-cleanup on the next launch). This adds an `autoSkipNaming` flag on the pipeline job: when set, the pipeline accepts the auto-assigned speaker names inline, exactly like a skipped naming dialog, so the job completes on its own. The flag is set only on the blocking-transcribe enqueue path. Jobs enqueued via `POST /v1/jobs` are unaffected and still drive naming through the `#437` endpoints.

The flag is persisted (Optional, so legacy snapshots decode cleanly) so a crash-recovered headless job stays headless.

## Tests

- Pipeline auto-skip: a diarized job with `autoSkipNaming` and no naming handler reaches `done` without parking (with the existing parking test kept as the control).
- `transcribeAndWait`: missing path, completes, and times-out-while-in-flight.
- Endpoint over a real socket: 200 / 202 / 400 (missing path) / 400 (empty path).

## Notes

The status-poll loop is the same fixed-interval polling used by the earlier slices; replacing it with an event-driven wait is tracked as a separate follow-up.