### PR TITLE
ci(release): make the GitHub Release step idempotent on re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,12 @@ jobs:
         # bumps the SHA + comment in lockstep.
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
+          # Idempotent re-runs: a partially-succeeded release job (e.g. the
+          # tap-update step failing on an expired token) leaves this release
+          # already created, so a `--failed` re-run would otherwise abort here
+          # with `422 already_exists`. Updating instead lets the re-run reach the
+          # downstream tap step. First runs have nothing to update.
+          allowUpdates: true
           artifacts: .build/release/${{ matrix.dmg-prefix }}-${{ steps.version.outputs.version }}.dmg
           generateReleaseNotes: true
           generateReleaseNotesPreviousTag: ${{ steps.prev.outputs.tag }}


### PR DESCRIPTION
## Problem

When a release job partially succeeds and is re-run with `gh run rerun --failed`, the "Create GitHub Release" step aborts with:

`422 Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`

because the first run already created the main-repo release and `ncipollo/release-action` defaults to create-only. The re-run never reaches the downstream tap-update step, so the Homebrew cask stays on the old version.

This bit v0.6.0-rc6: the first run created the release + DMG, then failed at the tap-update step on an expired `TAP_REPO_TOKEN`; a `--failed` re-run (after the token was refreshed) then failed here on `already_exists` and never updated the cask, which had to be finished by hand.

## Fix

Set `allowUpdates: true` on the release step so a re-run updates the existing release (replacing its artifacts) instead of failing. First-run behaviour is unchanged (nothing to update).

CI-only change; workflow YAML validated locally.