### PR TITLE
refactor(app): extract pipeline event log from PipelineQueue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     DiarizationProcess.swift  # DiarizationProvider protocol + result types
     PipelineQueue.swift    # Decouples recording from post-processing (transcription → diarization → protocol)
     ProcessedRecordingsLedger.swift  # File-backed skip-list of successfully-processed mix paths (backs PipelineQueue orphan recovery)
+    PipelineEventLog.swift  # Appends per-job state transitions to pipeline_log.jsonl (owner-only; extracted from PipelineQueue)
     PipelineJob.swift      # Pipeline job model
     PipelineSnapshot.swift  # Pure I/O helpers for persisting pipeline queue jobs to disk (atomic rename)
     SnapshotWriterActor.swift  # Actor isolating pipeline queue snapshot writes (prevents main-actor stalls)

--- a/app/MeetingTranscriber/Sources/PipelineEventLog.swift
+++ b/app/MeetingTranscriber/Sources/PipelineEventLog.swift
@@ -1,0 +1,69 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PipelineEventLog")
+
+/// Append-only JSONL log of `PipelineQueue` job state transitions, one JSON
+/// object per line in `pipeline_log.jsonl` (in `logDir`).
+///
+/// Pure persistence with no back-references into queue state, so it needs no
+/// delegate. Each entry is `timestamp`/`job_id`/`event`/`from`/`to`; the first
+/// write creates the file and restricts it to owner-only (0600) so the meeting
+/// log isn't world-readable, and subsequent writes append via a `FileHandle`
+/// (inheriting those permissions). It self-ensures `logDir` before a write
+/// (creating it only when absent) rather than sharing the queue's cached
+/// `logDirCreated` flag.
+struct PipelineEventLog {
+    let logDir: URL
+
+    /// Shared formatter — `ISO8601DateFormatter` init is non-trivial.
+    /// `nonisolated(unsafe)`: thread-safe for read-only use since macOS 10.9
+    /// despite not being formally `Sendable`.
+    nonisolated(unsafe) private static let isoFormatter = ISO8601DateFormatter()
+
+    var path: URL {
+        logDir.appendingPathComponent("pipeline_log.jsonl")
+    }
+
+    /// Append one entry describing a job state transition. `from == nil`
+    /// serializes as `"-"` (enqueue and recovery have no prior state).
+    func append(jobID: UUID, event: String, from: JobState?, to: JobState) {
+        let entry: [String: String] = [
+            "timestamp": Self.isoFormatter.string(from: Date()),
+            "job_id": jobID.uuidString,
+            "event": event,
+            "from": from?.rawValue ?? "-",
+            "to": to.rawValue,
+        ]
+        do {
+            ensureLogDir()
+            let data = try JSONEncoder().encode(entry)
+            let logPath = path
+            // swiftlint:disable:next force_unwrapping
+            let line = String(data: data, encoding: .utf8)! + "\n"
+            if FileManager.default.fileExists(atPath: logPath.path) {
+                let handle = try FileHandle(forWritingTo: logPath)
+                defer { handle.closeFile() }
+                handle.seekToEndOfFile()
+                // swiftlint:disable:next force_unwrapping
+                handle.write(line.data(using: .utf8)!)
+            } else {
+                try line.write(to: logPath, atomically: true, encoding: .utf8)
+                // First write creates the file — restrict it to owner-only so
+                // the meeting log isn't world-readable. Subsequent appends go
+                // through the FileHandle branch and inherit these permissions.
+                try FileManager.default.restrictToOwner(logPath)
+            }
+        } catch {
+            logger.error("Failed to append pipeline log: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Ensure `logDir` exists before a write. Skips the `createDirectory`
+    /// syscall when the directory already exists (the steady-state case, since
+    /// the queue creates its log dir early), so no cached flag is needed.
+    private func ensureLogDir() {
+        guard !FileManager.default.fileExists(atPath: logDir.path) else { return }
+        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -28,6 +28,11 @@ class PipelineQueue {
     /// orphans on the next launch.
     let processedLedger: ProcessedRecordingsLedger
 
+    /// Append-only JSONL log of job state transitions (`pipeline_log.jsonl`).
+    /// Self-ensures its own dir, so it doesn't share the queue's cached
+    /// `logDirCreated` flag.
+    let eventLog: PipelineEventLog
+
     // Dependencies for processing
     let engine: (any TranscribingEngine)?
     let diarizationFactory: (() -> any DiarizationProvider)?
@@ -185,6 +190,7 @@ class PipelineQueue {
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
+        eventLog = PipelineEventLog(logDir: self.logDir)
         self.engine = nil
         self.diarizationFactory = nil
         self.diarizationFactoryWithMode = nil
@@ -275,6 +281,7 @@ class PipelineQueue {
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
+        eventLog = PipelineEventLog(logDir: self.logDir)
         self.engine = engine
         self.diarizationFactory = diarizationFactory
         self.diarizationFactoryWithMode = diarizationFactoryWithMode
@@ -325,7 +332,7 @@ class PipelineQueue {
 
     func enqueue(_ job: PipelineJob) {
         jobs.append(job)
-        appendLog(jobID: job.id, event: "enqueued", from: nil, to: job.state)
+        eventLog.append(jobID: job.id, event: "enqueued", from: nil, to: job.state)
         saveSnapshot()
         logger.info("Enqueued job: \(job.meetingTitle, privacy: .private) (\(job.id))")
         triggerProcessing()
@@ -413,7 +420,7 @@ class PipelineQueue {
         jobs[index].state = newState
         if let error { jobs[index].error = error }
         recordStageTransition(from: oldState, to: newState, jobID: id)
-        appendLog(jobID: id, event: "state_change", from: oldState, to: newState)
+        eventLog.append(jobID: id, event: "state_change", from: oldState, to: newState)
         saveSnapshot()
         onJobStateChange?(jobs[index], oldState, newState)
 
@@ -1332,16 +1339,15 @@ class PipelineQueue {
                 micDelay: 0,
             )
             jobs.append(job)
-            appendLog(jobID: job.id, event: "recovered", from: nil, to: .waiting)
+            eventLog.append(jobID: job.id, event: "recovered", from: nil, to: .waiting)
         }
         saveSnapshot()
         logger.info("Recovered \(candidates.count) orphaned recording(s)")
         triggerProcessing()
     }
 
-    // MARK: - JSON Logging
+    // MARK: - Log Directory
 
-    private static let isoFormatter = ISO8601DateFormatter()
     private var logDirCreated = false
 
     private func ensureLogDir() {
@@ -1414,38 +1420,6 @@ class PipelineQueue {
     /// Lets tests assert the worker drains and clears itself.
     var isSnapshotWorkerActive: Bool {
         snapshotWorker != nil
-    }
-
-    private func appendLog(jobID: UUID, event: String, from: JobState?, to: JobState) {
-        let entry: [String: String] = [
-            "timestamp": Self.isoFormatter.string(from: Date()),
-            "job_id": jobID.uuidString,
-            "event": event,
-            "from": from?.rawValue ?? "-",
-            "to": to.rawValue,
-        ]
-        do {
-            ensureLogDir()
-            let data = try JSONEncoder().encode(entry)
-            let logPath = logDir.appendingPathComponent("pipeline_log.jsonl")
-            // swiftlint:disable:next force_unwrapping
-            let line = String(data: data, encoding: .utf8)! + "\n"
-            if FileManager.default.fileExists(atPath: logPath.path) {
-                let handle = try FileHandle(forWritingTo: logPath)
-                defer { handle.closeFile() }
-                handle.seekToEndOfFile()
-                // swiftlint:disable:next force_unwrapping
-                handle.write(line.data(using: .utf8)!)
-            } else {
-                try line.write(to: logPath, atomically: true, encoding: .utf8)
-                // First write creates the file — restrict it to owner-only so
-                // the meeting log isn't world-readable. Subsequent appends go
-                // through the FileHandle branch and inherit these permissions.
-                try FileManager.default.restrictToOwner(logPath)
-            }
-        } catch {
-            logger.error("Failed to append pipeline log: \(error.localizedDescription, privacy: .public)")
-        }
     }
 }
 

--- a/app/MeetingTranscriber/Tests/PipelineEventLogTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineEventLogTests.swift
@@ -1,0 +1,93 @@
+@testable import MeetingTranscriber
+import XCTest
+
+// Temp-dir cleanup is registered via `makeTempDirectory`'s `addTeardownBlock`,
+// so there's no explicit `tearDown` to balance `setUp`.
+@MainActor
+// swiftlint:disable:next attributes balanced_xctest_lifecycle
+final class PipelineEventLogTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "pipeline_event_log_test")
+    }
+
+    /// One decoded log entry. Mirrors the append entry's `[String: String]`
+    /// shape so tests can assert on the exact fields.
+    private struct Entry: Decodable {
+        let timestamp: String
+        // swiftlint:disable:next identifier_name
+        let job_id: String
+        let event: String
+        let from: String
+        let to: String
+    }
+
+    private func decodeLines(_ url: URL) throws -> [Entry] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        return try content
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { try JSONDecoder().decode(Entry.self, from: Data($0.utf8)) }
+    }
+
+    // MARK: - append
+
+    func testFirstAppendCreatesDecodableLine() throws {
+        let log = PipelineEventLog(logDir: tmpDir)
+        let jobID = UUID()
+        log.append(jobID: jobID, event: "enqueued", from: nil, to: .waiting)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: log.path.path))
+
+        let entries = try decodeLines(log.path)
+        XCTAssertEqual(entries.count, 1)
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.job_id, jobID.uuidString)
+        XCTAssertEqual(entry.event, "enqueued")
+        // nil `from` serializes as "-".
+        XCTAssertEqual(entry.from, "-")
+        XCTAssertEqual(entry.to, JobState.waiting.rawValue)
+        XCTAssertFalse(entry.timestamp.isEmpty)
+    }
+
+    func testFirstAppendSetsOwnerOnlyPermissions() throws {
+        let log = PipelineEventLog(logDir: tmpDir)
+        log.append(jobID: UUID(), event: "enqueued", from: nil, to: .waiting)
+
+        let mode = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: log.path.path)[.posixPermissions] as? Int,
+        )
+        XCTAssertEqual(mode & 0o777, 0o600)
+    }
+
+    func testSecondAppendAppendsSecondLine() throws {
+        let log = PipelineEventLog(logDir: tmpDir)
+        let jobID = UUID()
+        log.append(jobID: jobID, event: "enqueued", from: nil, to: .waiting)
+        log.append(jobID: jobID, event: "state_change", from: .waiting, to: .transcribing)
+
+        let entries = try decodeLines(log.path)
+        XCTAssertEqual(entries.count, 2)
+
+        // Both lines are valid JSON and preserve their fields, including a
+        // real (non-nil) `from` on the transition.
+        XCTAssertEqual(entries[0].event, "enqueued")
+        XCTAssertEqual(entries[0].from, "-")
+        XCTAssertEqual(entries[0].to, JobState.waiting.rawValue)
+        XCTAssertEqual(entries[1].event, "state_change")
+        XCTAssertEqual(entries[1].from, JobState.waiting.rawValue)
+        XCTAssertEqual(entries[1].to, JobState.transcribing.rawValue)
+    }
+
+    func testAppendCreatesMissingLogDir() throws {
+        // Point at a not-yet-existing subdirectory: append must self-ensure it.
+        let nestedDir = tmpDir.appendingPathComponent("nested/logs")
+        let log = PipelineEventLog(logDir: nestedDir)
+        log.append(jobID: UUID(), event: "recovered", from: nil, to: .waiting)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: log.path.path))
+        XCTAssertEqual(try decodeLines(log.path).count, 1)
+    }
+}


### PR DESCRIPTION
## What

Extracts the JSON event log that appends one line per job state transition to `pipeline_log.jsonl` out of the oversized `PipelineQueue` into a new standalone `PipelineEventLog` value type. Continues the queue's incremental decomposition (sibling to the recently extracted `ProcessedRecordingsLedger`).

```swift
struct PipelineEventLog {
    let logDir: URL
    var path: URL { logDir.appendingPathComponent("pipeline_log.jsonl") }
    func append(jobID: UUID, event: String, from: JobState?, to: JobState)
    private func ensureLogDir()  // fileExists-guarded createDirectory
}
```

## Why

The append logic is a self-contained persistence concern with no back-references into queue state, so it reads and tests better on its own. It now has focused standalone coverage instead of only being exercised transitively through the queue.

## Behavior preserved exactly

- Same entry shape: `timestamp` / `job_id` / `event` / `from` / `to`, with a nil `from` serialized as `"-"`.
- Same create-vs-append branch: the first write creates the file and restricts it to owner-only (0600) so the meeting log isn't world-readable; later writes append via `FileHandle` + `seekToEndOfFile` and inherit those permissions.
- Same shared `ISO8601DateFormatter` (moved onto the type as a `nonisolated(unsafe)` static, matching the existing house pattern for shared formatters).
- The three call sites (`enqueue`, `updateJobState`, `recoverOrphanedRecordings`) now delegate to `eventLog.append(...)`.

The new type self-ensures its own log directory via a `fileExists`-guarded `createDirectory`, so it does not share the queue's cached `logDirCreated` flag. `ensureLogDir` / `logDirCreated` stay on the queue because `saveSnapshot()` still relies on them; the snapshot worker is out of scope for this change.

`PipelineQueue.swift`: 1480 to 1454 lines. The two existing SwiftLint suppressions stay this slice (the decomposition continues in follow-ups).

## Tests

New `PipelineEventLogTests`: first append creates a decodable JSON line with owner-only (0600) perms; a second append adds a second valid line; a nil `from` serializes as `"-"`; entry fields match; append self-creates a missing log dir. The existing queue-level log assertions (`testLogAppendedOnEnqueue`, `testUpdateJobStateSameStateIsNoOp`) continue to pass unchanged.

## Verification

- `swift test --parallel`: green (the 5 `MenuBarIconSnapshotTests` image-snapshot failures are a pre-existing environmental issue, confirmed to fail identically on `main`).
- `./scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict` (via `xcodebuild build-for-testing` log): 0 violations, including the new files.
- `./scripts/pre-push.sh`: release-build parity passed.