### PR TITLE
fix(app): stop menu-bar animation timer crashing during status-bar menu tracking

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -23,7 +23,11 @@ private struct AnimatedMenuBarIcon: View {
     let appSilentOverlay: Bool
 
     @State private var animationFrame = 0
-    private let iconTimer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
+    // `.default` (not `.common`) so the timer never fires inside the status-bar
+    // menu's tracking loop — see MenuBarIcon.animationRunLoopMode for why.
+    private let iconTimer = Timer.publish(
+        every: 0.4, on: .main, in: MenuBarIcon.animationRunLoopMode,
+    ).autoconnect()
 
     var body: some View {
         Image(nsImage: MenuBarIcon.image(

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -42,6 +42,16 @@ enum MenuBarIcon {
     /// Number of distinct animation frames. Pure constant.
     nonisolated static let frameCount = 6
 
+    /// Run-loop mode for the menu-bar animation timer (`AnimatedMenuBarIcon`).
+    ///
+    /// `.default`, not `.common`: `.common` includes `.eventTracking`, so the
+    /// timer would fire while the status-bar menu is tracked and deliver its
+    /// `@MainActor` tick from inside that nested run loop — which crashes in the
+    /// Swift concurrency executor check (`swift_task_isCurrentExecutor` →
+    /// EXC_BAD_ACCESS). Trade-off: the badge animation pauses while a menu is
+    /// open (cosmetic, sub-second) and resumes when tracking ends.
+    nonisolated static let animationRunLoopMode: RunLoop.Mode = .default
+
     /// Returns the next animation frame for `badge`, or `current` if `badge`
     /// is non-animated. Static badges (idle, error, …) ignore the timer tick
     /// so the App scene's body does not re-evaluate every 0.4 s. Pure math —

--- a/app/MeetingTranscriber/Tests/MenuBarIconNextFrameTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconNextFrameTests.swift
@@ -26,4 +26,12 @@ final class MenuBarIconNextFrameTests: XCTestCase {
         let last = MenuBarIcon.frameCount - 1
         XCTAssertEqual(MenuBarIcon.nextFrame(last, badge: .recording), 0)
     }
+
+    // Regression guard: the animation timer must stay `.default`. `.common`
+    // includes `.eventTracking`, which fires the @MainActor tick inside the
+    // status-bar menu's nested run loop and crashes (EXC_BAD_ACCESS).
+    func testAnimationTimerAvoidsEventTrackingMode() {
+        XCTAssertEqual(MenuBarIcon.animationRunLoopMode, .default)
+        XCTAssertNotEqual(MenuBarIcon.animationRunLoopMode, .common)
+    }
 }


### PR DESCRIPTION
Fixes #451.

## What & why

Clicking the menu-bar icon while a badge is animating (recording / transcribing / diarizing / processing) can crash with `EXC_BAD_ACCESS (SIGSEGV)` on the main thread.

**Trigger (well-supported by the stack trace):** the animation `Timer` runs in `.common` mode, which includes `.eventTracking`. While the status-bar menu is open it spins a nested `NSMenuTrackingSession` run loop, so the timer keeps firing and delivers its `@MainActor` `onReceive` tick from inside that nested loop, with no Swift concurrency executor-tracking context. The fault is in the runtime's main-actor executor check (`swift_task_isCurrentExecutor` → `swift_task_isMainExecutorImpl` → `objc_opt_class`, near-null address).

**Underlying cause (best-supported hypothesis, not fully isolated):** this matches a known Swift 6.2+ runtime regression in the executor check, where the "no current executor" fallback dereferences the expected-executor identity (it was a non-dereferencing pointer compare in 6.0/6.1), so a bad identity faults instead of comparing unequal. The same crash family is tracked upstream at swiftlang/swift#89197. I could not reduce it to a standalone minimal reproducer; the corruption appears to depend on optimizer output around the main-actor hop, which is consistent with the upstream reporter also being unable to minimize it.

**Fix:** schedule the timer in `.default`, via a documented + tested `MenuBarIcon.animationRunLoopMode` constant. `.default` isn't in the event-tracking set, so the timer can't fire during menu tracking, which removes the trigger condition entirely regardless of the exact runtime mechanism. The only trade-off is that the badge animation pauses while a menu is open (cosmetic, sub-second; resumes when tracking ends). Deferring the tick with `DispatchQueue.main.async` was considered, but the main queue is also serviced in `.common` modes, so it wouldn't reliably help.

## Crash evidence

| | |
|---|---|
| App | 0.5.1 (build 1), Homebrew (also reproduced on `main` `5ddd0e25` — line unchanged) |
| OS | macOS 26.5.1 (25F80), arm64 |
| Exception | `EXC_BAD_ACCESS (SIGSEGV)` · `KERN_INVALID_ADDRESS` (near-null) |
| Thread | 0 — `com.apple.main-thread` |

Faulting thread, most-recent frame first (trimmed):

```
0   libobjc.A.dylib       objc_opt_class
2   libswift_Concurrency  swift_task_isMainExecutorImpl
4   libswift_Concurrency  swift_task_isCurrentExecutorWithFlagsImpl
5   MeetingTranscriber    closure #1 in AnimatedMenuBarIcon.body.getter        <- onReceive tick
…
17  Foundation            NSTimer.TimerPublisher.Inner.send(_:)                 <- iconTimer fires
23  CoreFoundation        __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK…
…
35  AppKit                -[NSMenuTrackingSession startRunningMenuEventLoop:]   <- menu is open
42  AppKit                +[NSStatusBarButtonCell popUpStatusBarMenu:…]         <- status-bar click
52  AppKit                -[NSApplication run]
```

## Reproduction

1. Have an animated badge active (start a recording, etc.) so `iconTimer` is advancing frames.
2. Open the menu-bar menu and keep it open across a 0.4 s tick.
3. The tick lands inside the tracking loop → `EXC_BAD_ACCESS` on the main thread.

Intermittent (the tick must land *during* tracking); static badges don't animate (`MenuBarIcon.nextFrame` returns early), so they never trigger it.

## Testing

- Added `testAnimationTimerAvoidsEventTrackingMode` — asserts the mode constant stays `.default`, guarding against a silent revert to `.common`. It locks the constant, not the scheduling wiring (a real `NSMenuTrackingSession` test would be flaky and disproportionate for a one-line fix).
- `swift build` is clean against the full deps (WhisperKit / FluidAudio); CI runs the XCTest suite.

## Risk

Cosmetic only: the badge animation holds its frame while a menu/tracking loop is open. No functional, recording, or pipeline behaviour changes.
