### PR TITLE
feat(app): filter meeting detection by the Apps to Watch toggles

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -448,6 +448,10 @@ final class AppSettings {
 
     // MARK: - Computed
 
+    /// The meeting apps the user opted to watch. Drives auto-detection: the
+    /// `WatchingController` default detector keeps only the assertion patterns
+    /// whose app is listed here (`PowerAssertionDetector.patterns(watching:)`),
+    /// read at each watch start. Freshness: FROZEN per watch session.
     var watchApps: [String] {
         var apps: [String] = []
         if watchTeams { apps.append("Microsoft Teams") }

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -57,6 +57,21 @@ class PowerAssertionDetector: MeetingDetecting {
         ),
     ]
 
+    /// The `defaultPatterns` subset to watch given the user's "Apps to Watch"
+    /// toggles (`AppSettings.watchApps`). A user-facing meeting app is kept only
+    /// when its name is in `watchedAppNames`; the internal meeting-simulator
+    /// pattern is always retained (it is an e2e/test hook, never user-toggleable,
+    /// so automated detection keeps working regardless of the toggles). With all
+    /// toggles on — the default — this returns every pattern, i.e. unchanged
+    /// behaviour; with an empty selection only the simulator remains, so no
+    /// user-facing app auto-detects (the user opted them all out).
+    static func patterns(watching watchedAppNames: [String]) -> [AssertionPattern] {
+        let watched = Set(watchedAppNames)
+        return defaultPatterns.filter { pattern in
+            pattern.appName == AppMeetingPattern.simulator.appName || watched.contains(pattern.appName)
+        }
+    }
+
     private let patterns: [AssertionPattern]
     private let confirmationCount: Int
     private var consecutiveHits: [String: Int] = [:]

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -66,7 +66,7 @@ final class WatchingController {
         permissions: PermissionsController,
         liveTranscription: LiveTranscriptionCoordinator,
         ensureMicAccess: @escaping () async -> Bool = { await Permissions.ensureMicrophoneAccess() },
-        makeDetector: @escaping () -> any MeetingDetecting = { PowerAssertionDetector() },
+        makeDetector: (() -> any MeetingDetecting)? = nil,
     ) {
         self.settings = settings
         self.notifier = notifier
@@ -75,7 +75,18 @@ final class WatchingController {
         self.permissions = permissions
         self.liveTranscription = liveTranscription
         self.ensureMicAccess = ensureMicAccess
-        self.makeDetector = makeDetector
+        // Tests inject a deterministic detector; production defaults to one
+        // filtered by the "Apps to Watch" toggles, re-read at each watch start.
+        self.makeDetector = makeDetector ?? { [settings] in
+            Self.defaultDetector(settings: settings)
+        }
+    }
+
+    /// The auto-detect detector, filtered by the user's "Apps to Watch" toggles
+    /// (`settings.watchApps`). Extracted so the toggle → detection wiring is
+    /// unit-testable without spinning up a watch loop.
+    static func defaultDetector(settings: AppSettings) -> any MeetingDetecting {
+        PowerAssertionDetector(patterns: PowerAssertionDetector.patterns(watching: settings.watchApps))
     }
 
     /// Wire the engine-sync hook. Called once from `AppState.init` after its
@@ -152,6 +163,10 @@ final class WatchingController {
 
             pipeline.ensureQueue()
 
+            // Manual recording never polls the detector, so WatchLoop's default
+            // (unfiltered) detector here is inert. If this path ever gains
+            // auto-detection, route it through `makeDetector()` like toggleWatching
+            // so the "Apps to Watch" filter still applies.
             let loop = WatchLoop(
                 recorderFactory: makeRecorderFactory(),
                 pipelineQueue: pipeline.queue,

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -1,0 +1,93 @@
+@testable import MeetingTranscriber
+import XCTest
+
+private func assertionDict(processName: String, assertName: String) -> [Int32: [[String: Any]]] {
+    [1: [[
+        "Process Name": processName,
+        "AssertName": assertName,
+        "AssertType": "PreventUserIdleDisplaySleep",
+    ]]]
+}
+
+/// Tests for `PowerAssertionDetector.patterns(watching:)` — the "Apps to Watch"
+/// toggle filtering (`AppSettings.watchApps`) that `WatchingController`'s default
+/// detector applies. Split out of `PowerAssertionDetectorTests` (which is at the
+/// type_body_length cap) since this is a distinct concern.
+final class PowerAssertionDetectorPatternsTests: XCTestCase {
+    func testPatternsWatchingAllKeepsEveryPattern() {
+        // All toggles on (the default) → every default pattern, unchanged.
+        let names = PowerAssertionDetector
+            .patterns(watching: ["Microsoft Teams", "Zoom", "Webex"])
+            .map(\.appName)
+        XCTAssertEqual(Set(names), Set(PowerAssertionDetector.defaultPatterns.map(\.appName)))
+    }
+
+    func testPatternsWatchingSubsetDropsUnselectedApps() {
+        let names = PowerAssertionDetector.patterns(watching: ["Zoom"]).map(\.appName)
+        XCTAssertTrue(names.contains("Zoom"))
+        XCTAssertFalse(names.contains("Microsoft Teams"))
+        XCTAssertFalse(names.contains("Webex"))
+    }
+
+    func testPatternsWatchingAlwaysKeepsSimulator() {
+        // The e2e/test meeting-simulator hook is never user-toggleable, so it
+        // survives even when no meeting app is selected.
+        let simulator = AppMeetingPattern.simulator.appName
+        XCTAssertEqual(PowerAssertionDetector.patterns(watching: []).map(\.appName), [simulator])
+        XCTAssertTrue(
+            PowerAssertionDetector.patterns(watching: ["Microsoft Teams"]).map(\.appName).contains(simulator),
+        )
+    }
+
+    func testDetectorWithFilteredPatternsIgnoresUnwatchedApp() {
+        // A detector built for "Zoom only" must not fire on a Teams call, but a
+        // Zoom call still fires — the user-visible effect of unchecking Teams.
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Zoom"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+
+        detector.assertionProvider = {
+            assertionDict(processName: "MSTeams", assertName: "Microsoft Teams Call in progress")
+        }
+        XCTAssertNil(detector.checkOnce(), "a Teams call must not be detected when only Zoom is watched")
+
+        detector.assertionProvider = {
+            assertionDict(processName: "zoom.us", assertName: "zoom call")
+        }
+        XCTAssertNotNil(detector.checkOnce(), "a Zoom call must still be detected")
+    }
+
+    @MainActor
+    func testDefaultDetectorReadsWatchAppToggles() throws {
+        // Pins the WatchingController wiring: the default detector must read the
+        // toggles. With Teams off and Zoom on, a Teams call is ignored and a
+        // Zoom call fires.
+        let suite = "WatchAppWiring-\(getpid())-\(UUID().uuidString)"
+        let settings = try AppSettings(defaults: XCTUnwrap(UserDefaults(suiteName: suite)))
+        settings.watchTeams = false
+        settings.watchZoom = true
+        settings.watchWebex = false
+
+        let detector = try XCTUnwrap(
+            WatchingController.defaultDetector(settings: settings) as? PowerAssertionDetector,
+        )
+        detector.windowListProvider = { [] }
+
+        // The default confirmationCount is 2, so a matched app fires on the
+        // second poll; poll twice each so the assertions actually distinguish
+        // "filtered out" (never fires) from "would fire".
+        detector.assertionProvider = {
+            assertionDict(processName: "MSTeams", assertName: "Microsoft Teams Call in progress")
+        }
+        _ = detector.checkOnce()
+        XCTAssertNil(detector.checkOnce(), "Teams off → a Teams call must never fire, even after two polls")
+
+        detector.assertionProvider = {
+            assertionDict(processName: "zoom.us", assertName: "zoom call")
+        }
+        _ = detector.checkOnce()
+        XCTAssertNotNil(detector.checkOnce(), "Zoom on → a Zoom call must fire")
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -107,6 +107,25 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertNoThrow(try body.find(text: "Webex"))
     }
 
+    func testAppsToWatchTogglesBindToSettings() throws {
+        // Each toggle flips its OWN setting (the UI end of the watchApps wiring).
+        let settings = makeSettings()
+        let view = makeGeneral(settings: settings)
+        let cases: [(label: String, get: () -> Bool)] = [
+            ("Microsoft Teams", { settings.watchTeams }),
+            ("Zoom", { settings.watchZoom }),
+            ("Webex", { settings.watchWebex }),
+        ]
+        for (label, get) in cases {
+            XCTAssertTrue(get(), "precondition: \(label) defaults on")
+            let toggle = try view.inspect().find(ViewType.Toggle.self) { toggle in
+                try toggle.labelView().text().string() == label
+            }
+            try toggle.tap()
+            XCTAssertFalse(get(), "tapping the \(label) toggle must turn its own setting off")
+        }
+    }
+
     func testPollIntervalFieldExists() throws {
         let body = try makeGeneral().inspect()
         XCTAssertNoThrow(try body.find(text: "Poll Interval"))


### PR DESCRIPTION
## What
The **Apps to Watch** toggles (`watchTeams` / `watchZoom` / `watchWebex` → `AppSettings.watchApps`) were dead: the Settings UI wrote them but nothing read them, so `PowerAssertionDetector` always watched every default pattern regardless of what the user selected. This wires them up so the toggles actually filter which meeting apps are auto-detected.

## How
- **`PowerAssertionDetector.patterns(watching:)`** — a pure static that keeps only the assertion patterns whose app the user selected, and **always retains the internal meeting-simulator pattern** (an e2e/test hook, never user-toggleable).
- **`WatchingController.defaultDetector(settings:)`** — builds the auto-detect detector from `patterns(watching: settings.watchApps)`, extracted as a named static so the toggle → detection wiring is unit-testable. The default `makeDetector` now uses it, re-read at each watch start; the injected-detector test seam is unchanged.

## Behaviour
- All three toggles **default to `true`**, so a fresh install keeps watching every app — **unchanged behaviour**. Only unchecking an app now removes it from detection.
- Freshness: `watchApps` is read at watch-start (frozen per watch session, consistent with the other watch settings). A mid-watch toggle change applies on the next watch start.

## Tests
- `PowerAssertionDetectorPatternsTests` (5): pin the filter (all / subset / none, simulator always kept), the detector's user-visible effect (a Zoom-only detector ignores a Teams call but fires on a Zoom call), and the `WatchingController.defaultDetector` wiring (Teams off / Zoom on → Teams ignored, Zoom fires, polling twice for the default `confirmationCount = 2`).
- `SettingsViewTests.testAppsToWatchTogglesBindToSettings` (ViewInspector): taps each of the three toggles and asserts its OWN setting flips — the UI end of the wiring, pinned against cross-wiring.
- Every branch mutation-verified (the UI test reds when a toggle is cross-wired to another setting). Lint clean.

## Review notes (from `/code-review high`)
- **All apps unchecked → nothing auto-detects (no UI cue).** Intended per the literal toggle semantics (the user opted every app out), but the menu bar still shows "watching" with no warning. A product/UX call — a Settings cue, or treating empty as "watch all", or disallowing the last uncheck, would be a reasonable follow-up. Documented in `patterns(watching:)`.
- **Mid-session freeze** (toggle changes apply only on the next watch start): the documented frozen-per-session contract; same UI-cue consideration.
- **Manual-recording `WatchLoop`** keeps its default (unfiltered) detector but never polls it, so it is inert; documented in code (with how to route it through `makeDetector()` if that path ever gains auto-detection) rather than changed, to avoid expanding the manual `Task` closure past its lint cap for an inert path.