### PR TITLE
feat(app): expose posted notifications in the debug RPC state

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -70,23 +70,22 @@
             )
         }
 
-        /// Snapshot the recently-posted notifications. Reads the production
-        /// notifier — `NotificationManager.shared` is what `@main` injects into
-        /// `AppState`, and its ring buffer accumulates across the whole app
-        /// lifetime — and maps each entry to the wire shape with an ISO-8601
-        /// `postedAt`. Extracted (like the other `*Snapshot` helpers) to keep
-        /// `rpcStateSnapshot`'s literal under the type-check budget.
+        /// Snapshot the recently-posted notifications from the notifier this
+        /// AppState was actually constructed with (the `@main` wiring passes
+        /// `NotificationManager.shared`; other notifiers default to an empty log
+        /// via the protocol extension) and map each entry to the wire shape with
+        /// an ISO-8601 `postedAt`. Extracted (like the other `*Snapshot` helpers)
+        /// to keep `rpcStateSnapshot`'s literal under the type-check budget.
         private func notificationsSnapshot() -> [RPCStateSnapshot.Notification] {
-            NotificationManager.shared.recentNotificationsLog.entries.map { entry in
+            notifier.recentNotifications.map { entry in
                 RPCStateSnapshot.Notification(
                     title: entry.title,
                     body: entry.body,
-                    postedAt: Self.rpcISOFormatter.string(from: entry.postedAt),
+                    postedAt: Self.isoFormatter.string(from: entry.postedAt),
+                    delivered: entry.delivered,
                 )
             }
         }
-
-        private static let rpcISOFormatter = ISO8601DateFormatter()
 
         /// Snapshot the live-caption overlay state. `LiveCaptionLine`'s
         /// `Codable` conformance encodes each entry as

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -66,8 +66,27 @@
                 permissionHealth: permissionHealthSnapshot(),
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
+                notifications: notificationsSnapshot(),
             )
         }
+
+        /// Snapshot the recently-posted notifications. Reads the production
+        /// notifier — `NotificationManager.shared` is what `@main` injects into
+        /// `AppState`, and its ring buffer accumulates across the whole app
+        /// lifetime — and maps each entry to the wire shape with an ISO-8601
+        /// `postedAt`. Extracted (like the other `*Snapshot` helpers) to keep
+        /// `rpcStateSnapshot`'s literal under the type-check budget.
+        private func notificationsSnapshot() -> [RPCStateSnapshot.Notification] {
+            NotificationManager.shared.recentNotificationsLog.entries.map { entry in
+                RPCStateSnapshot.Notification(
+                    title: entry.title,
+                    body: entry.body,
+                    postedAt: Self.rpcISOFormatter.string(from: entry.postedAt),
+                )
+            }
+        }
+
+        private static let rpcISOFormatter = ISO8601DateFormatter()
 
         /// Snapshot the live-caption overlay state. `LiveCaptionLine`'s
         /// `Codable` conformance encodes each entry as

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -11,7 +11,24 @@ import os.log
 /// Test implementation: `RecordingNotifier` (records calls, no side effects).
 protocol AppNotifying {
     func notify(title: String, body: String)
+
+    #if !APPSTORE
+        /// Recently posted notifications, oldest first, for the debug RPC
+        /// `/state.notifications` snapshot. Defaults to empty — only the
+        /// production `NotificationManager` keeps a log.
+        var recentNotifications: [NotificationRingBuffer.Entry] {
+            get
+        }
+    #endif
 }
+
+#if !APPSTORE
+    extension AppNotifying {
+        var recentNotifications: [NotificationRingBuffer.Entry] {
+            []
+        }
+    }
+#endif
 
 // MARK: - AppState
 
@@ -30,7 +47,9 @@ final class AppState {
     // MARK: - Dependencies
 
     let settings: AppSettings
-    private let notifier: any AppNotifying
+    // Internal (not private): the RPC snapshot extension (AppState+RPC.swift)
+    // reads `notifier.recentNotifications`, and file-private wouldn't reach.
+    let notifier: any AppNotifying
 
     // MARK: - State
 
@@ -406,7 +425,9 @@ final class AppState {
         channelHealth.appSilentActive || channelHealth.recordingSilentActive
     }
 
-    private static let isoFormatter = ISO8601DateFormatter()
+    // Internal (not private): also formats `postedAt` in the RPC snapshot
+    // extension (AppState+RPC.swift), where file-private wouldn't reach.
+    static let isoFormatter = ISO8601DateFormatter()
 
     var currentStatus: TranscriberStatus? {
         guard let loop = watching.watchLoop, loop.isActive else { return nil }

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -17,10 +17,17 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
     private(set) var isSetUp = false
 
-    /// Bounded in-memory log of every notification posted through `notify(...)`,
-    /// read by the dev-only debug RPC `/state.notifications` snapshot. Always
-    /// present (cheap array + trim); only read in the non-App-Store variant.
-    let recentNotificationsLog = NotificationRingBuffer()
+    #if !APPSTORE
+        /// Bounded in-memory log of every notification posted through
+        /// `notify(...)`, read by the dev-only debug RPC `/state.notifications`
+        /// snapshot (via the `AppNotifying.recentNotifications` conformance).
+        /// Gated out of the App Store variant, which has no RPC reader.
+        let recentNotificationsLog = NotificationRingBuffer()
+
+        var recentNotifications: [NotificationRingBuffer.Entry] {
+            recentNotificationsLog.entries
+        }
+    #endif
 
     override init() {
         super.init()
@@ -49,14 +56,18 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     }
 
     func notify(title: String, body: String) {
-        // Record before the delivery guard: this captures the app's decision to
-        // notify at the single chokepoint. In production `setUp()` always ran, so
-        // the log equals what was delivered; recording ahead of the guard also
-        // keeps the log observable in headless / test contexts where
-        // `UNUserNotificationCenter` (which needs a real app bundle) is absent.
-        recentNotificationsLog.record(title: title, body: body)
+        let deliverable = isSetUp && Bundle.main.bundleIdentifier != nil
 
-        guard isSetUp, Bundle.main.bundleIdentifier != nil else { return }
+        #if !APPSTORE
+            // Record before the delivery guard so the app's *decision* to notify
+            // is captured even in headless/test contexts where
+            // `UNUserNotificationCenter` (which needs a real app bundle) is
+            // absent. The `delivered` flag preserves the distinction: RPC
+            // consumers asserting a user-VISIBLE warning must check it.
+            recentNotificationsLog.record(title: title, body: body, delivered: deliverable)
+        #endif
+
+        guard deliverable else { return }
 
         let content = UNMutableNotificationContent()
         content.title = title

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -17,6 +17,11 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
     private(set) var isSetUp = false
 
+    /// Bounded in-memory log of every notification posted through `notify(...)`,
+    /// read by the dev-only debug RPC `/state.notifications` snapshot. Always
+    /// present (cheap array + trim); only read in the non-App-Store variant.
+    let recentNotificationsLog = NotificationRingBuffer()
+
     override init() {
         super.init()
     }
@@ -44,6 +49,13 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     }
 
     func notify(title: String, body: String) {
+        // Record before the delivery guard: this captures the app's decision to
+        // notify at the single chokepoint. In production `setUp()` always ran, so
+        // the log equals what was delivered; recording ahead of the guard also
+        // keeps the log observable in headless / test contexts where
+        // `UNUserNotificationCenter` (which needs a real app bundle) is absent.
+        recentNotificationsLog.record(title: title, body: body)
+
         guard isSetUp, Bundle.main.bundleIdentifier != nil else { return }
 
         let content = UNMutableNotificationContent()

--- a/app/MeetingTranscriber/Sources/NotificationRingBuffer.swift
+++ b/app/MeetingTranscriber/Sources/NotificationRingBuffer.swift
@@ -1,53 +1,64 @@
-import Foundation
-import os
+#if !APPSTORE
+    import Foundation
+    import os
 
-/// Bounded, thread-safe log of the most recent notifications the app posted.
-///
-/// Recorded at the single `NotificationManager.notify(...)` chokepoint so every
-/// caller (pipeline callbacks, `WatchLoop`, channel-health, permission-health,
-/// sidecar-write failures, ...) is captured without touching call sites, and
-/// read by the dev-only debug RPC `/state.notifications` snapshot. That surface
-/// makes user-facing warning paths observable to E2E assertions, which today
-/// cannot see a posted `UNUserNotification` from outside the process.
-///
-/// `@unchecked Sendable`: `notify(...)` is invoked from arbitrary actors and
-/// framework queues, so the entry array is guarded by an `OSAllocatedUnfairLock`
-/// (same pattern as `LevelPublisher` / `Permissions.accessibilityPromptLock`).
-final class NotificationRingBuffer: @unchecked Sendable {
-    struct Entry: Equatable {
-        let title: String
-        let body: String
-        let postedAt: Date
-    }
+    /// Bounded, thread-safe log of the most recent notifications the app posted.
+    ///
+    /// Recorded at the single `NotificationManager.notify(...)` chokepoint so every
+    /// caller (pipeline callbacks, `WatchLoop`, channel-health, permission-health,
+    /// sidecar-write failures, ...) is captured without touching call sites, and
+    /// read by the dev-only debug RPC `/state.notifications` snapshot. That surface
+    /// makes user-facing warning paths observable to E2E assertions, which today
+    /// cannot see a posted `UNUserNotification` from outside the process.
+    ///
+    /// The whole type is `#if !APPSTORE`: its only reader is the debug RPC, so the
+    /// sandboxed App Store variant doesn't retain notification strings it can
+    /// never serve.
+    ///
+    /// `@unchecked Sendable`: `notify(...)` is invoked from arbitrary actors and
+    /// framework queues, so the entry array is guarded by an `OSAllocatedUnfairLock`
+    /// (same pattern as `LevelPublisher`).
+    final class NotificationRingBuffer: @unchecked Sendable {
+        struct Entry: Equatable {
+            let title: String
+            let body: String
+            let postedAt: Date
+            /// Whether the notification passed the delivery guard and was handed
+            /// to `UNUserNotificationCenter`. `false` means the app *decided* to
+            /// notify but nothing reached the user (no bundle / `setUp()` never
+            /// ran) — E2E assertions about user-visible warnings must check this.
+            let delivered: Bool
+        }
 
-    /// Most entries retained; oldest evicted first once exceeded.
-    static let defaultCapacity = 50
+        /// Most entries retained; oldest evicted first once exceeded.
+        static let defaultCapacity = 50
 
-    private let capacity: Int
-    private let now: @Sendable () -> Date
-    private let state = OSAllocatedUnfairLock<[Entry]>(initialState: [])
+        private let capacity: Int
+        private let now: @Sendable () -> Date
+        private let state = OSAllocatedUnfairLock<[Entry]>(initialState: [])
 
-    /// `capacity` and `now` are injectable so the eviction/timestamp behaviour is
-    /// unit-testable without posting the full 50 entries or leaning on wall-clock.
-    init(capacity: Int = NotificationRingBuffer.defaultCapacity, now: @escaping @Sendable () -> Date = { Date() }) {
-        precondition(capacity > 0, "NotificationRingBuffer capacity must be positive")
-        self.capacity = capacity
-        self.now = now
-    }
+        /// `capacity` and `now` are injectable so the eviction/timestamp behaviour is
+        /// unit-testable without posting the full 50 entries or leaning on wall-clock.
+        init(capacity: Int = NotificationRingBuffer.defaultCapacity, now: @escaping @Sendable () -> Date = { Date() }) {
+            precondition(capacity > 0, "NotificationRingBuffer capacity must be positive")
+            self.capacity = capacity
+            self.now = now
+        }
 
-    /// Append a posted notification, dropping the oldest if over capacity.
-    func record(title: String, body: String) {
-        state.withLock { entries in
-            entries.append(Entry(title: title, body: body, postedAt: now()))
-            if entries.count > capacity {
-                entries.removeFirst(entries.count - capacity)
+        /// Append a posted notification, dropping the oldest if over capacity.
+        func record(title: String, body: String, delivered: Bool) {
+            state.withLock { entries in
+                entries.append(Entry(title: title, body: body, postedAt: now(), delivered: delivered))
+                if entries.count > capacity {
+                    entries.removeFirst(entries.count - capacity)
+                }
             }
         }
-    }
 
-    /// Snapshot of retained entries in chronological order (newest last), the
-    /// same ordering the RPC `notifications` array contracts.
-    var entries: [Entry] {
-        state.withLock { $0 }
+        /// Snapshot of retained entries in chronological order (newest last), the
+        /// same ordering the RPC `notifications` array contracts.
+        var entries: [Entry] {
+            state.withLock { $0 }
+        }
     }
-}
+#endif

--- a/app/MeetingTranscriber/Sources/NotificationRingBuffer.swift
+++ b/app/MeetingTranscriber/Sources/NotificationRingBuffer.swift
@@ -1,0 +1,53 @@
+import Foundation
+import os
+
+/// Bounded, thread-safe log of the most recent notifications the app posted.
+///
+/// Recorded at the single `NotificationManager.notify(...)` chokepoint so every
+/// caller (pipeline callbacks, `WatchLoop`, channel-health, permission-health,
+/// sidecar-write failures, ...) is captured without touching call sites, and
+/// read by the dev-only debug RPC `/state.notifications` snapshot. That surface
+/// makes user-facing warning paths observable to E2E assertions, which today
+/// cannot see a posted `UNUserNotification` from outside the process.
+///
+/// `@unchecked Sendable`: `notify(...)` is invoked from arbitrary actors and
+/// framework queues, so the entry array is guarded by an `OSAllocatedUnfairLock`
+/// (same pattern as `LevelPublisher` / `Permissions.accessibilityPromptLock`).
+final class NotificationRingBuffer: @unchecked Sendable {
+    struct Entry: Equatable {
+        let title: String
+        let body: String
+        let postedAt: Date
+    }
+
+    /// Most entries retained; oldest evicted first once exceeded.
+    static let defaultCapacity = 50
+
+    private let capacity: Int
+    private let now: @Sendable () -> Date
+    private let state = OSAllocatedUnfairLock<[Entry]>(initialState: [])
+
+    /// `capacity` and `now` are injectable so the eviction/timestamp behaviour is
+    /// unit-testable without posting the full 50 entries or leaning on wall-clock.
+    init(capacity: Int = NotificationRingBuffer.defaultCapacity, now: @escaping @Sendable () -> Date = { Date() }) {
+        precondition(capacity > 0, "NotificationRingBuffer capacity must be positive")
+        self.capacity = capacity
+        self.now = now
+    }
+
+    /// Append a posted notification, dropping the oldest if over capacity.
+    func record(title: String, body: String) {
+        state.withLock { entries in
+            entries.append(Entry(title: title, body: body, postedAt: now()))
+            if entries.count > capacity {
+                entries.removeFirst(entries.count - capacity)
+            }
+        }
+    }
+
+    /// Snapshot of retained entries in chronological order (newest last), the
+    /// same ordering the RPC `notifications` array contracts.
+    var entries: [Entry] {
+        state.withLock { $0 }
+    }
+}

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -116,6 +116,11 @@
             let body: String
             /// ISO-8601 wall-clock time the notification was posted.
             let postedAt: String
+            /// Whether it passed the delivery guard and reached
+            /// `UNUserNotificationCenter`. Assertions about user-VISIBLE
+            /// warnings must require `true`; `false` means the app only
+            /// *decided* to notify (headless context, setup not run).
+            let delivered: Bool
         }
 
         struct LastJob: Codable {

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -34,6 +34,12 @@
         /// `watchState == "recording"` when no caption signal is available
         /// (live transcription off — the default user profile).
         let watchState: String?
+        /// Recently-posted macOS notifications (capped ring buffer, oldest
+        /// dropped), chronological — newest last. E2E drivers poll this to
+        /// assert user-facing warning paths (meeting detected, silent recording,
+        /// permission problems, sidecar-write failures) actually fired, which is
+        /// otherwise unobservable from outside the process.
+        let notifications: [Notification]
 
         struct Pipeline: Codable {
             let isProcessing: Bool
@@ -105,6 +111,13 @@
             )
         }
 
+        struct Notification: Codable {
+            let title: String
+            let body: String
+            /// ISO-8601 wall-clock time the notification was posted.
+            let postedAt: String
+        }
+
         struct LastJob: Codable {
             let jobID: String
             let state: JobState
@@ -157,6 +170,7 @@
             permissionHealth: PermissionHealth = .unknown,
             liveCaptions: LiveCaptions = .empty,
             watchState: String? = nil,
+            notifications: [Notification] = [],
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
@@ -167,6 +181,7 @@
             self.permissionHealth = permissionHealth
             self.liveCaptions = liveCaptions
             self.watchState = watchState
+            self.notifications = notifications
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
@@ -232,6 +232,27 @@
             XCTAssertEqual(snapshot.liveCaptions.recentFinals[1].text, "guten morgen")
         }
 
+        // MARK: - notifications mapping in rpcStateSnapshot
+
+        /// `rpcStateSnapshot()` reads the production notifier
+        /// (`NotificationManager.shared`), so a notification posted through it
+        /// surfaces in `snapshot.notifications` with the ISO-8601 `postedAt`
+        /// wire shape. A UUID-tagged title keeps the assertion robust against the
+        /// shared singleton's cross-test accumulation.
+        func test_snapshot_notifications_readsSharedNotifierWithISOTimestamp() throws {
+            let tag = "rpc-notif-\(UUID().uuidString)"
+            NotificationManager.shared.notify(title: tag, body: "silent recording")
+
+            let snapshot = state.rpcStateSnapshot()
+
+            let posted = try XCTUnwrap(snapshot.notifications.last { $0.title == tag })
+            XCTAssertEqual(posted.body, "silent recording")
+            XCTAssertNotNil(
+                ISO8601DateFormatter().date(from: posted.postedAt),
+                "postedAt should be a parseable ISO-8601 timestamp, got \(posted.postedAt)",
+            )
+        }
+
         // MARK: - Helpers
 
         private func makeJob(title: String) -> PipelineJob {

--- a/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateRPCActionsTests.swift
@@ -234,23 +234,36 @@
 
         // MARK: - notifications mapping in rpcStateSnapshot
 
-        /// `rpcStateSnapshot()` reads the production notifier
-        /// (`NotificationManager.shared`), so a notification posted through it
-        /// surfaces in `snapshot.notifications` with the ISO-8601 `postedAt`
-        /// wire shape. A UUID-tagged title keeps the assertion robust against the
-        /// shared singleton's cross-test accumulation.
-        func test_snapshot_notifications_readsSharedNotifierWithISOTimestamp() throws {
-            let tag = "rpc-notif-\(UUID().uuidString)"
-            NotificationManager.shared.notify(title: tag, body: "silent recording")
+        /// `rpcStateSnapshot()` reads the notifier the AppState was constructed
+        /// with, so notifications posted through THAT instance surface in
+        /// `snapshot.notifications` with the ISO-8601 `postedAt` wire shape and
+        /// the delivered flag (false here: `setUp()` never ran in the test host).
+        func test_snapshot_notifications_readsInjectedNotifier() throws {
+            let manager = NotificationManager()
+            let notifierState = AppState(settings: state.settings, notifier: manager)
+            defer { notifierState.liveCaptions.clear() }
+            manager.notify(title: "Silent Recording", body: "Both channels silent")
+            manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
 
-            let snapshot = state.rpcStateSnapshot()
+            let snapshot = notifierState.rpcStateSnapshot()
 
-            let posted = try XCTUnwrap(snapshot.notifications.last { $0.title == tag })
-            XCTAssertEqual(posted.body, "silent recording")
+            XCTAssertEqual(snapshot.notifications.map(\.title), ["Silent Recording", "Meeting Detected"])
+            XCTAssertEqual(snapshot.notifications.map(\.body), ["Both channels silent", "Recording: Standup (Teams)"])
+            XCTAssertEqual(snapshot.notifications.map(\.delivered), [false, false])
+            let posted = try XCTUnwrap(snapshot.notifications.first)
             XCTAssertNotNil(
                 ISO8601DateFormatter().date(from: posted.postedAt),
                 "postedAt should be a parseable ISO-8601 timestamp, got \(posted.postedAt)",
             )
+        }
+
+        /// The snapshot must NOT read through any global: an AppState built with
+        /// a different notifier (the fixture's default `SilentNotifier`) stays
+        /// empty even while other instances post.
+        func test_snapshot_notifications_ignoresOtherNotifierInstances() {
+            NotificationManager().notify(title: "elsewhere", body: "not ours")
+
+            XCTAssertTrue(state.rpcStateSnapshot().notifications.isEmpty)
         }
 
         // MARK: - Helpers

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -124,6 +124,45 @@
             XCTAssertEqual(decoded.speakerDB.count, 7)
         }
 
+        /// End-to-end wire check for the notification ring buffer: post through
+        /// the production notifier chokepoint, project its buffer into the
+        /// snapshot exactly as `AppState.rpcStateSnapshot()` does, and assert the
+        /// `{title, body, postedAt}` rows come back over a real socket in
+        /// chronological order. A fresh `NotificationManager` (not `.shared`)
+        /// keeps the buffer isolated from other tests.
+        func testStateExposesPostedNotifications() async throws {
+            let manager = NotificationManager()
+            manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+            manager.notify(title: "Silent Recording", body: "Both channels silent")
+
+            let iso = ISO8601DateFormatter()
+            let notifications = manager.recentNotificationsLog.entries.map { entry in
+                RPCStateSnapshot.Notification(
+                    title: entry.title,
+                    body: entry.body,
+                    postedAt: iso.string(from: entry.postedAt),
+                )
+            }
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(isProcessing: false, activeJobCount: 0, waitingJobCount: 0, pendingNamingJobCount: 0),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                notifications: notifications,
+            )
+
+            let base = try await startServer(snapshot: snapshot)
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("state"), headers: authHeader),
+            )
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: data)
+            XCTAssertEqual(decoded.notifications.map(\.title), ["Meeting Detected", "Silent Recording"])
+            XCTAssertEqual(decoded.notifications.map(\.body), ["Recording: Standup (Teams)", "Both channels silent"])
+            let first = try XCTUnwrap(decoded.notifications.first)
+            XCTAssertNotNil(iso.date(from: first.postedAt), "postedAt should be ISO-8601, got \(first.postedAt)")
+        }
+
         func testMetricsReturnsLiveResourceSnapshot() async throws {
             let base = try await startServer()
             let (data, response) = try await URLSession.shared.data(

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -125,32 +125,21 @@
         }
 
         /// End-to-end wire check for the notification ring buffer: post through
-        /// the production notifier chokepoint, project its buffer into the
-        /// snapshot exactly as `AppState.rpcStateSnapshot()` does, and assert the
-        /// `{title, body, postedAt}` rows come back over a real socket in
-        /// chronological order. A fresh `NotificationManager` (not `.shared`)
-        /// keeps the buffer isolated from other tests.
+        /// the production notifier chokepoint, project it through the REAL
+        /// `AppState.rpcStateSnapshot()` (injected notifier, no re-implemented
+        /// mapping), and assert the `{title, body, postedAt, delivered}` rows
+        /// come back over a real socket in chronological order. A fresh
+        /// `NotificationManager` (not `.shared`) keeps the buffer isolated.
         func testStateExposesPostedNotifications() async throws {
             let manager = NotificationManager()
+            let suite = "DebugRPCServerIntegrationTests-\(getpid())-\(UUID().uuidString)"
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+            let state = AppState(settings: AppSettings(defaults: defaults), notifier: manager)
+            defer { state.liveCaptions.clear() }
             manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
             manager.notify(title: "Silent Recording", body: "Both channels silent")
 
-            let iso = ISO8601DateFormatter()
-            let notifications = manager.recentNotificationsLog.entries.map { entry in
-                RPCStateSnapshot.Notification(
-                    title: entry.title,
-                    body: entry.body,
-                    postedAt: iso.string(from: entry.postedAt),
-                )
-            }
-            let snapshot = RPCStateSnapshot(
-                pipeline: .init(isProcessing: false, activeJobCount: 0, waitingJobCount: 0, pendingNamingJobCount: 0),
-                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
-                pendingNamingJobs: [],
-                notifications: notifications,
-            )
-
-            let base = try await startServer(snapshot: snapshot)
+            let base = try await startServer(snapshot: state.rpcStateSnapshot())
             let (data, response) = try await URLSession.shared.data(
                 for: request("GET", base.appendingPathComponent("state"), headers: authHeader),
             )
@@ -159,8 +148,14 @@
             let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: data)
             XCTAssertEqual(decoded.notifications.map(\.title), ["Meeting Detected", "Silent Recording"])
             XCTAssertEqual(decoded.notifications.map(\.body), ["Recording: Standup (Teams)", "Both channels silent"])
+            // Test host has no app bundle, so the delivery guard fails: the wire
+            // must report the entries as NOT delivered.
+            XCTAssertEqual(decoded.notifications.map(\.delivered), [false, false])
             let first = try XCTUnwrap(decoded.notifications.first)
-            XCTAssertNotNil(iso.date(from: first.postedAt), "postedAt should be ISO-8601, got \(first.postedAt)")
+            XCTAssertNotNil(
+                ISO8601DateFormatter().date(from: first.postedAt),
+                "postedAt should be ISO-8601, got \(first.postedAt)",
+            )
         }
 
         func testMetricsReturnsLiveResourceSnapshot() async throws {

--- a/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
@@ -62,6 +62,24 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertIdentical(a, b)
     }
 
+    // MARK: - notify records into the ring buffer (RPC observability chokepoint)
+
+    /// The buffer records ahead of the delivery guard, so a notify() call is
+    /// captured even when `setUp()` never ran (no app bundle in the test host).
+    /// This is the single chokepoint the debug RPC `/state.notifications`
+    /// snapshot reads, so every caller is observable without touching call sites.
+    func testNotifyRecordsIntoRingBufferEvenWithoutSetUp() {
+        let manager = NotificationManager()
+        XCTAssertFalse(manager.isSetUp)
+
+        manager.notify(title: "Silent Recording", body: "Both channels silent")
+        manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+
+        let entries = manager.recentNotificationsLog.entries
+        XCTAssertEqual(entries.map(\.title), ["Silent Recording", "Meeting Detected"])
+        XCTAssertEqual(entries.map(\.body), ["Both channels silent", "Recording: Standup (Teams)"])
+    }
+
     // MARK: - notificationContent (pure helper)
 
     func testNotificationContentRecordingUsesMeetingTitleAndApp() {

--- a/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
@@ -62,23 +62,39 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertIdentical(a, b)
     }
 
-    // MARK: - notify records into the ring buffer (RPC observability chokepoint)
+    #if !APPSTORE
 
-    /// The buffer records ahead of the delivery guard, so a notify() call is
-    /// captured even when `setUp()` never ran (no app bundle in the test host).
-    /// This is the single chokepoint the debug RPC `/state.notifications`
-    /// snapshot reads, so every caller is observable without touching call sites.
-    func testNotifyRecordsIntoRingBufferEvenWithoutSetUp() {
-        let manager = NotificationManager()
-        XCTAssertFalse(manager.isSetUp)
+        // MARK: - notify records into the ring buffer (RPC observability chokepoint)
 
-        manager.notify(title: "Silent Recording", body: "Both channels silent")
-        manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+        /// The buffer records ahead of the delivery guard, so a notify() call is
+        /// captured even when `setUp()` never ran (no app bundle in the test host)
+        /// BUT is marked undelivered — the entry means "the app decided to
+        /// notify", not "the user saw it". This is the single chokepoint the
+        /// debug RPC `/state.notifications` snapshot reads, so every caller is
+        /// observable without touching call sites.
+        func testNotifyRecordsUndeliveredEntryWhenSetUpNeverRan() {
+            let manager = NotificationManager()
+            XCTAssertFalse(manager.isSetUp)
 
-        let entries = manager.recentNotificationsLog.entries
-        XCTAssertEqual(entries.map(\.title), ["Silent Recording", "Meeting Detected"])
-        XCTAssertEqual(entries.map(\.body), ["Both channels silent", "Recording: Standup (Teams)"])
-    }
+            manager.notify(title: "Silent Recording", body: "Both channels silent")
+            manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+
+            let entries = manager.recentNotificationsLog.entries
+            XCTAssertEqual(entries.map(\.title), ["Silent Recording", "Meeting Detected"])
+            XCTAssertEqual(entries.map(\.body), ["Both channels silent", "Recording: Standup (Teams)"])
+            XCTAssertEqual(entries.map(\.delivered), [false, false], "delivery guard failed, so entries must be marked undelivered")
+        }
+
+        /// The `AppNotifying.recentNotifications` conformance exposes the same
+        /// entries the buffer holds — this is what `AppState.rpcStateSnapshot()`
+        /// reads through the injected notifier.
+        func testRecentNotificationsConformanceMirrorsBuffer() {
+            let manager = NotificationManager()
+            manager.notify(title: "Silent Recording", body: "Both channels silent")
+
+            XCTAssertEqual(manager.recentNotifications, manager.recentNotificationsLog.entries)
+        }
+    #endif
 
     // MARK: - notificationContent (pure helper)
 

--- a/app/MeetingTranscriber/Tests/NotificationRingBufferTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationRingBufferTests.swift
@@ -1,0 +1,98 @@
+@testable import MeetingTranscriber
+import os
+import XCTest
+
+final class NotificationRingBufferTests: XCTestCase {
+    // MARK: - Records title / body / timestamp
+
+    func testRecordCapturesTitleBodyAndTimestamp() {
+        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+        let buffer = NotificationRingBuffer { fixed }
+
+        buffer.record(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+
+        XCTAssertEqual(buffer.entries.count, 1)
+        let entry = buffer.entries[0]
+        XCTAssertEqual(entry.title, "Meeting Detected")
+        XCTAssertEqual(entry.body, "Recording: Standup (Teams)")
+        XCTAssertEqual(entry.postedAt, fixed)
+    }
+
+    func testTimestampAdvancesWithClock() {
+        let times = [
+            Date(timeIntervalSince1970: 10),
+            Date(timeIntervalSince1970: 20),
+        ]
+        // `now` is @Sendable, so drive the tick through a lock rather than a
+        // captured mutable var.
+        let tick = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let buffer = NotificationRingBuffer {
+            tick.withLock { i in
+                defer { i += 1 }
+                return times[i]
+            }
+        }
+
+        buffer.record(title: "a", body: "1")
+        buffer.record(title: "b", body: "2")
+
+        XCTAssertEqual(buffer.entries.map(\.postedAt), times)
+    }
+
+    // MARK: - Ordering (chronological, newest last)
+
+    func testEntriesAreChronologicalNewestLast() {
+        let buffer = NotificationRingBuffer()
+
+        buffer.record(title: "first", body: "1")
+        buffer.record(title: "second", body: "2")
+        buffer.record(title: "third", body: "3")
+
+        XCTAssertEqual(buffer.entries.map(\.title), ["first", "second", "third"])
+    }
+
+    // MARK: - Cap + oldest-first eviction
+
+    func testCapsAtCapacityEvictingOldestFirst() {
+        let buffer = NotificationRingBuffer(capacity: 3)
+
+        for i in 1 ... 5 {
+            buffer.record(title: "n\(i)", body: "b\(i)")
+        }
+
+        // Oldest two (n1, n2) dropped; newest three retained in order.
+        XCTAssertEqual(buffer.entries.map(\.title), ["n3", "n4", "n5"])
+    }
+
+    func testStaysAtCapacityAcrossManyRecords() {
+        let buffer = NotificationRingBuffer(capacity: 2)
+
+        for i in 0 ..< 100 {
+            buffer.record(title: "n\(i)", body: "")
+        }
+
+        XCTAssertEqual(buffer.entries.count, 2)
+        XCTAssertEqual(buffer.entries.map(\.title), ["n98", "n99"])
+    }
+
+    // MARK: - Default capacity is 50
+
+    func testDefaultCapacityIsFifty() {
+        XCTAssertEqual(NotificationRingBuffer.defaultCapacity, 50)
+
+        let buffer = NotificationRingBuffer()
+        for i in 0 ..< 60 {
+            buffer.record(title: "n\(i)", body: "")
+        }
+
+        XCTAssertEqual(buffer.entries.count, 50)
+        XCTAssertEqual(buffer.entries.first?.title, "n10")
+        XCTAssertEqual(buffer.entries.last?.title, "n59")
+    }
+
+    // MARK: - Empty by default
+
+    func testStartsEmpty() {
+        XCTAssertTrue(NotificationRingBuffer().entries.isEmpty)
+    }
+}

--- a/app/MeetingTranscriber/Tests/NotificationRingBufferTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationRingBufferTests.swift
@@ -1,98 +1,109 @@
-@testable import MeetingTranscriber
-import os
-import XCTest
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import os
+    import XCTest
 
-final class NotificationRingBufferTests: XCTestCase {
-    // MARK: - Records title / body / timestamp
+    final class NotificationRingBufferTests: XCTestCase {
+        // MARK: - Records title / body / timestamp / delivered
 
-    func testRecordCapturesTitleBodyAndTimestamp() {
-        let fixed = Date(timeIntervalSince1970: 1_700_000_000)
-        let buffer = NotificationRingBuffer { fixed }
+        func testRecordCapturesTitleBodyTimestampAndDelivered() {
+            let fixed = Date(timeIntervalSince1970: 1_700_000_000)
+            let buffer = NotificationRingBuffer { fixed }
 
-        buffer.record(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+            buffer.record(title: "Meeting Detected", body: "Recording: Standup (Teams)", delivered: true)
 
-        XCTAssertEqual(buffer.entries.count, 1)
-        let entry = buffer.entries[0]
-        XCTAssertEqual(entry.title, "Meeting Detected")
-        XCTAssertEqual(entry.body, "Recording: Standup (Teams)")
-        XCTAssertEqual(entry.postedAt, fixed)
-    }
+            XCTAssertEqual(buffer.entries.count, 1)
+            let entry = buffer.entries[0]
+            XCTAssertEqual(entry.title, "Meeting Detected")
+            XCTAssertEqual(entry.body, "Recording: Standup (Teams)")
+            XCTAssertEqual(entry.postedAt, fixed)
+            XCTAssertTrue(entry.delivered)
+        }
 
-    func testTimestampAdvancesWithClock() {
-        let times = [
-            Date(timeIntervalSince1970: 10),
-            Date(timeIntervalSince1970: 20),
-        ]
-        // `now` is @Sendable, so drive the tick through a lock rather than a
-        // captured mutable var.
-        let tick = OSAllocatedUnfairLock<Int>(initialState: 0)
-        let buffer = NotificationRingBuffer {
-            tick.withLock { i in
-                defer { i += 1 }
-                return times[i]
+        func testRecordPreservesDeliveredFalse() {
+            let buffer = NotificationRingBuffer()
+
+            buffer.record(title: "Silent Recording", body: "Both channels silent", delivered: false)
+
+            XCTAssertEqual(buffer.entries.map(\.delivered), [false])
+        }
+
+        func testTimestampAdvancesWithClock() {
+            let times = [
+                Date(timeIntervalSince1970: 10),
+                Date(timeIntervalSince1970: 20),
+            ]
+            // `now` is @Sendable, so drive the tick through a lock rather than a
+            // captured mutable var.
+            let tick = OSAllocatedUnfairLock<Int>(initialState: 0)
+            let buffer = NotificationRingBuffer {
+                tick.withLock { i in
+                    defer { i += 1 }
+                    return times[i]
+                }
             }
+
+            buffer.record(title: "a", body: "1", delivered: true)
+            buffer.record(title: "b", body: "2", delivered: true)
+
+            XCTAssertEqual(buffer.entries.map(\.postedAt), times)
         }
 
-        buffer.record(title: "a", body: "1")
-        buffer.record(title: "b", body: "2")
+        // MARK: - Ordering (chronological, newest last)
 
-        XCTAssertEqual(buffer.entries.map(\.postedAt), times)
-    }
+        func testEntriesAreChronologicalNewestLast() {
+            let buffer = NotificationRingBuffer()
 
-    // MARK: - Ordering (chronological, newest last)
+            buffer.record(title: "first", body: "1", delivered: true)
+            buffer.record(title: "second", body: "2", delivered: true)
+            buffer.record(title: "third", body: "3", delivered: true)
 
-    func testEntriesAreChronologicalNewestLast() {
-        let buffer = NotificationRingBuffer()
-
-        buffer.record(title: "first", body: "1")
-        buffer.record(title: "second", body: "2")
-        buffer.record(title: "third", body: "3")
-
-        XCTAssertEqual(buffer.entries.map(\.title), ["first", "second", "third"])
-    }
-
-    // MARK: - Cap + oldest-first eviction
-
-    func testCapsAtCapacityEvictingOldestFirst() {
-        let buffer = NotificationRingBuffer(capacity: 3)
-
-        for i in 1 ... 5 {
-            buffer.record(title: "n\(i)", body: "b\(i)")
+            XCTAssertEqual(buffer.entries.map(\.title), ["first", "second", "third"])
         }
 
-        // Oldest two (n1, n2) dropped; newest three retained in order.
-        XCTAssertEqual(buffer.entries.map(\.title), ["n3", "n4", "n5"])
-    }
+        // MARK: - Cap + oldest-first eviction
 
-    func testStaysAtCapacityAcrossManyRecords() {
-        let buffer = NotificationRingBuffer(capacity: 2)
+        func testCapsAtCapacityEvictingOldestFirst() {
+            let buffer = NotificationRingBuffer(capacity: 3)
 
-        for i in 0 ..< 100 {
-            buffer.record(title: "n\(i)", body: "")
+            for i in 1 ... 5 {
+                buffer.record(title: "n\(i)", body: "b\(i)", delivered: true)
+            }
+
+            // Oldest two (n1, n2) dropped; newest three retained in order.
+            XCTAssertEqual(buffer.entries.map(\.title), ["n3", "n4", "n5"])
         }
 
-        XCTAssertEqual(buffer.entries.count, 2)
-        XCTAssertEqual(buffer.entries.map(\.title), ["n98", "n99"])
-    }
+        func testStaysAtCapacityAcrossManyRecords() {
+            let buffer = NotificationRingBuffer(capacity: 2)
 
-    // MARK: - Default capacity is 50
+            for i in 0 ..< 100 {
+                buffer.record(title: "n\(i)", body: "", delivered: true)
+            }
 
-    func testDefaultCapacityIsFifty() {
-        XCTAssertEqual(NotificationRingBuffer.defaultCapacity, 50)
-
-        let buffer = NotificationRingBuffer()
-        for i in 0 ..< 60 {
-            buffer.record(title: "n\(i)", body: "")
+            XCTAssertEqual(buffer.entries.count, 2)
+            XCTAssertEqual(buffer.entries.map(\.title), ["n98", "n99"])
         }
 
-        XCTAssertEqual(buffer.entries.count, 50)
-        XCTAssertEqual(buffer.entries.first?.title, "n10")
-        XCTAssertEqual(buffer.entries.last?.title, "n59")
-    }
+        // MARK: - Default capacity is 50
 
-    // MARK: - Empty by default
+        func testDefaultCapacityIsFifty() {
+            XCTAssertEqual(NotificationRingBuffer.defaultCapacity, 50)
 
-    func testStartsEmpty() {
-        XCTAssertTrue(NotificationRingBuffer().entries.isEmpty)
+            let buffer = NotificationRingBuffer()
+            for i in 0 ..< 60 {
+                buffer.record(title: "n\(i)", body: "", delivered: true)
+            }
+
+            XCTAssertEqual(buffer.entries.count, 50)
+            XCTAssertEqual(buffer.entries.first?.title, "n10")
+            XCTAssertEqual(buffer.entries.last?.title, "n59")
+        }
+
+        // MARK: - Empty by default
+
+        func testStartsEmpty() {
+            XCTAssertTrue(NotificationRingBuffer().entries.isEmpty)
+        }
     }
-}
+#endif


### PR DESCRIPTION
## What

Expose every notification the app posts in the dev-only debug RPC: `GET /state` gains a `notifications` array (`[{title, body, postedAt, delivered}]`, ISO-8601, chronological, capped at the 50 most recent). Until now a posted `UNUserNotification` was unobservable from outside the process, so E2E drivers could not assert that user-facing warning paths (meeting detected, silent recording, permission problems, sidecar-write failures) actually fired.

## How

- New `NotificationRingBuffer` (thread-safe via `OSAllocatedUnfairLock`, same pattern as `LevelPublisher`): bounded append, oldest-first eviction, injectable capacity and clock for deterministic tests. Gated `#if !APPSTORE`: its only reader is the debug RPC, so the sandboxed App Store variant does not retain notification strings it can never serve.
- Recorded at the single production chokepoint, `NotificationManager.notify(...)`, so every caller is captured without touching call sites. Recording happens before the delivery guard so headless/test contexts stay observable; each entry carries a `delivered` flag telling consumers whether the notification actually reached `UNUserNotificationCenter`. Assertions about user-VISIBLE warnings must require `delivered == true`.
- The snapshot reads the log through the notifier `AppState` was constructed with (`AppNotifying.recentNotifications`, empty default via protocol extension), not through a global. The `@main` wiring passes `NotificationManager.shared`, so production behavior is unchanged, but the RPC surface can no longer diverge from the instance the app actually posts through.
- Snapshot wiring follows the existing `*Snapshot()` helper pattern in `AppState+RPC.swift` (keeps the literal under the type-check budget) and reuses the existing `AppState.isoFormatter`.

## Tests

- `NotificationRingBufferTests`: recording, ordering, capacity eviction (mutation-proven: disabling the cap fails 5 assertions), injected-clock timestamps, delivered flag preserved.
- `NotificationManagerTests`: notify() without `setUp()` records entries marked `delivered == false`; the `recentNotifications` conformance mirrors the buffer.
- `AppStateRPCActionsTests`: snapshot reads the injected notifier (fails against a singleton-backed implementation) and ignores foreign notifier instances.
- `DebugRPCServerIntegrationTests`: real-socket `GET /state` through the production `rpcStateSnapshot()` projection (no re-implemented mapping), asserting titles, bodies, delivered flags, and ISO-8601 parseability.

## Verification

- Full suite green apart from the pre-existing machine-local `MenuBarIconSnapshotTests` flake, which reproduces identically on main on this machine and is environment-consistent in CI.
- `./scripts/pre-push.sh --with-appstore` green (release parity, both variants; the App Store variant compiles with the buffer fully gated out).
- `./scripts/lint.sh` clean.
- Labeled `run-e2e` + `run-quality`: fixture E2E, live-recording E2E, TSan/ASan, and the WER/DER quality gate all ran green on this PR (TSan matters here: the buffer adds lock-guarded state written from arbitrary queues).

## Deliberately not done

`scripts/e2e-channel-health.sh` was NOT given a `/state.notifications` assertion: its `FORCE_MIC_SILENT` hook sets the indicator flags directly and bypasses `notifier.notify`, so the assertion would pass without exercising the notification path. Wiring the E2E through the real signal chain is a separate change.
