### PR TITLE
feat(app): expose the menu-bar badge in the RPC /state snapshot

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -70,6 +70,7 @@
                 // Built inside AppSettings (single-hop `self.` reads) to stay
                 // under the type-check budget — see `rpcSettingsSnapshot`.
                 settings: settings.rpcSettingsSnapshot(),
+                badge: currentBadge,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -1,15 +1,25 @@
 import AppKit
 
 /// Badge overlay kind for the menu bar icon.
-enum BadgeKind: CaseIterable {
+///
+/// `String`-backed + `Codable` so the RPC `/state` snapshot can expose the
+/// current badge directly (it encodes to the case-name raw value), letting a
+/// driver script assert the menu-bar state deterministically instead of
+/// pixel-matching a screenshot.
+enum BadgeKind: String, CaseIterable, Codable {
     case inactive
     case recording
     case transcribing
     case diarizing
     case processing
+    // SwiftFormat strips a redundant `= "userAction"`, which then trips the
+    // camel-cased-Codable rule; the implicit rawValue already matches, so
+    // disable rather than fight the formatter (same as JobState / AppSettings).
+    // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
     case userAction
     case done
     case error
+    // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
     case updateAvailable
 
     /// Whether this badge kind uses animation.

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -48,6 +48,13 @@
         /// redirect). Secrets (OpenAI API key, any Keychain value) are never
         /// included — see `AppSettings.rpcSettingsSnapshot()`.
         let settings: Settings
+        /// The current menu-bar `BadgeKind` — the single glanceable summary a
+        /// human reads off the menu bar. Exposing it lets a driver script assert
+        /// the app reflects the right state deterministically instead of counting
+        /// red pixels in a `/screenshot`. Serialises to the `BadgeKind` case-name
+        /// raw value (e.g. "recording"). Record-only mode is a separate
+        /// persistent overlay; derive it from `settings.recording.recordOnly`.
+        let badge: BadgeKind
 
         struct Pipeline: Codable {
             let isProcessing: Bool
@@ -322,6 +329,7 @@
             watchState: String? = nil,
             notifications: [Notification] = [],
             settings: Settings = .empty,
+            badge: BadgeKind = .inactive,
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
@@ -334,6 +342,7 @@
             self.watchState = watchState
             self.notifications = notifications
             self.settings = settings
+            self.badge = badge
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/RPCBadgeStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCBadgeStateTests.swift
@@ -1,0 +1,91 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the menu-bar `badge` field exposed in the RPC `/state` snapshot:
+    /// the `BadgeKind` -> wire-string contract, that the snapshot builder wires it
+    /// from `AppState.currentBadge` (not a hardcode), and that it serialises into
+    /// the snapshot JSON. Lets a driver script assert the menu-bar state
+    /// deterministically instead of pixel-matching a `/screenshot`.
+    @MainActor
+    final class RPCBadgeStateTests: XCTestCase {
+        // MARK: - BadgeKind wire contract
+
+        func testBadgeKindRawValueMapsEveryCase() {
+            // Exact wire strings — a driver script asserts against these, so a
+            // rename/reorder is a breaking contract change that must be deliberate.
+            XCTAssertEqual(BadgeKind.inactive.rawValue, "inactive")
+            XCTAssertEqual(BadgeKind.recording.rawValue, "recording")
+            XCTAssertEqual(BadgeKind.transcribing.rawValue, "transcribing")
+            XCTAssertEqual(BadgeKind.diarizing.rawValue, "diarizing")
+            XCTAssertEqual(BadgeKind.processing.rawValue, "processing")
+            XCTAssertEqual(BadgeKind.userAction.rawValue, "userAction")
+            XCTAssertEqual(BadgeKind.done.rawValue, "done")
+            XCTAssertEqual(BadgeKind.error.rawValue, "error")
+            XCTAssertEqual(BadgeKind.updateAvailable.rawValue, "updateAvailable")
+            // Guard: every case is pinned above — a newly-added case fails this
+            // count and forces the author to add its wire string here.
+            XCTAssertEqual(BadgeKind.allCases.count, 9)
+        }
+
+        // MARK: - Wiring: snapshot.badge follows currentBadge (non-vacuous)
+
+        func testSnapshotBadgeReflectsCurrentBadge() throws {
+            let state = makeState()
+
+            // Fresh idle app -> inactive, on both the computed property and the wire.
+            XCTAssertEqual(state.currentBadge, .inactive)
+            XCTAssertEqual(state.rpcStateSnapshot().badge, .inactive)
+
+            // Drive currentBadge to a NON-inactive value; the snapshot must follow.
+            // A hardcoded `.inactive` in the builder would fail this.
+            let url = try XCTUnwrap(URL(string: "https://example.com"))
+            state.updateChecker.availableUpdate = ReleaseInfo(
+                tagName: "v9.9.9",
+                name: "Test Release",
+                prerelease: false,
+                htmlURL: url,
+                dmgURL: nil,
+            )
+            XCTAssertEqual(state.currentBadge, .updateAvailable)
+            // Bind once — every rpcStateSnapshot() does a real speakers.json read.
+            let snap = state.rpcStateSnapshot()
+            XCTAssertEqual(snap.badge, .updateAvailable)
+            XCTAssertEqual(snap.badge, state.currentBadge)
+        }
+
+        // MARK: - Serialisation
+
+        func testBadgeSerialisesIntoSnapshotJSON() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                badge: .recording,
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            // jsonData() is pretty-printed with sorted keys -> `"key" : "value"`;
+            // a String-raw Codable enum encodes to its raw value.
+            XCTAssertTrue(json.contains("\"badge\" : \"recording\""), json)
+        }
+
+        // MARK: - Helpers
+
+        private func makeState() -> AppState {
+            let suite = "RPCBadgeStateTests-\(getpid())-\(UUID().uuidString)"
+            guard let defaults = UserDefaults(suiteName: suite) else {
+                fatalError("Could not create test UserDefaults suite")
+            }
+            // Per-call unique volatile suite — remove it after the test so repeated
+            // runs don't accumulate orphaned preference domains (mirrors the sibling
+            // RPC test classes' tearDown). Capture only the Sendable suite name.
+            addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
+            return AppState(settings: AppSettings(defaults: defaults))
+        }
+    }
+#endif


### PR DESCRIPTION
## Problem

`GET /state` exposes pipeline, channel-health, permission, and settings state, but the single glanceable summary a human reads off the menu bar — the **badge** (idle/recording/transcribing/diarizing/processing/userAction/done/error/updateAvailable) — was only checkable by **pixel-matching a `/screenshot`** (`e2e-channel-health.sh` counts red pixels). That makes UI-state assertions flaky and blocks a driver script (or Claude Code) from verifying the badge wiring deterministically.

## Change

Expose the computed badge:
- Make `BadgeKind` a `String`-backed `Codable` enum (the case name is the stable wire string).
- Add a **`badge: BadgeKind`** field to `RPCStateSnapshot`, wired from `AppState.currentBadge` — the exact value the menu-bar scene binds to. The field is **enum-typed**, matching the sibling `JobState` / `TranscriptionEngineSetting` fields, so there is no magic wire string to drift; it serialises to the case-name raw value, unchanged on the wire:

```
GET /state → { ..., "badge": "recording" }
```

Record-only mode is a separate persistent overlay, already observable via `settings.recording.recordOnly`, so it is intentionally not folded in.

## Tests
- Exhaustive `BadgeKind` wire-string contract (all 9 cases + a count guard so a new case must pin its string).
- **Non-vacuous** wiring test: drives `currentBadge` to `.updateAvailable` and asserts the snapshot follows. Verified via an identity-stub probe — hardcoding `.inactive` in the builder makes it fail.
- JSON serialisation.
- Purely additive; no test asserts the full `/state` shape or counts top-level keys, so nothing regresses.

## Review
Went through `/simplify` (4 angles) + a high-effort code review. Applied: enum-typed the `badge` field (removes the magic-string default + a doc value-list that duplicated the enum); bound the snapshot once in the wiring test (each call does a real `speakers.json` read); added test-suite teardown to match the sibling RPC test classes. Local verify: build (debug + release), lint, the full RPC-shape test subset all green.

## Scope
Pure Swift RPC-observability add — does not touch `e2e-app.sh` or the recording pipeline, so standard CI fully covers it; no `run-e2e` needed. A follow-up could replace the flaky red-pixel assertion in `e2e-channel-health.sh` with a deterministic `badge` check.