### PR TITLE
perf(app): stop the meeting-start system slowdown from concurrent model warm-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     Bundle+AppVersion.swift # Bundle extension: appVersion + gitCommitHash from Info.plist
     FileManager+OwnerOnly.swift # FileManager extension: owner-only file permission constant (rw-------, single source of truth)
     SingleFlight.swift        # Single-flight async deduplication coordinator (concurrent callers await one shared run)
+    ModelWarmupQueue.swift    # Serial async gate ordering launch model warm-ups one-at-a-time (avoids the concurrent CoreML compile storm that starves the system on a meeting join)
     DiagnosticExporter.swift # Reads log entries → shareable .log file (Settings → Advanced → Export Diagnostics)
     PersistentDiagnosticLog.swift # Persistent log stream subprocess with sliding-window restart policy
     String+LogRedaction.swift # String extensions: .pseudonymized and .redactedName for log privacy

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -144,7 +144,12 @@ final class AppState {
         // inference here to a plain function reference. Behaviour is identical.
         self.settings = settings
         self.notifier = notifier
-        self.engines = EngineController(settings: settings)
+        // One shared serial warm-up queue: the ASR engine preload and the
+        // live-caption model prewarm both route their loads through it so the
+        // two big CoreML loads don't compile concurrently at launch (the
+        // simultaneous ANE / compiler peak that starves the system on a join).
+        let warmupQueue = ModelWarmupQueue()
+        self.engines = EngineController(settings: settings, warmupQueue: warmupQueue)
         self.permissions = PermissionsController(notifier: notifier)
         self.updateChecker = updateChecker ?? Self.makeUpdateChecker()
         self.pipeline = PipelineController(settings: settings, notifier: notifier)
@@ -159,6 +164,7 @@ final class AppState {
             engineSupportsLive: { [settings] in settings.transcriptionEngine.supportsLiveTranscription },
             engineLanguage: { [settings] in settings.activeEngineLanguageOrNil },
             verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
+            warmupQueue: warmupQueue,
         )
         self.watching = WatchingController(
             settings: settings,

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -29,6 +29,12 @@ final class EngineController {
 
     private let settings: AppSettings
 
+    /// Shared serial warm-up queue. The launch model preload runs through it so
+    /// it doesn't compile concurrently with the live-caption models (the
+    /// simultaneous ANE / CoreML-compiler peak that starves the system on a
+    /// meeting join). Defaulted so tests get an isolated queue.
+    private let warmupQueue: ModelWarmupQueue
+
     // Dependency-default factories keep `init`'s body-type-check under the 300 ms
     // budget — an inline `@Observable` engine constructor forces the type-checker
     // to re-solve that engine's own init constraints at this call site (the same
@@ -42,8 +48,9 @@ final class EngineController {
         ParakeetEngine()
     }
 
-    init(settings: AppSettings) {
+    init(settings: AppSettings, warmupQueue: ModelWarmupQueue = ModelWarmupQueue()) {
         self.settings = settings
+        self.warmupQueue = warmupQueue
         self.whisperKit = Self.makeWhisperKit()
         self.parakeetEngine = Self.makeParakeet()
 
@@ -74,7 +81,10 @@ final class EngineController {
         // variant/language writes through `syncEngineSettings` keeps a single
         // settings→engine path instead of re-inlining a whisperKit-only subset.
         syncEngineSettings()
-        await activeTranscriptionEngine.loadModel()
+        // Serialize against the live-caption model warm-up so the two big CoreML
+        // loads don't compile at once. `run` awaits the load, so the caller still
+        // returns only after the model is loaded.
+        await warmupQueue.run { [self] in await activeTranscriptionEngine.loadModel() }
     }
 
     /// Push current model / language / vocabulary settings into the active

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -116,7 +116,16 @@ final class LiveTranscriptionCoordinator {
     /// boundary that keeps a slow `asr.finish()` from interleaving with the next
     /// recording's ingests on the same session actor.
     func attachSinks(to recorder: DualSourceRecorder) async {
-        guard captionsEligible, let controller = ensureController() else { return }
+        // Existing-only: never cold-build the controller here. A cold build kicks
+        // a heavy CoreML model load (Nemotron ~584 MB) from the recorder-start
+        // path, landing the compile on the meeting edge and saturating the ANE /
+        // compiler daemons system-wide. The controller is warmed at launch/idle
+        // via `prewarmIfEligible()`; if its models are still loading its object
+        // already exists (built synchronously in `ensureController` before the
+        // async `prepare()`), so sinks attach and captions light up when the load
+        // finishes. If it was never warmed, this recording gets no captions and
+        // they come online at the next idle prewarm.
+        guard captionsEligible, let controller else { return }
         await controller.prepareForNextRecording()
         recorder.micLiveSink = controller.micSink
         recorder.appLiveSink = controller.appSink

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -37,6 +37,12 @@ final class LiveTranscriptionCoordinator {
     private let verboseDiagnostics: () -> Bool
     private let makeController: ControllerFactory
 
+    /// Shared serial warm-up queue. The controller's `prepare()` (the heavy
+    /// Nemotron / WeSpeaker load) runs through it so it doesn't compile
+    /// concurrently with the ASR engine preload. Defaulted so tests get an
+    /// isolated queue.
+    private let warmupQueue: ModelWarmupQueue
+
     /// Builds the streaming controller for the (optional) active engine. The
     /// engine is nil when a language-driven streaming backend (German/English)
     /// applies with a non-streaming active engine — those sessions don't need it.
@@ -56,6 +62,7 @@ final class LiveTranscriptionCoordinator {
         engineLanguage: @escaping () -> String? = { nil },
         verboseDiagnostics: @escaping () -> Bool,
         makeController: @escaping ControllerFactory = LiveTranscriptionCoordinator.makeDefaultController,
+        warmupQueue: ModelWarmupQueue = ModelWarmupQueue(),
     ) {
         self.captions = captions
         self.liveEnabled = liveEnabled
@@ -63,6 +70,7 @@ final class LiveTranscriptionCoordinator {
         self.engineLanguage = engineLanguage
         self.verboseDiagnostics = verboseDiagnostics
         self.makeController = makeController
+        self.warmupQueue = warmupQueue
     }
 
     private static func makeDefaultController(
@@ -200,7 +208,10 @@ final class LiveTranscriptionCoordinator {
         guard strategy != .reTranscribe || streamingEngine != nil else { return nil }
         let controller = makeController(streamingEngine, captions, language, verboseDiagnostics)
         self.controller = controller
-        Task { @MainActor in await controller.prepare() }
+        // Route `prepare()` through the shared warm-up queue (see `warmupQueue`).
+        // Bind it locally so the fire-and-forget Task doesn't capture `self`.
+        let queue = warmupQueue
+        Task { @MainActor in await queue.run { await controller.prepare() } }
         return controller
     }
 }

--- a/app/MeetingTranscriber/Sources/ModelWarmupQueue.swift
+++ b/app/MeetingTranscriber/Sources/ModelWarmupQueue.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Serial gate that runs model warm-up loads one at a time, FIFO.
+///
+/// At launch the ASR engine model and the live-caption streaming models load on
+/// independent Tasks. Compiling/loading them concurrently produces a
+/// simultaneous ANE + CoreML-compiler + CPU peak that, when it coincides with a
+/// meeting join, starves WindowServer and makes the whole machine sluggish for
+/// the first seconds of the call. Routing every warm-up load through one shared
+/// queue keeps at most one compiling at a time, so the total work is spread out
+/// instead of hitting all at once.
+///
+/// A plain actor would NOT serialize: actor methods are reentrant at every
+/// `await`, so two overlapping `run` calls would interleave their ops. This
+/// chains each op after the previous op's `Task` has completed, which does
+/// serialize. `run` awaits its op, so callers keep their existing "await until
+/// loaded" contract; the queue only orders the loads, it does not replace each
+/// engine's own concurrent-load dedupe or its failure handling.
+@MainActor
+final class ModelWarmupQueue {
+    /// The most recently enqueued op's task. Each new op waits on this before
+    /// running, then becomes the new tail. `Task<Void, Never>` never throws, so
+    /// an op that fails internally cannot poison the chain for later ops.
+    private var tail: Task<Void, Never>?
+
+    /// Enqueue `op` to run after every previously-enqueued op has finished, and
+    /// await its completion. At most one op runs at a time.
+    func run(_ op: @escaping @MainActor () async -> Void) async {
+        let predecessor = tail
+        let task = Task { @MainActor in
+            await predecessor?.value
+            await op()
+        }
+        tail = task
+        await task.value
+    }
+}

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -42,13 +42,13 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
     /// for a cold CoreML model load) or reuses the warmed one.
     private func countingControllerFactory()
         -> (LiveTranscriptionCoordinator.ControllerFactory, () -> Int) {
-        let counter = BuildCounter()
+        let counter = ManagedCounter()
         let base = mockControllerFactory()
         let factory: LiveTranscriptionCoordinator.ControllerFactory = { engine, captions, lang, verbose in
-            counter.count += 1
+            _ = counter.increment()
             return base(engine, captions, lang, verbose)
         }
-        return (factory, { counter.count })
+        return (factory, { counter.value })
     }
 
     func testAttachSinksInstallsWhenGateOpenAndControllerReady() async {
@@ -196,13 +196,72 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(buildCount(), 1, "warm controller must be reused across recordings, never rebuilt")
     }
+
+    // MARK: - Warm-up queue routing
+
+    /// The controller's `prepare()` (its heavy model load) must run through the
+    /// injected shared `ModelWarmupQueue`, so it serializes against the ASR
+    /// engine preload rather than compiling concurrently.
+    ///
+    /// Proven by occupying the queue with a blocker: while the blocker holds the
+    /// queue, `prepare()` cannot run (no backend published); it only completes
+    /// once the blocker is released. If `prepare()` bypassed the queue it would
+    /// publish a backend immediately, failing the mid-test `XCTAssertNil`.
+    func testControllerPrepareRunsThroughTheSharedWarmupQueue() async {
+        let queue = ModelWarmupQueue()
+        let captions = LiveCaptionsState()
+        let gate = TestGate()
+        let blocker = Task { @MainActor in await queue.run { await gate.wait() } }
+        // Let the blocker take the queue head before anything is enqueued behind it.
+        for _ in 0 ..< 5 {
+            await Task.yield()
+        }
+
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: captions,
+            liveEnabled: { true },
+            engineSupportsLive: { true },
+            verboseDiagnostics: { false },
+            makeController: mockControllerFactory(),
+            warmupQueue: queue,
+        )
+        coordinator.beginPrewarm { MockStreamingEngine() } // enqueues prepare() behind the blocker
+
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        XCTAssertNil(
+            captions.activeBackend,
+            "prepare() must wait behind the queued blocker — proves it routes through the shared queue",
+        )
+
+        gate.release()
+        var settled = false
+        for _ in 0 ..< 500 where !settled {
+            if captions.activeBackend != nil { settled = true } else { await Task.yield() }
+        }
+        XCTAssertTrue(settled, "prepare() should complete and publish its backend once the queue drains")
+        _ = await blocker.value
+    }
 }
 
-/// Mutable reference counter for `countingControllerFactory` (all accesses are
-/// `@MainActor`-isolated via the test case).
+/// Manual gate: an enqueued op awaits `wait()` until the test calls `release()`,
+/// letting a test hold the warm-up queue head to observe what queues behind it.
 @MainActor
-private final class BuildCounter {
-    var count = 0
+private final class TestGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        if released { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
 }
 
 /// A `TranscribingEngine` that does NOT conform to `StreamingTranscribingEngine`

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -37,6 +37,20 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
         }
     }
 
+    /// Same as `mockControllerFactory` but counts how many controllers it builds,
+    /// so tests can assert whether a code path (re)builds a controller (a proxy
+    /// for a cold CoreML model load) or reuses the warmed one.
+    private func countingControllerFactory()
+        -> (LiveTranscriptionCoordinator.ControllerFactory, () -> Int) {
+        let counter = BuildCounter()
+        let base = mockControllerFactory()
+        let factory: LiveTranscriptionCoordinator.ControllerFactory = { engine, captions, lang, verbose in
+            counter.count += 1
+            return base(engine, captions, lang, verbose)
+        }
+        return (factory, { counter.count })
+    }
+
     func testAttachSinksInstallsWhenGateOpenAndControllerReady() async {
         let coordinator = LiveTranscriptionCoordinator(
             captions: LiveCaptionsState(),
@@ -121,6 +135,74 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
         )
         XCTAssertNotNil(recorder.appLiveSink)
     }
+
+    // MARK: - No cold-build at the recording edge
+
+    /// `attachSinks` runs at recording start. It must NOT cold-build the
+    /// controller there — a cold build kicks a heavy CoreML model load
+    /// (Nemotron ~584 MB) from the recorder-start path, landing the compile on
+    /// the meeting edge and starving the system. The controller is warmed at
+    /// launch/idle instead; if it isn't warmed yet, this recording simply gets
+    /// no captions (they come online at the next idle prewarm).
+    ///
+    /// Non-vacuity: the engine provider IS set (via `beginPrewarm`) and captions
+    /// ARE eligible when `attachSinks` runs, so the pre-fix `ensureController()`
+    /// path would build one (proven by reverting `attachSinks` to `ensureController`).
+    func testAttachSinksDoesNotColdBuildControllerAtRecordingStart() async {
+        var enabled = false
+        let (factory, buildCount) = countingControllerFactory()
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { enabled },
+            engineSupportsLive: { true },
+            verboseDiagnostics: { false },
+            makeController: factory,
+        )
+        // Prewarm while captions are disabled: engine provider is wired, but
+        // nothing is built (not eligible). Plain-`var` toggles don't fire the
+        // @Observable re-warm observer, so the controller stays nil.
+        coordinator.beginPrewarm { MockStreamingEngine() }
+        XCTAssertEqual(buildCount(), 0, "prewarm with captions disabled must not build a controller")
+
+        enabled = true // captions now eligible, controller still nil
+
+        let recorder = DualSourceRecorder()
+        await coordinator.attachSinks(to: recorder)
+
+        XCTAssertEqual(buildCount(), 0, "attachSinks must not cold-build the controller at the recording edge")
+        XCTAssertNil(recorder.micLiveSink, "no warmed controller → no sinks this recording")
+        XCTAssertNil(recorder.appLiveSink)
+    }
+
+    /// The warm path: once the controller is prewarmed, repeated recordings reuse
+    /// the SAME instance and never trigger a rebuild (which would recompile models).
+    func testWarmedControllerIsReusedAcrossRecordingsWithoutRebuild() async {
+        let (factory, buildCount) = countingControllerFactory()
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { true },
+            engineSupportsLive: { true },
+            verboseDiagnostics: { false },
+            makeController: factory,
+        )
+        coordinator.beginPrewarm { MockStreamingEngine() }
+        XCTAssertEqual(buildCount(), 1, "prewarm builds the controller once")
+
+        for _ in 0 ..< 3 {
+            let recorder = DualSourceRecorder()
+            await coordinator.attachSinks(to: recorder)
+            XCTAssertNotNil(recorder.micLiveSink)
+        }
+
+        XCTAssertEqual(buildCount(), 1, "warm controller must be reused across recordings, never rebuilt")
+    }
+}
+
+/// Mutable reference counter for `countingControllerFactory` (all accesses are
+/// `@MainActor`-isolated via the test case).
+@MainActor
+private final class BuildCounter {
+    var count = 0
 }
 
 /// A `TranscribingEngine` that does NOT conform to `StreamingTranscribingEngine`

--- a/app/MeetingTranscriber/Tests/ModelWarmupQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/ModelWarmupQueueTests.swift
@@ -1,0 +1,71 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// `ModelWarmupQueue` serializes model warm-up loads so the ASR engine and the
+/// live-caption streaming models don't compile/load concurrently at launch (the
+/// simultaneous ANE + CoreML-compiler peak that starves the system on a meeting
+/// join). These tests pin the two load-bearing guarantees: submitted ops never
+/// overlap, and `run` awaits its op (so callers keep their "await until loaded"
+/// contract).
+@MainActor
+final class ModelWarmupQueueTests: XCTestCase {
+    /// Records op lifecycle events in submission-independent order.
+    @MainActor
+    private final class EventLog {
+        var events: [String] = []
+        func add(_ event: String) {
+            events.append(event)
+        }
+    }
+
+    /// Two ops submitted concurrently must run one-at-a-time: each op's `enter`
+    /// and `exit` stay contiguous (no interleaving), even though each op yields
+    /// in the middle. A non-serializing queue (fire-and-forget) would interleave
+    /// them to `[enter1, enter2, ...]`, so this fails against that stub.
+    func testRunsSubmittedOperationsSeriallyNeverInterleaved() async {
+        let queue = ModelWarmupQueue()
+        let log = EventLog()
+        func op(_ id: Int) -> @MainActor () async -> Void {
+            {
+                log.add("enter\(id)")
+                await Task.yield()
+                await Task.yield()
+                log.add("exit\(id)")
+            }
+        }
+
+        // Submit both without awaiting the first: only the queue can serialize them.
+        async let first: Void = queue.run(op(1))
+        async let second: Void = queue.run(op(2))
+        _ = await (first, second)
+
+        // Order between the two ops is not guaranteed, but they must not overlap.
+        XCTAssertTrue(
+            log.events == ["enter1", "exit1", "enter2", "exit2"]
+                || log.events == ["enter2", "exit2", "enter1", "exit1"],
+            "ops must run serially without interleaving; got \(log.events)",
+        )
+    }
+
+    /// FIFO: sequential submissions preserve order.
+    func testPreservesSubmissionOrder() async {
+        let queue = ModelWarmupQueue()
+        let log = EventLog()
+        for id in 1 ... 4 {
+            await queue.run { log.add("op\(id)") }
+        }
+        XCTAssertEqual(log.events, ["op1", "op2", "op3", "op4"])
+    }
+
+    /// `run` must await its op's completion (the "await until loaded" contract
+    /// callers depend on). A fire-and-forget queue would return before `done`.
+    func testRunAwaitsOperationCompletion() async {
+        let queue = ModelWarmupQueue()
+        var done = false
+        await queue.run {
+            await Task.yield()
+            done = true
+        }
+        XCTAssertTrue(done, "run must not return until its op has finished")
+    }
+}


### PR DESCRIPTION
## Problem

Joining a meeting made the **whole machine** sluggish for the first several seconds (cursor lag, other apps stuttering) — not just this app's UI. Investigation on a live session (with live captions on, Parakeet/DE) traced it to a **concurrent CoreML compile/load storm at launch**: the ASR engine model and the live-caption streaming models all load on independent Tasks, so a batch of large models (Parakeet ~461 MB + Nemotron ~584 MB compiled twice + WeSpeaker) compiles at once. When that coincides with the meeting join (the app is often launched moments before the call), the simultaneous ANE + CoreML-compiler + CPU peak starves WindowServer and the whole compositor lags.

Memory pressure was ruled out with measurements (128 GB machine, swap 0, ~83 % free); the driver is compute/ANE/compiler contention, and specifically the *concurrent peak*, not the total work.

## Changes (two commits)

**1. Don't cold-build the live-caption controller at recording start.**
`attachSinks` ran on every recording start and, if no controller existed yet, cold-built one — which kicks a heavy CoreML load (Nemotron) from the recorder-start path, landing the compile exactly on the meeting edge. It's now existing-only: it attaches sinks to the already-warmed controller (whose object exists synchronously even while its models finish loading) and otherwise no-ops. The controller is built only at launch/idle prewarm, never at the recording edge.

**2. Serialize the launch model warm-ups through a shared queue.**
A new `ModelWarmupQueue` (a serial async gate) is shared between the engine preload and the live-caption prewarm, so at most one model compiles at a time. The total work is unchanged, but the concurrent peak — the system-wide driver — is removed. `run` awaits its op, so callers keep their existing "await until loaded" contract, and each engine keeps its own concurrent-load dedupe / failure handling. The already-warm reuse path (back-to-back recordings) is deliberately not routed through the queue, so it stays instant.

## Behavior note (intended trade-off)

If live captions are toggled on at the exact instant a meeting starts, that recording gets no captions and they come online at the next recording. This is by design: the alternative is exactly the cold compile-at-the-meeting-edge this PR removes. Captions that were already warmed (the normal case) are unaffected.

## Testing

- New unit tests: `attachSinks` must not cold-build at the recording edge (fails against the pre-change build-if-nil path); warm controller is reused across recordings without rebuild; `ModelWarmupQueue` runs ops serially without interleaving (fails against a parallel stub), FIFO order, awaits completion; and the controller's `prepare()` actually routes through the shared queue.
- Full unit suite green; lint clean; release-mode parity build passes.
- Biggest single mitigation for users right now is behavioral and needs no code: keep the app running before meetings so the warm-up finishes ahead of the join. This PR makes the launch peak gentler regardless.

## Possible follow-ups (not in this PR)

- Pin the live speaker-matcher model to CPU+ANE (drop its GPU/Metal compile variant) — small, and needs a check that the sustained matching cost and speaker-match stability don't regress.
- Defer a mid-recording engine/language settings change so it can't drop and rebuild the controller during a live meeting.
