### PR TITLE
ci(e2e): run crash-recovery nightly and on run-e2e label

### DIFF
--- a/.github/workflows/e2e-crash-recovery.yml
+++ b/.github/workflows/e2e-crash-recovery.yml
@@ -8,13 +8,38 @@ name: E2E (Crash Recovery)
 # into its workdir within seconds). Pre-fix the launch cleanup deletes the temp
 # first → no recovery (RED); the fix re-mixes + enqueues it (GREEN).
 #
-# Kept out of the always-run e2e-app.yml sequence: it SIGKILLs + relaunches the
-# shared bundle mid-run, which would disrupt the other lanes. Dispatch-only: run
-# manually when touching the recovery / recorder-teardown path or before a
-# release. GitHub indexes workflow_dispatch from the default branch, so this is
-# dispatchable once merged: gh workflow run e2e-crash-recovery.yml
+# Kept out of the always-run e2e-app.yml step sequence because it SIGKILLs and
+# relaunches the shared bundle mid-run, which would disrupt that workflow's other
+# lanes; running it as its own serialized workflow keeps the disruption contained.
+# It still needs automatic coverage against silent rot in the recovery /
+# recorder-teardown path, so it now runs nightly (its own late UTC slot, see the
+# schedule below) and on the `run-e2e` label for same-repo PRs, while staying
+# manually dispatchable when touching that path or before a release. GitHub
+# indexes workflow_dispatch from the default branch, so this is dispatchable once
+# merged: gh workflow run e2e-crash-recovery.yml
 on:
   workflow_dispatch:
+  # Label-gated PR runs, same-repo branches only. Deliberately
+  # `pull_request`, NOT `pull_request_target`: this workflow checks out and
+  # executes the PR head on a self-hosted Mac mini with a real signing
+  # identity and TCC grants. Fork PRs are excluded entirely (the job `if:`
+  # checks head.repo): a label would be a STANDING approval — every later
+  # fork push would re-run unreviewed code on the runner — and a fork run
+  # would fail anyway, since fork `pull_request` runs get no secrets, the
+  # bundle falls back to the self-signed cert, which lacks the Mini's TCC
+  # microphone grant, and the leftover consent prompt poisons later runs.
+  # To E2E a fork contribution, push it to a same-repo branch and label
+  # that PR. `run-e2e` is the same label the other heavy E2E lanes use.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # 06:15 UTC = 08:15 CEST. Deliberately the latest nightly slot. Every
+    # self-hosted audio lane (quality-and-safety 03:00, e2e-app 04:30,
+    # e2e-cpu-load 05:15, e2e-mic-device-change 05:30 UTC) serializes on the
+    # single `[self-hosted, macOS, ARM64, audio]` Mac mini, so starting after
+    # the last of them minimizes queueing and contention for the BlackHole
+    # input device and the deployed bundle.
+    - cron: '15 6 * * *'
 
 # Shares e2e-app.yml's concurrency group so the two never race for the
 # BlackHole input device / RPC port / deployed bundle on the Mini.
@@ -24,6 +49,17 @@ concurrency:
 
 jobs:
   e2e-crash-recovery:
+    # Non-PR events (schedule/dispatch) always run. PR events run only for
+    # same-repo branches carrying the `run-e2e` label (fork PRs never reach the
+    # runner, see the trigger comment). The label-name check keeps `labeled`
+    # events for any OTHER label from queueing a duplicate run.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-e2e')
+      )
     runs-on: [self-hosted, macOS, ARM64, audio]
     timeout-minutes: 15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   build-perf-tracking.yml  # Weekly build performance trend analysis (flags regressions vs 28-day baseline)
   quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch + label-gated PR runs via `run-quality`)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps
-  e2e-crash-recovery.yml    # E2E — crash recovery: SIGKILL mid-recording + verify pipeline recovers via WAV header repair
+  e2e-crash-recovery.yml    # E2E — crash recovery: SIGKILL mid-recording + verify pipeline recovers via WAV header repair (dispatch + nightly + label-gated PR runs via `run-e2e`)
   e2e-mic-device-change.yml # E2E — mic device-change NSException survival (issue #379, fault-injection build)
   pages.yml                 # Deploy landing page to GitHub Pages (site/ → GitHub Pages, main push + dispatch)
 docs/
@@ -444,6 +444,15 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 Two complementary E2E approaches, run by different workflows. Pick by what
 you're validating:
+
+**CI trigger labels:** the heavy self-hosted lanes stay off ordinary PRs (only
+`ci.yml` runs there) and otherwise fire post-merge or nightly. Two opt-in PR
+labels start them pre-merge, on same-repo branches only (fork PRs never run on
+the Mac mini): `run-e2e` gates `e2e.yml`, `e2e-app.yml`, and
+`e2e-crash-recovery.yml`; `run-quality` gates `quality-and-safety.yml` (TSan/ASan
+plus WER/DER). Apply with `gh pr edit <n> --add-label run-e2e`. Each lane's
+job-level `if:` guard checks `head.repo.full_name == github.repository`, so fork
+PRs are excluded from the self-hosted runner.
 
 **Fixture-based xctest E2E (`e2e.yml`)**
 - Engine + pipeline tests in `app/MeetingTranscriber/Tests/*E2ETests.swift`


### PR DESCRIPTION
## What

Add automatic triggers to `.github/workflows/e2e-crash-recovery.yml`, which was `workflow_dispatch:` only:

1. A nightly `schedule` cron at **06:15 UTC**.
2. A `run-e2e` label-gated `pull_request` trigger, restricted to same-repo PRs only.

The existing `workflow_dispatch` trigger and the shared `concurrency` group are unchanged. No Swift source is touched.

## Why

Because the workflow was dispatch-only, it had never run automatically. A regression in the crash-recovery / recorder-teardown path (SIGKILL mid-recording, relaunch, orphan re-mix back into the pipeline) would have gone unnoticed until someone remembered to dispatch it by hand or run it before a release. This closes that "never runs, could silently rot" gap.

The workflow deliberately lives on its own rather than as a step inside the always-run `e2e-app.yml` sequence: it SIGKILLs and relaunches the shared bundle mid-run, which would disrupt the other lanes. Keeping it a separate, serialized workflow (it still shares `e2e-app.yml`'s concurrency group) contains that disruption, and the design is preserved here: automatic coverage is added without folding it back into the always-run sequence.

## Nightly slot choice (06:15 UTC)

All the self-hosted audio lanes serialize on the single ARM64 audio Mac mini, so the slot is chosen to sit after the last existing nightly to minimize queueing and contention for the BlackHole input device and the deployed bundle:

- quality-and-safety: 03:00 UTC
- e2e-app: 04:30 UTC
- e2e-cpu-load: 05:15 UTC
- e2e-mic-device-change: 05:30 UTC
- **this lane: 06:15 UTC** (latest, distinct slot)

## Fork safety (hard constraint)

The job-level `if:` guard is copied verbatim from `e2e-app.yml`, so the fork-exclusion semantics are identical: PR events run only for same-repo branches (`head.repo.full_name == github.repository`) that carry the `run-e2e` label (the same label the other heavy E2E lanes already use). Fork PRs never execute PR code on the self-hosted Mac mini. A fork label would otherwise act as a standing approval, and a fork run would fail anyway (no signing secrets, no TCC microphone grant). The trigger is `pull_request`, not `pull_request_target`, matching the sibling lanes.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"`: parses cleanly.
- `actionlint`: no findings other than the pre-existing custom `audio` self-hosted runner-label note, which fires identically on `e2e-app.yml` (it is a real custom runner label, not an error introduced here).