### PR TITLE
test(ci): assert transcript content in the live-recording E2E lane

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -205,6 +205,27 @@ RECORD_ONLY_MARKER="/tmp/e2e-app-record-only-marker.$$"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 
+# Content-assertion keywords for the default two_speakers_de fixture. The
+# `run_one_meeting` transcript check greps for these German content words so a
+# live-recorded run can't go green on a >100-byte GARBAGE transcript: an empty
+# file, a wrong-language hallucination, or silent-capture noise all clear the
+# size check but hit zero of these. This list is identical to the xctest E2E's
+# `expectedKeywords` (ParakeetE2ETests.swift / WhisperKitE2ETests.swift) and
+# must stay in sync with them if the fixture is regenerated. The fixture also
+# speaks "Meeting", but neither this list nor the xctest set includes it: it is
+# the one English word, so requiring only German words proves the German
+# fixture actually transcribed rather than an English hallucination.
+# Threshold is 2-of-5, below the xctest's 3-of-5: the live-capture path
+# (BlackHole → CATap → dual-track merge) is lossier than the xctest's
+# direct-engine path, so 2 leaves margin against capture variance while still
+# decisively rejecting garbage (which matches 0). Applied only when the
+# simulator plays the known fixture (and not the mic-device-change survival
+# lane); a custom --fixture keeps only the >100-byte size check.
+DEFAULT_FIXTURE_KEYWORDS=(willkommen Projekt Status Entwicklung Zeitplan)
+DEFAULT_FIXTURE_KEYWORDS_MIN=2
+IS_DEFAULT_FIXTURE=false
+[ "$SIMULATOR_FIXTURE" = "$DEFAULT_FIXTURE" ] && IS_DEFAULT_FIXTURE=true
+
 # --- timing budgets -------------------------------------------------------
 
 # Cold first run downloads ~50 MB Parakeet model — give it room. Hot run
@@ -790,6 +811,30 @@ _poll_for_new_lastjob_terminal() {
     POLL_LJ_STATE="$lj_state"
 }
 
+# Assert the transcript contains at least DEFAULT_FIXTURE_KEYWORDS_MIN of the
+# expected German content words (case-insensitive). Guards the live-recording
+# lanes against a transcript that clears the >100-byte size check but is
+# actually garbage — wrong-language hallucination, silent-capture noise, or an
+# empty-ish file — none of which contain the fixture's spoken words. Logs which
+# keywords matched so a near-miss is diagnosable straight from the CI log.
+# Accumulates hit/miss as strings (not arrays) to stay safe under `set -u` on
+# the runner's bash regardless of version.
+assert_transcript_keywords() {
+    local label="$1" transcript_path="$2"
+    local matched=0 hit="" miss="" kw
+    for kw in "${DEFAULT_FIXTURE_KEYWORDS[@]}"; do
+        if grep -qi -- "$kw" "$transcript_path"; then
+            matched=$(( matched + 1 )); hit="$hit $kw"
+        else
+            miss="$miss $kw"
+        fi
+    done
+    if [ "$matched" -lt "$DEFAULT_FIXTURE_KEYWORDS_MIN" ]; then
+        fail "$label: transcript matched only $matched/${#DEFAULT_FIXTURE_KEYWORDS[@]} expected German fixture keywords (need >= $DEFAULT_FIXTURE_KEYWORDS_MIN) — likely garbage or wrong-language despite passing the >100-byte size check. matched=[${hit# }] missing=[${miss# }]. Preview:"$'\n'"$(head -c 500 "$transcript_path")"
+    fi
+    log "$label: transcript content OK — matched $matched/${#DEFAULT_FIXTURE_KEYWORDS[@]} keywords [${hit# }]"
+}
+
 run_one_meeting() {
     local label="$1"
     # Reset between meetings so --two-meetings captures each run's first
@@ -821,6 +866,24 @@ run_one_meeting() {
     log "$label: transcript $transcript_path ($transcript_size bytes)"
     log "$label: preview:"
     head -c 500 "$transcript_path" | sed 's/^/    /'
+
+    # Content assertion: a >100-byte transcript can still be garbage (an
+    # empty-ish file, a wrong-language hallucination, or silent-capture noise
+    # all clear the size gate). For the known fixture, require its German
+    # content words actually appear so this lane can't go green on a broken
+    # audio-path or wrong-language regression.
+    if [ "$MIC_DEVICE_CHANGE" = true ]; then
+        # Survival lane (issue #379): the injected mid-recording tap fault can
+        # degrade capture, and its PASS criterion is "app survived + recording
+        # completed", not ASR content quality. A content gate here would risk a
+        # false regression that masks the real survival signal, so skip it.
+        log "$label: mic-device-change survival lane — skipping content keyword assertion"
+    elif [ "$IS_DEFAULT_FIXTURE" = true ]; then
+        assert_transcript_keywords "$label" "$transcript_path"
+    else
+        # Custom --fixture: unknown spoken content, so keep only the size check.
+        log "$label: custom fixture — skipping content keyword assertion (size check only)"
+    fi
 
     # Phase 1 of #165 production-chain assertion: when caller sets
     # MTT_EXPECT_NAMING_SPEAKERS_MIN, require that the pending naming


### PR DESCRIPTION
## Problem

`run_one_meeting` in `scripts/e2e-app.sh` (the production-app live-recording E2E lane) only asserted the transcript file was **> 100 bytes**. A live-recorded run could therefore go green on a garbage transcript: an empty-ish file, a wrong-language hallucination, or silent-capture noise all clear that size gate while containing none of the fixture's spoken words. A regression in the audio-capture path or language selection would not turn this lane red.

## Change

Add a content assertion to `run_one_meeting`: require at least **2 of 5** known German fixture words (`willkommen`, `Projekt`, `Status`, `Entwicklung`, `Zeitplan`) to appear, case-insensitive. This list is **identical** to the fixture-based xctest E2E's `expectedKeywords` (Parakeet/WhisperKit); a match on German-only words proves the **German** fixture actually transcribed rather than an English hallucination (the fixture's one English word, "Meeting", is excluded from both this list and the xctest set).

### Why 2-of-5 (vs the xctest's 3-of-5)
The live-capture path (BlackHole -> CATap -> dual-track merge) is lossier than the xctest's direct-engine path, so 2 leaves margin against capture variance while still decisively rejecting garbage (which matches 0 keywords). **Field data from the Mini confirms this directly:** the live lanes landed at `2/5 [Status Entwicklung]` and `4/5 [willkommen Projekt Status Entwicklung]` — so a 3-of-5 threshold would have false-red'd this exact green run.

### Scope
- Gated on the default fixture (`two_speakers_de.wav`). A custom `--fixture` keeps only the size check, since its spoken content is unknown (logged explicitly, no silent skip).
- The `--mic-device-change` **survival** lane is exempted: its PASS criterion is "app survived the injected fault + recording completed", not ASR content, and the injected mid-recording fault can degrade capture — a content gate there would risk a false regression masking the real survival signal.
- Applies to the plain meeting and `--two-meetings` lanes. The standalone `--naming-confirm` lane is untouched.
- hit/miss accumulated as strings (not arrays) to stay safe under `set -u` on any runner bash version.

## Verification
- `bash -n` + `shellcheck -x` clean (zero findings from this diff).
- Standalone logic test (5/5): ground-truth transcript passes; a 2-keyword lossy transcript passes (boundary); a 1-keyword transcript fails; an English/garbage >100-byte transcript fails; uppercase keywords pass (case-insensitivity).
- `run-e2e` label applied so the self-hosted Mac mini exercises the real live-recording path on this PR; the assertion is proven **non-vacuous** — it fired and matched on three real live recordings (2/5, 4/5, 2/5).
- Reviewed: fixed a swallowed-newline in the failure preview, corrected a comment that misdescribed the mirrored xctest set, and scoped the check out of the mic-device-change survival lane.

## Acceptance
Reverting the audio-capture or language-selection path now turns this lane **red** (garbage transcript) instead of green-on-size.