### PR TITLE
refactor(app): introduce SpeakerKey value type for speaker-track identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     SpeakerMatcher+Logging.swift # Forensic match-decision logging (pseudonymized speaker names)
     LiveSpeakerMatcher.swift  # Actor for real-time speaker matching in live captions overlay (same WeSpeaker model as batch path)
     StoredSpeaker.swift    # Codable speaker DB entry model (centroid + FIFO embeddings + metadata)
+    SpeakerKey.swift       # Speaker-track identity value type (track + raw id); single serialization boundary for the R_/M_ prefix strings
     RecognitionStats.swift # Recognition event logging + aggregate stats model (recognition_log.jsonl)
     RecordingSidecar.swift # Metadata sidecar written next to dual-source recordings in record-only mode
     RecordingFileSuffix.swift  # Filename suffixes for dual-source recordings (_app.wav, _mic.wav, _mix.wav)

--- a/app/MeetingTranscriber/Sources/RecognitionStats.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStats.swift
@@ -13,7 +13,13 @@ enum RecognitionTrack: String, Codable {
     case app, mic, single
 
     init(label: String) {
-        if label.hasPrefix("R_") { self = .app } else if label.hasPrefix("M_") { self = .mic } else { self = .single }
+        // Delegate prefix parsing to SpeakerKey, the single home for the
+        // R_/M_ track-prefix knowledge.
+        switch SpeakerKey(encoded: label).track {
+        case .app: self = .app
+        case .mic: self = .mic
+        case .single: self = .single
+        }
     }
 }
 

--- a/app/MeetingTranscriber/Sources/SpeakerKey.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerKey.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A speaker identity in the dual-track pipeline: a raw diarizer id plus the
+/// track it came from. This type is the single home for the `R_`/`M_` track
+/// prefix knowledge that is otherwise duplicated across the codebase.
+///
+/// `encoded` / `init(encoded:)` are the ONE serialization boundary between this
+/// value and the legacy prefixed-string form used by persistence, wire formats,
+/// and the diarization merge. Raw diarizer ids are `SPEAKER_\d+` (they never
+/// begin with `R_` or `M_`), so the round-trip is bijective:
+/// `SpeakerKey(encoded: key.encoded) == key` for every key.
+struct SpeakerKey: Hashable, Comparable {
+    /// Which diarized track a speaker id belongs to. `single` is the
+    /// unprefixed single-source form.
+    enum Track: String, Codable {
+        case app, mic, single
+    }
+
+    let track: Track
+    /// Raw diarizer id, e.g. `"SPEAKER_0"` (never carries a track prefix).
+    let id: String
+}
+
+extension SpeakerKey {
+    /// The exact legacy string form. This is the ONE place the prefix strings
+    /// live: `R_` for the remote/app track, `M_` for the mic track, and the
+    /// bare id for single-source.
+    var encoded: String {
+        switch track {
+        case .app: "R_\(id)"
+        case .mic: "M_\(id)"
+        case .single: id
+        }
+    }
+
+    /// Parses the legacy prefix form. Total, never fails: an id that lacks an
+    /// `R_`/`M_` prefix is treated as single-source (its raw ids are
+    /// `SPEAKER_\d+`, so this is unambiguous).
+    init(encoded: String) {
+        if encoded.hasPrefix("R_") {
+            self.init(track: .app, id: String(encoded.dropFirst(2)))
+        } else if encoded.hasPrefix("M_") {
+            self.init(track: .mic, id: String(encoded.dropFirst(2)))
+        } else {
+            self.init(track: .single, id: encoded)
+        }
+    }
+
+    /// Orders by the encoded string form so downstream (UI / DTO) ordering is
+    /// preserved when later slices sort `SpeakerKey`s directly instead of their
+    /// legacy string labels.
+    static func < (lhs: SpeakerKey, rhs: SpeakerKey) -> Bool {
+        lhs.encoded < rhs.encoded
+    }
+}

--- a/app/MeetingTranscriber/Tests/SpeakerKeyTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerKeyTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import MeetingTranscriber
+import XCTest
+
+final class SpeakerKeyTests: XCTestCase {
+    // MARK: - Round-trip
+
+    func testRoundTripApp() {
+        let key = SpeakerKey(track: .app, id: "SPEAKER_0")
+        XCTAssertEqual(key.encoded, "R_SPEAKER_0")
+        XCTAssertEqual(SpeakerKey(encoded: key.encoded), key)
+    }
+
+    func testRoundTripMic() {
+        let key = SpeakerKey(track: .mic, id: "SPEAKER_0")
+        XCTAssertEqual(key.encoded, "M_SPEAKER_0")
+        XCTAssertEqual(SpeakerKey(encoded: key.encoded), key)
+    }
+
+    func testRoundTripSingle() {
+        let key = SpeakerKey(track: .single, id: "SPEAKER_0")
+        XCTAssertEqual(key.encoded, "SPEAKER_0")
+        XCTAssertEqual(SpeakerKey(encoded: key.encoded), key)
+    }
+
+    // MARK: - Parse
+
+    func testParseAppPrefix() {
+        let key = SpeakerKey(encoded: "R_SPEAKER_1")
+        XCTAssertEqual(key.track, .app)
+        XCTAssertEqual(key.id, "SPEAKER_1")
+    }
+
+    func testParseMicPrefix() {
+        let key = SpeakerKey(encoded: "M_SPEAKER_2")
+        XCTAssertEqual(key.track, .mic)
+        XCTAssertEqual(key.id, "SPEAKER_2")
+    }
+
+    func testParseSingleUnprefixed() {
+        let key = SpeakerKey(encoded: "SPEAKER_3")
+        XCTAssertEqual(key.track, .single)
+        XCTAssertEqual(key.id, "SPEAKER_3")
+    }
+
+    // MARK: - Edge cases
+
+    func testParseEmptyStringIsSingle() {
+        let key = SpeakerKey(encoded: "")
+        XCTAssertEqual(key.track, .single)
+        XCTAssertEqual(key.id, "")
+    }
+
+    func testUnderscoreWithoutTrackPrefixStaysSingle() {
+        // A raw id can contain underscores; only a leading R_/M_ marks a track.
+        let key = SpeakerKey(encoded: "SPEAKER_10")
+        XCTAssertEqual(key.track, .single)
+        XCTAssertEqual(key.id, "SPEAKER_10")
+    }
+
+    // MARK: - Comparable / lexical ordering
+
+    func testComparableSortsByEncoded() {
+        // Later slices rely on encoded-lexical ordering to preserve UI/DTO order:
+        // "M_..." < "R_..." < "SPEAKER..." lexically.
+        let mic = SpeakerKey(track: .mic, id: "SPEAKER_0")
+        let app = SpeakerKey(track: .app, id: "SPEAKER_0")
+        let single = SpeakerKey(track: .single, id: "SPEAKER_0")
+        XCTAssertEqual([single, app, mic].sorted(), [mic, app, single])
+        XCTAssertTrue(mic < app)
+        XCTAssertTrue(app < single)
+    }
+}


### PR DESCRIPTION
## What

Introduces a `SpeakerKey` value type that owns the `R_` / `M_` speaker-track prefix knowledge, and reroutes the one read-only recognition-stats parser through it.

`SpeakerKey` shape:

```swift
struct SpeakerKey: Hashable, Comparable {
    enum Track: String, Codable { case app, mic, single }
    let track: Track
    let id: String            // raw diarizer id, e.g. "SPEAKER_0"
    var encoded: String       // "R_…" | "M_…" | bare id
    init(encoded: String)     // total, parses the legacy prefix form
}
```

`encoded` / `init(encoded:)` are the single serialization boundary between the value and the legacy prefixed-string form. Since raw diarizer ids are `SPEAKER_\d+` (never begin with `R_`/`M_`), the round-trip is bijective. `Comparable` orders by `encoded` so downstream UI/DTO ordering is preserved when later slices adopt the type.

`RecognitionTrack.init(label:)` now delegates its prefix parsing to `SpeakerKey`, so that logic lives in one place. `RecognitionTrack` stays its own enum for now.

## Why

Speaker IDs in the dual-track pipeline are stringly-typed with track prefixes, and that prefix knowledge is duplicated across the codebase, which has been a recurring source of bugs (double-counting, dropped mappings). This centralizes the prefix strings behind one type.

## Scope

This is slice 1 of a larger refactor. It only adds the type and reroutes the recognition-stats parser. There is no persistence, wire-format, diarization-merge, naming, or behavior change. The other prefix sites (the diarization merge / unprefix helpers, naming paths, `SpeakerMatcher`) are intentionally left untouched for later slices.

## Tests

New `SpeakerKeyTests`: round-trip per track, prefix parsing, edge cases (empty string, underscore-in-id without a track prefix stays `.single`), and `Comparable` lexical ordering (`M_…` < `R_…` < `SPEAKER…`). Existing `RecognitionStatsTests` (which pin `RecognitionTrack` classification) pass unchanged after the delegation rewrite.

## Verification

- `swift test --parallel`: green except the pre-existing/environmental `MenuBarIconSnapshotTests` pixel-diffs (this diff touches no rendering code). `SpeakerKeyTests` (9) + `RecognitionStatsTests` (16) pass.
- `./scripts/lint.sh`: 0 violations (no `redundantSendable` — Sendable is left implicit).
- `swiftlint analyze --strict` via `xcodebuild build-for-testing`: 0 violations.
- `./scripts/pre-push.sh`: release-build parity passed.