### PR TITLE
fix(app): rebuild transcript from late re-diarization on confirm

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1179,26 +1179,42 @@ class PipelineQueue {
         from run: DiarizationRun, autoNames: [String: String],
         transcription: TranscriptionOutput, engine: any TranscribingEngine, mix16k: URL,
     ) async throws -> String? {
-        let cachedSegments = transcription.cachedSegments
-        let useDualTrack = transcription.isDualSource
+        // cachedSegments is set by the transcribe stage in practice; the
+        // single-source branch re-transcribes defensively if it's somehow nil.
+        let cachedSegments: [TimestampedSegment]
+        if let cached = transcription.cachedSegments {
+            cachedSegments = cached
+        } else if transcription.isDualSource {
+            return nil
+        } else {
+            cachedSegments = try await engine.transcribeSegments(audioPath: mix16k)
+        }
+        return renderLabeledTranscript(
+            run: run, cachedSegments: cachedSegments,
+            isDualSource: transcription.isDualSource, autoNames: autoNames,
+        )
+    }
 
+    /// Render the speaker-labeled transcript text from a diarization run +
+    /// transcript segments: pick the topology, assign speakers, merge
+    /// consecutive blocks, and format. Shared by the batch path
+    /// (`labeledTranscript`) and the late re-diarization rewrite
+    /// (`rewriteTranscriptFromLateRun`) so both re-segment identically. Returns
+    /// nil when the run carries no usable diarization.
+    private func renderLabeledTranscript(
+        run: DiarizationRun, cachedSegments: [TimestampedSegment],
+        isDualSource: Bool, autoNames: [String: String],
+    ) -> String? {
         let topology: DiarizationProcess.LabelingTopology?
-        if useDualTrack, let appDiar = run.app, let micDiar = run.mic, let cached = cachedSegments {
-            topology = .dualTrack(cached: cached, micLabel: micLabel, app: appDiar, mic: micDiar)
-        } else if useDualTrack, let appDiar = run.app, let cached = cachedSegments {
+        if isDualSource, let appDiar = run.app, let micDiar = run.mic {
+            topology = .dualTrack(cached: cachedSegments, micLabel: micLabel, app: appDiar, mic: micDiar)
+        } else if isDualSource, let appDiar = run.app {
             // Mic diarization failed (silent track / no input device). Keep the
             // mic transcript with its raw `micLabel` — better than emitting
             // "speakers not identified" on a recording with good remote audio.
-            topology = .dualTrackAppOnly(cached: cached, micLabel: micLabel, app: appDiar)
-        } else if let currentDiarization = run.combined {
-            // Single-source: standard assignment. cachedSegments is set by the
-            // transcribe stage in practice; re-transcribe defensively.
-            let segments = if let cached = cachedSegments {
-                cached
-            } else {
-                try await engine.transcribeSegments(audioPath: mix16k)
-            }
-            topology = .single(segments: segments, diarization: currentDiarization)
+            topology = .dualTrackAppOnly(cached: cachedSegments, micLabel: micLabel, app: appDiar)
+        } else if let combined = run.combined {
+            topology = .single(segments: cachedSegments, diarization: combined)
         } else {
             return nil
         }
@@ -1401,17 +1417,7 @@ class PipelineQueue {
         }
 
         let recordingsDir = outputDir.appendingPathComponent("recordings")
-        let diarizeProcess: any DiarizationProvider = {
-            if let mode, let factory = diarizationFactoryWithMode {
-                return factory(mode)
-            }
-            if let mode {
-                logger.warning(
-                    "Late re-diarize requested mode=\(mode.rawValue, privacy: .public) but no mode-aware factory wired; falling back to global setting",
-                )
-            }
-            return diarizationFactory()
-        }()
+        let diarizeProcess = resolveLateDiarizer(mode: mode, defaultFactory: diarizationFactory)
         guard diarizeProcess.isAvailable else {
             logger.warning("Diarization not available for late re-run")
             return
@@ -1422,7 +1428,7 @@ class PipelineQueue {
 
         do {
             let title = jobs[jobIndex].meetingTitle
-            let diarization = try await runLateDiarization(
+            let run = try await runLateDiarization(
                 diarizer: diarizeProcess,
                 recording: (dir: recordingsDir, slug: slug, jobID: jobID, micDelay: jobs[jobIndex].micDelay),
                 isDualSource: namingData.isDualSource,
@@ -1430,9 +1436,12 @@ class PipelineQueue {
             )
             stopElapsedTimer()
 
+            // Dual-track always yields a combined result (the merge or the
+            // app-only fallback); single-source sets it directly.
+            guard let combined = run.combined else { throw DiarizationError.notAvailable }
             guard let newNamingData = buildNamingData(
                 jobID: jobID, title: title,
-                diarization: diarization, prior: namingData,
+                diarization: combined, prior: namingData,
             ) else {
                 logger.warning("Late re-diarization produced no embeddings")
                 updateJobState(id: jobID, to: .speakerNamingPending)
@@ -1441,6 +1450,16 @@ class PipelineQueue {
 
             speakerNamingDataByJob[jobID] = newNamingData
             saveNamingData(newNamingData, slug: slug)
+            // Re-segment the saved transcript to match the fresh diarization.
+            // A re-run can change the speaker count and segment boundaries, but
+            // the late-confirm path only renames labels already present in the
+            // .txt — so without this rewrite any speakers the re-run adds never
+            // reach the transcript. Mirrors the batch path, which renders the
+            // transcript from its final run.
+            rewriteTranscriptFromLateRun(
+                run: run, autoNames: newNamingData.mapping,
+                isDualSource: namingData.isDualSource, slug: slug, jobID: jobID,
+            )
             // Track which mode produced this fresh naming data so the next
             // dialog open initialises the mode picker correctly.
             jobs[jobIndex].usedDiarizerMode = diarizeProcess.mode
@@ -1459,6 +1478,23 @@ class PipelineQueue {
         }
     }
 
+    /// Resolve the diarizer for a late re-run: a mode override uses the
+    /// mode-aware factory (falling back to `defaultFactory` plus a warning when
+    /// none is wired); `nil` keeps the current global setting.
+    private func resolveLateDiarizer(
+        mode: DiarizerMode?, defaultFactory: () -> any DiarizationProvider,
+    ) -> any DiarizationProvider {
+        if let mode, let factory = diarizationFactoryWithMode {
+            return factory(mode)
+        }
+        if let mode {
+            logger.warning(
+                "Late re-diarize requested mode=\(mode.rawValue, privacy: .public) but no mode-aware factory wired; falling back to global setting",
+            )
+        }
+        return defaultFactory()
+    }
+
     /// Re-diarize the persisted 16 kHz audio for a job. Dispatches between
     /// dual-source (separate app + mic tracks merged) and single-source
     /// (mix only). Pure I/O helper extracted from `lateDiarization` to
@@ -1469,14 +1505,14 @@ class PipelineQueue {
         isDualSource: Bool,
         speakerCount: Int,
         title: String,
-    ) async throws -> DiarizationResult {
+    ) async throws -> DiarizationRun {
         let (recordingsDir, slug, jobID, micDelay) = recording
         if isDualSource {
             // Mirror the batch path's mic-fail fallback (via the shared helper):
             // a silent/failing mic track must degrade to the unprefixed app-only
             // diarization, not throw (a no-op re-run) or emit prefixed keys the
             // persisted app-only transcript can't match.
-            let run = try await runDualTrackDiarization(
+            return try await runDualTrackDiarization(
                 diarizeProcess: diarizer,
                 tracks: (
                     app: recordingsDir.appendingPathComponent("\(slug)_app_16k.wav"),
@@ -1485,16 +1521,12 @@ class PipelineQueue {
                 ),
                 speakerCount: speakerCount, title: title, jobID: jobID,
             )
-            // Dual-track always yields a combined result (the merge or the
-            // app-only fallback); the optional is only the diarize-loop
-            // placeholder's concern.
-            guard let combined = run.combined else { throw DiarizationError.notAvailable }
-            return combined
         }
         let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
-        return try await diarizer.run(
+        let diarization = try await diarizer.run(
             audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
         )
+        return DiarizationRun(app: nil, mic: nil, combined: diarization)
     }
 
     /// Build SpeakerNamingData from fresh diarization, reusing context from prior naming data.
@@ -1523,6 +1555,58 @@ class PipelineQueue {
             },
             participants: prior.participants, isDualSource: prior.isDualSource,
         )
+    }
+
+    /// Rewrite the persisted transcript so its speaker segmentation reflects a
+    /// fresh late re-diarization. Re-labels the cached transcript segments
+    /// (persisted as `<slug>_segments.json`) against the new run with the new
+    /// auto-names. A no-op when the cached segments are missing (older
+    /// recordings predating segment persistence) — the late-confirm rename then
+    /// falls back to the prior behaviour rather than wiping the transcript.
+    private func rewriteTranscriptFromLateRun(
+        run: DiarizationRun, autoNames: [String: String],
+        isDualSource: Bool, slug: String, jobID: UUID,
+    ) {
+        guard let outputDir,
+              let transcriptPath = jobs.first(where: { $0.id == jobID })?.transcriptPath else { return }
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        guard let cachedSegments = loadCachedSegments(dir: recordingsDir, slug: slug) else {
+            logger.warning("Late re-diarization: no persisted transcript segments — speaker labels not re-segmented")
+            // Don't let the re-run silently appear to succeed: an older recording
+            // (predating segment persistence) can't be re-segmented, so any
+            // speakers the re-run added won't reach the transcript.
+            addWarning(
+                id: jobID,
+                "This recording has no saved transcript segments, so the re-run's speaker changes could not be applied to the transcript",
+            )
+            return
+        }
+        guard let rebuilt = renderLabeledTranscript(
+            run: run, cachedSegments: cachedSegments,
+            isDualSource: isDualSource, autoNames: autoNames,
+        ) else { return }
+        do {
+            try rebuilt.write(to: transcriptPath, atomically: true, encoding: .utf8)
+            // Keep the rewritten transcript owner-only, matching the original save.
+            try FileManager.default.restrictToOwner(transcriptPath)
+        } catch {
+            // Error left redacted: the write target is `<title>_transcript.txt`,
+            // so a file-write error description would leak the meeting title.
+            logger.error("Late re-diarization: failed to rewrite transcript: \(error.localizedDescription)")
+        }
+    }
+
+    /// Load the transcript segments persisted by `generateAndSaveProtocol`
+    /// (`<slug>_segments.json`). Returns nil when the file is absent or
+    /// undecodable.
+    private func loadCachedSegments(dir: URL, slug: String)
+        -> [TimestampedSegment]? { // swiftlint:disable:this discouraged_optional_collection
+        let segPath = dir.appendingPathComponent("\(slug)_segments.json")
+        guard let data = try? Data(contentsOf: segPath),
+              let segments = try? JSONDecoder().decode([TimestampedSegment].self, from: data) else {
+            return nil
+        }
+        return segments
     }
 
     // MARK: - Speaker Naming Persistence

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -1461,8 +1461,13 @@ class PipelineQueue {
                 isDualSource: namingData.isDualSource, slug: slug, jobID: jobID,
             )
             // Track which mode produced this fresh naming data so the next
-            // dialog open initialises the mode picker correctly.
-            jobs[jobIndex].usedDiarizerMode = diarizeProcess.mode
+            // dialog open initialises the mode picker correctly. Re-resolve the
+            // index by id: the diarization await can outlive another finished
+            // job's `completedJobLifetime` eviction, which shifts the array and
+            // would invalidate the `jobIndex` captured before the await.
+            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
+                jobs[idx].usedDiarizerMode = diarizeProcess.mode
+            }
 
             updateJobState(id: jobID, to: .speakerNamingPending)
             NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2045,6 +2045,264 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(pQueue.jobs.first?.state, .done)
     }
 
+    /// Regression: a late re-run that detects MORE speakers than the initial
+    /// diarization must re-segment the saved transcript, not just rename the
+    /// labels that already exist in it. The original bug: the initial mix
+    /// diarization collapsed to one speaker, the re-run correctly found three
+    /// (shown in the dialog), but Confirm only string-replaced the single label
+    /// present in the saved transcript — so the .txt still had one speaker.
+    func testLateRerunConfirmRebuildsTranscriptWithNewSpeakers() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "How are you"),
+            TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
+        ]
+        let mockDiar = MockDiarization()
+        // Initial diarization collapses everything onto one speaker.
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 15, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 15],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Rerun Rebuild Test",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+
+        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pendingExpectation], timeout: 10)
+
+        // Sanity: the initial transcript really did collapse to one speaker.
+        let initialPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        let initialTranscript = try String(contentsOf: initialPath, encoding: .utf8)
+        XCTAssertFalse(initialTranscript.contains("SPEAKER_1:"), "Setup precondition: initial diarization is single-speaker")
+
+        // The re-run now detects three distinct speakers across the timeline.
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+                .init(start: 10, end: 15, speaker: "SPEAKER_2"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5, "SPEAKER_2": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0], "SPEAKER_2": [0, 0, 1]],
+        )
+
+        pQueue.speakerNamingHandler = { _ in
+            .confirmed(["SPEAKER_0": "Alice", "SPEAKER_1": "Bob", "SPEAKER_2": "Carol"])
+        }
+
+        let doneExpectation = XCTestExpectation(description: "done after rerun")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { doneExpectation.fulfill() }
+        }
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        await fulfillment(of: [doneExpectation], timeout: 60)
+
+        let finalPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        let finalTranscript = try String(contentsOf: finalPath, encoding: .utf8)
+        XCTAssertTrue(finalTranscript.contains("] Alice: Hello"), "First speaker should appear after re-run confirm")
+        XCTAssertTrue(finalTranscript.contains("] Bob: How are you"), "Second speaker must survive into the transcript")
+        XCTAssertTrue(finalTranscript.contains("] Carol: Goodbye"), "Third speaker must survive into the transcript")
+    }
+
+    /// Dual-source variant of the re-segment regression: a late re-run that
+    /// splits the remote/app track into more speakers must re-segment the saved
+    /// dual-track transcript, not just rename the labels already in it.
+    func testLateRerunConfirmRebuildsDualSourceTranscript() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "First"),
+            TimestampedSegment(start: 5, end: 10, text: "Second"),
+        ]
+        let mockDiar = MockDiarization()
+        // Initial: one speaker per track → one remote speaker in the transcript.
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 10, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 10],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { mockDiar },
+            diarizeEnabled: true,
+        )
+
+        try pQueue.enqueue(makeDualSourceJob(title: "Dual Rerun Rebuild"))
+        let jobID = try XCTUnwrap(pQueue.jobs.first?.id)
+        let pending = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pending.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pending], timeout: 10)
+
+        let initialPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        let initialTranscript = try String(contentsOf: initialPath, encoding: .utf8)
+        XCTAssertFalse(initialTranscript.contains("R_SPEAKER_1:"), "Setup precondition: one remote speaker initially")
+
+        // Re-run splits the remote/app track into two speakers across the timeline.
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0]],
+        )
+        pQueue.speakerNamingHandler = { _ in
+            .confirmed(["R_SPEAKER_0": "Alice", "R_SPEAKER_1": "Bob"])
+        }
+        let done = XCTestExpectation(description: "done after dual rerun")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+        pQueue.completeSpeakerNaming(jobID: jobID, result: .rerun(2))
+        await fulfillment(of: [done], timeout: 60)
+
+        let finalPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        let finalTranscript = try String(contentsOf: finalPath, encoding: .utf8)
+        XCTAssertTrue(finalTranscript.contains("] Alice: First"), "First remote speaker should appear after re-run confirm")
+        XCTAssertTrue(finalTranscript.contains("] Bob: Second"), "Second remote speaker must survive into the transcript")
+    }
+
+    /// The re-run rewrite happens before the dialog result is known, so a
+    /// re-run followed by SKIP (accept auto-names) must also carry the new
+    /// segmentation into the saved transcript — the rewrite must not depend on
+    /// a confirm mapping.
+    func testLateRerunSkipKeepsRebuiltSegmentation() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "How are you"),
+            TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 15, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 15], autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine, diarizationFactory: { mockDiar }, diarizeEnabled: true,
+        )
+        let job = try PipelineJob(
+            meetingTitle: "Rerun Skip Test", appName: "Teams",
+            mixPath: createTestAudioFile(in: tmpDir), appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pending = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pending.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pending], timeout: 10)
+
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+                .init(start: 10, end: 15, speaker: "SPEAKER_2"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5, "SPEAKER_2": 5], autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0], "SPEAKER_2": [0, 0, 1]],
+        )
+        pQueue.speakerNamingHandler = { _ in .skipped }
+        let done = XCTestExpectation(description: "done after rerun skip")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        await fulfillment(of: [done], timeout: 60)
+
+        let finalTranscript = try String(contentsOf: XCTUnwrap(pQueue.jobs.first?.transcriptPath), encoding: .utf8)
+        XCTAssertTrue(finalTranscript.contains("SPEAKER_1:"), "Skip must keep the re-run's added speakers (auto-named)")
+        XCTAssertTrue(finalTranscript.contains("SPEAKER_2:"), "Skip must keep all re-run speakers")
+    }
+
+    /// When the persisted transcript segments are absent (older recordings
+    /// predating segment persistence), the re-run rewrite degrades gracefully:
+    /// it does NOT wipe the transcript, and surfaces a warning so the user
+    /// isn't silently misled into thinking the new speakers were applied.
+    func testLateRerunWithoutPersistedSegmentsWarnsAndKeepsTranscript() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Hello"),
+            TimestampedSegment(start: 5, end: 10, text: "World"),
+        ]
+        let mockDiar = MockDiarization()
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 10, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 10], autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine, diarizationFactory: { mockDiar }, diarizeEnabled: true,
+        )
+        let job = try PipelineJob(
+            meetingTitle: "No Segments Test", appName: "Teams",
+            mixPath: createTestAudioFile(in: tmpDir), appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pending = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pending.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pending], timeout: 10)
+
+        let transcriptPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        let before = try String(contentsOf: transcriptPath, encoding: .utf8)
+        // Simulate an older recording: remove the persisted transcript segments.
+        let slug = try XCTUnwrap(pQueue.jobs.first?.namingSlug)
+        try FileManager.default.removeItem(
+            at: tmpDir.appendingPathComponent("recordings").appendingPathComponent("\(slug)_segments.json"),
+        )
+
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5], autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0]],
+        )
+        pQueue.speakerNamingHandler = { _ in .skipped }
+        let done = XCTestExpectation(description: "done")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(2))
+        await fulfillment(of: [done], timeout: 60)
+
+        let after = try String(contentsOf: transcriptPath, encoding: .utf8)
+        XCTAssertEqual(after, before, "Missing segments must not wipe or alter the saved transcript")
+        let warnings = try XCTUnwrap(pQueue.jobs.first?.warnings)
+        XCTAssertTrue(
+            warnings.contains { $0.contains("no saved transcript segments") },
+            "User should be warned the re-run could not re-segment — got: \(warnings)",
+        )
+    }
+
     /// Factory helper for the mode-override integration tests. Returns a
     /// `MockDiarization` with `.mode` set + a small fixture result keyed off
     /// the mode, so the two test bodies can verify which provider was used.

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -2275,6 +2275,53 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// A transcript-write failure during the re-run rewrite (e.g. the output
+    /// directory vanished) must degrade gracefully: the rewrite's catch swallows
+    /// it and the job still reaches a terminal state rather than wedging.
+    func testLateRerunTranscriptWriteFailureIsNonFatal() async throws {
+        let (pQueue, mockDiar, jobID) = try await makeSingleSourceJobAtNamingPending(
+            title: "Write Fail Test",
+            transcriptSegments: [
+                TimestampedSegment(start: 0, end: 5, text: "Hello"),
+                TimestampedSegment(start: 5, end: 10, text: "World"),
+            ],
+        )
+
+        // Force the rewrite's write to fail: delete the protocols directory so
+        // the atomic write to the job's transcriptPath has no parent. The
+        // persisted segments live in recordings/, so loadCachedSegments still
+        // succeeds and the failure lands in the write (not the no-segments early
+        // return). Confirm (not skip) so the job still reaches .done despite the
+        // now-missing transcript file.
+        try FileManager.default.removeItem(at: tmpDir.appendingPathComponent("protocols"))
+
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"),
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"),
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5], autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0], "SPEAKER_1": [0, 1, 0]],
+        )
+        pQueue.speakerNamingHandler = { _ in .confirmed([:]) }
+        let done = XCTestExpectation(description: "done despite write failure")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+        let transcriptPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
+        pQueue.completeSpeakerNaming(jobID: jobID, result: .rerun(2))
+        await fulfillment(of: [done], timeout: 60)
+
+        XCTAssertEqual(pQueue.jobs.first?.state, .done, "Write failure during re-segmentation must not wedge the job")
+        // Proves the write genuinely failed (exercising the rewrite's catch):
+        // the atomic write can't recreate the deleted parent directory, so no
+        // transcript file exists afterwards.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: transcriptPath.path),
+            "The rewrite write must have failed (no parent dir), exercising the catch path",
+        )
+    }
+
     /// Factory helper for the mode-override integration tests. Returns a
     /// `MockDiarization` with `.mode` set + a small fixture result keyed off
     /// the mode, so the two test bodies can verify which provider was used.

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -862,6 +862,41 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// Drive a single-source job through the pipeline to `.speakerNamingPending`
+    /// with a one-speaker initial diarization, returning the queue, the mock
+    /// diarizer (set `resultToReturn` to a multi-speaker result for the re-run),
+    /// and the job id. Shared setup for the late-rerun re-segmentation tests.
+    private func makeSingleSourceJobAtNamingPending(
+        title: String, transcriptSegments: [TimestampedSegment],
+    ) async throws -> (PipelineQueue, MockDiarization, UUID) {
+        let engine = MockEngine()
+        engine.segmentsToReturn = transcriptSegments
+        let mockDiar = MockDiarization()
+        let span = transcriptSegments.last?.end ?? 0
+        // Initial diarization collapses everything onto one speaker.
+        mockDiar.resultToReturn = DiarizationResult(
+            segments: [.init(start: transcriptSegments.first?.start ?? 0, end: span, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": span],
+            autoNames: [:],
+            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        )
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine, diarizationFactory: { mockDiar }, diarizeEnabled: true,
+        )
+        let job = try PipelineJob(
+            meetingTitle: title, appName: "Teams",
+            mixPath: createTestAudioFile(in: tmpDir), appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        let pending = XCTestExpectation(description: "speakerNamingPending")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .speakerNamingPending { pending.fulfill() }
+        }
+        await pQueue.processNext()
+        await fulfillment(of: [pending], timeout: 10)
+        return (pQueue, mockDiar, job.id)
+    }
+
     func testDiarizeSingleSourceLabelsTranscriptWithAutoNames() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello world")]
@@ -2052,41 +2087,14 @@ final class PipelineQueueTests: XCTestCase {
     /// (shown in the dialog), but Confirm only string-replaced the single label
     /// present in the saved transcript — so the .txt still had one speaker.
     func testLateRerunConfirmRebuildsTranscriptWithNewSpeakers() async throws {
-        let engine = MockEngine()
-        engine.segmentsToReturn = [
-            TimestampedSegment(start: 0, end: 5, text: "Hello"),
-            TimestampedSegment(start: 5, end: 10, text: "How are you"),
-            TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
-        ]
-        let mockDiar = MockDiarization()
-        // Initial diarization collapses everything onto one speaker.
-        mockDiar.resultToReturn = DiarizationResult(
-            segments: [.init(start: 0, end: 15, speaker: "SPEAKER_0")],
-            speakingTimes: ["SPEAKER_0": 15],
-            autoNames: [:],
-            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        let (pQueue, mockDiar, jobID) = try await makeSingleSourceJobAtNamingPending(
+            title: "Rerun Rebuild Test",
+            transcriptSegments: [
+                TimestampedSegment(start: 0, end: 5, text: "Hello"),
+                TimestampedSegment(start: 5, end: 10, text: "How are you"),
+                TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
+            ],
         )
-        let (pQueue, _) = makeMockProcessingQueue(
-            engine: engine,
-            diarizationFactory: { mockDiar },
-            diarizeEnabled: true,
-        )
-
-        let audioPath = try createTestAudioFile(in: tmpDir)
-        let job = PipelineJob(
-            meetingTitle: "Rerun Rebuild Test",
-            appName: "Teams",
-            mixPath: audioPath,
-            appPath: nil, micPath: nil, micDelay: 0,
-        )
-        pQueue.enqueue(job)
-
-        let pendingExpectation = XCTestExpectation(description: "speakerNamingPending")
-        pQueue.onJobStateChange = { _, _, newState in
-            if newState == .speakerNamingPending { pendingExpectation.fulfill() }
-        }
-        await pQueue.processNext()
-        await fulfillment(of: [pendingExpectation], timeout: 10)
 
         // Sanity: the initial transcript really did collapse to one speaker.
         let initialPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
@@ -2113,7 +2121,7 @@ final class PipelineQueueTests: XCTestCase {
         pQueue.onJobStateChange = { _, _, newState in
             if newState == .done { doneExpectation.fulfill() }
         }
-        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        pQueue.completeSpeakerNaming(jobID: jobID, result: .rerun(3))
         await fulfillment(of: [doneExpectation], timeout: 60)
 
         let finalPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
@@ -2190,32 +2198,14 @@ final class PipelineQueueTests: XCTestCase {
     /// segmentation into the saved transcript — the rewrite must not depend on
     /// a confirm mapping.
     func testLateRerunSkipKeepsRebuiltSegmentation() async throws {
-        let engine = MockEngine()
-        engine.segmentsToReturn = [
-            TimestampedSegment(start: 0, end: 5, text: "Hello"),
-            TimestampedSegment(start: 5, end: 10, text: "How are you"),
-            TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
-        ]
-        let mockDiar = MockDiarization()
-        mockDiar.resultToReturn = DiarizationResult(
-            segments: [.init(start: 0, end: 15, speaker: "SPEAKER_0")],
-            speakingTimes: ["SPEAKER_0": 15], autoNames: [:],
-            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        let (pQueue, mockDiar, jobID) = try await makeSingleSourceJobAtNamingPending(
+            title: "Rerun Skip Test",
+            transcriptSegments: [
+                TimestampedSegment(start: 0, end: 5, text: "Hello"),
+                TimestampedSegment(start: 5, end: 10, text: "How are you"),
+                TimestampedSegment(start: 10, end: 15, text: "Goodbye"),
+            ],
         )
-        let (pQueue, _) = makeMockProcessingQueue(
-            engine: engine, diarizationFactory: { mockDiar }, diarizeEnabled: true,
-        )
-        let job = try PipelineJob(
-            meetingTitle: "Rerun Skip Test", appName: "Teams",
-            mixPath: createTestAudioFile(in: tmpDir), appPath: nil, micPath: nil, micDelay: 0,
-        )
-        pQueue.enqueue(job)
-        let pending = XCTestExpectation(description: "speakerNamingPending")
-        pQueue.onJobStateChange = { _, _, newState in
-            if newState == .speakerNamingPending { pending.fulfill() }
-        }
-        await pQueue.processNext()
-        await fulfillment(of: [pending], timeout: 10)
 
         mockDiar.resultToReturn = DiarizationResult(
             segments: [
@@ -2231,7 +2221,7 @@ final class PipelineQueueTests: XCTestCase {
         pQueue.onJobStateChange = { _, _, newState in
             if newState == .done { done.fulfill() }
         }
-        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(3))
+        pQueue.completeSpeakerNaming(jobID: jobID, result: .rerun(3))
         await fulfillment(of: [done], timeout: 60)
 
         let finalTranscript = try String(contentsOf: XCTUnwrap(pQueue.jobs.first?.transcriptPath), encoding: .utf8)
@@ -2244,31 +2234,13 @@ final class PipelineQueueTests: XCTestCase {
     /// it does NOT wipe the transcript, and surfaces a warning so the user
     /// isn't silently misled into thinking the new speakers were applied.
     func testLateRerunWithoutPersistedSegmentsWarnsAndKeepsTranscript() async throws {
-        let engine = MockEngine()
-        engine.segmentsToReturn = [
-            TimestampedSegment(start: 0, end: 5, text: "Hello"),
-            TimestampedSegment(start: 5, end: 10, text: "World"),
-        ]
-        let mockDiar = MockDiarization()
-        mockDiar.resultToReturn = DiarizationResult(
-            segments: [.init(start: 0, end: 10, speaker: "SPEAKER_0")],
-            speakingTimes: ["SPEAKER_0": 10], autoNames: [:],
-            embeddings: ["SPEAKER_0": [1, 0, 0]],
+        let (pQueue, mockDiar, jobID) = try await makeSingleSourceJobAtNamingPending(
+            title: "No Segments Test",
+            transcriptSegments: [
+                TimestampedSegment(start: 0, end: 5, text: "Hello"),
+                TimestampedSegment(start: 5, end: 10, text: "World"),
+            ],
         )
-        let (pQueue, _) = makeMockProcessingQueue(
-            engine: engine, diarizationFactory: { mockDiar }, diarizeEnabled: true,
-        )
-        let job = try PipelineJob(
-            meetingTitle: "No Segments Test", appName: "Teams",
-            mixPath: createTestAudioFile(in: tmpDir), appPath: nil, micPath: nil, micDelay: 0,
-        )
-        pQueue.enqueue(job)
-        let pending = XCTestExpectation(description: "speakerNamingPending")
-        pQueue.onJobStateChange = { _, _, newState in
-            if newState == .speakerNamingPending { pending.fulfill() }
-        }
-        await pQueue.processNext()
-        await fulfillment(of: [pending], timeout: 10)
 
         let transcriptPath = try XCTUnwrap(pQueue.jobs.first?.transcriptPath)
         let before = try String(contentsOf: transcriptPath, encoding: .utf8)
@@ -2291,7 +2263,7 @@ final class PipelineQueueTests: XCTestCase {
         pQueue.onJobStateChange = { _, _, newState in
             if newState == .done { done.fulfill() }
         }
-        pQueue.completeSpeakerNaming(jobID: job.id, result: .rerun(2))
+        pQueue.completeSpeakerNaming(jobID: jobID, result: .rerun(2))
         await fulfillment(of: [done], timeout: 60)
 
         let after = try String(contentsOf: transcriptPath, encoding: .utf8)


### PR DESCRIPTION
## Problem

When a recording's first diarization under-counts speakers (e.g. a single-source `_mix.wav` collapsing to 2), re-running speaker naming from the re-openable dialog with a higher count correctly detects all speakers **in the dialog** — but after Confirm the saved transcript still shows only the original 2 speakers.

## Root cause

The production late-naming flow never blocks the pipeline: the transcript is saved with auto-names, then the dialog is re-opened later. On that path:

- A re-run (`.rerun` → `lateDiarization`) re-diarizes the audio, produces a fresh `DiarizationResult` with the new speaker count + new segment boundaries, shows it in the dialog, and stashes it — **but never rewrites the saved transcript.**
- Confirm (`.confirmed` → `reapplySpeakerNames`) only does a textual find-and-replace of speaker labels in the already-saved transcript.

So the re-run's new segmentation never reaches the `.txt`: the new labels don't exist in the old 2-speaker text, so the rename can only relabel the 2 slots that were already there. The persisted `<slug>_segments.json` (written for exactly this "late re-assignment" purpose) was never read back.

The inline/batch path doesn't have the bug because it renders the transcript from the *final* run after the naming loop.

## Fix

`lateDiarization` now re-segments and rewrites the saved transcript from the fresh diarization **before** re-showing the dialog, mirroring the batch path:

- `runLateDiarization` returns the full `DiarizationRun` (app/mic/combined) instead of just the combined result.
- A shared `renderLabeledTranscript` helper (extracted from `labeledTranscript`) labels the persisted transcript segments against the new run, and the result is written back (owner-only).
- The existing confirm/skip rename then operates on the correctly-segmented transcript.

Graceful degradation: when the persisted segments are absent (older recordings predating segment persistence), the rewrite is a no-op and a user-visible warning is added, so the re-run doesn't silently appear to succeed.

Also folds in a separate robustness fix: `lateDiarization` re-resolves the job index by id after the diarization `await` (the `@MainActor` queue can run the `completedJobLifetime` eviction during a long await, shifting the array and invalidating the index captured beforehand).

## Tests

- `testLateRerunConfirmRebuildsTranscriptWithNewSpeakers` — single-source: 1 speaker → re-run 3 → confirm yields 3 named speakers (red before the fix: only the first name survived).
- `testLateRerunConfirmRebuildsDualSourceTranscript` — dual-source remote track split into 2 speakers survives confirm.
- `testLateRerunSkipKeepsRebuiltSegmentation` — re-run + skip keeps the new auto-named speakers (the rewrite must not depend on a confirm mapping).
- `testLateRerunWithoutPersistedSegmentsWarnsAndKeepsTranscript` — missing segments → transcript untouched + warning surfaced.

Full suite green (excluding the pre-existing environment-sensitive `MenuBarIconSnapshotTests`); lint clean; release-build parity check passes.