### PR TITLE
test(ci): RPC permission-health exposure + e2e for the #446 probes

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -181,6 +181,23 @@ jobs:
           path: /tmp/e2e-channel-health-menubar.png
           if-no-files-found: ignore
 
+      # Permission-health probe e2e (issue #446): asserts that the Screen
+      # Recording and Microphone probes report "healthy" via
+      # `/state.permissionHealth` on this granted runner. The runner is a
+      # natural reproduction of the #446 false-`.broken` bugs — Screen
+      # Recording is granted but the old window-title probe reported broken,
+      # and BlackHole (the default input) delivers silent buffers the old
+      # amplitude probe reported broken. `continue-on-error` while the mic
+      # assertion is validated against the runner's idle BlackHole input;
+      # flip to a hard gate once it has been green on a few nightlies.
+      # `--no-build` reuses the dev bundle the first e2e-app.sh lane built and
+      # signed; it shares the bundle-ID + signing cert with the granted bundle,
+      # so the runner's TCC grant applies (continue-on-error hedges a mismatch).
+      - name: Run permission-health probe E2E (issue #446)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: bash scripts/e2e-permission-health.sh --no-build
+
       # Silent-recording detector e2e (PR #295): drives the real
       # production polling chain — meeting-simulator plays the fixture
       # at volume=0 so the CATapDescription tap captures buffers of

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -1,6 +1,18 @@
 #if !APPSTORE
     import Foundation
 
+    extension PermissionStatus {
+        /// Stable wire string for the RPC `/state.permissionHealth` snapshot.
+        var rpcValue: String {
+            switch self {
+            case .healthy: "healthy"
+            case .denied: "denied"
+            case .broken: "broken"
+            case .notDetermined: "notDetermined"
+            }
+        }
+    }
+
     extension PipelineQueue {
         /// Build the RPC pipeline-queue status from inside `PipelineQueue`, so the
         /// counter reads are single-hop `self.` accesses. Constructing this
@@ -51,6 +63,7 @@
                 engines: enginesSnapshot(),
                 lastJob: lastFinishedJobSnapshot(),
                 channelHealth: channelHealthSnapshot(),
+                permissionHealth: permissionHealthSnapshot(),
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
             )
@@ -77,6 +90,19 @@
                 micSilent: channelHealth.micSilentActive,
                 appSilent: channelHealth.appSilentActive,
                 recordingSilent: channelHealth.recordingSilentActive,
+            )
+        }
+
+        /// Snapshot the permission health verdict. `nil` before the first async
+        /// check completes → `.unknown`. Extracted (like `channelHealthSnapshot`)
+        /// to keep `rpcStateSnapshot`'s literal under the type-check budget.
+        private func permissionHealthSnapshot() -> RPCStateSnapshot.PermissionHealth {
+            guard let health = permissions.health else { return .unknown }
+            return RPCStateSnapshot.PermissionHealth(
+                screenRecording: health.screenRecording.rpcValue,
+                microphone: health.microphone.rpcValue,
+                accessibility: health.accessibility.rpcValue,
+                isHealthy: health.isHealthy,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -48,11 +48,10 @@ enum PermissionProblem: Equatable {
     /// Compact, PII-free token for `os_log` (safe to log with `privacy: .public`):
     /// e.g. `screen-recording=broken`. The clear-text `description` is user-facing only.
     var logToken: String {
-        let key: String
-        switch self {
-        case .screenRecordingDenied, .screenRecordingBroken: key = "screen-recording"
-        case .microphoneDenied, .microphoneBroken: key = "microphone"
-        case .accessibilityDenied, .accessibilityBroken: key = "accessibility"
+        let key = switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: "screen-recording"
+        case .microphoneDenied, .microphoneBroken: "microphone"
+        case .accessibilityDenied, .accessibilityBroken: "accessibility"
         }
         return "\(key)=\(isBroken ? "broken" : "denied")"
     }
@@ -111,23 +110,23 @@ struct HealthCheckResult: Equatable {
 enum PermissionHealthCheck {
     // MARK: - Screen Recording (pure, testable)
 
-    /// Pure decision function: combines the TCC system verdict with a window-title probe.
+    /// Pure decision function for Screen Recording: trusts the TCC system verdict.
     ///
-    /// - `systemAllowed`: whether macOS says the process has the Screen Recording entitlement
-    ///   (via `CGPreflightScreenCaptureAccess()` or equivalent).
-    /// - `hasForeignWithTitle`: whether `CGWindowListCopyWindowInfo` returned at least one
-    ///   window from another process that has a non-empty `kCGWindowName`.
+    /// - `systemAllowed`: whether macOS says the process has the Screen Recording
+    ///   entitlement (via `CGPreflightScreenCaptureAccess()` or equivalent).
     ///
     /// Outcomes:
+    /// - `healthy`: system says yes
     /// - `denied`: system says no
-    /// - `healthy`: system says yes AND we can read foreign window titles
-    /// - `broken`: system says yes BUT we cannot read any foreign window titles (TCC mismatch)
-    static func checkScreenRecording(
-        systemAllowed: Bool,
-        hasForeignWithTitle: Bool,
-    ) -> PermissionStatus {
-        if !systemAllowed { return .denied }
-        return hasForeignWithTitle ? .healthy : .broken
+    ///
+    /// We deliberately do not down-rank to `.broken` when `CGWindowListCopyWindowInfo`
+    /// returns no foreign window title. Absence of a readable foreign title is not proof
+    /// of a broken grant: on recent macOS the window list omits foreign `kCGWindowName`
+    /// values even when Screen Recording is granted, which produced false `.broken`
+    /// verdicts and a persistent red error badge (issue #446). The window-title probe is
+    /// still computed for diagnostic logging in `checkScreenRecordingLive`.
+    static func checkScreenRecording(systemAllowed: Bool) -> PermissionStatus {
+        systemAllowed ? .healthy : .denied
     }
 
     /// Parses a raw window list and reports whether any foreign window has a non-empty title.
@@ -160,10 +159,9 @@ enum PermissionHealthCheck {
         }
         let hasForeignTitle = hasForeignWindowWithTitle(windowList: list, ownPID: ownPID)
 
-        let result = checkScreenRecording(
-            systemAllowed: systemAllowed,
-            hasForeignWithTitle: hasForeignTitle,
-        )
+        // `hasForeignTitle`/`foreignCount`/`windowCount` are no longer part of the
+        // verdict (see `checkScreenRecording`); they stay for diagnostic logging.
+        let result = checkScreenRecording(systemAllowed: systemAllowed)
         debugLog("checkScreenRecordingLive: systemAllowed=\(systemAllowed) ownPID=\(ownPID) " +
             "windows=\(windowCount) foreign=\(foreignCount) hasForeignTitle=\(hasForeignTitle) → \(result)")
         return result

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -44,6 +44,18 @@ enum PermissionProblem: Equatable {
             ? "\(permissionName) looks enabled but isn't working — toggle it off and on in System Settings"
             : "\(permissionName) permission denied"
     }
+
+    /// Compact, PII-free token for `os_log` (safe to log with `privacy: .public`):
+    /// e.g. `screen-recording=broken`. The clear-text `description` is user-facing only.
+    var logToken: String {
+        let key: String
+        switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: key = "screen-recording"
+        case .microphoneDenied, .microphoneBroken: key = "microphone"
+        case .accessibilityDenied, .accessibilityBroken: key = "accessibility"
+        }
+        return "\(key)=\(isBroken ? "broken" : "denied")"
+    }
 }
 
 struct HealthCheckResult: Equatable {
@@ -87,6 +99,12 @@ struct HealthCheckResult: Equatable {
 
     var notificationBody: String {
         problems.map(\.description).joined(separator: "\n")
+    }
+
+    /// Comma-joined `logToken`s, safe to log with `privacy: .public`: it names only
+    /// which permission is in which bad state, never any user data. Empty when healthy.
+    var logSummary: String {
+        problems.map(\.logToken).joined(separator: ",")
     }
 }
 
@@ -384,7 +402,7 @@ enum PermissionHealthCheck {
         let ax = checkAccessibilityLive()
         let result = overallHealth(screenRecording: sr, microphone: mic, accessibility: ax)
         if !result.isHealthy {
-            logger.warning("Permission health check failed: \(result.problems)")
+            logger.warning("Permission health check failed: \(result.logSummary, privacy: .public)")
         }
         return result
     }

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -188,9 +188,20 @@ enum PermissionHealthCheck {
         }
     }
 
-    /// Peak amplitude (linear, 0…1) below which a mic stream is treated as silence even
-    /// if buffers are flowing — a working mic in any real environment exceeds the
-    /// noise-floor by orders of magnitude. ~−80 dBFS.
+    /// The mic probe succeeds iff the tap delivered at least one audio buffer within the
+    /// timeout. Silence is NOT failure: a granted, working mic that is muted, virtual, or
+    /// in a quiet room delivers all-zero buffers but is perfectly fine. Genuine breakage
+    /// (no input device, `installTap`/`engine.start` throwing) yields zero buffers and is
+    /// caught upstream. Previously the verdict also required a sample above the noise floor,
+    /// which false-flagged silent-but-working mics as `.broken` (issue #446).
+    static func micProbeSucceeds(bufferCount: Int) -> Bool {
+        bufferCount > 0
+    }
+
+    /// Peak amplitude (linear, 0…1) below which a mic stream is considered silent.
+    /// Diagnostic only since issue #446: silence no longer fails the probe (see
+    /// `micProbeSucceeds`); this threshold just drives a `silentDespiteBuffers` log
+    /// breadcrumb that flags a likely muted/virtual input. ~−80 dBFS.
     static let silentMicPeakThreshold: Float = 0.0001
 
     /// Returns the maximum absolute sample amplitude in `buffer` on channel 0, normalized
@@ -238,9 +249,9 @@ enum PermissionHealthCheck {
         }
     }
 
-    /// Maximum time to wait for the mic probe to observe a non-silent sample.
+    /// Maximum time to wait for the mic probe to observe the first audio buffer.
     static let probeTimeout: TimeInterval = 0.5
-    /// Poll interval while waiting for the probe to confirm a healthy signal.
+    /// Poll interval while waiting for the first buffer to arrive.
     static let probePollInterval: TimeInterval = 0.02
 
     static func probeMicrophone() async -> Bool {
@@ -287,7 +298,6 @@ enum PermissionHealthCheck {
 
         let (stats, elapsedMs) = await waitForProbeSignal(
             deadline: Date().addingTimeInterval(probeTimeout),
-            threshold: Self.silentMicPeakThreshold,
             pollInterval: Self.probePollInterval,
             snapshot: counter.snapshot,
         )
@@ -295,20 +305,25 @@ enum PermissionHealthCheck {
         engine.stop()
         inputNode.removeTap(onBus: 0)
 
-        debugLog("probeMicrophone: buffers=\(stats.count) peak=\(stats.maxPeak) elapsed=\(elapsedMs)ms " +
+        // Diagnostic-only (issue #446): buffers flowing but below the noise floor means a
+        // likely muted/virtual input — healthy, not broken, but a useful breadcrumb.
+        let silentDespiteBuffers = micProbeSucceeds(bufferCount: stats.count)
+            && stats.maxPeak <= Self.silentMicPeakThreshold
+        debugLog("probeMicrophone: buffers=\(stats.count) peak=\(stats.maxPeak) " +
+            "silentDespiteBuffers=\(silentDespiteBuffers) elapsed=\(elapsedMs)ms " +
             "sampleRate=\(format.sampleRate) channels=\(format.channelCount)")
-        // swiftformat:disable:next preferIsEmpty
-        return stats.count > 0 && stats.maxPeak > Self.silentMicPeakThreshold // swiftlint:disable:this empty_count
+        return micProbeSucceeds(bufferCount: stats.count)
     }
 
-    /// Polls `snapshot` until peak crosses `threshold` (healthy) or `now()` passes `deadline`
-    /// (broken). Polling on `count > 0` would exit on the first warm-up buffer — which is
-    /// commonly all-zeros — and falsely report `.broken`.
+    /// Polls `snapshot` until the first audio buffer arrives (`count > 0`, healthy — the tap
+    /// is delivering data) or `now()` passes `deadline` (broken — no buffers at all). A
+    /// silent buffer counts: even an all-zero warm-up buffer proves the tap works, and a
+    /// muted/virtual/quiet mic that delivers silent buffers is healthy (issue #446). `maxPeak`
+    /// is still returned for diagnostic logging but no longer gates the verdict.
     ///
     /// `now` and `sleep` are injected so unit tests can drive the loop with a virtual clock.
     static func waitForProbeSignal(
         deadline: Date,
-        threshold: Float,
         pollInterval: TimeInterval,
         snapshot: @Sendable () -> (count: Int, maxPeak: Float),
         now: @Sendable () -> Date = { Date() },
@@ -318,7 +333,7 @@ enum PermissionHealthCheck {
     ) async -> (stats: (count: Int, maxPeak: Float), elapsedMs: Int) {
         let startedAt = now()
         while now() < deadline {
-            if snapshot().maxPeak > threshold { break }
+            if micProbeSucceeds(bufferCount: snapshot().count) { break }
             await sleep(pollInterval)
         }
         let elapsedMs = Int(now().timeIntervalSince(startedAt) * 1000)

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -18,6 +18,11 @@
         /// `asymmetricSilenceWarningSeconds`. E2E drivers poll these to assert
         /// the menu-bar red-tint indicator wiring without screenshot OCR.
         let channelHealth: ChannelHealth
+        /// Permission health: per-permission TCC+probe verdict ("healthy",
+        /// "denied", "broken", "notDetermined", or "unknown" before the first
+        /// check). E2E drivers poll this to assert the probes don't false-flag a
+        /// granted permission (issue #446) without screenshotting the menu bar.
+        let permissionHealth: PermissionHealth
         /// Snapshot of the live-caption overlay state. E2E drivers poll
         /// `recentFinals.count > 0` to assert that the full live-transcription
         /// chain produced text without scraping the OSLog or screenshotting
@@ -81,6 +86,25 @@
             )
         }
 
+        struct PermissionHealth: Codable {
+            let screenRecording: String
+            let microphone: String
+            let accessibility: String
+            /// Mirror of `HealthCheckResult.isHealthy` — true only when every
+            /// permission is healthy. Lets drivers assert the aggregate without
+            /// re-deriving it from the three strings.
+            let isHealthy: Bool
+
+            /// Pre-check placeholder: the health check runs asynchronously at
+            /// launch, so a snapshot taken before it completes reports "unknown".
+            static let unknown = Self(
+                screenRecording: "unknown",
+                microphone: "unknown",
+                accessibility: "unknown",
+                isHealthy: false,
+            )
+        }
+
         struct LastJob: Codable {
             let jobID: String
             let state: JobState
@@ -130,6 +154,7 @@
             engines: Engines = .empty,
             lastJob: LastJob? = nil,
             channelHealth: ChannelHealth = .inactive,
+            permissionHealth: PermissionHealth = .unknown,
             liveCaptions: LiveCaptions = .empty,
             watchState: String? = nil,
         ) {
@@ -139,6 +164,7 @@
             self.engines = engines
             self.lastJob = lastJob
             self.channelHealth = channelHealth
+            self.permissionHealth = permissionHealth
             self.liveCaptions = liveCaptions
             self.watchState = watchState
         }

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -3,40 +3,19 @@ import AVFoundation
 import XCTest
 
 final class PermissionHealthCheckTests: XCTestCase {
-    // MARK: - Screen Recording (new split API)
+    // MARK: - Screen Recording (trusts the system TCC verdict)
 
-    func testScreenRecordingHealthy() {
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: true,
-            hasForeignWithTitle: true,
-        )
-        XCTAssertEqual(result, .healthy)
+    func testScreenRecordingHealthyWhenSystemAllows() {
+        // Regression (issue #446): absence of a readable foreign window title is
+        // not proof of a broken grant — on recent macOS the window list omits
+        // foreign titles even when Screen Recording is granted, which produced
+        // false `.broken` verdicts (persistent red error badge). Trust the
+        // system TCC verdict instead.
+        XCTAssertEqual(PermissionHealthCheck.checkScreenRecording(systemAllowed: true), .healthy)
     }
 
     func testScreenRecordingDeniedWhenSystemSaysNo() {
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: false,
-            hasForeignWithTitle: false,
-        )
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testScreenRecordingDeniedEvenWithWindows() {
-        // System says no — we ignore the probe outcome.
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: false,
-            hasForeignWithTitle: true,
-        )
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testScreenRecordingBrokenSystemAllowsButNoTitles() {
-        // TCC says yes but window probe can't see any foreign titles.
-        let result = PermissionHealthCheck.checkScreenRecording(
-            systemAllowed: true,
-            hasForeignWithTitle: false,
-        )
-        XCTAssertEqual(result, .broken)
+        XCTAssertEqual(PermissionHealthCheck.checkScreenRecording(systemAllowed: false), .denied)
     }
 
     // MARK: - Screen Recording (window list parser)

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -93,6 +93,30 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(result, .notDetermined)
     }
 
+    // MARK: - Mic probe verdict (issue #446)
+
+    func testMicProbeSucceedsWhenBuffersFlow() {
+        // A flowing mic is healthy even when silent (muted / virtual / quiet room):
+        // silence no longer fails the probe.
+        XCTAssertTrue(PermissionHealthCheck.micProbeSucceeds(bufferCount: 1))
+        XCTAssertTrue(PermissionHealthCheck.micProbeSucceeds(bufferCount: 50))
+    }
+
+    func testMicProbeFailsWhenNoBuffers() {
+        // No buffers at all = genuinely stalled mic → .broken.
+        XCTAssertFalse(PermissionHealthCheck.micProbeSucceeds(bufferCount: 0))
+    }
+
+    func testSilentButFlowingMicIsHealthy() {
+        // Composes the two #446 seams as documentation: buffers flowed (silence is
+        // irrelevant) → probe succeeds → an authorized mic resolves to .healthy.
+        let probe = PermissionHealthCheck.micProbeSucceeds(bufferCount: 5)
+        XCTAssertEqual(
+            PermissionHealthCheck.checkMicrophone(authStatus: .authorized, probeSucceeds: probe),
+            .healthy,
+        )
+    }
+
     // MARK: - Accessibility
 
     func testAccessibilityHealthy() {
@@ -288,8 +312,9 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 1.0, accuracy: 1e-7)
     }
 
-    func testPeakAmplitudeFloat32BelowThresholdRejected() throws {
-        // Below silentMicPeakThreshold (~−80 dBFS) — typical broken-mic state.
+    func testPeakAmplitudeFloat32BelowThreshold() throws {
+        // Below silentMicPeakThreshold (~−80 dBFS): a sub-floor sample. Since #446 this
+        // only drives the diagnostic `silentDespiteBuffers` flag, not the verdict.
         let tiny = PermissionHealthCheck.silentMicPeakThreshold / 10
         let buffer = try makeFloatBuffer(samples: Array(repeating: tiny, count: 1024))
         XCTAssertLessThan(
@@ -313,10 +338,10 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 0)
     }
 
-    func testPeakAmplitudeUnknownFormatFallsBackToHealthy() throws {
+    func testPeakAmplitudeUnknownFormatFallsBackToNonSilent() throws {
         // Int32 buffers expose neither floatChannelData nor int16ChannelData.
-        // The fallback returns 1.0 so the silence-threshold check still passes —
-        // preserves pre-cherry-pick semantics (any buffer = live).
+        // The fallback returns 1.0 (treated as non-silent) so an unknown format never
+        // trips the diagnostic `silentDespiteBuffers` flag (any buffer = live).
         let format = try XCTUnwrap(AVAudioFormat(
             commonFormat: .pcmFormatInt32,
             sampleRate: 48000,
@@ -330,10 +355,10 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertEqual(PermissionHealthCheck.peakAmplitude(of: buffer), 1.0)
     }
 
-    func testPeakAmplitudeAtExactThresholdIsRejected() throws {
-        // The probe check is strict `>`, so a buffer whose peak equals the
-        // threshold counts as silent (broken). Pin this edge case so the
-        // comparison operator can't drift to `>=` unnoticed.
+    func testPeakAmplitudeAtExactThresholdCountsAsSilent() throws {
+        // The `silentDespiteBuffers` check is strict `>`, so a buffer whose peak equals
+        // the threshold counts as silent (diagnostic only since #446). Pin this edge case
+        // so the comparison operator can't drift to `>=` unnoticed.
         let exact = PermissionHealthCheck.silentMicPeakThreshold
         let buffer = try makeFloatBuffer(samples: [exact, -exact, 0])
         let peak = PermissionHealthCheck.peakAmplitude(of: buffer)
@@ -349,22 +374,19 @@ final class PermissionHealthCheckTests: XCTestCase {
     // then complain — disable the former for the whole section.
     // swiftlint:disable trailing_closure
 
-    func testWaitExitsEarlyOncePeakCrossesThreshold() async {
-        // Race-fix regression: previously the loop exited on `count > 0`, so a
-        // warm-up zero buffer (count=1, peak=0) would prematurely return .broken.
-        // The fix waits for peak > threshold instead. Pin that behavior.
+    func testWaitExitsEarlyOnceFirstBufferArrives() async {
+        // Issue #446: any buffer — even an all-zero warm-up — proves the tap is
+        // delivering audio, so the loop exits on the first `count > 0`.
         let snapshots: [(count: Int, maxPeak: Float)] = [
-            (0, 0), // pre-warmup
-            (1, 0), // warm-up zero buffer
-            (2, 0), // still silent
-            (3, 0.5), // real signal arrives — should exit
-            (4, 0.6), // would only see this if loop didn't exit early
+            (0, 0), // pre-warmup, no buffers yet
+            (0, 0), // still nothing
+            (1, 0), // first buffer arrives (silent) — should exit here
+            (2, 0), // only seen if the loop didn't exit early
         ]
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
         let cursor = AtomicCursor()
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: clock.start.addingTimeInterval(1.0),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
             snapshot: {
                 let i = cursor.next()
@@ -373,44 +395,42 @@ final class PermissionHealthCheckTests: XCTestCase {
             now: clock.now,
             sleep: { _ in clock.advance(by: 0.02) },
         )
-        // Loop exited on the 4th snapshot (peak=0.5). The post-loop snapshot is the 5th.
-        XCTAssertEqual(result.stats.count, 4)
-        XCTAssertEqual(result.stats.maxPeak, 0.6, accuracy: 1e-6)
+        // Exited after the 3rd snapshot (count=1); the post-loop snapshot is the 4th.
+        XCTAssertEqual(result.stats.count, 2)
+        XCTAssertLessThan(result.elapsedMs, 1000)
     }
 
-    func testWaitRunsToDeadlineWhenSignalStaysSilent() async {
-        // Broken-mic scenario: buffers arrive but peak never crosses threshold.
-        // Loop should run until the deadline, then return the silent snapshot.
+    func testWaitExitsOnSilentBuffers() async {
+        // Regression (issue #446): silent buffers (peak = 0) still mean the tap is
+        // delivering audio → exit immediately. The loop must NOT wait for non-silence.
+        let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
+        let result = await PermissionHealthCheck.waitForProbeSignal(
+            deadline: clock.start.addingTimeInterval(1.0),
+            pollInterval: 0.02,
+            snapshot: { (5, 0) }, // buffers flowing, all silent
+            now: clock.now,
+            sleep: { _ in
+                XCTFail("must not poll: a flowing (even silent) buffer is healthy")
+                clock.advance(by: 0.02)
+            },
+        )
+        XCTAssertEqual(result.stats.count, 5)
+        XCTAssertEqual(result.elapsedMs, 0)
+    }
+
+    func testWaitRunsToDeadlineWhenNoBuffers() async {
+        // Genuinely stalled mic: no buffers ever arrive. Loop runs to the deadline,
+        // then returns the empty snapshot → caller treats count == 0 as .broken.
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
         let deadline = clock.start.addingTimeInterval(0.1)
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: deadline,
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
-            snapshot: { (10, 0) }, // 10 buffers, all silent
+            snapshot: { (0, 0) }, // no buffers at all
             now: clock.now,
             sleep: { _ in clock.advance(by: 0.02) },
         )
-        XCTAssertEqual(result.stats.count, 10)
-        XCTAssertEqual(result.stats.maxPeak, 0)
-        XCTAssertGreaterThanOrEqual(result.elapsedMs, 100)
-    }
-
-    func testWaitTreatsPeakAtExactThresholdAsSilent() async {
-        // The polling check is strict `>`. A snapshot whose peak EQUALS the
-        // threshold must not cause early exit; the loop continues until either
-        // a higher peak shows up or the deadline elapses. Guards against the
-        // operator drifting to `>=`.
-        let clock = VirtualClock(start: Date(timeIntervalSince1970: 0))
-        let result = await PermissionHealthCheck.waitForProbeSignal(
-            deadline: clock.start.addingTimeInterval(0.1),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
-            pollInterval: 0.02,
-            snapshot: { (5, PermissionHealthCheck.silentMicPeakThreshold) },
-            now: clock.now,
-            sleep: { _ in clock.advance(by: 0.02) },
-        )
-        XCTAssertEqual(result.stats.maxPeak, PermissionHealthCheck.silentMicPeakThreshold)
+        XCTAssertEqual(result.stats.count, 0)
         XCTAssertGreaterThanOrEqual(result.elapsedMs, 100)
     }
 
@@ -419,9 +439,8 @@ final class PermissionHealthCheckTests: XCTestCase {
         let clock = VirtualClock(start: Date(timeIntervalSince1970: 100))
         let result = await PermissionHealthCheck.waitForProbeSignal(
             deadline: clock.start.addingTimeInterval(-1.0),
-            threshold: PermissionHealthCheck.silentMicPeakThreshold,
             pollInterval: 0.02,
-            snapshot: { (1, 0.9) }, // would normally cross threshold instantly
+            snapshot: { (1, 0.9) },
             now: clock.now,
             sleep: { _ in
                 XCTFail("sleep must not be called when deadline is in the past")

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -259,6 +259,22 @@ final class PermissionHealthCheckTests: XCTestCase {
         XCTAssertTrue(result.notificationBody.isEmpty)
     }
 
+    // MARK: - Log Summary (public, PII-free)
+
+    func testLogSummaryListsEachProblemAsToken() {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .denied,
+            microphone: .broken,
+            accessibility: .broken,
+        )
+        XCTAssertEqual(result.logSummary, "screen-recording=denied,microphone=broken,accessibility=broken")
+    }
+
+    func testLogSummaryEmptyWhenHealthy() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertEqual(result.logSummary, "")
+    }
+
     // MARK: - HealthCheckResult Equatable
 
     func testHealthCheckResultEquality() {

--- a/app/MeetingTranscriber/Tests/RPCPermissionHealthTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCPermissionHealthTests.swift
@@ -1,0 +1,56 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the permission-health surface exposed in the RPC `/state` snapshot
+    /// (issue #446 follow-up): the `PermissionStatus` → wire-string mapping, the
+    /// pre-check `.unknown` placeholder, and that it serialises into the snapshot JSON.
+    final class RPCPermissionHealthTests: XCTestCase {
+        // MARK: - PermissionStatus.rpcValue
+
+        func testRPCValueMapsEveryStatus() {
+            XCTAssertEqual(PermissionStatus.healthy.rpcValue, "healthy")
+            XCTAssertEqual(PermissionStatus.denied.rpcValue, "denied")
+            XCTAssertEqual(PermissionStatus.broken.rpcValue, "broken")
+            XCTAssertEqual(PermissionStatus.notDetermined.rpcValue, "notDetermined")
+        }
+
+        // MARK: - PermissionHealth placeholder
+
+        func testUnknownPlaceholderIsNotHealthy() {
+            let unknown = RPCStateSnapshot.PermissionHealth.unknown
+            XCTAssertEqual(unknown.screenRecording, "unknown")
+            XCTAssertEqual(unknown.microphone, "unknown")
+            XCTAssertEqual(unknown.accessibility, "unknown")
+            // "not yet checked" must not read as healthy.
+            XCTAssertFalse(unknown.isHealthy)
+        }
+
+        // MARK: - Serialisation
+
+        func testPermissionHealthSerialisesIntoSnapshotJSON() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                permissionHealth: .init(
+                    screenRecording: "healthy",
+                    microphone: "broken",
+                    accessibility: "denied",
+                    isHealthy: false,
+                ),
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            // jsonData() is pretty-printed with sorted keys → `"key" : "value"`.
+            XCTAssertTrue(json.contains("\"permissionHealth\""), json)
+            XCTAssertTrue(json.contains("\"screenRecording\" : \"healthy\""), json)
+            XCTAssertTrue(json.contains("\"microphone\" : \"broken\""), json)
+            XCTAssertTrue(json.contains("\"accessibility\" : \"denied\""), json)
+        }
+    }
+#endif

--- a/scripts/e2e-permission-health.sh
+++ b/scripts/e2e-permission-health.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# E2E test for the permission-health probes (issue #446 follow-up).
+#
+# Launches the dev .app and asserts, via the DebugRPCServer /state snapshot, that
+# the Screen Recording and Microphone permission probes report "healthy" on a
+# runner where those permissions are granted. This is a natural reproduction of
+# the #446 false-`.broken` bugs:
+#   - Screen Recording: granted, but the old window-title probe reported `.broken`
+#     when no foreign window title was readable (the default on recent macOS).
+#   - Microphone: granted (BlackHole 2ch is the runner's default input), but the
+#     old amplitude probe reported `.broken` because an idle input delivers
+#     silent buffers.
+# After the fix both must be "healthy" (the probes trust the system verdict /
+# buffer flow rather than an incidental signal).
+#
+# What this covers:
+#   - PermissionHealthCheck.runLive() against real TCC + real audio hardware
+#   - PermissionStatus → RPC /state.permissionHealth wiring
+#   - The #446 fixes holding on the real (silent-input, granted) runner
+#
+# Requires: granted Microphone + Screen Recording for the dev .app (see the
+# self-hosted runner setup in CLAUDE.md). Accessibility is logged, not asserted —
+# its grant is not part of the standard runner setup.
+#
+# Usage: bash scripts/e2e-permission-health.sh [--no-build]
+
+set -euo pipefail
+
+NO_BUILD=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-build) NO_BUILD=true ;;
+        -h | --help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/e2e-helpers.sh
+source "$ROOT/scripts/lib/e2e-helpers.sh"
+APP="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
+BIN="$APP/Contents/MacOS/MeetingTranscriber"
+MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
+
+cleanup() {
+    if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill -9 "$APP_PID" 2>/dev/null || true
+    fi
+    bootout_stale_launchctl
+}
+trap cleanup EXIT
+
+# --- 1. Build (unless --no-build) ----------------------------------------
+
+if [ "$NO_BUILD" = false ]; then
+    echo "▸ Building dev bundle…"
+    "$ROOT/scripts/run_app.sh" --build-only >/dev/null
+fi
+
+[ -x "$BIN" ] || die "dev binary not found at $BIN — run without --no-build first"
+
+if [ ! -x "$MTCLI" ]; then
+    echo "▸ Building mt-cli…"
+    (cd "$ROOT/tools/mt-cli" && swift build >/dev/null)
+fi
+
+# --- 2. Kill any running instance + clear launchctl ----------------------
+
+quit_running_app
+bootout_stale_launchctl
+
+# --- 3. Launch (suppress auto-watch so the app stays idle) ---------------
+
+env MEETINGTRANSCRIBER_DEBUG_RPC=1 \
+    MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1 \
+    "$BIN" &
+APP_PID=$!
+
+# --- 4. Wait for RPC server to come up (max 30 s) ------------------------
+
+echo "▸ Waiting for RPC on 127.0.0.1:9876…"
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
+echo "  RPC up"
+
+# --- 5. Wait for the async permission check to populate (max 20 s) -------
+
+echo "▸ Waiting for the permission health check to run…"
+SR=""
+MIC=""
+AX=""
+STATE_JSON=""
+for _ in $(seq 1 40); do
+    # Tolerate a transient fetch mid-poll: the loop exists to wait out
+    # not-yet-ready state, so a single failure must retry, not abort under
+    # `set -e` (`|| true` on the assignment, empty-guard before the read).
+    STATE_JSON="$("$MTCLI" state 2>/dev/null || true)"
+    [ -n "$STATE_JSON" ] || {
+        sleep 0.5
+        continue
+    }
+    read -r SR MIC AX < <(
+        echo "$STATE_JSON" | jq -r \
+            '"\(.permissionHealth.screenRecording) \(.permissionHealth.microphone) \(.permissionHealth.accessibility)"'
+    ) || true
+    [ "$MIC" != "unknown" ] && break
+    sleep 0.5
+done
+
+echo "▸ permissionHealth: screenRecording=$SR microphone=$MIC accessibility=$AX"
+
+# --- 6. Assert the #446-fixed probes report healthy ----------------------
+
+# A "broken" verdict here is a #446 regression (probe false-flagged a granted
+# permission). A "denied" verdict means the grant lapsed on the runner (re-grant
+# in the GUI session — see CLAUDE.md). Either way the probe is not healthy.
+fail=false
+[ "$SR" = "healthy" ] || {
+    echo "  ✗ screenRecording expected 'healthy', got '$SR'" >&2
+    fail=true
+}
+[ "$MIC" = "healthy" ] || {
+    echo "  ✗ microphone expected 'healthy', got '$MIC'" >&2
+    fail=true
+}
+echo "  (accessibility=$AX — informational, not asserted)"
+
+if [ "$fail" = true ]; then
+    echo "Full permissionHealth JSON:" >&2
+    echo "$STATE_JSON" | jq .permissionHealth >&2 || true
+    die "permission probe not healthy: 'broken' = #446 regression, 'denied' = grant lapsed on runner"
+fi
+
+echo "OK — Screen Recording + Microphone probes report healthy on the granted runner"


### PR DESCRIPTION
Follow-up to #447 (stacked on it — base is `fix/permission-health-check-446`; GitHub will retarget to `main` when #447 merges). This adds the live test infrastructure for the #446 permission-probe fixes.

## What

1. **RPC exposure:** `RPCStateSnapshot` gains `permissionHealth` (per-permission `"healthy"/"denied"/"broken"/"notDetermined"`, plus the aggregate `isHealthy`, or `"unknown"` before the first async check), mapped from the live `HealthCheckResult` via a new `PermissionStatus.rpcValue`. Mirrors how `channelHealth` is already exposed. Whole surface is `#if !APPSTORE`.
2. **E2E driver:** `scripts/e2e-permission-health.sh` launches the dev `.app` and asserts via `/state.permissionHealth` that Screen Recording and Microphone report `healthy` on the granted runner.

## Why this is a real test of the fix

The self-hosted runner is a natural reproduction of both #446 false-`.broken` bugs:
- **Screen Recording** is granted, but the old window-title probe reported `.broken` when no foreign window title was readable (the default on recent macOS).
- **Microphone**: BlackHole 2ch is the runner's default input; an idle input delivers silent buffers, which the old amplitude probe reported `.broken`.

So on `main`-before-#447 this driver would be RED, and GREEN with #447's fixes — a genuine regression guard, not a tautology.

## Rollout

Wired as a `--no-build` step in `e2e-app.yml` (reuses the signed + granted bundle from the first lane), **`continue-on-error: true`** initially so it surfaces the result without gating `main` while the mic assertion is validated against the runner's idle BlackHole input. Flip to a hard gate once it has been green on a few nightlies.

## Tests

`RPCPermissionHealthTests`: `rpcValue` mapping (all 4 cases), the `.unknown` placeholder, and JSON serialisation. `bash -n` + shellcheck clean; YAML validated. /code-review run (shell `set -e` abort findings folded: the poll loop now tolerates transient `mt-cli state` failures and empty JSON).

Relates to #446.