### PR TITLE
fix(app): fall back to mic-only diarization when the app track fails

### DIFF
--- a/app/MeetingTranscriber/Sources/DiarizationProcess.swift
+++ b/app/MeetingTranscriber/Sources/DiarizationProcess.swift
@@ -277,11 +277,12 @@ enum DiarizationProcess {
 }
 
 extension DiarizationProcess {
-    /// The three diarization topologies the pipeline produces, each carrying
-    /// the data its speaker assignment needs. `labelSegments` collapses what
-    /// used to be three near-duplicate inline assignment blocks in
-    /// `PipelineQueue.diarize` — the merge + formatting tail they all shared is
-    /// now applied once at the call site.
+    /// The diarization topologies the pipeline produces, each carrying the data
+    /// its speaker assignment needs (single-source, dual-track, and the app-only
+    /// and mic-only single-track fallbacks). `labelSegments` collapses what used
+    /// to be near-duplicate inline assignment blocks in `PipelineQueue.diarize`;
+    /// the merge + formatting tail they all shared is now applied once at the
+    /// call site.
     enum LabelingTopology {
         /// Single mixed track: every transcript segment is assigned against one
         /// diarization.
@@ -294,6 +295,11 @@ extension DiarizationProcess {
         /// the app diarization; mic segments keep their raw `micLabel` rather
         /// than being force-matched.
         case dualTrackAppOnly(cached: [TimestampedSegment], micLabel: String, app: DiarizationResult)
+        /// Dual track, app diarization failed (e.g. a silent remote side in a
+        /// solo meeting): mic segments are assigned against the mic diarization;
+        /// app segments keep their raw `remoteSpeakerLabel` tag rather than being
+        /// force-matched. Mirror of `dualTrackAppOnly`.
+        case dualTrackMicOnly(cached: [TimestampedSegment], micLabel: String, mic: DiarizationResult)
     }
 
     /// Apply speaker labels for any diarization topology, returning segments
@@ -348,6 +354,22 @@ extension DiarizationProcess {
             let labeledApp = assignSpeakers(transcript: appSegs, diarization: namedApp)
             // micSegs keep their original micLabel speaker tag.
             return (labeledApp + micSegs).sorted { $0.start < $1.start }
+
+        case let .dualTrackMicOnly(cached, micLabel, mic):
+            // App diarization failed, so `combined` is the *unprefixed* mic
+            // diarization — autoNames keys are raw ("SPEAKER_0"), not "M_"-prefixed.
+            // Pass them through directly (mirror of the app-only fallback above).
+            let namedMic = DiarizationResult(
+                segments: mic.segments,
+                speakingTimes: mic.speakingTimes,
+                autoNames: autoNames,
+                embeddings: mic.embeddings,
+            )
+            let appSegs = cached.filter { $0.speaker == remoteSpeakerLabel }
+            let micSegs = cached.filter { $0.speaker == micLabel }
+            let labeledMic = assignSpeakers(transcript: micSegs, diarization: namedMic)
+            // appSegs keep their original remoteSpeakerLabel tag.
+            return (labeledMic + appSegs).sorted { $0.start < $1.start }
         }
     }
 }

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -303,10 +303,11 @@ extension PipelineQueue {
     }
 
     /// Run diarization for one loop iteration. Dual-track diarizes the app and
-    /// mic tracks separately and tolerates a mic-track failure (silent track on
-    /// hosts without a real input device) by falling back to app-only; the
-    /// `combined` result is the prefixed merge (or the app-only result) fed into
-    /// speaker naming. Single-source diarizes the mix directly.
+    /// mic tracks separately and tolerates either track failing (a silent track
+    /// on a host without a real input device, or a silent remote side in a solo
+    /// meeting) by falling back to the surviving track; the `combined` result is
+    /// the prefixed merge, or the single-track fallback, fed into speaker naming.
+    /// Single-source diarizes the mix directly.
     private func runDiarization(
         diarizeProcess: any DiarizationProvider, useDualTrack: Bool,
         speakerCount: Int?, workDir: URL, ctx: JobContext,
@@ -330,23 +331,34 @@ extension PipelineQueue {
         )
     }
 
-    /// Diarize the app + mic tracks separately, tolerating a mic-track failure
-    /// (silent track on a host without a real input device). The app track is
-    /// required; on mic failure the `combined` result is the *unprefixed* app
-    /// diarization — so downstream naming keys stay consistent with the
-    /// persisted app-only transcript — rather than the `R_`/`M_`-prefixed merge.
-    /// Shared by the batch (`runDiarization`) and the session's late re-run so
-    /// the mic-fail fallback can't diverge between them. Internal (not private)
-    /// because it is a `SpeakerNamingSessionDelegate` witness.
+    /// Diarize the app + mic tracks separately, tolerating either track failing
+    /// (a silent mic on a host without a real input device, or a silent remote
+    /// side in a solo meeting) by falling back to the surviving track; only a
+    /// both-track failure propagates. On a single-track fallback the `combined`
+    /// result is that track's *unprefixed* diarization, so downstream naming keys
+    /// stay consistent with the persisted single-track transcript, rather than the
+    /// `R_`/`M_`-prefixed merge. Shared by the batch (`runDiarization`) and the
+    /// session's late re-run so the fallback can't diverge between them. Internal
+    /// (not private) because it is a `SpeakerNamingSessionDelegate` witness.
     func runDualTrackDiarization(
         diarizeProcess: any DiarizationProvider,
         tracks: (app: URL, mic: URL, micDelay: TimeInterval),
         speakerCount: Int?, title: String, jobID: UUID,
     ) async throws -> DiarizationRun {
-        let appDiarization = try await diarizeProcess.run(
-            audioPath: tracks.app, numSpeakers: speakerCount, meetingTitle: title,
-        )
+        let sid = PipelineJob.shortID(for: jobID)
+
+        var appDiarization: DiarizationResult?
+        var appError: (any Error)?
+        do {
+            appDiarization = try await diarizeProcess.run(
+                audioPath: tracks.app, numSpeakers: speakerCount, meetingTitle: title,
+            )
+        } catch {
+            appError = error
+        }
+
         var micDiarization: DiarizationResult?
+        var micError: (any Error)?
         do {
             let rawMic = try await diarizeProcess.run(
                 audioPath: tracks.mic,
@@ -358,27 +370,47 @@ extension PipelineQueue {
             // `mergeDualSourceSegments` already shifted by `+micDelay`.
             micDiarization = DiarizationProcess.shiftSegments(rawMic, by: tracks.micDelay)
         } catch {
-            logger.warning(
-                "[\(PipelineJob.shortID(for: jobID), privacy: .public)] mic_diarization_failed error=\(error.localizedDescription, privacy: .public) — falling back to app-only diarization",
-            )
-            addWarning(id: jobID, "Mic track diarization failed — speaker labels reflect remote audio only")
-            micDiarization = nil
+            micError = error
         }
 
-        // App-only fallback (mic nil) feeds the speaker-naming loop with the
-        // app diarization; the dual-track-app-only assignment branch then keeps
-        // mic segments with their raw `micLabel` instead of force-matching them.
-        let combined = micDiarization.map { mic in
-            DiarizationProcess.mergeDualTrackDiarization(appDiarization: appDiarization, micDiarization: mic)
-        } ?? appDiarization
+        // Tolerate one silent/failed track and fall back to the other: a silent
+        // local mic on a host without a real input device (app-only), or a silent
+        // remote side in a solo meeting (mic-only). Each fallback keeps the other
+        // track's segments with their raw tag instead of force-matching them; only
+        // a both-track failure is a genuine diarization failure that propagates.
+        let combined: DiarizationResult
+        switch (appDiarization, micDiarization) {
+        case let (app?, mic?):
+            combined = DiarizationProcess.mergeDualTrackDiarization(appDiarization: app, micDiarization: mic)
+
+        case let (app?, nil):
+            logger.warning(
+                "[\(sid, privacy: .public)] mic_diarization_failed error=\(micError?.localizedDescription ?? "unknown", privacy: .public) — falling back to app-only diarization",
+            )
+            addWarning(id: jobID, "Mic track diarization failed — speaker labels reflect remote audio only")
+            combined = app
+
+        case let (nil, mic?):
+            logger.warning(
+                "[\(sid, privacy: .public)] app_diarization_failed error=\(appError?.localizedDescription ?? "unknown", privacy: .public) — falling back to mic-only diarization",
+            )
+            addWarning(id: jobID, "App track diarization failed — speaker labels reflect local mic only")
+            combined = mic
+
+        case (nil, nil):
+            logger.warning(
+                "[\(sid, privacy: .public)] diarization_failed_both app=\(appError?.localizedDescription ?? "unknown", privacy: .public) mic=\(micError?.localizedDescription ?? "unknown", privacy: .public)",
+            )
+            throw appError ?? micError ?? DiarizationError.notAvailable
+        }
         return DiarizationRun(app: appDiarization, mic: micDiarization, combined: combined)
     }
 
     /// Apply speaker names to the transcript for whichever topology the run
-    /// produced (dual-track, mic-fail app-only fallback, or single-source),
-    /// returning the labeled transcript — or `nil` when no diarization is
-    /// available, leaving the caller's transcript unchanged. The three
-    /// topologies share the merge + format tail, applied once here.
+    /// produced (dual-track, mic-fail app-only fallback, app-fail mic-only
+    /// fallback, or single-source), returning the labeled transcript, or `nil`
+    /// when no diarization is available, leaving the caller's transcript
+    /// unchanged. The topologies share the merge + format tail, applied once here.
     private func labeledTranscript(
         from run: DiarizationRun, autoNames: [String: String],
         transcription: TranscriptionOutput, engine: any TranscribingEngine, mix16k: URL,
@@ -419,6 +451,12 @@ extension PipelineQueue {
             // mic transcript with its raw `micLabel` — better than emitting
             // "speakers not identified" on a recording with good remote audio.
             topology = .dualTrackAppOnly(cached: cachedSegments, micLabel: micLabel, app: appDiar)
+        } else if isDualSource, let micDiar = run.mic {
+            // App diarization failed (silent remote side / solo meeting). Keep the
+            // app transcript with its raw `Remote` tag and diarize the mic track —
+            // better than emitting "speakers not identified" on a recording with
+            // good local audio. Mirror of the app-only fallback above.
+            topology = .dualTrackMicOnly(cached: cachedSegments, micLabel: micLabel, mic: micDiar)
         } else if let combined = run.combined {
             topology = .single(segments: cachedSegments, diarization: combined)
         } else {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -6,8 +6,8 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Pipelin
 
 /// Raw diarization output for one run of the diarize loop. `combined` is the
 /// result fed into speaker naming (the prefixed dual-track merge, the app-only
-/// fallback, or the single-source result); `app`/`mic` are retained for the
-/// dual-track assignment step. Internal top-level (not `PipelineQueue`-nested)
+/// or mic-only single-track fallback, or the single-source result); `app`/`mic`
+/// are retained for the dual-track assignment step. Internal top-level (not `PipelineQueue`-nested)
 /// because it crosses the queue ↔ `SpeakerNamingSession` boundary in both
 /// directions via `SpeakerNamingSessionDelegate`.
 struct DiarizationRun {

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
@@ -123,8 +123,9 @@ extension SpeakerNamingSession {
             )
             delegate.namingStageDidEnd()
 
-            // Dual-track always yields a combined result (the merge or the
-            // app-only fallback); single-source sets it directly.
+            // Dual-track always yields a combined result (the merge, or the
+            // app-only / mic-only single-track fallback); single-source sets it
+            // directly. Only a both-track failure throws before a run exists.
             guard let combined = run.combined else { throw DiarizationError.notAvailable }
             guard let newNamingData = buildNamingData(
                 jobID: jobID, title: title,
@@ -197,10 +198,11 @@ extension SpeakerNamingSession {
     ) async throws -> DiarizationRun {
         let (recordingsDir, slug, jobID, micDelay) = recording
         if isDualSource {
-            // Mirror the batch path's mic-fail fallback: a silent/failing mic
-            // track must degrade to the unprefixed app-only diarization, not
-            // throw (a no-op re-run) or emit prefixed keys the persisted
-            // app-only transcript can't match. The weak var still resolves here
+            // Mirror the batch path's single-track fallback: a silent/failing
+            // track must degrade to the unprefixed surviving-track diarization
+            // (app-only on mic failure, mic-only on app failure), not throw (a
+            // no-op re-run) or emit prefixed keys the persisted single-track
+            // transcript can't match. The weak var still resolves here
             // because `lateDiarization`'s strong per-flow capture keeps the
             // queue alive; the guard is defensive for any future non-flow
             // caller → `notAvailable` rolls back to `.speakerNamingPending`.

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -29,8 +29,9 @@ protocol SpeakerNamingSessionDelegate: AnyObject {
     )
     /// Run the LLM protocol generator over a transcript (a queue pipeline stage).
     func generateProtocol(jobID: UUID, transcript: String, title: String, protocolsDir: URL) async
-    /// Diarize app + mic tracks separately with the shared mic-fail fallback
-    /// (a queue pipeline stage, reused by the late re-run).
+    /// Diarize app + mic tracks separately with the shared single-track fallback
+    /// (app-only on mic failure, mic-only on app failure; a queue pipeline stage,
+    /// reused by the late re-run).
     func runDualTrackDiarization(
         diarizeProcess: any DiarizationProvider,
         tracks: (app: URL, mic: URL, micDelay: TimeInterval),

--- a/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationLabelSegmentsTests.swift
@@ -73,6 +73,29 @@ final class DiarizationLabelSegmentsTests: XCTestCase {
         XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
     }
 
+    func testLabelSegmentsDualTrackMicOnlyKeepsRawRemoteLabel() {
+        // Mirror of the app-only fallback for the opposite failure: the app
+        // (remote) track diarization failed (e.g. a silent remote side in a
+        // solo meeting), so diarize() passes the *unprefixed* mic diarization
+        // (`diarization = micDiarization`); autoNames keys are raw ("SPEAKER_0").
+        let cached = [
+            TimestampedSegment(start: 0, end: 5, text: "app line", speaker: "Remote"),
+            TimestampedSegment(start: 5, end: 10, text: "mic line", speaker: "Me"),
+        ]
+        let mic = DiarizationResult(
+            segments: [.init(start: 5, end: 10, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5], autoNames: [:], embeddings: nil,
+        )
+        let result = DiarizationProcess.labelSegments(
+            .dualTrackMicOnly(cached: cached, micLabel: "Me", mic: mic),
+            autoNames: ["SPEAKER_0": "Bob"],
+        )
+        // Mic segments get their matched name; app segments keep their raw
+        // "Remote" tag (the app track wasn't diarized).
+        XCTAssertEqual(result.map(\.speaker), ["Remote", "Bob"])
+        XCTAssertEqual(result.map(\.text), ["app line", "mic line"])
+    }
+
     // MARK: - unprefixNames
 
     /// `unprefixNames` keeps only the keys belonging to the requested track and

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1009,6 +1009,60 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    func testDiarizeDualTrackAppFailFallsBackToMicOnly() async throws {
+        // Symmetric to the mic-fail fallback: when the app (remote) track
+        // diarization fails — e.g. a silent remote side in a solo meeting, where
+        // the app audio is at the noise floor while the mic has real speech — the
+        // stage must fall back to mic-only instead of aborting the whole
+        // diarization with "speakers not identified".
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let diar = MockDiarization()
+        diar.throwOnPathSuffix = "app_16k.wav" // app diarization fails → mic-only fallback
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: ["SPEAKER_0": "Bob"],
+            embeddings: nil,
+        )
+        let protocolGen = MockProtocolGen()
+        let q = makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen)
+
+        try q.enqueue(makeDualSourceJob(title: "Dual AppFail"))
+        await q.processNext()
+
+        let warnings = try XCTUnwrap(q.jobs.first?.warnings)
+        XCTAssertTrue(
+            warnings.contains { $0.contains("App track diarization failed") },
+            "app-fail should fall back to mic-only with a warning — got: \(warnings)",
+        )
+        XCTAssertFalse(
+            warnings.contains { $0.contains("speakers not identified") },
+            "app-fail must NOT surface a total diarization failure when the mic track is fine — got: \(warnings)",
+        )
+
+        // Mirror of the mic-fail content assertions: the mic track is still
+        // diarized + named, and the app segments keep their raw 'Remote' tag
+        // (not force-matched) rather than surfacing the raw diarizer ID.
+        let transcript = try XCTUnwrap(protocolGen.capturedTranscript)
+        XCTAssertTrue(
+            transcript.contains("Bob:"),
+            "mic-only fallback: mic segments keep their matched name; got: \(transcript)",
+        )
+        XCTAssertTrue(
+            transcript.contains("] Remote:"),
+            "mic-only fallback: app segments keep their raw 'Remote' tag; got: \(transcript)",
+        )
+        XCTAssertFalse(
+            transcript.contains("] Me:"),
+            "mic-only fallback: mic segments must be diarized, not keep the raw mic label; got: \(transcript)",
+        )
+        XCTAssertFalse(
+            transcript.contains("SPEAKER_0:"),
+            "mic-only fallback: mic segments must not surface the raw diarizer ID; got: \(transcript)",
+        )
+    }
+
     /// Dual-track diarization must shift the mic track's diarization by
     /// `micDelay` so it lands on the same (app/canonical) timeline as the mic
     /// transcript segments — which `mergeDualSourceSegments` already shifted by


### PR DESCRIPTION
## Problem

Recording a meeting where the remote side is silent (a solo Zoom call, or any call where the app/remote audio sits at the noise floor while the local mic has real speech) surfaced "Diarization failed - speakers not identified", even though the mic track had perfectly usable audio and the transcript + protocol were still produced.

## Root cause

Dual-track diarization runs the app (remote) and mic (local) tracks through the diarizer separately. A mic-track failure was already tolerated (fall back to app-only diarization), but the app track was required: its diarizer call propagated on throw, so a silent/failed app track aborted the whole diarization stage.

Measured on a real solo Zoom call: app track -91 dBFS (digital silence), mic track -27 dBFS (speech). The silent app track made the diarizer throw, and there was no mic-only fallback to catch it.

## Fix

Make the fallback symmetric.

- `runDualTrackDiarization` wraps both tracks in try/catch and dispatches on the (app, mic) outcome: merge when both succeed, app-only on mic failure, mic-only on app failure, and propagate only when BOTH fail (the genuine "speakers not identified" case).
- New `.dualTrackMicOnly` labeling topology mirrors the existing `.dualTrackAppOnly`: mic segments are assigned against the mic diarization, app segments keep their raw "Remote" tag instead of being force-matched.

## Tests

- `testDiarizeDualTrackAppFailFallsBackToMicOnly` (integration): app-track diarization fails, the stage falls back to mic-only with an "App track diarization failed" warning instead of "speakers not identified". Red against the old code.
- `testLabelSegmentsDualTrackMicOnlyKeepsRawRemoteLabel` (unit): the new topology names mic segments and keeps app segments' raw "Remote" tag.
- The existing mic-fail (app-only) and single-source paths are unchanged; their tests stay green.

All affected suites pass (147 tests); release build and `swiftlint analyze --strict` clean.