### PR TITLE
test: cover high-value untested branches in pipeline, diarization, and audio

### DIFF
--- a/app/MeetingTranscriber/Tests/AudioMixerTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Accelerate
 import AVFoundation
 @testable import MeetingTranscriber
@@ -81,6 +82,87 @@ final class AudioMixerTests: XCTestCase {
 
         // Mic should be untouched
         XCTAssertTrue(micSamples.allSatisfy { $0 == 0.5 })
+    }
+
+    /// Places app energy in exactly one window (index 20), so the gate mask covers
+    /// app windows [20 - marginBefore, 20 + marginAfter] = [18, 30], then asserts
+    /// which mic windows the delay-shifted gate silences. Mic window i is gated iff
+    /// (i + delayWindows) lands in [18, 30], so `gatedWindows` is that range shifted
+    /// by -delayWindows. Boundaries just outside the range must stay untouched.
+    private func assertEchoGateShiftedBy(
+        micDelay: TimeInterval,
+        gatedWindows: ClosedRange<Int>,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+    ) {
+        let sampleRate = 1000 // 20-sample / 20 ms windows
+        let windowSize = 20
+        let windowCount = 40
+
+        var appSamples = [Float](repeating: 0, count: windowCount * windowSize)
+        let energyWindow = 20
+        for j in (energyWindow * windowSize) ..< ((energyWindow + 1) * windowSize) {
+            appSamples[j] = 1.0
+        }
+        var micSamples = [Float](repeating: 0.5, count: windowCount * windowSize)
+
+        AudioMixer.suppressEcho(
+            appSamples: appSamples,
+            micSamples: &micSamples,
+            sampleRate: sampleRate,
+            micDelay: micDelay,
+        )
+
+        func micWindow(_ w: Int) -> Float {
+            micSamples[w * windowSize]
+        }
+        XCTAssertEqual(micWindow(gatedWindows.lowerBound - 1), 0.5, "just below the shifted gate stays untouched", file: file, line: line)
+        XCTAssertEqual(micWindow(gatedWindows.lowerBound), 0.0, "first gated mic window", file: file, line: line)
+        XCTAssertEqual(micWindow(gatedWindows.upperBound), 0.0, "last gated mic window", file: file, line: line)
+        XCTAssertEqual(micWindow(gatedWindows.upperBound + 1), 0.5, "just above the shifted gate stays untouched", file: file, line: line)
+    }
+
+    func testEchoSuppressionShiftsGateByPositiveMicDelay() {
+        // delayWindows = Int(0.1 * 1000) / 20 = 5, so the [18, 30] app gate lands on
+        // mic windows [13, 25]. The existing echo tests only cover micDelay == 0, so
+        // this offset branch (appIdx = i + delayWindows) was unexercised; a sign flip
+        // would silence the wrong mic windows.
+        assertEchoGateShiftedBy(micDelay: 0.1, gatedWindows: 13 ... 25)
+    }
+
+    func testEchoSuppressionShiftsGateByNegativeMicDelay() {
+        // A negative micDelay shifts the gate the other way (delayWindows = -5 → mic
+        // windows [23, 35]). The appIdx < 0 lower-bound guard is covered separately by
+        // testEchoSuppressionGuardsAgainstNegativeGateIndex.
+        assertEchoGateShiftedBy(micDelay: -0.1, gatedWindows: 23 ... 35)
+    }
+
+    func testEchoSuppressionGuardsAgainstNegativeGateIndex() {
+        // With a negative micDelay the earliest mic windows map to appIdx < 0
+        // (window i → i + delayWindows, delayWindows = -5). The `appIdx >= 0` guard
+        // must skip them; without it, gateMask[negative] is an out-of-bounds access.
+        // App energy fills every window so, absent the guard, every in-range appIdx
+        // would gate, isolating the guard as the only reason an early window survives.
+        let sampleRate = 1000
+        let windowSize = 20
+        let windowCount = 40
+
+        let appSamples = [Float](repeating: 1.0, count: windowCount * windowSize)
+        var micSamples = [Float](repeating: 0.5, count: windowCount * windowSize)
+
+        AudioMixer.suppressEcho(
+            appSamples: appSamples,
+            micSamples: &micSamples,
+            sampleRate: sampleRate,
+            micDelay: -0.1, // delayWindows = -5 → mic windows 0...4 have appIdx < 0
+        )
+
+        func micWindow(_ w: Int) -> Float {
+            micSamples[w * windowSize]
+        }
+        // Window 4 → appIdx -1 → guarded (untouched). Window 5 → appIdx 0 → gated.
+        XCTAssertEqual(micWindow(4), 0.5, "window 4 (appIdx -1) is skipped by the appIdx >= 0 guard")
+        XCTAssertEqual(micWindow(5), 0.0, "window 5 (appIdx 0) is gated")
     }
 
     // MARK: - Resampling

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -483,6 +483,77 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(freshQueue.jobs.count, 0)
     }
 
+    func testLoadSnapshotKeepsNamingPendingJobWhenMixAudioMissing() throws {
+        // A .speakerNamingPending job keeps its own slug-based `_16k.wav` sidecar
+        // and doesn't need the original mix.wav. loadSnapshot must NOT discard it
+        // just because mixPath is gone; this guards the
+        // `state != .speakerNamingPending` exception in the missing-audio removeAll.
+        // (testLoadSnapshotDiscardsMissingAudio writes a real mix file, so it can't
+        // catch a regression that drops the naming exception.)
+        // mixPath deliberately points at a file that does NOT exist on disk.
+        var job = PipelineJob(
+            meetingTitle: "Naming Ghost",
+            appName: "App",
+            mixPath: URL(fileURLWithPath: "/tmp/nonexistent_\(UUID().uuidString).wav"),
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        job.namingSlug = "naming_ghost"
+        let snapshotData = try JSONEncoder().encode([job])
+        try snapshotData.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        // Sidecar present so the rebuild loop keeps the job in .speakerNamingPending
+        // rather than falling to .done. Content is irrelevant (restore only stashes
+        // it), so use the minimal shape and the same writer loadSnapshot pairs with.
+        let namingData = PipelineQueue.SpeakerNamingData(
+            jobID: job.id,
+            meetingTitle: "Naming Ghost",
+            mapping: [:],
+            speakingTimes: [:],
+            embeddings: [:],
+            audioPath: nil,
+            segments: [],
+            participants: [],
+            isDualSource: false,
+        )
+        try SpeakerNamingStore(outputDir: tmpDir).save(namingData, slug: "naming_ghost")
+
+        let (freshQueue, _) = makeMockProcessingQueue()
+        freshQueue.loadSnapshot()
+
+        // The job survives despite the missing mix, and stays pending.
+        XCTAssertEqual(freshQueue.jobs.count, 1)
+        XCTAssertEqual(freshQueue.jobs.first?.state, .speakerNamingPending)
+    }
+
+    func testLoadSnapshotKeepsPairedImportJobWithNilMixPath() throws {
+        // Paired imports carry a nil mixPath; appPath is the ground-truth source,
+        // checked at processNext time. loadSnapshot must keep them, which guards the
+        // `guard let mixPath = job.mixPath else { return false }` in the
+        // missing-audio removeAll.
+        let appPath = tmpDir.appendingPathComponent("meeting_app.wav")
+        try Data("fake audio".utf8).write(to: appPath)
+
+        let job = PipelineJob(
+            meetingTitle: "Paired Import",
+            appName: "Zoom",
+            mixPath: nil,
+            appPath: appPath,
+            micPath: nil,
+            micDelay: 0,
+        )
+        let data = try JSONEncoder().encode([job])
+        try data.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        freshQueue.loadSnapshot()
+
+        XCTAssertEqual(freshQueue.jobs.count, 1)
+        XCTAssertEqual(freshQueue.jobs.first?.state, .waiting)
+    }
+
     func testLoadSnapshotNoFileIsNoOp() {
         let freshQueue = PipelineQueue(logDir: tmpDir)
         freshQueue.loadSnapshot()

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -1005,6 +1005,60 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result.count, 4)
     }
 
+    func testMergeCentroidsDimMismatchKeepsLargerCountSide() {
+        // A dimension mismatch must never be averaged element-wise (that would
+        // corrupt the centroid). The larger-count side is kept verbatim.
+        let aWins = SpeakerMatcher.mergeCentroids(a: [1, 0, 0], aCount: 5, b: [0, 1], bCount: 2)
+        XCTAssertEqual(aWins.centroid, [1, 0, 0])
+        XCTAssertEqual(aWins.count, 7)
+
+        // When the smaller-dim side carries the larger count, it wins instead.
+        let bWins = SpeakerMatcher.mergeCentroids(a: [1, 0, 0], aCount: 1, b: [0, 1], bCount: 9)
+        XCTAssertEqual(bWins.centroid, [0, 1])
+        XCTAssertEqual(bWins.count, 10)
+    }
+
+    func testMergedPromotesSyntheticToRealWhenEitherSideIsReal() {
+        // isSynthetic stays true only when BOTH sides are synthetic; merging a real
+        // entry in flips the result back to real, keeping RPC-seeded random-vector
+        // entries from silently becoming permanent synthetic-only speakers.
+        let synthetic = StoredSpeaker(name: "A", embeddings: [[1, 0, 0]], isSynthetic: true)
+        let real = StoredSpeaker(name: "B", embeddings: [[0, 1, 0]], isSynthetic: false)
+
+        XCTAssertFalse(SpeakerMatcher.merged(into: synthetic, from: real).isSynthetic)
+        XCTAssertFalse(SpeakerMatcher.merged(into: real, from: synthetic).isSynthetic)
+
+        let bothSynthetic = SpeakerMatcher.merged(
+            into: synthetic,
+            from: StoredSpeaker(name: "C", embeddings: [[0, 0, 1]], isSynthetic: true),
+        )
+        XCTAssertTrue(bothSynthetic.isSynthetic)
+    }
+
+    func testMergedDerivesCentroidFromSamplesWhenNeitherSideHasCentroid() {
+        // With no persisted centroid on either side, merged() falls back to the
+        // element-wise mean of the combined recent samples.
+        let a = StoredSpeaker(name: "A", embeddings: [[1, 0]])
+        let b = StoredSpeaker(name: "B", embeddings: [[0, 1]])
+
+        let result = SpeakerMatcher.merged(into: a, from: b)
+        // mean of (1,0) and (0,1) = (0.5, 0.5)
+        XCTAssertEqual(result.centroid?[0] ?? 0, 0.5, accuracy: 0.001)
+        XCTAssertEqual(result.centroid?[1] ?? 0, 0.5, accuracy: 0.001)
+    }
+
+    func testMergedTrimsCombinedSamplesToMostRecent() {
+        // dst.embeddings + src.embeddings can exceed maxRecentSamples; merged() drops
+        // the oldest from the front and keeps the most recent maxRecentSamples.
+        let dst = StoredSpeaker(name: "A", embeddings: [[1, 0, 0], [2, 0, 0]])
+        let src = StoredSpeaker(name: "B", embeddings: [[3, 0, 0], [4, 0, 0]])
+
+        // The exact 3-element array pins both the count (maxRecentSamples == 3) and
+        // that the oldest sample is dropped from the front.
+        let result = SpeakerMatcher.merged(into: dst, from: src)
+        XCTAssertEqual(result.embeddings, [[2, 0, 0], [3, 0, 0], [4, 0, 0]])
+    }
+
     // MARK: - Synthetic speaker marker
 
     /// Legacy entries written before the `isSynthetic` field existed must

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -100,6 +100,37 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(result["SPEAKER_0"], "SPEAKER_0")
     }
 
+    func testMatchRejectsWhenBestDistanceExactlyEqualsThreshold() {
+        // `best.hybrid < threshold` is strict: a candidate sitting exactly ON the
+        // threshold must be rejected. Orthogonal unit vectors give an exact 1.0
+        // cosine distance (norms are exactly 1), so the best candidate lands
+        // precisely on the threshold. A `<`→`<=` mutation would accept here; the
+        // existing tests all use comfortably-separated distances and can't catch it.
+        let matcher = SpeakerMatcher(dbPath: dbPath, threshold: 1.0)
+        matcher.saveDB([StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]])])
+
+        let embeddings: [String: [Float]] = ["SPEAKER_0": [0, 1, 0]] // distance exactly 1.0
+        let result = matcher.match(embeddings: embeddings)
+        XCTAssertEqual(result["SPEAKER_0"], "SPEAKER_0")
+    }
+
+    func testMatchAcceptsWhenConfidenceMarginExactlyMet() {
+        // The confidence-margin check `second - best >= margin` is inclusive: a gap
+        // exactly equal to the margin must still accept. Unit basis vectors give
+        // exact distances (identical → 0.0, orthogonal → 1.0), so the best-to-second
+        // gap is exactly 1.0 here. A `>=`→`>` mutation would reject.
+        let matcher = SpeakerMatcher(dbPath: dbPath, threshold: 0.5, confidenceMargin: 1.0)
+        matcher.saveDB([
+            StoredSpeaker(name: "Speaker A", embeddings: [[1, 0, 0]]),
+            StoredSpeaker(name: "Speaker B", embeddings: [[0, 1, 0]]),
+        ])
+
+        // Identical to A (distance 0.0), orthogonal to B (distance 1.0) → gap exactly 1.0.
+        let embeddings: [String: [Float]] = ["SPEAKER_0": [1, 0, 0]]
+        let result = matcher.match(embeddings: embeddings)
+        XCTAssertEqual(result["SPEAKER_0"], "Speaker A")
+    }
+
     // MARK: - Save/Load
 
     func testSaveAndLoadDB() {

--- a/tools/audiotap/Tests/StreamingMonoResamplerTests.swift
+++ b/tools/audiotap/Tests/StreamingMonoResamplerTests.swift
@@ -64,4 +64,36 @@ final class StreamingMonoResamplerTests: XCTestCase {
             "1 s of mono must still map to 1 s after a channel-count change",
         )
     }
+
+    // MARK: - Stream conservation (issue #379 backlog drift)
+
+    /// Feeding a long same-rate stream as many small buffers must produce the same
+    /// total sample count as feeding it as a single buffer: the reused converter
+    /// keeps resampling state continuous across calls, so no per-buffer fractional
+    /// sample loss accumulates into drift (the issue #379 backlog class). The
+    /// existing tests only feed 1 s single buffers, so a future change to the
+    /// capacity math that dropped a sample per call would pass them while re-drifting
+    /// recordings. Comparing the streamed total against the single-shot total cancels
+    /// AVAudioConverter's one-time (OS-version-dependent) filter latency, so the tight
+    /// bound catches per-call drift without flaking across macOS releases.
+    func testConservesTotalSampleCountAcrossManySmallBuffers() throws {
+        let totalFrames = 48000 // 1 s @ 48 kHz mono
+        let chunkSize = 480 // 10 ms
+        let signal = [Float](repeating: 0.3, count: totalFrames)
+
+        let singleShot = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+            .process(signal, inputRate: 48000, inputChannels: 1).count
+
+        let streamer = try XCTUnwrap(StreamingMonoResampler(targetRate: 16000))
+        var streamed = 0
+        for start in stride(from: 0, to: totalFrames, by: chunkSize) {
+            let chunk = Array(signal[start ..< min(start + chunkSize, totalFrames)])
+            streamed += streamer.process(chunk, inputRate: 48000, inputChannels: 1).count
+        }
+
+        // Same 48000 input frames + same converter config, so the two paths differ
+        // only by per-call drift; a 1-sample-per-call loss would open a ~100-frame gap.
+        // The absolute count and its OS-dependent filter latency cancel out.
+        XCTAssertEqual(streamed, singleShot, accuracy: 10)
+    }
 }


### PR DESCRIPTION
## What

Adds targeted unit tests for high-value untested logic branches surfaced by a coverage audit. **Test-only — no production code changes.**

Each test was written test-first and **mutation-verified**: after passing against the real code, the guarded production branch was temporarily flipped and the test confirmed to fail, so none is vacuous. Branches whose only "guard" is output-equivalent to the non-guarded path (an empty-centroid guard, an `init?` rate check `AVAudioFormat` already rejects) were deliberately left uncovered rather than pinned with a vacuous test.

### Covered branches

- **Pipeline snapshot recovery** — `loadSnapshot()` keeps a `.speakerNamingPending` job whose `mix.wav` is gone (it has its own slug sidecar) and a paired-import job with a nil `mixPath`. Both were mutation-survivors: the existing missing-audio / naming-restore tests write a real mix file, so collapsing the guard to the naive "discard any missing/nil mix" passed the whole suite.
- **Speaker-matcher accept/reject boundaries** — the exact `<` threshold and `>=` confidence-margin operators, landed exactly on the boundary using unit basis vectors (provably exact cosine distances) so an operator flip is caught.
- **Speaker-DB merge** — centroid dimension-mismatch (larger-count side wins, never averages mismatched dims), synthetic→real promotion on merge (keeps RPC-seeded vectors out of matching), sample-mean centroid fallback, and FIFO trim to the most recent samples.
- **Echo-suppression mic-delay offset** — positive and negative delay gate shifts plus the `appIdx` bounds; the existing echo tests only covered zero delay and only asserted window 0.
- **Streaming-resampler conservation** — a long same-rate stream fed as many small buffers conserves total sample count (guards the converter-continuity / issue-#379 drift class); existing tests only fed 1 s single buffers.

## Verification

- App suite (2120 tests) and audiotap suite (147 tests) green locally. The only local failures are the pre-existing `MenuBarIconSnapshotTests` rendering-environment mismatches, unrelated to this change (they pass in CI and are skipped under sanitizers).
- Lint clean.
- Branched from fresh `main`.