### PR TITLE
feat(app): expose effective settings in the debug RPC state

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
@@ -1,0 +1,112 @@
+#if !APPSTORE
+    import Foundation
+
+    extension AppSettings {
+        /// Build the read-only settings projection for the debug RPC `/state`
+        /// snapshot from inside `AppSettings`, so every field read is a
+        /// single-hop `self.` access. Assembling it in `AppState.rpcStateSnapshot`
+        /// from the two-hop `state.settings.…` `@Observable` chain instead risks
+        /// the 300 ms CI type-check budget (`-warn-long-function-bodies`, treated
+        /// as an error) — same precedent as `PipelineQueue.rpcQueueStatus`. Each
+        /// sub-object is built by its own small helper so no single expression
+        /// approaches the per-expression budget either.
+        ///
+        /// SECRETS ARE EXCLUDED BY CONSTRUCTION: `openAIAPIKey` (Keychain-backed)
+        /// and any other secret are never read here. Only non-secret scalars,
+        /// enum raw values, and paths are exposed. This is the localhost,
+        /// token-authed debug surface that already exposes job titles and
+        /// screenshots, so home-directory paths are acceptable; secrets are not.
+        func rpcSettingsSnapshot() -> RPCStateSnapshot.Settings {
+            RPCStateSnapshot.Settings(
+                detection: rpcDetectionSettings(),
+                recording: rpcRecordingSettings(),
+                transcription: rpcTranscriptionSettings(),
+                diarization: rpcDiarizationSettings(),
+                protocolGeneration: rpcProtocolSettings(),
+                output: rpcOutputSettings(),
+                diagnostics: rpcDiagnosticsSettings(),
+                updates: rpcUpdatesSettings(),
+            )
+        }
+
+        private func rpcDetectionSettings() -> RPCStateSnapshot.Settings.Detection {
+            RPCStateSnapshot.Settings.Detection(
+                watchTeams: watchTeams,
+                watchZoom: watchZoom,
+                watchWebex: watchWebex,
+                autoWatch: autoWatch,
+                pollIntervalSeconds: pollInterval,
+            )
+        }
+
+        private func rpcRecordingSettings() -> RPCStateSnapshot.Settings.Recording {
+            RPCStateSnapshot.Settings.Recording(
+                endGraceSeconds: endGrace,
+                noMic: noMic,
+                recordOnly: recordOnly,
+                micDeviceUID: micDeviceUID,
+                micName: micName,
+                perChannelIndicatorEnabled: perChannelIndicatorEnabled,
+                liveTranscriptionEnabled: liveTranscriptionEnabled,
+                asymmetricSilenceWarningSeconds: asymmetricSilenceWarningSeconds,
+            )
+        }
+
+        private func rpcTranscriptionSettings() -> RPCStateSnapshot.Settings.Transcription {
+            RPCStateSnapshot.Settings.Transcription(
+                engine: transcriptionEngine.rawValue,
+                whisperKitModel: whisperKitModel,
+                whisperLanguage: whisperLanguage,
+                parakeetLanguage: parakeetLanguage,
+                customVocabularyPath: customVocabularyPath,
+            )
+        }
+
+        private func rpcDiarizationSettings() -> RPCStateSnapshot.Settings.Diarization {
+            RPCStateSnapshot.Settings.Diarization(
+                diarize: diarize,
+                mode: diarizerMode.rawValue,
+                numSpeakers: numSpeakers,
+                vadEnabled: vadEnabled,
+                vadThreshold: vadThreshold,
+                clusterThreshold: clusterThreshold,
+                warmStartFa: warmStartFa,
+                warmStartFb: warmStartFb,
+                minSegmentDurationSeconds: minSegmentDurationSeconds,
+                excludeOverlap: excludeOverlap,
+            )
+        }
+
+        private func rpcProtocolSettings() -> RPCStateSnapshot.Settings.ProtocolGeneration {
+            RPCStateSnapshot.Settings.ProtocolGeneration(
+                provider: protocolProvider.rawValue,
+                language: protocolLanguage,
+                openAIEndpoint: openAIEndpoint,
+                openAIModel: openAIModel,
+                claudeBin: claudeBin,
+            )
+        }
+
+        private func rpcOutputSettings() -> RPCStateSnapshot.Settings.Output {
+            RPCStateSnapshot.Settings.Output(
+                directory: effectiveOutputDir.path,
+                hasCustomDirectory: customOutputDirBookmark != nil,
+                hasCustomPrompt: FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path),
+            )
+        }
+
+        private func rpcDiagnosticsSettings() -> RPCStateSnapshot.Settings.Diagnostics {
+            RPCStateSnapshot.Settings.Diagnostics(
+                verboseDiagnostics: verboseDiagnostics,
+                debugRPCEnabled: debugRPCEnabled,
+            )
+        }
+
+        private func rpcUpdatesSettings() -> RPCStateSnapshot.Settings.Updates {
+            RPCStateSnapshot.Settings.Updates(
+                checkForUpdates: checkForUpdates,
+                includePreReleases: includePreReleases,
+            )
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -67,6 +67,9 @@
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
                 notifications: notificationsSnapshot(),
+                // Built inside AppSettings (single-hop `self.` reads) to stay
+                // under the type-check budget — see `rpcSettingsSnapshot`.
+                settings: settings.rpcSettingsSnapshot(),
             )
         }
 

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -40,6 +40,14 @@
         /// permission problems, sidecar-write failures) actually fired, which is
         /// otherwise unobservable from outside the process.
         let notifications: [Notification]
+        /// Read-only projection of the app's EFFECTIVE settings — the values the
+        /// running process actually resolved from UserDefaults. E2E driver
+        /// scripts configure the app by writing UserDefaults blind (`defaults
+        /// write` / CFPreferences) and otherwise can't confirm what the app
+        /// sees; `defaults read` is unreliable for the dev bundle (container-plist
+        /// redirect). Secrets (OpenAI API key, any Keychain value) are never
+        /// included — see `AppSettings.rpcSettingsSnapshot()`.
+        let settings: Settings
 
         struct Pipeline: Codable {
             let isProcessing: Bool
@@ -165,6 +173,140 @@
             )
         }
 
+        /// Read-only projection of the non-secret `AppSettings` scalars, enum
+        /// raw values, and paths. Grouped into sub-objects that mirror the
+        /// Settings-window tabs. Built by `AppSettings.rpcSettingsSnapshot()`.
+        /// NEVER carries secrets: the OpenAI API key and any other
+        /// Keychain-backed value are deliberately excluded.
+        struct Settings: Codable {
+            let detection: Detection
+            let recording: Recording
+            let transcription: Transcription
+            let diarization: Diarization
+            let protocolGeneration: ProtocolGeneration
+            let output: Output
+            let diagnostics: Diagnostics
+            let updates: Updates
+
+            struct Detection: Codable {
+                let watchTeams: Bool
+                let watchZoom: Bool
+                let watchWebex: Bool
+                let autoWatch: Bool
+                let pollIntervalSeconds: Double
+
+                static let empty = Self(
+                    watchTeams: false, watchZoom: false, watchWebex: false,
+                    autoWatch: false, pollIntervalSeconds: 0,
+                )
+            }
+
+            struct Recording: Codable {
+                let endGraceSeconds: Double
+                let noMic: Bool
+                let recordOnly: Bool
+                /// CoreAudio device UID; empty string = system default.
+                let micDeviceUID: String
+                let micName: String
+                let perChannelIndicatorEnabled: Bool
+                let liveTranscriptionEnabled: Bool
+                let asymmetricSilenceWarningSeconds: Double
+
+                static let empty = Self(
+                    endGraceSeconds: 0, noMic: false, recordOnly: false,
+                    micDeviceUID: "", micName: "", perChannelIndicatorEnabled: false,
+                    liveTranscriptionEnabled: false, asymmetricSilenceWarningSeconds: 0,
+                )
+            }
+
+            struct Transcription: Codable {
+                /// `TranscriptionEngineSetting` raw value ("whisperKit" | "parakeet").
+                let engine: String
+                let whisperKitModel: String
+                /// Empty string = auto-detect (mirrors the UserDefaults sentinel).
+                let whisperLanguage: String
+                let parakeetLanguage: String
+                let customVocabularyPath: String
+
+                static let empty = Self(
+                    engine: "", whisperKitModel: "", whisperLanguage: "",
+                    parakeetLanguage: "", customVocabularyPath: "",
+                )
+            }
+
+            struct Diarization: Codable {
+                let diarize: Bool
+                /// `DiarizerMode` raw value ("offline" | "sortformer").
+                let mode: String
+                /// 0 = auto-detect speaker count.
+                let numSpeakers: Int
+                let vadEnabled: Bool
+                let vadThreshold: Float
+                let clusterThreshold: Double
+                let warmStartFa: Double
+                let warmStartFb: Double
+                let minSegmentDurationSeconds: Double
+                let excludeOverlap: Bool
+
+                static let empty = Self(
+                    diarize: false, mode: "", numSpeakers: 0, vadEnabled: false,
+                    vadThreshold: 0, clusterThreshold: 0, warmStartFa: 0,
+                    warmStartFb: 0, minSegmentDurationSeconds: 0, excludeOverlap: false,
+                )
+            }
+
+            struct ProtocolGeneration: Codable {
+                /// `ProtocolProvider` raw value ("claudeCLI" | "openAICompatible" | "none").
+                let provider: String
+                let language: String
+                let openAIEndpoint: String
+                let openAIModel: String
+                /// Claude CLI binary name/path (non-secret). The App Store build
+                /// never compiles this file (`#if !APPSTORE`).
+                let claudeBin: String
+
+                static let empty = Self(
+                    provider: "", language: "", openAIEndpoint: "",
+                    openAIModel: "", claudeBin: "",
+                )
+            }
+
+            struct Output: Codable {
+                /// Effective output directory the app writes to.
+                let directory: String
+                /// A user-picked custom output dir (security-scoped bookmark) is
+                /// set, vs the default ~/Downloads/MeetingTranscriber.
+                let hasCustomDirectory: Bool
+                /// A custom protocol-prompt file exists on disk. The content is
+                /// intentionally not exposed (potentially large / user-authored).
+                let hasCustomPrompt: Bool
+
+                static let empty = Self(directory: "", hasCustomDirectory: false, hasCustomPrompt: false)
+            }
+
+            struct Diagnostics: Codable {
+                let verboseDiagnostics: Bool
+                let debugRPCEnabled: Bool
+
+                static let empty = Self(verboseDiagnostics: false, debugRPCEnabled: false)
+            }
+
+            struct Updates: Codable {
+                let checkForUpdates: Bool
+                let includePreReleases: Bool
+
+                static let empty = Self(checkForUpdates: false, includePreReleases: false)
+            }
+
+            /// Placeholder for snapshots built without a live `AppSettings`
+            /// (test fixtures, `RPCStateSnapshot.empty`).
+            static let empty = Self(
+                detection: .empty, recording: .empty, transcription: .empty,
+                diarization: .empty, protocolGeneration: .empty, output: .empty,
+                diagnostics: .empty, updates: .empty,
+            )
+        }
+
         init(
             pipeline: Pipeline,
             speakerDB: SpeakerDB,
@@ -176,6 +318,7 @@
             liveCaptions: LiveCaptions = .empty,
             watchState: String? = nil,
             notifications: [Notification] = [],
+            settings: Settings = .empty,
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
@@ -187,6 +330,7 @@
             self.liveCaptions = liveCaptions
             self.watchState = watchState
             self.notifications = notifications
+            self.settings = settings
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -158,6 +158,40 @@
             )
         }
 
+        /// End-to-end wire check for the effective-settings readback: build an
+        /// AppState on an isolated settings suite, tweak a few values across
+        /// sub-objects, project through the REAL `AppState.rpcStateSnapshot()`,
+        /// and assert `GET /state.settings` returns them over a real socket.
+        /// This is the surface E2E drivers use to confirm a blind `defaults
+        /// write` actually took effect (`defaults read` is unreliable for the
+        /// dev bundle's container-plist redirect).
+        func testStateExposesEffectiveSettings() async throws {
+            let suite = "DebugRPCServerIntegrationTests-\(getpid())-\(UUID().uuidString)"
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+            defer { defaults.removePersistentDomain(forName: suite) }
+            let settings = AppSettings(defaults: defaults)
+            settings.recordOnly = true
+            settings.transcriptionEngine = .parakeet
+            settings.numSpeakers = 4
+            settings.diarizerMode = .sortformer
+            settings.liveTranscriptionEnabled = true
+            let state = AppState(settings: settings)
+            defer { state.liveCaptions.clear() }
+
+            let base = try await startServer(snapshot: state.rpcStateSnapshot())
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("state"), headers: authHeader),
+            )
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: data)
+            XCTAssertTrue(decoded.settings.recording.recordOnly)
+            XCTAssertTrue(decoded.settings.recording.liveTranscriptionEnabled)
+            XCTAssertEqual(decoded.settings.transcription.engine, "parakeet")
+            XCTAssertEqual(decoded.settings.diarization.numSpeakers, 4)
+            XCTAssertEqual(decoded.settings.diarization.mode, "sortformer")
+        }
+
         func testMetricsReturnsLiveResourceSnapshot() async throws {
             let base = try await startServer()
             let (data, response) = try await URLSession.shared.data(

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -1,0 +1,217 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Verifies that `rpcStateSnapshot().settings` (and the
+    /// `AppSettings.rpcSettingsSnapshot()` projection behind it) mirrors the
+    /// EFFECTIVE settings so E2E driver scripts can read back what the app
+    /// actually resolved instead of trusting a blind `defaults write`. Also
+    /// pins that secrets never reach the wire.
+    @MainActor
+    final class RPCSettingsStateTests: XCTestCase {
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        private var defaults: UserDefaults!
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        private var settings: AppSettings!
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        private var testSuiteName: String!
+
+        override func setUp() async throws {
+            try await super.setUp()
+            testSuiteName = "RPCSettingsStateTests-\(getpid())-\(UUID().uuidString)"
+            guard let suite = UserDefaults(suiteName: testSuiteName) else {
+                XCTFail("Could not create test UserDefaults suite")
+                return
+            }
+            defaults = suite
+            settings = AppSettings(defaults: defaults)
+        }
+
+        override func tearDown() async throws {
+            settings = nil
+            defaults.removePersistentDomain(forName: testSuiteName)
+            defaults = nil
+            testSuiteName = nil
+            try await super.tearDown()
+        }
+
+        // MARK: - Snapshot mirrors defaults
+
+        func test_snapshot_mirrorsDefaultSettings() {
+            let s = settings.rpcSettingsSnapshot()
+
+            // A representative default from each sub-object — enough to prove
+            // the projection reads live values, not hardcoded zeros.
+            XCTAssertTrue(s.detection.watchTeams)
+            XCTAssertFalse(s.detection.autoWatch)
+            XCTAssertEqual(s.detection.pollIntervalSeconds, 3.0)
+            XCTAssertEqual(s.recording.endGraceSeconds, 15.0)
+            XCTAssertFalse(s.recording.recordOnly)
+            XCTAssertEqual(s.recording.micName, "Me")
+            XCTAssertTrue(s.recording.perChannelIndicatorEnabled)
+            XCTAssertEqual(s.recording.asymmetricSilenceWarningSeconds, 90.0)
+            XCTAssertEqual(s.transcription.engine, "whisperKit")
+            XCTAssertEqual(s.transcription.whisperLanguage, "de")
+            XCTAssertTrue(s.diarization.diarize)
+            XCTAssertEqual(s.diarization.mode, "offline")
+            XCTAssertEqual(s.diarization.numSpeakers, 0)
+            XCTAssertFalse(s.diarization.vadEnabled)
+            XCTAssertEqual(s.diarization.clusterThreshold, AppSettings.DiarizerTuningDefaults.clusterThreshold)
+            XCTAssertEqual(s.protocolGeneration.language, "German")
+            XCTAssertTrue(s.updates.checkForUpdates)
+            XCTAssertFalse(s.updates.includePreReleases)
+        }
+
+        // MARK: - Snapshot reflects flipped values (mutation-proof target)
+
+        func test_snapshot_reflectsFlippedValues() {
+            settings.autoWatch = true
+            settings.recordOnly = true
+            settings.liveTranscriptionEnabled = true
+            settings.noMic = true
+            settings.endGrace = 42
+            settings.micName = "Bob"
+            settings.micDeviceUID = "AppleUSBAudioEngine:Test"
+            settings.numSpeakers = 3
+            settings.vadEnabled = true
+            settings.vadThreshold = 0.75
+            settings.diarize = false
+            settings.verboseDiagnostics = true
+            settings.includePreReleases = true
+
+            let s = settings.rpcSettingsSnapshot()
+
+            XCTAssertTrue(s.detection.autoWatch)
+            XCTAssertTrue(s.recording.recordOnly)
+            XCTAssertTrue(s.recording.liveTranscriptionEnabled)
+            XCTAssertTrue(s.recording.noMic)
+            XCTAssertEqual(s.recording.endGraceSeconds, 42)
+            XCTAssertEqual(s.recording.micName, "Bob")
+            XCTAssertEqual(s.recording.micDeviceUID, "AppleUSBAudioEngine:Test")
+            XCTAssertEqual(s.diarization.numSpeakers, 3)
+            XCTAssertTrue(s.diarization.vadEnabled)
+            XCTAssertEqual(s.diarization.vadThreshold, 0.75)
+            XCTAssertFalse(s.diarization.diarize)
+            XCTAssertTrue(s.diagnostics.verboseDiagnostics)
+            XCTAssertTrue(s.updates.includePreReleases)
+        }
+
+        // MARK: - Enum raw-value mapping is pinned
+
+        func test_snapshot_enumRawValuesMatchSourceEnums() {
+            settings.transcriptionEngine = .parakeet
+            settings.parakeetLanguage = "fr"
+            settings.diarizerMode = .sortformer
+            settings.protocolProvider = .openAICompatible
+
+            let s = settings.rpcSettingsSnapshot()
+
+            // Wire value IS the enum raw value — pin the exact strings AND the
+            // fact they equal the source enums' rawValues, so a case rename
+            // that changes the JSON shape breaks here.
+            XCTAssertEqual(s.transcription.engine, "parakeet")
+            XCTAssertEqual(s.transcription.engine, TranscriptionEngineSetting.parakeet.rawValue)
+            XCTAssertEqual(s.transcription.parakeetLanguage, "fr")
+            XCTAssertEqual(s.diarization.mode, "sortformer")
+            XCTAssertEqual(s.diarization.mode, DiarizerMode.sortformer.rawValue)
+            XCTAssertEqual(s.protocolGeneration.provider, "openAICompatible")
+            XCTAssertEqual(s.protocolGeneration.provider, ProtocolProvider.openAICompatible.rawValue)
+        }
+
+        func test_snapshot_protocolProviderNone_mapsToNoneRawValue() {
+            settings.protocolProvider = .none
+            let s = settings.rpcSettingsSnapshot()
+            XCTAssertEqual(s.protocolGeneration.provider, "none")
+        }
+
+        // MARK: - Output projection
+
+        func test_snapshot_output_reflectsDefaultDirAndNoCustomBookmark() {
+            let s = settings.rpcSettingsSnapshot()
+            // Fresh suite → no custom bookmark → effective dir is the default.
+            XCTAssertFalse(s.output.hasCustomDirectory)
+            XCTAssertEqual(s.output.directory, AppPaths.downloadsProtocolsDir.path)
+        }
+
+        // MARK: - Secrets never reach the wire
+
+        /// The ONLY secret `AppSettings` holds is the OpenAI API key, stored in
+        /// the process-global macOS Keychain. We deliberately do NOT write that
+        /// Keychain account here: it has no per-suite isolation and a second
+        /// writer would race `AppSettingsTests.testOpenAIAPIKeyViaKeychainHelper`
+        /// under `swift test --parallel` (a hazard that file already documents).
+        /// Instead we pin the projection can never carry a secret — no
+        /// secret-bearing field name or marker anywhere in the encoded JSON —
+        /// while proving the guard isn't vacuous: the non-secret OpenAI fields
+        /// that ARE exposed round-trip.
+        func test_snapshot_neverEncodesSecrets() throws {
+            settings.openAIEndpoint = "http://sentinel-endpoint.example/v1"
+            settings.openAIModel = "sentinel-model-name"
+
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false, activeJobCount: 0,
+                    waitingJobCount: 0, pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                settings: settings.rpcSettingsSnapshot(),
+            )
+            let json = try XCTUnwrap(String(bytes: snapshot.jsonData(), encoding: .utf8))
+
+            // Non-secret exposed fields present → snapshot is non-vacuous.
+            XCTAssertTrue(json.contains("sentinel-endpoint.example"))
+            XCTAssertTrue(json.contains("sentinel-model-name"))
+
+            // No secret-bearing field name / marker may appear anywhere.
+            XCTAssertFalse(json.contains("openAIAPIKey"), "secret field name leaked")
+            let lower = json.lowercased()
+            for needle in ["apikey", "api_key", "secret", "keychain", "bearer", "password"] {
+                XCTAssertFalse(lower.contains(needle), "settings JSON leaked secret marker: \(needle)")
+            }
+        }
+
+        // MARK: - JSON round-trip
+
+        func test_snapshot_settingsJSONRoundtrips() throws {
+            settings.recordOnly = true
+            settings.transcriptionEngine = .parakeet
+            settings.numSpeakers = 4
+            settings.diarizerMode = .sortformer
+
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false, activeJobCount: 0,
+                    waitingJobCount: 0, pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                settings: settings.rpcSettingsSnapshot(),
+            )
+            let decoded = try JSONDecoder().decode(
+                RPCStateSnapshot.self, from: snapshot.jsonData(),
+            )
+
+            XCTAssertTrue(decoded.settings.recording.recordOnly)
+            XCTAssertEqual(decoded.settings.transcription.engine, "parakeet")
+            XCTAssertEqual(decoded.settings.diarization.numSpeakers, 4)
+            XCTAssertEqual(decoded.settings.diarization.mode, "sortformer")
+        }
+
+        // MARK: - Wired through AppState
+
+        /// End-to-end within the process: the snapshot AppState hands the RPC
+        /// server carries the live settings, so `mt-cli state | jq .settings`
+        /// against the running app reflects a runtime change.
+        func test_appStateSnapshot_carriesLiveSettings() {
+            settings.recordOnly = true
+            settings.transcriptionEngine = .parakeet
+            let state = AppState(settings: settings)
+
+            let s = state.rpcStateSnapshot().settings
+
+            XCTAssertTrue(s.recording.recordOnly)
+            XCTAssertEqual(s.transcription.engine, "parakeet")
+        }
+    }
+#endif


### PR DESCRIPTION
## What

Adds a `settings` sub-object to the debug RPC `GET /state` snapshot: a read-only projection of the app's **effective** (resolved-from-UserDefaults) configuration. It is grouped into `detection`, `recording`, `transcription`, `diarization`, `protocolGeneration`, `output`, `diagnostics`, and `updates` sub-objects that mirror the Settings-window tabs.

## Why

E2E driver scripts (`scripts/e2e-*.sh`) configure the app by writing UserDefaults blind (`defaults write` / CFPreferences) and can never confirm what the app actually resolved. `defaults read` is unreliable for the dev bundle because of its container-plist redirect, so a misconfigured E2E fixture is currently undiagnosable from outside the process. This readback surface makes that entire class of misconfiguration observable.

## How

- New `RPCStateSnapshot.Settings` nested struct + a `settings` field on the snapshot (both `#if !APPSTORE`).
- Built by a new `AppSettings.rpcSettingsSnapshot()` (`AppSettings+RPC.swift`) via single-hop `self.` reads, so the multi-field construction stays well under the CI type-check budget. This mirrors the `PipelineQueue.rpcQueueStatus` precedent; `AppState.rpcStateSnapshot()` just calls `settings.rpcSettingsSnapshot()`.
- `GET /state` only. No new endpoint, no write access.

## Secrets

Excluded by construction: the OpenAI API key and any other Keychain-backed value are never read. Enums go over the wire as raw values, paths as strings (consistent with this token-authed localhost surface that already exposes job titles and screenshots). A test pins secret-absence: it encodes the full snapshot and asserts no secret-bearing field name or marker appears anywhere in the JSON, while proving the guard is non-vacuous (exposed non-secret OpenAI endpoint/model fields do round-trip).

## Tests

- `RPCSettingsStateTests` (unit): mirrors isolated-suite defaults, reflects flipped values, pins enum raw-value mappings, output projection, secret-absence, JSON round-trip, and the `AppState` wiring. Mutation-proven (temporarily hardcoding `recordOnly`/`engine` fails the relevant assertions).
- `DebugRPCServerIntegrationTests.testStateExposesEffectiveSettings`: real socket, projects through the live `AppState.rpcStateSnapshot()`, asserts `GET /state.settings` returns the tweaked values.

## Verification

- `swift test --parallel` (skipping the real-recording backtest + machine-local snapshot suite): 2060 tests, 0 failures.
- `./scripts/lint.sh`: clean (only the 2 pre-existing violations in the untracked `Tests/Quality/SortformerVariantsTests.swift`).
- `swiftlint analyze --strict`: 0 violations (no unused imports/declarations).
- `./scripts/pre-push.sh --with-appstore`: release build + `-DAPPSTORE` variant both compile. The whole surface is `#if !APPSTORE`, so the App Store build is unaffected.