### PR TITLE
refactor(app): extract ProcessedRecordingsLedger from PipelineQueue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     RecordingFileSuffix.swift  # Filename suffixes for dual-source recordings (_app.wav, _mic.wav, _mix.wav)
     DiarizationProcess.swift  # DiarizationProvider protocol + result types
     PipelineQueue.swift    # Decouples recording from post-processing (transcription → diarization → protocol)
+    ProcessedRecordingsLedger.swift  # File-backed skip-list of successfully-processed mix paths (backs PipelineQueue orphan recovery)
     PipelineJob.swift      # Pipeline job model
     PipelineSnapshot.swift  # Pure I/O helpers for persisting pipeline queue jobs to disk (atomic rename)
     SnapshotWriterActor.swift  # Actor isolating pipeline queue snapshot writes (prevents main-actor stalls)

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -23,6 +23,11 @@ class PipelineQueue {
     private(set) var jobs: [PipelineJob] = []
     private let logDir: URL
 
+    /// File-backed skip list of already-processed recordings, consulted by
+    /// `recoverOrphanedRecordings` so completed jobs aren't re-queued as
+    /// orphans on the next launch.
+    let processedLedger: ProcessedRecordingsLedger
+
     // Dependencies for processing
     let engine: (any TranscribingEngine)?
     let diarizationFactory: (() -> any DiarizationProvider)?
@@ -179,6 +184,7 @@ class PipelineQueue {
         terminalJobStore: TerminalJobStore? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
+        self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
         self.engine = nil
         self.diarizationFactory = nil
         self.diarizationFactoryWithMode = nil
@@ -268,6 +274,7 @@ class PipelineQueue {
         terminalJobStore: TerminalJobStore? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
+        self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
         self.engine = engine
         self.diarizationFactory = diarizationFactory
         self.diarizationFactoryWithMode = diarizationFactoryWithMode
@@ -350,7 +357,7 @@ class PipelineQueue {
 
     func removeJob(id: UUID) {
         if let index = jobs.firstIndex(where: { $0.id == id }) {
-            markProcessed(mixPath: jobs[index].mixPath)
+            processedLedger.markProcessed(mixPath: jobs[index].mixPath)
             jobs.remove(at: index)
         }
         stageStartByJob.removeValue(forKey: id)
@@ -411,7 +418,7 @@ class PipelineQueue {
         onJobStateChange?(jobs[index], oldState, newState)
 
         if newState == .done || newState == .error {
-            markProcessed(mixPath: jobs[index].mixPath)
+            processedLedger.markProcessed(mixPath: jobs[index].mixPath)
             recordTerminalJob(jobs[index])
         }
         if newState == .done {
@@ -1261,37 +1268,6 @@ class PipelineQueue {
 
     // MARK: - Orphaned Recording Recovery
 
-    /// One-time migration: if no processed_recordings.json exists yet, seed it with
-    /// all existing `_mix.wav` files so they don't get recovered on first launch after update.
-    ///
-    /// Dir scan + JSON encode + atomic write run on a detached task. The
-    /// guard + `ensureLogDir` stay on the main actor so the migration is a
-    /// no-op (no detached task spawned) when the processed file already
-    /// exists — which is the steady-state case.
-    func migrateProcessedRecordings(recordingsDir: URL) async {
-        guard !FileManager.default.fileExists(atPath: processedRecordingsPath.path) else { return }
-        ensureLogDir()
-        let processedRecordingsPath = self.processedRecordingsPath
-        await Task.detached(priority: .utility) {
-            let fm = FileManager.default
-            guard let entries = try? fm.contentsOfDirectory(
-                at: recordingsDir, includingPropertiesForKeys: nil,
-            ) else { return }
-            var paths = Set<String>()
-            for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
-                paths.insert(file.standardizedFileURL.path)
-            }
-            guard !paths.isEmpty else { return }
-            do {
-                let data = try JSONEncoder().encode(Array(paths))
-                try data.write(to: processedRecordingsPath, options: .atomic)
-                logger.info("Migration: seeded \(paths.count) existing recordings as processed")
-            } catch {
-                logger.error("Migration failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }.value
-    }
-
     /// Scan `recordingsDir` for `*_mix.wav` files not tracked by any loaded job.
     /// Creates recovery jobs for untracked recordings younger than `maxAge`.
     /// Skips files that were already successfully processed (tracked in processed_recordings.json).
@@ -1307,11 +1283,11 @@ class PipelineQueue {
         // One-time migration: seed processed list with existing recordings
         // Only for the default recordings directory (not test overrides)
         if recordingsDir == AppPaths.recordingsDir {
-            await migrateProcessedRecordings(recordingsDir: recordingsDir)
+            await processedLedger.migrate(recordingsDir: recordingsDir)
         }
 
         let trackedPaths = Set(jobs.compactMap { $0.mixPath?.standardizedFileURL.path })
-        let processedRecordingsPath = self.processedRecordingsPath
+        let ledger = processedLedger
 
         // Off-main: directory scan + processed-list read + per-file
         // attributesOfItem probes + filtering all happen here.
@@ -1321,12 +1297,7 @@ class PipelineQueue {
                 at: recordingsDir,
                 includingPropertiesForKeys: [.fileSizeKey, .creationDateKey],
             ) else { return [] }
-            let processedPaths: Set<String> = {
-                guard let data = try? Data(contentsOf: processedRecordingsPath),
-                      let paths = try? JSONDecoder().decode([String].self, from: data)
-                else { return [] }
-                return Set(paths)
-            }()
+            let processedPaths = ledger.load()
             let now = Date()
             return PairedRecordingResolver.resolve(urls: entries).paired.filter { group in
                 // Groups without a real mix file (app+mic-only paired imports)
@@ -1366,37 +1337,6 @@ class PipelineQueue {
         saveSnapshot()
         logger.info("Recovered \(candidates.count) orphaned recording(s)")
         triggerProcessing()
-    }
-
-    // MARK: - Processed Recordings Tracking
-
-    private var processedRecordingsPath: URL {
-        logDir.appendingPathComponent("processed_recordings.json")
-    }
-
-    /// Load the set of mix paths that completed successfully.
-    private func loadProcessedPaths() -> Set<String> {
-        guard let data = try? Data(contentsOf: processedRecordingsPath),
-              let paths = try? JSONDecoder().decode([String].self, from: data) else {
-            return []
-        }
-        return Set(paths)
-    }
-
-    /// Record that a job's mix file was successfully processed. Nil mixPath
-    /// (paired imports without a `_mix.wav` source) is a no-op — there's no
-    /// path to track for orphan recovery.
-    func markProcessed(mixPath: URL?) {
-        guard let mixPath else { return }
-        var paths = loadProcessedPaths()
-        paths.insert(mixPath.standardizedFileURL.path)
-        do {
-            ensureLogDir()
-            let data = try JSONEncoder().encode(Array(paths))
-            try data.write(to: processedRecordingsPath, options: .atomic)
-        } catch {
-            logger.error("Failed to write processed recordings: \(error.localizedDescription, privacy: .public)")
-        }
     }
 
     // MARK: - JSON Logging

--- a/app/MeetingTranscriber/Sources/ProcessedRecordingsLedger.swift
+++ b/app/MeetingTranscriber/Sources/ProcessedRecordingsLedger.swift
@@ -1,0 +1,92 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "ProcessedRecordingsLedger")
+
+/// File-backed ledger of mix-file paths that completed the pipeline
+/// successfully, backing `PipelineQueue`'s orphan-recovery skip list.
+///
+/// Pure persistence over one JSON file (`processed_recordings.json` in
+/// `logDir`): a JSON array of standardized file paths (`[String]`), written
+/// atomically and restricted to owner-only (0600) like the other
+/// sensitive-JSON stores, since the paths embed the account username.
+/// `PipelineQueue.recoverOrphanedRecordings` reads this set to skip recordings
+/// that were already processed, so they aren't re-queued as orphans on the
+/// next launch.
+///
+/// A value type with no back-references into queue state, so it needs no
+/// delegate. It self-ensures `logDir` before writes (creating it only when
+/// absent) rather than sharing the queue's cached `logDirCreated` flag.
+struct ProcessedRecordingsLedger {
+    let logDir: URL
+
+    var path: URL {
+        logDir.appendingPathComponent("processed_recordings.json")
+    }
+
+    /// Load the set of mix paths that completed successfully. Returns an empty
+    /// set when the file is missing or unreadable/corrupt.
+    func load() -> Set<String> {
+        guard let data = try? Data(contentsOf: path),
+              let paths = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return Set(paths)
+    }
+
+    /// Record that a job's mix file was successfully processed. Nil mixPath
+    /// (paired imports without a `_mix.wav` source) is a no-op — there's no
+    /// path to track for orphan recovery.
+    func markProcessed(mixPath: URL?) {
+        guard let mixPath else { return }
+        var paths = load()
+        paths.insert(mixPath.standardizedFileURL.path)
+        do {
+            ensureLogDir()
+            let data = try JSONEncoder().encode(Array(paths))
+            try data.write(to: path, options: .atomic)
+            try? FileManager.default.restrictToOwner(path)
+        } catch {
+            logger.error("Failed to write processed recordings: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// One-time migration: if no processed_recordings.json exists yet, seed it with
+    /// all existing `_mix.wav` files so they don't get recovered on first launch after update.
+    ///
+    /// Dir scan + JSON encode + atomic write run on a detached task. The
+    /// existence guard makes it a no-op (no detached task spawned) when the
+    /// processed file already exists — which is the steady-state case.
+    func migrate(recordingsDir: URL) async {
+        guard !FileManager.default.fileExists(atPath: path.path) else { return }
+        ensureLogDir()
+        let path = self.path
+        await Task.detached(priority: .utility) {
+            let fm = FileManager.default
+            guard let entries = try? fm.contentsOfDirectory(
+                at: recordingsDir, includingPropertiesForKeys: nil,
+            ) else { return }
+            var paths = Set<String>()
+            for file in entries where file.lastPathComponent.hasSuffix(RecordingFileSuffix.mix) {
+                paths.insert(file.standardizedFileURL.path)
+            }
+            guard !paths.isEmpty else { return }
+            do {
+                let data = try JSONEncoder().encode(Array(paths))
+                try data.write(to: path, options: .atomic)
+                try? FileManager.default.restrictToOwner(path)
+                logger.info("Migration: seeded \(paths.count) existing recordings as processed")
+            } catch {
+                logger.error("Migration failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }.value
+    }
+
+    /// Ensure `logDir` exists before a write. Skips the `createDirectory`
+    /// syscall when the directory already exists (the steady-state case, since
+    /// the queue creates its log dir early), so no cached flag is needed.
+    private func ensureLogDir() {
+        guard !FileManager.default.fileExists(atPath: logDir.path) else { return }
+        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -582,7 +582,7 @@ final class PipelineQueueTests: XCTestCase {
 
         // Mark it as already processed
         let freshQueue = PipelineQueue(logDir: tmpDir)
-        freshQueue.markProcessed(mixPath: mixFile)
+        freshQueue.processedLedger.markProcessed(mixPath: mixFile)
 
         await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertEqual(freshQueue.jobs.count, 0)
@@ -612,97 +612,11 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(freshQueue.jobs.isEmpty, "Failed recording should not be re-queued")
     }
 
-    func testMarkProcessedPersists() throws {
-        let mixPath = tmpDir.appendingPathComponent("test_mix.wav")
-
-        let q1 = PipelineQueue(logDir: tmpDir)
-        q1.markProcessed(mixPath: mixPath)
-
-        // New queue instance should see the processed path
-        _ = PipelineQueue(logDir: tmpDir)
-        let recDir = tmpDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
-        // Create a file with the same standardized name
-        try Data(repeating: 0xFF, count: 100).write(to: mixPath)
-
-        // Won't find it if the path is in processed list — but the file is in tmpDir not recDir
-        // So test directly via the processed set behavior
-        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: processedPath.path))
-        let data = try Data(contentsOf: processedPath)
-        let paths = try JSONDecoder().decode([String].self, from: data)
-        XCTAssertTrue(paths.contains(mixPath.standardizedFileURL.path))
-    }
-
     func testRecoverEmptyDirIsNoOp() async {
         let recDir = tmpDir.appendingPathComponent("nonexistent_recordings")
         let freshQueue = PipelineQueue(logDir: tmpDir)
         await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
         XCTAssertTrue(freshQueue.jobs.isEmpty)
-    }
-
-    func testMigrateSeedsProcessedRecordingsFromExistingMixFiles() async throws {
-        let recDir = tmpDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
-        let mixA = recDir.appendingPathComponent("20260101_100000_mix.wav")
-        let mixB = recDir.appendingPathComponent("20260102_100000_mix.wav")
-        try Data(repeating: 0xFF, count: 100).write(to: mixA)
-        try Data(repeating: 0xFF, count: 100).write(to: mixB)
-        // Non-mix file must be ignored.
-        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("notes.txt"))
-
-        let freshQueue = PipelineQueue(logDir: tmpDir)
-        await freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
-
-        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: processedPath.path))
-        let paths = try JSONDecoder().decode([String].self, from: Data(contentsOf: processedPath))
-        XCTAssertEqual(Set(paths), Set([
-            mixA.standardizedFileURL.path,
-            mixB.standardizedFileURL.path,
-        ]))
-    }
-
-    func testMigrateIsNoOpWhenProcessedFileAlreadyExists() async throws {
-        let recDir = tmpDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
-        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("20260101_mix.wav"))
-
-        // Pre-create the processed file with a sentinel value; migration must
-        // not overwrite it.
-        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
-        let sentinel = try JSONEncoder().encode(["/preexisting/path/mix.wav"])
-        try sentinel.write(to: processedPath)
-
-        let freshQueue = PipelineQueue(logDir: tmpDir)
-        await freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
-
-        let paths = try JSONDecoder().decode([String].self, from: Data(contentsOf: processedPath))
-        XCTAssertEqual(paths, ["/preexisting/path/mix.wav"])
-    }
-
-    func testMigrateRunsOffMainActor() async throws {
-        // Smoke test parity with testRecoverRunsDirScanOffMainActor:
-        // verify the dir scan + JSON write don't starve main-actor work.
-        let recDir = tmpDir.appendingPathComponent("recordings")
-        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
-        for i in 0 ..< 50 {
-            let mixFile = recDir.appendingPathComponent("20260311_10000\(i)_mix.wav")
-            try Data(repeating: 0xFF, count: 100).write(to: mixFile)
-        }
-
-        let freshQueue = PipelineQueue(logDir: tmpDir)
-        async let migration: Void = freshQueue.migrateProcessedRecordings(recordingsDir: recDir)
-
-        var counter = 0
-        for _ in 0 ..< 10000 {
-            counter += 1
-        }
-        XCTAssertEqual(counter, 10000)
-
-        await migration
-        let processedPath = tmpDir.appendingPathComponent("processed_recordings.json")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: processedPath.path))
     }
 
     func testRecoverRunsDirScanOffMainActor() async throws {

--- a/app/MeetingTranscriber/Tests/ProcessedRecordingsLedgerTests.swift
+++ b/app/MeetingTranscriber/Tests/ProcessedRecordingsLedgerTests.swift
@@ -1,0 +1,120 @@
+@testable import MeetingTranscriber
+import XCTest
+
+// Temp-dir cleanup is registered via `makeTempDirectory`'s `addTeardownBlock`,
+// so there's no explicit `tearDown` to balance `setUp`.
+@MainActor
+// swiftlint:disable:next attributes balanced_xctest_lifecycle
+final class ProcessedRecordingsLedgerTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "processed_ledger_test")
+    }
+
+    // MARK: - markProcessed
+
+    func testMarkProcessedRoundTrips() throws {
+        let mixPath = tmpDir.appendingPathComponent("test_mix.wav")
+
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        ledger.markProcessed(mixPath: mixPath)
+
+        // A fresh ledger over the same dir must see the persisted path.
+        let reloaded = ProcessedRecordingsLedger(logDir: tmpDir)
+        XCTAssertTrue(reloaded.load().contains(mixPath.standardizedFileURL.path))
+
+        // On-disk format stays a JSON array of standardized path strings.
+        let data = try Data(contentsOf: ledger.path)
+        let paths = try JSONDecoder().decode([String].self, from: data)
+        XCTAssertEqual(paths, [mixPath.standardizedFileURL.path])
+    }
+
+    func testMarkProcessedNilIsNoOp() {
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        ledger.markProcessed(mixPath: nil)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: ledger.path.path),
+            "nil mixPath must not create the ledger file",
+        )
+        XCTAssertTrue(ledger.load().isEmpty)
+    }
+
+    // MARK: - load
+
+    func testLoadReturnsEmptyWhenFileMissing() {
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        XCTAssertTrue(ledger.load().isEmpty)
+    }
+
+    func testLoadReturnsEmptyOnCorruptFile() throws {
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        try Data("not json".utf8).write(to: ledger.path)
+        XCTAssertTrue(ledger.load().isEmpty)
+    }
+
+    // MARK: - migrate
+
+    func testMigrateSeedsProcessedFromExistingMixFiles() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixA = recDir.appendingPathComponent("20260101_100000_mix.wav")
+        let mixB = recDir.appendingPathComponent("20260102_100000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixA)
+        try Data(repeating: 0xFF, count: 100).write(to: mixB)
+        // Non-mix file must be ignored.
+        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("notes.txt"))
+
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        await ledger.migrate(recordingsDir: recDir)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: ledger.path.path))
+        XCTAssertEqual(ledger.load(), Set([
+            mixA.standardizedFileURL.path,
+            mixB.standardizedFileURL.path,
+        ]))
+    }
+
+    func testMigrateIsNoOpWhenFileAlreadyExists() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        try Data(repeating: 0xFF, count: 100).write(to: recDir.appendingPathComponent("20260101_mix.wav"))
+
+        // Pre-seed with a sentinel value; migration must not overwrite it.
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        let sentinel = try JSONEncoder().encode(["/preexisting/path/mix.wav"])
+        try sentinel.write(to: ledger.path)
+
+        await ledger.migrate(recordingsDir: recDir)
+
+        let paths = try JSONDecoder().decode([String].self, from: Data(contentsOf: ledger.path))
+        XCTAssertEqual(paths, ["/preexisting/path/mix.wav"])
+    }
+
+    func testMigrateRunsOffMainActor() async throws {
+        // Smoke test that the dir scan + JSON write don't starve main-actor
+        // work: kick off migrate with `async let`, do synchronous work
+        // concurrently, verify both complete.
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        for i in 0 ..< 50 {
+            let mixFile = recDir.appendingPathComponent("20260311_10000\(i)_mix.wav")
+            try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+        }
+
+        let ledger = ProcessedRecordingsLedger(logDir: tmpDir)
+        async let migration: Void = ledger.migrate(recordingsDir: recDir)
+
+        var counter = 0
+        for _ in 0 ..< 10000 {
+            counter += 1
+        }
+        XCTAssertEqual(counter, 10000)
+
+        await migration
+        XCTAssertTrue(FileManager.default.fileExists(atPath: ledger.path.path))
+    }
+}


### PR DESCRIPTION
## What

Extracts the processed-recordings persistence out of the oversized
`PipelineQueue` into a standalone, unit-testable `ProcessedRecordingsLedger`
value type (new file `Sources/ProcessedRecordingsLedger.swift`).

The ledger owns the orphan-recovery skip list backed by
`processed_recordings.json`:

```swift
struct ProcessedRecordingsLedger {
    let logDir: URL
    var path: URL { logDir.appendingPathComponent("processed_recordings.json") }
    func load() -> Set<String>                 // was loadProcessedPaths
    func markProcessed(mixPath: URL?)          // nil mixPath stays a no-op
    func migrate(recordingsDir: URL) async     // was migrateProcessedRecordings; seeds from *_mix.wav
}
```

`PipelineQueue` now holds a `let processedLedger` built from `logDir` in both
inits, and the two `markProcessed` call sites (`removeJob`, `updateJobState`)
plus `recoverOrphanedRecordings`'s migrate + off-main processed-list read go
through it.

## Why

The persistence is pure file I/O with no back-references into queue state, so
it needs no delegate and reads and tests far more clearly on its own. This is
one step toward eventually dropping `PipelineQueue`'s `file_length` /
`type_body_length` suppressions. The file drops from 1540 to 1485 lines here;
the suppressions stay for now and come off in a later slice.

## No behavior change

- JSON format stays byte-identical (`JSONEncoder().encode(Array(paths))`
  written `.atomic`, decoded as `[String].self`), so existing
  `processed_recordings.json` files stay readable across the change.
- The `os_log` lines (migration seeded/failed, write-failed) and their
  `privacy: .public` markers are preserved verbatim.
- `recoverOrphanedRecordings` stays on the queue (it mutates `jobs`, calls
  `appendLog`/`saveSnapshot`/`triggerProcessing`); the detached-Task
  boundaries and the main-actor `jobs` mutation are unchanged.
- The ledger self-ensures its directory with an idempotent
  `createDirectory(withIntermediateDirectories:)` instead of the queue's
  cached `logDirCreated` flag, which the queue's event-logging path still
  uses.

## Tests

- New `Tests/ProcessedRecordingsLedgerTests.swift` covers the ledger in
  isolation: `markProcessed` round-trip, nil-mixPath no-op, `load` returns
  empty on missing/corrupt file, `migrate` seeds `*_mix.wav`, `migrate`
  no-op when the file already exists, and `migrate` runs off the main actor.
- The pure-ledger cases move out of `PipelineQueueTests`; the recovery tests
  stay and reach the ledger through the queue (`queue.processedLedger`).

## Verification

- `swift test --parallel`: green except the 5 pre-existing
  `MenuBarIconSnapshotTests` image-snapshot failures (confirmed identical on
  a clean `origin/main` checkout; untouched by this change).
- `./scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict` (via `xcodebuild build-for-testing`): 0
  violations.
- `./scripts/pre-push.sh`: release-build parity passed.