### PR TITLE
test(ci): RPC permission-health exposure + e2e for the #446 probes

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -181,6 +181,23 @@ jobs:
           path: /tmp/e2e-channel-health-menubar.png
           if-no-files-found: ignore
 
+      # Permission-health probe e2e (issue #446): asserts that the Screen
+      # Recording and Microphone probes report "healthy" via
+      # `/state.permissionHealth` on this granted runner. The runner is a
+      # natural reproduction of the #446 false-`.broken` bugs — Screen
+      # Recording is granted but the old window-title probe reported broken,
+      # and BlackHole (the default input) delivers silent buffers the old
+      # amplitude probe reported broken. `continue-on-error` while the mic
+      # assertion is validated against the runner's idle BlackHole input;
+      # flip to a hard gate once it has been green on a few nightlies.
+      # `--no-build` reuses the dev bundle the first e2e-app.sh lane built and
+      # signed; it shares the bundle-ID + signing cert with the granted bundle,
+      # so the runner's TCC grant applies (continue-on-error hedges a mismatch).
+      - name: Run permission-health probe E2E (issue #446)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: bash scripts/e2e-permission-health.sh --no-build
+
       # Silent-recording detector e2e (PR #295): drives the real
       # production polling chain — meeting-simulator plays the fixture
       # at volume=0 so the CATapDescription tap captures buffers of

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -1,6 +1,18 @@
 #if !APPSTORE
     import Foundation
 
+    extension PermissionStatus {
+        /// Stable wire string for the RPC `/state.permissionHealth` snapshot.
+        var rpcValue: String {
+            switch self {
+            case .healthy: "healthy"
+            case .denied: "denied"
+            case .broken: "broken"
+            case .notDetermined: "notDetermined"
+            }
+        }
+    }
+
     extension PipelineQueue {
         /// Build the RPC pipeline-queue status from inside `PipelineQueue`, so the
         /// counter reads are single-hop `self.` accesses. Constructing this
@@ -51,6 +63,7 @@
                 engines: enginesSnapshot(),
                 lastJob: lastFinishedJobSnapshot(),
                 channelHealth: channelHealthSnapshot(),
+                permissionHealth: permissionHealthSnapshot(),
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
             )
@@ -77,6 +90,19 @@
                 micSilent: channelHealth.micSilentActive,
                 appSilent: channelHealth.appSilentActive,
                 recordingSilent: channelHealth.recordingSilentActive,
+            )
+        }
+
+        /// Snapshot the permission health verdict. `nil` before the first async
+        /// check completes → `.unknown`. Extracted (like `channelHealthSnapshot`)
+        /// to keep `rpcStateSnapshot`'s literal under the type-check budget.
+        private func permissionHealthSnapshot() -> RPCStateSnapshot.PermissionHealth {
+            guard let health = permissions.health else { return .unknown }
+            return RPCStateSnapshot.PermissionHealth(
+                screenRecording: health.screenRecording.rpcValue,
+                microphone: health.microphone.rpcValue,
+                accessibility: health.accessibility.rpcValue,
+                isHealthy: health.isHealthy,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -18,6 +18,11 @@
         /// `asymmetricSilenceWarningSeconds`. E2E drivers poll these to assert
         /// the menu-bar red-tint indicator wiring without screenshot OCR.
         let channelHealth: ChannelHealth
+        /// Permission health: per-permission TCC+probe verdict ("healthy",
+        /// "denied", "broken", "notDetermined", or "unknown" before the first
+        /// check). E2E drivers poll this to assert the probes don't false-flag a
+        /// granted permission (issue #446) without screenshotting the menu bar.
+        let permissionHealth: PermissionHealth
         /// Snapshot of the live-caption overlay state. E2E drivers poll
         /// `recentFinals.count > 0` to assert that the full live-transcription
         /// chain produced text without scraping the OSLog or screenshotting
@@ -81,6 +86,25 @@
             )
         }
 
+        struct PermissionHealth: Codable {
+            let screenRecording: String
+            let microphone: String
+            let accessibility: String
+            /// Mirror of `HealthCheckResult.isHealthy` — true only when every
+            /// permission is healthy. Lets drivers assert the aggregate without
+            /// re-deriving it from the three strings.
+            let isHealthy: Bool
+
+            /// Pre-check placeholder: the health check runs asynchronously at
+            /// launch, so a snapshot taken before it completes reports "unknown".
+            static let unknown = Self(
+                screenRecording: "unknown",
+                microphone: "unknown",
+                accessibility: "unknown",
+                isHealthy: false,
+            )
+        }
+
         struct LastJob: Codable {
             let jobID: String
             let state: JobState
@@ -130,6 +154,7 @@
             engines: Engines = .empty,
             lastJob: LastJob? = nil,
             channelHealth: ChannelHealth = .inactive,
+            permissionHealth: PermissionHealth = .unknown,
             liveCaptions: LiveCaptions = .empty,
             watchState: String? = nil,
         ) {
@@ -139,6 +164,7 @@
             self.engines = engines
             self.lastJob = lastJob
             self.channelHealth = channelHealth
+            self.permissionHealth = permissionHealth
             self.liveCaptions = liveCaptions
             self.watchState = watchState
         }

--- a/app/MeetingTranscriber/Tests/RPCPermissionHealthTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCPermissionHealthTests.swift
@@ -1,0 +1,56 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the permission-health surface exposed in the RPC `/state` snapshot
+    /// (issue #446 follow-up): the `PermissionStatus` → wire-string mapping, the
+    /// pre-check `.unknown` placeholder, and that it serialises into the snapshot JSON.
+    final class RPCPermissionHealthTests: XCTestCase {
+        // MARK: - PermissionStatus.rpcValue
+
+        func testRPCValueMapsEveryStatus() {
+            XCTAssertEqual(PermissionStatus.healthy.rpcValue, "healthy")
+            XCTAssertEqual(PermissionStatus.denied.rpcValue, "denied")
+            XCTAssertEqual(PermissionStatus.broken.rpcValue, "broken")
+            XCTAssertEqual(PermissionStatus.notDetermined.rpcValue, "notDetermined")
+        }
+
+        // MARK: - PermissionHealth placeholder
+
+        func testUnknownPlaceholderIsNotHealthy() {
+            let unknown = RPCStateSnapshot.PermissionHealth.unknown
+            XCTAssertEqual(unknown.screenRecording, "unknown")
+            XCTAssertEqual(unknown.microphone, "unknown")
+            XCTAssertEqual(unknown.accessibility, "unknown")
+            // "not yet checked" must not read as healthy.
+            XCTAssertFalse(unknown.isHealthy)
+        }
+
+        // MARK: - Serialisation
+
+        func testPermissionHealthSerialisesIntoSnapshotJSON() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                permissionHealth: .init(
+                    screenRecording: "healthy",
+                    microphone: "broken",
+                    accessibility: "denied",
+                    isHealthy: false,
+                ),
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            // jsonData() is pretty-printed with sorted keys → `"key" : "value"`.
+            XCTAssertTrue(json.contains("\"permissionHealth\""), json)
+            XCTAssertTrue(json.contains("\"screenRecording\" : \"healthy\""), json)
+            XCTAssertTrue(json.contains("\"microphone\" : \"broken\""), json)
+            XCTAssertTrue(json.contains("\"accessibility\" : \"denied\""), json)
+        }
+    }
+#endif

--- a/scripts/e2e-permission-health.sh
+++ b/scripts/e2e-permission-health.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# E2E test for the permission-health probes (issue #446 follow-up).
+#
+# Launches the dev .app and asserts, via the DebugRPCServer /state snapshot, that
+# the Screen Recording and Microphone permission probes report "healthy" on a
+# runner where those permissions are granted. This is a natural reproduction of
+# the #446 false-`.broken` bugs:
+#   - Screen Recording: granted, but the old window-title probe reported `.broken`
+#     when no foreign window title was readable (the default on recent macOS).
+#   - Microphone: granted (BlackHole 2ch is the runner's default input), but the
+#     old amplitude probe reported `.broken` because an idle input delivers
+#     silent buffers.
+# After the fix both must be "healthy" (the probes trust the system verdict /
+# buffer flow rather than an incidental signal).
+#
+# What this covers:
+#   - PermissionHealthCheck.runLive() against real TCC + real audio hardware
+#   - PermissionStatus → RPC /state.permissionHealth wiring
+#   - The #446 fixes holding on the real (silent-input, granted) runner
+#
+# Requires: granted Microphone + Screen Recording for the dev .app (see the
+# self-hosted runner setup in CLAUDE.md). Accessibility is logged, not asserted —
+# its grant is not part of the standard runner setup.
+#
+# Usage: bash scripts/e2e-permission-health.sh [--no-build]
+
+set -euo pipefail
+
+NO_BUILD=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-build) NO_BUILD=true ;;
+        -h | --help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/e2e-helpers.sh
+source "$ROOT/scripts/lib/e2e-helpers.sh"
+APP="$ROOT/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app"
+BIN="$APP/Contents/MacOS/MeetingTranscriber"
+MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
+
+cleanup() {
+    if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill -9 "$APP_PID" 2>/dev/null || true
+    fi
+    bootout_stale_launchctl
+}
+trap cleanup EXIT
+
+# --- 1. Build (unless --no-build) ----------------------------------------
+
+if [ "$NO_BUILD" = false ]; then
+    echo "▸ Building dev bundle…"
+    "$ROOT/scripts/run_app.sh" --build-only >/dev/null
+fi
+
+[ -x "$BIN" ] || die "dev binary not found at $BIN — run without --no-build first"
+
+if [ ! -x "$MTCLI" ]; then
+    echo "▸ Building mt-cli…"
+    (cd "$ROOT/tools/mt-cli" && swift build >/dev/null)
+fi
+
+# --- 2. Kill any running instance + clear launchctl ----------------------
+
+quit_running_app
+bootout_stale_launchctl
+
+# --- 3. Launch (suppress auto-watch so the app stays idle) ---------------
+
+env MEETINGTRANSCRIBER_DEBUG_RPC=1 \
+    MEETINGTRANSCRIBER_DEBUG_SUPPRESS_AUTOWATCH=1 \
+    "$BIN" &
+APP_PID=$!
+
+# --- 4. Wait for RPC server to come up (max 30 s) ------------------------
+
+echo "▸ Waiting for RPC on 127.0.0.1:9876…"
+wait_for_rpc "$MTCLI" 30 || die "RPC server did not start within 30 s"
+echo "  RPC up"
+
+# --- 5. Wait for the async permission check to populate (max 20 s) -------
+
+echo "▸ Waiting for the permission health check to run…"
+SR=""
+MIC=""
+AX=""
+STATE_JSON=""
+for _ in $(seq 1 40); do
+    # Tolerate a transient fetch mid-poll: the loop exists to wait out
+    # not-yet-ready state, so a single failure must retry, not abort under
+    # `set -e` (`|| true` on the assignment, empty-guard before the read).
+    STATE_JSON="$("$MTCLI" state 2>/dev/null || true)"
+    [ -n "$STATE_JSON" ] || {
+        sleep 0.5
+        continue
+    }
+    read -r SR MIC AX < <(
+        echo "$STATE_JSON" | jq -r \
+            '"\(.permissionHealth.screenRecording) \(.permissionHealth.microphone) \(.permissionHealth.accessibility)"'
+    ) || true
+    [ "$MIC" != "unknown" ] && break
+    sleep 0.5
+done
+
+echo "▸ permissionHealth: screenRecording=$SR microphone=$MIC accessibility=$AX"
+
+# --- 6. Assert the #446-fixed probes report healthy ----------------------
+
+# A "broken" verdict here is a #446 regression (probe false-flagged a granted
+# permission). A "denied" verdict means the grant lapsed on the runner (re-grant
+# in the GUI session — see CLAUDE.md). Either way the probe is not healthy.
+fail=false
+[ "$SR" = "healthy" ] || {
+    echo "  ✗ screenRecording expected 'healthy', got '$SR'" >&2
+    fail=true
+}
+[ "$MIC" = "healthy" ] || {
+    echo "  ✗ microphone expected 'healthy', got '$MIC'" >&2
+    fail=true
+}
+echo "  (accessibility=$AX — informational, not asserted)"
+
+if [ "$fail" = true ]; then
+    echo "Full permissionHealth JSON:" >&2
+    echo "$STATE_JSON" | jq .permissionHealth >&2 || true
+    die "permission probe not healthy: 'broken' = #446 regression, 'denied' = grant lapsed on runner"
+fi
+
+echo "OK — Screen Recording + Microphone probes report healthy on the granted runner"


### PR DESCRIPTION
Follow-up to #447 (now merged). Adds the live test infrastructure for the #446 permission-probe fixes.

> Reopened as a fresh PR: the original #448 was auto-closed by GitHub when #447 merged with `--delete-branch` (its base was the #447 branch). This branch is rebased onto `main`, so it contains only the two commits below.

## What

1. **RPC exposure:** `RPCStateSnapshot` gains `permissionHealth` (per-permission `"healthy"/"denied"/"broken"/"notDetermined"`, plus the aggregate `isHealthy`, or `"unknown"` before the first async check), mapped from the live `HealthCheckResult` via a new `PermissionStatus.rpcValue`. Mirrors how `channelHealth` is already exposed. Whole surface is `#if !APPSTORE`.
2. **E2E driver:** `scripts/e2e-permission-health.sh` launches the dev `.app` and asserts via `/state.permissionHealth` that Screen Recording and Microphone report `healthy` on the granted runner.

## Why this is a real test of the fix

The self-hosted runner is a natural reproduction of both #446 false-`.broken` bugs:
- **Screen Recording** is granted, but the old window-title probe reported `.broken` when no foreign window title was readable (the default on recent macOS).
- **Microphone**: BlackHole 2ch is the runner's default input; an idle input delivers silent buffers, which the old amplitude probe reported `.broken`.

So on `main`-before-#447 this driver would be RED, and GREEN with #447's fixes — a genuine regression guard, not a tautology.

## Rollout

Wired as a `--no-build` step in `e2e-app.yml` (reuses the signed + granted bundle from the first lane), **`continue-on-error: true`** initially so it surfaces the result without gating `main` while the mic assertion is validated against the runner's idle BlackHole input. Flip to a hard gate once it has been green on a few nightlies.

## Tests

`RPCPermissionHealthTests`: `rpcValue` mapping (all 4 cases), the `.unknown` placeholder, and JSON serialisation. `bash -n` + shellcheck clean; YAML validated. /code-review run (shell `set -e` abort findings folded: the poll loop now tolerates transient `mt-cli state` failures and empty JSON).

Relates to #446.