### PR TITLE
feat(app): inline transcript in /v1 response via ?include=transcript

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -1,6 +1,36 @@
 #if !APPSTORE
     import Foundation
 
+    /// Response-only envelope for the `/v1` job-status endpoints: the persisted
+    /// `JobStatusDTO` plus an optional inline `transcript`, flattened onto the
+    /// same JSON object so the transcript is a top-level sibling of the status
+    /// fields (issue #431). Kept as a distinct type from `JobStatusDTO` so the
+    /// persisted/base shape can never carry — and never accidentally persist —
+    /// transcript text; the text is attached only at response-render time.
+    struct JobStatusResponse: Codable, Equatable {
+        let status: JobStatusDTO
+        let transcript: String?
+
+        init(_ status: JobStatusDTO, transcript: String?) {
+            self.status = status
+            self.transcript = transcript
+        }
+
+        private enum CodingKeys: String, CodingKey { case transcript }
+
+        init(from decoder: any Decoder) throws {
+            status = try JobStatusDTO(from: decoder)
+            transcript = try decoder.container(keyedBy: CodingKeys.self)
+                .decodeIfPresent(String.self, forKey: .transcript)
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            try status.encode(to: encoder) // flattens the status fields into this object
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(transcript, forKey: .transcript)
+        }
+    }
+
     /// `/v1` automation-API routing, line-cap split from `DebugRPCServer.route`.
     extension DebugRPCServer {
         // Internal (not private): the legacy `/action/enqueueFiles` route in
@@ -22,6 +52,21 @@
         private static let defaultTranscribeWaitSeconds: Double = 600
         private static let maxTranscribeWaitSeconds: Double = 1800
 
+        /// Whether the request target opted into an inline transcript via
+        /// `?include=transcript`. Comma-separated include values are honoured
+        /// (`?include=protocol,transcript`); the value match is case-insensitive.
+        nonisolated static func wantsInlineTranscript(target: String) -> Bool {
+            guard let query = target.split(separator: "?", maxSplits: 1).dropFirst().first else { return false }
+            for pair in query.split(separator: "&") {
+                let kv = pair.split(separator: "=", maxSplits: 1)
+                guard kv.count == 2, kv[0] == "include" else { continue }
+                if kv[1].split(separator: ",").contains(where: { $0.lowercased() == "transcript" }) {
+                    return true
+                }
+            }
+            return false
+        }
+
         /// Route the versioned automation surface. The query string is already
         /// stripped from `path` by the caller. Resources:
         /// - `POST /v1/transcribe` — enqueue one file, block until terminal
@@ -32,8 +77,12 @@
         /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
         func routeV1(_ request: HTTPRequest, path: String) async -> HTTPResponse {
             let idempotencyKey = request.headers["idempotency-key"]
+            // `path` is query-stripped; read the opt-in off the raw target.
+            let includeTranscript = Self.wantsInlineTranscript(target: request.path)
             if request.method == "POST", path == "/v1/transcribe" {
-                return await transcribeResponse(body: request.body, idempotencyKey: idempotencyKey)
+                return await transcribeResponse(
+                    body: request.body, idempotencyKey: idempotencyKey, includeTranscript: includeTranscript,
+                )
             }
             // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
             // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
@@ -50,7 +99,8 @@
             let sub = Array(comps.dropFirst(3))
 
             if sub.isEmpty, request.method == "GET" {
-                return encodedOrNotFound(jobStatus(jobID))
+                guard let dto = jobStatus(jobID) else { return HTTPResponse.notFound() }
+                return encodedStatus(dto, includeTranscript: includeTranscript)
             }
             if sub == ["naming"], request.method == "GET" {
                 return encodedOrNotFound(namingStatus(jobID))
@@ -90,14 +140,16 @@
             return HTTPResponse.ok(body: body, contentType: "application/json")
         }
 
-        private func transcribeResponse(body: Data, idempotencyKey: String?) async -> HTTPResponse {
+        private func transcribeResponse(
+            body: Data, idempotencyKey: String?, includeTranscript: Bool,
+        ) async -> HTTPResponse {
             guard let p = try? JSONDecoder().decode(TranscribePayload.self, from: body), !p.path.isEmpty
             else { return HTTPResponse.badRequest() }
             // Repeat with a seen key → the existing job's current status, no new
             // job. Falls through to a fresh run if that job has fully vanished.
             if let key = idempotencyKey, let existing = idempotency.lookup(key)?.first,
                let dto = jobStatus(existing) {
-                return statusResponse(for: dto)
+                return statusResponse(for: dto, includeTranscript: includeTranscript)
             }
             let requested = p.maxWaitSeconds ?? Self.defaultTranscribeWaitSeconds
             let wait = min(max(0, requested), Self.maxTranscribeWaitSeconds)
@@ -108,20 +160,40 @@
                 return HTTPResponse.badRequest()
 
             case let .completed(dto):
-                return statusResponse(for: dto)
+                return statusResponse(for: dto, includeTranscript: includeTranscript)
 
             case let .timedOut(dto):
                 guard let dto else { return HTTPResponse.badRequest() }
-                return statusResponse(for: dto)
+                return statusResponse(for: dto, includeTranscript: includeTranscript)
             }
         }
 
         /// Map a job status to its HTTP response: 200 with the DTO once terminal,
-        /// 202 (still running; client polls GET /v1/jobs/<id>) otherwise.
-        private func statusResponse(for dto: JobStatusDTO) -> HTTPResponse {
-            guard !dto.state.isTerminal else { return encodedOrNotFound(dto) }
+        /// 202 (still running; client polls GET /v1/jobs/<id>) otherwise. When the
+        /// caller opted into `?include=transcript`, the terminal 200 carries the
+        /// transcript text inline (the 202 path has no transcript yet).
+        private func statusResponse(for dto: JobStatusDTO, includeTranscript: Bool) -> HTTPResponse {
+            guard !dto.state.isTerminal else {
+                return encodedStatus(dto, includeTranscript: includeTranscript)
+            }
             guard let body = try? JSONEncoder().encode(dto) else { return HTTPResponse.badRequest() }
             return HTTPResponse(status: 202, reason: "Accepted", body: body, contentType: "application/json")
+        }
+
+        /// Encode a job status as a 200 — the single choke point that decides
+        /// between the plain `JobStatusDTO` and the transcript-carrying
+        /// `JobStatusResponse` based on the `?include=transcript` opt-in.
+        private func encodedStatus(_ dto: JobStatusDTO, includeTranscript: Bool) -> HTTPResponse {
+            guard includeTranscript else { return encodedOrNotFound(dto) }
+            return encodedOrNotFound(JobStatusResponse(dto, transcript: readTranscript(dto)))
+        }
+
+        /// Read the transcript file at `dto.transcriptPath`, or nil when it is
+        /// absent or unreadable — so opting in never turns a finished job into a
+        /// failure, and a still-running job (no transcript yet) omits the field.
+        private func readTranscript(_ dto: JobStatusDTO) -> String? {
+            guard let path = dto.transcriptPath else { return nil }
+            return try? String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
         }
 
         private func confirmNamingResponse(_ jobID: UUID, body: Data) -> HTTPResponse {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -900,6 +900,89 @@
             XCTAssertEqual(j1, j2, "repeat returns the same job via the idempotency store, no re-run")
         }
 
+        // MARK: - POST /v1/transcribe?include=transcript (inline text)
+
+        /// Issue #431: a headless remote consumer with no shared filesystem
+        /// can't read `transcriptPath`. `?include=transcript` inlines the file's
+        /// text into the response body so the agent gets the transcript directly.
+        func testV1TranscribeIncludeTranscriptInlinesFileText() async throws {
+            let file = FileManager.default.temporaryDirectory
+                .appendingPathComponent("mt-inline-\(UUID().uuidString).txt")
+            let text = "[00:00] S1: Hallo, dies ist ein Test.\n[00:04] S2: Alles klar."
+            try Data(text.utf8).write(to: file)
+            defer { try? FileManager.default.removeItem(at: file) }
+
+            let dto = JobStatusDTO(
+                jobID: UUID().uuidString, state: .done, meetingTitle: "M",
+                transcriptPath: file.path, protocolPath: nil, error: nil, warnings: [],
+            )
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in
+                await Task.yield(); return .completed(dto)
+            }
+            let base = try await startServer(transcribe: transcribe)
+
+            let url = try XCTUnwrap(URL(string: "\(base.absoluteString)/v1/transcribe?include=transcript"))
+            var req = request("POST", url, headers: authHeader)
+            let body = Data(#"{"path":"/inbox/a.wav"}"#.utf8)
+            req.httpBody = body
+            let (data, response) = try await URLSession.shared.upload(for: req, from: body)
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(JobStatusResponse.self, from: data)
+            XCTAssertEqual(decoded.transcript, text)
+            XCTAssertEqual(decoded.status.transcriptPath, file.path, "the path stays alongside the inline text")
+        }
+
+        /// Without the opt-in, the response is metadata-only — no `transcript`
+        /// key at all, so the default wire shape is unchanged.
+        func testV1TranscribeWithoutIncludeOmitsTranscript() async throws {
+            let file = FileManager.default.temporaryDirectory
+                .appendingPathComponent("mt-inline-\(UUID().uuidString).txt")
+            try Data("[00:00] S1: text".utf8).write(to: file)
+            defer { try? FileManager.default.removeItem(at: file) }
+
+            let dto = JobStatusDTO(
+                jobID: UUID().uuidString, state: .done, meetingTitle: "M",
+                transcriptPath: file.path, protocolPath: nil, error: nil, warnings: [],
+            )
+            let transcribe: (URL, Double) async -> BlockingTranscribeResult = { _, _ in
+                await Task.yield(); return .completed(dto)
+            }
+            let base = try await startServer(transcribe: transcribe)
+
+            var req = request("POST", base.appendingPathComponent("v1/transcribe"), headers: authHeader)
+            let body = Data(#"{"path":"/inbox/a.wav"}"#.utf8)
+            req.httpBody = body
+            let (data, response) = try await URLSession.shared.upload(for: req, from: body)
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let raw = try XCTUnwrap(String(data: data, encoding: .utf8))
+            XCTAssertFalse(raw.contains("\"transcript\""), "no include → no inline transcript key: \(raw)")
+        }
+
+        /// The poll-based flow (`GET /v1/jobs/<id>`) supports the same opt-in.
+        func testV1JobStatusIncludeTranscriptInlinesFileText() async throws {
+            let file = FileManager.default.temporaryDirectory
+                .appendingPathComponent("mt-inline-\(UUID().uuidString).txt")
+            let text = "[00:00] S1: polled transcript"
+            try Data(text.utf8).write(to: file)
+            defer { try? FileManager.default.removeItem(at: file) }
+
+            let id = UUID()
+            let dto = JobStatusDTO(
+                jobID: id.uuidString, state: .done, meetingTitle: "M",
+                transcriptPath: file.path, protocolPath: nil, error: nil, warnings: [],
+            )
+            let lookup: (UUID) -> JobStatusDTO? = { $0 == id ? dto : nil }
+            let base = try await startServer(jobStatus: lookup)
+
+            let url = try XCTUnwrap(URL(string: "\(base.absoluteString)/v1/jobs/\(id.uuidString)?include=transcript"))
+            let (data, response) = try await URLSession.shared.data(for: request("GET", url, headers: authHeader))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual(try JSONDecoder().decode(JobStatusResponse.self, from: data).transcript, text)
+        }
+
         // MARK: - M6: Host header allowlist (raw-socket)
 
         /// `URLRequest.setValue(_:forHTTPHeaderField: "Host")` is silently

--- a/app/MeetingTranscriber/Tests/DebugRPCServerV1QueryTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerV1QueryTests.swift
@@ -1,0 +1,36 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Pure query-string parsing for the `?include=transcript` opt-in on the
+    /// `/v1` surface (issue #431).
+    final class DebugRPCServerV1QueryTests: XCTestCase {
+        func testWantsInlineTranscriptFalseWithoutQuery() {
+            XCTAssertFalse(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe"))
+            XCTAssertFalse(DebugRPCServer.wantsInlineTranscript(target: "/v1/jobs/\(UUID().uuidString)"))
+        }
+
+        func testWantsInlineTranscriptTrueForIncludeTranscript() {
+            XCTAssertTrue(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe?include=transcript"))
+        }
+
+        func testWantsInlineTranscriptTrueWithinCommaList() {
+            XCTAssertTrue(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe?include=protocol,transcript"))
+        }
+
+        func testWantsInlineTranscriptTrueAlongsideOtherParams() {
+            XCTAssertTrue(DebugRPCServer.wantsInlineTranscript(
+                target: "/v1/jobs/\(UUID().uuidString)?wait=1&include=transcript",
+            ))
+        }
+
+        func testWantsInlineTranscriptIsCaseInsensitiveOnValue() {
+            XCTAssertTrue(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe?include=Transcript"))
+        }
+
+        func testWantsInlineTranscriptFalseForUnrelatedInclude() {
+            XCTAssertFalse(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe?include=protocol"))
+            XCTAssertFalse(DebugRPCServer.wantsInlineTranscript(target: "/v1/transcribe?other=transcript"))
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/JobStatusResponseTests.swift
+++ b/app/MeetingTranscriber/Tests/JobStatusResponseTests.swift
@@ -1,0 +1,40 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// The `/v1` wire shape is a stability contract. `JobStatusResponse` flattens
+    /// the persisted `JobStatusDTO` plus an opt-in inline `transcript` onto one
+    /// JSON object (issue #431). These lock that: with no transcript the bytes are
+    /// exactly a `JobStatusDTO` (no `transcript` key), so a client sees no change
+    /// unless it passes `?include=transcript`; with one it is a top-level sibling.
+    final class JobStatusResponseTests: XCTestCase {
+        private let dto = JobStatusDTO(
+            jobID: "1B4E28BA-2FA1-11D2-883F-0016D3CCA427",
+            state: .done,
+            meetingTitle: "Daily Standup",
+            transcriptPath: "/out/call.txt",
+            protocolPath: nil,
+            error: nil,
+            warnings: [],
+        )
+
+        func testTranscriptKeyOmittedWhenNil() throws {
+            let json = try XCTUnwrap(String(data: JSONEncoder().encode(JobStatusResponse(dto, transcript: nil)), encoding: .utf8))
+            XCTAssertFalse(json.contains("\"transcript\""), "nil transcript must not appear in the JSON: \(json)")
+            // The status fields are flattened onto the same object, not nested.
+            XCTAssertTrue(json.contains("\"jobID\""))
+            XCTAssertTrue(json.contains("\"transcriptPath\""))
+            XCTAssertFalse(json.contains("\"status\""), "the base DTO must be flattened, not nested under a key")
+        }
+
+        func testTranscriptIsATopLevelSiblingWhenSet() throws {
+            let data = try JSONEncoder().encode(JobStatusResponse(dto, transcript: "[00:00] S1: hello"))
+            // Decodes back into the same envelope: status fields + transcript.
+            let decoded = try JSONDecoder().decode(JobStatusResponse.self, from: data)
+            XCTAssertEqual(decoded.transcript, "[00:00] S1: hello")
+            XCTAssertEqual(decoded.status, dto)
+            // And a plain JobStatusDTO decode still sees the flattened status fields.
+            XCTAssertEqual(try JSONDecoder().decode(JobStatusDTO.self, from: data), dto)
+        }
+    }
+#endif

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -65,7 +65,8 @@ per connection; exceeding it closes the connection without sending a response.
 | `POST` | `/v1/jobs/<id>/naming/skip` | Skip naming for a job (accept auto-assigned names). |
 
 A query string is stripped before routing, so `/v1/jobs/<id>?foo=bar` still
-resolves the id.
+resolves the id. The one query parameter with meaning is `include=transcript`
+on `POST /v1/transcribe` and `GET /v1/jobs/<id>` (see [Inline transcript](#inline-transcript)).
 
 ### POST /v1/transcribe
 
@@ -99,6 +100,27 @@ curl -sS -X POST "$BASE/v1/transcribe" \
   -H "Content-Type: application/json" \
   -d '{"path":"/Users/me/Recordings/standup.wav","maxWaitSeconds":900}'
 ```
+
+#### Inline transcript
+
+By default the response carries only metadata and a `transcriptPath` — fine when
+the client shares a filesystem with the app, useless for a remote agent that
+cannot read that path. Add `?include=transcript` to fold the transcript text into
+the response as a `transcript` field:
+
+```bash
+curl -sS -X POST "$BASE/v1/transcribe?include=transcript" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"path":"/Users/me/Recordings/standup.wav"}'
+```
+
+- Opt-in only. Without the parameter the wire shape is unchanged (no `transcript`
+  key), so existing clients are unaffected.
+- Populated on the terminal `200` response (and on `GET /v1/jobs/<id>?include=transcript`).
+  A `202` (still running) has no transcript yet, so the field is absent.
+- Best-effort: if the transcript file is missing or unreadable the field is
+  omitted and `transcriptPath` is still returned — opting in never turns a
+  finished job into an error.
 
 ### POST /v1/jobs
 
@@ -229,6 +251,9 @@ Scope and limits:
 - `error`: a message string when `state == "error"`, else `null`.
 - `warnings`: zero or more non-fatal warning strings (for example a partial
   diarization failure on one track).
+- `transcript`: the transcript text, present **only** when the request opted in
+  via `?include=transcript` (see [Inline transcript](#inline-transcript)). Absent
+  otherwise, so the default shape is unchanged.
 
 ### NamingStatusDTO
 


### PR DESCRIPTION
## What

Adds an opt-in `?include=transcript` query parameter to the `/v1` automation API. When present, the transcript text is folded into the response body so a headless remote consumer gets it directly instead of only a `transcriptPath`.

Applies to the blocking `POST /v1/transcribe` and the poll `GET /v1/jobs/<id>`.

```bash
curl -sS -X POST "$BASE/v1/transcribe?include=transcript" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"path":"/abs/audio.wav"}'
# → 200 { "jobID": "...", "state": "done", ..., "transcript": "[00:00] S1: ..." }
```

## Why

Reported on #431 after a live test of the shipped v1 API: the blocking endpoint returns only metadata plus `transcriptPath`. For a headless setup where the agent runs on a different host than the app (no shared filesystem), that path is unreadable, so the agent never obtains the transcript at all. Protocol/LLM generation is also commonly unavailable on such a box, which makes the transcript the only usable output.

## Design

- A response-only `JobStatusResponse` envelope wraps the persisted `JobStatusDTO` plus an optional `transcript`, flattened onto the same JSON object so the text is a top-level sibling of the status fields. Keeping it a distinct type means `JobStatusDTO` — the shape `TerminalJobStore` persists — can never carry, and so never accidentally persist, transcript text.
- **Opt-in only.** Without the parameter the response bytes are exactly a `JobStatusDTO` (the nil transcript is omitted by the encoder), so existing clients are unaffected.
- Populated on the terminal `200` (and on `GET /v1/jobs/<id>?include=transcript`); a `202` (still running) has no transcript yet.
- **Best-effort read:** a missing/unreadable transcript file omits the field and keeps `transcriptPath`, so opting in never turns a finished job into an error.

## Tests

- Pure query-parser unit tests (`?include=transcript`, comma-lists, case-insensitive value, unrelated params, no-query).
- `JobStatusResponse` wire-contract tests: transcript key omitted when nil (bytes identical to a plain `JobStatusDTO`), and present as a top-level sibling when set (round-trips into both the envelope and a plain `JobStatusDTO`).
- Integration (real socket) tests: `POST /v1/transcribe?include=transcript` and `GET /v1/jobs/<id>?include=transcript` inline the file's text; without the opt-in the response has no `transcript` key.

Full suite green, `swiftlint analyze --strict` clean, release-mode parity built (Homebrew + App Store). Docs updated in `docs/automation-api.md`.