### PR TITLE
fix(audiotap): default to ScreenCaptureKit so Teams/Zoom audio is captured

### DIFF
--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -134,7 +134,7 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `AudioConstants.swift` | Shared audio pipeline constants (target sample rate) |
 | `MicRecorder.swift` | Microphone recording via AVAudioEngine |
 | `FluidVAD.swift` | VAD preprocessing via FluidAudio Silero v6 — silence trimming + `VadSegmentMap` timeline remapping |
-| `tools/audiotap/Sources/` | AudioTapLib — CATapDescription-based app audio capture (SPM library) |
+| `tools/audiotap/Sources/` | AudioTapLib — app audio capture (SPM library); ScreenCaptureKit default + CATapDescription fallback |
 
 ### Support
 
@@ -234,14 +234,24 @@ Configurable in **Settings → Audio → Per-Channel Indicator**: master toggle 
 ### Capture
 
 ```
-AudioTapLib (CATapDescription)
-├─ Input: App PID → CoreAudio process tap → aggregate device
+AudioTapLib (default: ScreenCaptureKit; fallback: CATapDescription)
+├─ Input: system audio mix (all apps − self) → SCStream(capturesAudio)
 ├─ Output: Interleaved float32 (mono or stereo) → FileHandle (raw PCM)
 ├─ Mic: AVAudioEngine → mono WAV file (MicCaptureHandler)
 └─ Metadata: micDelay, actualSampleRate, actualChannels via AudioCaptureResult
 ```
 
-**Key:** CATapDescription requires NO Screen Recording permission (purple dot indicator only). Handles output device changes by recreating tap automatically.
+**Backends** (`AppAudioCapturing`, selected by `AudioCaptureSession`):
+
+- **`SCKAudioCapture` (default)** — ScreenCaptureKit. Captures conferencing apps
+  (Microsoft Teams, Zoom) whose call audio is rendered through WebRTC /
+  Voice-Processing pipelines a process tap reads back as zero-filled silence.
+  Follows output-device changes automatically. Requires Screen Recording
+  permission.
+- **`AppAudioCapture`** — CoreAudio `CATapDescription` global process tap. Lower
+  overhead but silent for Teams/Zoom; opt back in with
+  `MEETINGTRANSCRIBER_AUDIO_BACKEND=catap`. Recreates the tap on output-device
+  changes.
 
 ### Processing (DualSourceRecorder.stop())
 

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -195,6 +195,7 @@ require_command curl
 require_command jq
 require_command swift
 require_command codesign
+require_command python3  # scripts/wav_rms.py — app-track silence guard
 
 [ -f "$SIMULATOR_FIXTURE" ] || fail "simulator fixture not found: $SIMULATOR_FIXTURE"
 
@@ -493,6 +494,29 @@ run_one_record_only_meeting() {
     # → expect > 64 KB even after worst-case truncation.
     [ "$mix_size" -gt 65536 ] || fail "$label: mix WAV suspiciously small: $mix_size bytes (expected > 64 KB)"
     log "$label: mix WAV $mix_path ($mix_size bytes)"
+
+    # The mix-size check above only proves bytes were written — a fully silent
+    # app track (the Teams/Zoom "all-zeros capture" failure mode) is byte-for-
+    # byte the same size as a good one, and the mic can mask it in the mix via
+    # speaker bleed. So assert the *app* track itself carries energy: the
+    # simulator plays the fixture for the whole meeting, so a silent app track
+    # means system-audio capture is broken (e.g. wrong/regressed backend).
+    local app_filename app_path app_dbfs app_min
+    app_min="${E2E_APP_TRACK_MIN_DBFS:--60}"
+    app_filename="$(jq -r '.files.app // empty' "$sidecar")"
+    if [ -n "$app_filename" ]; then
+        app_path="$sidecar_dir/$app_filename"
+        [ -f "$app_path" ] || fail "$label: app track WAV not found: $app_path"
+        app_dbfs="$(python3 "$SCRIPT_DIR/wav_rms.py" "$app_path")" \
+            || fail "$label: could not measure app track RMS ($app_path)"
+        if awk -v v="$app_dbfs" -v t="$app_min" 'BEGIN { exit !(v > t) }'; then
+            log "$label: app track $app_filename energy ${app_dbfs} dBFS (> ${app_min}) — capture OK"
+        else
+            fail "$label: app track $app_filename is SILENT (${app_dbfs} dBFS ≤ ${app_min} dBFS) — system-audio capture produced no signal. Conferencing apps (Teams/Zoom) are silent under the CATapDescription process tap; the SCK backend is required. Check AudioCaptureSession.selectedBackend / MEETINGTRANSCRIBER_AUDIO_BACKEND."
+        fi
+    else
+        log "$label: sidecar has no app track (.files.app null) — skipping app-track energy check"
+    fi
 
     # Negative: record-only short-circuits before VAD/transcription/protocol.
     # No `.txt`/`.md` files from THIS meeting should exist in recordings/.

--- a/scripts/wav_rms.py
+++ b/scripts/wav_rms.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Print the mean RMS level of a WAV file in dBFS.
+
+Used by the live-recording E2E (scripts/e2e-app.sh) to assert that a captured
+*track* actually carries audio — a silent-but-full-size WAV (the Teams/Zoom
+"app track is all zeros" failure mode) is otherwise indistinguishable from a
+real recording by file size alone.
+
+Reads integer PCM WAV (what AudioMixer.saveWAV writes: 16-bit mono). Prints a
+single float dBFS value to stdout; silence floors at -120.0. Exit code is 0 on
+success, 1 on unreadable/unsupported input.
+
+Usage:
+    wav_rms.py <file.wav>
+"""
+import math
+import sys
+import wave
+from array import array
+
+SILENCE_FLOOR_DBFS = -120.0
+
+
+def rms_dbfs(path: str) -> float:
+    with wave.open(path, "rb") as w:
+        sampwidth = w.getsampwidth()
+        nframes = w.getnframes()
+        raw = w.readframes(nframes)
+
+    if nframes == 0 or not raw:
+        return SILENCE_FLOOR_DBFS
+
+    # AudioMixer.saveWAV emits 16-bit signed PCM. Support the common widths so
+    # the helper stays useful if that ever changes; reject anything exotic.
+    if sampwidth == 2:
+        samples = array("h")  # signed 16-bit
+        full_scale = 32768.0
+    elif sampwidth == 4:
+        samples = array("i")  # signed 32-bit
+        full_scale = 2147483648.0
+    elif sampwidth == 1:
+        # WAV 8-bit is unsigned; recentre to signed.
+        samples = array("b", bytes((b - 128) & 0xFF for b in raw))
+        full_scale = 128.0
+        raw = None  # already consumed
+    else:
+        raise ValueError(f"unsupported sample width: {sampwidth} bytes")
+
+    if raw is not None:
+        samples.frombytes(raw)
+
+    if len(samples) == 0:
+        return SILENCE_FLOOR_DBFS
+
+    acc = 0.0
+    for s in samples:
+        n = s / full_scale
+        acc += n * n
+    mean_sq = acc / len(samples)
+    if mean_sq <= 0:
+        return SILENCE_FLOOR_DBFS
+    return max(SILENCE_FLOOR_DBFS, 20.0 * math.log10(math.sqrt(mean_sq)))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: wav_rms.py <file.wav>", file=sys.stderr)
+        return 1
+    try:
+        print(f"{rms_dbfs(sys.argv[1]):.2f}")
+        return 0
+    except (OSError, wave.Error, ValueError) as exc:
+        print(f"wav_rms: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audiotap/Sources/AppAudioCapturing.swift
+++ b/tools/audiotap/Sources/AppAudioCapturing.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Common surface for the system/app-audio capture backends consumed by
+/// `AudioCaptureSession`. Two implementations exist:
+///
+/// - `SCKAudioCapture` — ScreenCaptureKit system-audio capture. This is the
+///   default. It captures the audio of every app you can hear, *including*
+///   conferencing apps (Microsoft Teams, Zoom) that render their call audio
+///   through WebRTC / Voice-Processing pipelines a CoreAudio process tap
+///   cannot see.
+/// - `AppAudioCapture` — CoreAudio process tap (`CATapDescription`). Lighter
+///   weight and lower latency, but Teams/Zoom call audio arrives zero-filled
+///   (silent) because their downlink bypasses the process-tap mixdown. Kept as
+///   an opt-in fallback via `MEETINGTRANSCRIBER_AUDIO_BACKEND=catap`.
+///
+/// Both deliver interleaved float32 PCM to the same file descriptor, so the
+/// downstream mix/resample pipeline is backend-agnostic.
+@available(macOS 14.2, *)
+protocol AppAudioCapturing: AnyObject {
+    /// Begin capturing. Throws if the backend cannot start (missing permission,
+    /// no display, tap creation failure).
+    func start() throws
+
+    /// Stop capturing and drain any pending writes before the caller closes the
+    /// output file descriptor.
+    func stop()
+
+    /// Instantaneous capture level in dBFS, decayed to -120 when no buffer has
+    /// arrived in the last 0.5 s. Drives the menu-bar silence indicator.
+    var currentLevelDBFS: Double { get }
+
+    /// `mach_absolute_time()` of the first delivered audio buffer (0 before any).
+    /// Used to align the app track against the mic track.
+    var appFirstFrameTime: UInt64 { get }
+
+    /// Actual sample rate observed from the delivered buffers.
+    var actualSampleRate: Int { get }
+
+    /// Actual channel count observed from the delivered buffers.
+    var actualChannels: Int { get }
+}
+
+@available(macOS 14.2, *)
+extension AppAudioCapture: AppAudioCapturing {}

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -15,9 +15,29 @@ public class AudioCaptureSession {
     private let micDeviceUID: String?
     private let debugLogging: Bool
 
-    private var appCapture: AppAudioCapture?
+    private var appCapture: (any AppAudioCapturing)?
     private var micCapture: MicCaptureHandler?
     private var appFileHandle: FileHandle?
+
+    /// Selects the system/app-audio capture backend.
+    enum AudioBackend {
+        /// ScreenCaptureKit — captures conferencing apps (Teams/Zoom) correctly.
+        case screenCaptureKit
+        /// CoreAudio process tap — lighter, but misses Teams/Zoom downlink.
+        case processTap
+    }
+
+    /// Backend resolved from `MEETINGTRANSCRIBER_AUDIO_BACKEND`. Defaults to
+    /// ScreenCaptureKit because the process tap captures only silence for
+    /// Teams/Zoom calls; set `catap` to opt back into the process tap.
+    static var selectedBackend: AudioBackend {
+        switch ProcessInfo.processInfo.environment["MEETINGTRANSCRIBER_AUDIO_BACKEND"]?.lowercased() {
+        case "catap", "processtap", "tap":
+            .processTap
+        default:
+            .screenCaptureKit
+        }
+    }
 
     public init(
         pid: pid_t,
@@ -48,17 +68,32 @@ public class AudioCaptureSession {
         )
         let handle = try FileHandle(forWritingTo: appOutputURL)
 
-        let capture = AppAudioCapture(
-            pid: pid,
-            outputFileDescriptor: handle.fileDescriptor,
-            sampleRate: sampleRate,
-            channels: channels,
-            debugLogging: debugLogging,
-        )
+        let capture: any AppAudioCapturing
+        switch Self.selectedBackend {
+        case .screenCaptureKit:
+            capture = SCKAudioCapture(
+                outputFileDescriptor: handle.fileDescriptor,
+                sampleRate: sampleRate,
+                channels: channels,
+                debugLogging: debugLogging,
+            )
+        case .processTap:
+            capture = AppAudioCapture(
+                pid: pid,
+                outputFileDescriptor: handle.fileDescriptor,
+                sampleRate: sampleRate,
+                channels: channels,
+                debugLogging: debugLogging,
+            )
+        }
         do {
             try capture.start()
         } catch {
             try? handle.close()
+            // Don't leave a 0-byte temp file behind when tap creation fails
+            // (e.g. -12988 permission denied) — DualSourceRecorder's stop()
+            // cleanup path doesn't run because start() threw.
+            try? FileManager.default.removeItem(at: appOutputURL)
             throw error
         }
         appFileHandle = handle

--- a/tools/audiotap/Sources/SCKAudioCapture.swift
+++ b/tools/audiotap/Sources/SCKAudioCapture.swift
@@ -1,0 +1,336 @@
+import CoreMedia
+import Foundation
+import os.log
+import ScreenCaptureKit
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "SCKAudioCapture")
+
+/// System-audio capture via ScreenCaptureKit (`SCStream` with `capturesAudio`).
+///
+/// Unlike the CoreAudio process tap (`AppAudioCapture`), ScreenCaptureKit taps
+/// the system audio mix at a stage that *includes* conferencing apps which
+/// render their call audio through non-standard pipelines — Microsoft Teams and
+/// Zoom in particular, whose downlink is zero-filled when read through a process
+/// tap. This is the default app-audio backend for that reason.
+///
+/// Captures everything you can hear except this process's own audio
+/// (`excludesCurrentProcessAudio`), matching the previous global-tap behaviour
+/// so single-app meetings are captured cleanly. Output is interleaved float32
+/// PCM written to `outputFileDescriptor`, identical in layout to the process-tap
+/// backend so the downstream mix/resample pipeline is unchanged.
+@available(macOS 14.2, *)
+public final class SCKAudioCapture: NSObject {
+    private let sampleRate: Int
+    private let channels: Int
+    private let outputFileDescriptor: Int32
+    private let debugLogging: Bool
+
+    private var stream: SCStream?
+    private var isRunning = false
+
+    /// Serial queue that both receives SCStream sample buffers and performs the
+    /// blocking file writes, so buffer handling never races and the
+    /// `interleaveScratch` reuse below is single-threaded.
+    private let writeQueue = DispatchQueue(label: "audiotap.sck.writer", qos: .userInteractive)
+
+    private var debugRMS = DebugRMSReporter()
+    private var debugTotalBytes: UInt64 = 0
+    private let levelPublisher = LevelPublisher()
+
+    /// Reused interleave buffer for the non-interleaved (planar) SCK path.
+    /// writeQueue-confined — never touch from another thread.
+    private var interleaveScratch = [Float]()
+
+    public private(set) var appFirstFrameTime: UInt64 = 0
+    public private(set) var actualSampleRate: Int = 0
+    public private(set) var actualChannels: Int = 0
+    private var didLogFormat = false
+
+    public var currentLevelDBFS: Double {
+        levelPublisher.currentLevelDBFS
+    }
+
+    /// - Parameters:
+    ///   - outputFileDescriptor: File descriptor to write raw interleaved
+    ///     float32 PCM to.
+    ///   - sampleRate: Requested capture sample rate (default 48000).
+    ///   - channels: Requested channel count (default 2).
+    ///   - debugLogging: Emit periodic RMS-energy log lines.
+    public init(
+        outputFileDescriptor: Int32,
+        sampleRate: Int = 48000,
+        channels: Int = 2,
+        debugLogging: Bool = false,
+    ) {
+        self.outputFileDescriptor = outputFileDescriptor
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.debugLogging = debugLogging
+        super.init()
+    }
+
+    public func start() throws {
+        let content = try fetchShareableContent()
+        guard let display = content.displays.first else {
+            throw NSError(
+                domain: "audiotap.sck", code: -1,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "No display available for ScreenCaptureKit audio capture"],
+            )
+        }
+
+        // Audio-only intent, but SCK requires a content filter rooted at a
+        // display and (on some macOS versions) only pumps audio while a video
+        // stream is also running. A 2×2 @ 1 fps video config keeps that path
+        // alive at negligible cost; the frames are received and discarded.
+        let filter = SCContentFilter(
+            display: display, excludingApplications: [], exceptingWindows: [],
+        )
+
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.sampleRate = sampleRate
+        config.channelCount = channels
+        config.excludesCurrentProcessAudio = true
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+        config.queueDepth = 6
+
+        let newStream = SCStream(filter: filter, configuration: config, delegate: self)
+        try newStream.addStreamOutput(self, type: .audio, sampleHandlerQueue: writeQueue)
+        // Consume the throwaway video stream too; see the 2×2 note above.
+        try newStream.addStreamOutput(self, type: .screen, sampleHandlerQueue: writeQueue)
+
+        isRunning = true
+        do {
+            try startStream(newStream)
+        } catch {
+            isRunning = false
+            throw error
+        }
+        stream = newStream
+
+        // Authoritative format is read from the first delivered buffer; seed
+        // with the requested values so callers have something before then.
+        actualSampleRate = sampleRate
+        actualChannels = channels
+
+        if debugLogging {
+            logger.info(
+                "[debug] SCK audio capture started on display \(display.displayID, privacy: .public) (requested \(self.sampleRate, privacy: .public) Hz, \(self.channels, privacy: .public)ch)",
+            )
+        }
+        logger.info("SCK audio capture started (rate: \(self.sampleRate) Hz, \(self.channels)ch)")
+    }
+
+    public func stop() {
+        isRunning = false
+        if let stream {
+            let sem = DispatchSemaphore(value: 0)
+            stream.stopCapture { error in
+                if let error {
+                    logger.warning("SCK stopCapture error: \(error.localizedDescription, privacy: .public)")
+                }
+                sem.signal()
+            }
+            _ = sem.wait(timeout: .now() + 5)
+            self.stream = nil
+        }
+        // Drain pending buffer-handling/writes before the caller closes the fd —
+        // a late buffer must not write to a recycled descriptor.
+        writeQueue.sync {}
+        didLogFormat = false
+        if debugLogging {
+            logger.info("[debug] SCK audio capture stopping: totalBytes=\(self.debugTotalBytes, privacy: .public)")
+        }
+        logger.info("SCK audio capture stopped")
+    }
+
+    // MARK: - SCK lifecycle bridging (async → sync)
+
+    /// Fetch shareable content, blocking the caller until SCK responds. SCK's
+    /// completion runs on an internal queue (never the caller's thread), so the
+    /// semaphore wait can't deadlock.
+    private func fetchShareableContent() throws -> SCShareableContent {
+        let sem = DispatchSemaphore(value: 0)
+        var result: Result<SCShareableContent, Error> = .failure(NSError(
+            domain: "audiotap.sck", code: -2,
+            userInfo: [NSLocalizedDescriptionKey: "ScreenCaptureKit content query did not complete"],
+        ))
+        SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { content, error in
+            if let content {
+                result = .success(content)
+            } else if let error {
+                result = .failure(error)
+            }
+            sem.signal()
+        }
+        guard sem.wait(timeout: .now() + 10) == .success else {
+            throw NSError(
+                domain: "audiotap.sck", code: -3,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "Timed out querying ScreenCaptureKit shareable content"],
+            )
+        }
+        return try result.get()
+    }
+
+    private func startStream(_ stream: SCStream) throws {
+        let sem = DispatchSemaphore(value: 0)
+        var startError: Error?
+        stream.startCapture { error in
+            startError = error
+            sem.signal()
+        }
+        guard sem.wait(timeout: .now() + 10) == .success else {
+            throw NSError(
+                domain: "audiotap.sck", code: -4,
+                userInfo: [NSLocalizedDescriptionKey: "Timed out starting ScreenCaptureKit capture"],
+            )
+        }
+        if let startError { throw startError }
+    }
+
+    // MARK: - Audio handling
+
+    private func handleAudio(_ sampleBuffer: CMSampleBuffer) {
+        guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbdPtr = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc) else { return }
+        let asbd = asbdPtr.pointee
+        let channelCount = Int(asbd.mChannelsPerFrame)
+        guard channelCount > 0 else { return }
+
+        var blockBuffer: CMBlockBuffer?
+        var sizeNeeded = 0
+        CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: &sizeNeeded,
+            bufferListOut: nil,
+            bufferListSize: 0,
+            blockBufferAllocator: nil,
+            blockBufferMemoryAllocator: nil,
+            flags: 0,
+            blockBufferOut: nil,
+        )
+        guard sizeNeeded > 0 else { return }
+
+        let ablRaw = UnsafeMutableRawPointer.allocate(
+            byteCount: sizeNeeded, alignment: MemoryLayout<AudioBufferList>.alignment,
+        )
+        defer { ablRaw.deallocate() }
+        let ablPtr = ablRaw.assumingMemoryBound(to: AudioBufferList.self)
+
+        let status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: ablPtr,
+            bufferListSize: sizeNeeded,
+            blockBufferAllocator: nil,
+            blockBufferMemoryAllocator: nil,
+            flags: 0,
+            blockBufferOut: &blockBuffer,
+        )
+        guard status == noErr else { return }
+        // blockBuffer retains the backing samples for the body of this method.
+        let list = UnsafeMutableAudioBufferListPointer(ablPtr)
+        guard list.count > 0 else { return }
+
+        if !didLogFormat {
+            didLogFormat = true
+            if appFirstFrameTime == 0 {
+                appFirstFrameTime = mach_absolute_time()
+            }
+            actualChannels = channelCount
+            actualSampleRate = Int(asbd.mSampleRate)
+            logger.info(
+                "SCK audio format: \(self.actualSampleRate) Hz, \(self.actualChannels)ch, \(list.count) buffers",
+            )
+        }
+
+        let isNonInterleaved = (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
+        if isNonInterleaved, channelCount > 1 {
+            writeInterleaving(list: list, channelCount: channelCount)
+        } else if let data = list[0].mData {
+            // Already interleaved (or mono) — write straight through.
+            let byteCount = Int(list[0].mDataByteSize)
+            writeAllToFileHandle(outputFileDescriptor, data, count: byteCount)
+            accumulate(dataPtr: data, byteCount: byteCount)
+        }
+    }
+
+    /// Interleave planar (non-interleaved) SCK buffers into a single
+    /// L,R,L,R… float32 stream and write it. Reuses `interleaveScratch`.
+    private func writeInterleaving(list: UnsafeMutableAudioBufferListPointer, channelCount: Int) {
+        let frames = Int(list[0].mDataByteSize) / MemoryLayout<Float>.size
+        guard frames > 0 else { return }
+        let total = frames * channelCount
+        if interleaveScratch.count < total {
+            interleaveScratch = [Float](repeating: 0, count: total)
+        }
+
+        interleaveScratch.withUnsafeMutableBufferPointer { out in
+            for ch in 0 ..< channelCount {
+                guard let chData = list[ch].mData else { continue }
+                let src = chData.assumingMemoryBound(to: Float.self)
+                for i in 0 ..< frames {
+                    out[i * channelCount + ch] = src[i]
+                }
+            }
+        }
+
+        let byteCount = total * MemoryLayout<Float>.size
+        interleaveScratch.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            writeAllToFileHandle(outputFileDescriptor, base, count: byteCount)
+            accumulate(dataPtr: base, byteCount: byteCount)
+        }
+    }
+
+    /// Accumulate RMS energy, publish the instantaneous level, and emit the
+    /// throttled debug log line. Mirrors `AppAudioCapture`'s metering so the
+    /// menu-bar indicator behaves identically across backends.
+    private func accumulate(dataPtr: UnsafeRawPointer, byteCount: Int) {
+        let count = byteCount / MemoryLayout<Float>.size
+        guard count > 0 else { return }
+        let buf = UnsafeBufferPointer(
+            start: dataPtr.assumingMemoryBound(to: Float.self), count: count,
+        )
+        var sumSq: Double = 0
+        for sample in buf {
+            sumSq += Double(sample) * Double(sample)
+        }
+        debugRMS.add(sumSq: sumSq, samples: count)
+        debugTotalBytes += UInt64(byteCount)
+        levelPublisher.publish(level: debugRMS.lastLevelDBFS)
+
+        guard let report = debugRMS.tick(), debugLogging else { return }
+        let dBStr = String(format: "%.1f", report.dBFS)
+        logger.info(
+            "[debug] SCK app audio RMS (5s): \(dBStr, privacy: .public) dBFS, samples=\(report.samples, privacy: .public), totalBytes=\(self.debugTotalBytes, privacy: .public)",
+        )
+    }
+}
+
+// MARK: - SCStreamOutput / SCStreamDelegate
+
+@available(macOS 14.2, *)
+extension SCKAudioCapture: SCStreamOutput, SCStreamDelegate {
+    public func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType,
+    ) {
+        guard isRunning, type == .audio else { return }
+        guard sampleBuffer.isValid, CMSampleBufferGetNumSamples(sampleBuffer) > 0 else { return }
+        handleAudio(sampleBuffer)
+    }
+
+    public func stream(_ stream: SCStream, didStopWithError error: Error) {
+        logger.error("SCK stream stopped with error: \(error.localizedDescription, privacy: .public)")
+        isRunning = false
+    }
+}
+
+@available(macOS 14.2, *)
+extension SCKAudioCapture: AppAudioCapturing {}


### PR DESCRIPTION
## Problem

The app track is silent when recording **Microsoft Teams** and **Zoom** calls (resolves #79). CoreAudio process taps (`CATapDescription`) deliver zero-filled buffers for these apps — their call/downlink audio renders through WebRTC / Voice-Processing pipelines that the process-tap mixdown excludes. Apps with a conventional output path (e.g. Webex) are captured fine, which is why the failure looked app-specific.

## Fix

Add a **ScreenCaptureKit** capture backend (`SCStream` with `capturesAudio`) that taps the system audio mix — including conferencing apps — and make it the **default**. The CoreAudio process tap stays as an opt-in fallback via `MEETINGTRANSCRIBER_AUDIO_BACKEND=catap`.

- `SCKAudioCapture` — SCStream-based capture, planar→interleaved float32, same level metering as the tap path. Requires Screen Recording permission (already requested by the app).
- `AppAudioCapturing` — protocol both backends satisfy; `AudioCaptureSession` selects the backend.
- Both deliver identical interleaved float32 PCM, so the downstream mix/resample pipeline is unchanged.

## Regression guard

The record-only e2e previously only checked the **mix** WAV's size — but a fully silent app track is byte-for-byte the same size as a good one, and mic speaker-bleed masks it in the mix. Added:

- `scripts/wav_rms.py` — stdlib WAV mean-dBFS meter.
- `scripts/e2e-app.sh` — asserts the recorded **app track** carries energy (`> -60 dBFS`), so a silent-capture regression fails instead of passing on file size alone.

## Notes

- No new permissions (Screen Recording + Microphone already in entitlements/Info.plist).
- Verified: AudioTapLib + full app build clean; 70 audiotap tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)