### PR TITLE
fix(app): skip no-op transitions in PipelineQueue.updateJobState

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -396,6 +396,13 @@ class PipelineQueue {
     func updateJobState(id: UUID, to newState: JobState, error: String? = nil) {
         guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
         let oldState = jobs[index].state
+        // Skip a true no-op: same state AND no error to record. Without this,
+        // re-entering the same state (e.g. the confirm path enters
+        // `.generatingProtocol` twice) fires a redundant log line, snapshot
+        // write, and `onJobStateChange` callback, and would latently schedule a
+        // second `removeJob` cleanup Task on a re-`.done`. An error-only update
+        // (same state, new message) must still apply and persist.
+        guard oldState != newState || error != nil else { return }
         jobs[index].state = newState
         if let error { jobs[index].error = error }
         recordStageTransition(from: oldState, to: newState, jobID: id)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -225,6 +225,74 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(content.contains("enqueued"))
     }
 
+    // MARK: - updateJobState no-op guard
+
+    /// Count non-empty lines in the pipeline log (one JSON entry per line).
+    private func logLineCount(_ url: URL) throws -> Int {
+        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
+        let content = try String(contentsOf: url, encoding: .utf8)
+        return content.split(separator: "\n", omittingEmptySubsequences: true).count
+    }
+
+    func testUpdateJobStateSameStateIsNoOp() throws {
+        var job = makeJob()
+        job.state = .transcribing
+        queue.enqueue(job)
+
+        let logPath = tmpDir.appendingPathComponent("pipeline_log.jsonl")
+        let baseline = try logLineCount(logPath)
+
+        var callbackCount = 0
+        queue.onJobStateChange = { _, _, _ in callbackCount += 1 }
+
+        queue.updateJobState(id: job.id, to: .transcribing)
+
+        XCTAssertEqual(callbackCount, 0, "same-state update must not fire onJobStateChange")
+        XCTAssertEqual(
+            try logLineCount(logPath), baseline,
+            "same-state update must not append a redundant state_change log line",
+        )
+    }
+
+    func testUpdateJobStateRealTransitionFiresCallbackOnce() {
+        var job = makeJob()
+        job.state = .transcribing
+        queue.enqueue(job)
+
+        var callbackCount = 0
+        var observed: (old: JobState, new: JobState)?
+        queue.onJobStateChange = { _, old, new in
+            callbackCount += 1
+            observed = (old, new)
+        }
+
+        queue.updateJobState(id: job.id, to: .diarizing)
+
+        XCTAssertEqual(callbackCount, 1, "a real transition must fire onJobStateChange exactly once")
+        XCTAssertEqual(observed?.old, .transcribing)
+        XCTAssertEqual(observed?.new, .diarizing)
+    }
+
+    func testUpdateJobStateSameStateWithErrorStillApplies() {
+        var job = makeJob()
+        job.state = .transcribing
+        queue.enqueue(job)
+
+        var callbackCount = 0
+        queue.onJobStateChange = { _, _, _ in callbackCount += 1 }
+
+        queue.updateJobState(id: job.id, to: .transcribing, error: "boom")
+
+        XCTAssertEqual(
+            queue.jobs.first?.error, "boom",
+            "a same-state update carrying an error must still persist it",
+        )
+        XCTAssertEqual(
+            callbackCount, 1,
+            "an error-bearing update must still notify even when the state is unchanged",
+        )
+    }
+
     func testActiveJobs() {
         var job1 = makeJob(title: "Active")
         job1.state = .transcribing


### PR DESCRIPTION
## Problem

`PipelineQueue.updateJobState(id:to:error:)` unconditionally fired `recordStageTransition`, `appendLog`, `saveSnapshot`, and `onJobStateChange` even when the state did not actually change (`oldState == newState`).

The speaker-naming confirm path re-enters `.generatingProtocol` twice (once in the naming session, once in the protocol stage), so a same-state "transition" produced a redundant `pipeline_log.jsonl` line, a redundant snapshot write, and a redundant `onJobStateChange` callback. It also latently scheduled a SECOND `removeJob` cleanup Task whenever `updateJobState(.done)` ran on an already-`.done` job.

## Fix

Add a no-op guard right after reading `oldState`:

```swift
let oldState = jobs[index].state
guard oldState != newState || error != nil else { return }
```

The `|| error != nil` clause preserves the ability to attach an error message without changing state; only a same-state, no-error call is skipped.

## Why this is safe

- The sole `onJobStateChange` subscriber (`PipelineController.configureCallbacks`) switches on `newState` and reacts only to `.done` / `.error`; it does not depend on same-state re-notification.
- Every error-setting call site already transitions to `.error`, so no caller relies on the dropped no-op fire.

`recordStageTransition` already guarded `oldState != newState` internally; the point of this change is the redundant log line, snapshot write, callback, and the latent `.done` cleanup Task.

## Tests

- `testUpdateJobStateSameStateIsNoOp` (written first, confirmed failing before the guard): same-state update fires no callback and appends no log line.
- `testUpdateJobStateRealTransitionFiresCallbackOnce`: a real transition still fires `onJobStateChange` exactly once with the correct old/new states.
- `testUpdateJobStateSameStateWithErrorStillApplies`: a same-state update carrying an error still applies and persists it (pins the `|| error != nil` branch).

## Verification

- `swift test --parallel`: green apart from the pre-existing `MenuBarIconSnapshotTests` image-snapshot failures, which fail identically on the base commit (verified by stashing this change) and are unrelated to this diff.
- `./scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict` via `xcodebuild build-for-testing` log: 0 violations.
- `./scripts/pre-push.sh`: release-build parity check passed.