### PR TITLE
test(app): cover mutation-survivor edge branches (drift guard, centroid guards, overlap tie-break)

### DIFF
--- a/app/MeetingTranscriber/Tests/DiarizationProcessTests.swift
+++ b/app/MeetingTranscriber/Tests/DiarizationProcessTests.swift
@@ -84,6 +84,23 @@ final class DiarizationProcessTests: XCTestCase { // swiftlint:disable:this type
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testAssignSpeakersEqualOverlapKeepsFirstSegment() {
+        // Equal overlap on two segments: the strict `>` keeps the FIRST seen;
+        // a `>=` slip would flip the label to the last. Pins the tie-break.
+        let transcript = [TimestampedSegment(start: 0, end: 10, text: "Split evenly")]
+        let diarization = DiarizationResult(
+            segments: [
+                .init(start: 0, end: 5, speaker: "SPEAKER_0"), // overlap 5
+                .init(start: 5, end: 10, speaker: "SPEAKER_1"), // overlap 5
+            ],
+            speakingTimes: ["SPEAKER_0": 5, "SPEAKER_1": 5],
+            autoNames: [:],
+            embeddings: nil,
+        )
+        let result = DiarizationProcess.assignSpeakers(transcript: transcript, diarization: diarization)
+        XCTAssertEqual(result[0].speaker, "SPEAKER_0", "equal overlap keeps the first segment (strict >)")
+    }
+
     // MARK: - Nearest Fallback
 
     func testAssignSpeakersNearestFallback() {

--- a/app/MeetingTranscriber/Tests/SampleRateDriftDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/SampleRateDriftDetectorTests.swift
@@ -109,6 +109,25 @@ final class SampleRateDriftDetectorTests: XCTestCase {
         XCTAssertNil(detector.observe(empty))
     }
 
+    func testNoReportWhenClaimedRateIsZero() {
+        // A buffer header claiming 0 Hz (seen mid CoreAudio renegotiation) must
+        // not divide by zero into a spurious drift warning: the claimedRate
+        // guard bails to nil even though the observed frame rate is non-zero.
+        var detector = SampleRateDriftDetector()
+        var report: SampleRateDriftDetector.Report?
+        for i in 0 ..< 5 {
+            let buf = buffer(
+                claimedRate: 0,
+                actualFramesPerCallback: 26000,
+                atSeconds: Double(i) * 0.5,
+            )
+            if let r = detector.observe(buf, now: Date(timeIntervalSince1970: Double(i))) {
+                report = r
+            }
+        }
+        XCTAssertNil(report, "a zero claimed rate must not produce a drift report")
+    }
+
     // MARK: - mach-tick helpers (pure)
 
     /// Round-trip across the helper pair must be exact to within the

--- a/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerMatcherTests.swift
@@ -269,6 +269,15 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertNil(SpeakerMatcher.updateCentroid(current: [1, 2], count: 1, with: [1, 2, 3]))
     }
 
+    func testUpdateCentroidEmptySampleReturnsNil() {
+        // An empty sample must never seed a centroid: without the guard, a nil
+        // current + empty sample would seed an empty [] centroid with count 1,
+        // permanently corrupting the entry. Only the nil-current path isolates
+        // this guard; with a non-nil current an empty sample already returns nil
+        // via the dimension-mismatch guard, so that case would not pin it.
+        XCTAssertNil(SpeakerMatcher.updateCentroid(current: nil, count: 0, with: []))
+    }
+
     // MARK: - applyConfirmation / newSpeaker
 
     func testNewSpeakerWithSufficientDurationSeedsCentroid() {
@@ -327,6 +336,29 @@ final class SpeakerMatcherTests: XCTestCase {
         XCTAssertEqual(updated.centroid, [1, 0], "short snippet must not pollute centroid")
         XCTAssertEqual(updated.centroidSampleCount, 1)
         XCTAssertEqual(updated.embeddings.count, 2, "but is still kept as fallback sample")
+    }
+
+    func testApplyConfirmationDimMismatchWhileQualifyingKeepsCentroid() {
+        // A qualifying (long) confirmation whose embedding dimensionality does
+        // not match the stored centroid must not corrupt or crash it:
+        // updateCentroid returns nil on the mismatch and applyConfirmation
+        // keeps the old centroid + count, while still appending the sample to
+        // the FIFO and bumping useCount. Distinct from the short-snippet case,
+        // which skips the centroid via the duration gate, not the dim guard.
+        let speaker = StoredSpeaker(
+            name: "Speaker B",
+            embeddings: [[1, 0]],
+            centroid: [1, 0],
+            centroidSampleCount: 1,
+            useCount: 2,
+        )
+        let updated = SpeakerMatcher.applyConfirmation(
+            to: speaker, embedding: [9, 9, 9], duration: 5, now: Self.testEpoch,
+        )
+        XCTAssertEqual(updated.centroid, [1, 0], "dim-mismatched embedding must not move the centroid")
+        XCTAssertEqual(updated.centroidSampleCount, 1, "centroid sample count must not advance on a rejected fold")
+        XCTAssertEqual(updated.embeddings, [[1, 0], [9, 9, 9]], "the sample is still kept as a fallback")
+        XCTAssertEqual(updated.useCount, 3, "a confirmation still bumps useCount")
     }
 
     // MARK: - updateDB recency tracking with quality filter


### PR DESCRIPTION
Test-only. Adds regression coverage for four untested logic branches, each a mutation survivor today (flip the guarded production line and the current suite stays green). No production code changes; every added test reuses the existing in-file fixtures.

## What is covered
- **SampleRateDriftDetector zero claimed-rate guard** — `checkDrift` bails to nil when a buffer header claims 0 Hz (seen mid CoreAudio renegotiation) so it never divides by zero into a spurious drift warning. No test drove a zero claimed rate.
- **SpeakerMatcher.updateCentroid empty-sample guard** — an empty sample must never seed a centroid; without the guard a nil current plus empty sample would seed an empty `[]` centroid with count 1.
- **SpeakerMatcher.applyConfirmation dimension-mismatch fold** — a qualifying confirmation whose embedding dimensionality does not match the stored centroid keeps the old centroid and count (the fold is rejected) while still appending the sample to the FIFO and bumping useCount. Distinct from the already-covered short-snippet case, which skips the centroid via the duration gate rather than the dimension guard.
- **DiarizationProcess.assignSpeakers equal-overlap tie-break** — when a transcript segment overlaps two diarization segments by the exact same amount, the strict `>` comparison keeps the first segment; every existing test used unequal overlaps.

## Verification
Each test was written against current behavior, confirmed green, then re-run with the guarded production branch flipped to confirm it goes red (dropped claimed-rate guard, removed empty-sample guard, removed the centroid dimension guard, and `>` changed to `>=`). All restored afterward. Lint clean.