### PR TITLE
refactor(app): add an injected seam for DualSourceRecorder.resolveTapPIDs

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -507,11 +507,26 @@ class DualSourceRecorder: RecordingProvider {
     /// prepending the root if enumeration somehow missed it — order matters
     /// for the aggregate device's cosmetic name tag (root first).
     static func resolveTapPIDs(rootPID: pid_t) -> [pid_t] {
-        guard let bundleURL = NSRunningApplication(processIdentifier: rootPID)?.bundleURL else {
-            return [rootPID]
-        }
-        let enumerated = ProcessTreeEnumerator.pidsRooted(in: bundleURL)
-        guard !enumerated.isEmpty else { return [rootPID] }
+        resolveTapPIDs(
+            rootPID: rootPID,
+            bundleURL: NSRunningApplication(processIdentifier: rootPID)?.bundleURL,
+            enumerate: ProcessTreeEnumerator.pidsRooted(in:),
+        )
+    }
+
+    /// Test seam — same PID-set decision as `resolveTapPIDs(rootPID:)` but with
+    /// the running-app bundle lookup + child-PID enumeration injected, so the
+    /// empty-enumeration fallback, the already-includes-root passthrough, and the
+    /// load-bearing root-prepend ordering (aggregate device name tag; #84) are
+    /// unit-testable without real running processes.
+    static func resolveTapPIDs(
+        rootPID: pid_t,
+        bundleURL: URL?,
+        enumerate: (URL) -> [pid_t],
+    ) -> [pid_t] {
+        guard let bundleURL else { return [rootPID] }
+        let enumerated = enumerate(bundleURL)
+        // Empty `enumerated` needs no guard: it falls through to `[rootPID] + []`, the root alone.
         return enumerated.contains(rootPID) ? enumerated : [rootPID] + enumerated
     }
 

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderResolveTapPIDsTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderResolveTapPIDsTests.swift
@@ -1,0 +1,48 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit tests for `DualSourceRecorder.resolveTapPIDs` — the PID-set decision for
+/// which processes to tap under a meeting-matched root PID. The injected-closure
+/// overload exercises the fallback / passthrough / root-prepend branches without
+/// real running processes; the no-arg form covers the real nil-bundle fallback.
+@MainActor
+final class DualSourceRecorderResolveTapPIDsTests: XCTestCase {
+    private let bundle = URL(fileURLWithPath: "/Applications/Teams.app")
+
+    /// `NSRunningApplication(processIdentifier:)` returns nil for a PID that
+    /// isn't running — falls back to the single root PID rather than silently
+    /// tapping nothing. The safety net for command-line tools, exited processes,
+    /// or detection failures. This drives the real (non-injected) path.
+    func testResolveTapPIDsFallsBackWhenBundleURLUnavailable() {
+        // PID_MAX on macOS is 99999. Pick something deliberately past it.
+        let bogusPID: pid_t = 999_999
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: bogusPID)
+        XCTAssertEqual(pids, [bogusPID])
+    }
+
+    func testResolveTapPIDsFallsBackToRootWhenNoBundleURL() {
+        // nil bundle URL (command-line tool / exited process) → just the root.
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: 42, bundleURL: nil) { _ in [7, 8, 9] }
+        XCTAssertEqual(pids, [42], "no bundle URL must fall back to the root PID alone")
+    }
+
+    func testResolveTapPIDsFallsBackToRootWhenEnumerationEmpty() {
+        // Bundle resolved but no PIDs found under it → the root alone, not [].
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: 42, bundleURL: bundle) { _ in [] }
+        XCTAssertEqual(pids, [42], "empty enumeration must fall back to the root PID, never an empty tap set")
+    }
+
+    func testResolveTapPIDsPassesEnumerationThroughWhenItAlreadyIncludesRoot() {
+        // Enumeration already contains the root → use it verbatim (no reordering).
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: 42, bundleURL: bundle) { _ in [100, 42, 200] }
+        XCTAssertEqual(pids, [100, 42, 200], "when enumeration already includes the root, order is preserved as-is")
+    }
+
+    func testResolveTapPIDsPrependsRootWhenEnumerationMissesIt() {
+        // Enumeration missed the root → prepend it. Order is load-bearing: the
+        // root must come FIRST because the aggregate device's cosmetic name tag
+        // is taken from the first PID (#84, Electron helper children).
+        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: 42, bundleURL: bundle) { _ in [100, 200] }
+        XCTAssertEqual(pids, [42, 100, 200], "the root must be prepended (first), not appended")
+    }
+}

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -320,19 +320,6 @@ final class DualSourceRecorderTests: XCTestCase {
         XCTAssertEqual(result, 24000)
     }
 
-    // MARK: - resolveTapPIDs
-
-    /// `NSRunningApplication(processIdentifier:)` returns nil for a PID that
-    /// isn't running — falls back to the single root PID rather than
-    /// silently tapping nothing. This is the safety net for command-line
-    /// tools, exited processes, or detection failures.
-    func testResolveTapPIDsFallsBackWhenBundleURLUnavailable() {
-        // PID_MAX on macOS is 99999. Pick something deliberately past it.
-        let bogusPID: pid_t = 999_999
-        let pids = DualSourceRecorder.resolveTapPIDs(rootPID: bogusPID)
-        XCTAssertEqual(pids, [bogusPID])
-    }
-
     // MARK: - buildRecording
 
     /// Neither channel produced audio (0-byte app temp, no mic) → noAudioData.


### PR DESCRIPTION
## What

`resolveTapPIDs(rootPID:)` decides which PIDs to tap for a meeting: it looks up the running app's bundle URL, enumerates child PIDs under it, then either falls back to the root alone (nil bundle), passes the enumeration through when it already includes the root, or **prepends** the root when it doesn't. That last branch is load-bearing: the aggregate device's cosmetic name tag is taken from the first PID, so the root must come first (#84, Electron helper children).

Only the nil-bundle fallback had coverage (via a bogus PID); the passthrough and prepend branches were reachable only with real running processes.

## Change

Add an injected-closure overload `resolveTapPIDs(rootPID:bundleURL:enumerate:)` (mirroring `ProcessTreeEnumerator.pidsRooted`'s own test seam) so the pure branch logic is unit-testable without spawning processes. The no-arg form wires the real `NSRunningApplication` lookup + `ProcessTreeEnumerator.pidsRooted(in:)` and delegates.

Also **drop the now-redundant `guard !enumerated.isEmpty else { return [rootPID] }`**: an empty enumeration already falls through to `[rootPID] + []` (the root alone), so the guard was dead code. Because deleting it is behavior-identical, it also made the empty-enumeration test impossible to mutation-verify; removing it routes the empty case through the tested prepend expression. Behavior unchanged.

## Tests

Four new characterization tests cover the previously-uncovered branches (injected nil bundle, empty enumeration, already-includes-root passthrough, root-prepend); the existing bogus-PID test still covers the real nil path. Three branches are mutation-verified: append-instead-of-prepend, dropping the `contains` guard, and dropping the prepend each turn the matching test red. The `resolveTapPIDs` tests move to their own file so `DualSourceRecorderTests` stays under the type-body-length cap.

## Review

/simplify (reuse/altitude/simplification/efficiency) found the seam clean and correctly mirroring the existing pattern. A high-effort code-review caught that the empty-enumeration test was vacuous against the redundant guard; resolved by removing the guard (above), which is the deeper fix.