### PR TITLE
feat(app): /v1 automation API polish — idempotency, 409, relabel (#431)

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -31,8 +31,9 @@
         /// - `POST /v1/jobs/<id>/naming` — confirm speaker names `{mapping}`
         /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
         func routeV1(_ request: HTTPRequest, path: String) async -> HTTPResponse {
+            let idempotencyKey = request.headers["idempotency-key"]
             if request.method == "POST", path == "/v1/transcribe" {
-                return await transcribeResponse(body: request.body)
+                return await transcribeResponse(body: request.body, idempotencyKey: idempotencyKey)
             }
             // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
             // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
@@ -40,7 +41,7 @@
             let comps = path.split(separator: "/").map(String.init)
 
             if request.method == "POST", comps.count == 2 {
-                return enqueueResponse(body: request.body)
+                return enqueueResponse(body: request.body, idempotencyKey: idempotencyKey)
             }
 
             guard comps.count >= 3, let jobID = UUID(uuidString: comps[2]) else {
@@ -58,46 +59,76 @@
                 return confirmNamingResponse(jobID, body: request.body)
             }
             if sub == ["naming", "skip"], request.method == "POST" {
-                return skipJobNaming(jobID) ? HTTPResponse.ok() : HTTPResponse.notFound()
+                return skipJobNaming(jobID) ? HTTPResponse.ok() : namingFailureStatus(jobID)
             }
             return HTTPResponse.notFound()
         }
 
-        private func enqueueResponse(body: Data) -> HTTPResponse {
+        /// Failure status for confirm/skip naming: 409 when the job exists but
+        /// isn't awaiting naming (wrong state), 404 when the job id is unknown.
+        private func namingFailureStatus(_ jobID: UUID) -> HTTPResponse {
+            jobStatus(jobID) != nil ? HTTPResponse.conflict() : HTTPResponse.notFound()
+        }
+
+        private func enqueueResponse(body: Data, idempotencyKey: String?) -> HTTPResponse {
             guard let p = try? JSONDecoder().decode(EnqueueFilesPayload.self, from: body),
                   !p.paths.isEmpty
             else { return HTTPResponse.badRequest() }
+            // Repeat with a seen key → the original jobIDs, no new job.
+            if let key = idempotencyKey, let existing = idempotency.lookup(key) {
+                return jobIDsResponse(existing)
+            }
             let ids = enqueueReturningIDs(p.paths.map { URL(fileURLWithPath: $0) })
+            if let key = idempotencyKey { idempotency.remember(key, ids) }
+            return jobIDsResponse(ids)
+        }
+
+        private func jobIDsResponse(_ ids: [UUID]) -> HTTPResponse {
             guard let body = try? JSONEncoder().encode(["jobIDs": ids.map(\.uuidString)]) else {
                 return HTTPResponse.badRequest()
             }
             return HTTPResponse.ok(body: body, contentType: "application/json")
         }
 
-        private func transcribeResponse(body: Data) async -> HTTPResponse {
+        private func transcribeResponse(body: Data, idempotencyKey: String?) async -> HTTPResponse {
             guard let p = try? JSONDecoder().decode(TranscribePayload.self, from: body), !p.path.isEmpty
             else { return HTTPResponse.badRequest() }
+            // Repeat with a seen key → the existing job's current status, no new
+            // job. Falls through to a fresh run if that job has fully vanished.
+            if let key = idempotencyKey, let existing = idempotency.lookup(key)?.first,
+               let dto = jobStatus(existing) {
+                return statusResponse(for: dto)
+            }
             let requested = p.maxWaitSeconds ?? Self.defaultTranscribeWaitSeconds
             let wait = min(max(0, requested), Self.maxTranscribeWaitSeconds)
-            switch await transcribe(URL(fileURLWithPath: p.path), wait) {
+            let result = await transcribe(URL(fileURLWithPath: p.path), wait)
+            if let key = idempotencyKey, let jobID = result.jobID { idempotency.remember(key, [jobID]) }
+            switch result {
             case .noFile:
                 return HTTPResponse.badRequest()
 
             case let .completed(dto):
-                return encodedOrNotFound(dto)
+                return statusResponse(for: dto)
 
             case let .timedOut(dto):
-                // 202 Accepted: still running; client polls GET /v1/jobs/<id>.
-                guard let dto, let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
-                return HTTPResponse(status: 202, reason: "Accepted", body: body, contentType: "application/json")
+                guard let dto else { return HTTPResponse.badRequest() }
+                return statusResponse(for: dto)
             }
+        }
+
+        /// Map a job status to its HTTP response: 200 with the DTO once terminal,
+        /// 202 (still running; client polls GET /v1/jobs/<id>) otherwise.
+        private func statusResponse(for dto: JobStatusDTO) -> HTTPResponse {
+            guard !dto.state.isTerminal else { return encodedOrNotFound(dto) }
+            guard let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
+            return HTTPResponse(status: 202, reason: "Accepted", body: body, contentType: "application/json")
         }
 
         private func confirmNamingResponse(_ jobID: UUID, body: Data) -> HTTPResponse {
             guard let p = try? JSONDecoder().decode(ConfirmNamingPayload.self, from: body) else {
                 return HTTPResponse.badRequest()
             }
-            return confirmNaming(jobID, p.mapping) ? HTTPResponse.ok() : HTTPResponse.notFound()
+            return confirmNaming(jobID, p.mapping) ? HTTPResponse.ok() : namingFailureStatus(jobID)
         }
 
         /// JSON-encode `dto` (404 if nil, 400 if encoding fails).

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -90,6 +90,7 @@
         let confirmNaming: (UUID, [String: String]) -> Bool // POST .../naming
         let skipJobNaming: (UUID) -> Bool // POST .../naming/skip
         let transcribe: (URL, Double) async -> BlockingTranscribeResult // POST /v1/transcribe
+        var idempotency = IdempotencyStore() // Idempotency-Key -> job IDs; internal for the +V1 extension
         private let expectedAuth: String
         private var listener: NWListener?
         /// OS-assigned port once the listener is `.ready`. Useful for tests

--- a/app/MeetingTranscriber/Sources/HTTPResponse.swift
+++ b/app/MeetingTranscriber/Sources/HTTPResponse.swift
@@ -34,6 +34,13 @@
             Self(status: 400, reason: "Bad Request", body: Data(), contentType: "text/plain")
         }
 
+        /// 409: the job exists but isn't in a state that accepts this action
+        /// (e.g. confirm/skip naming on a job not awaiting naming). Distinct
+        /// from 404 (unknown job id).
+        static func conflict() -> Self {
+            Self(status: 409, reason: "Conflict", body: Data(), contentType: "text/plain")
+        }
+
         func serialize() -> Data {
             var response = "HTTP/1.1 \(status) \(reason)\r\n"
             response += "Content-Type: \(contentType)\r\n"

--- a/app/MeetingTranscriber/Sources/IdempotencyStore.swift
+++ b/app/MeetingTranscriber/Sources/IdempotencyStore.swift
@@ -1,0 +1,43 @@
+#if !APPSTORE
+    import Foundation
+
+    /// Bounded FIFO map of `Idempotency-Key` -> created job IDs, so a repeated
+    /// automation request carrying the same key returns the original job(s)
+    /// instead of enqueuing duplicates.
+    ///
+    /// In-memory, per `DebugRPCServer` instance: the dedup window is a session,
+    /// which is all client retry-dedup needs (a toggle off/on resets it). The
+    /// FIFO cap stops an unbounded leak on a long-running headless server.
+    ///
+    /// The key is recorded after the job is created, so this dedupes *sequential*
+    /// retries (a client re-sending after a response or timeout, the common
+    /// case). Two same-key requests racing in-flight can both enqueue; hardening
+    /// that needs reserve-before-work and is left as a follow-up.
+    struct IdempotencyStore {
+        private var byKey: [String: [UUID]] = [:]
+        private var order: [String] = []
+        let capacity: Int
+
+        init(capacity: Int = 1024) {
+            self.capacity = capacity
+        }
+
+        // Optional, not empty-collection: nil (key never seen) must be
+        // distinguishable from [] (key seen, but the enqueue matched no files),
+        // else a fresh key would be mistaken for a duplicate and skip enqueuing.
+        // swiftlint:disable:next discouraged_optional_collection
+        func lookup(_ key: String) -> [UUID]? {
+            byKey[key]
+        }
+
+        mutating func remember(_ key: String, _ ids: [UUID]) {
+            if byKey[key] == nil {
+                order.append(key)
+                if order.count > capacity {
+                    byKey.removeValue(forKey: order.removeFirst())
+                }
+            }
+            byKey[key] = ids
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -345,7 +345,7 @@ final class PipelineController {
         let deadline = ContinuousClock.now.advanced(by: .seconds(maxWaitSeconds))
         while ContinuousClock.now < deadline {
             if let job = queue.jobs.first(where: { $0.id == jobID }) {
-                if job.state == .done || job.state == .error { return .completed(JobStatusDTO(job: job)) }
+                if job.state.isTerminal { return .completed(JobStatusDTO(job: job)) }
             } else if let record = terminalJobStore.lookup(jobID: jobID) {
                 return .completed(record) // already reaped from the live queue
             }
@@ -355,7 +355,7 @@ final class PipelineController {
         // (or while we were enqueuing with maxWaitSeconds==0) is completed, not
         // timed out.
         let final = jobStatus(forID: jobID)
-        if let final, final.state == .done || final.state == .error { return .completed(final) }
+        if let final, final.state.isTerminal { return .completed(final) }
         return .timedOut(final)
     }
 }
@@ -366,4 +366,14 @@ enum BlockingTranscribeResult {
     case noFile
     case completed(JobStatusDTO)
     case timedOut(JobStatusDTO?)
+
+    /// The job this result refers to, if any (nil only for `.noFile`). Lets the
+    /// RPC layer record the created job under an Idempotency-Key.
+    var jobID: UUID? {
+        switch self {
+        case .noFile: nil
+        case let .completed(dto): UUID(uuidString: dto.jobID)
+        case let .timedOut(dto): dto.flatMap { UUID(uuidString: $0.jobID) }
+        }
+    }
 }

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -11,6 +11,11 @@ enum JobState: String, Codable {
     case done
     case error
 
+    /// A finished state the pipeline won't move out of on its own.
+    var isTerminal: Bool {
+        self == .done || self == .error
+    }
+
     /// Human-readable label for this job state.
     var label: String {
         switch self {

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -110,11 +110,13 @@ struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                    Toggle("Debug RPC Server", isOn: $settings.debugRPCEnabled)
+                    Toggle("Local Automation API", isOn: $settings.debugRPCEnabled)
                     Text(
-                        "Exposes pipeline state on 127.0.0.1:9876 for `mt-cli`."
-                            + " Localhost-only, bearer-token auth. Off by default;"
-                            + " enable only when you need shell-driven inspection.",
+                        "Exposes the local automation API + pipeline state on"
+                            + " 127.0.0.1:9876 (POST /v1/transcribe, /v1/jobs; also"
+                            + " `mt-cli`). Localhost-only, bearer-token auth. Off by"
+                            + " default; enable for headless automation or"
+                            + " shell-driven inspection.",
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -443,14 +443,15 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             let statusCode = try await send("GET", "v1/jobs/\(jobID)")
             XCTAssertEqual(statusCode, 200)
 
-            // namingStatus / confirmNaming / skipJobNaming closures: the job isn't
-            // awaiting naming, so each returns 404 — but the AppState closures run.
+            // The job exists but isn't awaiting naming, so the AppState closures
+            // run and: GET naming has nothing to return (404), while the
+            // state-changing confirm/skip are a conflict on a live job (409).
             let naming = try await send("GET", "v1/jobs/\(jobID)/naming")
             XCTAssertEqual(naming, 404)
             let confirm = try await send("POST", "v1/jobs/\(jobID)/naming", body: Data(#"{"mapping":{}}"#.utf8))
-            XCTAssertEqual(confirm, 404)
+            XCTAssertEqual(confirm, 409)
             let skip = try await send("POST", "v1/jobs/\(jobID)/naming/skip")
-            XCTAssertEqual(skip, 404)
+            XCTAssertEqual(skip, 409)
 
             // transcribe closure (blocking one-call): maxWaitSeconds 0 leaves the
             // just-enqueued job in-flight at the deadline → 202, exercising the

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -564,6 +564,35 @@
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
         }
 
+        /// A job that exists but isn't awaiting naming → confirm/skip is a
+        /// state conflict (409), distinct from an unknown id (404).
+        private func wrongStateStatus(_ id: UUID) -> (UUID) -> JobStatusDTO? {
+            { jid in
+                jid == id ? JobStatusDTO(
+                    jobID: jid.uuidString, state: .transcribing, meetingTitle: "M",
+                    transcriptPath: nil, protocolPath: nil, error: nil, warnings: [],
+                ) : nil
+            }
+        }
+
+        func testV1ConfirmNamingWrongStateReturns409() async throws {
+            let id = UUID()
+            // Default confirmNaming returns false; jobStatus says the job exists.
+            let base = try await startServer(jobStatus: wrongStateStatus(id))
+            var req = request("POST", base.appendingPathComponent("v1/jobs/\(id.uuidString)/naming"), headers: authHeader)
+            req.httpBody = Data(#"{"mapping":{}}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 409)
+        }
+
+        func testV1SkipNamingWrongStateReturns409() async throws {
+            let id = UUID()
+            let base = try await startServer(jobStatus: wrongStateStatus(id))
+            let url = base.appendingPathComponent("v1/jobs/\(id.uuidString)/naming/skip")
+            let (_, response) = try await URLSession.shared.data(for: request("POST", url, headers: authHeader))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 409)
+        }
+
         func testV1UnknownSubResourceOrMethodReturns404() async throws {
             let base = try await startServer()
             let id = UUID().uuidString
@@ -627,6 +656,86 @@
             req.httpBody = Data(#"{"path":""}"#.utf8)
             let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        // MARK: - Idempotency-Key
+
+        private func idempotentHeaders(_ key: String) -> [String: String] {
+            authHeader.merging(["Idempotency-Key": key]) { _, new in new }
+        }
+
+        func testV1JobsIdempotencyKeyReturnsSameJobsWithoutNewEnqueue() async throws {
+            // enqueue yields a fresh id every call → identical responses can only
+            // mean the second request was served from the idempotency store.
+            let enqueue: ([URL]) -> [UUID] = { _ in [UUID()] }
+            let base = try await startServer(enqueueReturningIDs: enqueue)
+            let url = base.appendingPathComponent("v1/jobs")
+            let body = Data(#"{"paths":["/inbox/a.wav"]}"#.utf8)
+            let hdrs = idempotentHeaders("jobs-key-1")
+
+            var req1 = request("POST", url, headers: hdrs); req1.httpBody = body
+            let (d1, r1) = try await URLSession.shared.upload(for: req1, from: body)
+            var req2 = request("POST", url, headers: hdrs); req2.httpBody = body
+            let (d2, r2) = try await URLSession.shared.upload(for: req2, from: body)
+
+            XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 200)
+            struct EnqueueIDs: Decodable { let jobIDs: [String] }
+            let ids1 = try JSONDecoder().decode(EnqueueIDs.self, from: d1).jobIDs
+            let ids2 = try JSONDecoder().decode(EnqueueIDs.self, from: d2).jobIDs
+            XCTAssertFalse(ids1.isEmpty)
+            XCTAssertEqual(ids1, ids2, "same Idempotency-Key returns the original jobIDs, no new job")
+        }
+
+        func testV1JobsDifferentKeysEnqueueSeparately() async throws {
+            let enqueue: ([URL]) -> [UUID] = { _ in [UUID()] }
+            let base = try await startServer(enqueueReturningIDs: enqueue)
+            let url = base.appendingPathComponent("v1/jobs")
+            let body = Data(#"{"paths":["/inbox/a.wav"]}"#.utf8)
+
+            var req1 = request("POST", url, headers: idempotentHeaders("k-a")); req1.httpBody = body
+            let (d1, _) = try await URLSession.shared.upload(for: req1, from: body)
+            var req2 = request("POST", url, headers: idempotentHeaders("k-b")); req2.httpBody = body
+            let (d2, _) = try await URLSession.shared.upload(for: req2, from: body)
+
+            struct EnqueueIDs: Decodable { let jobIDs: [String] }
+            let ids1 = try JSONDecoder().decode(EnqueueIDs.self, from: d1).jobIDs
+            let ids2 = try JSONDecoder().decode(EnqueueIDs.self, from: d2).jobIDs
+            XCTAssertNotEqual(ids1, ids2, "distinct keys create distinct jobs")
+        }
+
+        func testV1TranscribeIdempotencyKeyReturnsExistingJobWithoutReRun() async throws {
+            // transcribe yields a fresh job each call; the repeat path instead
+            // resolves the stored id via jobStatus (echoed here), so identical
+            // jobIDs prove the second request did not re-run transcribe.
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in
+                await Task.yield()
+                return .completed(JobStatusDTO(
+                    jobID: UUID().uuidString, state: .done, meetingTitle: "M",
+                    transcriptPath: "/out/t.txt", protocolPath: nil, error: nil, warnings: [],
+                ))
+            }
+            let status: (UUID) -> JobStatusDTO? = { id in
+                JobStatusDTO(
+                    jobID: id.uuidString, state: .done, meetingTitle: "M",
+                    transcriptPath: "/out/t.txt", protocolPath: nil, error: nil, warnings: [],
+                )
+            }
+            let base = try await startServer(jobStatus: status, transcribe: transcribe)
+            let url = base.appendingPathComponent("v1/transcribe")
+            let body = Data(#"{"path":"/inbox/a.wav"}"#.utf8)
+            let hdrs = idempotentHeaders("tx-key-1")
+
+            var req1 = request("POST", url, headers: hdrs); req1.httpBody = body
+            let (d1, r1) = try await URLSession.shared.upload(for: req1, from: body)
+            var req2 = request("POST", url, headers: hdrs); req2.httpBody = body
+            let (d2, r2) = try await URLSession.shared.upload(for: req2, from: body)
+
+            XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 200)
+            let j1 = try JSONDecoder().decode(JobStatusDTO.self, from: d1).jobID
+            let j2 = try JSONDecoder().decode(JobStatusDTO.self, from: d2).jobID
+            XCTAssertEqual(j1, j2, "repeat returns the same job via the idempotency store, no re-run")
         }
 
         // MARK: - M6: Host header allowlist (raw-socket)

--- a/app/MeetingTranscriber/Tests/IdempotencyStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/IdempotencyStoreTests.swift
@@ -1,0 +1,39 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    final class IdempotencyStoreTests: XCTestCase {
+        func testLookupMissingKeyReturnsNil() {
+            let store = IdempotencyStore()
+            XCTAssertNil(store.lookup("absent"))
+        }
+
+        func testRememberThenLookupReturnsIDs() {
+            var store = IdempotencyStore()
+            let ids = [UUID(), UUID()]
+            store.remember("k", ids)
+            XCTAssertEqual(store.lookup("k"), ids)
+        }
+
+        func testRememberSameKeyUpdatesInPlaceWithoutSelfEviction() {
+            // capacity 1: a same-key re-remember must update in place, not append
+            // a second slot (which would push count past capacity and evict "k").
+            var store = IdempotencyStore(capacity: 1)
+            let first = [UUID()]
+            let second = [UUID()]
+            store.remember("k", first)
+            store.remember("k", second)
+            XCTAssertEqual(store.lookup("k"), second, "same-key remember updates in place, no self-eviction")
+        }
+
+        func testEvictsOldestKeyBeyondCapacity() {
+            var store = IdempotencyStore(capacity: 2)
+            store.remember("a", [UUID()])
+            store.remember("b", [UUID()])
+            store.remember("c", [UUID()]) // evicts "a" (oldest)
+            XCTAssertNil(store.lookup("a"), "oldest key evicted past capacity")
+            XCTAssertNotNil(store.lookup("b"))
+            XCTAssertNotNil(store.lookup("c"))
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -520,7 +520,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
     #if !APPSTORE
         func testDebugRPCToggleExists() throws {
             let body = try makeAdvanced().inspect()
-            XCTAssertNoThrow(try body.find(text: "Debug RPC Server"))
+            XCTAssertNoThrow(try body.find(text: "Local Automation API"))
         }
 
         func testDebugRPCToggleBindsToSetting() throws {
@@ -528,7 +528,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
             settings.debugRPCEnabled = false
             let view = AdvancedSettingsView(settings: settings)
             let toggle = try view.inspect().find(ViewType.Toggle.self) { toggle in
-                try toggle.labelView().text().string() == "Debug RPC Server"
+                try toggle.labelView().text().string() == "Local Automation API"
             }
             try toggle.tap()
             XCTAssertTrue(settings.debugRPCEnabled)


### PR DESCRIPTION
Follow-up polish on the local automation API from #431 (after #436 status readback, #437 naming, #438 blocking transcribe). Three items:

## 1. Idempotency-Key
`POST /v1/jobs` and `POST /v1/transcribe` now honour an `Idempotency-Key` request header. A repeat carrying a key already seen returns the original job(s) instead of enqueuing or re-running a duplicate, so a client that retries (lost response, timeout) doesn't create a second job.

Backed by `IdempotencyStore`, a bounded in-memory FIFO (key → job IDs) on the server instance. It dedupes sequential retries (the common case). The key is recorded after the job is created, so two same-key requests racing in-flight can still both enqueue; reserve-before-work hardening is noted as a follow-up.

## 2. 409 Conflict for wrong-state naming
`POST /v1/jobs/<id>/naming` and `.../naming/skip` now return **409** when the job exists but isn't awaiting naming (a state conflict), distinct from **404** for an unknown job id. Previously both collapsed to 404.

## 3. Relabel the toggle
Settings → Advanced "Debug RPC Server" → "Local Automation API" (with updated help text). The UserDefaults key is unchanged, so existing enablement carries over.

## Refactor
`JobState.isTerminal` replaces the `.done || .error` predicate that had spread to three sites; the transcribe response path maps a job status to 200/202 through one shared `statusResponse(for:)`.

## Tests
- `IdempotencyStoreTests`: FIFO eviction, same-key in-place update, lookup.
- Integration (real socket): /v1/jobs and /v1/transcribe idempotency (same key → same job, distinct keys → distinct jobs); confirm/skip wrong-state → 409, unknown → 404.
- Settings toggle label test updated.