### PR TITLE
docs: note Homebrew 6.0 tap trust across install instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,8 @@ jobs:
             brew install --cask ${{ steps.version.outputs.prerelease == 'true' && 'meeting-transcriber@beta' || 'meeting-transcriber' }}
             ```
 
+            > Homebrew 6.0+ may flag the third-party tap as untrusted. If so, run `brew trust --tap pasrom/meeting-transcriber` before installing.
+
             ${{ steps.version.outputs.prerelease == 'true' && '> Release candidate from the **beta channel**. The stable and beta casks conflict — uninstall one before installing the other.' || '' }}
 
             **Manual:**

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ brew tap pasrom/meeting-transcriber
 brew install --cask meeting-transcriber
 ```
 
+> Homebrew 6.0+ may flag the third-party tap as untrusted. If so, run `brew trust --tap pasrom/meeting-transcriber` before installing.
+
 The app lives in your menu bar — open it, grant microphone + screen-recording permission, and the first detected Teams/Zoom/Webex call records automatically.
 
 ---
@@ -141,6 +143,8 @@ The app detects ffmpeg automatically. Status is shown in Settings → About.
 brew tap pasrom/meeting-transcriber
 brew install --cask meeting-transcriber
 ```
+
+> **Tap trust:** Homebrew 6.0 added [tap trust](https://docs.brew.sh/Tap-Trust) for third-party taps. During the 6.0.x transition non-official taps are still allowed by default (you may just see a warning); enforcement is opt-in via `HOMEBREW_REQUIRE_TAP_TRUST` and becomes mandatory in a later release. If your Homebrew enforces it, run `brew trust --tap pasrom/meeting-transcriber` before `brew install --cask`.
 
 ### Pre-release (RC) via Homebrew
 

--- a/site/index.html
+++ b/site/index.html
@@ -82,6 +82,7 @@
   <h2>Install</h2>
   <pre><code>brew tap pasrom/meeting-transcriber
 brew install --cask meeting-transcriber</code></pre>
+  <p class="note">Homebrew 6.0+ may flag the third-party tap as untrusted. If so, run <code>brew trust --tap pasrom/meeting-transcriber</code> before installing.</p>
   <p class="note">Requires macOS 14.2 or later on Apple Silicon (M1 or newer). The transcription runs on the Neural Engine, which Intel Macs do not have.</p>
 
   <h2>Privacy</h2>


### PR DESCRIPTION
Relates to #441.

## What

Adds a short, conditional note pointing users at `brew trust --tap pasrom/meeting-transcriber` if Homebrew flags the third-party tap as untrusted. Applied to every user-facing place that repeats the install commands:

- `README.md` (both install blocks)
- `.github/workflows/release.yml` (auto-generated GitHub Release notes)
- `site/index.html` (landing page at meetingtranscriber.app)

## Why

Homebrew 6.0 introduced [tap trust](https://docs.brew.sh/Tap-Trust) for third-party taps. During the 6.0.x transition non-official taps are still allowed by default (you may just see a warning); enforcement is opt-in via `HOMEBREW_REQUIRE_TAP_TRUST` and becomes mandatory in a later release. Users who have enforcement on (or will, on a future Homebrew) hit `Error: Refusing to load cask ... from untrusted tap` on first install, which is a confusing wall without guidance.

This addresses the secondary suggestion in #441. The primary point of that issue (the `depends_on macos:` deprecation warning) is intentionally not changed here: the cask stays on `">= :sonoma"`, which is correct (`>=`) on every Homebrew release and never blocks a newer macOS, whereas the bare-symbol form resolves to `==` on Homebrew <= 5.1.10 and would block newer macOS there.

## Notes

- Correct syntax is `brew trust --tap <tap>` (the `--tap` flag trusts the whole tap, covering both the stable and `@beta` casks). The bare `brew trust <tap>` form is not the documented invocation.
- The note is **conditional**, not an unconditional install step, so it does not break older Homebrew versions that predate the `brew trust` command.
- No cask change: `release.yml` only seds version/sha into the tap cask, so it does not touch the `depends_on` line.
- Docs/release-notes only; no application code paths touched.