### PR TITLE
test(app): cover mutation-survivor edge branches (WAV repair, StoredSpeaker, UpdateChecker, ChannelHealth)

### DIFF
--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -263,4 +263,51 @@ final class ChannelHealthIntegrationTests: XCTestCase {
             "60s under new threshold should fire — confirms threshold = 60",
         )
     }
+
+    // MARK: - stop() teardown
+
+    func testStopClearsLatchedMicSilentFlagAndResetsMonitor() {
+        let (controller, recorder, _, _) = makeController()
+        recorder.micLevelDBFS = -80
+        recorder.appLevelDBFS = -25
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30)) // mic .started
+        XCTAssertTrue(controller.micSilentActive, "precondition: mic-silent is latched")
+
+        controller.stop()
+        XCTAssertFalse(controller.micSilentActive, "stop() must clear the latched mic-silent flag")
+        XCTAssertFalse(controller.appSilentActive)
+        XCTAssertFalse(controller.recordingSilentActive)
+
+        // Monitor was reset: replaying the same silence needs a FRESH full
+        // debounce before it re-fires (a non-reset monitor stays latched and
+        // never re-fires the .started event).
+        let t1 = t0.addingTimeInterval(200)
+        _ = controller.applyTick(recorder: recorder, now: t1) // warmup on the fresh monitor
+        let reFired = controller.applyTick(recorder: recorder, now: t1.addingTimeInterval(30))
+        XCTAssertEqual(
+            reFired, .started(channel: .mic, quietSince: t1),
+            "a reset monitor starts a new episode and re-fires after a full debounce",
+        )
+        XCTAssertTrue(controller.micSilentActive)
+    }
+
+    func testStopClearsLatchedRecordingSilentFlagAndResetsSiblingMonitor() {
+        let (controller, recorder, _, _) = makeController()
+        recorder.micLevelDBFS = -80
+        recorder.appLevelDBFS = -80
+        _ = controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
+        XCTAssertTrue(controller.recordingSilentActive, "precondition: symmetric-silence is latched")
+
+        controller.stop()
+        XCTAssertFalse(controller.recordingSilentActive, "stop() must clear the latched recording-silent flag")
+
+        // The sibling SilentRecordingMonitor is reset too: a fresh silent window
+        // re-fires after a full debounce (a non-reset monitor stays latched).
+        let t1 = t0.addingTimeInterval(200)
+        _ = controller.applyTick(recorder: recorder, now: t1)
+        _ = controller.applyTick(recorder: recorder, now: t1.addingTimeInterval(30))
+        XCTAssertTrue(controller.recordingSilentActive, "reset sibling monitor re-fires on a fresh silent window")
+    }
 }

--- a/app/MeetingTranscriber/Tests/StoredSpeakerCodingTests.swift
+++ b/app/MeetingTranscriber/Tests/StoredSpeakerCodingTests.swift
@@ -1,0 +1,72 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// `StoredSpeaker.encode` deliberately omits `centroidSampleCount` / `useCount` /
+/// `isSynthetic` when they hold their zero/false default, and `centroid` /
+/// `lastUsed` when nil, so a `speakers.json` written before those fields existed
+/// round-trips byte-identically (no spurious keys added on first save). These
+/// tests pin that omission contract — an unconditional encode would silently
+/// rewrite every legacy DB entry on first load.
+final class StoredSpeakerCodingTests: XCTestCase {
+    private func encodedKeys(_ speaker: StoredSpeaker) throws -> Set<String> {
+        let data = try JSONEncoder().encode(speaker)
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return Set(obj.keys)
+    }
+
+    func testOmitsDefaultFieldsForLegacyStyleEntry() throws {
+        let speaker = StoredSpeaker(name: "Speaker A", embeddings: [[0.1, 0.2]])
+        XCTAssertEqual(
+            try encodedKeys(speaker), ["name", "embeddings"],
+            "a zero/false/nil entry must encode only name + embeddings",
+        )
+    }
+
+    func testEmitsEveryFieldOncePopulated() throws {
+        let speaker = StoredSpeaker(
+            name: "Speaker B",
+            embeddings: [[0.1, 0.2]],
+            centroid: [0.15, 0.2],
+            centroidSampleCount: 3,
+            lastUsed: Date(timeIntervalSince1970: 1_700_000_000),
+            useCount: 5,
+            isSynthetic: true,
+        )
+        XCTAssertEqual(
+            try encodedKeys(speaker),
+            ["name", "embeddings", "centroid", "centroidSampleCount", "lastUsed", "useCount", "isSynthetic"],
+            "a fully-populated entry must encode every field",
+        )
+    }
+
+    func testZeroCountAndFalseSyntheticAreOmittedIndividually() throws {
+        // useCount > 0 but the other two still default → only useCount appears.
+        let speaker = StoredSpeaker(name: "Speaker C", embeddings: [[0.1]], useCount: 2)
+        let keys = try encodedKeys(speaker)
+        XCTAssertTrue(keys.contains("useCount"), "a non-zero useCount must be encoded")
+        XCTAssertFalse(keys.contains("centroidSampleCount"), "a zero centroidSampleCount must stay omitted")
+        XCTAssertFalse(keys.contains("isSynthetic"), "a false isSynthetic must stay omitted")
+    }
+
+    func testRoundTripsPopulatedEntry() throws {
+        let original = StoredSpeaker(
+            name: "Speaker D",
+            embeddings: [[0.1, 0.2], [0.3, 0.4]],
+            centroid: [0.2, 0.3],
+            centroidSampleCount: 2,
+            lastUsed: Date(timeIntervalSince1970: 1_700_000_000),
+            useCount: 4,
+            isSynthetic: true,
+        )
+        let decoded = try JSONDecoder().decode(
+            StoredSpeaker.self, from: JSONEncoder().encode(original),
+        )
+        XCTAssertEqual(decoded.name, original.name)
+        XCTAssertEqual(decoded.embeddings, original.embeddings)
+        XCTAssertEqual(decoded.centroid, original.centroid)
+        XCTAssertEqual(decoded.centroidSampleCount, original.centroidSampleCount)
+        XCTAssertEqual(decoded.lastUsed, original.lastUsed)
+        XCTAssertEqual(decoded.useCount, original.useCount)
+        XCTAssertEqual(decoded.isSynthetic, original.isSynthetic)
+    }
+}

--- a/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
+++ b/app/MeetingTranscriber/Tests/UpdateCheckerTests.swift
@@ -56,6 +56,16 @@ final class UpdateCheckerTests: XCTestCase {
         XCTAssertNil(UpdateChecker.parseVersion("v"))
     }
 
+    func testParseVersionDropsBuildMetadata() {
+        // Semver build-metadata ("1.2.3+build42") is not handled: only the "-"
+        // pre-release suffix is stripped, so "3+build42" fails Int parsing, the
+        // part count drops below 3, and the whole string is rejected → the app
+        // silently reports "no update". Pinned so a future "support build
+        // metadata" change is a deliberate, tested choice rather than a surprise.
+        XCTAssertNil(UpdateChecker.parseVersion("1.2.3+build42"))
+        XCTAssertNil(UpdateChecker.parseVersion("v1.2.3+build42"))
+    }
+
     // MARK: - Version Comparison
 
     func testIsNewerMajor() {

--- a/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
+++ b/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
@@ -149,4 +149,78 @@ final class WavHeaderRepairTests: XCTestCase {
         XCTAssertEqual(count, 0, "a recently-modified (possibly live) WAV must be skipped")
         XCTAssertEqual(readableFrames(liveURL), 0, "the live WAV's header must be left untouched")
     }
+
+    // MARK: - Chunk-walk edges (byte-level, no AVAudioFile)
+
+    private func fourCC(_ s: String) -> Data {
+        Data(s.utf8)
+    }
+
+    private func leU32(_ v: UInt32) -> Data {
+        withUnsafeBytes(of: v.littleEndian) { Data($0) }
+    }
+
+    private func readU32LE(_ d: Data, _ offset: Int) -> UInt32 {
+        d.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) }
+    }
+
+    /// A chunk with an ODD payload size is padded to an even boundary on disk
+    /// (RIFF spec). The walk must add that pad byte via `size & 1`, or the next
+    /// read lands one byte early — mid-chunk — and never finds `data`. Craft an
+    /// odd-sized prelude chunk followed by an unfinalized `data` chunk and assert
+    /// the repair still finds and rewrites it.
+    func testRepairWalksPastOddSizedChunkToDataChunk() throws {
+        var wav = Data()
+        wav.append(fourCC("RIFF"))
+        wav.append(leU32(4)) // placeholder RIFF size (unfinalized)
+        wav.append(fourCC("WAVE"))
+        // Odd-sized prelude chunk: 3-byte payload → 1 pad byte on disk.
+        wav.append(fourCC("JUNK"))
+        wav.append(leU32(3))
+        wav.append(Data([0xAA, 0xBB, 0xCC]))
+        wav.append(Data([0x00])) // pad to even length
+        // Unfinalized data chunk: size 0 is the killed-writer signature.
+        wav.append(fourCC("data"))
+        wav.append(leU32(0))
+        let pcm = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        wav.append(pcm)
+
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try wav.write(to: url)
+
+        let repaired = try WavHeaderRepair.repairIfNeeded(at: url)
+        XCTAssertTrue(repaired, "must walk past the padded odd-sized chunk and repair the data size")
+
+        let out = try Data(contentsOf: url)
+        let dataRange = try XCTUnwrap(out.range(of: fourCC("data")), "data chunk id must survive the rewrite")
+        XCTAssertEqual(
+            readU32LE(out, dataRange.upperBound), UInt32(pcm.count),
+            "data size rewritten to the actual PCM byte count",
+        )
+        XCTAssertEqual(
+            readU32LE(out, 4), UInt32(out.count - 8),
+            "RIFF size rewritten to fileSize - 8",
+        )
+    }
+
+    /// No `data` chunk at all → the walk exhausts and `repairIfNeeded` must bail
+    /// without touching the file.
+    func testReturnsFalseWhenNoDataChunkPresent() throws {
+        var wav = Data()
+        wav.append(fourCC("RIFF"))
+        wav.append(leU32(4))
+        wav.append(fourCC("WAVE"))
+        wav.append(fourCC("fmt "))
+        wav.append(leU32(4))
+        wav.append(Data([0, 0, 0, 0]))
+
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try wav.write(to: url)
+        let before = try Data(contentsOf: url)
+
+        XCTAssertFalse(try WavHeaderRepair.repairIfNeeded(at: url), "no data chunk → nothing to repair")
+        XCTAssertEqual(try Data(contentsOf: url), before, "file must be untouched when no data chunk is found")
+    }
 }


### PR DESCRIPTION
Test-only. Adds regression coverage for four untested logic branches, each a mutation survivor today (delete or flip the guarded production line and the current suite stays green). No production code changes.

## What is covered
- **WavHeaderRepair chunk walk** — an odd-sized prelude chunk is padded to an even boundary on disk; the walk must add that pad byte (`size & 1`) or it lands mid-chunk and never finds `data`. Adds a byte-level fixture for the padded odd chunk plus a valid-RIFF-but-no-`data`-chunk case (walk exhausts, bails without touching the file). Existing tests only exercised even-sized preludes written by AVAudioFile.
- **StoredSpeaker.encode field omission** — `centroidSampleCount`/`useCount`/`isSynthetic` are omitted at their zero/false default (and `centroid`/`lastUsed` when nil) so a `speakers.json` written before those fields existed round-trips byte-identically. Pins the JSON key set for the legacy-style, fully-populated, and mixed cases; an unconditional encode would silently rewrite every legacy DB entry on first load.
- **UpdateChecker.parseVersion build metadata** — a semver build-metadata tag (`1.2.3+build42`) fails the three-part count check and returns nil, so the app silently reports "no update". Pins that behavior so a future decision to support build metadata is deliberate and tested.
- **ChannelHealthController.stop() teardown** — `stop()` clears the three red-tint flags and resets both silence monitors so a latched indicator cannot survive into the next recording (the stuck-menu-bar failure mode). Existing tests only drove `applyTick`/`simulateStartForTests`, never `stop()`.

## Verification
Each test was written against current behavior, confirmed green, then re-run with the guarded production branch flipped to confirm it goes red (padded-chunk walk, unconditional useCount encode, plus-suffix strip in parseVersion, and both the flag-clear and monitor-reset lines in stop()). All restored afterward. Lint clean.