### PR TITLE
fix(app): defer live-caption re-warm when settings change mid-recording

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -187,7 +187,10 @@ final class AppState {
         // `EngineController` does its own up-front sync + reactive observe in its
         // init; these hooks let the pipeline / live-transcription / watch paths
         // reach the active engine and re-sync before the first transcription.
-        liveTranscription.beginPrewarm { [weak self] in self?.engines.activeTranscriptionEngine }
+        liveTranscription.beginPrewarm(
+            engineProvider: { [weak self] in self?.engines.activeTranscriptionEngine },
+            isRecording: { [weak self] in self?.watching.isRecording == true },
+        )
         pipeline.activate { [weak self] in self?.engines.activeTranscriptionEngine }
         watching.activate { [weak self] in self?.engines.syncEngineSettings() }
 
@@ -365,7 +368,7 @@ final class AppState {
             liveEnabled: settings.liveTranscriptionEnabled,
             engineLanguage: settings.activeEngineLanguageOrNil,
             engineSupportsLive: settings.transcriptionEngine.supportsLiveTranscription,
-        ) && watching.watchLoop?.state == .recording
+        ) && watching.isRecording
     }
 
     var currentBadge: BadgeKind {

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionCoordinator.swift
@@ -12,9 +12,9 @@ import Observation
 /// caption-overlay window + RPC snapshot) and injects it here; the coordinator
 /// only owns the streaming `LiveTranscriptionController` and its warm-up.
 ///
-/// The active engine is supplied via `beginPrewarm(engineProvider:)` (called from
-/// `AppState.init` after stored-property init, where the `[weak self]` engine
-/// closure is valid) rather than captured at construction — so the coordinator
+/// The active engine + the `isRecording` probe are supplied via
+/// `beginPrewarm(engineProvider:isRecording:)` (called from `AppState.init` after
+/// stored-property init, where the `[weak self]` closures are valid) rather than captured at construction — so the coordinator
 /// never holds an AppState back-reference. `liveEnabled` / `engineSupportsLive` /
 /// `engineLanguage` / `verboseDiagnostics` are settings-backed closures.
 ///
@@ -29,6 +29,22 @@ final class LiveTranscriptionCoordinator {
     /// then (so `ensureController` safely no-ops if called early). Captures the
     /// owner weakly, so it returns nil once the owner is gone.
     private var engineProvider: (() -> (any TranscribingEngine)?)?
+
+    /// Whether a recording is currently in progress. Set by `beginPrewarm`;
+    /// defaults to "not recording". Drives the mid-recording re-warm defer in
+    /// `handleSettingsChange`.
+    private var isRecording: () -> Bool = { false }
+
+    /// Set when a settings change arrived during a recording and its re-warm was
+    /// deferred; applied at the next idle `flush()`.
+    private var needsRewarmWhenIdle = false
+
+    /// True while `attachSinks` is mid-flight (it awaits `prepareForNextRecording()`
+    /// between reading the controller and installing its sinks). The deferred
+    /// re-warm in `flush()` must not swap the controller out during that window,
+    /// or a fast manual stop→restart could leave the new recording feeding an
+    /// orphaned controller the coordinator no longer owns.
+    private var attachInFlight = false
 
     private let captions: LiveCaptionsState
     private let liveEnabled: () -> Bool
@@ -110,8 +126,12 @@ final class LiveTranscriptionCoordinator {
     /// calls in the AppState init body) to keep that init's type-check under the
     /// 300 ms budget — the compiler's constraint solver slows with every method
     /// call inside a long initializer.
-    func beginPrewarm(engineProvider: @escaping () -> (any TranscribingEngine)?) {
+    func beginPrewarm(
+        engineProvider: @escaping () -> (any TranscribingEngine)?,
+        isRecording: @escaping () -> Bool = { false },
+    ) {
         self.engineProvider = engineProvider
+        self.isRecording = isRecording
         prewarmAndObserve()
     }
 
@@ -134,6 +154,8 @@ final class LiveTranscriptionCoordinator {
         // finishes. If it was never warmed, this recording gets no captions and
         // they come online at the next idle prewarm.
         guard captionsEligible, let controller else { return }
+        attachInFlight = true
+        defer { attachInFlight = false }
         await controller.prepareForNextRecording()
         recorder.micLiveSink = controller.micSink
         recorder.appLiveSink = controller.appSink
@@ -144,24 +166,33 @@ final class LiveTranscriptionCoordinator {
     /// engine / never warmed). Called at STOP time — before any `prepareForNextRecording()` that
     /// clears caption state on the next recording — so the user sees the final
     /// caption of the last utterance. Idempotent: a second call after the
-    /// pipelines already flushed finds nothing pending and emits nothing.
+    /// pipelines already flushed finds nothing pending and emits nothing. Also
+    /// applies any re-warm deferred by a mid-recording settings change (see
+    /// `handleSettingsChange`), now that we are idle.
     func flush() async {
         await controller?.flush()
+        // Now idle: apply any re-warm deferred by a mid-recording settings change.
+        // Skip while an `attachSinks` is mid-flight — swapping the controller then
+        // would orphan the one it is binding (fast manual stop→restart).
+        if needsRewarmWhenIdle, !isRecording(), !attachInFlight {
+            needsRewarmWhenIdle = false
+            controller = nil
+            prewarmIfEligible()
+        }
     }
 
     /// Eagerly load the VAD + engine models when the toggle is on (or already on
     /// at launch with a streaming engine) so the first utterance after the
-    /// recorder starts doesn't pay the cold-load cost. Plus a re-arming
-    /// `withObservationTracking` watcher on the toggle + engine setting: on every
-    /// change, drop the cached controller so the next `ensureController()` rebuilds
-    /// against the (possibly new) active engine and re-warms it.
-    ///
-    /// Engine changes take effect on the **next** recording. Switching the engine
-    /// mid-recording deallocates the controller, buffers from the running recorder
-    /// no longer reach any engine, and the live overlay goes silent until the next
-    /// recording. Live mid-recording engine swap is a deferred follow-up.
+    /// recorder starts doesn't pay the cold-load cost, then arm the settings
+    /// observer.
     private func prewarmAndObserve() {
         prewarmIfEligible()
+        observeSettings()
+    }
+
+    /// Arm a one-shot `withObservationTracking` watcher on the toggle + engine
+    /// settings and route each change through `handleSettingsChange`.
+    private func observeSettings() {
         withObservationTracking {
             // Touch the underlying settings via the gate closures so the change
             // tracker observes `liveTranscriptionEnabled` + `transcriptionEngine`
@@ -170,12 +201,25 @@ final class LiveTranscriptionCoordinator {
             _ = engineSupportsLive()
             _ = engineLanguage()
         } onChange: { [weak self] in
-            Task { @MainActor in
-                guard let self else { return }
-                self.controller = nil
-                self.prewarmAndObserve()
-            }
+            Task { @MainActor in self?.handleSettingsChange() }
         }
+    }
+
+    /// React to a toggle / engine / language change. While idle, drop the cached
+    /// controller and rebuild against the new settings immediately. While a
+    /// recording is in progress, DEFER: keep the current meeting's warm
+    /// controller (so no CoreML recompile lands mid-recording and the overlay
+    /// stays live on the current engine), re-arm the observer, and apply the
+    /// rebuild at the next idle `flush()`. Either way the engine change takes
+    /// effect on the next recording.
+    private func handleSettingsChange() {
+        guard !isRecording() else {
+            needsRewarmWhenIdle = true
+            observeSettings()
+            return
+        }
+        controller = nil
+        prewarmAndObserve()
     }
 
     private func prewarmIfEligible() {

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -101,6 +101,12 @@ final class WatchingController {
         watchLoop?.isActive == true && watchLoop?.isManualRecording == false
     }
 
+    /// Whether a recording is currently in progress (the watch loop is in its
+    /// `.recording` state).
+    var isRecording: Bool {
+        watchLoop?.state == .recording
+    }
+
     // MARK: - Start / Stop
 
     func toggleWatching() {

--- a/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveTranscriptionCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import MeetingTranscriber
 import XCTest
 
@@ -242,6 +243,82 @@ final class LiveTranscriptionCoordinatorTests: XCTestCase {
         }
         XCTAssertTrue(settled, "prepare() should complete and publish its backend once the queue drains")
         _ = await blocker.value
+    }
+
+    // MARK: - Mid-recording settings-change defer
+
+    /// Builds a `LiveTranscriptionCoordinator` wired to a real @Observable
+    /// `AppSettings` (on a volatile suite) that makes live captions eligible via
+    /// the re-transcribe path. Deliberately nil-language so the mock controller's
+    /// `prepare()` stays on the re-transcribe branch (the mock engine's no-op
+    /// `loadModel`) and never loads a real streaming model. A real settings
+    /// mutation drives the coordinator's `withObservationTracking`. Returns the
+    /// coordinator, its settings (mutate to fire the observer), and a
+    /// controller-build counter.
+    private func makeEligibleCoordinator(_ suiteName: String, isRecording: @escaping () -> Bool)
+        -> (LiveTranscriptionCoordinator, AppSettings, () -> Int) {
+        // swiftlint:disable:next force_unwrapping
+        let settings = AppSettings(defaults: UserDefaults(suiteName: suiteName)!)
+        settings.transcriptionEngine = .parakeet
+        settings.parakeetLanguage = ""
+        settings.whisperLanguage = ""
+        settings.liveTranscriptionEnabled = true
+        let (factory, buildCount) = countingControllerFactory()
+        let coordinator = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { settings.liveTranscriptionEnabled },
+            engineSupportsLive: { settings.transcriptionEngine.supportsLiveTranscription },
+            engineLanguage: { settings.activeEngineLanguageOrNil },
+            verboseDiagnostics: { false },
+            makeController: factory,
+        )
+        let makeEngine: () -> (any TranscribingEngine)? = { MockStreamingEngine() }
+        coordinator.beginPrewarm(engineProvider: makeEngine, isRecording: isRecording)
+        return (coordinator, settings, buildCount)
+    }
+
+    /// A settings change (here: engine) DURING a recording must not drop and
+    /// rebuild the controller — that would recompile a model mid-meeting and
+    /// black out the overlay. The re-warm is deferred and applied at the next idle
+    /// `flush()`, so the current meeting keeps its warm controller and the new
+    /// settings take effect on the next recording.
+    ///
+    /// Non-vacuity: against the pre-change "always rebuild on change" behavior the
+    /// mid-recording assertion sees a rebuild (count 2) and fails.
+    func testSettingsChangeDuringRecordingDefersRebuildUntilIdle() async {
+        let suiteName = "LiveTxCoordTests-\(getpid())-\(UUID().uuidString)"
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        var recording = true
+        let (coordinator, settings, buildCount) = makeEligibleCoordinator(suiteName) { recording }
+        XCTAssertEqual(buildCount(), 1, "prewarm builds the controller once")
+
+        // Settings change (engine) while recording → deferred, controller kept.
+        settings.transcriptionEngine = .whisperKit
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertEqual(buildCount(), 1, "a mid-recording settings change must not rebuild the controller")
+
+        // Back to idle + flush → the deferred rebuild applies.
+        recording = false
+        await coordinator.flush()
+        XCTAssertEqual(buildCount(), 2, "the deferred rebuild applies at the next idle flush")
+    }
+
+    /// The idle path is unchanged: a settings change while NOT recording rebuilds
+    /// the controller immediately (so it re-warms against the new engine).
+    func testSettingsChangeWhileIdleRebuildsImmediately() async {
+        let suiteName = "LiveTxCoordTests-\(getpid())-\(UUID().uuidString)"
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        let (coordinator, settings, buildCount) = makeEligibleCoordinator(suiteName) { false }
+        XCTAssertEqual(buildCount(), 1)
+
+        settings.transcriptionEngine = .whisperKit
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertEqual(buildCount(), 2, "an idle settings change rebuilds the controller immediately")
+        _ = coordinator // retain through the observer fire above
     }
 }
 


### PR DESCRIPTION
## Problem

Follow-up to the meeting-start warm-up work. The live-caption coordinator watches the toggle / engine / language settings and, on any change, dropped the cached controller and rebuilt it immediately. When that change lands **during a recording** it deallocates the warm controller mid-meeting: the caption overlay goes silent, and the rebuild recompiles a CoreML model in the middle of the call — the exact compile-at-the-wrong-moment this line of work is removing.

## Change

Add an `isRecording` probe (wired from AppState to the watch-loop state) and defer the re-warm while a recording is in progress:

- **Idle** settings change: drop + rebuild immediately (unchanged).
- **Mid-recording** settings change: keep the current meeting on its already-warm controller, remember that a re-warm is pending, and apply it at the next idle `flush()`.

So an engine/language change still takes effect on the next recording, just without dropping the controller or recompiling during the live meeting. The `WatchingController.isRecording` predicate is extracted and reused by the existing `shouldShowLiveCaptions` check (it was duplicated inline).

## Concurrency hardening

`flush()` now applies the deferred rebuild, which means it can null the controller after an `await`. A fast manual stop→restart within the stop-time flush window could otherwise leave the new recording feeding a controller the coordinator no longer owns (lost final caption + a transient duplicate model stack). An `attachInFlight` guard makes `flush()` skip the swap while `attachSinks` is mid-flight, so the two never race; the deferred rebuild self-heals at the following idle flush. The auto-detect path was already immune (it enters `.recording` before the recorder is built); this covers the manual path too.

## Testing

- New unit tests drive a real `@Observable` AppSettings through the observer: a mid-recording settings change does not rebuild the controller (fails against the prior always-rebuild behavior), the deferred rebuild applies at the next idle flush, and an idle settings change still rebuilds immediately.
- Full unit suite green; lint clean; release-mode parity build passes.
