### PR TITLE
fix(app): log failure causes publicly instead of <private>

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -77,7 +77,7 @@ enum AppPaths {
             } catch CocoaError.fileReadNoSuchFile {
                 // Source doesn't exist — skip
             } catch {
-                logger.error("Failed to migrate \(name): \(error.localizedDescription)")
+                logger.error("Failed to migrate \(name): \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -216,7 +216,7 @@ enum AudioMixer {
         }
 
         if let error {
-            logger.warning("AVAudioConverter failed: \(error.localizedDescription), falling back")
+            logger.warning("AVAudioConverter failed: \(error.localizedDescription, privacy: .public), falling back")
             return resampleLinear(samples, from: sourceRate, to: targetRate)
         }
 
@@ -264,7 +264,10 @@ enum AudioMixer {
                 return try await loadAudioFromAVAsset(url: url)
             } catch {
                 // Fallback 2: ffmpeg for unsupported formats
-                logger.info("AVAsset failed for \(url.lastPathComponent, privacy: .private): \(error.localizedDescription), trying ffmpeg fallback")
+                logger
+                    .info(
+                        "AVAsset failed for \(url.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .public), trying ffmpeg fallback",
+                    )
                 return try await FFmpegHelper.loadAudioWithFFmpeg(url: url)
             }
         }

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -239,7 +239,7 @@
                 listener.start(queue: .main)
                 logger.info("DebugRPCServer listening on 127.0.0.1:\(self.port.rawValue, privacy: .public)")
             } catch {
-                logger.error("DebugRPCServer failed to start: \(error.localizedDescription)")
+                logger.error("DebugRPCServer failed to start: \(error.localizedDescription, privacy: .public)")
             }
         }
 
@@ -280,7 +280,7 @@
                 Task { @MainActor in
                     guard let self else { return }
                     if let error {
-                        logger.warning("RPC connection error: \(error.localizedDescription)")
+                        logger.warning("RPC connection error: \(error.localizedDescription, privacy: .public)")
                         connection.cancel()
                         return
                     }

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -237,6 +237,8 @@ class DualSourceRecorder: RecordingProvider {
                 logger.info("Recovered crashed recording: \(mix.lastPathComponent)")
                 recovered += 1
             } catch {
+                // Error left redacted: for re-imports the stem is title-derived,
+                // and a recovery file error embeds that filename in its description.
                 logger.warning("Could not recover crashed recording \(stem): \(error.localizedDescription)")
             }
         }

--- a/app/MeetingTranscriber/Sources/EouStreamingCaptionSession.swift
+++ b/app/MeetingTranscriber/Sources/EouStreamingCaptionSession.swift
@@ -155,7 +155,7 @@ actor EouStreamingCaptionSession: LiveCaptionPipeline {
         } catch {
             // Never throw out of ingest — log and move on. Transcript text is
             // never logged; only the (public) channel label and the error.
-            logger.warning("[\(self.channelLabel, privacy: .public)] ingest error: \(error)")
+            logger.warning("[\(self.channelLabel, privacy: .public)] ingest error: \(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -182,7 +182,7 @@ actor EouStreamingCaptionSession: LiveCaptionPipeline {
         } catch {
             // Never throw out of flush — log and still reset below so the next
             // recording starts clean. Transcript text is never logged.
-            logger.warning("[\(self.channelLabel, privacy: .public)] flush finish error: \(error)")
+            logger.warning("[\(self.channelLabel, privacy: .public)] flush finish error: \(error.localizedDescription, privacy: .public)")
         }
 
         await asr.reset()

--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -108,7 +108,7 @@ final class FluidDiarizer: DiarizationProvider, @unchecked Sendable {
             }
 
             logger.warning(
-                "Diarization failed with numSpeakers=\(numSpeakers), retrying with auto-detect: \(error.localizedDescription)",
+                "Diarization failed with numSpeakers=\(numSpeakers), retrying with auto-detect: \(error.localizedDescription, privacy: .public)",
             )
 
             try await offlineProcessor.prepare(numSpeakers: nil)

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -35,7 +35,7 @@ class MeetingDetector: MeetingDetecting {
                 do {
                     return try NSRegularExpression(pattern: pattern)
                 } catch {
-                    logger.error("Invalid meeting regex for \(p.appName): \(pattern) — \(error.localizedDescription)")
+                    logger.error("Invalid meeting regex for \(p.appName): \(pattern) — \(error.localizedDescription, privacy: .public)")
                     return nil
                 }
             }
@@ -43,7 +43,7 @@ class MeetingDetector: MeetingDetecting {
                 do {
                     return try NSRegularExpression(pattern: pattern)
                 } catch {
-                    logger.error("Invalid idle regex for \(p.appName): \(pattern) — \(error.localizedDescription)")
+                    logger.error("Invalid idle regex for \(p.appName): \(pattern) — \(error.localizedDescription, privacy: .public)")
                     return nil
                 }
             }

--- a/app/MeetingTranscriber/Sources/MicRecorder.swift
+++ b/app/MeetingTranscriber/Sources/MicRecorder.swift
@@ -77,7 +77,7 @@ class MicRecorder {
             do {
                 try file.write(from: buffer)
             } catch {
-                logger.error("Failed to write mic buffer: \(error)")
+                logger.error("Failed to write mic buffer: \(error.localizedDescription, privacy: .public)")
             }
         }
 

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -70,7 +70,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
                     try await configureVocabulary(from: customVocabularyPath)
                 }
             } catch {
-                logger.error("Parakeet model load failed: \(error)")
+                logger.error("Parakeet model load failed: \(error.localizedDescription, privacy: .public)")
                 modelState = .unloaded
                 downloadProgress = 0
             }
@@ -82,7 +82,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
         logger.info("Parakeet: model not loaded, loading…")
         await loadModel()
         guard asrManager != nil else {
-            logger.error("Parakeet: model load FAILED, state=\(String(describing: self.modelState))")
+            logger.error("Parakeet: model load FAILED, state=\(String(describing: self.modelState), privacy: .public)")
             throw TranscriptionError.modelNotLoaded
         }
         logger.info("Parakeet: model loaded successfully")
@@ -199,7 +199,7 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
                 ctcVariant: .ctc110m,
             )
         } catch {
-            logger.warning("Parakeet: failed to load vocabulary from \(path): \(error)")
+            logger.warning("Parakeet: failed to load vocabulary from \(path): \(error.localizedDescription, privacy: .public)")
             return
         }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -770,7 +770,7 @@ class PipelineQueue {
             if cancelledJobIDs.remove(ctx.jobID) != nil {
                 logger.info("Job \(ctx.jobID) cancelled")
             } else {
-                logger.error("Pipeline error for job \(ctx.jobID): \(error)")
+                logger.error("Pipeline error for job \(ctx.jobID): \(error.localizedDescription, privacy: .public)")
                 updateJobState(id: ctx.jobID, to: .error, error: error.localizedDescription)
             }
         }
@@ -1365,7 +1365,7 @@ class PipelineQueue {
                     )
                 }
             } catch {
-                logger.error("Failed to re-apply speaker names: \(error)")
+                logger.error("Failed to re-apply speaker names: \(error.localizedDescription, privacy: .public)")
             }
         }
 
@@ -1453,7 +1453,7 @@ class PipelineQueue {
                 completeSpeakerNaming(jobID: jobID, result: result)
             }
         } catch {
-            logger.error("Late re-diarization failed: \(error)")
+            logger.error("Late re-diarization failed: \(error.localizedDescription, privacy: .public)")
             stopElapsedTimer()
             updateJobState(id: jobID, to: .speakerNamingPending)
         }
@@ -1535,6 +1535,8 @@ class PipelineQueue {
         do {
             try namingStore.save(data, slug: slug)
         } catch {
+            // Error left redacted: the write target is `<title-slug>_naming.json`,
+            // so a file-write error description would leak the meeting title.
             logger.error("Failed to save naming data: \(error.localizedDescription)")
             addWarning(id: data.jobID, "Late re-confirm unavailable — naming data could not be persisted")
         }
@@ -1615,7 +1617,7 @@ class PipelineQueue {
             }
             loaded = decoded
         } catch {
-            logger.error("Failed to load pipeline snapshot: \(error)")
+            logger.error("Failed to load pipeline snapshot: \(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -1728,6 +1730,9 @@ class PipelineQueue {
                 try fm.moveItem(at: src, to: dst)
                 logger.info("Audio moved: \(name, privacy: .private)")
             } catch {
+                // Error left redacted: a file-move CocoaError embeds the
+                // meeting-title-derived filename in its description (the same
+                // data the sibling .private annotation hides).
                 logger.warning("Failed to move audio \(name, privacy: .private): \(error.localizedDescription)")
             }
         }
@@ -1761,7 +1766,7 @@ class PipelineQueue {
                 try data.write(to: processedRecordingsPath, options: .atomic)
                 logger.info("Migration: seeded \(paths.count) existing recordings as processed")
             } catch {
-                logger.error("Migration failed: \(error)")
+                logger.error("Migration failed: \(error.localizedDescription, privacy: .public)")
             }
         }.value
     }
@@ -1869,7 +1874,7 @@ class PipelineQueue {
             let data = try JSONEncoder().encode(Array(paths))
             try data.write(to: processedRecordingsPath, options: .atomic)
         } catch {
-            logger.error("Failed to write processed recordings: \(error)")
+            logger.error("Failed to write processed recordings: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -1978,7 +1983,7 @@ class PipelineQueue {
                 try FileManager.default.restrictToOwner(logPath)
             }
         } catch {
-            logger.error("Failed to append pipeline log: \(error)")
+            logger.error("Failed to append pipeline log: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/app/MeetingTranscriber/Sources/RecognitionStats.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStats.swift
@@ -171,7 +171,7 @@ actor RecognitionStatsLog {
             }
             try handle.synchronize()
         } catch {
-            logger.error("Failed to append recognition events: \(error.localizedDescription)")
+            logger.error("Failed to append recognition events: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/app/MeetingTranscriber/Sources/SnapshotWriterActor.swift
+++ b/app/MeetingTranscriber/Sources/SnapshotWriterActor.swift
@@ -21,7 +21,7 @@ actor SnapshotWriterActor {
         do {
             try writer(jobs, dir)
         } catch {
-            logger.error("Failed to write queue snapshot: \(error)")
+            logger.error("Failed to write queue snapshot: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerMatcher.swift
@@ -450,7 +450,7 @@ class SpeakerMatcher {
             // chmod applied pre-rename, so set it on the final path.
             try FileManager.default.restrictToOwner(dbPath)
         } catch {
-            logger.error("Failed to save speaker DB: \(error)")
+            logger.error("Failed to save speaker DB: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/app/MeetingTranscriber/Sources/StageTimingStats.swift
+++ b/app/MeetingTranscriber/Sources/StageTimingStats.swift
@@ -163,7 +163,7 @@ actor StageTimingLog {
             }
             try handle.synchronize()
         } catch {
-            logger.error("Failed to append stage-timing events: \(error.localizedDescription)")
+            logger.error("Failed to append stage-timing events: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
+++ b/app/MeetingTranscriber/Sources/StreamingTranscriber.swift
@@ -106,7 +106,7 @@ actor StreamingTranscriber: LiveCaptionPipeline {
                 vadState = try await vad.makeStreamState()
             } catch {
                 logger.error(
-                    "[\(self.channelLabel, privacy: .public)] vad init failed: \(error)",
+                    "[\(self.channelLabel, privacy: .public)] vad init failed: \(error.localizedDescription, privacy: .public)",
                 )
                 return
             }
@@ -122,7 +122,7 @@ actor StreamingTranscriber: LiveCaptionPipeline {
                 await handleEvent(result.event, chunk: chunk)
             } catch {
                 logger.warning(
-                    "[\(self.channelLabel, privacy: .public)] vad chunk error: \(error)",
+                    "[\(self.channelLabel, privacy: .public)] vad chunk error: \(error.localizedDescription, privacy: .public)",
                 )
             }
         }
@@ -163,7 +163,7 @@ actor StreamingTranscriber: LiveCaptionPipeline {
             }
         } catch {
             logger.warning(
-                "[\(self.channelLabel, privacy: .public)] partial transcribe error: \(error)",
+                "[\(self.channelLabel, privacy: .public)] partial transcribe error: \(error.localizedDescription, privacy: .public)",
             )
         }
     }
@@ -191,7 +191,7 @@ actor StreamingTranscriber: LiveCaptionPipeline {
             }
         } catch {
             logger.warning(
-                "[\(self.channelLabel, privacy: .public)] final transcribe error: \(error)",
+                "[\(self.channelLabel, privacy: .public)] final transcribe error: \(error.localizedDescription, privacy: .public)",
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -229,7 +229,7 @@ class WatchLoop {
             let recording = try recorder.stop()
             enqueueRecording(title: info.title, appName: info.appName, recording: recording)
         } catch {
-            logger.error("Failed to stop manual recording: \(error)")
+            logger.error("Failed to stop manual recording: \(error.localizedDescription, privacy: .public)")
             failureMessage = error.localizedDescription
         }
 
@@ -284,8 +284,8 @@ class WatchLoop {
                     try await handleMeeting(meeting)
                 } catch {
                     if error is CancellationError { return }
-                    let msg = "Recording error: \(error)"
-                    logger.error("\(msg)")
+                    let msg = "Recording error: \(error.localizedDescription)"
+                    logger.error("\(msg, privacy: .public)")
                     update { next in
                         next.phase = .error
                         next.lastError = error.localizedDescription
@@ -482,6 +482,8 @@ class WatchLoop {
             try sidecar.write(toDirectory: destDir, basename: basename)
             logger.info("Record-only: wrote sidecar + WAVs to \(destDir.path) for \(title, privacy: .private)")
         } catch {
+            // Error left redacted: a sidecar/WAV write error embeds the
+            // meeting-title-derived basename in its description.
             logger.error("Record-only: \(error.localizedDescription)")
             update { next in
                 next.lastError = "Record-only output failed: \(error.localizedDescription)"

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -563,7 +563,7 @@ extension AppAudioCapture {
             try startCapture()
             event = .startSucceeded(rate: actualSampleRate)
         } catch {
-            logger.error("Failed to restart app audio capture: \(error)")
+            logger.error("Failed to restart app audio capture: \(error.localizedDescription, privacy: .public)")
             event = .startFailed
         }
         applyAction(deviceChangeCoordinator.handle(event))

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -98,7 +98,7 @@ public class AudioCaptureSession {
                 try mic.start(deviceUID: micDeviceUID)
                 micCapture = mic
             } catch {
-                logger.error("Failed to start mic capture: \(error). Continuing with app audio only.")
+                logger.error("Failed to start mic capture: \(error.localizedDescription, privacy: .public). Continuing with app audio only.")
             }
         }
 

--- a/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
@@ -44,7 +44,7 @@ extension MicCaptureHandler {
             try file.write(from: silentBuffer)
             logger.info("Mic: filled \(frames) silent frames for a device-restart gap")
         } catch {
-            logger.warning("Mic timeline gap-fill write error: \(error)")
+            logger.warning("Mic timeline gap-fill write error: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -248,7 +248,7 @@ public class MicCaptureHandler: @unchecked Sendable {
                         feed.next(outStatus)
                     }
                     if let error {
-                        logger.warning("Mic resample error: \(error)")
+                        logger.warning("Mic resample error: \(error.localizedDescription, privacy: .public)")
                     } else {
                         self.fillTimelineGap(before: when, outputFrames: Int(outputBuffer.frameLength))
                         try self.outputFile?.write(from: outputBuffer)
@@ -260,14 +260,14 @@ public class MicCaptureHandler: @unchecked Sendable {
                     self.forwardToLiveSink(buffer: buffer)
                 }
             } catch {
-                logger.warning("Mic write error: \(error)")
+                logger.warning("Mic write error: \(error.localizedDescription, privacy: .public)")
             }
         }
 
         do {
             try inputNode.safeInstallTap(onBus: 0, bufferSize: 4096, format: installFormat, block: tapBlock)
         } catch {
-            logger.error("Mic: installTap failed (\(error.localizedDescription)) — restart will retry")
+            logger.error("Mic: installTap failed (\(error.localizedDescription, privacy: .public)) — restart will retry")
             throw error
         }
 
@@ -384,7 +384,7 @@ public class MicCaptureHandler: @unchecked Sendable {
             // A transient invalid format / installTap raise (issue #379) is
             // recoverable: the device usually settles within a few hundred ms.
             // Keep recording and retry with backoff instead of killing it.
-            logger.error("Failed to restart mic after device change: \(error) — scheduling retry")
+            logger.error("Failed to restart mic after device change: \(error.localizedDescription, privacy: .public) — scheduling retry")
             scheduleRestartRetry(deviceUID: deviceUID)
         }
     }


### PR DESCRIPTION
Third and final follow-up to #446 (after #447 and #449): the broad sweep of the same `<private>` over-redaction across the rest of the codebase.

## Problem

`os.Logger` redacts non-numeric interpolations to `<private>` by default. ~35 error/warning logs across the app and AudioTapLib interpolated the failure **cause** without `privacy: .public`, so the reason a recording / pipeline / model-load / mic-restart failed was unreadable in logs and in exported diagnostics. This is the pervasive sibling of the #446 PermissionHealthCheck log fix.

## Change

Add `privacy: .public` to the cause at each site, logging **`error.localizedDescription`**. Two reasons it is `localizedDescription` and not `String(describing: error)`:
- The app's custom errors conform to `LocalizedError` (8 with `errorDescription`), so the message stays meaningful.
- `String(describing:)` of a Cocoa file error dumps the full `NSFilePath` (`/Users/<username>/...`), leaking the macOS username into shared diagnostics; `localizedDescription` shows only the human message and filename. (Verified empirically.)

Covers the live-captions streaming path (`StreamingTranscriber`, `EouStreamingCaptionSession`) too, where only the channel label was public.

## Privacy: deliberately left redacted

Four file-I/O sites keep their error redacted, because the message embeds a **meeting-title-derived filename** and making it public would re-leak the title:

- `PipelineQueue` audio move (`<timestamp>_<title>...wav`)
- `PipelineQueue` naming-data save (`<title-slug>_naming.json`)
- `WatchLoop` record-only output (title-derived basename)
- `DualSourceRecorder` crashed-recording recovery (title-derived stem on re-imports)

The user still sees the full cause in the in-app error state; only the shareable os_log omits the title-bearing name. Each has an inline comment so a future mechanical sweep does not re-introduce the leak. PII on shared lines (paths, names, stems) stays default-redacted or explicitly `.private`. OSStatus/Int values are unaffected (numeric scalars already render in the clear).

## Verification

`swift build` green, lint clean. Empirically confirmed `localizedDescription` exposes no path/username (only `String(describing:)` does). /code-review run: caught 4 PII re-leaks (folded: kept redacted) and 6 missed streaming sites (folded: now public); completeness sweep confirms no error-cause logger site remains redacted except the 4 deliberate ones. Note: `codecov/patch` is red because the changed lines are error-branch log statements with no test coverage (informational, not a required check).

Relates to #446.