### PR TITLE
Fix custom output directory not persisting in non-sandboxed builds

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -1,4 +1,7 @@
+import os.log
 import SwiftUI
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "AppSettings")
 
 // SwiftFormat strips redundant raw values matching their case name, which then
 // trips SwiftLint's `raw_value_for_camel_cased_codable_enum`; the rawValues
@@ -367,42 +370,78 @@ final class AppSettings {
 
     // MARK: - Output Directory
 
-    /// Security-scoped bookmark for a user-chosen output directory.
+    /// Bookmark (security-scoped when sandboxed) for a user-chosen output directory.
     var customOutputDirBookmark: Data? {
         get { defaults.data(forKey: "customOutputDirBookmark") }
         set { defaults.set(newValue, forKey: "customOutputDirBookmark") }
     }
 
-    /// Resolved URL from the security-scoped bookmark. Calls `startAccessingSecurityScopedResource()`.
+    /// Resolved URL from the stored bookmark (scoped or regular).
     var customOutputDir: URL? {
         guard let data = customOutputDirBookmark else { return nil }
         var isStale = false
-        guard let url = try? URL(
-            resolvingBookmarkData: data,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale,
-        ) else { return nil }
+        guard let url = Self.resolveOutputDirBookmark(data, isStale: &isStale) else { return nil }
         if isStale {
             // Re-create bookmark from resolved URL
-            if let newData = try? url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil,
-            ) {
+            if let newData = Self.makeOutputDirBookmark(url) {
                 customOutputDirBookmark = newData
             }
         }
         return url
     }
 
-    /// Store a user-selected directory as a security-scoped bookmark.
-    func setCustomOutputDir(_ url: URL) {
-        guard let data = try? url.bookmarkData(
+    /// Create a bookmark for the output directory.
+    ///
+    /// Security-scoped bookmarks require the App Sandbox. The direct
+    /// (non-App-Store) build is NOT sandboxed — there
+    /// `bookmarkData(options: .withSecurityScope)` throws, and the previous
+    /// `guard try?` swallowed the error, so the chosen folder silently never
+    /// persisted and output always fell back to ~/Downloads while the
+    /// Settings UI kept showing the selected path. Try the scoped variant
+    /// first (APPSTORE build), fall back to a regular bookmark, and log a
+    /// failure instead of silently returning.
+    static func makeOutputDirBookmark(_ url: URL) -> Data? {
+        if let data = try? url.bookmarkData(
             options: .withSecurityScope,
             includingResourceValuesForKeys: nil,
             relativeTo: nil,
-        ) else { return }
+        ) {
+            return data
+        }
+        if let data = try? url.bookmarkData(
+            options: [],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil,
+        ) {
+            return data
+        }
+        logger.error("Output dir bookmark creation failed for \(url.path, privacy: .private)")
+        return nil
+    }
+
+    /// Resolve a stored output-dir bookmark, accepting both scoped and
+    /// regular forms (older installs may hold either kind).
+    static func resolveOutputDirBookmark(_ data: Data, isStale: inout Bool) -> URL? {
+        if let url = try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale,
+        ) {
+            return url
+        }
+        return try? URL(
+            resolvingBookmarkData: data,
+            options: [],
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale,
+        )
+    }
+
+    /// Store a user-selected directory as a bookmark (security-scoped in the
+    /// sandboxed build, regular otherwise).
+    func setCustomOutputDir(_ url: URL) {
+        guard let data = Self.makeOutputDirBookmark(url) else { return }
         customOutputDirBookmark = data
     }
 


### PR DESCRIPTION
## Symptom

Settings → Output → choosing a custom output folder appears to work (the UI shows the selected path), but nothing persists: every new recording writes to the default `~/Downloads/MeetingTranscriber/` again, and the folder is silently recreated there. Observed on the Homebrew/direct build v0.6.0-rc6, macOS 26.5.

## Root cause

`AppSettings.setCustomOutputDir` stores the folder as a **security-scoped** bookmark:

```swift
guard let data = try? url.bookmarkData(options: .withSecurityScope, ...) else { return }
```

Security-scoped bookmarks require the App Sandbox. The direct (non-App-Store) build is not sandboxed (it can't be — CATap capture), so `bookmarkData(options: .withSecurityScope)` throws, the `guard try?` swallows the error, and the setting is never written. `effectiveOutputDir` then falls back to `AppPaths.downloadsProtocolsDir` forever, while the Settings UI keeps displaying the user's chosen path.

## Fix

- Extract bookmark creation/resolution into `makeOutputDirBookmark` / `resolveOutputDirBookmark` helpers.
- Creation: try `.withSecurityScope` first (APPSTORE build keeps its behavior), fall back to a regular bookmark for the non-sandboxed build, and log an error instead of failing silently.
- Resolution: mirror the fallback (`.withSecurityScope` → plain), so both bookmark kinds resolve regardless of which build wrote them.
- Stale-bookmark re-creation goes through the same helper.

`AppSettings+RPC.rpcOutputDirPath` needs no change — it already resolves with `[.withoutUI, .withoutMounting]`, which works for both bookmark kinds.

## Testing

Reproduced the symptom on macOS 26.5 with the rc6 direct build (chosen folder shows in UI, files keep landing in `~/Downloads/MeetingTranscriber`). The patch was reviewed against the existing style but not compiled locally — relying on CI (unit tests + E2E) to exercise it; happy to adjust if anything trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)