### PR TITLE
refactor(app): make AudioCaptureSession.stop() result arithmetic unit-testable

### DIFF
--- a/tools/audiotap/Sources/AudioCaptureResult.swift
+++ b/tools/audiotap/Sources/AudioCaptureResult.swift
@@ -30,3 +30,47 @@ public struct AudioCaptureResult: Sendable {
         self.micDelay = micDelay
     }
 }
+
+extension AudioCaptureResult {
+    /// First-frame + output-format readings from the app-audio track at stop().
+    struct AppReadings {
+        let firstFrameTicks: UInt64
+        let sampleRate: Int
+        let channels: Int
+    }
+
+    /// Mic-track reading at stop(): whether a mic was actually recorded (mic
+    /// start can fail, leaving app-audio only) plus its first-frame ticks.
+    struct MicReadings {
+        let recorded: Bool
+        let firstFrameTicks: UInt64
+    }
+
+    /// Builds the `AudioCaptureSession.stop()` result from the two tracks' raw
+    /// readings, split out of the hardware glue so the delay / rate / channel
+    /// arithmetic is unit-testable. Ticks are `mach_absolute_time` values (0 when
+    /// that track never delivered a frame). `micDelay` is the mic-minus-app
+    /// first-frame delta in seconds — positive when the mic started later — and is
+    /// only non-zero when a mic was recorded AND both tracks produced a frame.
+    /// Sample rate / channels fall back to `configured` when the app track
+    /// reported 0 (never wrote output).
+    static func make(
+        appOutputURL: URL,
+        micOutputURL: URL?,
+        configured: (sampleRate: Int, channels: Int),
+        app: AppReadings,
+        mic: MicReadings,
+    ) -> AudioCaptureResult {
+        var micDelay: TimeInterval = 0
+        if mic.recorded, app.firstFrameTicks > 0, mic.firstFrameTicks > 0 {
+            micDelay = machTicksToSeconds(mic.firstFrameTicks) - machTicksToSeconds(app.firstFrameTicks)
+        }
+        return AudioCaptureResult(
+            appAudioFileURL: appOutputURL,
+            micAudioFileURL: mic.recorded ? micOutputURL : nil,
+            actualSampleRate: app.sampleRate > 0 ? app.sampleRate : configured.sampleRate,
+            actualChannels: app.channels > 0 ? app.channels : configured.channels,
+            micDelay: micDelay,
+        )
+    }
+}

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -122,33 +122,27 @@ public class AudioCaptureSession {
         appCapture?.stop()
         micCapture?.stop()
 
-        // Compute mic delay
-        var micDelay: TimeInterval = 0
-        if let app = appCapture, let mic = micCapture {
-            let appTime = app.appFirstFrameTime
-            let micTime = mic.firstFrameTime
-            if appTime > 0 && micTime > 0 {
-                micDelay = machTicksToSeconds(micTime) - machTicksToSeconds(appTime)
-            }
-        }
-
-        // The app file is what `AppAudioCapture` actually WROTE — 16 kHz mono
-        // after the in-IOProc resample, not the device's raw capture format.
-        let actualRate = appCapture?.outputSampleRate ?? 0
-        let actualChannels = appCapture?.outputChannels ?? 0
-
-        // Close file handle
-        try? appFileHandle?.close()
-        appFileHandle = nil
-
-        let result = AudioCaptureResult(
-            appAudioFileURL: appOutputURL,
-            micAudioFileURL: micCapture != nil ? micOutputURL : nil,
-            actualSampleRate: actualRate > 0 ? actualRate : sampleRate,
-            actualChannels: actualChannels > 0 ? actualChannels : channels,
-            micDelay: micDelay,
+        // Gather the raw per-track readings and hand the delay/rate/channel
+        // arithmetic to a pure, unit-tested builder. The app file is what
+        // `AppAudioCapture` actually WROTE — 16 kHz mono after the in-IOProc
+        // resample, not the device's raw capture format.
+        let result = AudioCaptureResult.make(
+            appOutputURL: appOutputURL,
+            micOutputURL: micOutputURL,
+            configured: (sampleRate: sampleRate, channels: channels),
+            app: .init(
+                firstFrameTicks: appCapture?.appFirstFrameTime ?? 0,
+                sampleRate: appCapture?.outputSampleRate ?? 0,
+                channels: appCapture?.outputChannels ?? 0,
+            ),
+            mic: .init(
+                recorded: micCapture != nil,
+                firstFrameTicks: micCapture?.firstFrameTime ?? 0,
+            ),
         )
 
+        try? appFileHandle?.close()
+        appFileHandle = nil
         appCapture = nil
         micCapture = nil
 

--- a/tools/audiotap/Tests/AudioCaptureResultTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureResultTests.swift
@@ -45,4 +45,79 @@ final class AudioCaptureResultTests: XCTestCase {
 
         XCTAssertEqual(result.actualChannels, 1)
     }
+
+    // MARK: - AudioCaptureResult.make (stop() delay/rate/channel arithmetic)
+
+    private static let appURL = URL(fileURLWithPath: "/tmp/app.raw")
+    private static let micURL = URL(fileURLWithPath: "/tmp/mic.wav")
+
+    private func make(
+        micRecorded: Bool = true,
+        appTicks: UInt64 = 1000,
+        micTicks: UInt64 = 5000,
+        appRate: Int = 16000,
+        appChannels: Int = 1,
+        configuredRate: Int = 48000,
+        configuredChannels: Int = 2,
+    ) -> AudioCaptureResult {
+        AudioCaptureResult.make(
+            appOutputURL: Self.appURL,
+            micOutputURL: Self.micURL,
+            configured: (sampleRate: configuredRate, channels: configuredChannels),
+            app: .init(firstFrameTicks: appTicks, sampleRate: appRate, channels: appChannels),
+            mic: .init(recorded: micRecorded, firstFrameTicks: micTicks),
+        )
+    }
+
+    func testMakePositiveMicDelayWhenMicStartsLater() {
+        // mic ticks > app ticks → mic started later → positive delay. Pins the
+        // subtraction order (a sign flip is the #99 "mix.wav 2× duration" class).
+        let result = make(appTicks: 1000, micTicks: 5000)
+        XCTAssertGreaterThan(result.micDelay, 0)
+        XCTAssertEqual(
+            result.micDelay,
+            machTicksToSeconds(5000) - machTicksToSeconds(1000),
+            accuracy: 1e-12,
+        )
+    }
+
+    func testMakeNegativeMicDelayWhenMicStartsEarlier() {
+        XCTAssertLessThan(make(appTicks: 5000, micTicks: 1000).micDelay, 0)
+    }
+
+    func testMakeZeroDelayWhenAppNeverDeliveredAFrame() {
+        // app tick 0 (no app frame) → the guard skips the delta, no bogus delay.
+        XCTAssertEqual(make(appTicks: 0, micTicks: 5000).micDelay, 0)
+    }
+
+    func testMakeZeroDelayWhenMicNeverDeliveredAFrame() {
+        XCTAssertEqual(make(appTicks: 1000, micTicks: 0).micDelay, 0)
+    }
+
+    func testMakeZeroDelayAndNilMicURLWhenMicNotRecorded() {
+        // Valid ticks but no mic recorded → no delay and no mic URL.
+        let result = make(micRecorded: false, appTicks: 1000, micTicks: 5000)
+        XCTAssertEqual(result.micDelay, 0)
+        XCTAssertNil(result.micAudioFileURL)
+    }
+
+    func testMakeIncludesMicURLWhenRecorded() {
+        XCTAssertEqual(make(micRecorded: true).micAudioFileURL, Self.micURL)
+    }
+
+    func testMakeFallsBackToConfiguredRateWhenAppReportedZero() {
+        XCTAssertEqual(make(appRate: 0, configuredRate: 48000).actualSampleRate, 48000)
+    }
+
+    func testMakeUsesAppReportedRateWhenNonZero() {
+        XCTAssertEqual(make(appRate: 16000, configuredRate: 48000).actualSampleRate, 16000)
+    }
+
+    func testMakeFallsBackToConfiguredChannelsWhenAppReportedZero() {
+        XCTAssertEqual(make(appChannels: 0, configuredChannels: 2).actualChannels, 2)
+    }
+
+    func testMakeUsesAppReportedChannelsWhenNonZero() {
+        XCTAssertEqual(make(appChannels: 1, configuredChannels: 2).actualChannels, 1)
+    }
 }


### PR DESCRIPTION
Behaviour-preserving refactor. `AudioCaptureSession.stop()` computed the mic delay, the sample-rate/channel fallbacks, and the mic-file-URL branch inline against the live `AppAudioCapture`/`MicCaptureHandler`, so none of that arithmetic had a unit test — a sign flip or a dropped zero-guard (the #99 "mix.wav 2× duration" class) could only surface at runtime.

## Change
- Extract the arithmetic verbatim into a pure `AudioCaptureResult.make(...)` that takes the raw per-track readings (`AppReadings`: first-frame ticks + output rate/channels; `MicReadings`: whether a mic was recorded + its first-frame ticks) plus the configured fallback rate/channels, and returns the result.
- `stop()` now just gathers the readings from the (already-stopped) captures and calls the builder. No behaviour change: the mic-delay guard, the `> 0` rate/channel fallbacks, and the `micRecorded ? url : nil` branch are identical to the old inline logic. Reading through `AppReadings`/`MicReadings` with `?? 0` also makes a double-`stop()` gracefully yield zeros rather than depending on both captures being non-nil.

## Tests (`AudioCaptureResultTests`, +10)
Pin every branch of the extracted builder: mic-later → positive delay and mic-earlier → negative delay (the subtraction order / #99 sign class), the `appTick==0` and `micTick==0` zero-guards, the no-mic-recorded path (zero delay + nil mic URL), and the sample-rate/channel fallbacks to the configured values when the app track reported 0. Each branch was mutation-verified across three probe runs (sign flip; dropped micDelay guards; dropped fallbacks) — every mutation reds the relevant test.

## Deferred
`start()`'s "mic start failed → continue app-only" branch is still untested — testing it needs an injectable factory over the two hardware capture classes (a bigger seam). It's covered by the live e2e (`e2e-app`), so it's left as a follow-up rather than growing this PR into a hardware-class protocolisation.

Full `audiotap` suite green (159), release build clean, lint clean.