### PR TITLE
refactor(app): extract FluidVAD speech-region math into a testable seam

### DIFF
--- a/app/MeetingTranscriber/Sources/FluidVAD.swift
+++ b/app/MeetingTranscriber/Sources/FluidVAD.swift
@@ -181,28 +181,13 @@ final class FluidVAD: @unchecked Sendable {
     /// Convert per-chunk VAD results into merged, filtered speech regions.
     private func buildSegmentMap(from results: [VadResult]) -> VadSegmentMap {
         let chunkDuration = Double(VadManager.chunkSize) / Double(VadManager.sampleRate) // ~0.256s
-        var regions: [SpeechRegion] = []
-        var speechStart: TimeInterval?
-
-        for (index, result) in results.enumerated() {
-            let chunkTime = Double(index) * chunkDuration
-            if result.probability >= threshold {
-                if speechStart == nil {
-                    speechStart = chunkTime
-                }
-            } else if let start = speechStart {
-                regions.append(SpeechRegion(start: start, end: chunkTime))
-                speechStart = nil
-            }
-        }
-        // Close any open region
-        if let start = speechStart {
-            let endTime = Double(results.count) * chunkDuration
-            regions.append(SpeechRegion(start: start, end: endTime))
-        }
-
-        regions = mergeCloseRegions(regions, maxGap: Self.mergeGapSeconds)
-        regions = regions.filter { $0.duration >= Self.minRegionSeconds }
+        let regions = Self.speechRegions(
+            fromProbabilities: results.map(\.probability),
+            threshold: threshold,
+            chunkDuration: chunkDuration,
+            mergeGap: Self.mergeGapSeconds,
+            minRegion: Self.minRegionSeconds,
+        )
 
         let totalDuration = Double(results.count) * chunkDuration
         let speechDuration = regions.reduce(0.0) { $0 + $1.duration }
@@ -290,8 +275,47 @@ final class FluidVAD: @unchecked Sendable {
         return (result.state, event)
     }
 
+    /// Pure core of `buildSegmentMap`: turn a stream of per-chunk speech
+    /// probabilities into merged, duration-filtered speech regions. Extracted as
+    /// a static over `[Float]` so the hysteresis + merge + min-duration math (the
+    /// logic that decides which audio ever reaches transcription/diarization) is
+    /// unit-testable without a loaded VAD model. `chunkDuration` is each chunk's
+    /// wall-clock length; a chunk counts as speech when its probability is `>=`
+    /// `threshold`; an open region is closed at the end of the stream; regions
+    /// closer than `mergeGap` are merged, then any shorter than `minRegion` are
+    /// dropped.
+    static func speechRegions(
+        fromProbabilities probabilities: [Float],
+        threshold: Float,
+        chunkDuration: TimeInterval,
+        mergeGap: TimeInterval,
+        minRegion: TimeInterval,
+    ) -> [SpeechRegion] {
+        var regions: [SpeechRegion] = []
+        var speechStart: TimeInterval?
+
+        for (index, probability) in probabilities.enumerated() {
+            let chunkTime = Double(index) * chunkDuration
+            if probability >= threshold {
+                if speechStart == nil {
+                    speechStart = chunkTime
+                }
+            } else if let start = speechStart {
+                regions.append(SpeechRegion(start: start, end: chunkTime))
+                speechStart = nil
+            }
+        }
+        // Close any open region at the end of the stream.
+        if let start = speechStart {
+            regions.append(SpeechRegion(start: start, end: Double(probabilities.count) * chunkDuration))
+        }
+
+        regions = mergeCloseRegions(regions, maxGap: mergeGap)
+        return regions.filter { $0.duration >= minRegion }
+    }
+
     /// Merge regions that are closer together than maxGap seconds.
-    private func mergeCloseRegions(_ regions: [SpeechRegion], maxGap: TimeInterval) -> [SpeechRegion] {
+    private static func mergeCloseRegions(_ regions: [SpeechRegion], maxGap: TimeInterval) -> [SpeechRegion] {
         guard !regions.isEmpty else { return [] }
         var merged: [SpeechRegion] = [regions[0]]
         for region in regions.dropFirst() {

--- a/app/MeetingTranscriber/Tests/FluidVADTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidVADTests.swift
@@ -233,6 +233,110 @@ final class FluidVADTests: XCTestCase {
         XCTAssertEqual(remapped[1].end, 4.0, accuracy: 1e-9)
     }
 
+    // MARK: - speechRegions (segment-map core: hysteresis + merge + filter)
+
+    // These pin the pure math that decides which audio survives VAD trimming.
+    // chunkDuration is 1.0s throughout so region times equal chunk indices, and
+    // mergeGap/minRegion are set per-test to isolate one rule at a time.
+
+    func testSpeechRegionsOpensAndClosesOnThresholdCrossing() throws {
+        // Above threshold for chunks 0–1, drops at chunk 2 → region [0, 2).
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.6, 0.6, 0.2],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 0, minRegion: 0,
+        )
+
+        XCTAssertEqual(regions.count, 1)
+        let region = try XCTUnwrap(regions.first)
+        XCTAssertEqual(region.start, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(region.end, 2.0, accuracy: 1e-9)
+    }
+
+    func testSpeechRegionsClosesOpenRegionAtStreamEnd() throws {
+        // Speech starts at chunk 1 and never drops → region closes at stream end
+        // (count * chunkDuration = 3.0), not left dangling.
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.2, 0.6, 0.6],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 0, minRegion: 0,
+        )
+
+        XCTAssertEqual(regions.count, 1)
+        let region = try XCTUnwrap(regions.first)
+        XCTAssertEqual(region.start, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(region.end, 3.0, accuracy: 1e-9)
+    }
+
+    func testSpeechRegionsTreatsExactThresholdAsSpeech() throws {
+        // Probability exactly at the threshold counts as speech (`>=`, not `>`).
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.5],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 0, minRegion: 0,
+        )
+
+        XCTAssertEqual(regions.count, 1, "prob == threshold must open a region")
+        let region = try XCTUnwrap(regions.first)
+        XCTAssertEqual(region.start, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(region.end, 1.0, accuracy: 1e-9)
+    }
+
+    func testSpeechRegionsMergesRegionsCloserThanMergeGap() throws {
+        // Two regions [0,1) and [2,3) with a 1.0s gap; mergeGap 1.5 > gap → merge.
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.6, 0.2, 0.6],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 1.5, minRegion: 0,
+        )
+
+        XCTAssertEqual(regions.count, 1, "gap 1.0 < mergeGap 1.5 must merge")
+        let region = try XCTUnwrap(regions.first)
+        XCTAssertEqual(region.start, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(region.end, 3.0, accuracy: 1e-9)
+    }
+
+    func testSpeechRegionsKeepsRegionsAtOrBeyondMergeGap() {
+        // Same 1.0s gap, but mergeGap == gap. Merge is strict `<`, so a gap equal
+        // to mergeGap must NOT merge.
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.6, 0.2, 0.6],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 1.0, minRegion: 0,
+        )
+
+        XCTAssertEqual(regions.count, 2, "gap == mergeGap must stay separate")
+    }
+
+    func testSpeechRegionsFiltersRegionsShorterThanMinRegion() throws {
+        // One 0.1s region (below minRegion) and one 0.3s region (at/above it).
+        // chunkDuration 0.1: chunk 0 speech → [0, 0.1); chunks 2–4 speech → [0.2, 0.5).
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.6, 0.2, 0.6, 0.6, 0.6],
+            threshold: 0.5, chunkDuration: 0.1, mergeGap: 0, minRegion: 0.15,
+        )
+
+        XCTAssertEqual(regions.count, 1, "the 0.1s region is dropped, the 0.3s region survives")
+        let region = try XCTUnwrap(regions.first)
+        XCTAssertEqual(region.start, 0.2, accuracy: 1e-9)
+        XCTAssertEqual(region.end, 0.5, accuracy: 1e-9)
+    }
+
+    func testSpeechRegionsKeepsRegionExactlyAtMinRegion() {
+        // A region whose duration equals minRegion survives (the filter is `>=`,
+        // not `>`). chunkDuration 0.15, one speech chunk → region [0, 0.15).
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.6],
+            threshold: 0.5, chunkDuration: 0.15, mergeGap: 0, minRegion: 0.15,
+        )
+
+        XCTAssertEqual(regions.count, 1, "duration == minRegion must be kept")
+    }
+
+    func testSpeechRegionsEmptyWhenAllBelowThreshold() {
+        let regions = FluidVAD.speechRegions(
+            fromProbabilities: [0.1, 0.2, 0.3],
+            threshold: 0.5, chunkDuration: 1.0, mergeGap: 0, minRegion: 0,
+        )
+
+        XCTAssertTrue(regions.isEmpty)
+    }
+
     // MARK: - Streaming API (pure value-type behavior)
 
     func testStreamEventStartConstruction() {


### PR DESCRIPTION
## What

`FluidVAD.buildSegmentMap`'s threshold hysteresis + close-region merge + min-duration filter is the pure math that decides which audio ever reaches transcription and diarization. It lived inline in a `private` method only reachable through the model-gated `detectSpeech`, so it had **no direct coverage** — the sibling region logic in `FluidDiarizer` was extracted and covered, this was not (coverage-audit item #5).

Extract it into a static `speechRegions(fromProbabilities:threshold:chunkDuration:mergeGap:minRegion:)` over `[Float]`, and make `mergeCloseRegions` static. `buildSegmentMap` now maps its `VadResult`s to probabilities and delegates, keeping the logging + `VadSegmentMap` construction + round-trip sanity check unchanged.

**Behavior-preserving:** the existing `VadSegmentMap` tests still pass, and the moved code is verbatim (only `result.probability` → `probability`). Taking `[Float]` (not `[VadResult]`) keeps the pure unit decoupled from FluidAudio, so the tests need no loaded VAD model.

## Tests

Eight characterization tests pin each rule, each isolated with `chunkDuration = 1.0s` (so region times equal chunk indices) and per-test `mergeGap`/`minRegion`:
- threshold open/close, open region closed at stream end
- exact-threshold-counts-as-speech (pins `>=`, not `>`)
- merge below `mergeGap`, no-merge at `gap == mergeGap` (pins strict `<`)
- min-duration filter, exact-min-region-kept (pins `>=`)
- empty when all below threshold

Each boundary is mutation-verified: flipping `>=`→`>`, `<`→`<=`, or the filter `>=`→`>` turns the matching test red.

## Review

/simplify + a high-effort code-review both ran. Code-review surfaced no surviving findings. /simplify flagged the `results.map(\.probability)` intermediate array; kept as-is deliberately — the `[Float]` boundary is the intended model-free testability seam and the map is a one-time per-job allocation, not a hot path.