### PR TITLE
feat(app): expose update-checker status in the RPC /state snapshot

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -71,6 +71,22 @@
                 // under the type-check budget — see `rpcSettingsSnapshot`.
                 settings: settings.rpcSettingsSnapshot(),
                 badge: currentBadge,
+                updateStatus: updateStatusSnapshot(),
+            )
+        }
+
+        /// Snapshot the update-checker status. Extracted (like the other
+        /// `*Snapshot` helpers) to keep `rpcStateSnapshot`'s literal under the
+        /// type-check budget. Only the release identity + check status — no
+        /// download URLs.
+        private func updateStatusSnapshot() -> RPCStateSnapshot.UpdateStatus {
+            let update = updateChecker.availableUpdate
+            return RPCStateSnapshot.UpdateStatus(
+                available: update != nil,
+                availableVersion: update?.tagName,
+                isPrerelease: update?.prerelease ?? false,
+                isChecking: updateChecker.isChecking,
+                lastError: updateChecker.lastError,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -55,6 +55,31 @@
         /// raw value (e.g. "recording"). Record-only mode is a separate
         /// persistent overlay; derive it from `settings.recording.recordOnly`.
         let badge: BadgeKind
+        /// Update-checker runtime status. E2E drivers assert the update-check flow
+        /// (the found version, an in-flight check, a check error) that the badge
+        /// only summarises as the boolean `.updateAvailable`. Named `updateStatus`
+        /// (not `updates`) to avoid clashing with `settings.updates`, the user's
+        /// update *preferences* — mirroring the `permissionHealth` status family.
+        /// Contains no secrets.
+        let updateStatus: UpdateStatus
+
+        struct UpdateStatus: Codable {
+            /// True when a release newer than the running version was found.
+            let available: Bool
+            /// The available release's tag (e.g. "v1.2.3"); nil when none.
+            let availableVersion: String?
+            /// Whether the available release is a pre-release; false when none.
+            let isPrerelease: Bool
+            /// True while an update check is in flight.
+            let isChecking: Bool
+            /// The last check's error message; nil on success / not-yet-checked.
+            let lastError: String?
+
+            static let empty = Self(
+                available: false, availableVersion: nil, isPrerelease: false,
+                isChecking: false, lastError: nil,
+            )
+        }
 
         struct Pipeline: Codable {
             let isProcessing: Bool
@@ -330,6 +355,7 @@
             notifications: [Notification] = [],
             settings: Settings = .empty,
             badge: BadgeKind = .inactive,
+            updateStatus: UpdateStatus = .empty,
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
@@ -343,6 +369,7 @@
             self.notifications = notifications
             self.settings = settings
             self.badge = badge
+            self.updateStatus = updateStatus
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/RPCUpdateStatusTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCUpdateStatusTests.swift
@@ -1,0 +1,96 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the update-checker `updateStatus` sub-object exposed in the RPC
+    /// `/state` snapshot: that the snapshot builder wires it from `AppState.updateChecker`
+    /// (not a hardcode), and that it serialises. Lets a driver script assert the
+    /// update-check flow (found version, in-flight check, error) that the `badge`
+    /// only summarises as the boolean `.updateAvailable`.
+    @MainActor
+    final class RPCUpdateStatusTests: XCTestCase {
+        // MARK: - Empty default
+
+        func testEmptyUpdatesReadsAsNoUpdate() {
+            let empty = RPCStateSnapshot.UpdateStatus.empty
+            XCTAssertFalse(empty.available)
+            XCTAssertNil(empty.availableVersion)
+            XCTAssertFalse(empty.isPrerelease)
+            XCTAssertFalse(empty.isChecking)
+            XCTAssertNil(empty.lastError)
+        }
+
+        // MARK: - Wiring: snapshot.updateStatus follows updateChecker (non-vacuous)
+
+        func testSnapshotUpdatesReflectAvailableUpdate() throws {
+            let state = makeState()
+
+            // Fresh app: no update, not checking, no error.
+            let idle = state.rpcStateSnapshot().updateStatus
+            XCTAssertFalse(idle.available)
+            XCTAssertNil(idle.availableVersion)
+            XCTAssertFalse(idle.isChecking)
+
+            // Drive the update-checker; the snapshot must follow. A hardcoded
+            // `.empty` in the builder would fail these.
+            let url = try XCTUnwrap(URL(string: "https://example.com"))
+            state.updateChecker.availableUpdate = ReleaseInfo(
+                tagName: "v9.9.9",
+                name: "Test Release",
+                prerelease: true,
+                htmlURL: url,
+                dmgURL: nil,
+            )
+            state.updateChecker.isChecking = true
+            state.updateChecker.lastError = "network down"
+
+            let snap = state.rpcStateSnapshot().updateStatus
+            XCTAssertTrue(snap.available)
+            XCTAssertEqual(snap.availableVersion, "v9.9.9")
+            XCTAssertTrue(snap.isPrerelease)
+            XCTAssertTrue(snap.isChecking)
+            XCTAssertEqual(snap.lastError, "network down")
+        }
+
+        // MARK: - Serialisation
+
+        func testUpdatesSerialiseIntoSnapshotJSON() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                updateStatus: .init(
+                    available: true,
+                    availableVersion: "v1.2.3",
+                    isPrerelease: false,
+                    isChecking: false,
+                    lastError: nil,
+                ),
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            // jsonData() is pretty-printed with sorted keys -> `"key" : value`.
+            XCTAssertTrue(json.contains("\"updateStatus\""), json)
+            XCTAssertTrue(json.contains("\"available\" : true"), json)
+            XCTAssertTrue(json.contains("\"availableVersion\" : \"v1.2.3\""), json)
+        }
+
+        // MARK: - Helpers
+
+        private func makeState() -> AppState {
+            let suite = "RPCUpdateStatusTests-\(getpid())-\(UUID().uuidString)"
+            guard let defaults = UserDefaults(suiteName: suite) else {
+                fatalError("Could not create test UserDefaults suite")
+            }
+            // Per-call unique volatile suite — remove it after the test so repeated
+            // runs don't accumulate orphaned preference domains. Capture only the
+            // Sendable suite name.
+            addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
+            return AppState(settings: AppSettings(defaults: defaults))
+        }
+    }
+#endif


### PR DESCRIPTION
## Problem

The `badge` field (added to `/state` in the prior slice) summarises "an update is available" as a single `BadgeKind` case, but a driver script or headless automation could not observe the update-check **flow**: which version was found, whether a check is in flight, or whether a check errored.

## Change

Add an **`updateStatus`** sub-object to `RPCStateSnapshot`, wired from `AppState.updateChecker` via an `updateStatusSnapshot()` helper (following the sibling `*Snapshot` helpers that keep `rpcStateSnapshot`'s literal under the type-check budget):

```
GET /state → { ..., "updateStatus": {
  "available": true,
  "availableVersion": "v1.2.3",
  "isPrerelease": false,
  "isChecking": false,
  "lastError": null
}}
```

Named `updateStatus` (not `updates`) to avoid clashing with `settings.updates` — the user's update *preferences* — matching the convention where every runtime status object (`permissionHealth`, `channelHealth`, `engines`) avoids sharing a name with its settings counterpart. Download URLs are intentionally omitted; a driver needs the release identity + check status, not the artifacts.

## Tests
- `.empty` default reads as no-update.
- **Non-vacuous** wiring test: drives `updateChecker.availableUpdate`/`isChecking`/`lastError` and asserts the snapshot follows. Verified via an identity-stub probe — hardcoding `.empty` makes it fail.
- JSON serialisation.
- Purely additive; no test asserts the full `/state` shape.

## Review
`/simplify` (4 angles) + a high-effort code review. Applied: renamed the sub-object `updates` → `updateStatus` to resolve the naming clash with `settings.updates` (a wire-contract name, cheapest to fix pre-consumer). Kept the `available` convenience boolean (mirrors `PermissionHealth.isHealthy`). The duplicated test `makeState()` helper matches the per-class RPC-test convention (no shared AppState-test factory exists); left for a dedicated test-support refactor. Local verify: debug + release build, lint, RPC-shape test subset all green.

## Scope
Pure Swift RPC-observability add — does not touch `e2e-app.sh` or the recording pipeline, so standard CI fully covers it; no `run-e2e` needed. (Branch name is a leftover from the original plan; the change is update-checker status.)