### PR TITLE
feat(app): expose isManualRecording in the RPC /state snapshot

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -66,6 +66,7 @@
                 permissionHealth: permissionHealthSnapshot(),
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
+                isManualRecording: isManualRecording,
                 notifications: notificationsSnapshot(),
                 // Built inside AppSettings (single-hop `self.` reads) to stay
                 // under the type-check budget — see `rpcSettingsSnapshot`.

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -34,6 +34,11 @@
         /// `watchState == "recording"` when no caption signal is available
         /// (live transcription off — the default user profile).
         let watchState: String?
+        /// True while the active recording is a manual (app-picker) recording
+        /// rather than an auto-detected meeting. `watchState` reads "recording"
+        /// for both, so this is the only wire signal that distinguishes the
+        /// manual-recording path — letting a driver assert it took that path.
+        let isManualRecording: Bool
         /// Recently-posted macOS notifications (capped ring buffer, oldest
         /// dropped), chronological — newest last. E2E drivers poll this to
         /// assert user-facing warning paths (meeting detected, silent recording,
@@ -352,6 +357,7 @@
             permissionHealth: PermissionHealth = .unknown,
             liveCaptions: LiveCaptions = .empty,
             watchState: String? = nil,
+            isManualRecording: Bool = false,
             notifications: [Notification] = [],
             settings: Settings = .empty,
             badge: BadgeKind = .inactive,
@@ -366,6 +372,7 @@
             self.permissionHealth = permissionHealth
             self.liveCaptions = liveCaptions
             self.watchState = watchState
+            self.isManualRecording = isManualRecording
             self.notifications = notifications
             self.settings = settings
             self.badge = badge

--- a/app/MeetingTranscriber/Tests/RPCBadgeStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCBadgeStateTests.swift
@@ -31,7 +31,7 @@
         // MARK: - Wiring: snapshot.badge follows currentBadge (non-vacuous)
 
         func testSnapshotBadgeReflectsCurrentBadge() throws {
-            let state = makeState()
+            let state = makeRPCTestState()
 
             // Fresh idle app -> inactive, on both the computed property and the wire.
             XCTAssertEqual(state.currentBadge, .inactive)
@@ -72,20 +72,6 @@
             // jsonData() is pretty-printed with sorted keys -> `"key" : "value"`;
             // a String-raw Codable enum encodes to its raw value.
             XCTAssertTrue(json.contains("\"badge\" : \"recording\""), json)
-        }
-
-        // MARK: - Helpers
-
-        private func makeState() -> AppState {
-            let suite = "RPCBadgeStateTests-\(getpid())-\(UUID().uuidString)"
-            guard let defaults = UserDefaults(suiteName: suite) else {
-                fatalError("Could not create test UserDefaults suite")
-            }
-            // Per-call unique volatile suite — remove it after the test so repeated
-            // runs don't accumulate orphaned preference domains (mirrors the sibling
-            // RPC test classes' tearDown). Capture only the Sendable suite name.
-            addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
-            return AppState(settings: AppSettings(defaults: defaults))
         }
     }
 #endif

--- a/app/MeetingTranscriber/Tests/RPCManualRecordingStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCManualRecordingStateTests.swift
@@ -1,0 +1,51 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the `isManualRecording` flag exposed in the RPC `/state` snapshot:
+    /// that the snapshot builder wires it from `AppState.isManualRecording` (not a
+    /// hardcode), and that it serialises. `watchState` reads "recording" for both
+    /// auto-detected and manual recordings, so this is the only wire signal that
+    /// distinguishes the manual (app-picker) path.
+    @MainActor
+    final class RPCManualRecordingStateTests: XCTestCase {
+        // MARK: - Wiring: snapshot.isManualRecording follows AppState (non-vacuous)
+
+        func testSnapshotReflectsManualRecording() async throws {
+            let state = makeRPCTestState()
+
+            // Fresh app: no watch loop → not a manual recording.
+            XCTAssertFalse(state.isManualRecording)
+            XCTAssertFalse(state.rpcStateSnapshot().isManualRecording)
+
+            // Start a manual recording via the mock-backed test WatchLoop; the
+            // snapshot must follow. A hardcoded `false` in the builder fails this.
+            let (loop, _) = makeTestWatchLoop()
+            state.watching.watchLoop = loop
+            try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+            defer { loop.stop() }
+
+            XCTAssertTrue(state.isManualRecording)
+            XCTAssertTrue(state.rpcStateSnapshot().isManualRecording)
+        }
+
+        // MARK: - Serialisation
+
+        func testIsManualRecordingSerialisesIntoSnapshotJSON() throws {
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                isManualRecording: true,
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            // jsonData() is pretty-printed with sorted keys -> `"key" : value`.
+            XCTAssertTrue(json.contains("\"isManualRecording\" : true"), json)
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/RPCUpdateStatusTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCUpdateStatusTests.swift
@@ -23,7 +23,7 @@
         // MARK: - Wiring: snapshot.updateStatus follows updateChecker (non-vacuous)
 
         func testSnapshotUpdatesReflectAvailableUpdate() throws {
-            let state = makeState()
+            let state = makeRPCTestState()
 
             // Fresh app: no update, not checking, no error.
             let idle = state.rpcStateSnapshot().updateStatus
@@ -77,20 +77,6 @@
             XCTAssertTrue(json.contains("\"updateStatus\""), json)
             XCTAssertTrue(json.contains("\"available\" : true"), json)
             XCTAssertTrue(json.contains("\"availableVersion\" : \"v1.2.3\""), json)
-        }
-
-        // MARK: - Helpers
-
-        private func makeState() -> AppState {
-            let suite = "RPCUpdateStatusTests-\(getpid())-\(UUID().uuidString)"
-            guard let defaults = UserDefaults(suiteName: suite) else {
-                fatalError("Could not create test UserDefaults suite")
-            }
-            // Per-call unique volatile suite — remove it after the test so repeated
-            // runs don't accumulate orphaned preference domains. Capture only the
-            // Sendable suite name.
-            addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
-            return AppState(settings: AppSettings(defaults: defaults))
         }
     }
 #endif

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -529,3 +529,21 @@ actor MockEouManager: EouStreamingAsrManaging {
         []
     }
 }
+
+extension XCTestCase {
+    /// Build an `AppState` over a per-call unique, volatile `UserDefaults` suite
+    /// that is torn down after the test. Shared by the RPC-snapshot test classes
+    /// (`RPCBadgeStateTests`, `RPCUpdateStatusTests`, `RPCManualRecordingStateTests`,
+    /// …) to exercise `rpcStateSnapshot()` without touching the real defaults
+    /// domain or leaking a preference domain across runs. Captures only the
+    /// Sendable suite name in the teardown block.
+    @MainActor
+    func makeRPCTestState() -> AppState {
+        let suite = "RPCTestState-\(getpid())-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Could not create test UserDefaults suite")
+        }
+        addTeardownBlock { UserDefaults().removePersistentDomain(forName: suite) }
+        return AppState(settings: AppSettings(defaults: defaults))
+    }
+}


### PR DESCRIPTION
Two commits (rebase-merge preserves both):

## 1. `refactor(test)`: hoist shared `makeRPCTestState` helper
The RPC-snapshot test classes (`RPCBadgeStateTests`, `RPCUpdateStatusTests`, and the new one below) each carried a verbatim copy of the same volatile-`UserDefaults` `AppState` builder. Hoisted into a single `XCTestCase.makeRPCTestState()` extension in `TestHelpers.swift` so a future setup change is made once instead of drifting across copies.

## 2. `feat(app)`: expose `isManualRecording`

### Problem
`watchState` reads `"recording"` for both an auto-detected meeting and a manual (app-picker) recording, so a driver script or headless automation had no way to tell the two apart — it could not confirm the manual-recording path was taken.

### Change
Add an `isManualRecording` field to `RPCStateSnapshot`, wired from `AppState.isManualRecording` (the active watch loop's `manualRecordingInfo != nil`).

```
GET /state → { ..., "watchState": "recording", "isManualRecording": true }
```

### Tests
- **Non-vacuous** wiring test: drives a mock-backed test WatchLoop into a manual recording (`makeTestWatchLoop()` + `startManualRecording`, no real audio) and asserts the snapshot follows. Verified via an identity-stub probe — a hardcoded `false` makes it fail. No visibility widening.
- JSON serialisation. Purely additive.

## Scope
Pure Swift RPC-observability + test-helper cleanup — no `e2e-app.sh`/recording-pipeline changes, so standard CI covers it; no `run-e2e` needed.