### PR TITLE
refactor(app): route DiarizationProcess R_/M_ prefixes through SpeakerKey

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -154,11 +154,19 @@ enum DiarizationProcess {
     ) -> DiarizationResult {
         // Prefix app segments with R_
         let appSegments = appDiarization.segments.map { seg in
-            DiarizationResult.Segment(start: seg.start, end: seg.end, speaker: "R_\(seg.speaker)")
+            DiarizationResult.Segment(
+                start: seg.start,
+                end: seg.end,
+                speaker: SpeakerKey(track: .app, id: seg.speaker).encoded,
+            )
         }
         // Prefix mic segments with M_
         let micSegments = micDiarization.segments.map { seg in
-            DiarizationResult.Segment(start: seg.start, end: seg.end, speaker: "M_\(seg.speaker)")
+            DiarizationResult.Segment(
+                start: seg.start,
+                end: seg.end,
+                speaker: SpeakerKey(track: .mic, id: seg.speaker).encoded,
+            )
         }
 
         // Merge and sort by start time
@@ -168,10 +176,10 @@ enum DiarizationProcess {
         // Merge speaking times with prefixed keys
         var speakingTimes: [String: TimeInterval] = [:]
         for (key, value) in appDiarization.speakingTimes {
-            speakingTimes["R_\(key)"] = value
+            speakingTimes[SpeakerKey(track: .app, id: key).encoded] = value
         }
         for (key, value) in micDiarization.speakingTimes {
-            speakingTimes["M_\(key)"] = value
+            speakingTimes[SpeakerKey(track: .mic, id: key).encoded] = value
         }
 
         // Merge embeddings with prefixed keys
@@ -179,20 +187,20 @@ enum DiarizationProcess {
         if appDiarization.embeddings != nil || micDiarization.embeddings != nil {
             embeddings = [:]
             for (key, value) in appDiarization.embeddings ?? [:] {
-                embeddings?["R_\(key)"] = value
+                embeddings?[SpeakerKey(track: .app, id: key).encoded] = value
             }
             for (key, value) in micDiarization.embeddings ?? [:] {
-                embeddings?["M_\(key)"] = value
+                embeddings?[SpeakerKey(track: .mic, id: key).encoded] = value
             }
         }
 
         // Merge autoNames with prefixed keys
         var autoNames: [String: String] = [:]
         for (key, value) in appDiarization.autoNames {
-            autoNames["R_\(key)"] = value
+            autoNames[SpeakerKey(track: .app, id: key).encoded] = value
         }
         for (key, value) in micDiarization.autoNames {
-            autoNames["M_\(key)"] = value
+            autoNames[SpeakerKey(track: .mic, id: key).encoded] = value
         }
 
         return DiarizationResult(
@@ -203,14 +211,21 @@ enum DiarizationProcess {
         )
     }
 
-    /// Strip a track prefix (e.g. `"R_"` or `"M_"`) from a `[speakerID: name]`
-    /// dictionary, dropping entries whose key doesn't carry the prefix.
-    /// Inverse of the prefixing done in `mergeDualTrackDiarization`.
-    static func unprefixNames(_ autoNames: [String: String], prefix: String) -> [String: String] {
-        autoNames.reduce(into: [:]) { acc, kv in
-            guard kv.key.hasPrefix(prefix) else { return }
-            acc[String(kv.key.dropFirst(prefix.count))] = kv.value
+    /// Strip a track prefix from a `[speakerID: name]` dictionary, keeping only
+    /// entries whose key belongs to `track` and re-keying them to the raw
+    /// diarizer id. Routes through `SpeakerKey`'s serialization boundary rather
+    /// than duplicating the prefix strings, so a key like `R_SPEAKER_0` maps to
+    /// `SPEAKER_0` under `.app`, while non-matching keys (other track, or a raw
+    /// unprefixed id that parses as `.single`) are excluded. Inverse of the
+    /// prefixing done in `mergeDualTrackDiarization`.
+    static func unprefixNames(_ autoNames: [String: String], track: SpeakerKey.Track) -> [String: String] {
+        var out: [String: String] = [:]
+        for (label, name) in autoNames {
+            let key = SpeakerKey(encoded: label)
+            guard key.track == track else { continue }
+            out[key.id] = name
         }
+        return out
     }
 
     /// Maximum silence gap (seconds) before breaking a same-speaker block.
@@ -299,13 +314,13 @@ extension DiarizationProcess {
             let namedApp = DiarizationResult(
                 segments: app.segments,
                 speakingTimes: app.speakingTimes,
-                autoNames: unprefixNames(autoNames, prefix: "R_"),
+                autoNames: unprefixNames(autoNames, track: .app),
                 embeddings: app.embeddings,
             )
             let namedMic = DiarizationResult(
                 segments: mic.segments,
                 speakingTimes: mic.speakingTimes,
-                autoNames: unprefixNames(autoNames, prefix: "M_"),
+                autoNames: unprefixNames(autoNames, track: .mic),
                 embeddings: mic.embeddings,
             )
             let appSegs = cached.filter { $0.speaker == remoteSpeakerLabel }

--- a/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
@@ -72,4 +72,36 @@ final class DiarizationLabelSegmentsTests: XCTestCase {
         XCTAssertEqual(result.map(\.speaker), ["Alice", "Me"])
         XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
     }
+
+    // MARK: - unprefixNames
+
+    /// `unprefixNames` keeps only the keys belonging to the requested track and
+    /// re-keys them to the raw diarizer id, silently excluding the other track
+    /// and any unprefixed (single-source) key. Pins the parse side of the
+    /// `SpeakerKey` boundary: the literal `R_`/`M_` prefixes must still be
+    /// recognised, so this fails if the prefix strings ever change.
+    func testUnprefixNamesFiltersAndRekeysByTrack() {
+        let autoNames = ["R_SPEAKER_0": "Alice", "M_SPEAKER_1": "Bob", "SPEAKER_2": "Carol"]
+
+        XCTAssertEqual(DiarizationProcess.unprefixNames(autoNames, track: .app), ["SPEAKER_0": "Alice"])
+        XCTAssertEqual(DiarizationProcess.unprefixNames(autoNames, track: .mic), ["SPEAKER_1": "Bob"])
+    }
+
+    /// Producing (`mergeDualTrackDiarization`) then parsing (`unprefixNames`)
+    /// round-trips each track's `autoNames` back to their raw ids, proving the
+    /// prefix production and parsing agree byte-for-byte through `SpeakerKey`.
+    func testMergeThenUnprefixNamesRoundTrips() {
+        let appDiar = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5], autoNames: ["SPEAKER_0": "Alice"], embeddings: nil,
+        )
+        let micDiar = DiarizationResult(
+            segments: [.init(start: 0, end: 3, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 3], autoNames: ["SPEAKER_0": "Bob"], embeddings: nil,
+        )
+        let merged = DiarizationProcess.mergeDualTrackDiarization(appDiarization: appDiar, micDiarization: micDiar)
+
+        XCTAssertEqual(DiarizationProcess.unprefixNames(merged.autoNames, track: .app), ["SPEAKER_0": "Alice"])
+        XCTAssertEqual(DiarizationProcess.unprefixNames(merged.autoNames, track: .mic), ["SPEAKER_0": "Bob"])
+    }
 }


### PR DESCRIPTION
## What

Route all `R_` (remote/app) and `M_` (mic) track-prefix production and parsing in `DiarizationProcess` through the `SpeakerKey` value type's serialization boundary, so the prefix knowledge lives in one place instead of being duplicated as bare string operations.

## Why

`SpeakerKey` (`encoded` / `init(encoded:)`) is meant to be the single home for the `R_`/`M_` prefix strings. `DiarizationProcess` still hand-rolled those strings in two spots: the producer (`mergeDualTrackDiarization`) string-interpolated `"R_\(...)"` / `"M_\(...)"` across segments, speaking times, embeddings, and auto-names, and the parser (`unprefixNames`) did `hasPrefix` + `dropFirst` and silently dropped non-matching keys. Both now go through `SpeakerKey`.

## Changes

- **Producer** (`mergeDualTrackDiarization`): all 8 prefix sites now build keys via `SpeakerKey(track: .app, id:).encoded` / `SpeakerKey(track: .mic, id:).encoded` (segments x2, speakingTimes x2, embeddings x2, autoNames x2).
- **Parser** (`unprefixNames`): signature changed from `prefix: String` to `track: SpeakerKey.Track`; it now filters and re-keys each entry by parsing with `SpeakerKey(encoded:)`. The historical silent drop of non-matching keys falls out of the typed parser (other-track keys and raw unprefixed ids that parse as `.single` are excluded exactly as before). Its two call sites in `labelSegments` move from `prefix: "R_"` / `prefix: "M_"` to `track: .app` / `track: .mic`.

## Scope guard

`DiarizationResult` stays `[String: ...]`-keyed, so its contract with `PipelineQueue` and the speaker-naming session is unchanged and there is zero ripple to callers. The `Remote` / mic-label routing tags on cached segments and the mic-fail fallback in the pipeline are untouched. Output strings are byte-identical to the prior interpolation.

## Behavior preservation

- The existing dual-track merge tests and the mic-fail fallback tests (which assert the fallback keeps raw, unprefixed app keys) pass unchanged, pinning byte-identical behavior.
- Adds two characterization tests: one proving `unprefixNames` filters by track, re-keys to the raw id, and silently excludes non-matching keys; one merge-then-unprefix round-trip proving production and parsing agree byte-for-byte.

## Verification

- `swift test --parallel`: green (only the pre-existing environment-dependent `MenuBarIconSnapshotTests` snapshot failures remain, identical to `origin/main`).
- `./scripts/lint.sh`: 0 violations.
- `swiftlint analyze --strict`: 0 violations.
- `./scripts/pre-push.sh`: release-build parity passed.