### PR TITLE
fix(app): apply WhisperKit model changes without a relaunch

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -183,7 +183,7 @@ final class AppState {
         // reach the active engine and re-sync before the first transcription.
         liveTranscription.beginPrewarm { [weak self] in self?.engines.activeTranscriptionEngine }
         pipeline.activate { [weak self] in self?.engines.activeTranscriptionEngine }
-        watching.activate { [weak self] in self?.engines.syncLanguageSettings() }
+        watching.activate { [weak self] in self?.engines.syncEngineSettings() }
 
         #if !APPSTORE
             applyForcedChannelFlagsFromEnvironment()

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -5,9 +5,9 @@ import Observation
 
 /// Owns the transcription-engine concern: the engine instances
 /// (`WhisperKitEngine`, `ParakeetEngine`),
-/// the active-engine selection, and keeping each engine's language / vocabulary
-/// in line with `AppSettings` (both an up-front sync at construction and a
-/// self-rearming reactive observer for runtime changes).
+/// the active-engine selection, and keeping each engine's model / language /
+/// vocabulary in line with `AppSettings` (both an up-front sync at construction
+/// and a self-rearming reactive observer for runtime changes).
 ///
 /// Extracted from `AppState` as the final concern-specific controller in the
 /// god-class split. Unlike the other controllers it is fully self-contained — it
@@ -15,7 +15,7 @@ import Observation
 /// own `init` (no post-init `activate` wiring). `AppState` exposes it as
 /// `engines` and the pipeline / live-transcription coordinators read
 /// `engines.activeTranscriptionEngine`; the watch-start path calls
-/// `engines.syncLanguageSettings()` for its belt-and-suspenders up-front sync.
+/// `engines.syncEngineSettings()` for its belt-and-suspenders up-front sync.
 ///
 /// Not `@Observable` — its stored engine references are `let`s and consumers
 /// observe the engine instances themselves (each is `@Observable`), so the
@@ -50,7 +50,7 @@ final class EngineController {
         // Bring engines in line with the current settings up front so the first
         // transcription doesn't run against stale defaults, then start observing
         // for runtime changes.
-        syncLanguageSettings()
+        syncEngineSettings()
         observeEngineSettings()
     }
 
@@ -80,12 +80,14 @@ final class EngineController {
         }
     }
 
-    /// Push current language/vocabulary settings into the active engine.
-    /// Idempotent — each branch only writes when the value actually differs,
-    /// so unchanged settings don't churn the engine's `@Observable` watchers.
-    func syncLanguageSettings() {
+    /// Push current model / language / vocabulary settings into the active
+    /// engine. Idempotent — each branch only writes when the value actually
+    /// differs, so unchanged settings don't churn the engine's `@Observable`
+    /// watchers (`applyModelVariant` self-guards the same way).
+    func syncEngineSettings() {
         switch settings.transcriptionEngine {
         case .whisperKit:
+            whisperKit.applyModelVariant(settings.whisperKitModel)
             let next = settings.whisperLanguageOrNil
             if whisperKit.language != next { whisperKit.language = next }
 
@@ -103,13 +105,14 @@ final class EngineController {
     private func observeEngineSettings() {
         withObservationTracking {
             _ = settings.transcriptionEngine
+            _ = settings.whisperKitModel
             _ = settings.whisperLanguage
             _ = settings.customVocabularyPath
             _ = settings.parakeetLanguage
         } onChange: { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
-                self.syncLanguageSettings()
+                self.syncEngineSettings()
                 self.observeEngineSettings()
             }
         }

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -69,15 +69,12 @@ final class EngineController {
     /// first) so the first transcription doesn't pay the cold-load cost. Called
     /// from the menu-bar `.task` at launch.
     func preloadActiveModel() async {
-        switch settings.transcriptionEngine {
-        case .whisperKit:
-            whisperKit.modelVariant = settings.whisperKitModel
-            whisperKit.language = settings.whisperLanguageOrNil
-            await whisperKit.loadModel()
-
-        case .parakeet:
-            await parakeetEngine.loadModel()
-        }
+        // Push settings into the active engine through the one canonical sync
+        // (idempotent — it already ran at init), then load it. Routing the
+        // variant/language writes through `syncEngineSettings` keeps a single
+        // settings→engine path instead of re-inlining a whisperKit-only subset.
+        syncEngineSettings()
+        await activeTranscriptionEngine.loadModel()
     }
 
     /// Push current model / language / vocabulary settings into the active

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -21,7 +21,7 @@ import Observation
 /// to the production `Permissions.ensureMicrophoneAccess` / `PowerAssertionDetector`)
 /// so `toggleWatching` can be exercised without real TCC or IOKit. `syncEngines`
 /// is wired post-init via `activate(syncEngines:)`: it bridges to
-/// `EngineController.syncLanguageSettings()` (held by `AppState`, not injected
+/// `EngineController.syncEngineSettings()` (held by `AppState`, not injected
 /// here as a sibling) and the closure must capture `self` after stored-property
 /// init — the same post-init wiring idiom the other controllers use.
 @Observable
@@ -53,7 +53,7 @@ final class WatchingController {
     private let makeDetector: () -> any MeetingDetecting
 
     /// Engine-sync hook, wired by `activate`. Bridges to
-    /// `EngineController.syncLanguageSettings()`; nil until `activate` runs, in
+    /// `EngineController.syncEngineSettings()`; nil until `activate` runs, in
     /// which case the up-front sync is skipped (EngineController's own reactive
     /// observer still keeps the engines in line).
     private var syncEngines: (() -> Void)?

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -51,12 +51,18 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     func loadModel() async {
         await modelLoad.run { [self] in
+            // Snapshot the requested variant once. `modelVariant` is `@MainActor`
+            // mutable (the reactive settings sync calls `applyModelVariant`), so
+            // reading it separately for the download and the init could tear
+            // across these awaits — downloading one variant's folder but
+            // initialising WhisperKit under another variant's name.
+            let variant = modelVariant
             modelState = .downloading
             downloadProgress = 0
             do {
                 // Step 1: Download with progress tracking
                 let modelFolder = try await WhisperKit.download(
-                    variant: modelVariant,
+                    variant: variant,
                 ) { progress in
                     Task { @MainActor in
                         self.downloadProgress = progress.fractionCompleted
@@ -68,17 +74,44 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
                 downloadProgress = 1.0
                 pipe = try await WhisperKit(
                     WhisperKitConfig(
-                        model: modelVariant,
+                        model: variant,
                         modelFolder: modelFolder.path(),
                     ),
                 )
                 modelState = .loaded
+
+                // A model change that landed mid-load set `modelVariant` but saw
+                // a nil `pipe`, so `applyModelVariant` couldn't drop it. Reconcile
+                // here so the next transcription lazily reloads the now-current
+                // variant instead of silently serving this stale one.
+                if modelVariant != variant {
+                    pipe = nil
+                    modelState = .unloaded
+                    downloadProgress = 0
+                }
             } catch {
                 logger.error("WhisperKit model load failed: \(error.localizedDescription, privacy: .public)")
                 modelState = .unloaded
                 downloadProgress = 0
             }
         }
+    }
+
+    /// Apply a model-variant change coming from settings. Updates `modelVariant`
+    /// and, if a model is already loaded, drops it so the next transcription
+    /// lazily reloads with the new variant — `ensureModel()` short-circuits on a
+    /// non-nil `pipe`, so without this drop a settings change would never reach
+    /// an already-loaded (e.g. launch-preloaded) engine. Safe against an
+    /// in-flight transcription: `transcribeSegments` holds its own local `pipe`
+    /// reference, so clearing this one only affects the *next* load. No-op when
+    /// the variant is unchanged.
+    func applyModelVariant(_ variant: String) {
+        guard variant != modelVariant else { return }
+        modelVariant = variant
+        guard pipe != nil else { return }
+        pipe = nil
+        modelState = .unloaded
+        downloadProgress = 0
     }
 
     /// Ensure model is loaded, loading it if necessary.

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -85,9 +85,7 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
                 // here so the next transcription lazily reloads the now-current
                 // variant instead of silently serving this stale one.
                 if modelVariant != variant {
-                    pipe = nil
-                    modelState = .unloaded
-                    downloadProgress = 0
+                    unloadModel()
                 }
             } catch {
                 logger.error("WhisperKit model load failed: \(error.localizedDescription, privacy: .public)")
@@ -109,6 +107,14 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
         guard variant != modelVariant else { return }
         modelVariant = variant
         guard pipe != nil else { return }
+        unloadModel()
+    }
+
+    /// Reset to the unloaded state: drop the loaded pipe and its progress. Shared
+    /// by `applyModelVariant` and `loadModel`'s mid-load reconcile. The load
+    /// `catch` deliberately does NOT call this — a failed *reload* keeps the
+    /// prior pipe rather than clobbering a still-good model.
+    private func unloadModel() {
         pipe = nil
         modelState = .unloaded
         downloadProgress = 0

--- a/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
+++ b/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
@@ -53,6 +53,13 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
     }
 
+    func test_initialSync_propagatesWhisperKitModelToEngine() {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperKitModel = "openai_whisper-small"
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.whisperKit.modelVariant, "openai_whisper-small")
+    }
+
     // MARK: - Runtime propagation
 
     func test_runtimeChange_whisperLanguage_propagatesToEngine() async {
@@ -65,6 +72,22 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
 
         await waitFor(engines.whisperKit.language == "en")
         XCTAssertEqual(engines.whisperKit.language, "en")
+    }
+
+    /// The model variant was the one engine-config key missing from the
+    /// reactive observer: changing it in Settings only reached the engine via
+    /// the explicit "Load Model" button or a relaunch, so a user who picked a
+    /// new model and started a meeting silently transcribed with the old one.
+    func test_runtimeChange_whisperKitModel_propagatesToEngine() async {
+        settings.transcriptionEngine = .whisperKit
+        let engines = EngineController(settings: settings)
+        let original = engines.whisperKit.modelVariant
+
+        settings.whisperKitModel = "openai_whisper-small"
+
+        await waitFor(engines.whisperKit.modelVariant == "openai_whisper-small")
+        XCTAssertEqual(engines.whisperKit.modelVariant, "openai_whisper-small")
+        XCTAssertNotEqual(engines.whisperKit.modelVariant, original)
     }
 
     func test_runtimeChange_customVocabularyPath_propagatesToParakeet() async {

--- a/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
@@ -39,6 +39,21 @@ final class WhisperKitEngineTests: XCTestCase {
         XCTAssertEqual(engine.modelState, .unloaded)
     }
 
+    func testApplyModelVariant_updatesVariant() {
+        let engine = WhisperKitEngine()
+        engine.applyModelVariant("openai_whisper-small")
+        XCTAssertEqual(engine.modelVariant, "openai_whisper-small")
+    }
+
+    func testApplyModelVariant_unchanged_isNoOp() {
+        let engine = WhisperKitEngine()
+        let original = engine.modelVariant
+        engine.applyModelVariant(original)
+        XCTAssertEqual(engine.modelVariant, original)
+        // No load ever happened, so the no-op must leave the state untouched.
+        XCTAssertEqual(engine.modelState, .unloaded)
+    }
+
     func testDownloadProgressStartsAtZero() {
         let engine = WhisperKitEngine()
         XCTAssertEqual(engine.downloadProgress, 0, accuracy: 0.001)


### PR DESCRIPTION
## Problem

Changing the WhisperKit model in **Settings → Transcription** had no effect until the app was relaunched or the user clicked **Load Model**. The reactive engine-settings observer (`EngineController.observeEngineSettings`) tracked `whisperLanguage`, `customVocabularyPath`, and `parakeetLanguage` — but **not** `whisperKitModel`. And even a direct variant write wouldn't apply, because `WhisperKitEngine.ensureModel()` short-circuits on an already-loaded pipe (`if pipe != nil { return }`), and the engine is launch-preloaded.

Net effect: a user picks a new model, sees it selected in the picker, starts a meeting — and silently transcribes with the *old* model.

## Fix (commit 1)

- Track `whisperKitModel` in the reactive observer.
- Push it through a new `WhisperKitEngine.applyModelVariant(_:)` that updates the variant and, **if a model is already loaded, drops the pipe** so the next transcription lazily reloads with the new variant. No eager 1 GB reload while idle; safe against an in-flight transcription, which holds its own local `pipe` reference.
- Rename `syncLanguageSettings()` → `syncEngineSettings()`, since it now also syncs the model variant.
- Handle the *change-during-load* race (most reachable against the launch preload): `loadModel()` snapshots the variant once (it previously re-read the mutable property for both the download and the WhisperKit init, which could tear), and after a successful load reconciles against the current `modelVariant`, dropping the pipe if it changed mid-load — otherwise the load finishes on the stale variant and `ensureModel()` never reloads.

## Cleanup (commit 2)

- Fold the repeated unload reset into a private `unloadModel()` (the load `catch` stays separate — it keeps a prior pipe on a failed reload).
- Collapse `preloadActiveModel` onto `syncEngineSettings()` + `activeTranscriptionEngine.loadModel()` so every settings→engine push travels one canonical path instead of re-inlining a whisperKit-only variant/language write.

## Tests

- `EngineSettingsRuntimeSyncTests.test_runtimeChange_whisperKitModel_propagatesToEngine` and `test_initialSync_propagatesWhisperKitModelToEngine` — characterization tests that **fail against the pre-fix code** (model stays at the `large-v3-turbo` default), proving the gap was real.
- `WhisperKitEngineTests.testApplyModelVariant_updatesVariant` / `_unchanged_isNoOp` — the engine-level unit for the new method.

The already-loaded → pipe-drop path and the mid-load reconciliation are covered by inspection: exercising them requires loading a real ~1 GB CoreML model (a documented no-go zone for the fast test suite). The real-model WhisperKit E2E tests exercise `loadModel` end-to-end.