### PR TITLE
fix(app): detect Zoom's placeholder power assertion on macOS 26

### DIFF
--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -2,7 +2,6 @@ import Foundation
 import IOKit.pwr_mgt
 import os.log
 
-// swiftlint:disable:next unused_declaration
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PowerAssertionDetector")
 
 /// Detects active meetings via IOKit power assertions.
@@ -63,6 +62,9 @@ class PowerAssertionDetector: MeetingDetecting {
     private var consecutiveHits: [String: Int] = [:]
     private var cooldownUntil: [String: Date] = [:]
     private let cooldownDuration: TimeInterval = 5
+    /// Diagnostic dedup: (process|name|type) keys already logged as unmatched,
+    /// so a persistently-running unmatched meeting app logs once per session.
+    private var loggedMissKeys: Set<String> = []
 
     /// Closure that provides assertion data. Defaults to IOPMCopyAssertionsByProcess.
     /// Override in tests to inject mock data.
@@ -110,6 +112,8 @@ class PowerAssertionDetector: MeetingDetecting {
                 }
             }
         }
+
+        logUnmatchedWatchedAssertions(assertions, hits: hitsThisRound)
 
         // Check confirmation threshold
         for (appName, hits) in consecutiveHits {
@@ -193,6 +197,48 @@ class PowerAssertionDetector: MeetingDetecting {
             return true
         }
         return pattern.assertionTypes.contains(assertType)
+    }
+
+    /// Keys ("process|name|type") for assertions from a watched meeting app that
+    /// produced no match this round. Pure so the selection logic is unit-testable;
+    /// the caller dedupes for the detector's lifetime and emits one log line each.
+    static func unmatchedWatchedAssertionKeys(
+        assertions: [Int32: [[String: Any]]],
+        patterns: [AssertionPattern],
+        hits: Set<String>,
+    ) -> [String] {
+        let watched = Set(patterns.flatMap(\.processNames))
+        var keys: [String] = []
+        for pidAssertions in assertions.values {
+            for assertion in pidAssertions {
+                guard let processName = assertion["Process Name"] as? String,
+                      watched.contains(processName),
+                      let pattern = patterns.first(where: { $0.processNames.contains(processName) }),
+                      !hits.contains(pattern.appName) else {
+                    continue
+                }
+                let assertName = assertion["AssertName"] as? String ?? ""
+                let assertType = assertion["AssertType"] as? String ?? ""
+                keys.append("\(processName)|\(assertName)|\(assertType)")
+            }
+        }
+        return keys
+    }
+
+    /// Log, once per distinct key, that a watched meeting app is running but its
+    /// assertion matched nothing this round — the "detection silently not firing"
+    /// signal from issue #446, previously visible only via manual pmset. The
+    /// names are app/OS-generated metadata (no user content), logged `.public`
+    /// so a reporter's diagnostic export names the actual assertion.
+    private func logUnmatchedWatchedAssertions(_ assertions: [Int32: [[String: Any]]], hits: Set<String>) {
+        for key in Self.unmatchedWatchedAssertionKeys(assertions: assertions, patterns: patterns, hits: hits) {
+            guard loggedMissKeys.insert(key).inserted else { continue }
+            logger.info("""
+            Watched meeting app is running but its power assertion did not match \
+            (process|name|type = \(key, privacy: .public)); \
+            if a meeting is active, detection is not firing.
+            """)
+        }
     }
 
     /// Default assertion provider using IOPMCopyAssertionsByProcess.

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -17,6 +17,21 @@ class PowerAssertionDetector: MeetingDetecting {
         let appName: String
         let processNames: [String]
         let keywords: [String]
+        /// Display-sleep assertion *types* that count as an active call for this
+        /// app even when the assertion name carries no keyword. Newer Zoom builds
+        /// name their in-call display-sleep assertion with Apple's sample-code
+        /// placeholder ("Describe Activity Type"), so "zoom" never appears in the
+        /// name; matching the type recovers detection (issue #446). Left empty for
+        /// Teams, whose WebView holds a display-sleep "Video Wake Lock" even with
+        /// no call in progress, so it must stay keyword-only.
+        let assertionTypes: [String]
+
+        init(appName: String, processNames: [String], keywords: [String], assertionTypes: [String] = []) {
+            self.appName = appName
+            self.processNames = processNames
+            self.keywords = keywords
+            self.assertionTypes = assertionTypes
+        }
     }
 
     static let defaultPatterns: [AssertionPattern] = [
@@ -27,8 +42,9 @@ class PowerAssertionDetector: MeetingDetecting {
         ),
         AssertionPattern(
             appName: "Zoom",
-            processNames: ["zoom.us", "CptHost"],
+            processNames: ["zoom.us"],
             keywords: ["zoom"],
+            assertionTypes: ["PreventUserIdleDisplaySleep", "NoDisplaySleepAssertion"],
         ),
         AssertionPattern(
             appName: "Webex",
@@ -75,6 +91,7 @@ class PowerAssertionDetector: MeetingDetecting {
                       let assertName = assertion["AssertName"] as? String else {
                     continue
                 }
+                let assertType = assertion["AssertType"] as? String ?? ""
 
                 for pattern in patterns {
                     // Skip apps in cooldown
@@ -85,7 +102,7 @@ class PowerAssertionDetector: MeetingDetecting {
                     // Only count each pattern once per poll
                     guard !hitsThisRound.contains(pattern.appName) else { continue }
 
-                    if matchAssertion(processName: processName, assertName: assertName, pattern: pattern) {
+                    if matchAssertion(processName: processName, assertName: assertName, assertType: assertType, pattern: pattern) {
                         hitsThisRound.insert(pattern.appName)
                         firstMatch[pattern.appName] = (pid, processName, assertName)
                         consecutiveHits[pattern.appName, default: 0] += 1
@@ -128,8 +145,9 @@ class PowerAssertionDetector: MeetingDetecting {
                       let assertName = assertion["AssertName"] as? String else {
                     continue
                 }
+                let assertType = assertion["AssertType"] as? String ?? ""
                 for pattern in patterns where pattern.appName == meeting.pattern.appName {
-                    if matchAssertion(processName: processName, assertName: assertName, pattern: pattern) {
+                    if matchAssertion(processName: processName, assertName: assertName, assertType: assertType, pattern: pattern) {
                         return true
                     }
                 }
@@ -168,10 +186,13 @@ class PowerAssertionDetector: MeetingDetecting {
 
     // MARK: - Private
 
-    private func matchAssertion(processName: String, assertName: String, pattern: AssertionPattern) -> Bool {
+    private func matchAssertion(processName: String, assertName: String, assertType: String, pattern: AssertionPattern) -> Bool {
         guard pattern.processNames.contains(processName) else { return false }
         let lowerAssert = assertName.lowercased()
-        return pattern.keywords.contains { lowerAssert.contains($0.lowercased()) }
+        if pattern.keywords.contains(where: { lowerAssert.contains($0.lowercased()) }) {
+            return true
+        }
+        return pattern.assertionTypes.contains(assertType)
     }
 
     /// Default assertion provider using IOPMCopyAssertionsByProcess.

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -107,6 +107,41 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertEqual(result?.pattern.appName, "Zoom")
     }
 
+    func testDetectsZoomPlaceholderAssertion() {
+        // Field data (macOS 26, Zoom Workplace, issue #446): the in-call assertion
+        // is a display-sleep assertion whose name is Apple's sample-code placeholder,
+        // so the "zoom" keyword never appears. Detection must fall back to the
+        // display-sleep assertion *type* for zoom.us.
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 65978,
+                processName: "zoom.us",
+                assertName: "Describe Activity Type",
+                assertType: "NoDisplaySleepAssertion",
+            )
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Zoom")
+    }
+
+    func testIgnoresZoomSystemSleepAssertion() {
+        // Only display-sleep assertion types count as an active Zoom call. A
+        // system-sleep assertion with the same placeholder name (e.g. during a
+        // recording conversion or update) must NOT trigger detection.
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 65978,
+                processName: "zoom.us",
+                assertName: "Describe Activity Type",
+                assertType: "PreventUserIdleSystemSleep",
+            )
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
     func testDetectsWebexCall() {
         let detector = makeDetector()
         detector.assertionProvider = {
@@ -278,6 +313,22 @@ final class PowerAssertionDetectorTests: XCTestCase {
         detector.assertionProvider = { assertions }
         let meeting = try XCTUnwrap(detector.checkOnce())
 
+        XCTAssertTrue(detector.isMeetingActive(meeting))
+    }
+
+    func testIsMeetingActiveDetectsZoomPlaceholder() throws {
+        // End-of-meeting detection shares the matcher, so the placeholder
+        // assertion must keep the Zoom meeting alive too.
+        let detector = makeDetector()
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 65978,
+                processName: "zoom.us",
+                assertName: "Describe Activity Type",
+                assertType: "NoDisplaySleepAssertion",
+            )
+        }
+        let meeting = try XCTUnwrap(detector.checkOnce())
         XCTAssertTrue(detector.isMeetingActive(meeting))
     }
 

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -220,6 +220,48 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNil(detector.checkOnce())
     }
 
+    // MARK: - Unmatched-App Diagnostics
+
+    func testUnmatchedWatchedAssertionKeysReportsRunningUnmatchedApp() {
+        // A watched meeting app is running but its assertion matches no pattern
+        // this round — the diagnostic must surface it so a "stopped detecting"
+        // report has a log line instead of needing manual pmset (issue #446).
+        let assertions = makeAssertionDict(
+            pid: 4211,
+            processName: "MSTeams",
+            assertName: "Downloading update",
+            assertType: "PreventUserIdleSystemSleep",
+        )
+        let keys = PowerAssertionDetector.unmatchedWatchedAssertionKeys(
+            assertions: assertions,
+            patterns: PowerAssertionDetector.defaultPatterns,
+            hits: [],
+        )
+        XCTAssertEqual(keys, ["MSTeams|Downloading update|PreventUserIdleSystemSleep"])
+    }
+
+    func testUnmatchedWatchedAssertionKeysSkipsMatchedAndUnwatched() {
+        // Zoom matched this round (in hits) → not reported; Safari isn't a
+        // watched meeting app → not reported.
+        var assertions = makeAssertionDict(
+            pid: 65978,
+            processName: "zoom.us",
+            assertName: "Describe Activity Type",
+            assertType: "NoDisplaySleepAssertion",
+        )
+        assertions[9999] = [[
+            "Process Name": "Safari",
+            "AssertName": "Playing video",
+            "AssertType": "PreventUserIdleDisplaySleep",
+        ]]
+        let keys = PowerAssertionDetector.unmatchedWatchedAssertionKeys(
+            assertions: assertions,
+            patterns: PowerAssertionDetector.defaultPatterns,
+            hits: ["Zoom"],
+        )
+        XCTAssertTrue(keys.isEmpty)
+    }
+
     // MARK: - Confirmation Threshold
 
     func testConfirmationThreshold() {


### PR DESCRIPTION
## Problem

Zoom meetings stopped being auto-detected on macOS 26 for multiple users (issue #446): the app never started recording a Zoom call automatically, while manual recording and Microsoft Teams auto-detection kept working on the same machine, back to back.

## Root cause

Auto-detection uses `PowerAssertionDetector`, which reads IOKit power assertions and required BOTH a matching process name AND a keyword substring in the assertion *name*. A field capture during a live Zoom call (macOS 26, Zoom Workplace) shows Zoom now names its in-call display-sleep assertion with Apple's sample-code placeholder, which contains no "zoom":

```
pid NNNN(zoom.us): NoDisplaySleepAssertion named: "Describe Activity Type"
```

So the "zoom" keyword never matched and detection never fired. Teams was unaffected because it names its assertion "... Call in progress".

Both cases were measured on a real machine: in-call, `zoom.us` holds a `NoDisplaySleepAssertion`; idle (Zoom open, no meeting) it holds no display-sleep assertion at all. So matching on the assertion type is safe against spuriously auto-recording when Zoom is merely open.

## Fix

- Add a per-pattern `assertionTypes` fallback: an assertion also matches when its type is one of the pattern's display-sleep types, even without a keyword. Zoom gets `PreventUserIdleDisplaySleep` + `NoDisplaySleepAssertion`; Teams and Webex stay keyword-only, because Teams' WebView holds a display-sleep "Video Wake Lock" even with no call in progress. Only display-sleep types are accepted, so a system-sleep assertion with the same placeholder name is ignored.
- Drop the stale "CptHost" process name: the real Zoom helper binary is "caphost", it holds no assertion during a call, and matching a helper under the new type gate would risk the recorder tapping the helper PID instead of the main client.
- Revive the detector's previously-unused logger: emit a deduped diagnostic line when a watched meeting app is running but its assertion matched nothing. Previously a "stopped detecting" report left no trace and required running `pmset -g assertions` by hand.

## Tests

- `testDetectsZoomPlaceholderAssertion` — the exact field capture now detects Zoom (red against the old matcher).
- `testIgnoresZoomSystemSleepAssertion` — a system-sleep assertion with the placeholder name stays ignored (pins display-sleep-only).
- `testIsMeetingActiveDetectsZoomPlaceholder` — end-of-meeting detection (shared matcher) also honors the placeholder.
- `testIgnoresTeamsVideoWakeLock` still green — Teams did not gain type matching.
- Two unit tests for the diagnostic selection logic.

All 28 `PowerAssertionDetector` tests pass; release build and `swiftlint analyze --strict` clean.