### PR TITLE
refactor(app): converge speaker-naming test handler onto the production flow

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -672,24 +672,6 @@ class PipelineQueue {
         let combined: DiarizationResult?
     }
 
-    /// What the speaker-naming step decided for one diarization result: either
-    /// re-run diarization with a new speaker count, or finalize with this
-    /// speaker→name mapping.
-    private enum SpeakerNamingOutcome {
-        case rerun(Int)
-        case finalized([String: String])
-    }
-
-    /// Per-run matcher outputs needed to update the speaker DB and write
-    /// recognition forensics once the user confirms the naming dialog.
-    private struct RecognitionContext {
-        let matcher: SpeakerMatcher
-        let embeddings: [String: [Float]]
-        let speakingTimes: [String: TimeInterval]
-        let suggested: [String: String]
-        let topCandidates: [String: [TopCandidate]]
-    }
-
     /// Typed errors thrown by the pipeline stages.
     enum PipelineError: LocalizedError {
         case missingMixPath
@@ -898,31 +880,23 @@ class PipelineQueue {
         let mix16k = try await ensureMixAudio(workDir: workDir, ctx: ctx)
 
         do {
-            // Diarization + naming loop: re-runs if the user requests a
-            // different speaker count.
-            var speakerCount = numSpeakers > 0 ? numSpeakers : nil
+            let speakerCount = numSpeakers > 0 ? numSpeakers : nil
+            let run = try await runDiarization(
+                diarizeProcess: diarizeProcess, useDualTrack: transcription.isDualSource,
+                speakerCount: speakerCount, workDir: workDir, ctx: ctx,
+            )
+            // Match against the speaker DB and park the job for the (possibly
+            // late) naming dialog. A speaker-count/mode re-run is no longer an
+            // in-line loop here; it's driven after the job reaches
+            // `.speakerNamingPending` via `completeSpeakerNaming`, so both the
+            // interactive UI and the test handler take the same path.
             var autoNames: [String: String] = [:]
-            var run = DiarizationRun(app: nil, mic: nil, combined: nil)
-
-            namingLoop: while true {
-                run = try await runDiarization(
-                    diarizeProcess: diarizeProcess, useDualTrack: transcription.isDualSource,
-                    speakerCount: speakerCount, workDir: workDir, ctx: ctx,
-                )
-                guard let currentDiarization = run.combined else { break }
-                switch await resolveSpeakerNames(
+            if let currentDiarization = run.combined {
+                autoNames = resolveSpeakerNames(
                     diarization: currentDiarization, ctx: ctx,
                     diarizeProcess: diarizeProcess, isDualSource: transcription.isDualSource,
                     outputDir: outputDir,
-                ) {
-                case let .rerun(count):
-                    speakerCount = count
-                    continue namingLoop
-
-                case let .finalized(names):
-                    autoNames = names
-                }
-                break namingLoop
+                )
             }
 
             if let labeled = try await labeledTranscript(
@@ -1036,15 +1010,18 @@ class PipelineQueue {
     }
 
     /// Match a diarization result against the speaker DB, persist naming data +
-    /// recognition forensics, and drive the speaker-naming dialog. Returns
-    /// `.rerun` when the user asks for a different speaker count (the caller
-    /// loops), or `.finalized` with the speaker→name mapping to apply.
+    /// recognition forensics, and return the auto-name mapping to apply to the
+    /// transcript. Parks the job for the (possibly late) naming dialog by
+    /// stashing `SpeakerNamingData`; the dialog is driven later by
+    /// `completeSpeakerNaming`, so this stage never blocks the pipeline. A job
+    /// that opts out via `autoSkipNaming` (headless blocking-transcribe)
+    /// finishes on the auto-names without a dialog.
     private func resolveSpeakerNames(
         diarization: DiarizationResult, ctx: JobContext,
         diarizeProcess: any DiarizationProvider, isDualSource: Bool, outputDir: URL,
-    ) async -> SpeakerNamingOutcome {
+    ) -> [String: String] {
         // No embeddings → no matching or dialog; keep the diarizer's own names.
-        guard let embeddings = diarization.embeddings else { return .finalized(diarization.autoNames) }
+        guard let embeddings = diarization.embeddings else { return diarization.autoNames }
 
         let matcher = speakerMatcherFactory()
         let verbose = matcher.matchVerbose(embeddings: embeddings)
@@ -1096,78 +1073,20 @@ class PipelineQueue {
         stashedSuggestedAtDialog[ctx.jobID] = suggestedAtDialog
         stashedTopCandidates[ctx.jobID] = topCandidates
 
-        let recog = RecognitionContext(
-            matcher: matcher, embeddings: embeddings, speakingTimes: diarization.speakingTimes,
-            suggested: suggestedAtDialog, topCandidates: topCandidates,
-        )
-        return await applyNamingHandler(namingData: namingData, autoNames: autoNames, recog: recog, ctx: ctx)
-    }
-
-    /// Run the speaker-naming dialog (if a handler is installed) and turn its
-    /// result into a `SpeakerNamingOutcome`. With no handler (production), stash
-    /// the data and finalize on the auto-names without blocking; the re-openable
-    /// dialog confirms later. `.confirmed` updates the speaker DB + records
-    /// recognition forensics from `recog`.
-    private func applyNamingHandler(
-        namingData: SpeakerNamingData, autoNames: [String: String],
-        recog: RecognitionContext, ctx: JobContext,
-    ) async -> SpeakerNamingOutcome {
         if jobs.first(where: { $0.id == ctx.jobID })?.autoSkipNaming == true {
             // Headless blocking-transcribe: accept the auto-assigned names
-            // inline (exactly like a `.skipped` dialog result) so the job
-            // finishes on its own. Don't stash naming data — there is no
-            // interactive client to resolve it, and parking would wedge the
-            // job until the next launch's 24h stale-cleanup.
-            return .finalized(autoNames)
+            // (exactly like a `.skipped` dialog result) so the job finishes on
+            // its own. Don't stash naming data: there is no interactive client
+            // to resolve it, and parking would wedge the job until the next
+            // launch's 24h stale-cleanup.
+            return autoNames
         }
-        guard let handler = speakerNamingHandler else {
-            // Production: stash data, don't block the pipeline. The notification
-            // is posted later — after the job transitions to
-            // .speakerNamingPending — so the window's onAppear doesn't auto-close
-            // it on a state mismatch.
-            speakerNamingDataByJob[ctx.jobID] = namingData
-            return .finalized(autoNames)
-        }
-
-        switch await handler(namingData) {
-        case let .confirmed(userMapping):
-            var confirmed = autoNames
-            for (label, name) in userMapping where !name.isEmpty {
-                confirmed[label] = name
-            }
-            updateSpeakerDB(
-                matcher: recog.matcher, mapping: confirmed,
-                embeddings: recog.embeddings, speakingTimes: recog.speakingTimes,
-            )
-            recordRecognition(
-                suggested: recog.suggested, userMapping: userMapping,
-                topCandidates: recog.topCandidates, jobID: ctx.jobID, title: ctx.title,
-            )
-            removeNamingData(jobID: ctx.jobID, slug: nil)
-            return .finalized(confirmed)
-
-        case let .rerun(count):
-            return beginRerun(count: count, jobID: ctx.jobID)
-
-        case let .rerunWithMode(_, count):
-            // Mode override is only honoured by the production
-            // completeSpeakerNaming -> lateDiarization path. The inline
-            // test-handler loop can't swap providers mid-iteration without
-            // rebuilding the factory; treat as a same-mode re-run.
-            return beginRerun(count: count, jobID: ctx.jobID, logSuffix: " (mode override ignored in inline path)")
-
-        case .skipped:
-            return .finalized(autoNames)
-        }
-    }
-
-    /// Transition back to diarizing for a speaker-count re-run and return the
-    /// `.rerun` outcome the naming loop acts on.
-    private func beginRerun(count: Int, jobID: UUID, logSuffix: String = "") -> SpeakerNamingOutcome {
-        updateJobState(id: jobID, to: .diarizing)
-        startElapsedTimer()
-        logger.info("Re-running diarization with \(count) speakers\(logSuffix)")
-        return .rerun(count)
+        // Production/interactive: stash the naming data so `generateAndSaveProtocol`
+        // parks the job at `.speakerNamingPending` and pops the (re-openable)
+        // dialog. The pipeline continues with the auto-names; the dialog confirms
+        // later via `completeSpeakerNaming` without blocking.
+        speakerNamingDataByJob[ctx.jobID] = namingData
+        return autoNames
     }
 
     /// Apply speaker names to the transcript for whichever topology the run
@@ -1282,13 +1201,25 @@ class PipelineQueue {
         }
 
         stopElapsedTimer()
-        if speakerNamingDataByJob[ctx.jobID] != nil {
+        if let namingData = speakerNamingDataByJob[ctx.jobID] {
             updateJobState(id: ctx.jobID, to: .speakerNamingPending)
             // Auto-pop the dialog now that the job is in the right state.
             // The window's onAppear guard reads pendingSpeakerNamingJobs,
             // which only includes .speakerNamingPending jobs, so the
             // notification has to come after the transition above.
             NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
+            // Tests drive naming through an injected handler instead of the UI.
+            // Re-invoke it here, after the `.speakerNamingPending` transition,
+            // mirroring the late-rerun re-invocation, so the test path runs the
+            // exact same `completeSpeakerNaming` flow the production UI does
+            // (rerun/mode-override/skip cleanup all included) rather than a
+            // divergent in-line state machine.
+            if let handler = speakerNamingHandler {
+                Task {
+                    let result = await handler(namingData)
+                    self.completeSpeakerNaming(jobID: ctx.jobID, result: result)
+                }
+            }
         } else {
             updateJobState(id: ctx.jobID, to: .done)
         }
@@ -1353,6 +1284,12 @@ class PipelineQueue {
             matcher: matcher,
             mapping: fullMapping,
             embeddings: namingData.embeddings,
+            // Thread the per-speaker speaking times so the matcher's
+            // centroid-quality filter (short segments stay as fallback samples,
+            // long ones seed the centroid) sees real durations. The now-deleted
+            // in-line confirm path passed these; production dropped them. Keep
+            // the richer signal.
+            speakingTimes: namingData.speakingTimes,
         )
 
         if let transcriptPath = jobs[jobIndex].transcriptPath {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -557,9 +557,9 @@ class PipelineQueue {
     /// the recorded duration matches exactly what the menu's elapsed timer shows
     /// and excludes the speaker-naming pause (see `StageKind(jobState:)`).
     private func recordStageTransition(from oldState: JobState, to newState: JobState, jobID: UUID) {
-        // A same-state "transition" (e.g. the inline speaker-count rerun re-enters
-        // .diarizing while already .diarizing) is not a stage boundary — ignore it
-        // so it neither logs a partial event nor resets the start.
+        // A same-state "transition" (e.g. the confirm path re-enters
+        // .generatingProtocol while already .generatingProtocol) is not a stage
+        // boundary; ignore it so it neither logs a partial event nor resets the start.
         guard oldState != newState else { return }
         if let leaving = StageKind(jobState: oldState), let start = stageStartByJob.removeValue(forKey: jobID) {
             let elapsed = ContinuousClock.now - start

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1126,6 +1126,14 @@ final class PipelineQueueTests: XCTestCase {
             return .skipped
         }
 
+        // The handler now runs after the job reaches `.speakerNamingPending`
+        // (the production flow), in a detached Task that outlives
+        // `processNext()`, so wait for the terminal state before asserting.
+        let done = XCTestExpectation(description: "job reaches done")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+
         let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Naming Test",
@@ -1135,6 +1143,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         pQueue.enqueue(job)
         await pQueue.processNext()
+        await fulfillment(of: [done], timeout: 10)
 
         XCTAssertTrue(handlerCalled)
     }
@@ -1159,6 +1168,11 @@ final class PipelineQueueTests: XCTestCase {
 
         pQueue.speakerNamingHandler = { _ in .skipped }
 
+        let done = XCTestExpectation(description: "job reaches a terminal state")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done || newState == .error { done.fulfill() }
+        }
+
         let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Skip Test",
@@ -1168,6 +1182,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         pQueue.enqueue(job)
         await pQueue.processNext()
+        await fulfillment(of: [done], timeout: 10)
 
         // Should complete without error (auto names used)
         let finalState = pQueue.jobs.first?.state
@@ -1201,6 +1216,14 @@ final class PipelineQueueTests: XCTestCase {
             return .skipped
         }
 
+        // First handler call (`.rerun`) drives a late re-diarization; the second
+        // (`.skipped`) finishes the job. All of that runs in detached Tasks after
+        // `processNext()` returns, so wait for the terminal state.
+        let done = XCTestExpectation(description: "job done after rerun")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+
         let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Rerun Test",
@@ -1210,6 +1233,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         pQueue.enqueue(job)
         await pQueue.processNext()
+        await fulfillment(of: [done], timeout: 60)
 
         // Handler should be called twice (first returns rerun, second returns skipped)
         XCTAssertEqual(callCount, 2)
@@ -1217,6 +1241,62 @@ final class PipelineQueueTests: XCTestCase {
         // run uses the default (nil → auto), second uses the rerun's count (3).
         XCTAssertEqual(mockDiar.runCount, 2)
         XCTAssertEqual(mockDiar.receivedNumSpeakers, [nil, 3])
+    }
+
+    /// The batch pipeline reaches `.speakerNamingPending`, then the injected
+    /// naming handler returns `.rerunWithMode`. The mode override must be
+    /// honoured end-to-end: routed through the mode-aware factory and written
+    /// back onto the job's `usedDiarizerMode`. The now-deleted in-line handler
+    /// path silently downgraded this to a same-mode re-run and had zero
+    /// coverage; converging both paths onto `completeSpeakerNaming` fixes it.
+    func testSpeakerNamingRerunWithModeThroughHandlerHonorsMode() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let offlineDiar = makeModeOverrideDiar(.offline)
+        let sortformerDiar = makeModeOverrideDiar(.sortformer)
+        let modeOverrideCalls = OSAllocatedUnfairLock<[DiarizerMode]>(initialState: [])
+        let (pQueue, _) = makeMockProcessingQueue(
+            engine: engine,
+            diarizationFactory: { offlineDiar },
+            diarizationFactoryWithMode: { mode in
+                modeOverrideCalls.withLock { $0.append(mode) }
+                return mode == .sortformer ? sortformerDiar : offlineDiar
+            },
+            diarizeEnabled: true,
+        )
+
+        var callCount = 0
+        pQueue.speakerNamingHandler = { _ in
+            callCount += 1
+            // First presentation: ask to re-run in Sortformer mode. Second
+            // presentation (after the mode-override re-diarization): accept.
+            return callCount == 1 ? .rerunWithMode(.sortformer, 4) : .confirmed([:])
+        }
+
+        let done = XCTestExpectation(description: "job done after mode-override rerun")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Handler Mode Override", appName: "TestApp",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        pQueue.enqueue(job)
+        await pQueue.processNext()
+        await fulfillment(of: [done], timeout: 60)
+
+        XCTAssertEqual(callCount, 2, "handler is re-invoked after the mode-override re-diarization")
+        XCTAssertEqual(
+            modeOverrideCalls.withLock(\.self), [.sortformer],
+            "the handler's mode override must route through the mode-aware factory",
+        )
+        XCTAssertEqual(
+            pQueue.jobs.first?.usedDiarizerMode, .sortformer,
+            "the honoured mode must be recorded on the job",
+        )
+        XCTAssertEqual(pQueue.jobs.first?.state, .done)
     }
 
     func testCompleteSpeakerNamingDoubleResumeIsNoOp() {
@@ -1662,6 +1742,13 @@ final class PipelineQueueTests: XCTestCase {
 
         pQueue.speakerNamingHandler = { _ in .confirmed(["SPEAKER_0": "Alice"]) }
 
+        // Confirm runs after `.speakerNamingPending`, in a detached Task that
+        // outlives `processNext()`, so wait for the terminal state.
+        let done = XCTestExpectation(description: "job done after confirm")
+        pQueue.onJobStateChange = { _, _, newState in
+            if newState == .done { done.fulfill() }
+        }
+
         let audioPath = try createTestAudioFile(in: tmpDir)
         let job = PipelineJob(
             meetingTitle: "Confirm Test",
@@ -1671,6 +1758,7 @@ final class PipelineQueueTests: XCTestCase {
         )
         pQueue.enqueue(job)
         await pQueue.processNext()
+        await fulfillment(of: [done], timeout: 60)
 
         let finalState = pQueue.jobs.first?.state
         XCTAssertEqual(finalState, .done, "Confirmed naming should end as .done")

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -404,8 +404,17 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
         XCTAssertEqual(queue.jobs.count, 1)
 
+        // The naming handler now runs after the job reaches
+        // `.speakerNamingPending`, in a detached Task that outlives
+        // `processNext()`, so wait for the terminal state before asserting.
+        let done = XCTestExpectation(description: "job reaches a terminal state")
+        queue.onJobStateChange = { _, _, newState in
+            if newState == .done || newState == .error { done.fulfill() }
+        }
+
         // Process the job (real transcription + real diarization)
         await queue.processNext()
+        await fulfillment(of: [done], timeout: 120)
 
         // Verify protocol was generated
         XCTAssertTrue(mockProtocol.generateCalled, "Protocol generator should have been called")

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -102,6 +102,19 @@ final class WorkflowIntegrationTests: XCTestCase {
         )
     }
 
+    /// Wait until the (single) job reaches a terminal state. Speaker naming was
+    /// converged onto the async production flow: the injected handler now runs
+    /// after the job reaches `.speakerNamingPending`, in a detached Task that
+    /// outlives `processNext()`. Tests asserting on the final state must wait
+    /// for it rather than reading it right after `processNext()` returns.
+    private func awaitJobTerminalState(_ queue: PipelineQueue, timeout: TimeInterval = 10) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let state = queue.jobs.first?.state, state == .done || state == .error { return }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     // MARK: - Happy Path: Single-Source, No Diarization
 
     func testWorkflowSingleSourceNoDiarization() async throws {
@@ -150,11 +163,21 @@ final class WorkflowIntegrationTests: XCTestCase {
         let job = makeJob(audioPath: h.audioPath)
         h.queue.enqueue(job)
         await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
 
-        // State transitions: waiting → transcribing → diarizing → generatingProtocol → done
+        // State transitions: waiting → transcribing → diarizing →
+        // speakerNamingPending → generatingProtocol → done. The confirm path
+        // re-enters .generatingProtocol (completeSpeakerNaming transitions the
+        // pending job, then the transcript-rewrite calls generateProtocol),
+        // which fires an identical consecutive state-change. Collapse those
+        // before comparing so the assertion pins the stage ORDER, not the
+        // production path's internal re-entry.
+        let stageOrder = collector.transitions.map(\.1).reduce(into: [JobState]()) { acc, state in
+            if acc.last != state { acc.append(state) }
+        }
         XCTAssertEqual(
-            collector.transitions.map(\.1),
-            [.transcribing, .diarizing, .generatingProtocol, .done],
+            stageOrder,
+            [.transcribing, .diarizing, .speakerNamingPending, .generatingProtocol, .done],
         )
 
         // Diarization called once, protocol generated
@@ -265,6 +288,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         )
         h.queue.enqueue(job)
         await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
 
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
         XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path), "user app source preserved")
@@ -400,6 +424,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         let job = try makeDualSourceJob(audioPath: h.audioPath)
         h.queue.enqueue(job)
         await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
 
         let finalJob = try XCTUnwrap(h.queue.jobs.first)
         XCTAssertEqual(finalJob.state, .done, "Pipeline must complete when only mic diarization fails")
@@ -443,6 +468,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         let job = makeJob(audioPath: h.audioPath)
         h.queue.enqueue(job)
         await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
 
         // Still completes even when naming is skipped
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
@@ -461,8 +487,11 @@ final class WorkflowIntegrationTests: XCTestCase {
         let job = makeJob(audioPath: h.audioPath)
         h.queue.enqueue(job)
         await h.queue.processNext()
+        await awaitJobTerminalState(h.queue, timeout: 30)
 
-        // Handler called twice (first rerun, then confirm), diarization ran twice
+        // Handler called twice (first rerun, then confirm), diarization ran twice.
+        // The rerun now routes through the late-diarization path
+        // (completeSpeakerNaming → lateDiarization), which re-diarizes once more.
         XCTAssertEqual(callCount, 2)
         XCTAssertGreaterThanOrEqual(h.diarization.runCount, 2)
         XCTAssertEqual(h.queue.jobs.first?.state, .done)


### PR DESCRIPTION
## Summary

The speaker-naming step in `PipelineQueue` had two separate state machines:

- **Production**: parks the job at `.speakerNamingPending` and resolves the (re-openable) dialog later via `completeSpeakerNaming`, which handles confirm / skip / rerun / rerunWithMode, recognition-stats logging, naming-sidecar cleanup, and late re-diarization.
- **Tests**: the injected `speakerNamingHandler` took a separate in-line path inside the `diarize` loop that reimplemented a subset of that logic and diverged from it.

So the test seam exercised a path production never took, and that path carried its own bugs. This PR deletes the in-line branch so both paths flow through `completeSpeakerNaming`.

## Why the second state machine was wrong

The in-line handler path:

- confirm never transitioned the job through `.speakerNamingPending`
- skip wrote no recognition-stats row
- confirm and skip left naming sidecar files on disk (a disk leak)
- `.rerunWithMode` was silently downgraded to a same-mode re-run, and the in-line rerun branch had **zero** test coverage

## Changes

- `resolveSpeakerNames` now only stashes the naming data (or, for `autoSkipNaming` headless jobs, finishes on the auto-names) and returns the mapping. It no longer drives a dialog.
- The now-dead machinery is removed: the `namingLoop` in `diarize`, `SpeakerNamingOutcome`, `RecognitionContext`, `applyNamingHandler`, and `beginRerun`.
- `generateAndSaveProtocol` re-invokes the test handler after the `.speakerNamingPending` transition, in the same detached-`Task` pattern the late-rerun path already uses, so tests and the production UI both go through `completeSpeakerNaming`.

## Deliberate behaviour changes (all fix in-line-path bugs)

- Handler-driven jobs now pass through `.speakerNamingPending`.
- A mode override from the handler is now honoured (previously silently downgraded to a same-mode re-run).
- Skip now writes the recognition-stats JSONL row.
- Confirm and skip now clean up the naming sidecars (previously leaked on disk).
- `reapplySpeakerNames` now threads `speakingTimes` into the speaker-DB update. The in-line confirm path passed them; production dropped them. Converging upward keeps the matcher's centroid-quality filter fed with real durations rather than losing the signal.

## Tests

- New: coverage for a mode override driven through the handler (batch job reaches pending, handler returns `.rerunWithMode`), pinning that the mode is honoured and recorded on `usedDiarizerMode`. This branch had no coverage before.
- Updated: tests that relied on in-line resolution inside `await processNext()` now await the terminal state, since naming resolution runs in a `Task` that outlives `processNext`.
- `WorkflowIntegrationTests` exact-transition assertion now includes `.speakerNamingPending` (and collapses the production confirm path's redundant consecutive `.generatingProtocol` re-entry, so it pins stage order rather than internal re-entry).
- The existing late-rerun tests already drive the production machine and pass unchanged.

## Verification

- `swift test --parallel`: green (the only failures are the pre-existing environmental `MenuBarIconSnapshotTests` image-snapshot mismatches, which fail identically on the base commit and are unrelated to this change).
- `./scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict` (with `xcodebuild build-for-testing` log): 0 violations.
- `./scripts/pre-push.sh`: release-build parity passed.