### PR TITLE
fix(app): skip queue rebuild while the queue owns unfinished work

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -61,9 +61,29 @@ final class PipelineController {
     // MARK: - Queue lifecycle
 
     /// Rebuild the queue against the current settings + active engine and
-    /// re-install the job-state callbacks. Unconditional — the watch-start path
-    /// always rebuilds so a fresh session picks up the latest settings/engine.
+    /// re-install the job-state callbacks. The watch-start path calls this so a
+    /// fresh session picks up the latest settings/engine, but it must not swap the
+    /// queue while that queue still owns unfinished work. Two hazards:
+    ///
+    /// 1. An in-flight job (`isProcessing`): the running job's `processTask` holds
+    ///    the current queue alive to completion, so a replacement would
+    ///    `loadSnapshot()` the same job (reset from `.transcribing`/`.diarizing`/
+    ///    `.generatingProtocol` back to `.waiting`) and process it a second time.
+    /// 2. A job parked at `.speakerNamingPending`: `isProcessing` is already false
+    ///    (`processNext` returned), but the naming session's in-memory data lives
+    ///    only on the current queue. A fresh queue restores the parked job from
+    ///    the snapshot without that data, orphaning the user's pending naming.
+    ///
+    /// When either holds, keep the existing queue and let it drain. Note this
+    /// defers queue-captured settings (engine choice, output dir, diarization,
+    /// VAD, numSpeakers) to the next idle watch-start rather than refreshing them
+    /// automatically; live engine language/vocabulary still sync separately onto
+    /// the shared engine instances meanwhile.
     func rebuild() {
+        guard !queue.isProcessing, queue.pendingSpeakerNamingJobs.isEmpty else {
+            logger.info("Skipping queue rebuild: a job is in flight or awaiting speaker naming")
+            return
+        }
         queue = makeQueue()
         configureCallbacks()
     }

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -78,6 +78,53 @@ final class PipelineControllerTests: XCTestCase {
         )
     }
 
+    // MARK: - rebuild() double-processing guard
+
+    func testRebuildSkippedWhileQueueIsProcessing() {
+        let pc = makeWiredController()
+        // Provider wired → without the guard, rebuild() WOULD build a fresh queue
+        // (otherwise makeQueue's own engine-provider guard would no-op for an
+        // unrelated reason and the test would be vacuous).
+        pc.activate { MockEngine() }
+        pc.queue.isProcessing = true
+        let before = pc.queue
+
+        pc.rebuild()
+
+        XCTAssertIdentical(
+            pc.queue, before,
+            "rebuild must not swap a queue mid-job: the running job's queue owns it to completion, "
+                + "while a replacement would loadSnapshot() the same in-flight job and process it twice",
+        )
+    }
+
+    // The idle case (rebuild DOES replace an idle queue, so the guard can't
+    // over-fire into never rebuilding) is already characterized by
+    // `testEnsureQueueRebuildsBareQueueUsingProviderEngine` above, which drives
+    // ensureQueue() -> rebuild() on an idle queue and asserts the provider's
+    // engine got wired in. Re-asserting it here would only add a second test that
+    // runs the production makeQueue() against the real data directories.
+
+    func testRebuildSkippedWhileSpeakerNamingPending() {
+        let pc = makeWiredController()
+        pc.activate { MockEngine() }
+        // A parked naming job: not processing (isProcessing stays false once
+        // processNext returns), so only the pendingSpeakerNamingJobs half of the
+        // guard keeps the queue — the naming session's data lives only here and a
+        // fresh queue would restore the job from the snapshot without it.
+        _ = seedPendingNaming(on: pc, mapping: ["Speaker 1": "Speaker 1"])
+        XCTAssertFalse(pc.queue.isProcessing, "precondition: parked at naming, not processing")
+        let before = pc.queue
+
+        pc.rebuild()
+
+        XCTAssertIdentical(
+            pc.queue, before,
+            "rebuild must not swap a queue with a job awaiting speaker naming: its in-memory "
+                + "naming session can't be reconstructed on a fresh queue",
+        )
+    }
+
     // MARK: - enqueueFiles (bare controller)
 
     func testEnqueueFilesCreatesJobOnBareController() {


### PR DESCRIPTION
## Problem

`PipelineController.rebuild()` unconditionally swapped in a freshly-built `PipelineQueue`. The watch-start path (`WatchingController.toggleWatching`) calls it on every start, so starting a watch while the current queue still owns unfinished work replaced it underneath, stranding or duplicating that work.

Two hazards:

1. **In-flight job** (`isProcessing == true`): the old queue's `processTask` holds it alive to completion, while `makeQueue()` builds a new queue that `loadSnapshot()`s the same job (reset from `.transcribing`/`.diarizing`/`.generatingProtocol` back to `.waiting`) and processes it a **second time** — duplicate transcript/protocol and double LLM spend.
2. **Job parked at `.speakerNamingPending`**: `isProcessing` is already `false` (`processNext` returned after parking), but the naming session's data lives only in memory on the current queue. `loadSnapshot()` keeps the parked job on disk yet can't reconstruct that data, so a fresh queue **orphans the user's pending speaker-naming confirmation**.

## Fix

Guard `rebuild()` on both signals: while a job is in flight **or** awaiting speaker naming, keep the existing queue. The manual-recording and file-enqueue paths already go through `ensureQueue()` (short-circuits on a wired engine), so only the watch-start `rebuild()` had the gap.

## Tradeoff (deliberate)

When the guard skips, queue-captured settings (engine choice, output dir, diarization, VAD, `numSpeakers`) only refresh at the **next idle watch-start**, not automatically. Concretely: if a user finishes meeting A (still processing), switches the ASR engine or output folder, then starts watching meeting B, B is recorded with the queue's old captured settings until an idle rebuild happens. Live engine language/vocabulary still sync separately onto the shared engine instances.

This defers a rare mid-job settings change in exchange for never double-processing or orphaning a parked job. A fuller mitigation — deferring the rebuild and retrying automatically once the queue goes idle — is a separate design change (new idle-callback pathway) and is intentionally out of scope here; happy to add it as a follow-up if preferred.

## Tests

Two characterization tests on the bare controller:
- `testRebuildSkippedWhileQueueIsProcessing` — no-op while processing (queue identity preserved)
- `testRebuildSkippedWhileSpeakerNamingPending` — no-op while a job is parked at naming

Each mutation-verified: reverting the corresponding guard clause turns the matching test red. The idle direction (rebuild still replaces an idle queue, so the guard can't over-fire into never rebuilding) is already covered by the existing `testEnsureQueueRebuildsBareQueueUsingProviderEngine` — verified via an always-skip mutation that turns that test red.

## Review notes

A code review flagged that `PipelineController` tests drive the production `makeQueue()` against the real `MeetingTranscriber` data directories (`loadSnapshot()` + an off-main recovery scan). That is a pre-existing pattern (`testEnsureQueueRebuildsBareQueueUsingProviderEngine` already does it); this PR avoids adding a second instance by not introducing an idle-rebuild test. Isolating `makeQueue()`'s data dir behind a test seam would be a separate cleanup.