### PR TITLE
refactor(app): extract SpeakerNamingSession from PipelineQueue

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -4,6 +4,18 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PipelineQueue")
 
+/// Raw diarization output for one run of the diarize loop. `combined` is the
+/// result fed into speaker naming (the prefixed dual-track merge, the app-only
+/// fallback, or the single-source result); `app`/`mic` are retained for the
+/// dual-track assignment step. Internal top-level (not `PipelineQueue`-nested)
+/// because it crosses the queue ↔ `SpeakerNamingSession` boundary in both
+/// directions via `SpeakerNamingSessionDelegate`.
+struct DiarizationRun {
+    let app: DiarizationResult?
+    let mic: DiarizationResult?
+    let combined: DiarizationResult?
+}
+
 @MainActor
 @Observable
 // swiftlint:disable:next attributes type_body_length
@@ -35,10 +47,6 @@ class PipelineQueue {
     let stageTimingLog: StageTimingLog?
 
     let completedJobLifetime: TimeInterval
-
-    /// Disk persistence for speaker-naming sidecars (keyed by per-job slug).
-    /// Pure I/O over `outputDir`; see `SpeakerNamingStore`.
-    private let namingStore: SpeakerNamingStore
 
     /// Durable store of finished-job records for the automation API readback.
     /// nil (default) disables it; production injects one, tests opt in.
@@ -76,61 +84,28 @@ class PipelineQueue {
 
     // MARK: - Speaker Naming
 
-    /// Data for the speaker naming popup.
-    struct SpeakerNamingData: Codable {
-        let jobID: UUID
-        let meetingTitle: String
-        let mapping: [String: String] // label → auto-matched name or label
-        let speakingTimes: [String: TimeInterval]
-        let embeddings: [String: [Float]]
-        let audioPath: URL? // 16kHz mix for playback
-        let segments: [Segment] // for extracting speaker snippets
-        let participants: [String] // Teams participant names as suggestions
-        let isDualSource: Bool
-        /// Per-instance identity for SwiftUI `.onChange` change-detection.
-        /// Late re-diarization can produce a `mapping`/`speakingTimes` set
-        /// that compares byte-equal to the previous run (same speaker count,
-        /// same matcher output) — without a fresh marker, the naming view's
-        /// per-presentation reset never fires and consecutive Re-run clicks
-        /// are silently swallowed by the `completedJobID` guard. Excluded
-        /// from CodingKeys so disk reloads regenerate it.
-        var revision: UUID = .init()
+    /// Owns the speaker-naming session (dialog, sidecars, recognition
+    /// forensics, late re-run). Held strongly; the session holds this queue as
+    /// a *weak* delegate, so there's no retain cycle. Exposed as a stored
+    /// property so SwiftUI observation follows into the nested `@Observable`
+    /// when the UI reads the forwarders below.
+    let naming: SpeakerNamingSession
 
-        private enum CodingKeys: String, CodingKey {
-            case jobID, meetingTitle, mapping, speakingTimes, embeddings,
-                 audioPath, segments, participants, isDualSource
-        }
-
-        struct Segment: Codable {
-            let start: TimeInterval
-            let end: TimeInterval
-            let speaker: String
-        }
+    /// RAM cache of naming data, owned by `naming`. Forwarded (get + set) so the
+    /// direct-dict reads at `PipelineController` / `AppState+RPC` and the tests
+    /// keep working AND keep observing the session's storage.
+    var speakerNamingDataByJob: [UUID: SpeakerNamingData] {
+        get { naming.speakerNamingDataByJob }
+        set { naming.speakerNamingDataByJob = newValue }
     }
 
-    /// Result from the speaker naming popup.
-    enum SpeakerNamingResult {
-        case confirmed([String: String]) // user confirmed with mapping
-        case rerun(Int) // re-run diarization with N speakers (current mode)
-        /// Re-run diarization with a different mode AND speaker count. New in
-        /// the Mode↔Count-coupling follow-up: lets the user recover from a
-        /// wrong-mode-at-recording-time (e.g. Sortformer's 4-speaker cap hit
-        /// on a 6-speaker meeting) without leaving the naming dialog.
-        case rerunWithMode(DiarizerMode, Int)
-        case skipped // user skipped
+    /// Handler for speaker naming, owned by `naming`. Forwarded so tests can set
+    /// it on the queue as before. When set, called instead of the default
+    /// continuation-based popup.
+    var speakerNamingHandler: ((SpeakerNamingData) async -> SpeakerNamingResult)? {
+        get { naming.speakerNamingHandler }
+        set { naming.speakerNamingHandler = newValue }
     }
-
-    /// RAM cache of naming data, rebuilt from disk on loadSnapshot().
-    /// Internal setter allows test access via @testable import.
-    var speakerNamingDataByJob: [UUID: SpeakerNamingData] = [:]
-
-    /// Per-job snapshot of the auto-name suggestions shown in the dialog,
-    /// kept until the user confirms/skips so `recordRecognition` can write
-    /// the JSONL row. Cleared on completion. Not persisted across launches —
-    /// if the user confirms in a fresh session, the recognition log row will
-    /// have nil/empty `autoName` (acceptable; user data is the real signal).
-    private var stashedSuggestedAtDialog: [UUID: [String: String]] = [:]
-    private var stashedTopCandidates: [UUID: [String: [TopCandidate]]] = [:]
 
     /// The currently displayed naming data (first pending item).
     var pendingSpeakerNaming: SpeakerNamingData? {
@@ -163,113 +138,21 @@ class PipelineQueue {
         jobs.filter { $0.state == .speakerNamingPending }
     }
 
-    /// Called by the UI when the user confirms, skips, or re-runs speaker naming.
-    /// Always handles "late" completion — the pipeline never blocks on naming.
+    /// Called by the UI (and the test handler) when the user confirms, skips, or
+    /// re-runs speaker naming. Thin forwarder to the naming session, which
+    /// always handles "late" completion — the pipeline never blocks on naming.
     func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
-        guard let data = speakerNamingDataByJob[jobID] else { return }
-        let slug = jobs.first { $0.id == jobID }?.namingSlug
-
-        switch result {
-        case let .confirmed(userMapping):
-            recordRecognition(
-                jobID: jobID, title: data.meetingTitle,
-                userMapping: userMapping, fallback: data.mapping,
-            )
-            // Transition out of .speakerNamingPending synchronously so the
-            // UI's close-when-empty check sees the change immediately. The
-            // transcript rewrite + protocol generation happens async below.
-            if let idx = jobs.firstIndex(where: { $0.id == jobID }),
-               jobs[idx].state == .speakerNamingPending {
-                updateJobState(id: jobID, to: .generatingProtocol)
-            }
-            Task { await reapplySpeakerNames(jobID: jobID, mapping: userMapping) }
-
-        case let .rerun(count):
-            Task { await lateDiarization(jobID: jobID, speakerCount: count) }
-
-        case let .rerunWithMode(mode, count):
-            Task { await lateDiarization(jobID: jobID, speakerCount: count, mode: mode) }
-
-        case .skipped:
-            recordRecognition(
-                jobID: jobID, title: data.meetingTitle,
-                userMapping: nil, fallback: data.mapping,
-            )
-            acceptAutoNames(jobID: jobID, slug: slug)
-        }
+        naming.completeSpeakerNaming(jobID: jobID, result: result)
     }
 
-    /// Pull stashed forensics for a job and write the recognition-stats row.
-    /// Falls back to the original SpeakerNamingData mapping when the stash is
-    /// missing (e.g. the user confirmed in a fresh app session).
-    private func recordRecognition(
-        jobID: UUID, title: String,
-        // swiftlint:disable:next discouraged_optional_collection
-        userMapping: [String: String]?, fallback: [String: String],
-    ) {
-        recordRecognition(
-            suggested: stashedSuggestedAtDialog[jobID] ?? fallback,
-            userMapping: userMapping,
-            topCandidates: stashedTopCandidates[jobID] ?? [:],
-            jobID: jobID,
-            title: title,
-        )
-    }
-
-    /// Skipped or stale-cleanup path: the user accepted (implicitly or by
-    /// timeout) the auto-names. Drops sidecar files synchronously, transitions
-    /// to .done. If a protocol generator is configured AND the transcript file
-    /// exists, fires off protocol generation in the background; the job
-    /// transitions through .generatingProtocol → .done as that completes.
-    private func acceptAutoNames(jobID: UUID, slug: String?) {
-        // Probe the factory's actual output, not just its existence — the
-        // closure is wired even when protocolProvider is `.none`, but
-        // returns nil. Without this, the Task path below fizzles silently
-        // (generateProtocol guards on factory()) and the job sits in
-        // .speakerNamingPending forever.
-        let canGenerateProtocol = (protocolGeneratorFactory?() != nil)
-            && outputDir != nil
-            && jobs.first { $0.id == jobID }?.transcriptPath != nil
-
-        removeNamingData(jobID: jobID, slug: slug)
-
-        if canGenerateProtocol {
-            Task { await generateProtocolForExistingJob(jobID: jobID) }
-        } else if let idx = jobs.firstIndex(where: { $0.id == jobID }),
-                  jobs[idx].state == .speakerNamingPending {
-            updateJobState(id: jobID, to: .done)
-        }
-    }
-
-    private func generateProtocolForExistingJob(jobID: UUID) async {
-        guard let jobIndex = jobs.firstIndex(where: { $0.id == jobID }),
-              let transcriptPath = jobs[jobIndex].transcriptPath,
-              let outputDir,
-              let transcript = try? String(contentsOf: transcriptPath, encoding: .utf8)
-        else { return }
-        await generateProtocol(
-            jobID: jobID,
-            transcript: transcript,
-            title: jobs[jobIndex].meetingTitle,
-            protocolsDir: outputDir.appendingPathComponent("protocols"),
-        )
-        if let idx = jobs.firstIndex(where: { $0.id == jobID }),
-           jobs[idx].state == .generatingProtocol {
-            updateJobState(id: jobID, to: .done)
-        }
-    }
-
-    /// Called by the UI when the user confirms or skips speaker naming.
+    /// Called by the UI when the user confirms or skips speaker naming without a
+    /// specific job in hand — resolves the first pending job (or any stashed
+    /// naming data) and forwards to the session.
     func completeSpeakerNaming(result: SpeakerNamingResult) {
-        if let jobID = pendingSpeakerNamingJobs.first?.id ?? speakerNamingDataByJob.keys.first {
-            completeSpeakerNaming(jobID: jobID, result: result)
+        if let jobID = pendingSpeakerNamingJobs.first?.id ?? naming.speakerNamingDataByJob.keys.first {
+            naming.completeSpeakerNaming(jobID: jobID, result: result)
         }
     }
-
-    /// Handler for speaker naming. When set, called instead of the default
-    /// continuation-based popup. Receives naming data, returns result.
-    /// Used by tests to auto-complete without UI interaction.
-    var speakerNamingHandler: ((SpeakerNamingData) async -> SpeakerNamingResult)?
 
     /// Default factory for `speakerMatcherFactory`: a matcher that writes to a
     /// throwaway tmp path. Production callers (AppState) MUST inject an explicit
@@ -310,8 +193,12 @@ class PipelineQueue {
         self.recognitionStatsLog = nil
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
-        self.namingStore = SpeakerNamingStore(outputDir: nil)
         self.terminalJobStore = terminalJobStore
+        naming = SpeakerNamingSession(
+            namingStore: SpeakerNamingStore(outputDir: nil),
+            speakerMatcherFactory: speakerMatcherFactory,
+        )
+        naming.delegate = self
     }
 
     // MARK: - Known speaker names (issue #155)
@@ -344,7 +231,10 @@ class PipelineQueue {
     /// Apply a speaker DB update via the matcher AND refresh the cached
     /// names in one step. Use instead of calling `matcher.updateDB(...)` +
     /// `refreshKnownSpeakerNames()` separately at internal pipeline sites.
-    private func updateSpeakerDB(
+    /// Internal (not private) because it is the `SpeakerNamingSessionDelegate`
+    /// witness the session calls from `reapplySpeakerNames`; keeping the
+    /// write+refresh pairing here preserves its atomicity (issue #155).
+    func updateSpeakerDB(
         matcher: SpeakerMatcher,
         mapping: [String: String],
         embeddings: [String: [Float]],
@@ -400,8 +290,17 @@ class PipelineQueue {
         self.recognitionStatsLog = recognitionStatsLog
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
-        self.namingStore = SpeakerNamingStore(outputDir: outputDir)
         self.terminalJobStore = terminalJobStore
+        naming = SpeakerNamingSession(
+            namingStore: SpeakerNamingStore(outputDir: outputDir),
+            speakerMatcherFactory: speakerMatcherFactory,
+            diarizationFactory: diarizationFactory,
+            diarizationFactoryWithMode: diarizationFactoryWithMode,
+            protocolGeneratorFactory: protocolGeneratorFactory,
+            outputDir: outputDir,
+            recognitionStatsLog: recognitionStatsLog,
+        )
+        naming.delegate = self
         refreshStageAverages()
     }
 
@@ -478,14 +377,14 @@ class PipelineQueue {
         case .transcribing, .diarizing, .generatingProtocol:
             cancelledJobIDs.insert(id)
             processTask?.cancel()
-            removeNamingData(jobID: id, slug: slug)
+            naming.removeNamingData(jobID: id, slug: slug)
             jobs.remove(at: index)
             saveSnapshot()
 
         case .speakerNamingPending:
             // User cancelled while waiting for late-confirm — drop the sidecar
             // files and the in-memory state so it doesn't sit around.
-            removeNamingData(jobID: id, slug: slug)
+            naming.removeNamingData(jobID: id, slug: slug)
             jobs.remove(at: index)
             saveSnapshot()
 
@@ -660,16 +559,6 @@ class PipelineQueue {
         /// Segments cached for diarization reuse (avoids double transcription).
         let cachedSegments: [TimestampedSegment]? // swiftlint:disable:this discouraged_optional_collection
         let isDualSource: Bool
-    }
-
-    /// Raw diarization output for one run of the diarize loop. `combined` is the
-    /// result fed into speaker naming (the prefixed dual-track merge, the
-    /// app-only fallback, or the single-source result); `app`/`mic` are retained
-    /// for the dual-track assignment step.
-    private struct DiarizationRun {
-        let app: DiarizationResult?
-        let mic: DiarizationResult?
-        let combined: DiarizationResult?
     }
 
     /// Typed errors thrown by the pipeline stages.
@@ -892,8 +781,9 @@ class PipelineQueue {
             // interactive UI and the test handler take the same path.
             var autoNames: [String: String] = [:]
             if let currentDiarization = run.combined {
-                autoNames = resolveSpeakerNames(
-                    diarization: currentDiarization, ctx: ctx,
+                autoNames = naming.resolveSpeakerNames(
+                    diarization: currentDiarization,
+                    job: (jobID: ctx.jobID, title: ctx.title, slug: ctx.slug, participants: ctx.participants),
                     diarizeProcess: diarizeProcess, isDualSource: transcription.isDualSource,
                     outputDir: outputDir,
                 )
@@ -970,10 +860,10 @@ class PipelineQueue {
     /// required; on mic failure the `combined` result is the *unprefixed* app
     /// diarization — so downstream naming keys stay consistent with the
     /// persisted app-only transcript — rather than the `R_`/`M_`-prefixed merge.
-    /// Shared by the batch (`runDiarization`) and late re-run
-    /// (`runLateDiarization`) paths so the mic-fail fallback can't diverge
-    /// between them.
-    private func runDualTrackDiarization(
+    /// Shared by the batch (`runDiarization`) and the session's late re-run so
+    /// the mic-fail fallback can't diverge between them. Internal (not private)
+    /// because it is a `SpeakerNamingSessionDelegate` witness.
+    func runDualTrackDiarization(
         diarizeProcess: any DiarizationProvider,
         tracks: (app: URL, mic: URL, micDelay: TimeInterval),
         speakerCount: Int?, title: String, jobID: UUID,
@@ -1009,86 +899,6 @@ class PipelineQueue {
         return DiarizationRun(app: appDiarization, mic: micDiarization, combined: combined)
     }
 
-    /// Match a diarization result against the speaker DB, persist naming data +
-    /// recognition forensics, and return the auto-name mapping to apply to the
-    /// transcript. Parks the job for the (possibly late) naming dialog by
-    /// stashing `SpeakerNamingData`; the dialog is driven later by
-    /// `completeSpeakerNaming`, so this stage never blocks the pipeline. A job
-    /// that opts out via `autoSkipNaming` (headless blocking-transcribe)
-    /// finishes on the auto-names without a dialog.
-    private func resolveSpeakerNames(
-        diarization: DiarizationResult, ctx: JobContext,
-        diarizeProcess: any DiarizationProvider, isDualSource: Bool, outputDir: URL,
-    ) -> [String: String] {
-        // No embeddings → no matching or dialog; keep the diarizer's own names.
-        guard let embeddings = diarization.embeddings else { return diarization.autoNames }
-
-        let matcher = speakerMatcherFactory()
-        let verbose = matcher.matchVerbose(embeddings: embeddings)
-        let matched = verbose.mapValues(\.assignedName)
-        var autoNames = matched
-        let topCandidates = verbose.mapValues(\.topCandidates)
-
-        // Pre-match participants to remaining speakers.
-        if !ctx.participants.isEmpty {
-            autoNames = SpeakerMatcher.preMatchParticipants(
-                mapping: autoNames,
-                speakingTimes: diarization.speakingTimes,
-                participants: ctx.participants,
-            )
-        }
-
-        let suggestedAtDialog = autoNames
-        let autoMatched = matched.count { $0.key != $0.value }
-        logger.info("[recognition] \(matched.count) speakers, \(autoMatched) auto, \(matched.count - autoMatched) unknown")
-
-        // Use persisted 16kHz path (survives workDir cleanup).
-        let persistedAudioPath = outputDir.appendingPathComponent("recordings")
-            .appendingPathComponent("\(ctx.slug)_16k.wav")
-        let namingData = SpeakerNamingData(
-            jobID: ctx.jobID,
-            meetingTitle: ctx.title,
-            mapping: autoNames,
-            speakingTimes: diarization.speakingTimes,
-            embeddings: embeddings,
-            audioPath: persistedAudioPath,
-            segments: diarization.segments.map { seg in
-                SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
-            },
-            participants: ctx.participants,
-            isDualSource: isDualSource,
-        )
-
-        // Persist naming data and set slug early.
-        saveNamingData(namingData, slug: ctx.slug)
-        if let idx = jobs.firstIndex(where: { $0.id == ctx.jobID }) {
-            jobs[idx].namingSlug = ctx.slug
-            jobs[idx].usedDiarizerMode = diarizeProcess.mode
-        }
-        stopElapsedTimer()
-
-        // Stash recognition forensics so the late-confirm path can write the
-        // JSONL row when the user actually confirms (possibly later, via the
-        // re-openable dialog).
-        stashedSuggestedAtDialog[ctx.jobID] = suggestedAtDialog
-        stashedTopCandidates[ctx.jobID] = topCandidates
-
-        if jobs.first(where: { $0.id == ctx.jobID })?.autoSkipNaming == true {
-            // Headless blocking-transcribe: accept the auto-assigned names
-            // (exactly like a `.skipped` dialog result) so the job finishes on
-            // its own. Don't stash naming data: there is no interactive client
-            // to resolve it, and parking would wedge the job until the next
-            // launch's 24h stale-cleanup.
-            return autoNames
-        }
-        // Production/interactive: stash the naming data so `generateAndSaveProtocol`
-        // parks the job at `.speakerNamingPending` and pops the (re-openable)
-        // dialog. The pipeline continues with the auto-names; the dialog confirms
-        // later via `completeSpeakerNaming` without blocking.
-        speakerNamingDataByJob[ctx.jobID] = namingData
-        return autoNames
-    }
-
     /// Apply speaker names to the transcript for whichever topology the run
     /// produced (dual-track, mic-fail app-only fallback, or single-source),
     /// returning the labeled transcript — or `nil` when no diarization is
@@ -1118,9 +928,11 @@ class PipelineQueue {
     /// transcript segments: pick the topology, assign speakers, merge
     /// consecutive blocks, and format. Shared by the batch path
     /// (`labeledTranscript`) and the late re-diarization rewrite
-    /// (`rewriteTranscriptFromLateRun`) so both re-segment identically. Returns
-    /// nil when the run carries no usable diarization.
-    private func renderLabeledTranscript(
+    /// (the session's `rewriteTranscriptFromLateRun`) so both re-segment
+    /// identically. Returns nil when the run carries no usable diarization.
+    /// Internal (not private) because it is a `SpeakerNamingSessionDelegate`
+    /// witness.
+    func renderLabeledTranscript(
         run: DiarizationRun, cachedSegments: [TimestampedSegment],
         isDualSource: Bool, autoNames: [String: String],
     ) -> String? {
@@ -1193,7 +1005,7 @@ class PipelineQueue {
         // confirm (with the right names) or on skip/stale-cleanup (with
         // the current auto-names). Saves an LLM call we'd otherwise
         // have to redo.
-        if speakerNamingDataByJob[ctx.jobID] == nil {
+        if naming.speakerNamingDataByJob[ctx.jobID] == nil {
             await generateProtocol(
                 jobID: ctx.jobID, transcript: finalTranscript, title: ctx.title,
                 protocolsDir: protocolsDir,
@@ -1201,7 +1013,7 @@ class PipelineQueue {
         }
 
         stopElapsedTimer()
-        if let namingData = speakerNamingDataByJob[ctx.jobID] {
+        if let namingData = naming.speakerNamingDataByJob[ctx.jobID] {
             updateJobState(id: ctx.jobID, to: .speakerNamingPending)
             // Auto-pop the dialog now that the job is in the right state.
             // The window's onAppear guard reads pendingSpeakerNamingJobs,
@@ -1213,13 +1025,9 @@ class PipelineQueue {
             // mirroring the late-rerun re-invocation, so the test path runs the
             // exact same `completeSpeakerNaming` flow the production UI does
             // (rerun/mode-override/skip cleanup all included) rather than a
-            // divergent in-line state machine.
-            if let handler = speakerNamingHandler {
-                Task {
-                    let result = await handler(namingData)
-                    self.completeSpeakerNaming(jobID: ctx.jobID, result: result)
-                }
-            }
+            // divergent in-line state machine. The session captures `self`
+            // (the session) strongly for the op duration, never the delegate.
+            naming.invokeHandler(jobID: ctx.jobID, data: namingData)
         } else {
             updateJobState(id: ctx.jobID, to: .done)
         }
@@ -1229,9 +1037,10 @@ class PipelineQueue {
 
     /// Run the LLM protocol generator over a transcript, save the .md file,
     /// stash its path on the job. No-op if no protocol generator is configured.
-    /// Used by: main pipeline (if no naming pending), reapplySpeakerNames
-    /// (after confirm), skipped/stale paths (with current auto-names).
-    private func generateProtocol(
+    /// Used by: main pipeline (if no naming pending) and the session's
+    /// reapplySpeakerNames / skipped / stale paths. Internal (not private)
+    /// because it is a `SpeakerNamingSessionDelegate` witness.
+    func generateProtocol(
         jobID: UUID, transcript: String, title: String, protocolsDir: URL,
     ) async {
         guard let protocolGeneratorFactory, let generator = protocolGeneratorFactory() else {
@@ -1263,335 +1072,14 @@ class PipelineQueue {
         }
     }
 
-    // MARK: - Late re-apply speaker names
-
-    /// Late-confirm path: read the saved transcript, replace generic speaker
-    /// labels with user-provided names, update the matcher DB, regenerate the
-    /// protocol with the correct names.
-    private func reapplySpeakerNames(jobID: UUID, mapping: [String: String]) async {
-        guard let namingData = speakerNamingDataByJob[jobID],
-              let jobIndex = jobs.firstIndex(where: { $0.id == jobID }) else { return }
-
-        let slug = jobs[jobIndex].namingSlug
-
-        // Update speaker matcher DB
-        let matcher = speakerMatcherFactory()
-        var fullMapping = namingData.mapping
-        for (label, name) in mapping where !name.isEmpty {
-            fullMapping[label] = name
-        }
-        updateSpeakerDB(
-            matcher: matcher,
-            mapping: fullMapping,
-            embeddings: namingData.embeddings,
-            // Thread the per-speaker speaking times so the matcher's
-            // centroid-quality filter (short segments stay as fallback samples,
-            // long ones seed the centroid) sees real durations. The now-deleted
-            // in-line confirm path passed these; production dropped them. Keep
-            // the richer signal.
-            speakingTimes: namingData.speakingTimes,
-        )
-
-        if let transcriptPath = jobs[jobIndex].transcriptPath {
-            do {
-                var transcript = try String(contentsOf: transcriptPath, encoding: .utf8)
-                // Format from `TimestampedSegment.formattedLine`: `[MM:SS] Speaker: text`.
-                // Anchor the replace on `] ` + label + `:` so we hit the speaker
-                // slot and not a substring inside the spoken text.
-                for (label, name) in mapping where !name.isEmpty {
-                    transcript = transcript.replacingOccurrences(of: "] \(label):", with: "] \(name):")
-                    if let autoName = namingData.mapping[label], autoName != label, autoName != name {
-                        transcript = transcript.replacingOccurrences(of: "] \(autoName):", with: "] \(name):")
-                    }
-                }
-                try transcript.write(to: transcriptPath, atomically: true, encoding: .utf8)
-                // Re-applying speaker names rewrites the transcript — keep it
-                // owner-only (the original save in saveTranscript already is).
-                try FileManager.default.restrictToOwner(transcriptPath)
-
-                if let outputDir {
-                    await generateProtocol(
-                        jobID: jobID,
-                        transcript: transcript,
-                        title: jobs[jobIndex].meetingTitle,
-                        protocolsDir: outputDir.appendingPathComponent("protocols"),
-                    )
-                }
-            } catch {
-                logger.error("Failed to re-apply speaker names: \(error.localizedDescription, privacy: .public)")
-            }
-        }
-
-        removeNamingData(jobID: jobID, slug: slug)
-        updateJobState(id: jobID, to: .done)
-    }
-
-    // MARK: - Late Re-diarization
-
-    /// Re-run diarization from persisted 16kHz audio after pipeline completed.
-    ///
-    /// - Parameters:
-    ///   - jobID: the job to re-diarize.
-    ///   - speakerCount: target speaker count (ignored by Sortformer mode).
-    ///   - mode: optional override for the diarizer mode. `nil` (default)
-    ///     keeps the original behaviour — re-instantiate the diarizer with
-    ///     the current global setting via `diarizationFactory()`. Non-nil
-    ///     uses `diarizationFactoryWithMode` to instantiate a one-off
-    ///     diarizer in the requested mode, so the user can recover from a
-    ///     wrong-mode-at-recording-time without leaving the naming dialog.
-    private func lateDiarization(
-        jobID: UUID,
-        speakerCount: Int,
-        mode: DiarizerMode? = nil,
-    ) async {
-        guard let namingData = speakerNamingDataByJob[jobID],
-              let jobIndex = jobs.firstIndex(where: { $0.id == jobID }),
-              let diarizationFactory,
-              let slug = jobs[jobIndex].namingSlug,
-              let outputDir else {
-            logger.warning("Cannot re-diarize: missing data or configuration")
-            return
-        }
-
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        let diarizeProcess = resolveLateDiarizer(mode: mode, defaultFactory: diarizationFactory)
-        guard diarizeProcess.isAvailable else {
-            logger.warning("Diarization not available for late re-run")
-            return
-        }
-
-        updateJobState(id: jobID, to: .diarizing)
-        startElapsedTimer()
-
-        do {
-            let title = jobs[jobIndex].meetingTitle
-            let run = try await runLateDiarization(
-                diarizer: diarizeProcess,
-                recording: (dir: recordingsDir, slug: slug, jobID: jobID, micDelay: jobs[jobIndex].micDelay),
-                isDualSource: namingData.isDualSource,
-                speakerCount: speakerCount, title: title,
-            )
-            stopElapsedTimer()
-
-            // Dual-track always yields a combined result (the merge or the
-            // app-only fallback); single-source sets it directly.
-            guard let combined = run.combined else { throw DiarizationError.notAvailable }
-            guard let newNamingData = buildNamingData(
-                jobID: jobID, title: title,
-                diarization: combined, prior: namingData,
-            ) else {
-                logger.warning("Late re-diarization produced no embeddings")
-                updateJobState(id: jobID, to: .speakerNamingPending)
-                return
-            }
-
-            speakerNamingDataByJob[jobID] = newNamingData
-            saveNamingData(newNamingData, slug: slug)
-            // Re-segment the saved transcript to match the fresh diarization.
-            // A re-run can change the speaker count and segment boundaries, but
-            // the late-confirm path only renames labels already present in the
-            // .txt — so without this rewrite any speakers the re-run adds never
-            // reach the transcript. Mirrors the batch path, which renders the
-            // transcript from its final run.
-            rewriteTranscriptFromLateRun(
-                run: run, autoNames: newNamingData.mapping,
-                isDualSource: namingData.isDualSource, slug: slug, jobID: jobID,
-            )
-            // Track which mode produced this fresh naming data so the next
-            // dialog open initialises the mode picker correctly. Re-resolve the
-            // index by id: the diarization await can outlive another finished
-            // job's `completedJobLifetime` eviction, which shifts the array and
-            // would invalidate the `jobIndex` captured before the await.
-            if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
-                jobs[idx].usedDiarizerMode = diarizeProcess.mode
-            }
-
-            updateJobState(id: jobID, to: .speakerNamingPending)
-            NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
-
-            if let handler = speakerNamingHandler {
-                let result = await handler(newNamingData)
-                completeSpeakerNaming(jobID: jobID, result: result)
-            }
-        } catch {
-            logger.error("Late re-diarization failed: \(error.localizedDescription, privacy: .public)")
-            stopElapsedTimer()
-            updateJobState(id: jobID, to: .speakerNamingPending)
-        }
-    }
-
-    /// Resolve the diarizer for a late re-run: a mode override uses the
-    /// mode-aware factory (falling back to `defaultFactory` plus a warning when
-    /// none is wired); `nil` keeps the current global setting.
-    private func resolveLateDiarizer(
-        mode: DiarizerMode?, defaultFactory: () -> any DiarizationProvider,
-    ) -> any DiarizationProvider {
-        if let mode, let factory = diarizationFactoryWithMode {
-            return factory(mode)
-        }
-        if let mode {
-            logger.warning(
-                "Late re-diarize requested mode=\(mode.rawValue, privacy: .public) but no mode-aware factory wired; falling back to global setting",
-            )
-        }
-        return defaultFactory()
-    }
-
-    /// Re-diarize the persisted 16 kHz audio for a job. Dispatches between
-    /// dual-source (separate app + mic tracks merged) and single-source
-    /// (mix only). Pure I/O helper extracted from `lateDiarization` to
-    /// keep its function body under the lint cap.
-    private func runLateDiarization(
-        diarizer: any DiarizationProvider,
-        recording: (dir: URL, slug: String, jobID: UUID, micDelay: TimeInterval),
-        isDualSource: Bool,
-        speakerCount: Int,
-        title: String,
-    ) async throws -> DiarizationRun {
-        let (recordingsDir, slug, jobID, micDelay) = recording
-        if isDualSource {
-            // Mirror the batch path's mic-fail fallback (via the shared helper):
-            // a silent/failing mic track must degrade to the unprefixed app-only
-            // diarization, not throw (a no-op re-run) or emit prefixed keys the
-            // persisted app-only transcript can't match.
-            return try await runDualTrackDiarization(
-                diarizeProcess: diarizer,
-                tracks: (
-                    app: recordingsDir.appendingPathComponent("\(slug)_app_16k.wav"),
-                    mic: recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav"),
-                    micDelay: micDelay,
-                ),
-                speakerCount: speakerCount, title: title, jobID: jobID,
-            )
-        }
-        let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
-        let diarization = try await diarizer.run(
-            audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
-        )
-        return DiarizationRun(app: nil, mic: nil, combined: diarization)
-    }
-
-    /// Build SpeakerNamingData from fresh diarization, reusing context from prior naming data.
-    private func buildNamingData(
-        jobID: UUID, title: String,
-        diarization: DiarizationResult, prior: SpeakerNamingData,
-    ) -> SpeakerNamingData? {
-        guard let embeddings = diarization.embeddings else { return nil }
-
-        let matcher = speakerMatcherFactory()
-        var autoNames = matcher.match(embeddings: embeddings)
-        if !prior.participants.isEmpty {
-            autoNames = SpeakerMatcher.preMatchParticipants(
-                mapping: autoNames,
-                speakingTimes: diarization.speakingTimes,
-                participants: prior.participants,
-            )
-        }
-
-        return SpeakerNamingData(
-            jobID: jobID, meetingTitle: title, mapping: autoNames,
-            speakingTimes: diarization.speakingTimes, embeddings: embeddings,
-            audioPath: prior.audioPath,
-            segments: diarization.segments.map { seg in
-                SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
-            },
-            participants: prior.participants, isDualSource: prior.isDualSource,
-        )
-    }
-
-    /// Rewrite the persisted transcript so its speaker segmentation reflects a
-    /// fresh late re-diarization. Re-labels the cached transcript segments
-    /// (persisted as `<slug>_segments.json`) against the new run with the new
-    /// auto-names. A no-op when the cached segments are missing (older
-    /// recordings predating segment persistence) — the late-confirm rename then
-    /// falls back to the prior behaviour rather than wiping the transcript.
-    private func rewriteTranscriptFromLateRun(
-        run: DiarizationRun, autoNames: [String: String],
-        isDualSource: Bool, slug: String, jobID: UUID,
-    ) {
-        guard let outputDir,
-              let transcriptPath = jobs.first(where: { $0.id == jobID })?.transcriptPath else { return }
-        let recordingsDir = outputDir.appendingPathComponent("recordings")
-        guard let cachedSegments = loadCachedSegments(dir: recordingsDir, slug: slug) else {
-            logger.warning("Late re-diarization: no persisted transcript segments — speaker labels not re-segmented")
-            // Don't let the re-run silently appear to succeed: an older recording
-            // (predating segment persistence) can't be re-segmented, so any
-            // speakers the re-run added won't reach the transcript.
-            addWarning(
-                id: jobID,
-                "This recording has no saved transcript segments, so the re-run's speaker changes could not be applied to the transcript",
-            )
-            return
-        }
-        guard let rebuilt = renderLabeledTranscript(
-            run: run, cachedSegments: cachedSegments,
-            isDualSource: isDualSource, autoNames: autoNames,
-        ) else { return }
-        do {
-            try rebuilt.write(to: transcriptPath, atomically: true, encoding: .utf8)
-            // Keep the rewritten transcript owner-only, matching the original save.
-            try FileManager.default.restrictToOwner(transcriptPath)
-        } catch {
-            // Error left redacted: the write target is `<title>_transcript.txt`,
-            // so a file-write error description would leak the meeting title.
-            logger.error("Late re-diarization: failed to rewrite transcript: \(error.localizedDescription)")
-        }
-    }
-
-    /// Load the transcript segments persisted by `generateAndSaveProtocol`
-    /// (`<slug>_segments.json`). Returns nil when the file is absent or
-    /// undecodable.
-    private func loadCachedSegments(dir: URL, slug: String)
-        -> [TimestampedSegment]? { // swiftlint:disable:this discouraged_optional_collection
-        let segPath = dir.appendingPathComponent("\(slug)_segments.json")
-        guard let data = try? Data(contentsOf: segPath),
-              let segments = try? JSONDecoder().decode([TimestampedSegment].self, from: data) else {
-            return nil
-        }
-        return segments
-    }
-
-    // MARK: - Speaker Naming Persistence
-
-    /// Persist naming data via `namingStore`, surfacing a per-job warning on
-    /// failure (the store stays I/O-only; the queue owns the job-state side
-    /// effect). A silent failure would mean late-confirm won't work after a
-    /// restart, so make it visible: log + warning on the job.
-    private func saveNamingData(_ data: SpeakerNamingData, slug: String) {
-        do {
-            try namingStore.save(data, slug: slug)
-        } catch {
-            // Error left redacted: the write target is `<title-slug>_naming.json`,
-            // so a file-write error description would leak the meeting title.
-            logger.error("Failed to save naming data: \(error.localizedDescription)")
-            addWarning(id: data.jobID, "Late re-confirm unavailable — naming data could not be persisted")
-        }
-    }
-
-    /// Remove all naming-related data for a job: RAM caches, disk JSON, and
-    /// sidecar files. Also clears the recognition-stats stash dicts so they
-    /// don't leak across rerun / stale-cleanup paths.
-    private func removeNamingData(jobID: UUID, slug: String?) {
-        speakerNamingDataByJob.removeValue(forKey: jobID)
-        stashedSuggestedAtDialog.removeValue(forKey: jobID)
-        stashedTopCandidates.removeValue(forKey: jobID)
-        namingStore.deleteNamingJSON(slug: slug)
-        namingStore.cleanupSidecarFiles(slug: slug)
-    }
+    // MARK: - Speaker Naming forwarders
 
     /// Auto-resolve pending naming items older than maxAge (default: 24h).
-    /// Generates the protocol with auto-names, transitions them to .done,
-    /// deletes sidecar files.
+    /// Thin forwarder passing the queue's already-filtered
+    /// `.speakerNamingPending` list to the session, which generates the protocol
+    /// with auto-names, transitions them to .done, and deletes sidecar files.
     func cleanupStalePending(maxAge: TimeInterval = 86400) {
-        let now = Date()
-        for job in jobs where job.state == .speakerNamingPending {
-            if now.timeIntervalSince(job.enqueuedAt) > maxAge {
-                logger.info("Auto-resolving stale pending naming for \(job.meetingTitle, privacy: .private)")
-                let jobID = job.id
-                let slug = job.namingSlug
-                acceptAutoNames(jobID: jobID, slug: slug)
-            }
-        }
+        naming.cleanupStalePending(pendingJobs: pendingSpeakerNamingJobs, maxAge: maxAge)
     }
 
     // MARK: - VAD Preprocessing
@@ -1679,16 +1167,16 @@ class PipelineQueue {
 
         jobs = loaded
 
-        // Rebuild speaker naming cache from disk for .speakerNamingPending jobs
+        // Rebuild the session's naming cache from disk for
+        // .speakerNamingPending jobs.
         for job in jobs where job.state == .speakerNamingPending {
-            if let slug = job.namingSlug, let data = namingStore.load(slug: slug) {
-                speakerNamingDataByJob[job.id] = data
-            } else {
-                // Naming data lost — transition to done
-                logger.warning("Naming data not found for job \(job.id), marking as done")
-                if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
-                    jobs[idx].state = .done
-                }
+            if let slug = job.namingSlug, naming.restore(jobID: job.id, slug: slug) {
+                continue
+            }
+            // Naming data lost — transition to done
+            logger.warning("Naming data not found for job \(job.id), marking as done")
+            if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
+                jobs[idx].state = .done
             }
         }
 
@@ -2012,32 +1500,34 @@ class PipelineQueue {
             logger.error("Failed to append pipeline log: \(error.localizedDescription, privacy: .public)")
         }
     }
+}
 
-    /// Build recognition events and persist them off the pipeline path. Logs
-    /// outcome counts immediately; JSONL append runs in a detached Task.
-    private func recordRecognition(
-        suggested: [String: String],
-        // swiftlint:disable:next discouraged_optional_collection
-        userMapping: [String: String]?,
-        topCandidates: [String: [TopCandidate]],
-        jobID: UUID,
-        title: String,
-    ) {
-        let events = RecognitionStats.buildEvents(
-            suggested: suggested, userMapping: userMapping,
-            topCandidates: topCandidates,
-            jobID: jobID, meetingTitle: title,
-        )
-        var counts: [RecognitionAction: Int] = [:]
-        for e in events {
-            counts[e.action, default: 0] += 1
-        }
-        let parts = RecognitionAction.allCases
-            .map { "\($0.rawValue)=\(counts[$0] ?? 0)" }
-            .joined(separator: " ")
-        logger.info("[recognition] outcome \(parts, privacy: .public)")
-        if let recognitionStatsLog {
-            Task { await recognitionStatsLog.append(events) }
-        }
+// MARK: - SpeakerNamingSessionDelegate
+
+extension PipelineQueue: SpeakerNamingSessionDelegate {
+    /// A value copy of the tracked job, addressed by id (never by a stale index).
+    func job(withID id: UUID) -> PipelineJob? {
+        jobs.first { $0.id == id }
+    }
+
+    /// Persist the per-job naming metadata on the (queue-owned) job. `nil` for
+    /// either field means "leave unchanged". Mutates `jobs` in place (no
+    /// snapshot write — matches the previous inline mutations).
+    func setNamingMetadata(jobID: UUID, slug: String?, usedDiarizerMode: DiarizerMode?) {
+        guard let idx = jobs.firstIndex(where: { $0.id == jobID }) else { return }
+        if let slug { jobs[idx].namingSlug = slug }
+        if let usedDiarizerMode { jobs[idx].usedDiarizerMode = usedDiarizerMode }
+    }
+
+    /// Enter the diarizing stage for a late re-run: transition + start the
+    /// menu's elapsed timer (in that order, matching the original inline flow).
+    func namingStageDidStart(jobID: UUID) {
+        updateJobState(id: jobID, to: .diarizing)
+        startElapsedTimer()
+    }
+
+    /// Leave a timed naming stage.
+    func namingStageDidEnd() {
+        stopElapsedTimer()
     }
 }

--- a/app/MeetingTranscriber/Sources/SpeakerNamingData.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingData.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// The speaker-naming value types live in their own file (split out of
+// `PipelineQueue.swift`), but stay nested under `PipelineQueue` so the many
+// existing references (`PipelineQueue.SpeakerNamingData`, its `.Segment`, and
+// `PipelineQueue.SpeakerNamingResult`) across the UI, RPC, persistence, and
+// tests keep resolving unchanged. The Codable wire format is namespace-
+// independent (no type name is encoded), so the move is purely organisational.
+extension PipelineQueue {
+    /// Data for the speaker naming popup.
+    struct SpeakerNamingData: Codable {
+        let jobID: UUID
+        let meetingTitle: String
+        let mapping: [String: String] // label → auto-matched name or label
+        let speakingTimes: [String: TimeInterval]
+        let embeddings: [String: [Float]]
+        let audioPath: URL? // 16kHz mix for playback
+        let segments: [Segment] // for extracting speaker snippets
+        let participants: [String] // Teams participant names as suggestions
+        let isDualSource: Bool
+        /// Per-instance identity for SwiftUI `.onChange` change-detection.
+        /// Late re-diarization can produce a `mapping`/`speakingTimes` set
+        /// that compares byte-equal to the previous run (same speaker count,
+        /// same matcher output) — without a fresh marker, the naming view's
+        /// per-presentation reset never fires and consecutive Re-run clicks
+        /// are silently swallowed by the `completedJobID` guard. Excluded
+        /// from CodingKeys so disk reloads regenerate it.
+        var revision: UUID = .init()
+
+        private enum CodingKeys: String, CodingKey {
+            case jobID, meetingTitle, mapping, speakingTimes, embeddings,
+                 audioPath, segments, participants, isDualSource
+        }
+
+        struct Segment: Codable {
+            let start: TimeInterval
+            let end: TimeInterval
+            let speaker: String
+        }
+    }
+
+    /// Result from the speaker naming popup.
+    enum SpeakerNamingResult {
+        case confirmed([String: String]) // user confirmed with mapping
+        case rerun(Int) // re-run diarization with N speakers (current mode)
+        /// Re-run diarization with a different mode AND speaker count. New in
+        /// the Mode↔Count-coupling follow-up: lets the user recover from a
+        /// wrong-mode-at-recording-time (e.g. Sortformer's 4-speaker cap hit
+        /// on a 6-speaker meeting) without leaving the naming dialog.
+        case rerunWithMode(DiarizerMode, Int)
+        case skipped // user skipped
+    }
+}

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
@@ -1,0 +1,294 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "SpeakerNamingSession")
+
+/// Late-confirm and late re-diarization paths — the speaker-naming work that
+/// happens after the pipeline already reached `.speakerNamingPending`. Split
+/// out of `SpeakerNamingSession.swift` to keep both files under the lint cap.
+extension SpeakerNamingSession {
+    // MARK: - Late re-apply speaker names
+
+    /// Late-confirm path: read the saved transcript, replace generic speaker
+    /// labels with user-provided names, update the matcher DB, regenerate the
+    /// protocol with the correct names.
+    func reapplySpeakerNames(jobID: UUID, mapping: [String: String]) async {
+        guard let namingData = speakerNamingDataByJob[jobID],
+              let job = delegate?.job(withID: jobID) else { return }
+
+        let slug = job.namingSlug
+
+        // Update speaker matcher DB
+        let matcher = speakerMatcherFactory()
+        var fullMapping = namingData.mapping
+        for (label, name) in mapping where !name.isEmpty {
+            fullMapping[label] = name
+        }
+        delegate?.updateSpeakerDB(
+            matcher: matcher,
+            mapping: fullMapping,
+            embeddings: namingData.embeddings,
+            // Thread the per-speaker speaking times so the matcher's
+            // centroid-quality filter (short segments stay as fallback samples,
+            // long ones seed the centroid) sees real durations.
+            speakingTimes: namingData.speakingTimes,
+        )
+
+        if let transcriptPath = job.transcriptPath {
+            do {
+                var transcript = try String(contentsOf: transcriptPath, encoding: .utf8)
+                // Format from `TimestampedSegment.formattedLine`: `[MM:SS] Speaker: text`.
+                // Anchor the replace on `] ` + label + `:` so we hit the speaker
+                // slot and not a substring inside the spoken text.
+                for (label, name) in mapping where !name.isEmpty {
+                    transcript = transcript.replacingOccurrences(of: "] \(label):", with: "] \(name):")
+                    if let autoName = namingData.mapping[label], autoName != label, autoName != name {
+                        transcript = transcript.replacingOccurrences(of: "] \(autoName):", with: "] \(name):")
+                    }
+                }
+                try transcript.write(to: transcriptPath, atomically: true, encoding: .utf8)
+                // Re-applying speaker names rewrites the transcript — keep it
+                // owner-only (the original save in saveTranscript already is).
+                try FileManager.default.restrictToOwner(transcriptPath)
+
+                if let outputDir {
+                    await delegate?.generateProtocol(
+                        jobID: jobID,
+                        transcript: transcript,
+                        title: job.meetingTitle,
+                        protocolsDir: outputDir.appendingPathComponent("protocols"),
+                    )
+                }
+            } catch {
+                logger.error("Failed to re-apply speaker names: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        removeNamingData(jobID: jobID, slug: slug)
+        delegate?.updateJobState(id: jobID, to: .done)
+    }
+
+    // MARK: - Late Re-diarization
+
+    /// Re-run diarization from persisted 16kHz audio after pipeline completed.
+    ///
+    /// - Parameters:
+    ///   - jobID: the job to re-diarize.
+    ///   - speakerCount: target speaker count (ignored by Sortformer mode).
+    ///   - mode: optional override for the diarizer mode. `nil` (default)
+    ///     keeps the original behaviour — re-instantiate the diarizer with
+    ///     the current global setting via `diarizationFactory()`. Non-nil
+    ///     uses `diarizationFactoryWithMode` to instantiate a one-off
+    ///     diarizer in the requested mode, so the user can recover from a
+    ///     wrong-mode-at-recording-time without leaving the naming dialog.
+    func lateDiarization(
+        jobID: UUID,
+        speakerCount: Int,
+        mode: DiarizerMode? = nil,
+    ) async {
+        guard let namingData = speakerNamingDataByJob[jobID],
+              let job = delegate?.job(withID: jobID),
+              let diarizationFactory,
+              let slug = job.namingSlug,
+              let outputDir else {
+            logger.warning("Cannot re-diarize: missing data or configuration")
+            return
+        }
+
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        let diarizeProcess = resolveLateDiarizer(mode: mode, defaultFactory: diarizationFactory)
+        guard diarizeProcess.isAvailable else {
+            logger.warning("Diarization not available for late re-run")
+            return
+        }
+
+        delegate?.namingStageDidStart(jobID: jobID)
+
+        do {
+            let title = job.meetingTitle
+            let run = try await runLateDiarization(
+                diarizer: diarizeProcess,
+                recording: (dir: recordingsDir, slug: slug, jobID: jobID, micDelay: job.micDelay),
+                isDualSource: namingData.isDualSource,
+                speakerCount: speakerCount, title: title,
+            )
+            delegate?.namingStageDidEnd()
+
+            // Dual-track always yields a combined result (the merge or the
+            // app-only fallback); single-source sets it directly.
+            guard let combined = run.combined else { throw DiarizationError.notAvailable }
+            guard let newNamingData = buildNamingData(
+                jobID: jobID, title: title,
+                diarization: combined, prior: namingData,
+            ) else {
+                logger.warning("Late re-diarization produced no embeddings")
+                delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+                return
+            }
+
+            speakerNamingDataByJob[jobID] = newNamingData
+            saveNamingData(newNamingData, slug: slug)
+            // Re-segment the saved transcript to match the fresh diarization.
+            // A re-run can change the speaker count and segment boundaries, but
+            // the late-confirm path only renames labels already present in the
+            // .txt — so without this rewrite any speakers the re-run adds never
+            // reach the transcript. Mirrors the batch path, which renders the
+            // transcript from its final run.
+            rewriteTranscriptFromLateRun(
+                run: run, autoNames: newNamingData.mapping,
+                isDualSource: namingData.isDualSource, slug: slug, jobID: jobID,
+            )
+            // Track which mode produced this fresh naming data so the next
+            // dialog open initialises the mode picker correctly.
+            // `setNamingMetadata` re-resolves the job by id, so the diarization
+            // await outliving another job's `completedJobLifetime` eviction
+            // (which shifts the queue's array) can't corrupt a stale index.
+            delegate?.setNamingMetadata(jobID: jobID, slug: nil, usedDiarizerMode: diarizeProcess.mode)
+
+            delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+            NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
+
+            if let handler = speakerNamingHandler {
+                let result = await handler(newNamingData)
+                completeSpeakerNaming(jobID: jobID, result: result)
+            }
+        } catch {
+            logger.error("Late re-diarization failed: \(error.localizedDescription, privacy: .public)")
+            delegate?.namingStageDidEnd()
+            delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+        }
+    }
+
+    /// Resolve the diarizer for a late re-run: a mode override uses the
+    /// mode-aware factory (falling back to `defaultFactory` plus a warning when
+    /// none is wired); `nil` keeps the current global setting.
+    private func resolveLateDiarizer(
+        mode: DiarizerMode?, defaultFactory: () -> any DiarizationProvider,
+    ) -> any DiarizationProvider {
+        if let mode, let factory = diarizationFactoryWithMode {
+            return factory(mode)
+        }
+        if let mode {
+            logger.warning(
+                "Late re-diarize requested mode=\(mode.rawValue, privacy: .public) but no mode-aware factory wired; falling back to global setting",
+            )
+        }
+        return defaultFactory()
+    }
+
+    /// Re-diarize the persisted 16 kHz audio for a job. Dispatches between
+    /// dual-source (separate app + mic tracks merged, via the shared queue
+    /// helper) and single-source (mix only).
+    private func runLateDiarization(
+        diarizer: any DiarizationProvider,
+        recording: (dir: URL, slug: String, jobID: UUID, micDelay: TimeInterval),
+        isDualSource: Bool,
+        speakerCount: Int,
+        title: String,
+    ) async throws -> DiarizationRun {
+        let (recordingsDir, slug, jobID, micDelay) = recording
+        if isDualSource {
+            // Mirror the batch path's mic-fail fallback: a silent/failing mic
+            // track must degrade to the unprefixed app-only diarization, not
+            // throw (a no-op re-run) or emit prefixed keys the persisted
+            // app-only transcript can't match. A deallocated delegate can't run
+            // the stage → surface it as `notAvailable` so `lateDiarization`
+            // rolls the job back to `.speakerNamingPending`.
+            guard let delegate else { throw DiarizationError.notAvailable }
+            return try await delegate.runDualTrackDiarization(
+                diarizeProcess: diarizer,
+                tracks: (
+                    app: recordingsDir.appendingPathComponent("\(slug)_app_16k.wav"),
+                    mic: recordingsDir.appendingPathComponent("\(slug)_mic_16k.wav"),
+                    micDelay: micDelay,
+                ),
+                speakerCount: speakerCount, title: title, jobID: jobID,
+            )
+        }
+        let mix16k = recordingsDir.appendingPathComponent("\(slug)_16k.wav")
+        let diarization = try await diarizer.run(
+            audioPath: mix16k, numSpeakers: speakerCount, meetingTitle: title,
+        )
+        return DiarizationRun(app: nil, mic: nil, combined: diarization)
+    }
+
+    /// Build SpeakerNamingData from fresh diarization, reusing context from prior naming data.
+    private func buildNamingData(
+        jobID: UUID, title: String,
+        diarization: DiarizationResult, prior: SpeakerNamingData,
+    ) -> SpeakerNamingData? {
+        guard let embeddings = diarization.embeddings else { return nil }
+
+        let matcher = speakerMatcherFactory()
+        var autoNames = matcher.match(embeddings: embeddings)
+        if !prior.participants.isEmpty {
+            autoNames = SpeakerMatcher.preMatchParticipants(
+                mapping: autoNames,
+                speakingTimes: diarization.speakingTimes,
+                participants: prior.participants,
+            )
+        }
+
+        return SpeakerNamingData(
+            jobID: jobID, meetingTitle: title, mapping: autoNames,
+            speakingTimes: diarization.speakingTimes, embeddings: embeddings,
+            audioPath: prior.audioPath,
+            segments: diarization.segments.map { seg in
+                SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
+            },
+            participants: prior.participants, isDualSource: prior.isDualSource,
+        )
+    }
+
+    /// Rewrite the persisted transcript so its speaker segmentation reflects a
+    /// fresh late re-diarization. Re-labels the cached transcript segments
+    /// (persisted as `<slug>_segments.json`) against the new run with the new
+    /// auto-names. A no-op when the cached segments are missing (older
+    /// recordings predating segment persistence) — the late-confirm rename then
+    /// falls back to the prior behaviour rather than wiping the transcript.
+    private func rewriteTranscriptFromLateRun(
+        run: DiarizationRun, autoNames: [String: String],
+        isDualSource: Bool, slug: String, jobID: UUID,
+    ) {
+        guard let outputDir,
+              let transcriptPath = delegate?.job(withID: jobID)?.transcriptPath else { return }
+        let recordingsDir = outputDir.appendingPathComponent("recordings")
+        guard let cachedSegments = loadCachedSegments(dir: recordingsDir, slug: slug) else {
+            logger.warning("Late re-diarization: no persisted transcript segments — speaker labels not re-segmented")
+            // Don't let the re-run silently appear to succeed: an older recording
+            // (predating segment persistence) can't be re-segmented, so any
+            // speakers the re-run added won't reach the transcript.
+            delegate?.addWarning(
+                id: jobID,
+                "This recording has no saved transcript segments, so the re-run's speaker changes could not be applied to the transcript",
+            )
+            return
+        }
+        guard let delegate, let rebuilt = delegate.renderLabeledTranscript(
+            run: run, cachedSegments: cachedSegments,
+            isDualSource: isDualSource, autoNames: autoNames,
+        ) else { return }
+        do {
+            try rebuilt.write(to: transcriptPath, atomically: true, encoding: .utf8)
+            // Keep the rewritten transcript owner-only, matching the original save.
+            try FileManager.default.restrictToOwner(transcriptPath)
+        } catch {
+            // Error left redacted: the write target is `<title>_transcript.txt`,
+            // so a file-write error description would leak the meeting title.
+            logger.error("Late re-diarization: failed to rewrite transcript: \(error.localizedDescription)")
+        }
+    }
+
+    /// Load the transcript segments persisted by `generateAndSaveProtocol`
+    /// (`<slug>_segments.json`). Returns nil when the file is absent or
+    /// undecodable.
+    private func loadCachedSegments(dir: URL, slug: String)
+        -> [TimestampedSegment]? { // swiftlint:disable:this discouraged_optional_collection
+        let segPath = dir.appendingPathComponent("\(slug)_segments.json")
+        guard let data = try? Data(contentsOf: segPath),
+              let segments = try? JSONDecoder().decode([TimestampedSegment].self, from: data) else {
+            return nil
+        }
+        return segments
+    }
+}

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
@@ -13,8 +13,12 @@ extension SpeakerNamingSession {
     /// labels with user-provided names, update the matcher DB, regenerate the
     /// protocol with the correct names.
     func reapplySpeakerNames(jobID: UUID, mapping: [String: String]) async {
-        guard let namingData = speakerNamingDataByJob[jobID],
-              let job = delegate?.job(withID: jobID) else { return }
+        // Strong per-flow delegate capture (see `delegate`): keeps the queue
+        // alive until the transcript rewrite, protocol regeneration, and the
+        // final `.done` all land, even if the controller swaps queues mid-flow.
+        guard let delegate,
+              let namingData = speakerNamingDataByJob[jobID],
+              let job = delegate.job(withID: jobID) else { return }
 
         let slug = job.namingSlug
 
@@ -24,7 +28,7 @@ extension SpeakerNamingSession {
         for (label, name) in mapping where !name.isEmpty {
             fullMapping[label] = name
         }
-        delegate?.updateSpeakerDB(
+        delegate.updateSpeakerDB(
             matcher: matcher,
             mapping: fullMapping,
             embeddings: namingData.embeddings,
@@ -52,7 +56,7 @@ extension SpeakerNamingSession {
                 try FileManager.default.restrictToOwner(transcriptPath)
 
                 if let outputDir {
-                    await delegate?.generateProtocol(
+                    await delegate.generateProtocol(
                         jobID: jobID,
                         transcript: transcript,
                         title: job.meetingTitle,
@@ -65,7 +69,7 @@ extension SpeakerNamingSession {
         }
 
         removeNamingData(jobID: jobID, slug: slug)
-        delegate?.updateJobState(id: jobID, to: .done)
+        delegate.updateJobState(id: jobID, to: .done)
     }
 
     // MARK: - Late Re-diarization
@@ -86,8 +90,13 @@ extension SpeakerNamingSession {
         speakerCount: Int,
         mode: DiarizerMode? = nil,
     ) async {
-        guard let namingData = speakerNamingDataByJob[jobID],
-              let job = delegate?.job(withID: jobID),
+        // Strong per-flow delegate capture (see `delegate`): keeps the queue
+        // alive across the re-diarization await so the rewrite, metadata, and
+        // the return to `.speakerNamingPending` land even if the controller
+        // swaps queues mid-flow.
+        guard let delegate,
+              let namingData = speakerNamingDataByJob[jobID],
+              let job = delegate.job(withID: jobID),
               let diarizationFactory,
               let slug = job.namingSlug,
               let outputDir else {
@@ -102,7 +111,7 @@ extension SpeakerNamingSession {
             return
         }
 
-        delegate?.namingStageDidStart(jobID: jobID)
+        delegate.namingStageDidStart(jobID: jobID)
 
         do {
             let title = job.meetingTitle
@@ -112,7 +121,7 @@ extension SpeakerNamingSession {
                 isDualSource: namingData.isDualSource,
                 speakerCount: speakerCount, title: title,
             )
-            delegate?.namingStageDidEnd()
+            delegate.namingStageDidEnd()
 
             // Dual-track always yields a combined result (the merge or the
             // app-only fallback); single-source sets it directly.
@@ -122,7 +131,7 @@ extension SpeakerNamingSession {
                 diarization: combined, prior: namingData,
             ) else {
                 logger.warning("Late re-diarization produced no embeddings")
-                delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+                delegate.updateJobState(id: jobID, to: .speakerNamingPending)
                 return
             }
 
@@ -143,9 +152,9 @@ extension SpeakerNamingSession {
             // `setNamingMetadata` re-resolves the job by id, so the diarization
             // await outliving another job's `completedJobLifetime` eviction
             // (which shifts the queue's array) can't corrupt a stale index.
-            delegate?.setNamingMetadata(jobID: jobID, slug: nil, usedDiarizerMode: diarizeProcess.mode)
+            delegate.setNamingMetadata(jobID: jobID, slug: nil, usedDiarizerMode: diarizeProcess.mode)
 
-            delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+            delegate.updateJobState(id: jobID, to: .speakerNamingPending)
             NotificationCenter.default.post(name: .showSpeakerNaming, object: nil)
 
             if let handler = speakerNamingHandler {
@@ -154,8 +163,8 @@ extension SpeakerNamingSession {
             }
         } catch {
             logger.error("Late re-diarization failed: \(error.localizedDescription, privacy: .public)")
-            delegate?.namingStageDidEnd()
-            delegate?.updateJobState(id: jobID, to: .speakerNamingPending)
+            delegate.namingStageDidEnd()
+            delegate.updateJobState(id: jobID, to: .speakerNamingPending)
         }
     }
 
@@ -191,9 +200,10 @@ extension SpeakerNamingSession {
             // Mirror the batch path's mic-fail fallback: a silent/failing mic
             // track must degrade to the unprefixed app-only diarization, not
             // throw (a no-op re-run) or emit prefixed keys the persisted
-            // app-only transcript can't match. A deallocated delegate can't run
-            // the stage → surface it as `notAvailable` so `lateDiarization`
-            // rolls the job back to `.speakerNamingPending`.
+            // app-only transcript can't match. The weak var still resolves here
+            // because `lateDiarization`'s strong per-flow capture keeps the
+            // queue alive; the guard is defensive for any future non-flow
+            // caller → `notAvailable` rolls back to `.speakerNamingPending`.
             guard let delegate else { throw DiarizationError.notAvailable }
             return try await delegate.runDualTrackDiarization(
                 diarizeProcess: diarizer,

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -8,9 +8,10 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Speaker
 /// stale across an `await` when another finished job is evicted by
 /// `completedJobLifetime`, a documented past bug — so the session only ever
 /// addresses a job by its `UUID`. The queue owns the session strongly
-/// (`let naming`); the session holds this delegate weakly, so a deallocated
-/// queue turns every delegate call into a harmless no-op (optional chaining)
-/// instead of a crash or a retain cycle.
+/// (`let naming`); the session holds this delegate weakly at rest (no retain
+/// cycle) but captures it strongly per async flow, so an in-flight naming flow
+/// keeps the queue alive to completion while a flow started against an
+/// already-gone queue no-ops harmlessly. See `SpeakerNamingSession.delegate`.
 @MainActor
 protocol SpeakerNamingSessionDelegate: AnyObject {
     /// A value copy of the job, or nil if it is no longer tracked.
@@ -69,8 +70,20 @@ final class SpeakerNamingSession {
     typealias SpeakerNamingData = PipelineQueue.SpeakerNamingData
     typealias SpeakerNamingResult = PipelineQueue.SpeakerNamingResult
 
-    /// The queue. Weak so the queue can own the session strongly with no cycle;
-    /// a nil delegate makes every callback a no-op.
+    /// The queue. Weak *at rest* so the queue can own the session strongly with
+    /// no retain cycle; a nil delegate makes the synchronous callbacks no-ops.
+    ///
+    /// Long-running async flows (`reapplySpeakerNames`, `lateDiarization`,
+    /// `generateProtocolForExistingJob`) capture this strongly ONCE at flow
+    /// start and use the local reference throughout. The strong local keeps the
+    /// queue alive for the flow's duration, exactly like the pre-extraction
+    /// `self` capture on the queue's own Tasks did, so an in-flight confirm or
+    /// re-run survives a `PipelineController.rebuild()` queue swap instead of
+    /// dying half-way (transcript rewritten and sidecar deleted, but the
+    /// protocol and `.done` never landing, so the new queue re-processes the
+    /// job from auto-names and drops the user's corrections). The strong local
+    /// also keeps this weak var resolving for any helper that still reads it
+    /// mid-flow. Flows that start with an already-nil delegate no-op harmlessly.
     weak var delegate: (any SpeakerNamingSessionDelegate)?
 
     /// Disk persistence for speaker-naming sidecars (keyed by per-job slug).
@@ -191,27 +204,35 @@ final class SpeakerNamingSession {
 
         removeNamingData(jobID: jobID, slug: slug)
 
-        if canGenerateProtocol {
-            Task { await generateProtocolForExistingJob(jobID: jobID) }
+        // `canGenerateProtocol == true` implies the delegate was alive above
+        // (it resolved the job's transcriptPath); binding it here lets the Task
+        // closure hold the queue strongly from spawn (see `delegate`).
+        if canGenerateProtocol, let delegate {
+            Task { await generateProtocolForExistingJob(jobID: jobID, delegate: delegate) }
         } else if delegate?.job(withID: jobID)?.state == .speakerNamingPending {
             delegate?.updateJobState(id: jobID, to: .done)
         }
     }
 
-    private func generateProtocolForExistingJob(jobID: UUID) async {
-        guard let job = delegate?.job(withID: jobID),
+    /// Takes the delegate as a strong parameter (captured by the spawning Task
+    /// in `acceptAutoNames`) so the queue stays alive across the LLM-generation
+    /// await; see `delegate` for the keep-alive rationale.
+    private func generateProtocolForExistingJob(
+        jobID: UUID, delegate: any SpeakerNamingSessionDelegate,
+    ) async {
+        guard let job = delegate.job(withID: jobID),
               let transcriptPath = job.transcriptPath,
               let outputDir,
               let transcript = try? String(contentsOf: transcriptPath, encoding: .utf8)
         else { return }
-        await delegate?.generateProtocol(
+        await delegate.generateProtocol(
             jobID: jobID,
             transcript: transcript,
             title: job.meetingTitle,
             protocolsDir: outputDir.appendingPathComponent("protocols"),
         )
-        if delegate?.job(withID: jobID)?.state == .generatingProtocol {
-            delegate?.updateJobState(id: jobID, to: .done)
+        if delegate.job(withID: jobID)?.state == .generatingProtocol {
+            delegate.updateJobState(id: jobID, to: .done)
         }
     }
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -1,0 +1,394 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "SpeakerNamingSession")
+
+/// Collaborator that `PipelineQueue` calls for whatever it still owns while the
+/// naming session runs. Strictly id-based (never index-based): a job index goes
+/// stale across an `await` when another finished job is evicted by
+/// `completedJobLifetime`, a documented past bug — so the session only ever
+/// addresses a job by its `UUID`. The queue owns the session strongly
+/// (`let naming`); the session holds this delegate weakly, so a deallocated
+/// queue turns every delegate call into a harmless no-op (optional chaining)
+/// instead of a crash or a retain cycle.
+@MainActor
+protocol SpeakerNamingSessionDelegate: AnyObject {
+    /// A value copy of the job, or nil if it is no longer tracked.
+    func job(withID id: UUID) -> PipelineJob?
+    func updateJobState(id: UUID, to newState: JobState, error: String?)
+    func addWarning(id: UUID, _ message: String)
+    /// Persist the per-job naming metadata on the (queue-owned) job. `nil`
+    /// for either field means "leave unchanged".
+    func setNamingMetadata(jobID: UUID, slug: String?, usedDiarizerMode: DiarizerMode?)
+    /// Apply a speaker DB update AND refresh the queue's cached known-names in
+    /// one step (issue #155): the write+refresh pairing must stay atomic.
+    func updateSpeakerDB(
+        matcher: SpeakerMatcher, mapping: [String: String],
+        embeddings: [String: [Float]], speakingTimes: [String: TimeInterval],
+    )
+    /// Run the LLM protocol generator over a transcript (a queue pipeline stage).
+    func generateProtocol(jobID: UUID, transcript: String, title: String, protocolsDir: URL) async
+    /// Diarize app + mic tracks separately with the shared mic-fail fallback
+    /// (a queue pipeline stage, reused by the late re-run).
+    func runDualTrackDiarization(
+        diarizeProcess: any DiarizationProvider,
+        tracks: (app: URL, mic: URL, micDelay: TimeInterval),
+        speakerCount: Int?, title: String, jobID: UUID,
+    ) async throws -> DiarizationRun
+    /// Render the speaker-labeled transcript from a diarization run + cached
+    /// transcript segments (a queue pipeline stage, reused by the late rewrite).
+    func renderLabeledTranscript(
+        run: DiarizationRun, cachedSegments: [TimestampedSegment],
+        isDualSource: Bool, autoNames: [String: String],
+    ) -> String?
+    /// Enter the diarizing stage for a late re-run: `updateJobState(.diarizing)`
+    /// + start the menu's elapsed timer.
+    func namingStageDidStart(jobID: UUID)
+    /// Leave a timed naming stage: stop the elapsed timer.
+    func namingStageDidEnd()
+}
+
+extension SpeakerNamingSessionDelegate {
+    /// Convenience wrapper so call sites that never carry an error message can
+    /// omit the `error:` argument.
+    func updateJobState(id: UUID, to newState: JobState) {
+        updateJobState(id: id, to: newState, error: nil)
+    }
+}
+
+/// Owns the speaker-naming half of the pipeline: the (possibly late) naming
+/// dialog, its persisted sidecars + recognition forensics, and the late
+/// re-diarization / re-apply paths. `PipelineQueue` holds this strongly as
+/// `let naming` and sets `naming.delegate = self` post-init, so SwiftUI
+/// observation follows through the stored property into this nested
+/// `@Observable` (the queue exposes thin forwarders for the direct-dict reads
+/// at `PipelineController` / `AppState+RPC`).
+@MainActor
+@Observable
+final class SpeakerNamingSession {
+    typealias SpeakerNamingData = PipelineQueue.SpeakerNamingData
+    typealias SpeakerNamingResult = PipelineQueue.SpeakerNamingResult
+
+    /// The queue. Weak so the queue can own the session strongly with no cycle;
+    /// a nil delegate makes every callback a no-op.
+    weak var delegate: (any SpeakerNamingSessionDelegate)?
+
+    /// Disk persistence for speaker-naming sidecars (keyed by per-job slug).
+    private let namingStore: SpeakerNamingStore
+    let speakerMatcherFactory: () -> SpeakerMatcher
+    let diarizationFactory: (() -> any DiarizationProvider)?
+    /// Optional mode-overriding factory used by `lateDiarization` when the user
+    /// picks a different mode in the re-run UI. `nil` = mode override not
+    /// supported; `lateDiarization` falls back to `diarizationFactory()`.
+    let diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)?
+    let protocolGeneratorFactory: (() -> (any ProtocolGenerating)?)?
+    let outputDir: URL?
+    /// nil disables JSONL logging. AppState injects a real instance for
+    /// production; tests leave it nil unless they explicitly assert on the log.
+    let recognitionStatsLog: RecognitionStatsLog?
+
+    /// RAM cache of naming data, rebuilt from disk on `loadSnapshot()` (via
+    /// `restore`). Exposed via a queue forwarder for UI/RPC.
+    var speakerNamingDataByJob: [UUID: SpeakerNamingData] = [:]
+
+    /// Handler for speaker naming. When set, called instead of the default
+    /// continuation-based popup. Used by tests to auto-complete without UI.
+    var speakerNamingHandler: ((SpeakerNamingData) async -> SpeakerNamingResult)?
+
+    /// Per-job snapshot of the auto-name suggestions shown in the dialog, kept
+    /// until the user confirms/skips so `recordRecognition` can write the JSONL
+    /// row. Cleared on completion. Not persisted across launches — if the user
+    /// confirms in a fresh session, the recognition log row will have nil/empty
+    /// `autoName` (acceptable; user data is the real signal).
+    private var stashedSuggestedAtDialog: [UUID: [String: String]] = [:]
+    private var stashedTopCandidates: [UUID: [String: [TopCandidate]]] = [:]
+
+    init(
+        namingStore: SpeakerNamingStore,
+        speakerMatcherFactory: @escaping () -> SpeakerMatcher,
+        diarizationFactory: (() -> any DiarizationProvider)? = nil,
+        diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)? = nil,
+        protocolGeneratorFactory: (() -> (any ProtocolGenerating)?)? = nil,
+        outputDir: URL? = nil,
+        recognitionStatsLog: RecognitionStatsLog? = nil,
+    ) {
+        self.namingStore = namingStore
+        self.speakerMatcherFactory = speakerMatcherFactory
+        self.diarizationFactory = diarizationFactory
+        self.diarizationFactoryWithMode = diarizationFactoryWithMode
+        self.protocolGeneratorFactory = protocolGeneratorFactory
+        self.outputDir = outputDir
+        self.recognitionStatsLog = recognitionStatsLog
+    }
+
+    // MARK: - Completion
+
+    /// Called by the UI (or the test handler, via the queue forwarder) when the
+    /// user confirms, skips, or re-runs speaker naming. Always handles "late"
+    /// completion — the pipeline never blocks on naming.
+    func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
+        guard let data = speakerNamingDataByJob[jobID] else { return }
+        let slug = delegate?.job(withID: jobID)?.namingSlug
+
+        switch result {
+        case let .confirmed(userMapping):
+            recordRecognition(
+                jobID: jobID, title: data.meetingTitle,
+                userMapping: userMapping, fallback: data.mapping,
+            )
+            // Transition out of .speakerNamingPending synchronously so the UI's
+            // close-when-empty check sees the change immediately. This synchronous
+            // pending → generatingProtocol hop is the RPC idempotency contract; a
+            // duplicate confirm is rejected before it can double-record. The
+            // transcript rewrite + protocol generation happen async below.
+            if delegate?.job(withID: jobID)?.state == .speakerNamingPending {
+                delegate?.updateJobState(id: jobID, to: .generatingProtocol)
+            }
+            Task { await reapplySpeakerNames(jobID: jobID, mapping: userMapping) }
+
+        case let .rerun(count):
+            Task { await lateDiarization(jobID: jobID, speakerCount: count) }
+
+        case let .rerunWithMode(mode, count):
+            Task { await lateDiarization(jobID: jobID, speakerCount: count, mode: mode) }
+
+        case .skipped:
+            recordRecognition(
+                jobID: jobID, title: data.meetingTitle,
+                userMapping: nil, fallback: data.mapping,
+            )
+            acceptAutoNames(jobID: jobID, slug: slug)
+        }
+    }
+
+    /// Re-invoke the injected naming handler after the job reached
+    /// `.speakerNamingPending`. Mirrors the late-rerun re-invocation so the test
+    /// path runs the exact same `completeSpeakerNaming` flow the production UI
+    /// does. Captures `self` strongly for the op duration (bounded); the delegate
+    /// stays weak. No-op when no handler is set (the interactive/production path).
+    func invokeHandler(jobID: UUID, data: SpeakerNamingData) {
+        guard let handler = speakerNamingHandler else { return }
+        Task {
+            let result = await handler(data)
+            completeSpeakerNaming(jobID: jobID, result: result)
+        }
+    }
+
+    /// Skipped or stale-cleanup path: the user accepted (implicitly or by
+    /// timeout) the auto-names. Drops sidecar files synchronously, transitions
+    /// to .done. If a protocol generator is configured AND the transcript file
+    /// exists, fires off protocol generation in the background; the job
+    /// transitions through .generatingProtocol → .done as that completes.
+    private func acceptAutoNames(jobID: UUID, slug: String?) {
+        // Probe the factory's actual output, not just its existence — the
+        // closure is wired even when protocolProvider is `.none`, but returns
+        // nil. Without this, the Task path below fizzles silently
+        // (generateProtocol guards on factory()) and the job sits in
+        // .speakerNamingPending forever.
+        let canGenerateProtocol = (protocolGeneratorFactory?() != nil)
+            && outputDir != nil
+            && delegate?.job(withID: jobID)?.transcriptPath != nil
+
+        removeNamingData(jobID: jobID, slug: slug)
+
+        if canGenerateProtocol {
+            Task { await generateProtocolForExistingJob(jobID: jobID) }
+        } else if delegate?.job(withID: jobID)?.state == .speakerNamingPending {
+            delegate?.updateJobState(id: jobID, to: .done)
+        }
+    }
+
+    private func generateProtocolForExistingJob(jobID: UUID) async {
+        guard let job = delegate?.job(withID: jobID),
+              let transcriptPath = job.transcriptPath,
+              let outputDir,
+              let transcript = try? String(contentsOf: transcriptPath, encoding: .utf8)
+        else { return }
+        await delegate?.generateProtocol(
+            jobID: jobID,
+            transcript: transcript,
+            title: job.meetingTitle,
+            protocolsDir: outputDir.appendingPathComponent("protocols"),
+        )
+        if delegate?.job(withID: jobID)?.state == .generatingProtocol {
+            delegate?.updateJobState(id: jobID, to: .done)
+        }
+    }
+
+    // MARK: - Resolve auto-names + park for the dialog
+
+    /// Match a diarization result against the speaker DB, persist naming data +
+    /// recognition forensics, and return the auto-name mapping to apply to the
+    /// transcript. Parks the job for the (possibly late) naming dialog by
+    /// stashing `SpeakerNamingData`; the dialog is driven later by
+    /// `completeSpeakerNaming`, so this stage never blocks the pipeline. A job
+    /// that opts out via `autoSkipNaming` (headless blocking-transcribe)
+    /// finishes on the auto-names without a dialog.
+    func resolveSpeakerNames(
+        diarization: DiarizationResult,
+        job: (jobID: UUID, title: String, slug: String, participants: [String]),
+        diarizeProcess: any DiarizationProvider,
+        isDualSource: Bool, outputDir: URL,
+    ) -> [String: String] {
+        let (jobID, title, slug, participants) = job
+        // No embeddings → no matching or dialog; keep the diarizer's own names.
+        guard let embeddings = diarization.embeddings else { return diarization.autoNames }
+
+        let matcher = speakerMatcherFactory()
+        let verbose = matcher.matchVerbose(embeddings: embeddings)
+        let matched = verbose.mapValues(\.assignedName)
+        var autoNames = matched
+        let topCandidates = verbose.mapValues(\.topCandidates)
+
+        // Pre-match participants to remaining speakers.
+        if !participants.isEmpty {
+            autoNames = SpeakerMatcher.preMatchParticipants(
+                mapping: autoNames,
+                speakingTimes: diarization.speakingTimes,
+                participants: participants,
+            )
+        }
+
+        let suggestedAtDialog = autoNames
+        let autoMatched = matched.count { $0.key != $0.value }
+        logger.info("[recognition] \(matched.count) speakers, \(autoMatched) auto, \(matched.count - autoMatched) unknown")
+
+        // Use persisted 16kHz path (survives workDir cleanup).
+        let persistedAudioPath = outputDir.appendingPathComponent("recordings")
+            .appendingPathComponent("\(slug)_16k.wav")
+        let namingData = SpeakerNamingData(
+            jobID: jobID,
+            meetingTitle: title,
+            mapping: autoNames,
+            speakingTimes: diarization.speakingTimes,
+            embeddings: embeddings,
+            audioPath: persistedAudioPath,
+            segments: diarization.segments.map { seg in
+                SpeakerNamingData.Segment(start: seg.start, end: seg.end, speaker: seg.speaker)
+            },
+            participants: participants,
+            isDualSource: isDualSource,
+        )
+
+        // Persist naming data and set slug + mode early.
+        saveNamingData(namingData, slug: slug)
+        delegate?.setNamingMetadata(jobID: jobID, slug: slug, usedDiarizerMode: diarizeProcess.mode)
+        delegate?.namingStageDidEnd()
+
+        // Stash recognition forensics so the late-confirm path can write the
+        // JSONL row when the user actually confirms (possibly later, via the
+        // re-openable dialog).
+        stashedSuggestedAtDialog[jobID] = suggestedAtDialog
+        stashedTopCandidates[jobID] = topCandidates
+
+        if delegate?.job(withID: jobID)?.autoSkipNaming == true {
+            // Headless blocking-transcribe: accept the auto-assigned names
+            // (exactly like a `.skipped` dialog result) so the job finishes on
+            // its own. Don't stash naming data: there is no interactive client
+            // to resolve it, and parking would wedge the job until the next
+            // launch's 24h stale-cleanup.
+            return autoNames
+        }
+        // Production/interactive: stash the naming data so the queue parks the
+        // job at `.speakerNamingPending` and pops the (re-openable) dialog. The
+        // pipeline continues with the auto-names; the dialog confirms later via
+        // `completeSpeakerNaming` without blocking.
+        speakerNamingDataByJob[jobID] = namingData
+        return autoNames
+    }
+
+    // MARK: - Persistence
+
+    /// Persist naming data via `namingStore`, surfacing a per-job warning on
+    /// failure (the store stays I/O-only; the session owns the job-state side
+    /// effect). A silent failure would mean late-confirm won't work after a
+    /// restart, so make it visible: log + warning on the job.
+    func saveNamingData(_ data: SpeakerNamingData, slug: String) {
+        do {
+            try namingStore.save(data, slug: slug)
+        } catch {
+            // Error left redacted: the write target is `<title-slug>_naming.json`,
+            // so a file-write error description would leak the meeting title.
+            logger.error("Failed to save naming data: \(error.localizedDescription)")
+            delegate?.addWarning(id: data.jobID, "Late re-confirm unavailable — naming data could not be persisted")
+        }
+    }
+
+    /// Remove all naming-related data for a job: RAM caches, disk JSON, and
+    /// sidecar files. Also clears the recognition-stats stash dicts so they
+    /// don't leak across rerun / stale-cleanup paths.
+    func removeNamingData(jobID: UUID, slug: String?) {
+        speakerNamingDataByJob.removeValue(forKey: jobID)
+        stashedSuggestedAtDialog.removeValue(forKey: jobID)
+        stashedTopCandidates.removeValue(forKey: jobID)
+        namingStore.deleteNamingJSON(slug: slug)
+        namingStore.cleanupSidecarFiles(slug: slug)
+    }
+
+    /// Rebuild the RAM naming cache for a restored `.speakerNamingPending` job
+    /// from its on-disk sidecar. Returns false when the sidecar is missing (the
+    /// queue then marks the job `.done`). Called from `loadSnapshot`.
+    func restore(jobID: UUID, slug: String) -> Bool {
+        guard let data = namingStore.load(slug: slug) else { return false }
+        speakerNamingDataByJob[jobID] = data
+        return true
+    }
+
+    /// Auto-resolve pending naming items older than maxAge. Generates the
+    /// protocol with auto-names, transitions them to .done, deletes sidecars.
+    /// `pendingJobs` is the queue's already-filtered `.speakerNamingPending` list.
+    func cleanupStalePending(pendingJobs: [PipelineJob], maxAge: TimeInterval = 86400) {
+        let now = Date()
+        for job in pendingJobs where now.timeIntervalSince(job.enqueuedAt) > maxAge {
+            logger.info("Auto-resolving stale pending naming for \(job.meetingTitle, privacy: .private)")
+            acceptAutoNames(jobID: job.id, slug: job.namingSlug)
+        }
+    }
+
+    // MARK: - Recognition forensics
+
+    /// Pull stashed forensics for a job and write the recognition-stats row.
+    /// Falls back to the original SpeakerNamingData mapping when the stash is
+    /// missing (e.g. the user confirmed in a fresh app session).
+    private func recordRecognition(
+        jobID: UUID, title: String,
+        // swiftlint:disable:next discouraged_optional_collection
+        userMapping: [String: String]?, fallback: [String: String],
+    ) {
+        recordRecognition(
+            suggested: stashedSuggestedAtDialog[jobID] ?? fallback,
+            userMapping: userMapping,
+            topCandidates: stashedTopCandidates[jobID] ?? [:],
+            jobID: jobID,
+            title: title,
+        )
+    }
+
+    /// Build recognition events and persist them off the pipeline path. Logs
+    /// outcome counts immediately; JSONL append runs in a detached Task.
+    private func recordRecognition(
+        suggested: [String: String],
+        // swiftlint:disable:next discouraged_optional_collection
+        userMapping: [String: String]?,
+        topCandidates: [String: [TopCandidate]],
+        jobID: UUID,
+        title: String,
+    ) {
+        let events = RecognitionStats.buildEvents(
+            suggested: suggested, userMapping: userMapping,
+            topCandidates: topCandidates,
+            jobID: jobID, meetingTitle: title,
+        )
+        var counts: [RecognitionAction: Int] = [:]
+        for e in events {
+            counts[e.action, default: 0] += 1
+        }
+        let parts = RecognitionAction.allCases
+            .map { "\($0.rawValue)=\(counts[$0] ?? 0)" }
+            .joined(separator: " ")
+        logger.info("[recognition] outcome \(parts, privacy: .public)")
+        if let recognitionStatsLog {
+            Task { await recognitionStatsLog.append(events) }
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
@@ -199,6 +199,118 @@ final class SpeakerNamingSessionTests: XCTestCase {
         XCTAssertNil(session.speakerNamingDataByJob[jobID])
     }
 
+    // MARK: - In-flight keep-alive
+
+    /// Records delegate activity into a box the test holds separately from the
+    /// mock, so assertions survive the mock itself being released mid-flow.
+    private final class FlowRecorder {
+        var jobs: [UUID: PipelineJob] = [:]
+        var transitions: [JobState] = []
+        var generateProtocolEntered = 0
+        var protocolGate: CheckedContinuation<Void, Never>?
+    }
+
+    /// Mock whose `generateProtocol` parks on a continuation, so the test can
+    /// deterministically release its own reference while the flow is in-flight.
+    private final class GatedMockDelegate: SpeakerNamingSessionDelegate {
+        let recorder: FlowRecorder
+
+        init(recorder: FlowRecorder) {
+            self.recorder = recorder
+        }
+
+        func job(withID id: UUID) -> PipelineJob? {
+            recorder.jobs[id]
+        }
+
+        func updateJobState(id: UUID, to newState: JobState, error _: String?) {
+            recorder.jobs[id]?.state = newState
+            recorder.transitions.append(newState)
+        }
+
+        func addWarning(id _: UUID, _: String) {}
+
+        func setNamingMetadata(jobID _: UUID, slug _: String?, usedDiarizerMode _: DiarizerMode?) {}
+
+        func updateSpeakerDB(
+            matcher _: SpeakerMatcher, mapping _: [String: String],
+            embeddings _: [String: [Float]], speakingTimes _: [String: TimeInterval],
+        ) {}
+
+        func generateProtocol(jobID _: UUID, transcript _: String, title _: String, protocolsDir _: URL) async {
+            recorder.generateProtocolEntered += 1
+            await withCheckedContinuation { recorder.protocolGate = $0 }
+        }
+
+        func runDualTrackDiarization(
+            diarizeProcess _: any DiarizationProvider,
+            tracks _: (app: URL, mic: URL, micDelay: TimeInterval),
+            speakerCount _: Int?, title _: String, jobID _: UUID,
+        ) throws -> DiarizationRun {
+            throw DiarizationError.notAvailable
+        }
+
+        func renderLabeledTranscript(
+            run _: DiarizationRun, cachedSegments _: [TimestampedSegment],
+            isDualSource _: Bool, autoNames _: [String: String],
+        ) -> String? {
+            nil
+        }
+
+        func namingStageDidStart(jobID _: UUID) {}
+        func namingStageDidEnd() {}
+    }
+
+    /// Pins the strong per-flow delegate capture: the delegate is weak *at
+    /// rest*, but an in-flight confirm flow must keep the queue alive to
+    /// completion (pre-extraction, the queue's own Tasks captured `self`
+    /// strongly). Without the capture, a `PipelineController.rebuild()` queue
+    /// swap mid-flow would strand the job after the transcript rewrite +
+    /// sidecar deletion, and the rebuilt queue would re-process it from
+    /// auto-names, dropping the user's corrections.
+    func testInFlightConfirmFlowKeepsDelegateAliveAcrossRelease() async throws {
+        let tmp = try makeTempDirectory(prefix: "SpeakerNamingSessionTests")
+        let transcriptPath = tmp.appendingPathComponent("transcript.txt")
+        try "] SPEAKER_0: hello".write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let session = makeSession(outputDir: tmp)
+        let recorder = FlowRecorder()
+        var mock: GatedMockDelegate? = GatedMockDelegate(recorder: recorder)
+        weak let weakMock = mock
+        session.delegate = mock
+
+        let job = pendingJob(namingSlug: "standup_abcd1234", transcriptPath: transcriptPath)
+        recorder.jobs[job.id] = job
+        session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
+
+        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+
+        // Wait until the re-apply flow is provably in-flight (parked inside the
+        // delegate's generateProtocol, i.e. mid-"LLM generation").
+        await waitUntil { recorder.generateProtocolEntered == 1 }
+        XCTAssertEqual(recorder.generateProtocolEntered, 1)
+
+        // Release the test's only strong reference — models the controller
+        // swapping queues mid-flow. The flow's strong capture must keep the
+        // delegate (the queue) alive.
+        mock = nil
+        XCTAssertNotNil(weakMock, "in-flight flow holds the delegate strongly")
+        XCTAssertNotNil(session.delegate)
+
+        // Let the protocol generation finish: the flow completes against the
+        // captured delegate, landing the final `.done`.
+        recorder.protocolGate?.resume()
+        recorder.protocolGate = nil
+        await waitUntil { recorder.transitions.contains(.done) }
+        XCTAssertEqual(recorder.transitions, [.generatingProtocol, .done])
+
+        // Once the flow ends, the weak-at-rest delegate zeroes — the per-flow
+        // capture is bounded, not a leak.
+        await waitUntil { weakMock == nil }
+        XCTAssertNil(weakMock, "delegate released once the flow completes")
+        XCTAssertNil(session.delegate)
+    }
+
     // MARK: - No-arg forwarder resolution
 
     func testHandlerIsInvokedAfterParking() async {

--- a/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
@@ -1,0 +1,225 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Focused unit tests for `SpeakerNamingSession` exercised directly against a
+/// mock delegate — no `PipelineQueue` construction needed, which is the whole
+/// point of the extraction. Covers delegate wiring, the synchronous
+/// `.speakerNamingPending → .generatingProtocol` transition (the RPC idempotency
+/// contract), the skip flow, and that a deallocated delegate degrades operations
+/// to no-ops instead of crashing.
+@MainActor
+final class SpeakerNamingSessionTests: XCTestCase {
+    // MARK: - Mock delegate
+
+    /// Records every delegate callback and models the minimal queue state the
+    /// session reads back (a per-id job whose `state` `updateJobState` mutates).
+    private final class MockDelegate: SpeakerNamingSessionDelegate {
+        var jobs: [UUID: PipelineJob] = [:]
+        private(set) var stateTransitions: [(id: UUID, state: JobState)] = []
+        private(set) var warnings: [(id: UUID, message: String)] = []
+        private(set) var generateProtocolCalls: [(jobID: UUID, title: String)] = []
+        private(set) var updateSpeakerDBCallCount = 0
+        private(set) var metadataUpdates: [(jobID: UUID, slug: String?, mode: DiarizerMode?)] = []
+        private(set) var stageStartCount = 0
+        private(set) var stageEndCount = 0
+
+        func job(withID id: UUID) -> PipelineJob? {
+            jobs[id]
+        }
+
+        func updateJobState(id: UUID, to newState: JobState, error _: String?) {
+            jobs[id]?.state = newState
+            stateTransitions.append((id, newState))
+        }
+
+        func addWarning(id: UUID, _ message: String) {
+            warnings.append((id, message))
+        }
+
+        func setNamingMetadata(jobID: UUID, slug: String?, usedDiarizerMode: DiarizerMode?) {
+            metadataUpdates.append((jobID, slug, usedDiarizerMode))
+        }
+
+        func updateSpeakerDB(
+            matcher _: SpeakerMatcher, mapping _: [String: String],
+            embeddings _: [String: [Float]], speakingTimes _: [String: TimeInterval],
+        ) {
+            updateSpeakerDBCallCount += 1
+        }
+
+        func generateProtocol(jobID: UUID, transcript _: String, title: String, protocolsDir _: URL) {
+            generateProtocolCalls.append((jobID, title))
+        }
+
+        func runDualTrackDiarization(
+            diarizeProcess _: any DiarizationProvider,
+            tracks _: (app: URL, mic: URL, micDelay: TimeInterval),
+            speakerCount _: Int?, title _: String, jobID _: UUID,
+        ) throws -> DiarizationRun {
+            throw DiarizationError.notAvailable
+        }
+
+        func renderLabeledTranscript(
+            run _: DiarizationRun, cachedSegments _: [TimestampedSegment],
+            isDualSource _: Bool, autoNames _: [String: String],
+        ) -> String? {
+            nil
+        }
+
+        func namingStageDidStart(jobID _: UUID) {
+            stageStartCount += 1
+        }
+
+        func namingStageDidEnd() {
+            stageEndCount += 1
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession(outputDir: URL?) -> SpeakerNamingSession {
+        SpeakerNamingSession(
+            namingStore: SpeakerNamingStore(outputDir: nil),
+            speakerMatcherFactory: PipelineQueue.throwawayMatcherFactory(),
+            outputDir: outputDir,
+        )
+    }
+
+    private func makeNamingData(jobID: UUID) -> PipelineQueue.SpeakerNamingData {
+        PipelineQueue.SpeakerNamingData(
+            jobID: jobID,
+            meetingTitle: "Standup",
+            mapping: ["SPEAKER_0": "SPEAKER_0"],
+            speakingTimes: ["SPEAKER_0": 12],
+            embeddings: ["SPEAKER_0": [0.1, 0.2, 0.3]],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+    }
+
+    private func pendingJob(namingSlug: String?, transcriptPath: URL?) -> PipelineJob {
+        var job = PipelineJob(
+            meetingTitle: "Standup", appName: "Test",
+            mixPath: nil, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.namingSlug = namingSlug
+        job.transcriptPath = transcriptPath
+        return job
+    }
+
+    private func waitUntil(_ condition: () -> Bool, timeout: TimeInterval = 2) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    // MARK: - Confirm
+
+    func testConfirmSynchronouslyTransitionsToGeneratingProtocolThenDone() async throws {
+        let tmp = try makeTempDirectory(prefix: "SpeakerNamingSessionTests")
+        let transcriptPath = tmp.appendingPathComponent("transcript.txt")
+        try "] SPEAKER_0: hello".write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let session = makeSession(outputDir: tmp)
+        let mock = MockDelegate()
+        session.delegate = mock
+
+        let job = pendingJob(namingSlug: "standup_abcd1234", transcriptPath: transcriptPath)
+        mock.jobs[job.id] = job
+        session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
+
+        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+
+        // The pending → generatingProtocol hop MUST be synchronous (the RPC
+        // idempotency contract): it has already happened when the call returns,
+        // before the async re-apply Task runs.
+        XCTAssertEqual(mock.stateTransitions.first?.state, .generatingProtocol)
+
+        // The async re-apply then updates the DB, regenerates the protocol, and
+        // finishes the job.
+        await waitUntil { mock.jobs[job.id]?.state == .done }
+        XCTAssertEqual(mock.jobs[job.id]?.state, .done)
+        XCTAssertEqual(mock.updateSpeakerDBCallCount, 1)
+        XCTAssertEqual(mock.generateProtocolCalls.map(\.jobID), [job.id])
+        XCTAssertNil(session.speakerNamingDataByJob[job.id], "naming data cleared on confirm")
+    }
+
+    // MARK: - Skip
+
+    func testSkipWithoutProtocolFactoryTransitionsToDoneAndClearsData() {
+        let session = makeSession(outputDir: nil) // no protocol factory, no outputDir
+        let mock = MockDelegate()
+        session.delegate = mock
+
+        let job = pendingJob(namingSlug: "standup_abcd1234", transcriptPath: nil)
+        mock.jobs[job.id] = job
+        session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
+
+        session.completeSpeakerNaming(jobID: job.id, result: .skipped)
+
+        // Skip with no protocol generator is fully synchronous.
+        XCTAssertEqual(mock.jobs[job.id]?.state, .done)
+        XCTAssertNil(session.speakerNamingDataByJob[job.id], "naming data cleared on skip")
+        XCTAssertFalse(mock.generateProtocolCalls.contains { $0.jobID == job.id })
+    }
+
+    // MARK: - Missing data / dealloc
+
+    func testCompleteWithNoNamingDataIsNoOp() {
+        let session = makeSession(outputDir: nil)
+        let mock = MockDelegate()
+        session.delegate = mock
+
+        // No speakerNamingDataByJob entry → guard returns immediately.
+        session.completeSpeakerNaming(jobID: UUID(), result: .confirmed(["SPEAKER_0": "Alice"]))
+        XCTAssertTrue(mock.stateTransitions.isEmpty)
+    }
+
+    func testDeallocatedDelegateMakesOperationsNoOpsNotCrashes() {
+        let session = makeSession(outputDir: nil)
+        let jobID = UUID()
+
+        do {
+            let mock = MockDelegate()
+            session.delegate = mock
+            XCTAssertNotNil(session.delegate)
+        }
+        // `delegate` is weak → the mock is gone once its only strong ref left scope.
+        XCTAssertNil(session.delegate, "delegate is weak and was released")
+
+        session.speakerNamingDataByJob[jobID] = makeNamingData(jobID: jobID)
+        // Must not crash even though every delegate callback resolves to nil.
+        session.completeSpeakerNaming(jobID: jobID, result: .skipped)
+
+        // removeNamingData still ran (session-owned, no delegate needed).
+        XCTAssertNil(session.speakerNamingDataByJob[jobID])
+    }
+
+    // MARK: - No-arg forwarder resolution
+
+    func testHandlerIsInvokedAfterParking() async {
+        let session = makeSession(outputDir: nil)
+        let mock = MockDelegate()
+        session.delegate = mock
+
+        let job = pendingJob(namingSlug: "standup_abcd1234", transcriptPath: nil)
+        mock.jobs[job.id] = job
+
+        let expectation = expectation(description: "handler invoked")
+        session.speakerNamingHandler = { data in
+            XCTAssertEqual(data.jobID, job.id)
+            expectation.fulfill()
+            return .skipped
+        }
+
+        let data = makeNamingData(jobID: job.id)
+        session.speakerNamingDataByJob[job.id] = data
+        session.invokeHandler(jobID: job.id, data: data)
+
+        await fulfillment(of: [expectation], timeout: 2)
+    }
+}


### PR DESCRIPTION
## What

Extracts the speaker-naming half of the pipeline out of the ~2050-line `PipelineQueue` into a dedicated `@MainActor @Observable SpeakerNamingSession` collaborator (`SpeakerNamingSession.swift` + `SpeakerNamingSession+Late.swift`), plus a small `SpeakerNamingData.swift` for the value types. `PipelineQueue.swift` drops from 2043 to 1534 lines.

This is a pure decomposition: no user-facing behaviour changes.

## Stacking

Builds on #457 (`refactor/naming-handler-convergence`) and is opened against that branch, not `main`. It must merge after #457. The diff shown here is only this step's changes.

## Design

- The queue owns the session strongly (`let naming`) and sets `naming.delegate = self` after init; the session holds the delegate **weakly at rest**, so there is no retain cycle and a flow started against an already-released queue no-ops harmlessly.
- Each long-running async flow (`reapplySpeakerNames`, `lateDiarization`, `generateProtocolForExistingJob`) captures the delegate **strongly once at flow start** and uses that local reference throughout. This restores the pre-extraction semantics where the queue's own Tasks captured `self` strongly: an in-flight confirm or re-run keeps the (old) queue alive to completion even when `PipelineController.rebuild()` swaps the queue mid-flow, so the user's confirmed speaker names cannot be lost half-applied. The capture is bounded to the flow's duration, so the at-rest reference stays weak and cycle-free. Pinned by a mutation-proven regression test that releases the delegate mid-flight and asserts the flow still lands `.done`.
- A same-isolation delegate (not an actor split): the naming work reads and mutates queue-owned job state on the main actor with no suspension between the reads and the mutation the RPC contract depends on.
- The delegate protocol is strictly **id-based, never index-based**: a job index goes stale across an `await` when another finished job is evicted by `completedJobLifetime` (a documented past bug), so the session addresses jobs only by `UUID`.
- `DiarizationRun` becomes an internal top-level type since it crosses the queue and session boundary in both directions.

### Delegate protocol

```swift
@MainActor
protocol SpeakerNamingSessionDelegate: AnyObject {
    func job(withID id: UUID) -> PipelineJob?
    func updateJobState(id: UUID, to newState: JobState, error: String?)
    func addWarning(id: UUID, _ message: String)
    func setNamingMetadata(jobID: UUID, slug: String?, usedDiarizerMode: DiarizerMode?)
    func updateSpeakerDB(matcher: SpeakerMatcher, mapping: [String: String],
                         embeddings: [String: [Float]], speakingTimes: [String: TimeInterval])
    func generateProtocol(jobID: UUID, transcript: String, title: String, protocolsDir: URL) async
    func runDualTrackDiarization(diarizeProcess: any DiarizationProvider,
                                 tracks: (app: URL, mic: URL, micDelay: TimeInterval),
                                 speakerCount: Int?, title: String, jobID: UUID) async throws -> DiarizationRun
    func renderLabeledTranscript(run: DiarizationRun, cachedSegments: [TimestampedSegment],
                                 isDualSource: Bool, autoNames: [String: String]) -> String?
    func namingStageDidStart(jobID: UUID)   // updateJobState(.diarizing) + start elapsed timer
    func namingStageDidEnd()                // stop elapsed timer
}
// + a convenience extension `updateJobState(id:to:)` defaulting error to nil
```

## Preserved invariants

- The synchronous `.speakerNamingPending -> .generatingProtocol` hop inside `completeSpeakerNaming` stays synchronous (the `/v1/jobs/<id>/naming` idempotency contract).
- The `updateSpeakerDB` write + `refreshKnownSpeakerNames` pairing stays on the queue as one atomic delegate call (issue #155 CPU-regression guard).
- The `SpeakerNamingData` Codable shape and its `revision` UUID change-detection marker are moved verbatim; the types stay nested under `PipelineQueue` (via an extension), so every `PipelineQueue.SpeakerNamingData` reference across the UI, RPC, persistence, and tests keeps resolving unchanged.
- The queue keeps thin get/set forwarders (`speakerNamingDataByJob`, `speakerNamingHandler`, `completeSpeakerNaming`, `cleanupStalePending`, `pendingSpeakerNaming`, `speakerNamingData(forJobID:)`), so external call sites and SwiftUI observation through `queue.naming` keep working unchanged.

## Tests

- Existing naming tests continue to target the queue forwarders, unchanged.
- New `SpeakerNamingSessionTests` drives the session directly against a mock delegate: the synchronous confirm transition then async completion, the skip flow, missing-data no-op, a deallocated-delegate no-op, and handler invocation after parking.

## Verification

- `swift test --parallel`: green (the only failures are the pre-existing `MenuBarIconSnapshotTests` image-snapshot mismatches on this machine, unrelated to this diff).
- `scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict` (via `xcodebuild build-for-testing`): 0 violations.
- `scripts/pre-push.sh`: release-build parity passed.

## Notes

`PipelineQueue.swift` keeps its existing lint suppressions; they are scheduled to drop in a later step once the remaining concerns move out.
