### PR TITLE
fix(app): harden the RPC settings snapshot (read-only bookmark resolution)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
@@ -89,10 +89,34 @@
 
         private func rpcOutputSettings() -> RPCStateSnapshot.Settings.Output {
             RPCStateSnapshot.Settings.Output(
-                directory: effectiveOutputDir.path,
+                directory: rpcOutputDirPath(),
                 hasCustomDirectory: customOutputDirBookmark != nil,
                 hasCustomPrompt: FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path),
             )
+        }
+
+        /// Read-only, fail-fast resolution of the effective output dir for the
+        /// snapshot. Deliberately NOT `effectiveOutputDir`: that resolves the
+        /// bookmark with `.withSecurityScope`, which can block the main actor
+        /// while a detached network volume is contacted (the RPC snapshot runs
+        /// MainActor-isolated on every `GET /state` poll), and on a stale
+        /// bookmark it WRITES a re-created bookmark back to UserDefaults, a
+        /// persisted mutation from a read-only debug GET. Here we resolve with
+        /// `.withoutUI`/`.withoutMounting` (fails fast instead of mounting),
+        /// ignore staleness, and report nil when the custom dir is currently
+        /// unresolvable.
+        private func rpcOutputDirPath() -> String? {
+            guard let data = customOutputDirBookmark else {
+                return AppPaths.downloadsProtocolsDir.path
+            }
+            var isStale = false
+            guard let url = try? URL(
+                resolvingBookmarkData: data,
+                options: [.withoutUI, .withoutMounting],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale,
+            ) else { return nil }
+            return url.path
         }
 
         private func rpcDiagnosticsSettings() -> RPCStateSnapshot.Settings.Diagnostics {

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -272,8 +272,11 @@
             }
 
             struct Output: Codable {
-                /// Effective output directory the app writes to.
-                let directory: String
+                /// Effective output directory the app writes to. `nil` when a
+                /// custom bookmark is set but not cheaply resolvable right now
+                /// (e.g. the volume is detached) — the snapshot never mounts,
+                /// never repairs bookmarks, and never blocks on I/O for this.
+                let directory: String?
                 /// A user-picked custom output dir (security-scoped bookmark) is
                 /// set, vs the default ~/Downloads/MeetingTranscriber.
                 let hasCustomDirectory: Bool
@@ -281,7 +284,7 @@
                 /// intentionally not exposed (potentially large / user-authored).
                 let hasCustomPrompt: Bool
 
-                static let empty = Self(directory: "", hasCustomDirectory: false, hasCustomPrompt: false)
+                static let empty = Self(directory: nil, hasCustomDirectory: false, hasCustomPrompt: false)
             }
 
             struct Diagnostics: Codable {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -174,7 +174,11 @@
             settings.transcriptionEngine = .parakeet
             settings.numSpeakers = 4
             settings.diarizerMode = .sortformer
-            settings.liveTranscriptionEnabled = true
+            // Deliberately NOT liveTranscriptionEnabled: with it on,
+            // AppState.init's prewarm builds the real live-transcription
+            // controller and kicks off actual CoreML/VAD model loads (network
+            // download on a cold CI runner) in an unawaited background Task.
+            settings.vadEnabled = true
             let state = AppState(settings: settings)
             defer { state.liveCaptions.clear() }
 
@@ -186,7 +190,7 @@
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
             let decoded = try JSONDecoder().decode(RPCStateSnapshot.self, from: data)
             XCTAssertTrue(decoded.settings.recording.recordOnly)
-            XCTAssertTrue(decoded.settings.recording.liveTranscriptionEnabled)
+            XCTAssertTrue(decoded.settings.diarization.vadEnabled)
             XCTAssertEqual(decoded.settings.transcription.engine, "parakeet")
             XCTAssertEqual(decoded.settings.diarization.numSpeakers, 4)
             XCTAssertEqual(decoded.settings.diarization.mode, "sortformer")

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -163,12 +163,55 @@
             XCTAssertTrue(json.contains("sentinel-endpoint.example"))
             XCTAssertTrue(json.contains("sentinel-model-name"))
 
-            // No secret-bearing field name / marker may appear anywhere.
+            // The one secret-bearing field name must never appear.
             XCTAssertFalse(json.contains("openAIAPIKey"), "secret field name leaked")
-            let lower = json.lowercased()
-            for needle in ["apikey", "api_key", "secret", "keychain", "bearer", "password"] {
-                XCTAssertFalse(lower.contains(needle), "settings JSON leaked secret marker: \(needle)")
+        }
+
+        /// Exact key allowlist: the settings wire shape may only ever contain
+        /// these leaf fields. Any new field must be consciously added here (and
+        /// consciously judged non-secret); a secret slipping into the projection
+        /// under ANY name fails this test, which generic substring scans can't
+        /// guarantee.
+        func test_snapshot_settingsKeysAreExactlyTheAllowlist() throws {
+            let data = try JSONEncoder().encode(settings.rpcSettingsSnapshot())
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+            var keys = Set<String>()
+            func collect(_ dict: [String: Any], prefix: String) {
+                for (key, value) in dict {
+                    let path = prefix.isEmpty ? key : "\(prefix).\(key)"
+                    if let nested = value as? [String: Any] {
+                        collect(nested, prefix: path)
+                    } else {
+                        keys.insert(path)
+                    }
+                }
             }
+            collect(object, prefix: "")
+
+            let allowlist: Set = [
+                "detection.watchTeams", "detection.watchZoom", "detection.watchWebex",
+                "detection.autoWatch", "detection.pollIntervalSeconds",
+                "recording.endGraceSeconds", "recording.noMic", "recording.recordOnly",
+                "recording.micDeviceUID", "recording.micName",
+                "recording.perChannelIndicatorEnabled", "recording.liveTranscriptionEnabled",
+                "recording.asymmetricSilenceWarningSeconds",
+                "transcription.engine", "transcription.whisperKitModel",
+                "transcription.whisperLanguage", "transcription.parakeetLanguage",
+                "transcription.customVocabularyPath",
+                "diarization.diarize", "diarization.mode", "diarization.numSpeakers",
+                "diarization.vadEnabled", "diarization.vadThreshold",
+                "diarization.clusterThreshold", "diarization.warmStartFa",
+                "diarization.warmStartFb", "diarization.minSegmentDurationSeconds",
+                "diarization.excludeOverlap",
+                "protocolGeneration.provider", "protocolGeneration.language",
+                "protocolGeneration.openAIEndpoint", "protocolGeneration.openAIModel",
+                "protocolGeneration.claudeBin",
+                "output.directory", "output.hasCustomDirectory", "output.hasCustomPrompt",
+                "diagnostics.verboseDiagnostics", "diagnostics.debugRPCEnabled",
+                "updates.checkForUpdates", "updates.includePreReleases",
+            ]
+            XCTAssertEqual(keys, allowlist)
         }
 
         // MARK: - JSON round-trip

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -133,6 +133,36 @@
             XCTAssertEqual(s.output.directory, AppPaths.downloadsProtocolsDir.path)
         }
 
+        func test_snapshot_output_resolvesCustomBookmark() throws {
+            let dir = try makeTempDirectory(prefix: "RPCSettingsOutput")
+            // Plain (non-security-scoped) bookmark data resolves fine under the
+            // snapshot's `.withoutUI/.withoutMounting` read-only options.
+            settings.customOutputDirBookmark = try dir.bookmarkData()
+
+            let s = settings.rpcSettingsSnapshot()
+
+            XCTAssertTrue(s.output.hasCustomDirectory)
+            let reported = try XCTUnwrap(s.output.directory)
+            // Normalise /var vs /private/var so the symlinked temp dir compares.
+            XCTAssertEqual(
+                URL(fileURLWithPath: reported).resolvingSymlinksInPath().path,
+                dir.resolvingSymlinksInPath().path,
+            )
+        }
+
+        func test_snapshot_output_unresolvableBookmarkIsNilAndNotRepaired() {
+            let garbage = Data([0xDE, 0xAD, 0xBE, 0xEF])
+            settings.customOutputDirBookmark = garbage
+
+            let s = settings.rpcSettingsSnapshot()
+
+            XCTAssertTrue(s.output.hasCustomDirectory)
+            XCTAssertNil(s.output.directory, "unresolvable custom dir must report null, not a wrong fallback")
+            // Read-only guarantee: the snapshot must never rewrite the persisted
+            // bookmark (unlike `effectiveOutputDir`'s stale-repair path).
+            XCTAssertEqual(settings.customOutputDirBookmark, garbage)
+        }
+
         // MARK: - Secrets never reach the wire
 
         /// The ONLY secret `AppSettings` holds is the OpenAI API key, stored in


### PR DESCRIPTION
## What

Post-merge hardening of the settings snapshot added in #461, fixing three review findings.

## Fixes

1. **Read-only, fail-fast output-dir resolution (shipped-code fix).** The snapshot read `effectiveOutputDir` on every `GET /state`, which resolves the security-scoped bookmark: that can block the main actor while a detached network volume is contacted (the snapshot closure runs MainActor-isolated on every automation poll), and on a stale bookmark it WRITES a re-created bookmark back to UserDefaults, a persisted mutation from a read-only debug GET, racing concurrent Settings-window edits. The snapshot now resolves with `.withoutUI`/`.withoutMounting`, ignores staleness, and reports `output.directory` as `null` when a custom dir is currently unresolvable (wire shape: `directory` is now nullable).

2. **Integration test no longer triggers a real model prewarm.** `testStateExposesEffectiveSettings` enabled live transcription before constructing a real `AppState`, so init's prewarm built the real live-transcription controller and kicked off actual CoreML/VAD model loads (a network download on a cold CI runner) in an unawaited background Task. The test flips `vadEnabled` instead.

3. **Secrets guard is now an exact key allowlist.** The previous guard scanned the whole snapshot JSON for generic marker substrings ("secret", "keychain", "password", ...), which would fail spuriously on legitimate future field names and, worse, stay green if an actual secret VALUE leaked under an innocuous field name. The test now asserts the settings wire shape contains exactly the 41 allowlisted leaf fields; any new field must be consciously added (and consciously judged non-secret).

## Verification

- Full suite green (CI-equivalent skips), `./scripts/pre-push.sh --with-appstore` green, lint clean.
- Targeted suites: RPCSettingsStateTests 9/9, DebugRPCServerIntegrationTests 43/43.
