### PR TITLE
feat(app): multilingual Nemotron live captions via language-driven backend

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -86,6 +86,19 @@ ignore:
   # xctest suite never executes its init. Exercised by e2e-mic-device-change.yml;
   # a unit test would only pin a struct literal (vacuous).
   - "tools/audiotap/Sources/DebugTapFault.swift"
+  # Real-model Nemotron pipeline builder: downloadVariant + preloadShared +
+  # session construction, only exercisable with the ~0.6 GB CoreML model. The
+  # mockable seam is the injected NemotronPipelineFactory (covered by
+  # LiveTranscriptionNemotronStreamingTests's build/fallback tests); this default
+  # builder is the glue, exercised end-to-end by the gated NemotronFinishDriftTests
+  # and live recording. `\\+` escapes the literal `+` in the filename.
+  - "app/MeetingTranscriber/Sources/LiveTranscriptionController\\+Nemotron.swift"
+  # Real-model seam implementations (NemotronAsrManager / FluidVADBoundaryDetector /
+  # PartialCollector): wrap FluidAudio's Nemotron model + the Silero VAD, only
+  # exercisable with the downloaded CoreML models (gated NemotronFinishDriftTests +
+  # live recording). The session logic that drives them via the seam protocols is
+  # unit-tested in NemotronStreamingCaptionSession.swift.
+  - "app/MeetingTranscriber/Sources/NemotronAsrManager.swift"
   # Thin installTap wrapper bridging the NSException to a throw. The bridging
   # shim itself is unit-tested (CExceptionCatcherTests); the installTap call is
   # hardware-bound (exercised by e2e-app.yml). `+` is a regex metachar — escape

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -165,20 +165,6 @@ final class AppSettings {
         didSet { defaults.set(liveTranscriptionEnabled, forKey: "liveTranscriptionEnabled") }
     }
 
-    /// Opt-in: route live captions through the low-latency English streaming
-    /// session (`EouStreamingCaptionSession`, FluidAudio's Parakeet EOU model)
-    /// instead of the VAD + re-transcribe path. English-only — explicit opt-in
-    /// rather than auto-detect because the batch engine auto-detects the spoken
-    /// language, so the session language isn't statically knowable, and routing
-    /// a German speaker to an English model is worse than opt-in friction. When
-    /// on (and `liveTranscriptionEnabled` is on) captions become available even
-    /// for engines that don't support the re-transcribe path, because the
-    /// streaming session bypasses `TranscribingEngine` entirely.
-    /// Default: off. Only effective while the live-captions master toggle is on.
-    var liveCaptionsEnglishStreaming: Bool {
-        didSet { defaults.set(liveCaptionsEnglishStreaming, forKey: "liveCaptionsEnglishStreaming") }
-    }
-
     /// Seconds of continuous asymmetric silence before the indicator + notification
     /// fire. Clamped to [30, 300] on write — short enough to surface a dead channel
     /// inside a meeting, long enough not to trigger on normal speaking pauses.
@@ -233,6 +219,17 @@ final class AppSettings {
     /// Language as Optional for Parakeet. Empty string → nil (auto-detect).
     var parakeetLanguageOrNil: String? {
         parakeetLanguage.isEmpty ? nil : parakeetLanguage
+    }
+
+    /// The active transcription engine's EXPLICITLY configured language
+    /// (ISO 639-1), or nil for auto-detect. Drives the live-caption streaming
+    /// backend (`LiveCaptionsGate`): `de` → Nemotron German streaming, `en` →
+    /// Parakeet EOU streaming, else → engine-driven re-transcribe.
+    var activeEngineLanguageOrNil: String? {
+        switch transcriptionEngine {
+        case .whisperKit: whisperLanguageOrNil
+        case .parakeet: parakeetLanguageOrNil
+        }
     }
 
     /// Path to a custom vocabulary file for Parakeet CTC boosting (one term per line).
@@ -476,7 +473,7 @@ final class AppSettings {
         micDeviceUID = defaults.object(forKey: "micDeviceUID") as? String ?? ""
         micName = defaults.object(forKey: "micName") as? String ?? "Me"
         perChannelIndicatorEnabled = defaults.object(forKey: "perChannelIndicatorEnabled") as? Bool ?? true
-        (liveTranscriptionEnabled, liveCaptionsEnglishStreaming) = Self.loadLiveCaptionFlags(from: defaults)
+        liveTranscriptionEnabled = defaults.object(forKey: "liveTranscriptionEnabled") as? Bool ?? false
         asymmetricSilenceWarningSeconds = max(30, min(300, defaults.object(forKey: "asymmetricSilenceWarningSeconds") as? Double ?? 90))
 
         transcriptionEngine = (defaults.string(forKey: "transcriptionEngine")
@@ -543,17 +540,6 @@ final class AppSettings {
         let warmStartFb: Double
         let minSegmentDuration: Double
         let excludeOverlap: Bool
-    }
-
-    /// Reads the two live-caption flags in one call so the init body stays
-    /// under the function-length budget. Both default off (explicit opt-in).
-    private static func loadLiveCaptionFlags(
-        from defaults: UserDefaults,
-    ) -> (liveTranscription: Bool, englishStreaming: Bool) {
-        (
-            defaults.object(forKey: "liveTranscriptionEnabled") as? Bool ?? false,
-            defaults.object(forKey: "liveCaptionsEnglishStreaming") as? Bool ?? false,
-        )
     }
 
     private static func loadDiarizerTuning(from defaults: UserDefaults) -> LoadedDiarizerTuning {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -138,7 +138,7 @@ final class AppState {
             captions: liveCaptions,
             liveEnabled: { [settings] in settings.liveTranscriptionEnabled },
             engineSupportsLive: { [settings] in settings.transcriptionEngine.supportsLiveTranscription },
-            englishStreaming: { [settings] in settings.liveCaptionsEnglishStreaming },
+            engineLanguage: { [settings] in settings.activeEngineLanguageOrNil },
             verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
         )
         self.watching = WatchingController(
@@ -338,7 +338,7 @@ final class AppState {
     var shouldShowLiveCaptions: Bool {
         LiveCaptionsGate.captionsAvailable(
             liveEnabled: settings.liveTranscriptionEnabled,
-            englishStreaming: settings.liveCaptionsEnglishStreaming,
+            engineLanguage: settings.activeEngineLanguageOrNil,
             engineSupportsLive: settings.transcriptionEngine.supportsLiveTranscription,
         ) && watching.watchLoop?.state == .recording
     }

--- a/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
@@ -20,8 +20,9 @@
 enum LiveCaptionsGate {
     /// Which per-channel pipeline strategy to build, or none.
     enum Strategy: Equatable {
-        /// Low-latency German streaming session (Nemotron multilingual). Engine-independent.
-        case germanStreaming
+        /// Low-latency streaming session via Nemotron multilingual (one of the
+        /// Latin-script languages in `nemotronLanguages`). Engine-independent.
+        case nemotronStreaming
         /// Low-latency English streaming session (Parakeet EOU). Engine-independent.
         case englishStreaming
         /// VAD + re-transcribe via the active engine.
@@ -29,6 +30,12 @@ enum LiveCaptionsGate {
         /// Captions are off — build nothing.
         case none // swiftlint:disable:this discouraged_none_name
     }
+
+    /// Languages the Nemotron multilingual "latin" model transcribes well (its
+    /// vocab is pruned to Latin-script). English is excluded on purpose — it
+    /// routes to the English-optimized EOU streaming path instead. ISO 639-1,
+    /// matching the engine language pickers + the model's prompt dictionary.
+    static let nemotronLanguages: Set<String> = ["de", "es", "fr", "it", "pt"]
 
     /// Resolve the active strategy from the gate inputs.
     ///
@@ -44,11 +51,9 @@ enum LiveCaptionsGate {
         engineSupportsLive: Bool,
     ) -> Strategy {
         guard liveEnabled else { return .none }
-        switch engineLanguage {
-        case "de": return .germanStreaming
-        case "en": return .englishStreaming
-        default: return engineSupportsLive ? .reTranscribe : .none
-        }
+        if engineLanguage == "en" { return .englishStreaming }
+        if let engineLanguage, nemotronLanguages.contains(engineLanguage) { return .nemotronStreaming }
+        return engineSupportsLive ? .reTranscribe : .none
     }
 
     /// Whether live captions are available at all (any non-`none` strategy).

--- a/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
@@ -1,5 +1,5 @@
 /// Pure decision logic for whether live captions run, and which per-channel
-/// pipeline strategy they use. Shared single source of truth between
+/// streaming backend they use. Shared single source of truth between
 /// `AppState.shouldShowLiveCaptions` (overlay-window visibility),
 /// `LiveTranscriptionCoordinator` (whether to build + arm the controller), and
 /// `LiveTranscriptionController` (which pipeline each channel gets) so all three
@@ -9,15 +9,19 @@
 /// **Master toggle (`liveEnabled`) gates everything** — off means no captions,
 /// regardless of the other inputs.
 ///
-/// **`englishStreaming` bypasses the engine-support gate**: the low-latency
-/// English streaming session (`EouStreamingCaptionSession`) drives FluidAudio's
-/// Parakeet EOU model directly and never touches the active `TranscribingEngine`,
-/// so captions become available even for engines without the re-transcribe hook.
-/// With `englishStreaming` off, captions still require the engine to support the
-/// re-transcribe path (today's behaviour).
+/// **The backend follows the active engine's EXPLICITLY configured language**
+/// (not auto-detect): `de` → German Nemotron streaming, `en` → English Parakeet
+/// EOU streaming. Both streaming sessions drive their FluidAudio models directly
+/// and never touch the active `TranscribingEngine`, so they are available even
+/// for engines without the re-transcribe hook. Auto-detect (nil language) or any
+/// other language deliberately does NOT route to a streaming model — the spoken
+/// language isn't statically known, and a wrong-language model is worse than the
+/// engine-driven `.reTranscribe` fallback.
 enum LiveCaptionsGate {
     /// Which per-channel pipeline strategy to build, or none.
     enum Strategy: Equatable {
+        /// Low-latency German streaming session (Nemotron multilingual). Engine-independent.
+        case germanStreaming
         /// Low-latency English streaming session (Parakeet EOU). Engine-independent.
         case englishStreaming
         /// VAD + re-transcribe via the active engine.
@@ -26,21 +30,25 @@ enum LiveCaptionsGate {
         case none // swiftlint:disable:this discouraged_none_name
     }
 
-    /// Resolve the active strategy from the three gate inputs.
+    /// Resolve the active strategy from the gate inputs.
     ///
     /// - Parameters:
     ///   - liveEnabled: master live-captions toggle.
-    ///   - englishStreaming: the English low-latency opt-in.
+    ///   - engineLanguage: the active engine's explicitly configured language
+    ///     (ISO 639-1, e.g. `de`/`en`), or `nil` for auto-detect.
     ///   - engineSupportsLive: whether the active engine implements the
     ///     in-memory `transcribeSamples` re-transcribe hook.
     static func strategy(
         liveEnabled: Bool,
-        englishStreaming: Bool,
+        engineLanguage: String?,
         engineSupportsLive: Bool,
     ) -> Strategy {
         guard liveEnabled else { return .none }
-        if englishStreaming { return .englishStreaming }
-        return engineSupportsLive ? .reTranscribe : .none
+        switch engineLanguage {
+        case "de": return .germanStreaming
+        case "en": return .englishStreaming
+        default: return engineSupportsLive ? .reTranscribe : .none
+        }
     }
 
     /// Whether live captions are available at all (any non-`none` strategy).
@@ -48,12 +56,12 @@ enum LiveCaptionsGate {
     /// (the latter ANDs in the recording-in-progress condition separately).
     static func captionsAvailable(
         liveEnabled: Bool,
-        englishStreaming: Bool,
+        engineLanguage: String?,
         engineSupportsLive: Bool,
     ) -> Bool {
         strategy(
             liveEnabled: liveEnabled,
-            englishStreaming: englishStreaming,
+            engineLanguage: engineLanguage,
             engineSupportsLive: engineSupportsLive,
         ) != .none
     }

--- a/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsGate.swift
@@ -20,8 +20,9 @@
 enum LiveCaptionsGate {
     /// Which per-channel pipeline strategy to build, or none.
     enum Strategy: Equatable {
-        /// Low-latency streaming session via Nemotron multilingual (one of the
-        /// Latin-script languages in `nemotronLanguages`). Engine-independent.
+        /// Low-latency streaming session via Nemotron multilingual (any explicitly
+        /// configured non-English language). FluidAudio auto-selects the Latin or
+        /// full multilingual model variant from the language. Engine-independent.
         case nemotronStreaming
         /// Low-latency English streaming session (Parakeet EOU). Engine-independent.
         case englishStreaming
@@ -31,13 +32,13 @@ enum LiveCaptionsGate {
         case none // swiftlint:disable:this discouraged_none_name
     }
 
-    /// Languages the Nemotron multilingual "latin" model transcribes well (its
-    /// vocab is pruned to Latin-script). English is excluded on purpose — it
-    /// routes to the English-optimized EOU streaming path instead. ISO 639-1,
-    /// matching the engine language pickers + the model's prompt dictionary.
-    static let nemotronLanguages: Set<String> = ["de", "es", "fr", "it", "pt"]
-
     /// Resolve the active strategy from the gate inputs.
+    ///
+    /// English routes to the English-optimized EOU path; any other explicitly
+    /// configured language routes to Nemotron multilingual (the manager + its
+    /// `downloadVariant` pick the right model + prompt). Auto-detect (nil) does
+    /// NOT pick a language-specific streaming model — it falls back to the
+    /// engine-driven re-transcribe path.
     ///
     /// - Parameters:
     ///   - liveEnabled: master live-captions toggle.
@@ -51,9 +52,8 @@ enum LiveCaptionsGate {
         engineSupportsLive: Bool,
     ) -> Strategy {
         guard liveEnabled else { return .none }
-        if engineLanguage == "en" { return .englishStreaming }
-        if let engineLanguage, nemotronLanguages.contains(engineLanguage) { return .nemotronStreaming }
-        return engineSupportsLive ? .reTranscribe : .none
+        guard let engineLanguage else { return engineSupportsLive ? .reTranscribe : .none }
+        return engineLanguage == "en" ? .englishStreaming : .nemotronStreaming
     }
 
     /// Whether live captions are available at all (any non-`none` strategy).

--- a/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
@@ -41,6 +41,12 @@ struct LiveCaptionsOverlay: View {
 
     private var content: some View {
         VStack(alignment: .leading, spacing: 4) {
+            if let backend = state.activeBackend {
+                Text(backend)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.45))
+                    .accessibilityIdentifier("liveCaptionBackend")
+            }
             ForEach(state.recentFinals.suffix(LiveCaptionsState.maxFinalsKept), id: \.self) { line in
                 row(speaker: line.speaker, text: line.text, opacity: 1.0)
             }

--- a/app/MeetingTranscriber/Sources/LiveCaptionsState.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsState.swift
@@ -65,6 +65,18 @@ final class LiveCaptionsState {
     /// silence — the overlay can compare against `Date()` to dim or hide.
     private(set) var lastEventAt: Date = .distantPast
 
+    /// Human label of the resolved live-caption backend, set by the controller
+    /// once it builds the pipelines (e.g. "Nemotron · DE", "Parakeet EOU · EN",
+    /// "Re-transcribe"). Nil when captions aren't active. Surfaced in the overlay
+    /// so the user sees which engine actually drives captions — including a
+    /// silent re-transcribe fallback.
+    private(set) var activeBackend: String?
+
+    /// Set by the controller after it resolves + builds the caption pipelines.
+    func setActiveBackend(_ label: String?) {
+        activeBackend = label
+    }
+
     /// Cap on `recentFinals` length. 2 keeps the bar at most two prior lines
     /// plus the two live hypothesis rows on top.
     static let maxFinalsKept = 2

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController+Nemotron.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController+Nemotron.swift
@@ -1,0 +1,47 @@
+import FluidAudio
+
+// Nemotron streaming-pipeline construction, split out of LiveTranscriptionController
+// (file-length cap) and behind an injectable factory so tests can exercise the
+// controller's build + model-load-failure fallback state machine without the
+// real ~0.6 GB CoreML model.
+
+extension LiveTranscriptionController {
+    /// Builds both channel pipelines for a Nemotron streaming language off one
+    /// shared model load. `makeSink` produces the per-channel event sink (speaker
+    /// matching + captions routing) so the builder needs no controller-private
+    /// state. Injectable; the default loads the real model, tests substitute a
+    /// fake that returns mock pipelines or throws (fallback).
+    typealias NemotronPipelineFactory = @MainActor (
+        _ languageCode: String,
+        _ vad: FluidVAD,
+        _ makeSink: (LiveCaptionChannel) -> StreamingTranscriber.EventSink,
+    ) async throws -> (mic: any LiveCaptionPipeline, app: any LiveCaptionPipeline)
+
+    /// Production builder: download + preload the shared model once, then build
+    /// one Nemotron session per channel (each with its own manager + VAD boundary
+    /// detector) and load it. Throws on download/preload/load failure so the
+    /// caller falls back to re-transcribe.
+    static func makeDefaultNemotronPipelines(
+        languageCode: String,
+        vad: FluidVAD,
+        makeSink: (LiveCaptionChannel) -> StreamingTranscriber.EventSink,
+    ) async throws -> (mic: any LiveCaptionPipeline, app: any LiveCaptionPipeline) {
+        let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(
+            languageCode: languageCode, chunkMs: 2240,
+        )
+        let shared = try await StreamingNemotronMultilingualAsrManager.preloadShared(from: dir)
+        func make(_ channel: LiveCaptionChannel) -> NemotronStreamingCaptionSession {
+            NemotronStreamingCaptionSession(
+                manager: NemotronAsrManager(shared: shared, languageCode: languageCode),
+                detector: FluidVADBoundaryDetector(vad: vad),
+                channelLabel: channel.rawValue,
+                onEvent: makeSink(channel),
+            )
+        }
+        let mic = make(.mic)
+        try await mic.prepare()
+        let app = make(.app)
+        try await app.prepare()
+        return (mic, app)
+    }
+}

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -72,7 +72,7 @@ final class LiveTranscriptionController {
     /// True for the engine-independent streaming sessions (German/English), kept
     /// across recordings vs. the rebuilt re-transcribe actors.
     private var isStreamingStrategy: Bool {
-        captionStrategy == .germanStreaming || captionStrategy == .englishStreaming
+        captionStrategy == .nemotronStreaming || captionStrategy == .englishStreaming
     }
 
     private let eouSessionFactory: EouSessionFactory
@@ -188,7 +188,7 @@ final class LiveTranscriptionController {
             // fallback to re-transcribe is otherwise indistinguishable from the
             // EOU path in the unified log (live-diagnosis seam, no content).
             let strategy = usingStreamingSession
-                ? (captionStrategy == .germanStreaming ? "german-streaming" : "english-streaming")
+                ? (captionStrategy == .nemotronStreaming ? "nemotron-streaming" : "english-streaming")
                 : (micPipeline != nil ? "re-transcribe" : "none")
             logger.info(
                 "Live transcription ready (strategy: \(strategy, privacy: .public), engine: \(String(describing: type(of: self.engine)), privacy: .public))",
@@ -200,8 +200,8 @@ final class LiveTranscriptionController {
     /// backend that fails its model load falls through to re-transcribe.
     private func buildPipelines() async {
         switch captionStrategy {
-        case .germanStreaming:
-            if await buildGermanStreamingPipelines() { return }
+        case .nemotronStreaming:
+            if await buildNemotronStreamingPipelines() { return }
 
         case .englishStreaming:
             if await buildEnglishStreamingPipelines() { return }
@@ -217,18 +217,20 @@ final class LiveTranscriptionController {
         appPipeline = makeReTranscribePipeline(channel: .app, engine: engine)
     }
 
-    /// Build German Nemotron sessions for both channels off one preloaded model
-    /// set. Returns false (pipelines nil) on load failure so the caller falls
-    /// back. The ~611 MB model downloads on first use.
-    private func buildGermanStreamingPipelines() async -> Bool {
+    /// Build Nemotron sessions for both channels off one preloaded model set, in
+    /// the active engine's language (~611 MB Latin model, shared by de/es/fr/it/pt,
+    /// downloads on first use). Returns false on load failure so the caller falls back.
+    private func buildNemotronStreamingPipelines() async -> Bool {
+        // Reached only via `.nemotronStreaming`, so `engineLanguage` is non-nil.
+        guard let languageCode = engineLanguage else { return false }
         do {
             let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(
-                languageCode: Self.germanLocale, chunkMs: 2240,
+                languageCode: languageCode, chunkMs: 2240,
             )
             let shared = try await StreamingNemotronMultilingualAsrManager.preloadShared(from: dir)
-            let mic = makeNemotronPipeline(channel: .mic, shared: shared)
+            let mic = makeNemotronPipeline(channel: .mic, shared: shared, languageCode: languageCode)
             try await mic.prepare()
-            let app = makeNemotronPipeline(channel: .app, shared: shared)
+            let app = makeNemotronPipeline(channel: .app, shared: shared, languageCode: languageCode)
             try await app.prepare()
             micPipeline = mic
             appPipeline = app
@@ -394,17 +396,15 @@ final class LiveTranscriptionController {
         )
     }
 
-    /// Nemotron variant locale for the German streaming backend (`de`).
-    private static let germanLocale = "de-DE"
-
-    /// Build the German Nemotron session for one channel off the shared model set.
+    /// Build the Nemotron session for one channel off the shared model set.
     private func makeNemotronPipeline(
         channel: LiveCaptionChannel,
         shared: SharedNemotronMultilingualModels,
+        languageCode: String,
     ) -> NemotronStreamingCaptionSession {
         let logChannel = channel.rawValue
         return NemotronStreamingCaptionSession(
-            manager: NemotronAsrManager(shared: shared, languageCode: Self.germanLocale),
+            manager: NemotronAsrManager(shared: shared, languageCode: languageCode),
             detector: FluidVADBoundaryDetector(vad: vad),
             channelLabel: logChannel,
             onEvent: makeEventSink(channel: channel, logChannel: logChannel),

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -190,15 +190,19 @@ final class LiveTranscriptionController {
             await bindFeeds()
         }
         strategyResolved = true
+        // Resolve the ACTUAL backend (a failed streaming load shows here as the
+        // re-transcribe fallback, not the selected streaming engine) and publish
+        // it for the overlay indicator + the diagnostic log.
+        let engine: String? = usingStreamingSession
+            ? (captionStrategy == .nemotronStreaming ? "Nemotron" : "Parakeet EOU")
+            : (micPipeline != nil ? "Re-transcribe" : nil)
+        let backend = engine.map { name in
+            engineLanguage.map { "\(name) · \($0.uppercased())" } ?? name
+        }
+        captions.setActiveBackend(backend)
         if verboseDiagnostics() {
-            // Strategy named explicitly: with the English opt-in on, a silent
-            // fallback to re-transcribe is otherwise indistinguishable from the
-            // EOU path in the unified log (live-diagnosis seam, no content).
-            let strategy = usingStreamingSession
-                ? (captionStrategy == .nemotronStreaming ? "nemotron-streaming" : "english-streaming")
-                : (micPipeline != nil ? "re-transcribe" : "none")
             logger.info(
-                "Live transcription ready (strategy: \(strategy, privacy: .public), engine: \(String(describing: type(of: self.engine)), privacy: .public))",
+                "Live transcription ready (backend: \(backend ?? "none", privacy: .public))",
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -46,9 +46,9 @@ final class LiveTranscriptionController {
     typealias EouSessionFactory = @MainActor () -> any EouStreamingAsrManaging
 
     /// Active engine for the VAD + re-transcribe path. Optional because the
-    /// English streaming path is engine-independent: when `englishStreaming` is
-    /// on with a non-streaming active engine there is no streaming engine to
-    /// hold, and captions still run via the EOU sessions.
+    /// language-driven streaming backends (Nemotron/EOU) are engine-independent:
+    /// with a non-streaming active engine there is no streaming engine to hold,
+    /// and captions still run via those sessions.
     private let engine: (any StreamingTranscribingEngine)?
     private let vad: FluidVAD
     private let captions: LiveCaptionsState
@@ -165,13 +165,13 @@ final class LiveTranscriptionController {
     /// `LiveTranscriptionCoordinator.ensureController()` — concurrent calls
     /// are not defended against and must not be introduced.
     ///
-    /// When `englishStreaming` is on, builds the low-latency EOU sessions; if
-    /// their model load throws (e.g. first-use download offline) it logs and
-    /// degrades to the re-transcribe path when the active engine supports it,
-    /// or to no captions when it doesn't. A failed EOU load
-    /// is **not** retried until the controller is rebuilt (a settings change or
-    /// relaunch drops + re-creates it) — deliberate, so a failing first-use model
-    /// download isn't re-hammered on every recording.
+    /// When a streaming language is configured, builds the low-latency streaming
+    /// sessions (Nemotron or EOU); if their model load throws (e.g. first-use
+    /// download offline) it logs and degrades to the re-transcribe path when the
+    /// active engine supports it, or to no captions when it doesn't. A failed
+    /// streaming load is **not** retried until the controller is rebuilt (a
+    /// settings change or relaunch drops + re-creates it) — deliberate, so a
+    /// failing first-use model download isn't re-hammered on every recording.
     func prepare() async {
         await prewarmSpeakerMatcher()
         if micPipeline == nil, appPipeline == nil {

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -76,6 +76,7 @@ final class LiveTranscriptionController {
     }
 
     private let eouSessionFactory: EouSessionFactory
+    private let nemotronPipelineFactory: NemotronPipelineFactory
     /// Gate for caption-text logging. Caption strings are spoken user content
     /// — privacy-sensitive — so even with `privacy: .private` on the log
     /// arguments we don't emit by default. Same `() -> Bool` closure pattern
@@ -140,6 +141,11 @@ final class LiveTranscriptionController {
         speakerMatcher: any LiveSpeakerMatching = LiveSpeakerMatcher(),
         engineLanguage: String? = nil,
         eouSessionFactory: @escaping EouSessionFactory = LiveTranscriptionController.makeDefaultEouManager,
+        nemotronPipelineFactory: @escaping NemotronPipelineFactory = { language, vad, makeSink in
+            try await LiveTranscriptionController.makeDefaultNemotronPipelines(
+                languageCode: language, vad: vad, makeSink: makeSink,
+            )
+        },
         verboseDiagnostics: @escaping () -> Bool = { false },
     ) {
         self.engine = engine
@@ -148,6 +154,7 @@ final class LiveTranscriptionController {
         self.speakerMatcher = speakerMatcher
         self.engineLanguage = engineLanguage
         self.eouSessionFactory = eouSessionFactory
+        self.nemotronPipelineFactory = nemotronPipelineFactory
         self.verboseDiagnostics = verboseDiagnostics
     }
 
@@ -224,14 +231,9 @@ final class LiveTranscriptionController {
         // Reached only via `.nemotronStreaming`, so `engineLanguage` is non-nil.
         guard let languageCode = engineLanguage else { return false }
         do {
-            let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(
-                languageCode: languageCode, chunkMs: 2240,
-            )
-            let shared = try await StreamingNemotronMultilingualAsrManager.preloadShared(from: dir)
-            let mic = makeNemotronPipeline(channel: .mic, shared: shared, languageCode: languageCode)
-            try await mic.prepare()
-            let app = makeNemotronPipeline(channel: .app, shared: shared, languageCode: languageCode)
-            try await app.prepare()
+            let (mic, app) = try await nemotronPipelineFactory(languageCode, vad) { channel in
+                self.makeEventSink(channel: channel, logChannel: channel.rawValue)
+            }
             micPipeline = mic
             appPipeline = app
             usingStreamingSession = true
@@ -391,21 +393,6 @@ final class LiveTranscriptionController {
         let logChannel = channel.rawValue
         return EouStreamingCaptionSession(
             asr: eouSessionFactory(),
-            channelLabel: logChannel,
-            onEvent: makeEventSink(channel: channel, logChannel: logChannel),
-        )
-    }
-
-    /// Build the Nemotron session for one channel off the shared model set.
-    private func makeNemotronPipeline(
-        channel: LiveCaptionChannel,
-        shared: SharedNemotronMultilingualModels,
-        languageCode: String,
-    ) -> NemotronStreamingCaptionSession {
-        let logChannel = channel.rawValue
-        return NemotronStreamingCaptionSession(
-            manager: NemotronAsrManager(shared: shared, languageCode: languageCode),
-            detector: FluidVADBoundaryDetector(vad: vad),
             channelLabel: logChannel,
             onEvent: makeEventSink(channel: channel, logChannel: logChannel),
         )

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -53,11 +53,28 @@ final class LiveTranscriptionController {
     private let vad: FluidVAD
     private let captions: LiveCaptionsState
     private let speakerMatcher: any LiveSpeakerMatching
-    /// Opt-in to the low-latency English streaming session. When true,
-    /// `prepare()` tries to build EOU sessions for both channels; on model-load
-    /// failure it degrades to the re-transcribe path if the engine supports it,
-    /// or to no captions otherwise.
-    private let englishStreaming: Bool
+    /// The active engine's EXPLICITLY-configured language (`de`/`en`/nil), which
+    /// picks the streaming backend via `LiveCaptionsGate` (`de` → Nemotron, `en`
+    /// → EOU, else → re-transcribe). On a streaming-model load failure
+    /// `prepare()` degrades to re-transcribe (if supported) or to no captions.
+    private let engineLanguage: String?
+
+    /// Resolved per-channel strategy (`liveEnabled` is implicit — the controller
+    /// only exists when captions are eligible).
+    private var captionStrategy: LiveCaptionsGate.Strategy {
+        LiveCaptionsGate.strategy(
+            liveEnabled: true,
+            engineLanguage: engineLanguage,
+            engineSupportsLive: engine != nil,
+        )
+    }
+
+    /// True for the engine-independent streaming sessions (German/English), kept
+    /// across recordings vs. the rebuilt re-transcribe actors.
+    private var isStreamingStrategy: Bool {
+        captionStrategy == .germanStreaming || captionStrategy == .englishStreaming
+    }
+
     private let eouSessionFactory: EouSessionFactory
     /// Gate for caption-text logging. Caption strings are spoken user content
     /// — privacy-sensitive — so even with `privacy: .private` on the log
@@ -79,17 +96,12 @@ final class LiveTranscriptionController {
     /// `flush()`/`retireFeeds()`.
     private let micFeed = CaptionChannelFeed()
     private let appFeed = CaptionChannelFeed()
-    /// True once `prepare()` resolved the active strategy to the EOU sessions.
-    /// `prepareForNextRecording()` keeps those sessions (already flushed clean at
-    /// stop, reloading their models would be wasteful) and only rebuilds the
-    /// cheap re-transcribe actors.
-    private var usingEnglishStreaming = false
-    /// True once `prepare()` has finished resolving + building the pipelines.
-    /// Distinguishes "EOU opted-in but `prepare()` hasn't run yet" (pipelines
-    /// nil → let `prepare()` own construction) from "EOU opted-in but load failed
-    /// and we fell back to re-transcribe" (resolved → refresh those actors). The
-    /// two states both have `usingEnglishStreaming == false`; this flag tells
-    /// them apart so a reset-before-prepare ordering doesn't pre-empt the EOU path.
+    /// True once `prepare()` resolved to a kept streaming session (German/English),
+    /// which `prepareForNextRecording()` keeps instead of rebuilding.
+    private var usingStreamingSession = false
+    /// True once `prepare()` built the pipelines — distinguishes "not yet resolved"
+    /// (pipelines nil → let `prepare()` build) from "resolved to re-transcribe
+    /// fallback" (refresh actors), since both have `usingStreamingSession == false`.
     private var strategyResolved = false
     /// The most recent stop-time flush, kept so the NEXT recording's reset can
     /// await it before reusing a kept EOU session. `flush()` is dispatched
@@ -126,7 +138,7 @@ final class LiveTranscriptionController {
         vad: FluidVAD,
         captions: LiveCaptionsState,
         speakerMatcher: any LiveSpeakerMatching = LiveSpeakerMatcher(),
-        englishStreaming: Bool = false,
+        engineLanguage: String? = nil,
         eouSessionFactory: @escaping EouSessionFactory = LiveTranscriptionController.makeDefaultEouManager,
         verboseDiagnostics: @escaping () -> Bool = { false },
     ) {
@@ -134,7 +146,7 @@ final class LiveTranscriptionController {
         self.vad = vad
         self.captions = captions
         self.speakerMatcher = speakerMatcher
-        self.englishStreaming = englishStreaming
+        self.engineLanguage = engineLanguage
         self.eouSessionFactory = eouSessionFactory
         self.verboseDiagnostics = verboseDiagnostics
     }
@@ -175,8 +187,8 @@ final class LiveTranscriptionController {
             // Strategy named explicitly: with the English opt-in on, a silent
             // fallback to re-transcribe is otherwise indistinguishable from the
             // EOU path in the unified log (live-diagnosis seam, no content).
-            let strategy = usingEnglishStreaming
-                ? "english-streaming"
+            let strategy = usingStreamingSession
+                ? (captionStrategy == .germanStreaming ? "german-streaming" : "english-streaming")
                 : (micPipeline != nil ? "re-transcribe" : "none")
             logger.info(
                 "Live transcription ready (strategy: \(strategy, privacy: .public), engine: \(String(describing: type(of: self.engine)), privacy: .public))",
@@ -184,19 +196,53 @@ final class LiveTranscriptionController {
         }
     }
 
-    /// Resolve + construct both channel pipelines per the active strategy.
+    /// Construct both channel pipelines per the active strategy; a streaming
+    /// backend that fails its model load falls through to re-transcribe.
     private func buildPipelines() async {
-        if englishStreaming, await buildEnglishStreamingPipelines() {
-            return
+        switch captionStrategy {
+        case .germanStreaming:
+            if await buildGermanStreamingPipelines() { return }
+
+        case .englishStreaming:
+            if await buildEnglishStreamingPipelines() { return }
+
+        case .reTranscribe, .none:
+            break
         }
-        // Re-transcribe path (default, or EOU fallback). Needs a streaming
-        // engine; if there is none (English-streaming opt-in with a
-        // non-streaming engine that then failed to load EOU models) captions
-        // stay off for this session.
+        // Re-transcribe path (default or streaming fallback). With no streaming
+        // engine (failed streaming backend on a non-streaming engine) captions stay off.
         guard let engine else { return }
         await engine.loadModel()
         micPipeline = makeReTranscribePipeline(channel: .mic, engine: engine)
         appPipeline = makeReTranscribePipeline(channel: .app, engine: engine)
+    }
+
+    /// Build German Nemotron sessions for both channels off one preloaded model
+    /// set. Returns false (pipelines nil) on load failure so the caller falls
+    /// back. The ~611 MB model downloads on first use.
+    private func buildGermanStreamingPipelines() async -> Bool {
+        do {
+            let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(
+                languageCode: Self.germanLocale, chunkMs: 2240,
+            )
+            let shared = try await StreamingNemotronMultilingualAsrManager.preloadShared(from: dir)
+            let mic = makeNemotronPipeline(channel: .mic, shared: shared)
+            try await mic.prepare()
+            let app = makeNemotronPipeline(channel: .app, shared: shared)
+            try await app.prepare()
+            micPipeline = mic
+            appPipeline = app
+            usingStreamingSession = true
+            return true
+        } catch {
+            logger.warning(
+                "Nemotron streaming model load failed, falling back: \(error.localizedDescription, privacy: .public)",
+            )
+            micPipeline = nil
+            appPipeline = nil
+            usingStreamingSession = false
+            return false
+        }
     }
 
     /// Build EOU sessions for both channels, loading their models. Returns true
@@ -210,7 +256,7 @@ final class LiveTranscriptionController {
             try await app.prepare()
             micPipeline = mic
             appPipeline = app
-            usingEnglishStreaming = true
+            usingStreamingSession = true
             return true
         } catch {
             // Non-fatal: log and let the caller fall back to the re-transcribe
@@ -218,7 +264,7 @@ final class LiveTranscriptionController {
             logger.warning("EOU streaming model load failed, falling back: \(error.localizedDescription, privacy: .public)")
             micPipeline = nil
             appPipeline = nil
-            usingEnglishStreaming = false
+            usingStreamingSession = false
             return false
         }
     }
@@ -293,11 +339,11 @@ final class LiveTranscriptionController {
         await pendingFlush?.value
         pendingFlush = nil
 
-        if usingEnglishStreaming {
-            // EOU sessions kept (already drained by flush()).
-        } else if englishStreaming, !strategyResolved {
-            // EOU opted-in but prepare() hasn't resolved yet → defer to
-            // prepare(), which also arms the feeds once it built the pipelines.
+        if usingStreamingSession {
+            // Streaming sessions kept (already drained by flush()).
+        } else if isStreamingStrategy, !strategyResolved {
+            // A streaming backend was selected but prepare() hasn't resolved yet
+            // → defer to prepare(), which arms the feeds once it built the pipelines.
         } else if let engine {
             micPipeline = makeReTranscribePipeline(channel: .mic, engine: engine)
             appPipeline = makeReTranscribePipeline(channel: .app, engine: engine)
@@ -343,6 +389,23 @@ final class LiveTranscriptionController {
         let logChannel = channel.rawValue
         return EouStreamingCaptionSession(
             asr: eouSessionFactory(),
+            channelLabel: logChannel,
+            onEvent: makeEventSink(channel: channel, logChannel: logChannel),
+        )
+    }
+
+    /// Nemotron variant locale for the German streaming backend (`de`).
+    private static let germanLocale = "de-DE"
+
+    /// Build the German Nemotron session for one channel off the shared model set.
+    private func makeNemotronPipeline(
+        channel: LiveCaptionChannel,
+        shared: SharedNemotronMultilingualModels,
+    ) -> NemotronStreamingCaptionSession {
+        let logChannel = channel.rawValue
+        return NemotronStreamingCaptionSession(
+            manager: NemotronAsrManager(shared: shared, languageCode: Self.germanLocale),
+            detector: FluidVADBoundaryDetector(vad: vad),
             channelLabel: logChannel,
             onEvent: makeEventSink(channel: channel, logChannel: logChannel),
         )

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -16,7 +16,7 @@ import Observation
 /// `AppState.init` after stored-property init, where the `[weak self]` engine
 /// closure is valid) rather than captured at construction — so the coordinator
 /// never holds an AppState back-reference. `liveEnabled` / `engineSupportsLive` /
-/// `verboseDiagnostics` are settings-backed closures.
+/// `engineLanguage` / `verboseDiagnostics` are settings-backed closures.
 ///
 /// Not `@Observable` — it exposes no observable state (it drives the controller
 /// + captions imperatively). It still uses `withObservationTracking` internally
@@ -33,33 +33,34 @@ final class LiveTranscriptionCoordinator {
     private let captions: LiveCaptionsState
     private let liveEnabled: () -> Bool
     private let engineSupportsLive: () -> Bool
-    private let englishStreaming: () -> Bool
+    private let engineLanguage: () -> String?
     private let verboseDiagnostics: () -> Bool
     private let makeController: ControllerFactory
 
     /// Builds the streaming controller for the (optional) active engine. The
-    /// engine is nil when the English-streaming opt-in is on with a non-streaming
-    /// active engine — the EOU sessions don't need it. Injectable so tests can
-    /// supply a controller with mock collaborators (no model load); the default
-    /// builds the real one. Takes `captions` + `englishStreaming` +
-    /// `verboseDiagnostics` as parameters (rather than capturing `self`) so the
-    /// default can be a `static` function with no init-ordering dependency.
+    /// engine is nil when a language-driven streaming backend (German/English)
+    /// applies with a non-streaming active engine — those sessions don't need it.
+    /// Injectable so tests can supply a controller with mock collaborators (no
+    /// model load); the default builds the real one. Takes `captions` +
+    /// `engineLanguage` + `verboseDiagnostics` as parameters (rather than
+    /// capturing `self`) so the default can be a `static` function with no
+    /// init-ordering dependency.
     typealias ControllerFactory = @MainActor (
-        (any StreamingTranscribingEngine)?, LiveCaptionsState, Bool, @escaping () -> Bool,
+        (any StreamingTranscribingEngine)?, LiveCaptionsState, String?, @escaping () -> Bool,
     ) -> LiveTranscriptionController
 
     init(
         captions: LiveCaptionsState,
         liveEnabled: @escaping () -> Bool,
         engineSupportsLive: @escaping () -> Bool,
-        englishStreaming: @escaping () -> Bool = { false },
+        engineLanguage: @escaping () -> String? = { nil },
         verboseDiagnostics: @escaping () -> Bool,
         makeController: @escaping ControllerFactory = LiveTranscriptionCoordinator.makeDefaultController,
     ) {
         self.captions = captions
         self.liveEnabled = liveEnabled
         self.engineSupportsLive = engineSupportsLive
-        self.englishStreaming = englishStreaming
+        self.engineLanguage = engineLanguage
         self.verboseDiagnostics = verboseDiagnostics
         self.makeController = makeController
     }
@@ -67,7 +68,7 @@ final class LiveTranscriptionCoordinator {
     private static func makeDefaultController(
         engine: (any StreamingTranscribingEngine)?,
         captions: LiveCaptionsState,
-        englishStreaming: Bool,
+        engineLanguage: String?,
         verboseDiagnostics: @escaping () -> Bool,
     ) -> LiveTranscriptionController {
         // `verboseDiagnostics` passed labeled (not trailing): with two
@@ -78,18 +79,18 @@ final class LiveTranscriptionCoordinator {
             engine: engine,
             vad: FluidVAD(threshold: 0.5),
             captions: captions,
-            englishStreaming: englishStreaming,
+            engineLanguage: engineLanguage,
             verboseDiagnostics: verbose,
         )
     }
 
     /// Whether live captions are eligible to run at all, per the shared gate.
-    /// `englishStreaming` bypasses the engine-support requirement because the
-    /// EOU sessions are engine-independent.
+    /// The language-driven streaming backends (German/English) bypass the
+    /// engine-support requirement because their sessions are engine-independent.
     private var captionsEligible: Bool {
         LiveCaptionsGate.captionsAvailable(
             liveEnabled: liveEnabled(),
-            englishStreaming: englishStreaming(),
+            engineLanguage: engineLanguage(),
             engineSupportsLive: engineSupportsLive(),
         )
     }
@@ -111,7 +112,7 @@ final class LiveTranscriptionCoordinator {
     /// Called by `AppState`'s recorder factory on each recording start.
     ///
     /// `async` because `prepareForNextRecording()` awaits any in-flight stop-time
-    /// flush before reusing a kept EOU session — the deterministic stop→start
+    /// flush before reusing a kept streaming session — the deterministic stop→start
     /// boundary that keeps a slow `asr.finish()` from interleaving with the next
     /// recording's ingests on the same session actor.
     func attachSinks(to recorder: DualSourceRecorder) async {
@@ -147,10 +148,10 @@ final class LiveTranscriptionCoordinator {
         withObservationTracking {
             // Touch the underlying settings via the gate closures so the change
             // tracker observes `liveTranscriptionEnabled` + `transcriptionEngine`
-            // + `liveCaptionsEnglishStreaming`.
+            // + the active engine's language.
             _ = liveEnabled()
             _ = engineSupportsLive()
-            _ = englishStreaming()
+            _ = engineLanguage()
         } onChange: { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
@@ -168,20 +169,27 @@ final class LiveTranscriptionCoordinator {
     /// Lazily create + warm the controller against the active engine. Idempotent
     /// — `prepare()` dedupes concurrent `loadModel` calls.
     ///
-    /// The English-streaming path is engine-independent, so it builds a
-    /// controller with a nil streaming engine when the active engine doesn't
-    /// conform to `StreamingTranscribingEngine`. The re-transcribe
-    /// path still requires a streaming engine: it returns nil otherwise, the
-    /// static equivalent of the `supportsLiveTranscription` gate (callers already
-    /// check `captionsEligible`, so that nil only happens on a regression).
+    /// The language-driven streaming backends (German/English) are
+    /// engine-independent, so the controller is built with a nil streaming engine
+    /// when the active engine doesn't conform to `StreamingTranscribingEngine`.
+    /// The re-transcribe path still requires a streaming engine: it returns nil
+    /// otherwise, the static equivalent of the `supportsLiveTranscription` gate
+    /// (callers already check `captionsEligible`, so that nil only happens on a
+    /// regression).
     private func ensureController() -> LiveTranscriptionController? {
         if let existing = controller { return existing }
         guard let engine = engineProvider?() else { return nil }
         let streamingEngine = engine as? any StreamingTranscribingEngine
-        let english = englishStreaming()
-        // Re-transcribe path needs a streaming engine; English streaming doesn't.
-        guard english || streamingEngine != nil else { return nil }
-        let controller = makeController(streamingEngine, captions, english, verboseDiagnostics)
+        let language = engineLanguage()
+        let strategy = LiveCaptionsGate.strategy(
+            liveEnabled: liveEnabled(),
+            engineLanguage: language,
+            engineSupportsLive: engineSupportsLive(),
+        )
+        guard strategy != .none else { return nil }
+        // Re-transcribe needs a streaming engine; the streaming backends don't.
+        guard strategy != .reTranscribe || streamingEngine != nil else { return nil }
+        let controller = makeController(streamingEngine, captions, language, verboseDiagnostics)
         self.controller = controller
         Task { @MainActor in await controller.prepare() }
         return controller

--- a/app/MeetingTranscriber/Sources/NemotronAsrManager.swift
+++ b/app/MeetingTranscriber/Sources/NemotronAsrManager.swift
@@ -1,0 +1,90 @@
+import FluidAudio
+import os
+
+// Production implementations of the `NemotronStreamingCaptionSession` seams,
+// split into their own file: they wrap FluidAudio's real Nemotron model + the
+// Silero VAD, so they're only exercisable with the downloaded CoreML models
+// (covered end-to-end by the gated NemotronFinishDriftTests + live recording,
+// not the default xctest lane). The session logic that drives them through the
+// `NemotronStreamingAsrManaging` / `UtteranceBoundaryDetecting` seams stays
+// unit-tested in the main file.
+
+/// Lock-protected FIFO the manager's `@Sendable` partial callback appends into;
+/// drained on the session actor after each `process()`.
+private final class PartialCollector: Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: [String]())
+    func append(_ text: String) {
+        storage.withLock { $0.append(text) }
+    }
+
+    /// Latest appended transcript, clearing the buffer.
+    func drainLast() -> String? {
+        storage.withLock { items in
+            let last = items.last
+            items.removeAll(keepingCapacity: true)
+            return last
+        }
+    }
+}
+
+/// Real manager seam: wraps `StreamingNemotronMultilingualAsrManager` bound to a
+/// shared model set + an explicit locale (e.g. `de-DE`). The shared models are
+/// loaded once by the controller (`preloadShared`) and shared across channels.
+actor NemotronAsrManager: NemotronStreamingAsrManaging {
+    private let manager = StreamingNemotronMultilingualAsrManager()
+    private let shared: SharedNemotronMultilingualModels
+    private let languageCode: String
+    private let collector = PartialCollector()
+
+    init(shared: SharedNemotronMultilingualModels, languageCode: String) {
+        self.shared = shared
+        self.languageCode = languageCode
+    }
+
+    func prepare() async throws {
+        try await manager.loadFromShared(shared)
+        await manager.setLanguage(languageCode)
+        let collector = collector
+        await manager.setPartialCallback { collector.append($0) }
+    }
+
+    func process(_ samples: [Float]) async throws {
+        _ = try await manager.process(samples: samples)
+    }
+
+    func latestTranscript() -> String? {
+        collector.drainLast()
+    }
+
+    func finish() async throws -> String {
+        try await manager.finish()
+    }
+
+    func reset() async {
+        await manager.reset()
+    }
+}
+
+/// Real boundary detector: `FluidVAD` streaming with the `StreamState` threaded
+/// internally so the session sees only boundary events. Created lazily on the
+/// first chunk and dropped by `reset()`.
+actor FluidVADBoundaryDetector: UtteranceBoundaryDetecting {
+    private let vad: FluidVAD
+    private var state: FluidVAD.StreamState?
+
+    init(vad: FluidVAD) {
+        self.vad = vad
+    }
+
+    func boundary(in chunk: [Float]) async throws -> FluidVAD.StreamEvent.Kind? {
+        if state == nil { state = try await vad.makeStreamState() }
+        guard let current = state else { return nil }
+        let result = try await vad.processStreamingChunk(chunk, state: current)
+        state = result.state
+        return result.event?.kind
+    }
+
+    func reset() {
+        state = nil
+    }
+}

--- a/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
@@ -1,5 +1,4 @@
 import AudioTapLib
-import FluidAudio
 import Foundation
 import os
 
@@ -191,87 +190,5 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
     private func resetUtteranceState() {
         runningTranscript = ""
         lastEmittedPartial = ""
-    }
-}
-
-// MARK: - Production implementations
-
-/// Lock-protected FIFO the manager's `@Sendable` partial callback appends into;
-/// drained on the session actor after each `process()`.
-private final class PartialCollector: Sendable {
-    private let storage = OSAllocatedUnfairLock(initialState: [String]())
-    func append(_ text: String) {
-        storage.withLock { $0.append(text) }
-    }
-
-    /// Latest appended transcript, clearing the buffer.
-    func drainLast() -> String? {
-        storage.withLock { items in
-            let last = items.last
-            items.removeAll(keepingCapacity: true)
-            return last
-        }
-    }
-}
-
-/// Real manager seam: wraps `StreamingNemotronMultilingualAsrManager` bound to a
-/// shared model set + an explicit locale (e.g. `de-DE`). The shared models are
-/// loaded once by the controller (`preloadShared`) and shared across channels.
-actor NemotronAsrManager: NemotronStreamingAsrManaging {
-    private let manager = StreamingNemotronMultilingualAsrManager()
-    private let shared: SharedNemotronMultilingualModels
-    private let languageCode: String
-    private let collector = PartialCollector()
-
-    init(shared: SharedNemotronMultilingualModels, languageCode: String) {
-        self.shared = shared
-        self.languageCode = languageCode
-    }
-
-    func prepare() async throws {
-        try await manager.loadFromShared(shared)
-        await manager.setLanguage(languageCode)
-        let collector = collector
-        await manager.setPartialCallback { collector.append($0) }
-    }
-
-    func process(_ samples: [Float]) async throws {
-        _ = try await manager.process(samples: samples)
-    }
-
-    func latestTranscript() -> String? {
-        collector.drainLast()
-    }
-
-    func finish() async throws -> String {
-        try await manager.finish()
-    }
-
-    func reset() async {
-        await manager.reset()
-    }
-}
-
-/// Real boundary detector: `FluidVAD` streaming with the `StreamState` threaded
-/// internally so the session sees only boundary events. Created lazily on the
-/// first chunk and dropped by `reset()`.
-actor FluidVADBoundaryDetector: UtteranceBoundaryDetecting {
-    private let vad: FluidVAD
-    private var state: FluidVAD.StreamState?
-
-    init(vad: FluidVAD) {
-        self.vad = vad
-    }
-
-    func boundary(in chunk: [Float]) async throws -> FluidVAD.StreamEvent.Kind? {
-        if state == nil { state = try await vad.makeStreamState() }
-        guard let current = state else { return nil }
-        let result = try await vad.processStreamingChunk(chunk, state: current)
-        state = result.state
-        return result.event?.kind
-    }
-
-    func reset() {
-        state = nil
     }
 }

--- a/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
@@ -9,7 +9,7 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Nemotro
 
 /// The slice of `StreamingNemotronMultilingualAsrManager` the caption session
 /// drives, behind a protocol so the session is unit-testable without loading
-/// the ~1.5 GB CoreML models. `latestTranscript()` returns the manager's full
+/// the real CoreML models. `latestTranscript()` returns the manager's full
 /// running transcript since the previous call (nil if no new partial fired);
 /// the real implementation drains a callback FIFO, so the session reads it once
 /// per chunk and caches the value for the partial + final reads.
@@ -38,14 +38,15 @@ protocol UtteranceBoundaryDetecting: Actor {
 
 // MARK: - Session
 
-/// Live German captions for one channel via FluidAudio's cache-aware
-/// `StreamingNemotronMultilingualAsrManager`, behind the `LiveCaptionPipeline`
-/// seam. Audio is fed continuously to the manager (it keeps cross-utterance
-/// acoustic context); a `FluidVAD`-backed boundary detector decides when an
-/// utterance ends, at which point the manager's running transcript — prefix-
-/// stripped of everything already finalized — is emitted as a final paired
-/// with the utterance's speech audio (so the controller's event sink can derive
-/// a speaker embedding from the same window, as for the re-transcribe path).
+/// Live captions for one channel via FluidAudio's cache-aware
+/// `StreamingNemotronMultilingualAsrManager` (language set per session), behind
+/// the `LiveCaptionPipeline` seam. Audio is fed continuously to the manager (it
+/// keeps cross-utterance acoustic context); a `FluidVAD`-backed boundary
+/// detector decides when an utterance ends, at which point `finish()`
+/// force-decodes the tail and returns the complete utterance text, emitted as a
+/// final paired with the utterance's speech audio (so the controller's event
+/// sink can derive a speaker embedding from the same window, as for the
+/// re-transcribe path).
 ///
 /// Calls are serialized by the driver (the `LiveCaptionPipeline` contract), so
 /// `ingest`/`flush` never interleave and need no re-entrancy guards.
@@ -63,6 +64,9 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
     /// fired this chunk), so it's read once per chunk and cached for the partial
     /// emit. Reset to empty after each `finish()`.
     private var runningTranscript = ""
+    /// Last partial actually emitted, to skip re-emitting identical text on the
+    /// chunks where no new partial fired (the manager only decodes every ~2.24 s).
+    private var lastEmittedPartial = ""
 
     /// Silero v6 chunk size at 16 kHz — what `FluidVAD` expects per call.
     private static let chunkSize = 4096
@@ -105,7 +109,7 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
         await manager.reset()
         isSpeaking = false
         speechSamples = []
-        runningTranscript = ""
+        resetUtteranceState()
         inputAccumulator = []
     }
 
@@ -115,11 +119,12 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
             inputAccumulator.removeFirst(Self.chunkSize)
             do {
                 try await manager.process(chunk)
+                if let latest = await manager.latestTranscript() { runningTranscript = latest }
             } catch {
+                // Log but keep driving VAD: dropping the chunk's boundary check on a
+                // transient ASR error could lose a `speechEnd` and desync segmentation.
                 logger.warning("[\(self.channelLabel, privacy: .public)] process error: \(error)")
-                continue
             }
-            if let latest = await manager.latestTranscript() { runningTranscript = latest }
             let event: FluidVAD.StreamEvent.Kind?
             do {
                 event = try await detector.boundary(in: chunk)
@@ -151,7 +156,9 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
 
     private func emitPartial() {
         let text = runningTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !text.isEmpty { onEvent(.partial(text)) }
+        guard !text.isEmpty, text != lastEmittedPartial else { return }
+        lastEmittedPartial = text
+        onEvent(.partial(text))
     }
 
     /// Finalize the current utterance: `finish()` force-decodes the buffered tail
@@ -168,13 +175,22 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
             transcript = try await manager.finish()
         } catch {
             logger.warning("[\(self.channelLabel, privacy: .public)] finish error: \(error)")
-            runningTranscript = ""
+            resetUtteranceState()
             return
         }
-        runningTranscript = ""
+        // `finish()` decodes the padded tail and can push one last partial into
+        // the manager's FIFO; drain + discard it so it can't surface as the next
+        // utterance's first partial.
+        _ = await manager.latestTranscript()
+        resetUtteranceState()
         let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         guard audio.count >= Self.minFinalSamples, !text.isEmpty else { return }
         onEvent(.finalized(text: text, audio: audio))
+    }
+
+    private func resetUtteranceState() {
+        runningTranscript = ""
+        lastEmittedPartial = ""
     }
 }
 

--- a/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
@@ -1,0 +1,261 @@
+import AudioTapLib
+import FluidAudio
+import Foundation
+import os
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "NemotronCaptions")
+
+// MARK: - Seams
+
+/// The slice of `StreamingNemotronMultilingualAsrManager` the caption session
+/// drives, behind a protocol so the session is unit-testable without loading
+/// the ~1.5 GB CoreML models. `latestTranscript()` returns the manager's full
+/// running transcript since the previous call (nil if no new partial fired);
+/// the real implementation drains a callback FIFO, so the session reads it once
+/// per chunk and caches the value for the partial + final reads.
+protocol NemotronStreamingAsrManaging: Actor {
+    /// Bind to the shared models + language (real impl: `loadFromShared` + `setLanguage`).
+    func prepare() async throws
+    /// Feed one audio chunk (16 kHz mono Float32).
+    func process(_ samples: [Float]) async throws
+    /// Latest full running transcript since the previous call, or nil if none new.
+    func latestTranscript() -> String?
+    /// Flush remaining buffered audio and return the complete transcript.
+    func finish() async throws -> String
+    /// Full reset (encoder caches + accumulated transcript).
+    func reset() async
+}
+
+/// Per-channel streaming utterance-boundary detector. Wraps `FluidVAD`'s
+/// state-threading so the session (and its tests) see only `speechStart` /
+/// `speechEnd`, never the opaque `StreamState`.
+protocol UtteranceBoundaryDetecting: Actor {
+    /// Feed one 4096-sample chunk; returns a boundary kind if one occurred.
+    func boundary(in chunk: [Float]) async throws -> FluidVAD.StreamEvent.Kind?
+    /// Drop the streaming state so the next chunk starts a fresh stream.
+    func reset() async
+}
+
+// MARK: - Session
+
+/// Live German captions for one channel via FluidAudio's cache-aware
+/// `StreamingNemotronMultilingualAsrManager`, behind the `LiveCaptionPipeline`
+/// seam. Audio is fed continuously to the manager (it keeps cross-utterance
+/// acoustic context); a `FluidVAD`-backed boundary detector decides when an
+/// utterance ends, at which point the manager's running transcript — prefix-
+/// stripped of everything already finalized — is emitted as a final paired
+/// with the utterance's speech audio (so the controller's event sink can derive
+/// a speaker embedding from the same window, as for the re-transcribe path).
+///
+/// Calls are serialized by the driver (the `LiveCaptionPipeline` contract), so
+/// `ingest`/`flush` never interleave and need no re-entrancy guards.
+actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
+    private let manager: any NemotronStreamingAsrManaging
+    private let detector: any UtteranceBoundaryDetecting
+    private let channelLabel: String
+    private let onEvent: StreamingTranscriber.EventSink
+
+    private var inputAccumulator: [Float] = []
+    private var speechSamples: [Float] = []
+    private var isSpeaking = false
+    /// Cached in-progress partial for the current utterance. The manager's
+    /// `latestTranscript()` drains its callback FIFO (nil when no new partial
+    /// fired this chunk), so it's read once per chunk and cached for the partial
+    /// emit. Reset to empty after each `finish()`.
+    private var runningTranscript = ""
+
+    /// Silero v6 chunk size at 16 kHz — what `FluidVAD` expects per call.
+    private static let chunkSize = 4096
+    /// 1 s at 16 kHz — utterances shorter than this are dropped as noise.
+    private static let minFinalSamples = 16000
+    /// 5 s at 16 kHz — force a final when speech keeps going without an end event.
+    private static let forceFlushSamples = 16000 * 5
+
+    init(
+        manager: any NemotronStreamingAsrManaging,
+        detector: any UtteranceBoundaryDetecting,
+        channelLabel: String,
+        onEvent: @escaping StreamingTranscriber.EventSink,
+    ) {
+        self.manager = manager
+        self.detector = detector
+        self.channelLabel = channelLabel
+        self.onEvent = onEvent
+    }
+
+    /// Load the models for this channel. Rethrows so the controller can fall
+    /// back when the load fails.
+    func prepare() async throws {
+        try await manager.prepare()
+    }
+
+    func ingest(_ buffer: LiveAudioBuffer) async {
+        guard buffer.channelCount == 1, buffer.sampleRate == 16000 else { return }
+        inputAccumulator.append(contentsOf: buffer.samples)
+        await drainChunks()
+    }
+
+    /// Recording stopped — commit any pending speech as a final (the recorder
+    /// can stop mid-utterance, so no VAD `speechEnd` ever arrives for the tail),
+    /// then reset both collaborators to a clean idle state.
+    func flush() async {
+        if !inputAccumulator.isEmpty { await drainChunks() }
+        if !speechSamples.isEmpty { await commitFinal() }
+        await detector.reset()
+        await manager.reset()
+        isSpeaking = false
+        speechSamples = []
+        runningTranscript = ""
+        inputAccumulator = []
+    }
+
+    private func drainChunks() async {
+        while inputAccumulator.count >= Self.chunkSize {
+            let chunk = Array(inputAccumulator.prefix(Self.chunkSize))
+            inputAccumulator.removeFirst(Self.chunkSize)
+            do {
+                try await manager.process(chunk)
+            } catch {
+                logger.warning("[\(self.channelLabel, privacy: .public)] process error: \(error)")
+                continue
+            }
+            if let latest = await manager.latestTranscript() { runningTranscript = latest }
+            let event: FluidVAD.StreamEvent.Kind?
+            do {
+                event = try await detector.boundary(in: chunk)
+            } catch {
+                logger.warning("[\(self.channelLabel, privacy: .public)] vad error: \(error)")
+                event = nil
+            }
+            await handleEvent(event, chunk: chunk)
+        }
+    }
+
+    private func handleEvent(_ kind: FluidVAD.StreamEvent.Kind?, chunk: [Float]) async {
+        switch kind {
+        case .speechStart:
+            isSpeaking = true
+            speechSamples = chunk
+
+        case .speechEnd:
+            isSpeaking = false
+            await commitFinal()
+
+        case .none:
+            guard isSpeaking else { return }
+            speechSamples.append(contentsOf: chunk)
+            emitPartial()
+            if speechSamples.count >= Self.forceFlushSamples { await commitFinal() }
+        }
+    }
+
+    private func emitPartial() {
+        let text = runningTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty { onEvent(.partial(text)) }
+    }
+
+    /// Finalize the current utterance: `finish()` force-decodes the buffered tail
+    /// and returns the complete transcript, clearing the manager's token
+    /// accumulation while keeping encoder state (so the next utterance starts
+    /// fresh — no prefix bookkeeping). `finish()` runs even when the utterance is
+    /// dropped as sub-second noise, so its text can't leak into the next final.
+    /// Emits only when the utterance cleared the 1 s minimum and decoded to text.
+    private func commitFinal() async {
+        let audio = speechSamples
+        speechSamples = []
+        let transcript: String
+        do {
+            transcript = try await manager.finish()
+        } catch {
+            logger.warning("[\(self.channelLabel, privacy: .public)] finish error: \(error)")
+            runningTranscript = ""
+            return
+        }
+        runningTranscript = ""
+        let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard audio.count >= Self.minFinalSamples, !text.isEmpty else { return }
+        onEvent(.finalized(text: text, audio: audio))
+    }
+}
+
+// MARK: - Production implementations
+
+/// Lock-protected FIFO the manager's `@Sendable` partial callback appends into;
+/// drained on the session actor after each `process()`.
+private final class PartialCollector: Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: [String]())
+    func append(_ text: String) {
+        storage.withLock { $0.append(text) }
+    }
+
+    /// Latest appended transcript, clearing the buffer.
+    func drainLast() -> String? {
+        storage.withLock { items in
+            let last = items.last
+            items.removeAll(keepingCapacity: true)
+            return last
+        }
+    }
+}
+
+/// Real manager seam: wraps `StreamingNemotronMultilingualAsrManager` bound to a
+/// shared model set + an explicit locale (e.g. `de-DE`). The shared models are
+/// loaded once by the controller (`preloadShared`) and shared across channels.
+actor NemotronAsrManager: NemotronStreamingAsrManaging {
+    private let manager = StreamingNemotronMultilingualAsrManager()
+    private let shared: SharedNemotronMultilingualModels
+    private let languageCode: String
+    private let collector = PartialCollector()
+
+    init(shared: SharedNemotronMultilingualModels, languageCode: String) {
+        self.shared = shared
+        self.languageCode = languageCode
+    }
+
+    func prepare() async throws {
+        try await manager.loadFromShared(shared)
+        await manager.setLanguage(languageCode)
+        let collector = collector
+        await manager.setPartialCallback { collector.append($0) }
+    }
+
+    func process(_ samples: [Float]) async throws {
+        _ = try await manager.process(samples: samples)
+    }
+
+    func latestTranscript() -> String? {
+        collector.drainLast()
+    }
+
+    func finish() async throws -> String {
+        try await manager.finish()
+    }
+
+    func reset() async {
+        await manager.reset()
+    }
+}
+
+/// Real boundary detector: `FluidVAD` streaming with the `StreamState` threaded
+/// internally so the session sees only boundary events. Created lazily on the
+/// first chunk and dropped by `reset()`.
+actor FluidVADBoundaryDetector: UtteranceBoundaryDetecting {
+    private let vad: FluidVAD
+    private var state: FluidVAD.StreamState?
+
+    init(vad: FluidVAD) {
+        self.vad = vad
+    }
+
+    func boundary(in chunk: [Float]) async throws -> FluidVAD.StreamEvent.Kind? {
+        if state == nil { state = try await vad.makeStreamState() }
+        guard let current = state else { return nil }
+        let result = try await vad.processStreamingChunk(chunk, state: current)
+        state = result.state
+        return result.event?.kind
+    }
+
+    func reset() {
+        state = nil
+    }
+}

--- a/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/NemotronStreamingCaptionSession.swift
@@ -122,13 +122,13 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
             } catch {
                 // Log but keep driving VAD: dropping the chunk's boundary check on a
                 // transient ASR error could lose a `speechEnd` and desync segmentation.
-                logger.warning("[\(self.channelLabel, privacy: .public)] process error: \(error)")
+                logger.warning("[\(self.channelLabel, privacy: .public)] process error: \(error.localizedDescription, privacy: .public)")
             }
             let event: FluidVAD.StreamEvent.Kind?
             do {
                 event = try await detector.boundary(in: chunk)
             } catch {
-                logger.warning("[\(self.channelLabel, privacy: .public)] vad error: \(error)")
+                logger.warning("[\(self.channelLabel, privacy: .public)] vad error: \(error.localizedDescription, privacy: .public)")
                 event = nil
             }
             await handleEvent(event, chunk: chunk)
@@ -173,7 +173,7 @@ actor NemotronStreamingCaptionSession: LiveCaptionPipeline {
         do {
             transcript = try await manager.finish()
         } catch {
-            logger.warning("[\(self.channelLabel, privacy: .public)] finish error: \(error)")
+            logger.warning("[\(self.channelLabel, privacy: .public)] finish error: \(error.localizedDescription, privacy: .public)")
             resetUtteranceState()
             return
         }

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -99,22 +99,23 @@ struct TranscriptionSettingsView: View {
 
     /// Describes which low-latency backend the current transcription language
     /// selects. The backend follows the active engine's configured language (no
-    /// toggle): German/Spanish/French/Italian/Portuguese → Nemotron streaming,
-    /// English → Parakeet EOU, else → the standard re-transcribe engine.
+    /// toggle): English → Parakeet EOU, any other set language → Nemotron
+    /// multilingual streaming, auto-detect → the standard re-transcribe engine.
     private var captionBackendFootnote: String {
-        let language = settings.activeEngineLanguageOrNil
-        if let language, LiveCaptionsGate.nemotronLanguages.contains(language) {
-            return "Caption backend follows your transcription language. German, Spanish, "
-                + "French, Italian, and Portuguese use the low-latency Nemotron streaming "
-                + "model (~611 MB, downloads on first use)."
-        }
-        if language == "en" {
-            return "Caption backend follows your transcription language. English uses the "
+        switch settings.activeEngineLanguageOrNil {
+        case .none:
+            "Caption backend follows your transcription language. Auto-detect uses the "
+                + "standard re-transcribe engine; set a specific language for low-latency "
+                + "streaming captions."
+
+        case "en":
+            "Caption backend follows your transcription language. English uses the "
                 + "low-latency Parakeet streaming model."
+
+        default:
+            "Caption backend follows your transcription language. It uses the low-latency "
+                + "Nemotron multilingual streaming model (~0.6-0.7 GB, downloads on first use)."
         }
-        return "Caption backend follows your transcription language. Set German, Spanish, "
-            + "French, Italian, Portuguese, or English for low-latency streaming captions; "
-            + "other languages (or auto-detect) use the standard re-transcribe engine."
     }
 
     private var liveTranscriptionFootnote: String {

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -78,15 +78,12 @@ struct TranscriptionSettingsView: View {
     private var liveTranscriptionSection: some View {
         Section("Live transcription (PoC)") {
             // The toggle stays enabled even for engines without the
-            // re-transcribe hook, because the English low-latency sub-toggle
-            // below routes captions through an engine-independent streaming
-            // session.
+            // re-transcribe hook, because the language-driven streaming
+            // backends (German/English) route captions through an
+            // engine-independent streaming session.
             Toggle("Show partial transcripts during recording", isOn: $settings.liveTranscriptionEnabled)
 
-            Toggle("English low-latency captions", isOn: $settings.liveCaptionsEnglishStreaming)
-                .disabled(!settings.liveTranscriptionEnabled)
-
-            Text(englishStreamingFootnote)
+            Text(captionBackendFootnote)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -100,8 +97,25 @@ struct TranscriptionSettingsView: View {
         .recordOnlyDisabled(settings.recordOnly)
     }
 
-    private var englishStreamingFootnote: String {
-        "English-only model; other languages keep the standard caption engine."
+    /// Describes which low-latency backend the current transcription language
+    /// selects. The backend follows the active engine's configured language (no
+    /// toggle): German → Nemotron streaming, English → Parakeet EOU, else →
+    /// the standard re-transcribe engine.
+    private var captionBackendFootnote: String {
+        switch settings.activeEngineLanguageOrNil {
+        case "de":
+            "Caption backend follows your transcription language. German uses the "
+                + "low-latency Nemotron streaming model (~611 MB, downloads on first use)."
+
+        case "en":
+            "Caption backend follows your transcription language. English uses the "
+                + "low-latency Parakeet streaming model."
+
+        default:
+            "Caption backend follows your transcription language. Set German or "
+                + "English for low-latency streaming captions; other languages (or "
+                + "auto-detect) use the standard re-transcribe engine."
+        }
     }
 
     private var liveTranscriptionFootnote: String {

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -7,6 +7,10 @@ struct TranscriptionSettingsView: View {
     var whisperKitEngine: WhisperKitEngine
     var parakeetEngine: ParakeetEngine
 
+    /// Set when the user flips live captions on while a first-use Nemotron model
+    /// download is pending — defers the actual enable to the consent alert.
+    @State private var pendingCaptionEnable = false
+
     private static let whisperKitModels: [(variant: String, label: String)] = [
         ("openai_whisper-large-v3-v20240930_turbo", "Large V3 Turbo (recommended)"),
         ("openai_whisper-large-v3-v20240930", "Large V3"),
@@ -79,9 +83,28 @@ struct TranscriptionSettingsView: View {
         Section("Live transcription (PoC)") {
             // The toggle stays enabled even for engines without the
             // re-transcribe hook, because the language-driven streaming
-            // backends (German/English) route captions through an
-            // engine-independent streaming session.
-            Toggle("Show partial transcripts during recording", isOn: $settings.liveTranscriptionEnabled)
+            // backends route captions through an engine-independent session.
+            // Enabling it for a Nemotron language whose model isn't downloaded
+            // yet defers to a consent alert (the ~0.6 GB first-use download).
+            Toggle("Show partial transcripts during recording", isOn: Binding(
+                get: { settings.liveTranscriptionEnabled },
+                set: { enabled in
+                    if enabled, needsCaptionModelConsent {
+                        pendingCaptionEnable = true
+                    } else {
+                        settings.liveTranscriptionEnabled = enabled
+                    }
+                },
+            ))
+            .alert("Download caption model?", isPresented: $pendingCaptionEnable) {
+                Button("Cancel", role: .cancel) {}
+                Button("Enable") { settings.liveTranscriptionEnabled = true }
+            } message: {
+                Text(
+                    "Live captions in this language use a roughly 0.6 GB on-device model, "
+                        + "downloaded once on first use.",
+                )
+            }
 
             Text(captionBackendFootnote)
                 .font(.caption)
@@ -95,6 +118,23 @@ struct TranscriptionSettingsView: View {
         }
         .accessibilityIdentifier("liveTranscriptionSection")
         .recordOnlyDisabled(settings.recordOnly)
+    }
+
+    /// True when enabling captions would trigger the first-use Nemotron download:
+    /// the active language routes to Nemotron (set + non-English) and no model
+    /// variant is on disk yet.
+    private var needsCaptionModelConsent: Bool {
+        guard let language = settings.activeEngineLanguageOrNil, language != "en" else { return false }
+        return !nemotronModelDownloaded
+    }
+
+    /// Whether any Nemotron multilingual model variant is already on disk.
+    private var nemotronModelDownloaded: Bool {
+        guard let base = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+        ).first else { return false }
+        let dir = base.appendingPathComponent("FluidAudio/Models/nemotron-multilingual")
+        return FileManager.default.fileExists(atPath: dir.path)
     }
 
     /// Describes which low-latency backend the current transcription language

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -99,23 +99,22 @@ struct TranscriptionSettingsView: View {
 
     /// Describes which low-latency backend the current transcription language
     /// selects. The backend follows the active engine's configured language (no
-    /// toggle): German → Nemotron streaming, English → Parakeet EOU, else →
-    /// the standard re-transcribe engine.
+    /// toggle): German/Spanish/French/Italian/Portuguese → Nemotron streaming,
+    /// English → Parakeet EOU, else → the standard re-transcribe engine.
     private var captionBackendFootnote: String {
-        switch settings.activeEngineLanguageOrNil {
-        case "de":
-            "Caption backend follows your transcription language. German uses the "
-                + "low-latency Nemotron streaming model (~611 MB, downloads on first use)."
-
-        case "en":
-            "Caption backend follows your transcription language. English uses the "
-                + "low-latency Parakeet streaming model."
-
-        default:
-            "Caption backend follows your transcription language. Set German or "
-                + "English for low-latency streaming captions; other languages (or "
-                + "auto-detect) use the standard re-transcribe engine."
+        let language = settings.activeEngineLanguageOrNil
+        if let language, LiveCaptionsGate.nemotronLanguages.contains(language) {
+            return "Caption backend follows your transcription language. German, Spanish, "
+                + "French, Italian, and Portuguese use the low-latency Nemotron streaming "
+                + "model (~611 MB, downloads on first use)."
         }
+        if language == "en" {
+            return "Caption backend follows your transcription language. English uses the "
+                + "low-latency Parakeet streaming model."
+        }
+        return "Caption backend follows your transcription language. Set German, Spanish, "
+            + "French, Italian, Portuguese, or English for low-latency streaming captions; "
+            + "other languages (or auto-detect) use the standard re-transcribe engine."
     }
 
     private var liveTranscriptionFootnote: String {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -56,16 +56,20 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(settings.perChannelIndicatorEnabled)
         XCTAssertEqual(settings.asymmetricSilenceWarningSeconds, 90.0)
         XCTAssertFalse(settings.liveTranscriptionEnabled)
-        XCTAssertFalse(settings.liveCaptionsEnglishStreaming)
     }
 
-    func test_liveCaptionsEnglishStreaming_defaultsToFalse() {
-        XCTAssertFalse(settings.liveCaptionsEnglishStreaming)
+    func test_activeEngineLanguageOrNil_followsWhisperKitLanguage() {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperLanguage = "de"
+        XCTAssertEqual(settings.activeEngineLanguageOrNil, "de")
+        settings.whisperLanguage = ""
+        XCTAssertNil(settings.activeEngineLanguageOrNil, "empty language = auto-detect → nil")
     }
 
-    func test_liveCaptionsEnglishStreaming_persistsToUserDefaults() {
-        settings.liveCaptionsEnglishStreaming = true
-        XCTAssertTrue(defaults.bool(forKey: "liveCaptionsEnglishStreaming"))
+    func test_activeEngineLanguageOrNil_followsParakeetLanguageWhenParakeetActive() {
+        settings.transcriptionEngine = .parakeet
+        settings.parakeetLanguage = "en"
+        XCTAssertEqual(settings.activeEngineLanguageOrNil, "en")
     }
 
     // MARK: - Clamping

--- a/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionFeedTests.swift
@@ -189,7 +189,7 @@ final class LiveCaptionFeedTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
     }

--- a/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
@@ -8,11 +8,11 @@ import XCTest
 ///
 /// **Master toggle (`liveEnabled`) gates everything.** When on, the streaming
 /// backend is chosen from the active engine's EXPLICITLY configured language:
-///   * one of the Nemotron Latin-script languages (de/es/fr/it/pt) →
-///     `.nemotronStreaming` (Nemotron multilingual streaming session)
 ///   * `en` → `.englishStreaming` (Parakeet EOU streaming, English-optimized)
-///   * anything else (auto-detect / unsupported) → `.reTranscribe` if the
-///     engine supports the in-memory path, else `.none`.
+///   * any other explicit language → `.nemotronStreaming` (Nemotron multilingual;
+///     FluidAudio auto-selects the Latin or full multilingual model variant)
+///   * auto-detect (nil) → `.reTranscribe` if the engine supports the in-memory
+///     path, else `.none`.
 ///
 /// The two streaming backends bypass the active engine entirely, so they are
 /// available even when `engineSupportsLive` is false. Auto-detect deliberately
@@ -20,7 +20,7 @@ import XCTest
 /// known) — it falls back to the engine-driven re-transcribe path.
 final class LiveCaptionsGateTests: XCTestCase {
     func testLiveDisabledYieldsNoneRegardlessOfLanguage() {
-        for lang in ["de", "en", "es", nil, "nl"] {
+        for lang in ["de", "en", "ru", nil, "zh"] {
             XCTAssertEqual(
                 LiveCaptionsGate.strategy(liveEnabled: false, engineLanguage: lang, engineSupportsLive: true),
                 .none, "live disabled must be .none (lang=\(lang ?? "nil"))",
@@ -28,8 +28,10 @@ final class LiveCaptionsGateTests: XCTestCase {
         }
     }
 
-    func testNemotronLatinLanguagesYieldNemotronStreaming() {
-        for lang in ["de", "es", "fr", "it", "pt"] {
+    func testExplicitNonEnglishLanguagesYieldNemotronStreaming() {
+        // Latin-script (latin model) and non-Latin (multilingual model) both
+        // route to Nemotron; FluidAudio picks the variant from the language code.
+        for lang in ["de", "es", "fr", "it", "pt", "nl", "ru", "zh", "ja"] {
             XCTAssertEqual(
                 LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: lang, engineSupportsLive: true),
                 .nemotronStreaming, "\(lang) must route to Nemotron",
@@ -55,14 +57,6 @@ final class LiveCaptionsGateTests: XCTestCase {
         XCTAssertEqual(
             LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: nil, engineSupportsLive: false),
             .none,
-        )
-    }
-
-    func testNonLatinLanguageFallsBackToReTranscribe() {
-        // Dutch is a picker option but not a Nemotron Latin-model language.
-        XCTAssertEqual(
-            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "nl", engineSupportsLive: true),
-            .reTranscribe,
         )
     }
 

--- a/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
@@ -2,75 +2,89 @@
 import XCTest
 
 /// Truth table for `LiveCaptionsGate` — the shared decision logic for whether
-/// live captions run and which per-channel pipeline strategy they use. Pure +
-/// value-typed, so the full 2×2×2 input grid is enumerable here without
-/// constructing the coordinator/controller actors.
+/// live captions run and which per-channel streaming backend they use. Pure +
+/// value-typed, so the full input grid is enumerable here without constructing
+/// the coordinator/controller actors.
 ///
-/// The three inputs:
-///   * `liveEnabled` — the master live-captions toggle (gates everything).
-///   * `englishStreaming` — the English low-latency opt-in (bypasses the
-///     engine-support gate, because the EOU session is engine-independent).
-///   * `engineSupportsLive` — whether the active engine implements the
-///     in-memory `transcribeSamples` re-transcribe hook.
+/// **Master toggle (`liveEnabled`) gates everything.** When on, the streaming
+/// backend is chosen from the active engine's EXPLICITLY configured language:
+///   * `de` → `.germanStreaming` (Nemotron multilingual streaming session)
+///   * `en` → `.englishStreaming` (Parakeet EOU streaming session)
+///   * anything else (auto-detect / unsupported) → `.reTranscribe` if the
+///     engine supports the in-memory path, else `.none`.
+///
+/// The two streaming backends bypass the active engine entirely, so they are
+/// available even when `engineSupportsLive` is false. Auto-detect deliberately
+/// does NOT route to a streaming model (the spoken language isn't statically
+/// known) — it falls back to the engine-driven re-transcribe path.
 final class LiveCaptionsGateTests: XCTestCase {
-    // MARK: - Live-enabled toggle gates everything
-
-    func testLiveDisabledYieldsNoneRegardlessOfOtherInputs() {
-        for english in [true, false] {
-            for supports in [true, false] {
-                let strategy = LiveCaptionsGate.strategy(
-                    liveEnabled: false, englishStreaming: english, engineSupportsLive: supports,
-                )
-                XCTAssertEqual(
-                    strategy, .none,
-                    "master off must yield .none (english=\(english), supports=\(supports))",
-                )
-                XCTAssertFalse(LiveCaptionsGate.captionsAvailable(
-                    liveEnabled: false, englishStreaming: english, engineSupportsLive: supports,
-                ))
-            }
+    func testLiveDisabledYieldsNoneRegardlessOfLanguage() {
+        for lang in ["de", "en", nil, "fr"] {
+            XCTAssertEqual(
+                LiveCaptionsGate.strategy(liveEnabled: false, engineLanguage: lang, engineSupportsLive: true),
+                .none, "master off must be .none (lang=\(lang ?? "nil"))",
+            )
         }
     }
 
-    // MARK: - English streaming bypasses the engine-support gate
-
-    func testEnglishStreamingOnYieldsEnglishStreamingEvenWhenEngineSupportsLive() {
-        let strategy = LiveCaptionsGate.strategy(
-            liveEnabled: true, englishStreaming: true, engineSupportsLive: true,
+    func testGermanLanguageYieldsGermanStreaming() {
+        XCTAssertEqual(
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "de", engineSupportsLive: true),
+            .germanStreaming,
         )
-        XCTAssertEqual(strategy, .englishStreaming)
     }
 
-    func testEnglishStreamingOnYieldsEnglishStreamingEvenWhenEngineUnsupported() {
-        // The key bypass: an engine without the re-transcribe hook still gets
-        // captions via the engine-independent EOU session.
-        let strategy = LiveCaptionsGate.strategy(
-            liveEnabled: true, englishStreaming: true, engineSupportsLive: false,
+    func testEnglishLanguageYieldsEnglishStreaming() {
+        XCTAssertEqual(
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "en", engineSupportsLive: true),
+            .englishStreaming,
         )
-        XCTAssertEqual(strategy, .englishStreaming)
+    }
+
+    func testAutoDetectLanguageFallsBackToReTranscribe() {
+        XCTAssertEqual(
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: nil, engineSupportsLive: true),
+            .reTranscribe,
+        )
+    }
+
+    func testAutoDetectWithUnsupportedEngineYieldsNone() {
+        XCTAssertEqual(
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: nil, engineSupportsLive: false),
+            .none,
+        )
+    }
+
+    func testOtherLanguageFallsBackToReTranscribe() {
+        XCTAssertEqual(
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "fr", engineSupportsLive: true),
+            .reTranscribe,
+        )
+    }
+
+    // MARK: - captionsAvailable
+
+    func testStreamingBackendsAvailableEvenWhenEngineUnsupported() {
         XCTAssertTrue(LiveCaptionsGate.captionsAvailable(
-            liveEnabled: true, englishStreaming: true, engineSupportsLive: false,
-        ), "english streaming makes captions available even for an unsupported engine")
+            liveEnabled: true, engineLanguage: "de", engineSupportsLive: false,
+        ))
+        XCTAssertTrue(LiveCaptionsGate.captionsAvailable(
+            liveEnabled: true, engineLanguage: "en", engineSupportsLive: false,
+        ))
     }
 
-    // MARK: - Re-transcribe path requires engine support (unchanged behaviour)
-
-    func testReTranscribeWhenStreamingOffAndEngineSupportsLive() {
-        let strategy = LiveCaptionsGate.strategy(
-            liveEnabled: true, englishStreaming: false, engineSupportsLive: true,
-        )
-        XCTAssertEqual(strategy, .reTranscribe)
-    }
-
-    func testNoneWhenStreamingOffAndEngineUnsupported() {
-        // Today's behaviour: master on but neither the engine supports the
-        // re-transcribe path nor is the English opt-in set → no captions.
-        let strategy = LiveCaptionsGate.strategy(
-            liveEnabled: true, englishStreaming: false, engineSupportsLive: false,
-        )
-        XCTAssertEqual(strategy, .none)
+    func testReTranscribeAvailabilityRequiresEngineSupport() {
+        XCTAssertTrue(LiveCaptionsGate.captionsAvailable(
+            liveEnabled: true, engineLanguage: nil, engineSupportsLive: true,
+        ))
         XCTAssertFalse(LiveCaptionsGate.captionsAvailable(
-            liveEnabled: true, englishStreaming: false, engineSupportsLive: false,
+            liveEnabled: true, engineLanguage: nil, engineSupportsLive: false,
+        ))
+    }
+
+    func testCaptionsUnavailableWhenLiveDisabled() {
+        XCTAssertFalse(LiveCaptionsGate.captionsAvailable(
+            liveEnabled: false, engineLanguage: "de", engineSupportsLive: true,
         ))
     }
 }

--- a/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptionsGateTests.swift
@@ -8,8 +8,9 @@ import XCTest
 ///
 /// **Master toggle (`liveEnabled`) gates everything.** When on, the streaming
 /// backend is chosen from the active engine's EXPLICITLY configured language:
-///   * `de` → `.germanStreaming` (Nemotron multilingual streaming session)
-///   * `en` → `.englishStreaming` (Parakeet EOU streaming session)
+///   * one of the Nemotron Latin-script languages (de/es/fr/it/pt) →
+///     `.nemotronStreaming` (Nemotron multilingual streaming session)
+///   * `en` → `.englishStreaming` (Parakeet EOU streaming, English-optimized)
 ///   * anything else (auto-detect / unsupported) → `.reTranscribe` if the
 ///     engine supports the in-memory path, else `.none`.
 ///
@@ -19,25 +20,27 @@ import XCTest
 /// known) — it falls back to the engine-driven re-transcribe path.
 final class LiveCaptionsGateTests: XCTestCase {
     func testLiveDisabledYieldsNoneRegardlessOfLanguage() {
-        for lang in ["de", "en", nil, "fr"] {
+        for lang in ["de", "en", "es", nil, "nl"] {
             XCTAssertEqual(
                 LiveCaptionsGate.strategy(liveEnabled: false, engineLanguage: lang, engineSupportsLive: true),
-                .none, "master off must be .none (lang=\(lang ?? "nil"))",
+                .none, "live disabled must be .none (lang=\(lang ?? "nil"))",
             )
         }
     }
 
-    func testGermanLanguageYieldsGermanStreaming() {
-        XCTAssertEqual(
-            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "de", engineSupportsLive: true),
-            .germanStreaming,
-        )
+    func testNemotronLatinLanguagesYieldNemotronStreaming() {
+        for lang in ["de", "es", "fr", "it", "pt"] {
+            XCTAssertEqual(
+                LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: lang, engineSupportsLive: true),
+                .nemotronStreaming, "\(lang) must route to Nemotron",
+            )
+        }
     }
 
     func testEnglishLanguageYieldsEnglishStreaming() {
         XCTAssertEqual(
             LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "en", engineSupportsLive: true),
-            .englishStreaming,
+            .englishStreaming, "English uses the English-optimized EOU path, not Nemotron",
         )
     }
 
@@ -55,9 +58,10 @@ final class LiveCaptionsGateTests: XCTestCase {
         )
     }
 
-    func testOtherLanguageFallsBackToReTranscribe() {
+    func testNonLatinLanguageFallsBackToReTranscribe() {
+        // Dutch is a picker option but not a Nemotron Latin-model language.
         XCTAssertEqual(
-            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "fr", engineSupportsLive: true),
+            LiveCaptionsGate.strategy(liveEnabled: true, engineLanguage: "nl", engineSupportsLive: true),
             .reTranscribe,
         )
     }

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -22,7 +22,7 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
     /// The EOU factory returns a mock manager that never loads real models, so
     /// the English-streaming branch is exercisable without CoreML downloads.
     private func mockControllerFactory() -> LiveTranscriptionCoordinator.ControllerFactory {
-        { engine, captions, englishStreaming, verboseDiagnostics in
+        { engine, captions, engineLanguage, verboseDiagnostics in
             let eouFactory: LiveTranscriptionController.EouSessionFactory = { MockEouManager() }
             let verbose: () -> Bool = { verboseDiagnostics() }
             return LiveTranscriptionController(
@@ -30,7 +30,7 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
                 vad: FluidVAD(threshold: 0.5),
                 captions: captions,
                 speakerMatcher: FakeLiveSpeakerMatcher(),
-                englishStreaming: englishStreaming,
+                engineLanguage: engineLanguage,
                 eouSessionFactory: eouFactory,
                 verboseDiagnostics: verbose,
             )
@@ -102,7 +102,7 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
             captions: LiveCaptionsState(),
             liveEnabled: { true },
             engineSupportsLive: { false },
-            englishStreaming: { true },
+            engineLanguage: { "en" },
             verboseDiagnostics: { false },
             makeController: mockControllerFactory(),
         )

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionEnglishStreamingTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionEnglishStreamingTests.swift
@@ -70,7 +70,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -94,7 +94,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -122,7 +122,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: captions,
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -152,7 +152,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: false,
+            engineLanguage: nil,
             eouSessionFactory: eouFactory,
         )
 
@@ -183,7 +183,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -208,7 +208,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: LiveCaptionsState(),
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -237,7 +237,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: captions,
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
 
@@ -287,7 +287,7 @@ final class LiveTranscriptionEnglishStreamingTests: XCTestCase {
             vad: FluidVAD(threshold: 0.5),
             captions: captions,
             speakerMatcher: FakeLiveSpeakerMatcher(),
-            englishStreaming: true,
+            engineLanguage: "en",
             eouSessionFactory: eouFactory,
         )
         await controller.prepare()

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionNemotronStreamingTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionNemotronStreamingTests.swift
@@ -63,11 +63,15 @@ final class LiveTranscriptionNemotronStreamingTests: XCTestCase {
         }
     }
 
-    private func makeController(probe: NemotronFactoryProbe, engine: LoadTrackingEngine) -> LiveTranscriptionController {
+    private func makeController(
+        probe: NemotronFactoryProbe,
+        engine: LoadTrackingEngine,
+        captions: LiveCaptionsState = LiveCaptionsState(),
+    ) -> LiveTranscriptionController {
         LiveTranscriptionController(
             engine: engine,
             vad: FluidVAD(threshold: 0.5),
-            captions: LiveCaptionsState(),
+            captions: captions,
             speakerMatcher: FakeLiveSpeakerMatcher(),
             engineLanguage: "de",
             nemotronPipelineFactory: probe.factory(),
@@ -77,7 +81,8 @@ final class LiveTranscriptionNemotronStreamingTests: XCTestCase {
     func testNemotronLanguageBuildsStreamingSessionsWithoutLoadingEngine() async {
         let probe = NemotronFactoryProbe()
         let engine = LoadTrackingEngine()
-        let controller = makeController(probe: probe, engine: engine)
+        let captions = LiveCaptionsState()
+        let controller = makeController(probe: probe, engine: engine, captions: captions)
 
         await controller.prepare()
 
@@ -86,12 +91,14 @@ final class LiveTranscriptionNemotronStreamingTests: XCTestCase {
             engine.loadModelCount, 0,
             "the engine-independent Nemotron path must NOT load the active engine",
         )
+        XCTAssertEqual(captions.activeBackend, "Nemotron · DE", "the resolved backend is published for the overlay")
     }
 
     func testNemotronLoadFailureFallsBackToReTranscribe() async {
         let probe = NemotronFactoryProbe(loadError: LoadFailure())
         let engine = LoadTrackingEngine()
-        let controller = makeController(probe: probe, engine: engine)
+        let captions = LiveCaptionsState()
+        let controller = makeController(probe: probe, engine: engine, captions: captions)
 
         await controller.prepare()
 
@@ -99,6 +106,10 @@ final class LiveTranscriptionNemotronStreamingTests: XCTestCase {
         XCTAssertEqual(
             engine.loadModelCount, 1,
             "Nemotron load failure must fall back to the re-transcribe path, which loads the engine",
+        )
+        XCTAssertEqual(
+            captions.activeBackend, "Re-transcribe · DE",
+            "a silent fallback must publish the ACTUAL backend, not the selected Nemotron",
         )
     }
 

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionNemotronStreamingTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionNemotronStreamingTests.swift
@@ -1,0 +1,116 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// Behaviour pins for the Nemotron streaming path on `LiveTranscriptionController`
+/// — any explicitly-configured non-English language routes per-channel captions
+/// through `NemotronStreamingCaptionSession` instead of the VAD + re-transcribe
+/// `StreamingTranscriber`, with a non-fatal model-load fallback.
+///
+/// The real model is a multi-hundred-MB CoreML download, so the Nemotron pipeline
+/// factory is injected (mirroring the EOU `eouSessionFactory`) and the tests
+/// assert on the seams: the factory's call count and the engine's `loadModel`
+/// activity. The streaming path never touches the engine; the re-transcribe
+/// fallback loads it — those two signatures distinguish which strategy resolved.
+@MainActor
+final class LiveTranscriptionNemotronStreamingTests: XCTestCase {
+    private struct LoadFailure: Error {}
+
+    /// Counts factory invocations; returns two no-op pipelines, or throws.
+    @MainActor
+    private final class NemotronFactoryProbe {
+        private(set) var buildCount = 0
+        private let loadError: (any Error)?
+
+        init(loadError: (any Error)? = nil) {
+            self.loadError = loadError
+        }
+
+        func factory() -> LiveTranscriptionController.NemotronPipelineFactory {
+            { _, _, _ in
+                self.buildCount += 1
+                if let loadError = self.loadError { throw loadError }
+                return (NoopPipeline(), NoopPipeline())
+            }
+        }
+    }
+
+    private actor NoopPipeline: LiveCaptionPipeline {
+        // swiftlint:disable:next async_without_await
+        func ingest(_: LiveAudioBuffer) async {}
+        // swiftlint:disable:next async_without_await
+        func flush() async {}
+    }
+
+    /// Tracks whether the engine's `loadModel()` ran — the tell that the
+    /// re-transcribe path was built (the streaming path skips it).
+    private final class LoadTrackingEngine: StreamingTranscribingEngine {
+        var modelState: EngineModelState = .loaded
+        var downloadProgress: Double = 1.0
+        var transcriptionProgress: Double = 1.0
+        private(set) var loadModelCount = 0
+
+        func loadModel() {
+            loadModelCount += 1
+        }
+
+        func transcribeSegments(audioPath _: URL) -> [TimestampedSegment] {
+            []
+        }
+
+        func transcribeSamples(_: [Float]) -> String {
+            ""
+        }
+    }
+
+    private func makeController(probe: NemotronFactoryProbe, engine: LoadTrackingEngine) -> LiveTranscriptionController {
+        LiveTranscriptionController(
+            engine: engine,
+            vad: FluidVAD(threshold: 0.5),
+            captions: LiveCaptionsState(),
+            speakerMatcher: FakeLiveSpeakerMatcher(),
+            engineLanguage: "de",
+            nemotronPipelineFactory: probe.factory(),
+        )
+    }
+
+    func testNemotronLanguageBuildsStreamingSessionsWithoutLoadingEngine() async {
+        let probe = NemotronFactoryProbe()
+        let engine = LoadTrackingEngine()
+        let controller = makeController(probe: probe, engine: engine)
+
+        await controller.prepare()
+
+        XCTAssertEqual(probe.buildCount, 1, "the Nemotron path builds both channels in one factory call")
+        XCTAssertEqual(
+            engine.loadModelCount, 0,
+            "the engine-independent Nemotron path must NOT load the active engine",
+        )
+    }
+
+    func testNemotronLoadFailureFallsBackToReTranscribe() async {
+        let probe = NemotronFactoryProbe(loadError: LoadFailure())
+        let engine = LoadTrackingEngine()
+        let controller = makeController(probe: probe, engine: engine)
+
+        await controller.prepare()
+
+        XCTAssertGreaterThan(probe.buildCount, 0, "the Nemotron path must have been attempted")
+        XCTAssertEqual(
+            engine.loadModelCount, 1,
+            "Nemotron load failure must fall back to the re-transcribe path, which loads the engine",
+        )
+    }
+
+    func testPrepareThenResetKeepsNemotronSessions() async {
+        let probe = NemotronFactoryProbe()
+        let engine = LoadTrackingEngine()
+        let controller = makeController(probe: probe, engine: engine)
+
+        await controller.prepare()
+        await controller.prepareForNextRecording()
+
+        XCTAssertEqual(probe.buildCount, 1, "a kept streaming session must NOT be rebuilt for the next recording")
+        XCTAssertEqual(engine.loadModelCount, 0, "the kept Nemotron session path must not load the engine")
+    }
+}

--- a/app/MeetingTranscriber/Tests/NemotronFinishDriftTests.swift
+++ b/app/MeetingTranscriber/Tests/NemotronFinishDriftTests.swift
@@ -1,0 +1,125 @@
+import AudioTapLib
+import FluidAudio
+@testable import MeetingTranscriber
+import XCTest
+
+/// Empirical resolution of a code-review concern: the production session
+/// finalizes each utterance with `manager.finish()` and KEEPS feeding the same
+/// manager (resetting only on `flush()`). A reviewer flagged that `finish()`
+/// pads + decodes the tail (advancing the encoder cache) and clears only the
+/// token accumulation (not the decoder/encoder state), so cross-utterance state
+/// could carry over → progressive drift after the first `speechEnd`.
+///
+/// This drives the REAL Nemotron model two ways on the same multi-utterance
+/// German fixture and compares the transcripts:
+///   * PROD  — the actual `NemotronStreamingCaptionSession` (real manager + real
+///     FluidVAD), `finish()` per VAD boundary, joined finals.
+///   * BASE  — feed all audio, `finish()` ONCE (the validated PoC pattern).
+/// If PROD ≈ BASE the finalize-and-continue pattern is sound; if PROD degrades
+/// in the later utterances, it is not.
+///
+/// Gated (loads the ~0.6 GB model + runs inference):
+///   RUN_NEMOTRON_DRIFT=1 swift test --filter NemotronFinishDriftTests
+final class NemotronFinishDriftTests: XCTestCase {
+    func testFinishPerUtteranceMatchesFinishOnce() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_NEMOTRON_DRIFT"] == "1",
+            "gated: set RUN_NEMOTRON_DRIFT=1 (loads the real model)",
+        )
+
+        let (samples, sampleRate) = try await AudioMixer.loadAudioAsFloat32(url: fixtureURL("two_speakers_de.wav"))
+        XCTAssertEqual(sampleRate, 16000, "fixture must be 16 kHz")
+        print("[drift] fixture: \(samples.count) samples (\(Double(samples.count) / 16000.0)s)")
+
+        let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(languageCode: "de", chunkMs: 2240)
+        let shared = try await StreamingNemotronMultilingualAsrManager.preloadShared(from: dir)
+
+        // --- PROD: production session, finish()-per-VAD-boundary ---
+        let recorder = FinalRecorder()
+        let sink: StreamingTranscriber.EventSink = { event in
+            if case let .finalized(text, _) = event { recorder.add(text) }
+        }
+        let session = NemotronStreamingCaptionSession(
+            manager: NemotronAsrManager(shared: shared, languageCode: "de"),
+            detector: FluidVADBoundaryDetector(vad: FluidVAD(threshold: 0.5)),
+            channelLabel: "drift",
+            onEvent: sink,
+        )
+        try await session.prepare()
+        var index = 0
+        while index < samples.count {
+            let end = min(index + 4096, samples.count)
+            await session.ingest(LiveAudioBuffer(
+                samples: Array(samples[index ..< end]), channelCount: 1, sampleRate: 16000, hostTime: 0,
+            ))
+            index = end
+        }
+        await session.flush()
+        let finals = recorder.all()
+        let prodTranscript = finals.joined(separator: " ")
+
+        // --- BASE: feed all, finish() once ---
+        let base = StreamingNemotronMultilingualAsrManager()
+        try await base.loadFromShared(shared)
+        await base.setLanguage("de")
+        _ = try await base.process(samples: samples)
+        let baseTranscript = try await base.finish()
+
+        let wer = Self.wordErrorRate(hypothesis: prodTranscript, reference: baseTranscript)
+
+        print("[drift] PROD finalized utterances (\(finals.count)):")
+        for (i, f) in finals.enumerated() {
+            print("[drift]   [\(i)] \(f)")
+        }
+        print("[drift] PROD (finish-per-utterance, \(prodTranscript.split(separator: " ").count) words):\n\(prodTranscript)")
+        print("[drift] BASE (finish-once, \(baseTranscript.split(separator: " ").count) words):\n\(baseTranscript)")
+        print(String(format: "[drift] WER(prod vs base) = %.1f%%", wer * 100))
+
+        // Regression guard: finalize-and-continue must track the one-shot decode.
+        // Measured ~1.1% on the 2-speaker fixture; the generous 15% bound catches
+        // real cross-utterance drift (which would be 50%+) without flaking on
+        // benign boundary-segmentation differences.
+        XCTAssertGreaterThanOrEqual(finals.count, 5, "expected several finalized utterances")
+        XCTAssertLessThan(wer, 0.15, "finish-per-utterance drifted from finish-once (WER \(wer))")
+    }
+
+    /// Word-level Levenshtein WER, hypothesis vs reference (lowercased, punctuation-insensitive split).
+    private static func wordErrorRate(hypothesis: String, reference: String) -> Double {
+        let normalize: (String) -> [String] = { text in
+            text.lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { !$0.isEmpty }
+        }
+        let hyp = normalize(hypothesis)
+        let ref = normalize(reference)
+        guard !ref.isEmpty else { return hyp.isEmpty ? 0 : 1 }
+        var prev = Array(0 ... hyp.count)
+        var curr = [Int](repeating: 0, count: hyp.count + 1)
+        for i in 1 ... ref.count {
+            curr[0] = i
+            for j in 1 ... hyp.count {
+                let cost = ref[i - 1] == hyp[j - 1] ? 0 : 1
+                curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+            }
+            swap(&prev, &curr)
+        }
+        return Double(prev[hyp.count]) / Double(ref.count)
+    }
+}
+
+/// Thread-safe sink for the session's `@Sendable` finalized-caption callback.
+private final class FinalRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [String] = []
+    func add(_ text: String) {
+        lock.lock()
+        items.append(text)
+        lock.unlock()
+    }
+
+    func all() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return items
+    }
+}

--- a/app/MeetingTranscriber/Tests/NemotronStreamingCaptionSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/NemotronStreamingCaptionSessionTests.swift
@@ -1,0 +1,292 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `NemotronStreamingCaptionSession` — the VAD-driven German
+/// streaming caption session. Both collaborators are injected as seams so the
+/// finalization logic is exercised without loading the ~1.5 GB Nemotron models
+/// or the Silero VAD: a scripted `UtteranceBoundaryDetecting` decides when
+/// `speechStart`/`speechEnd` fire, and a `MockNemotronManager` models the real
+/// manager's contract — `latestTranscript()` returns the in-progress partial,
+/// and `finish()` returns the complete utterance text AND clears it (so the
+/// next utterance starts fresh, as the real `finish()` clears its token
+/// accumulation while keeping encoder state).
+final class NemotronStreamingCaptionSessionTests: XCTestCase {
+    /// 4096 non-silent samples = one VAD chunk at 16 kHz (~256 ms).
+    private func chunkBuffer(value: Float = 0.1) -> LiveAudioBuffer {
+        LiveAudioBuffer(
+            samples: [Float](repeating: value, count: 4096),
+            channelCount: 1,
+            sampleRate: 16000,
+            hostTime: 0,
+        )
+    }
+
+    private func makeSession(
+        manager: MockNemotronManager,
+        detector: ScriptedBoundaryDetector,
+        recorder: EventRecorder,
+    ) -> NemotronStreamingCaptionSession {
+        let sink: StreamingTranscriber.EventSink = { recorder.record($0) }
+        return NemotronStreamingCaptionSession(
+            manager: manager,
+            detector: detector,
+            channelLabel: "mic",
+            onEvent: sink,
+        )
+    }
+
+    private func finals(_ events: [StreamingTranscriber.Event]) -> [(text: String, audio: [Float])] {
+        events.compactMap { event in
+            if case let .finalized(text, audio) = event { return (text, audio) }
+            return nil
+        }
+    }
+
+    private func partials(_ events: [StreamingTranscriber.Event]) -> [String] {
+        events.compactMap { event in
+            if case let .partial(text) = event { return text }
+            return nil
+        }
+    }
+
+    /// A VAD `speechEnd` finalizes the in-progress utterance via `finish()`,
+    /// emitting the complete transcript paired with the buffered speech audio
+    /// (so the controller's event sink can derive a speaker embedding).
+    func testSpeechEndFinalizesUtteranceWithSpeechAudio() async {
+        let manager = MockNemotronManager()
+        await manager.setFinish("hallo welt")
+        let recorder = EventRecorder()
+        // start + 3×none = 4 chunks of speech (16384 samples ≈ 1.02 s) clears
+        // the 1 s noise minimum; the speechEnd chunk commits but isn't appended.
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [.speechStart, nil, nil, nil, .speechEnd]),
+            recorder: recorder,
+        )
+
+        for _ in 0 ..< 5 {
+            await session.ingest(chunkBuffer())
+        }
+
+        let finalEvents = finals(recorder.events)
+        XCTAssertEqual(finalEvents.count, 1, "exactly one final on speechEnd")
+        XCTAssertEqual(finalEvents.first?.text, "hallo welt")
+        XCTAssertEqual(finalEvents.first?.audio.count, 4 * 4096)
+    }
+
+    /// While speech is in progress (between start and end) the running partial
+    /// transcript is emitted as partials, not finals.
+    func testRunningTranscriptEmittedAsPartialDuringSpeech() async {
+        let manager = MockNemotronManager()
+        await manager.setPartial("guten")
+        let recorder = EventRecorder()
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [.speechStart, nil, nil]),
+            recorder: recorder,
+        )
+
+        for _ in 0 ..< 3 {
+            await session.ingest(chunkBuffer())
+        }
+
+        XCTAssertTrue(partials(recorder.events).contains("guten"), "partial emitted while speaking")
+        XCTAssertTrue(finals(recorder.events).isEmpty, "no final without a speechEnd")
+    }
+
+    /// A sub-second utterance (below the 1 s minimum) is dropped as noise
+    /// rather than finalized.
+    func testSubSecondUtteranceDroppedAsNoise() async {
+        let manager = MockNemotronManager()
+        await manager.setFinish("äh")
+        let recorder = EventRecorder()
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [.speechStart, .speechEnd]),
+            recorder: recorder,
+        )
+
+        for _ in 0 ..< 2 {
+            await session.ingest(chunkBuffer())
+        }
+
+        // 1 chunk of speech = 4096 samples = 0.256 s < 1 s minimum → dropped.
+        XCTAssertTrue(finals(recorder.events).isEmpty, "sub-second speech dropped")
+    }
+
+    /// Each utterance finalizes its own complete text via `finish()`, with no
+    /// carry-over between utterances.
+    func testEachUtteranceFinalizesItsOwnText() async {
+        let manager = MockNemotronManager()
+        let recorder = EventRecorder()
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [
+                .speechStart, nil, nil, nil, .speechEnd, // utterance 1
+                .speechStart, nil, nil, nil, .speechEnd, // utterance 2
+            ]),
+            recorder: recorder,
+        )
+
+        await manager.setFinish("erster satz")
+        for _ in 0 ..< 5 {
+            await session.ingest(chunkBuffer())
+        }
+        await manager.setFinish("zweiter satz")
+        for _ in 0 ..< 5 {
+            await session.ingest(chunkBuffer())
+        }
+
+        XCTAssertEqual(finals(recorder.events).map(\.text), ["erster satz", "zweiter satz"])
+    }
+
+    /// A dropped sub-second utterance must NOT leak its text into the next
+    /// utterance's final — `finish()` clears the manager's accumulation even on
+    /// the drop path, so the next final carries only its own text.
+    func testDroppedUtteranceDoesNotLeakIntoNextFinal() async {
+        let manager = MockNemotronManager()
+        let recorder = EventRecorder()
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [
+                .speechStart, .speechEnd, // utterance 1: sub-second, dropped
+                .speechStart, nil, nil, nil, .speechEnd, // utterance 2
+            ]),
+            recorder: recorder,
+        )
+
+        await manager.setFinish("äh") // dropped as noise (1 chunk)
+        for _ in 0 ..< 2 {
+            await session.ingest(chunkBuffer())
+        }
+        await manager.setFinish("hallo welt")
+        for _ in 0 ..< 5 {
+            await session.ingest(chunkBuffer())
+        }
+
+        XCTAssertEqual(finals(recorder.events).map(\.text), ["hallo welt"], "dropped 'äh' must not leak")
+    }
+
+    /// `flush()` (recorder stopped mid-utterance, no `speechEnd`) commits the
+    /// pending speech as a final via `finish()`.
+    func testFlushCommitsPendingTailUtterance() async {
+        let manager = MockNemotronManager()
+        await manager.setFinish("letzter satz")
+        let recorder = EventRecorder()
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: [.speechStart, nil, nil, nil]),
+            recorder: recorder,
+        )
+
+        for _ in 0 ..< 4 {
+            await session.ingest(chunkBuffer())
+        }
+        await session.flush()
+
+        XCTAssertEqual(finals(recorder.events).map(\.text), ["letzter satz"], "tail committed on flush")
+    }
+
+    /// Speech that runs past the 5 s force-flush without a `speechEnd` emits a
+    /// final so the overlay isn't stuck on a growing partial.
+    func testForceFlushEmitsFinalAfterFiveSeconds() async {
+        let manager = MockNemotronManager()
+        await manager.setFinish("langer monolog")
+        let recorder = EventRecorder()
+        // start + 20×none = 21 chunks ≈ 5.4 s of speech → crosses forceFlushSamples.
+        let script: [FluidVAD.StreamEvent.Kind?] = [.speechStart] + Array(repeating: nil, count: 20)
+        let session = makeSession(
+            manager: manager,
+            detector: ScriptedBoundaryDetector(script: script),
+            recorder: recorder,
+        )
+
+        for _ in 0 ..< 21 {
+            await session.ingest(chunkBuffer())
+        }
+
+        XCTAssertFalse(finals(recorder.events).isEmpty, "force-flush emits a final past 5 s")
+        XCTAssertEqual(finals(recorder.events).first?.text, "langer monolog")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Scriptable `UtteranceBoundaryDetecting`: returns the next scripted event per
+/// chunk (nil = no boundary), so tests drive utterance segmentation
+/// deterministically without the Silero model.
+private actor ScriptedBoundaryDetector: UtteranceBoundaryDetecting {
+    private var script: [FluidVAD.StreamEvent.Kind?]
+
+    init(script: [FluidVAD.StreamEvent.Kind?]) {
+        self.script = script
+    }
+
+    // swiftlint:disable:next async_without_await
+    func boundary(in _: [Float]) async -> FluidVAD.StreamEvent.Kind? {
+        script.isEmpty ? nil : script.removeFirst()
+    }
+
+    // swiftlint:disable:next async_without_await
+    func reset() async {}
+}
+
+/// Mock `NemotronStreamingAsrManaging` modelling the real contract:
+/// `latestTranscript()` returns the in-progress partial; `finish()` returns the
+/// complete utterance text and CLEARS both (the real `finish()` clears its
+/// accumulated tokens while keeping encoder state).
+private actor MockNemotronManager: NemotronStreamingAsrManaging {
+    private var partial = ""
+    private var finishText = ""
+
+    func setPartial(_ text: String) {
+        partial = text
+    }
+
+    func setFinish(_ text: String) {
+        finishText = text
+    }
+
+    // swiftlint:disable:next async_without_await
+    func prepare() async {}
+
+    // swiftlint:disable:next async_without_await
+    func process(_: [Float]) async {}
+
+    func latestTranscript() -> String? {
+        partial.isEmpty ? nil : partial
+    }
+
+    // swiftlint:disable:next async_without_await
+    func finish() async -> String {
+        let result = finishText
+        partial = ""
+        finishText = ""
+        return result
+    }
+
+    // swiftlint:disable:next async_without_await
+    func reset() async {
+        partial = ""
+        finishText = ""
+    }
+}
+
+/// Thread-safe sink for the session's `@Sendable` event callback.
+private final class EventRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [StreamingTranscriber.Event] = []
+
+    func record(_ event: StreamingTranscriber.Event) {
+        lock.lock()
+        stored.append(event)
+        lock.unlock()
+    }
+
+    var events: [StreamingTranscriber.Event] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}


### PR DESCRIPTION
## Summary
Live captions via a **language-driven streaming backend**. When live captions are on, the per-channel backend is chosen from the active engine's explicitly-configured language — no toggle:

- `en` → Parakeet EOU streaming (English-optimized; previously a manual opt-in)
- any other explicitly-set language → Nemotron multilingual streaming. FluidAudio's `downloadVariant` auto-selects the model from the language (the ~584 MB Latin model for de/es/fr/it/pt, the larger full multilingual model for the rest; the ~540 MB encoder is shared, only the vocab-scaled decoder differs).
- auto-detect → VAD + re-transcribe (the spoken language isn't statically known, so we don't pick a language-specific streaming model)

This replaces the manual `liveCaptionsEnglishStreaming` opt-in with the derived `AppSettings.activeEngineLanguageOrNil`, so captions follow the language you already configured.

## How it works
`NemotronStreamingCaptionSession` feeds 16 kHz audio continuously to FluidAudio's `StreamingNemotronMultilingualAsrManager` and finalizes each utterance on a FluidVAD `speechEnd` via `finish()` — which force-decodes the buffered tail, returns the complete transcript, and clears the token accumulation while keeping encoder state. Each final therefore carries exactly its own text (no cross-utterance leak), paired with the utterance's speech audio so the existing live speaker-matcher derives an embedding from the same window. The manager + VAD sit behind injectable seams (`NemotronStreamingAsrManaging` / `UtteranceBoundaryDetecting`) so the session + the controller's build/fallback state machine are unit-tested without the CoreML models. Models are shared across both channels (preload once, load-from-shared per channel).

Two UX touches:
- **Consent prompt:** enabling captions with a Nemotron-routed language whose model isn't downloaded yet asks before the first-use (~0.6 GB) download, rather than fetching silently.
- **Backend indicator:** a small badge at the top of the caption bar shows the *actually resolved* backend ("Nemotron · DE", "Parakeet EOU · EN", "Re-transcribe"), so a silent model-load fallback is visible.

## Testing / validation
- Pure gate truth table; session unit tests (speechEnd finalize, partials, sub-second drop, multi-utterance, dropped-text-no-leak, 5 s force-flush, flush-tail); controller build-success / load-failure-fallback / keep-across-recordings via the injected factory seam.
- A review flagged that `finish()`-per-utterance + continuing to feed could drift; a gated **real-model** test (`NemotronFinishDriftTests`) drives the production session vs a `finish()`-once baseline on a 2-speaker German fixture and confirms **10 coherent utterances, WER 1.1%, no drift**.
- Offline German quality ~2–3% WER on real clips; a real 28-min Teams meeting transcribed coherently. Other languages are enabled because the shared model supports them — only German has been benchmarked.
- In-app CPU/RAM measured on real hardware: recording **with Nemotron captions ≈ 15.7% CPU**, *below* the ~22.5% reference for the existing EOU/re-transcribe path (one streaming pass per chunk vs re-transcribing the whole utterance repeatedly).
- Debug + release builds clean, lint + analyze clean, all affected suites green. Rebased onto latest main; error logs follow the house `.public` cause convention.

## Coverage
Code only exercisable with the real CoreML models is split into its own files (`NemotronAsrManager.swift`, `LiveTranscriptionController+Nemotron.swift`) and codecov-ignored — same pattern as the existing hardware/model-glue ignores — so the diluted patch number reflects the untestable model glue, not the unit-tested logic.

## Known follow-ups (intentionally out of scope)
- Only German quality is benchmarked; es/fr/it/pt and the non-Latin languages are enabled by model support, not measured.
- The consent prompt gates the toggle-enable path; changing the language while captions are already on is not gated.
- The VAD-chunking skeleton (chunk pump + thresholds) overlaps with `StreamingTranscriber`/EOU and could be shared.

https://claude.ai/code/session_012E5U39bcJchXs37mNoJKgK
