### PR TITLE
fix(app): diagnosable + non-false-positive permission health check (#446)

### DIFF
--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -48,11 +48,10 @@ enum PermissionProblem: Equatable {
     /// Compact, PII-free token for `os_log` (safe to log with `privacy: .public`):
     /// e.g. `screen-recording=broken`. The clear-text `description` is user-facing only.
     var logToken: String {
-        let key: String
-        switch self {
-        case .screenRecordingDenied, .screenRecordingBroken: key = "screen-recording"
-        case .microphoneDenied, .microphoneBroken: key = "microphone"
-        case .accessibilityDenied, .accessibilityBroken: key = "accessibility"
+        let key = switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: "screen-recording"
+        case .microphoneDenied, .microphoneBroken: "microphone"
+        case .accessibilityDenied, .accessibilityBroken: "accessibility"
         }
         return "\(key)=\(isBroken ? "broken" : "denied")"
     }
@@ -111,23 +110,23 @@ struct HealthCheckResult: Equatable {
 enum PermissionHealthCheck {
     // MARK: - Screen Recording (pure, testable)
 
-    /// Pure decision function: combines the TCC system verdict with a window-title probe.
+    /// Pure decision function for Screen Recording: trusts the TCC system verdict.
     ///
-    /// - `systemAllowed`: whether macOS says the process has the Screen Recording entitlement
-    ///   (via `CGPreflightScreenCaptureAccess()` or equivalent).
-    /// - `hasForeignWithTitle`: whether `CGWindowListCopyWindowInfo` returned at least one
-    ///   window from another process that has a non-empty `kCGWindowName`.
+    /// - `systemAllowed`: whether macOS says the process has the Screen Recording
+    ///   entitlement (via `CGPreflightScreenCaptureAccess()` or equivalent).
     ///
     /// Outcomes:
+    /// - `healthy`: system says yes
     /// - `denied`: system says no
-    /// - `healthy`: system says yes AND we can read foreign window titles
-    /// - `broken`: system says yes BUT we cannot read any foreign window titles (TCC mismatch)
-    static func checkScreenRecording(
-        systemAllowed: Bool,
-        hasForeignWithTitle: Bool,
-    ) -> PermissionStatus {
-        if !systemAllowed { return .denied }
-        return hasForeignWithTitle ? .healthy : .broken
+    ///
+    /// We deliberately do not down-rank to `.broken` when `CGWindowListCopyWindowInfo`
+    /// returns no foreign window title. Absence of a readable foreign title is not proof
+    /// of a broken grant: on recent macOS the window list omits foreign `kCGWindowName`
+    /// values even when Screen Recording is granted, which produced false `.broken`
+    /// verdicts and a persistent red error badge (issue #446). The window-title probe is
+    /// still computed for diagnostic logging in `checkScreenRecordingLive`.
+    static func checkScreenRecording(systemAllowed: Bool) -> PermissionStatus {
+        systemAllowed ? .healthy : .denied
     }
 
     /// Parses a raw window list and reports whether any foreign window has a non-empty title.
@@ -160,10 +159,9 @@ enum PermissionHealthCheck {
         }
         let hasForeignTitle = hasForeignWindowWithTitle(windowList: list, ownPID: ownPID)
 
-        let result = checkScreenRecording(
-            systemAllowed: systemAllowed,
-            hasForeignWithTitle: hasForeignTitle,
-        )
+        // `hasForeignTitle`/`foreignCount`/`windowCount` are no longer part of the
+        // verdict (see `checkScreenRecording`); they stay for diagnostic logging.
+        let result = checkScreenRecording(systemAllowed: systemAllowed)
         debugLog("checkScreenRecordingLive: systemAllowed=\(systemAllowed) ownPID=\(ownPID) " +
             "windows=\(windowCount) foreign=\(foreignCount) hasForeignTitle=\(hasForeignTitle) → \(result)")
         return result

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -44,6 +44,18 @@ enum PermissionProblem: Equatable {
             ? "\(permissionName) looks enabled but isn't working — toggle it off and on in System Settings"
             : "\(permissionName) permission denied"
     }
+
+    /// Compact, PII-free token for `os_log` (safe to log with `privacy: .public`):
+    /// e.g. `screen-recording=broken`. The clear-text `description` is user-facing only.
+    var logToken: String {
+        let key: String
+        switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: key = "screen-recording"
+        case .microphoneDenied, .microphoneBroken: key = "microphone"
+        case .accessibilityDenied, .accessibilityBroken: key = "accessibility"
+        }
+        return "\(key)=\(isBroken ? "broken" : "denied")"
+    }
 }
 
 struct HealthCheckResult: Equatable {
@@ -87,6 +99,12 @@ struct HealthCheckResult: Equatable {
 
     var notificationBody: String {
         problems.map(\.description).joined(separator: "\n")
+    }
+
+    /// Comma-joined `logToken`s, safe to log with `privacy: .public`: it names only
+    /// which permission is in which bad state, never any user data. Empty when healthy.
+    var logSummary: String {
+        problems.map(\.logToken).joined(separator: ",")
     }
 }
 
@@ -384,7 +402,7 @@ enum PermissionHealthCheck {
         let ax = checkAccessibilityLive()
         let result = overallHealth(screenRecording: sr, microphone: mic, accessibility: ax)
         if !result.isHealthy {
-            logger.warning("Permission health check failed: \(result.problems)")
+            logger.warning("Permission health check failed: \(result.logSummary, privacy: .public)")
         }
         return result
     }

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -188,9 +188,20 @@ enum PermissionHealthCheck {
         }
     }
 
-    /// Peak amplitude (linear, 0…1) below which a mic stream is treated as silence even
-    /// if buffers are flowing — a working mic in any real environment exceeds the
-    /// noise-floor by orders of magnitude. ~−80 dBFS.
+    /// The mic probe succeeds iff the tap delivered at least one audio buffer within the
+    /// timeout. Silence is NOT failure: a granted, working mic that is muted, virtual, or
+    /// in a quiet room delivers all-zero buffers but is perfectly fine. Genuine breakage
+    /// (no input device, `installTap`/`engine.start` throwing) yields zero buffers and is
+    /// caught upstream. Previously the verdict also required a sample above the noise floor,
+    /// which false-flagged silent-but-working mics as `.broken` (issue #446).
+    static func micProbeSucceeds(bufferCount: Int) -> Bool {
+        bufferCount > 0
+    }
+
+    /// Peak amplitude (linear, 0…1) below which a mic stream is considered silent.
+    /// Diagnostic only since issue #446: silence no longer fails the probe (see
+    /// `micProbeSucceeds`); this threshold just drives a `silentDespiteBuffers` log
+    /// breadcrumb that flags a likely muted/virtual input. ~−80 dBFS.
     static let silentMicPeakThreshold: Float = 0.0001
 
     /// Returns the maximum absolute sample amplitude in `buffer` on channel 0, normalized
@@ -238,9 +249,9 @@ enum PermissionHealthCheck {
         }
     }
 
-    /// Maximum time to wait for the mic probe to observe a non-silent sample.
+    /// Maximum time to wait for the mic probe to observe the first audio buffer.
     static let probeTimeout: TimeInterval = 0.5
-    /// Poll interval while waiting for the probe to confirm a healthy signal.
+    /// Poll interval while waiting for the first buffer to arrive.
     static let probePollInterval: TimeInterval = 0.02
 
     static func probeMicrophone() async -> Bool {
@@ -287,7 +298,6 @@ enum PermissionHealthCheck {
 
         let (stats, elapsedMs) = await waitForProbeSignal(
             deadline: Date().addingTimeInterval(probeTimeout),
-            threshold: Self.silentMicPeakThreshold,
             pollInterval: Self.probePollInterval,
             snapshot: counter.snapshot,
         )
@@ -295,20 +305,25 @@ enum PermissionHealthCheck {
         engine.stop()
         inputNode.removeTap(onBus: 0)
 
-        debugLog("probeMicrophone: buffers=\(stats.count) peak=\(stats.maxPeak) elapsed=\(elapsedMs)ms " +
+        // Diagnostic-only (issue #446): buffers flowing but below the noise floor means a
+        // likely muted/virtual input — healthy, not broken, but a useful breadcrumb.
+        let silentDespiteBuffers = micProbeSucceeds(bufferCount: stats.count)
+            && stats.maxPeak <= Self.silentMicPeakThreshold
+        debugLog("probeMicrophone: buffers=\(stats.count) peak=\(stats.maxPeak) " +
+            "silentDespiteBuffers=\(silentDespiteBuffers) elapsed=\(elapsedMs)ms " +
             "sampleRate=\(format.sampleRate) channels=\(format.channelCount)")
-        // swiftformat:disable:next preferIsEmpty
-        return stats.count > 0 && stats.maxPeak > Self.silentMicPeakThreshold // swiftlint:disable:this empty_count
+        return micProbeSucceeds(bufferCount: stats.count)
     }
 
-    /// Polls `snapshot` until peak crosses `threshold` (healthy) or `now()` passes `deadline`
-    /// (broken). Polling on `count > 0` would exit on the first warm-up buffer — which is
-    /// commonly all-zeros — and falsely report `.broken`.
+    /// Polls `snapshot` until the first audio buffer arrives (`count > 0`, healthy — the tap
+    /// is delivering data) or `now()` passes `deadline` (broken — no buffers at all). A
+    /// silent buffer counts: even an all-zero warm-up buffer proves the tap works, and a
+    /// muted/virtual/quiet mic that delivers silent buffers is healthy (issue #446). `maxPeak`
+    /// is still returned for diagnostic logging but no longer gates the verdict.
     ///
     /// `now` and `sleep` are injected so unit tests can drive the loop with a virtual clock.
     static func waitForProbeSignal(
         deadline: Date,
-        threshold: Float,
         pollInterval: TimeInterval,
         snapshot: @Sendable () -> (count: Int, maxPeak: Float),
         now: @Sendable () -> Date = { Date() },
@@ -318,7 +333,7 @@ enum PermissionHealthCheck {
     ) async -> (stats: (count: Int, maxPeak: Float), elapsedMs: Int) {
         let startedAt = now()
         while now() < deadline {
-            if snapshot().maxPeak > threshold { break }
+            if micProbeSucceeds(bufferCount: snapshot().count) { break }
             await sleep(pollInterval)
         }
         let elapsedMs = Int(now().timeIntervalSince(startedAt) * 1000)

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -3,40 +3,19 @@ import AVFoundation
 import XCTest
 
 final class PermissionHealthCheckTests: XCTestCase {
-    // MARK: - Screen Recording (new split API)
+    // MARK: - Screen Recording (trusts the system TCC verdict)
 
-    func testScreenRecordingHealthy() {
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: true,
-            hasForeignWithTitle: true,
-        )
-        XCTAssertEqual(result, .healthy)
+    func testScreenRecordingHealthyWhenSystemAllows() {
+        // Regression (issue #446): absence of a readable foreign window title is
+        // not proof of a broken grant — on recent macOS the window list omits
+        // foreign titles even when Screen Recording is granted, which produced
+        // false `.broken` verdicts (persistent red error badge). Trust the
+        // system TCC verdict instead.
+        XCTAssertEqual(PermissionHealthCheck.checkScreenRecording(systemAllowed: true), .healthy)
     }
 
     func testScreenRecordingDeniedWhenSystemSaysNo() {
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: false,
-            hasForeignWithTitle: false,
-        )
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testScreenRecordingDeniedEvenWithWindows() {
-        // System says no — we ignore the probe outcome.
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: false,
-            hasForeignWithTitle: true,
-        )
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testScreenRecordingBrokenSystemAllowsButNoTitles() {
-        // TCC says yes but window probe can't see any foreign titles.
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: true,
-            hasForeignWithTitle: false,
-        )
-        XCTAssertEqual(result, .broken)
+        XCTAssertEqual(PermissionHealthCheck.checkScreenRecording(systemAllowed: false), .denied)
     }
 
     // MARK: - Screen Recording (window list parser)

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -93,6 +93,30 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(result, .notDetermined)
     }
 
+    // MARK: - Mic probe verdict (issue #446)
+
+    func testMicProbeSucceedsWhenBuffersFlow() {
+        // A flowing mic is healthy even when silent (muted / virtual / quiet room):
+        // silence no longer fails the probe.
+        XCTAssertTrue(PermissionHealthCheck.micProbeSucceeds(bufferCount: 1))
+        XCTAssertTrue(PermissionHealthCheck.micProbeSucceeds(bufferCount: 50))
+    }
+
+    func testMicProbeFailsWhenNoBuffers() {
+        // No buffers at all = genuinely stalled mic → .broken.
+        XCTAssertFalse(PermissionHealthCheck.micProbeSucceeds(bufferCount: 0))
+    }
+
+    func testSilentButFlowingMicIsHealthy() {
+        // Composes the two #446 seams as documentation: buffers flowed (silence is
+        // irrelevant) → probe succeeds → an authorized mic resolves to .healthy.
+        let probe = PermissionHealthCheck.micProbeSucceeds(bufferCount: 5)
+        XCTAssertEqual(
+            PermissionHealthCheck.checkMicrophone(authStatus: .authorized, probeSucceeds: probe),
+            .healthy,
+        )
+    }
+
     // MARK: - Accessibility
 
     func testAccessibilityHealthy() {
@@ -288,8 +312,9 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 1.0, accuracy: 1e-7)
     }
 
-    func testPeakAmplitudeFloat32BelowThresholdRejected() throws {
-        // Below silentMicPeakThreshold (~−80 dBFS) — typical broken-mic state.
+    func testPeakAmplitudeFloat32BelowThreshold() throws {
+        // Below silentMicPeakThreshold (~−80 dBFS): a sub-floor sample. Since #446 this
+        // only drives the diagnostic `silentDespiteBuffers` flag, not the verdict.
         let tiny = PermissionHealthCheck.silentMicPeakThreshold / 10
         let buffer = try makeFloatBuffer(samples: Array(repeating: tiny, count: 1024))
         XCTAssertLessThan(
@@ -313,10 +338,10 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 0)
     }
 
-    func testPeakAmplitudeUnknownFormatFallsBackToHealthy() throws {
+    func testPeakAmplitudeUnknownFormatFallsBackToNonSilent() throws {
         // Int32 buffers expose neither floatChannelData nor int16ChannelData.
-        // The fallback returns 1.0 so the silence-threshold check still passes —
-        // preserves pre-cherry-pick semantics (any buffer = live).
+        // The fallback returns 1.0 (treated as non-silent) so an unknown format never
+        // trips the diagnostic `silentDespiteBuffers` flag (any buffer = live).
         let format = try XCTUnwrap(AVAudioFormat(
             commonFormat: .pcmFormatInt32,
             sampleRate: 48000,
@@ -330,10 +355,10 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 1.0)
     }
 
-    func testPeakAmplitudeAtExactThresholdIsRejected() throws {
-        // The probe check is strict `>`, so a buffer whose peak equals the
-        // threshold counts as silent (broken). Pin this edge case so the
-        // comparison operator can't drift to `>=` unnoticed.
+    func testPeakAmplitudeAtExactThresholdCountsAsSilent() throws {
+        // The `silentDespiteBuffers` check is strict `>`, so a buffer whose peak equals
+        // the threshold counts as silent (diagnostic only since #446). Pin this edge case
+        // so the comparison operator can't drift to `>=` unnoticed.
         let exact = PermissionHealthCheck.silentMicPeakThreshold
         let buffer = try makeFloatBuffer(samples: [exact, -exact, 0])
         let peak = PermissionHealthCheck.peakAmplitude(of: buffer)
@@ -349,22 +374,19 @@ final class PermissionHealthCheckTests: XCTestCase {
     // then complain — disable the former for the whole section.
     // swiftlint:disable trailing_closure
 
-    func testWaitExitsEarlyOncePeakCrossesThreshold() async {
-        // Race-fix regression: previously the loop exited on `count > 0`, so a
-        // warm-up zero buffer (count=1, peak=0) would prematurely return .broken.
-        // The fix waits for peak > threshold instead. Pin that behavior.
+    func testWaitExitsEarlyOnceFirstBufferArrives() async {
+        // Issue #446: any buffer — even an all-zero warm-up — proves the tap is
+        // delivering audio, so the loop exits on the first `count > 0`.
         let snapshots: [(count: Int, maxPeak: Float)] = [
-            (0, 0), // pre-warmup
-            (1, 0), // warm-up zero buffer
-            (2, 0), // still silent
-            (3, 0.5), // real signal arrives — should exit
-            (4, 0.6), // would only see this if loop didn't exit early
+            (0, 0), // pre-warmup, no buffers yet
+            (0, 0), // still nothing
+            (1, 0), // first buffer arrives (silent) — should exit here
+            (2, 0), // only seen if the loop didn't exit early
         ]
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
         let cursor = AtomicCursor()
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: clock.start.addingTimeInterval(1.0),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
             snapshot: {
                 let i = cursor.next()
@@ -373,44 +395,42 @@ final class PermissionHealthCheckTests: XCTestCase {
             now: clock.now,
             sleep: { _ in clock.advance(by: 0.02) },
         )
-        // Loop exited on the 4th snapshot (peak=0.5). The post-loop snapshot is the 5th.
-        XCTAssertEqual(result.stats.count, 4)
-        XCTAssertEqual(result.stats.maxPeak, 0.6, accuracy: 1e-6)
+        // Exited after the 3rd snapshot (count=1); the post-loop snapshot is the 4th.
+        XCTAssertEqual(result.stats.count, 2)
+        XCTAssertLessThan(result.elapsedMs, 1000)
     }
 
-    func testWaitRunsToDeadlineWhenSignalStaysSilent() async {
-        // Broken-mic scenario: buffers arrive but peak never crosses threshold.
-        // Loop should run until the deadline, then return the silent snapshot.
+    func testWaitExitsOnSilentBuffers() async {
+        // Regression (issue #446): silent buffers (peak = 0) still mean the tap is
+        // delivering audio → exit immediately. The loop must NOT wait for non-silence.
+        let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
+        let result = await PermissionHealthCheck.waitForProbeSignal(
+            deadline: clock.start.addingTimeInterval(1.0),
+            pollInterval: 0.02,
+            snapshot: { (5, 0) }, // buffers flowing, all silent
+            now: clock.now,
+            sleep: { _ in
+                XCTFail("must not poll: a flowing (even silent) buffer is healthy")
+                clock.advance(by: 0.02)
+            },
+        )
+        XCTAssertEqual(result.stats.count, 5)
+        XCTAssertEqual(result.elapsedMs, 0)
+    }
+
+    func testWaitRunsToDeadlineWhenNoBuffers() async {
+        // Genuinely stalled mic: no buffers ever arrive. Loop runs to the deadline,
+        // then returns the empty snapshot → caller treats count == 0 as .broken.
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
         let deadline = clock.start.addingTimeInterval(0.1)
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: deadline,
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
-            snapshot: { (10, 0) }, // 10 buffers, all silent
+            snapshot: { (0, 0) }, // no buffers at all
             now: clock.now,
             sleep: { _ in clock.advance(by: 0.02) },
         )
-        XCTAssertEqual(result.stats.count, 10)
-        XCTAssertEqual(result.stats.maxPeak, 0)
-        XCTAssertGreaterThanOrEqual(result.elapsedMs, 100)
-    }
-
-    func testWaitTreatsPeakAtExactThresholdAsSilent() async {
-        // The polling check is strict `>`. A snapshot whose peak EQUALS the
-        // threshold must not cause early exit; the loop continues until either
-        // a higher peak shows up or the deadline elapses. Guards against the
-        // operator drifting to `>=`.
-        let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
-        let result = await PermissionHealthCheck.waitForProbeSignal(
-            deadline: clock.start.addingTimeInterval(0.1),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
-            pollInterval: 0.02,
-            snapshot: { (5, PermissionHealthCheck.silentMicPeakThreshold) },
-            now: clock.now,
-            sleep: { _ in clock.advance(by: 0.02) },
-        )
-        XCTAssertEqual(result.stats.maxPeak, PermissionHealthCheck.silentMicPeakThreshold)
+        XCTAssertEqual(result.stats.count, 0)
         XCTAssertGreaterThanOrEqual(result.elapsedMs, 100)
     }
 
@@ -419,9 +439,8 @@ final class PermissionHealthCheckTests: XCTestCase {
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 100))
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: clock.start.addingTimeInterval(-1.0),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
-            snapshot: { (1, 0.9) }, // would normally cross threshold instantly
+            snapshot: { (1, 0.9) },
             now: clock.now,
             sleep: { _ in
                 XCTFail("sleep must not be called when deadline is in the past")

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -259,6 +259,22 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertTrue(result.notificationBody.isEmpty)
     }
 
+    // MARK: - Log Summary (public, PII-free)
+
+    func testLogSummaryListsEachProblemAsToken() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .denied,
+            microphone: .broken,
+            accessibility: .broken,
+        )
+        XCTAssertEqual(result.logSummary, "screen-recording=denied,microphone=broken,accessibility=broken")
+    }
+
+    func testLogSummaryEmptyWhenHealthy() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertEqual(result.logSummary, "")
+    }
+
     // MARK: - HealthCheckResult Equatable
 
     func testHealthCheckResultEquality() {


### PR DESCRIPTION
Fixes the symptoms in #446: a persistent red error badge with `Permission health check failed: <private>` on macOS Tahoe, where the failing permission is unknowable and a granted permission is flagged broken.

## Root cause (from the reporter's diagnostic logs + code)

1. **Undiagnosable.** The failure was logged as `\(result.problems)` via `os.Logger`, which redacts non-numeric interpolations to `<private>`. Neither the reporter nor we could tell *which* permission failed.
2. **Two fragile probes that false-positive `.broken`** (verified by an adversarial agent swarm):
   - **Screen Recording** down-ranked to `.broken` when `CGWindowListCopyWindowInfo` returned no foreign window title. On recent macOS the window list omits foreign `kCGWindowName` even when granted, so it false-flagged deterministically.
   - **Microphone** down-ranked to `.broken` when no sample exceeded the ~-80 dBFS floor in the 0.5s probe. A muted, virtual (e.g. BlackHole with nothing routed), or genuinely-quiet input delivers silent buffers but is working. This also **blocked manual recording** via the `startManualRecording` health gate.

Amplitude cannot distinguish a dead mic from a muted/quiet one (both are silent), and a missing foreign window title is not proof of a broken grant, so both were false-positive sources, not real detectors. The app does not even need Screen Recording for the production path (detection uses `PowerAssertionDetector`/IOKit, capture uses `CATapDescription`).

## Changes (3 atomic commits)

1. **Observability:** PII-free `PermissionProblem.logToken` + `HealthCheckResult.logSummary`, logged with `privacy: .public`. The failing permission is now visible (e.g. `microphone=broken`).
2. **Screen Recording:** `checkScreenRecording(systemAllowed:)` trusts `CGPreflightScreenCaptureAccess()` (`.healthy`/`.denied`); window-title probe kept for diagnostic logging only.
3. **Microphone:** the probe is healthy iff the tap delivers any buffer (pure `micProbeSucceeds(bufferCount:)`); silence no longer fails it. Genuine failures (no device, `installTap`/`engine.start` throwing) still yield zero buffers → `.broken`. `waitForProbeSignal` now polls for the first buffer. Amplitude machinery demoted to a diagnostic-only `silentDespiteBuffers` log breadcrumb.

## Notes

- `PermissionProblem.screenRecordingBroken` is now dormant-by-design (kept for structural parity with mic/accessibility).
- Accessibility probe is left as-is: it calls the real AX API and accepts the benign `.noValue`, so it is a genuine functional check, not a fragile inference.

## Tests

TDD throughout (red proven before each fix; the mic kernel change is mutation-proven). New `logSummary` + `micProbeSucceeds` tests; screen-recording + waitForProbeSignal tests rewritten to the new semantics with #446 regression tests. Full `PermissionHealthCheckTests` green (49), lint clean. /simplify + /code-review run (findings folded).

A follow-up will expose permission health in the RPC `/state` snapshot and add an `e2e-permission-health.sh` that asserts both probes report healthy on the BlackHole-input runner (a natural reproduction of the silent-mic false-positive).