### PR TITLE
ci: add label-gated PR triggers to the heavy test lanes

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -5,6 +5,16 @@ name: E2E (Production App)
 
 on:
   workflow_dispatch:
+  # Label-gated PR runs. Deliberately `pull_request`, NOT
+  # `pull_request_target`: this workflow checks out and executes the PR head
+  # on a self-hosted Mac mini with a real signing identity and TCC grants, so
+  # untrusted fork code must never run automatically. Under `pull_request` a
+  # fork PR only reaches the runner when a maintainer consciously applies the
+  # `run-e2e` label (the job `if:` below is the gate); the label IS the
+  # human approval step. `pull_request_target` would run in the base-repo
+  # context with a writable token and is unsafe for a code-executing lane.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     # No paths-filter. Stable-tag ruleset requires a *push*-event check-run
     # on the SHA; `workflow_dispatch`-created check-runs don't satisfy the
@@ -21,12 +31,23 @@ on:
 # Live-recording E2E mutates host state (deploys the bundle, runs the
 # meeting-simulator which plays audio through the speakers). Two parallel
 # runs would race for the recorder; serialise.
+#
+# Non-PR events keep the existing behaviour exactly: the group falls back to
+# github.ref (refs/heads/main for push/schedule/dispatch), so those runs share
+# one group and queue rather than race, and cancel-in-progress stays false so
+# main-push and nightly runs are never cancelled. PR events group per PR number
+# and set cancel-in-progress true, so pushing new commits to a labeled PR
+# supersedes its own in-flight run without disturbing main/nightly.
 concurrency:
-  group: e2e-app-${{ github.ref }}
-  cancel-in-progress: false
+  group: e2e-app-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e-app:
+    # Non-PR events (push/schedule/dispatch) always run; PR events run only
+    # when a maintainer applied the `run-e2e` label (see the pull_request
+    # trigger comment for why the label is the fork-execution approval gate).
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
     # `audio` label pins the job to the runner that has exclusive access
     # to the BlackHole virtual input device. A second runner on the same
     # Mini handles other self-hosted workloads in parallel without

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -5,14 +5,17 @@ name: E2E (Production App)
 
 on:
   workflow_dispatch:
-  # Label-gated PR runs. Deliberately `pull_request`, NOT
-  # `pull_request_target`: this workflow checks out and executes the PR head
-  # on a self-hosted Mac mini with a real signing identity and TCC grants, so
-  # untrusted fork code must never run automatically. Under `pull_request` a
-  # fork PR only reaches the runner when a maintainer consciously applies the
-  # `run-e2e` label (the job `if:` below is the gate); the label IS the
-  # human approval step. `pull_request_target` would run in the base-repo
-  # context with a writable token and is unsafe for a code-executing lane.
+  # Label-gated PR runs, same-repo branches only. Deliberately
+  # `pull_request`, NOT `pull_request_target`: this workflow checks out and
+  # executes the PR head on a self-hosted Mac mini with a real signing
+  # identity and TCC grants. Fork PRs are excluded entirely (the job `if:`
+  # checks head.repo): a label would be a STANDING approval — every later
+  # fork push would re-run unreviewed code on the runner — and a fork run
+  # would fail anyway, since fork `pull_request` runs get no secrets, the
+  # bundle falls back to the self-signed cert, which lacks the Mini's TCC
+  # microphone grant, and the leftover consent prompt poisons later runs.
+  # To E2E a fork contribution, push it to a same-repo branch and label
+  # that PR.
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   push:
@@ -32,22 +35,31 @@ on:
 # meeting-simulator which plays audio through the speakers). Two parallel
 # runs would race for the recorder; serialise.
 #
-# Non-PR events keep the existing behaviour exactly: the group falls back to
-# github.ref (refs/heads/main for push/schedule/dispatch), so those runs share
-# one group and queue rather than race, and cancel-in-progress stays false so
-# main-push and nightly runs are never cancelled. PR events group per PR number
-# and set cancel-in-progress true, so pushing new commits to a labeled PR
-# supersedes its own in-flight run without disturbing main/nightly.
+# cancel-in-progress stays false for ALL events, including PR runs: the dev
+# app is launched detached (`open`), so a cancelled run cannot clean it up —
+# the app would keep recording, hold port 9876, and leave orphaned WAVs that
+# crash-recovery feeds into the NEXT run's pipeline assertions. PR runs
+# therefore queue instead of superseding. PR events group per PR number so a
+# labeled PR never sits in front of a main-push/nightly run (github.ref
+# group); mutual exclusion ACROSS groups relies on there being exactly ONE
+# `audio`-labeled runner — do not register a second audio runner.
 concurrency:
   group: e2e-app-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   e2e-app:
-    # Non-PR events (push/schedule/dispatch) always run; PR events run only
-    # when a maintainer applied the `run-e2e` label (see the pull_request
-    # trigger comment for why the label is the fork-execution approval gate).
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
+    # Non-PR events (push/schedule/dispatch) always run. PR events run only
+    # for same-repo branches carrying the `run-e2e` label (fork PRs never
+    # reach the runner — see the trigger comment). The label-name check keeps
+    # `labeled` events for any OTHER label from queueing a duplicate run.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-e2e')
+      )
     # `audio` label pins the job to the runner that has exclusive access
     # to the BlackHole virtual input device. A second runner on the same
     # Mini handles other self-hosted workloads in parallel without

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,13 +29,27 @@ on:
     # would fire a duplicate engine E2E run that the tag ruleset already
     # has covered via the main-push check-run.
     branches: [main]
+  # Label-gated PR runs: opening/updating a PR triggers this workflow, but
+  # the job below only executes when the `run-e2e` label is present. This
+  # lets a maintainer pull pre-merge feedback from the fixture E2E lane
+  # without waiting for the post-merge main-push run. `labeled` is included
+  # so applying the label to an already-open PR starts the run immediately.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
+# PR runs land in their own group (github.ref = refs/pull/<n>/merge), so
+# cancel-in-progress supersedes stale runs of the same PR while never
+# touching main-push or nightly runs (github.ref = refs/heads/main is a
+# distinct group). No change needed to serve label-gated PRs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
+    # Non-PR events (push/schedule/dispatch) always run; PR events run only
+    # when a maintainer applied the `run-e2e` label.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
     runs-on: [self-hosted, macOS, ARM64]
     # Cold-cache runs download multi-GB models (WhisperKit ~1 GB,
     # Parakeet ~50 MB); hot runs <10 min. 30 min job

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,27 +29,38 @@ on:
     # would fire a duplicate engine E2E run that the tag ruleset already
     # has covered via the main-push check-run.
     branches: [main]
-  # Label-gated PR runs: opening/updating a PR triggers this workflow, but
-  # the job below only executes when the `run-e2e` label is present. This
-  # lets a maintainer pull pre-merge feedback from the fixture E2E lane
-  # without waiting for the post-merge main-push run. `labeled` is included
-  # so applying the label to an already-open PR starts the run immediately.
+  # Label-gated PR runs, same-repo branches only (this lane executes PR code
+  # on the self-hosted Mini, so fork PRs are excluded — same rationale as
+  # e2e-app.yml). The job below only executes when the `run-e2e` label is
+  # present, giving pre-merge feedback from the fixture E2E lane without
+  # waiting for the post-merge main-push run. `labeled` is included so
+  # applying the label to an already-open PR starts the run immediately.
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
-# PR runs land in their own group (github.ref = refs/pull/<n>/merge), so
-# cancel-in-progress supersedes stale runs of the same PR while never
-# touching main-push or nightly runs (github.ref = refs/heads/main is a
-# distinct group). No change needed to serve label-gated PRs.
+# PR runs land in their own group (github.ref = refs/pull/<n>/merge), so they
+# can never cancel a main-push run (refs/heads/main is a distinct group).
+# Within a PR group only `synchronize` (new commits) supersedes the in-flight
+# run: `labeled` fires for ANY label addition, so cancelling on it would kill
+# an in-flight run just because an unrelated label arrived. Push/dispatch
+# events keep the old unconditional cancel (back-to-back main pushes
+# supersede the stale run).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action == 'synchronize' }}
 
 jobs:
   e2e:
-    # Non-PR events (push/schedule/dispatch) always run; PR events run only
-    # when a maintainer applied the `run-e2e` label.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
+    # Non-PR events (push/dispatch) always run. PR events run only for
+    # same-repo branches carrying the `run-e2e` label; the label-name check
+    # keeps `labeled` events for any OTHER label from starting a duplicate.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-e2e')
+      )
     runs-on: [self-hosted, macOS, ARM64]
     # Cold-cache runs download multi-GB models (WhisperKit ~1 GB,
     # Parakeet ~50 MB); hot runs <10 min. 30 min job

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -9,10 +9,13 @@ name: Quality & Safety
 #     in Tests/Fixtures/quality/quality-baseline.json; fails on regression).
 #
 # Triggers: push to main, nightly cron, explicit manual dispatch, and
-# label-gated PR runs. Unlabeled PRs skip every job, so day-to-day review
-# iteration stays fast; applying the `run-quality` label runs the same job
-# set a push to main runs (both the sanitizer matrix and the quality gate),
-# giving pre-merge feedback on demand.
+# label-gated PR runs for SAME-REPO branches only. Fork PR code never runs
+# here: the sanitizer leg executes on the self-hosted Mini right next to an
+# unlocked CI keychain, and fork `pull_request` tokens are read-only, which
+# would also break the cancel-on-failure step. Unlabeled PRs skip every job,
+# so day-to-day review iteration stays fast; applying the `run-quality`
+# label runs the same job set a push to main runs (both the sanitizer
+# matrix and the quality gate), giving pre-merge feedback on demand.
 on:
   push:
     branches: [main]
@@ -43,21 +46,30 @@ on:
 #
 # Non-PR events keep this exactly: the group falls back to github.ref and
 # cancel-in-progress stays false, so no push/schedule/dispatch run is ever
-# cancelled. PR events group per PR number and set cancel-in-progress true,
-# so a new commit on a labeled PR supersedes that PR's in-flight run (the
-# sanitizer leg shares the scarce self-hosted Mini) without touching any
-# main/nightly run.
+# cancelled. PR events group per PR number, never touching any main/nightly
+# run, and only a `synchronize` event (new commits) supersedes that PR's
+# in-flight run: `labeled` fires for ANY label addition, so cancelling on it
+# would kill a long in-flight quality run just because an unrelated label
+# arrived.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   test-sanitizer:
+    # PR leg: same-repo branches with the `run-quality` label only (see the
+    # trigger comment); the label-name check keeps `labeled` events for any
+    # OTHER label from starting a duplicate run.
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-quality'))
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-quality') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-quality')
+      )
     # Self-hosted Mini absorbs sanitizer instrumentation 4× better than
     # macos-26 GH-hosted (TSan ~6:41 vs ~25 min) and avoids the CoreML
     # model-load assertion race that flaked WhisperKitEngineTests on
@@ -127,11 +139,19 @@ jobs:
           job-name: sanitizers (${{ matrix.variant }})
 
   quality-baseline:
+    # Same PR gate as test-sanitizer: this job is GH-hosted, but the fork
+    # token would be read-only (403 on cancel-on-failure), and one label
+    # driving both jobs must mean one consistent audience.
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.run-quality) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-quality'))
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-quality') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-quality')
+      )
     runs-on: macos-26
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -8,11 +8,20 @@ name: Quality & Safety
 #     runs real ASR, then diffs the result against the committed baseline
 #     in Tests/Fixtures/quality/quality-baseline.json; fails on regression).
 #
-# Triggers: push to main, nightly cron, and explicit manual dispatch.
-# Never runs on pull requests — review iteration stays fast.
+# Triggers: push to main, nightly cron, explicit manual dispatch, and
+# label-gated PR runs. Unlabeled PRs skip every job, so day-to-day review
+# iteration stays fast; applying the `run-quality` label runs the same job
+# set a push to main runs (both the sanitizer matrix and the quality gate),
+# giving pre-merge feedback on demand.
 on:
   push:
     branches: [main]
+  # Label-gated PR runs: opening/updating a PR triggers the workflow, but the
+  # jobs below gate on the `run-quality` label so nothing heavy runs until a
+  # maintainer opts the PR in. `labeled` lets the label start the run on an
+  # already-open PR.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: "0 3 * * *"  # 03:00 UTC = 05:00 CEST
   workflow_dispatch:
@@ -31,16 +40,24 @@ on:
 # lose those baselines, so we don't cancel — let runs accumulate. Manual
 # back-to-back dispatches are rare enough that the wasted time isn't
 # worth a more complex carve-out.
+#
+# Non-PR events keep this exactly: the group falls back to github.ref and
+# cancel-in-progress stays false, so no push/schedule/dispatch run is ever
+# cancelled. PR events group per PR number and set cancel-in-progress true,
+# so a new commit on a labeled PR supersedes that PR's in-flight run (the
+# sanitizer leg shares the scarce self-hosted Mini) without touching any
+# main/nightly run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-sanitizer:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer)
+      (github.event_name == 'workflow_dispatch' && inputs.run-sanitizer) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-quality'))
     # Self-hosted Mini absorbs sanitizer instrumentation 4× better than
     # macos-26 GH-hosted (TSan ~6:41 vs ~25 min) and avoids the CoreML
     # model-load assertion race that flaked WhisperKitEngineTests on
@@ -113,7 +130,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.run-quality)
+      (github.event_name == 'workflow_dispatch' && inputs.run-quality) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-quality'))
     runs-on: macos-26
     timeout-minutes: 45
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,12 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   ci.yml                   # CI: lint + analyze + Swift tests (3 parallel jobs)
   release.yml              # CI: build DMG + GitHub Release on tag push
   pr-labels.yml            # Automatic PR labeling
-  e2e.yml                  # E2E — fixture-based xctest on self-hosted Mac (dispatch + main push)
-  e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly)
+  e2e.yml                  # E2E — fixture-based xctest on self-hosted Mac (dispatch + main push + label-gated PR runs via `run-e2e`)
+  e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly + label-gated PR runs via `run-e2e`)
   e2e-cpu-load.yml         # E2E — idle + in-meeting CPU/RAM measurement of the deployed app (dispatch + nightly trend cron, RESULT artifact)
   appstore.yml             # App Store variant smoke test: build + launch-check (main push + nightly + dispatch)
   build-perf-tracking.yml  # Weekly build performance trend analysis (flags regressions vs 28-day baseline)
-  quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch)
+  quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch + label-gated PR runs via `run-quality`)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
   e2e-crash-recovery.yml    # E2E — crash recovery: SIGKILL mid-recording + verify pipeline recovers via WAV header repair
   e2e-mic-device-change.yml # E2E — mic device-change NSException survival (issue #379, fault-injection build)
@@ -444,7 +444,8 @@ you're validating:
 - Engine + pipeline tests in `app/MeetingTranscriber/Tests/*E2ETests.swift`
   (Parakeet, WhisperKit, WatchLoop) feed pre-recorded `two_speakers_de.wav`
   into the components and assert on transcripts.
-- Triggered on `workflow_dispatch` and every push to `main`.
+- Triggered on `workflow_dispatch`, every push to `main`, and label-gated
+  PR runs (apply the `run-e2e` label to a PR).
 - No live recording — `DualSourceRecorder` is bypassed; tests substitute
   fixture WAVs at the same point the recorder would emit them.
 - Strengths: fast, deterministic, isolates engine logic; runs in xctest's
@@ -459,7 +460,9 @@ you're validating:
   `lastJob.state == .done`, asserts on the resulting transcript file.
 - Triggered on `workflow_dispatch`, every `push` to main (no paths-filter
   — so the stable-tag ruleset always has a push-event check-run on the
-  SHA), and a nightly cron at 04:30 UTC.
+  SHA), a nightly cron at 04:30 UTC, and label-gated PR runs (apply the
+  `run-e2e` label; on a fork PR the label is the maintainer approval gate,
+  since this lane executes PR code on the self-hosted Mac mini).
 - Exercises the production code path end-to-end including TCC, audio
   routing, CATapDescription tap, and the dual-track recorder/diarizer
   handoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,8 @@ you're validating:
   (Parakeet, WhisperKit, WatchLoop) feed pre-recorded `two_speakers_de.wav`
   into the components and assert on transcripts.
 - Triggered on `workflow_dispatch`, every push to `main`, and label-gated
-  PR runs (apply the `run-e2e` label to a PR).
+  PR runs (apply the `run-e2e` label to a same-repo PR; fork PRs are
+  excluded from the self-hosted lanes).
 - No live recording — `DualSourceRecorder` is bypassed; tests substitute
   fixture WAVs at the same point the recorder would emit them.
 - Strengths: fast, deterministic, isolates engine logic; runs in xctest's
@@ -461,8 +462,10 @@ you're validating:
 - Triggered on `workflow_dispatch`, every `push` to main (no paths-filter
   — so the stable-tag ruleset always has a push-event check-run on the
   SHA), a nightly cron at 04:30 UTC, and label-gated PR runs (apply the
-  `run-e2e` label; on a fork PR the label is the maintainer approval gate,
-  since this lane executes PR code on the self-hosted Mac mini).
+  `run-e2e` label; same-repo branches only — fork PRs never execute on
+  the self-hosted Mac mini, and a fork run would fail anyway because fork
+  runs get no signing secrets and thus no TCC mic grant; to E2E a fork
+  contribution, push it to a same-repo branch and label that PR).
 - Exercises the production code path end-to-end including TCC, audio
   routing, CATapDescription tap, and the dual-track recorder/diarizer
   handoff.


### PR DESCRIPTION
## What

Add `pull_request` triggers to the three heavy CI lanes so a maintainer can pull their feedback pre-merge by labeling a PR, instead of only after merge to main:

- `e2e.yml` (fixture-based xctest E2E) and `e2e-app.yml` (live-recording E2E on the self-hosted Mac mini): label `run-e2e`.
- `quality-and-safety.yml` (TSan/ASan matrix + WER/DER quality gate): label `run-quality`. A labeled PR runs the same job set a push to main runs (both the sanitizer matrix and the quality gate).

Label-gated PR runs are restricted to same-repo branches; fork PRs never execute through these lanes (see Security).

## How

- Each workflow gains a `pull_request` trigger with `types: [opened, synchronize, reopened, labeled]`. The `labeled` type lets applying the label to an already-open PR start the run immediately.
- The gate is enforced at job level via `if:`; it requires all three of: the gate label is present, the PR head lives in this repo, and (for `labeled` events) the label that was just added IS the gate label. An unlabeled PR triggers the workflow but every job is skipped, so no runner is consumed. The label-name condition keeps unrelated label additions (including the title auto-labeler) from starting duplicate runs.

## Security

- `pull_request`, not `pull_request_target`: the latter runs with a writable base-repo token and is unsafe for code-executing lanes.
- Fork PRs are excluded entirely from all three lanes (`head.repo == repository`). Two reasons:
  - A label would act as a standing approval: once applied, every later fork push (`synchronize`) would re-run new, unreviewed code on the self-hosted Mac mini, next to its signing identity, TCC grants, and the unlocked CI keychain.
  - A fork `e2e-app` run would fail deterministically anyway: fork `pull_request` runs get no secrets, so the bundle falls back to the self-signed cert, which lacks the Mini's TCC microphone grant; the run then blocks on the consent prompt and the leftover prompt poisons later runs.
- To E2E a fork contribution, push it to a same-repo branch and label that PR.

## Cancellation semantics

- `e2e-app.yml`: `cancel-in-progress: false` for all events. The dev app is launched detached, so a cancelled run cannot clean it up; the app would keep recording, hold port 9876, and leave orphaned WAVs that crash-recovery feeds into the next run's assertions. PR runs queue in a per-PR group instead of superseding, and never sit in front of main/nightly runs.
- `e2e.yml` and `quality-and-safety.yml`: PR runs are superseded only by `synchronize` events (new commits). `labeled` events never cancel, because that type fires for ANY label addition and would otherwise kill an in-flight run when an unrelated label arrives. Push/dispatch/schedule behavior is unchanged (e2e keeps back-to-back main-push supersede; quality keeps never-cancel).

## No behavior change for existing events

- No existing trigger is removed. The push-to-main triggers stay untouched (the stable-tag ruleset depends on a push-event check-run existing on every SHA).
- For every job, the new `if:` reduces to the old condition for push, schedule, and workflow_dispatch events; the concurrency group falls back to `github.ref` for those events.

## Labels

Created `run-e2e` and `run-quality` (they did not exist). The existing auto-labeler (`pr-labels.yml`) only applies a fixed allowlist derived from the PR title (enhancement/bug/documentation/chore), so it can never apply these gate labels automatically.

## Verification

- `actionlint` on all three files: clean apart from the pre-existing custom `audio` self-hosted runner-label warning, which is present identically on main.
- This PR is used to confirm the trigger mechanics live: opening it unlabeled skipped every job; applying the labels started `e2e`, `e2e-app`, and `quality-and-safety` via the `pull_request` event; pushing the follow-up commit exercised the `synchronize` supersede path.
