### PR TITLE
fix(app): guard MicCaptureHandler stop() tap teardown on input-less hosts

### DIFF
--- a/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
@@ -27,9 +27,8 @@ extension MicCaptureHandler {
     }
 
     /// Write `frames` zeroed frames to `file` in its processing format. Static
-    /// and engine-free so it is unit-testable without instantiating the handler
-    /// (whose deinit touches `AVAudioEngine.inputNode` — fatal on input-less CI
-    /// hosts, see the `noInputDevice` guard in `startEngine`).
+    /// (engine-free) so it can be unit-tested directly against an `AVAudioFile`
+    /// without any engine setup.
     static func writeSilence(frames: Int, to file: AVAudioFile) {
         guard frames > 0, let silentBuffer = AVAudioPCMBuffer(
             pcmFormat: file.processingFormat,

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -29,6 +29,12 @@ public class MicCaptureHandler: @unchecked Sendable {
     // build's composition root injects one (DualSourceRecorder, gated by
     // #if E2E_FAULT_INJECTION) to verify the installTap NSException recovery.
     private let debugFault: DebugTapFault?
+    /// Removes the engine's input tap in `stop()`. Injectable so a test can
+    /// assert the teardown is skipped when no tap was installed (reading
+    /// `AVAudioEngine.inputNode` throws an uncatchable NSException on an input-less host).
+    private let removeInputTap: (AVAudioEngine) -> Void
+    /// True once a tap is attached to the current engine's inputNode; gates the `inputNode` teardown in `stop()`.
+    private var tapInstalled = false
     private var isRecording = false
     private var isRestarting = false
     // Bounded retry for transient restart failures (issue #379): a device
@@ -81,11 +87,13 @@ public class MicCaptureHandler: @unchecked Sendable {
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
         debugFault: DebugTapFault? = nil,
+        removeInputTap: @escaping (AVAudioEngine) -> Void = { $0.inputNode.removeTap(onBus: 0) },
     ) {
         self.outputURL = outputURL
         self.debugLogging = debugLogging
         self.liveSink = liveSink
         self.debugFault = debugFault
+        self.removeInputTap = removeInputTap
     }
 
     deinit {
@@ -137,6 +145,7 @@ public class MicCaptureHandler: @unchecked Sendable {
 
     // swiftlint:disable:next function_body_length
     private func startEngine(deviceUID: String? = nil) throws {
+        tapInstalled = false // reset per attempt; re-set once safeInstallTap attaches a tap
         // No input device available (e.g. Mac Mini server without mic hardware) —
         // accessing AVAudioEngine.inputNode would throw an uncatchable NSException.
         guard AVCaptureDevice.default(for: .audio) != nil else {
@@ -270,6 +279,7 @@ public class MicCaptureHandler: @unchecked Sendable {
             logger.error("Mic: installTap failed (\(error.localizedDescription, privacy: .public)) — restart will retry")
             throw error
         }
+        tapInstalled = true // inputNode accessed + tap attached; stop() must remove it even if start() throws
 
         engine.prepare()
         try engine.start()
@@ -430,7 +440,11 @@ public class MicCaptureHandler: @unchecked Sendable {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil
         }
-        engine.inputNode.removeTap(onBus: 0)
+        // Skip the inputNode teardown when no tap was installed — the getter
+        // raises an uncatchable NSException on an input-less host (deinit path).
+        if tapInstalled {
+            removeInputTap(engine)
+        }
         engine.stop()
         engine.reset()
         outputFile = nil

--- a/tools/audiotap/Tests/MicCaptureHandlerStopTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerStopTests.swift
@@ -1,0 +1,52 @@
+@testable import AudioTapLib
+@preconcurrency import AVFoundation
+import Foundation
+import XCTest
+
+/// Regression tests for the input-less-host `deinit` crash. `stop()` (invoked
+/// from `deinit`) used to call `engine.inputNode.removeTap` unconditionally, and
+/// accessing `AVAudioEngine.inputNode` raises an uncatchable NSException on a
+/// host with no input device (a headless CI runner / Mac mini without a mic).
+/// `AudioCaptureSession.start()` drops its local `mic` the instant
+/// `mic.start()` throws `.noInputDevice`, running the drop straight into
+/// `deinit` → `stop()` on exactly that host. `stop()` must skip the tap
+/// teardown when the engine never started.
+///
+/// These are why the handler could not be instantiated in tests before the fix:
+/// the CI runner has no input device, so a bare `MicCaptureHandler()` + drop
+/// crashed the whole test process on `deinit`.
+final class MicCaptureHandlerStopTests: XCTestCase {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mic-stop-\(UUID().uuidString).wav")
+    }
+
+    func testStopWithoutSuccessfulStartDoesNotTouchInputTap() {
+        // Inject a spy for the tap removal so the guard is observable on ANY
+        // host: a dev Mac HAS an input device, so the real `inputNode` access
+        // would not crash here — only the spy makes the skip assertable.
+        final class Box: @unchecked Sendable { var calls = 0 }
+        let box = Box()
+        // Typed local (not a trailing closure) so SwiftFormat can't restyle the
+        // labelled argument into a trailing closure.
+        let spyRemove: (AVAudioEngine) -> Void = { _ in box.calls += 1 }
+        let handler = MicCaptureHandler(outputURL: tempURL(), removeInputTap: spyRemove)
+
+        handler.stop() // never started → must not remove the input tap
+
+        XCTAssertEqual(box.calls, 0, "stop() must not touch the input tap when the engine never started")
+    }
+
+    func testDroppedHandlerRunsDeinitStopWithoutCrash() {
+        // The exact production path: create a handler whose start() never
+        // succeeded (mirrors AudioCaptureSession dropping the local `mic` after
+        // `.noInputDevice`), drop it, and let `deinit` → `stop()` run with the
+        // real (default) tap remover. On an input-less host this raised an
+        // NSException before the fix; here it must simply complete.
+        autoreleasepool {
+            let handler = MicCaptureHandler(outputURL: tempURL())
+            _ = handler // keep alive to the end of the scope, then deinit → stop()
+        }
+        // Reaching here without crashing is the assertion.
+    }
+}


### PR DESCRIPTION
## Bug
`MicCaptureHandler.stop()` (called from `deinit`) accessed `engine.inputNode` unconditionally via `removeTap(onBus:)`. Reading `AVAudioEngine.inputNode` raises an **uncatchable NSException on a host with no input device** (a Mac mini / headless CI runner without a mic). `startEngine` already guards this by throwing `.noInputDevice` before touching `inputNode`, but `AudioCaptureSession.start()` drops its local `mic` handler the instant `mic.start()` throws — running `deinit` → `stop()` on exactly the input-less host the start guard protects, re-triggering the very crash the guard was meant to avoid.

This is why no test could instantiate the handler: the CI runner's own lack of a mic crashed the test process on `deinit`.

## Fix
- Track a `tapInstalled` flag: reset at the top of each `startEngine` attempt, set true the moment `safeInstallTap` attaches a tap (which is also the point past which `inputNode` has been accessed safely). `stop()` skips the `inputNode` teardown when it is false, so a never-started handler tears down without touching `inputNode`. Gating on tap-installed (rather than engine-started) also means a tap attached just before a throwing `engine.start()` is still removed in `stop()`, matching the old unconditional behaviour.
- Route the tap removal through an injectable `removeInputTap` closure (default: the real `removeTap`) so the guard is observable in a unit test on **any** host — a dev Mac has an input device, so the real access would not crash there; only a spy makes the skip assertable.

`engine.stop()` / `engine.reset()` stay unconditional: they are method calls on the always-valid engine instance (not the `inputNode` property getter) and are safe on a never-started engine. `executeRestart`'s direct `removeTap` is unchanged — it only runs mid-recording, after a successful start, on a host that has a device.

## Tests (`tools/audiotap/Tests/MicCaptureHandlerStopTests.swift`)
- `testStopWithoutSuccessfulStartDoesNotTouchInputTap` — injects a spy remover and asserts `stop()` on a never-started handler does not remove the tap. **Mutation-verified**: dropping the guard makes it call the remover (test goes red).
- `testDroppedHandlerRunsDeinitStopWithoutCrash` — exercises the real production teardown of a dropped, never-started handler via `deinit`. Passes trivially on a mic-equipped dev Mac (the guard's skip is only observable via the spy test above); its real job is the regression guard on the input-less CI runner, where it raised the NSException before the fix.

Full `audiotap` suite green (149), release build clean, lint clean.