### PR TITLE
fix(app): name meeting outputs from the meeting-start time, in one basename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     UpdateChecker.swift    # GitHub release update checker
     Bundle+AppVersion.swift # Bundle extension: appVersion + gitCommitHash from Info.plist
     FileManager+OwnerOnly.swift # FileManager extension: owner-only file permission constant (rw-------, single source of truth)
+    DateFormatter+FilenameStamp.swift # Shared Gregorian/POSIX filename-stamp formatter factory (used by ProtocolGenerator + DualSourceRecorder)
     SingleFlight.swift        # Single-flight async deduplication coordinator (concurrent callers await one shared run)
     ModelWarmupQueue.swift    # Serial async gate ordering launch model warm-ups one-at-a-time (avoids the concurrent CoreML compile storm that starves the system on a meeting join)
     DiagnosticExporter.swift # Reads log entries → shareable .log file (Settings → Advanced → Export Diagnostics)

--- a/app/MeetingTranscriber/Sources/DateFormatter+FilenameStamp.swift
+++ b/app/MeetingTranscriber/Sources/DateFormatter+FilenameStamp.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension DateFormatter {
+    /// A `DateFormatter` with the given format, pinned to the Gregorian calendar
+    /// and the POSIX locale. Filename stamps are the primary sort key for saved
+    /// files, so they must not resolve `yyyy` in the user's regional calendar
+    /// (e.g. a Buddhist or Japanese-era year) or localize digits. Timezone stays
+    /// `.current` so the stamp reads in local time.
+    static func filenameStamp(_ format: String) -> DateFormatter {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.dateFormat = format
+        return fmt
+    }
+}

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -571,11 +571,9 @@ class DualSourceRecorder: RecordingProvider {
         return deviceRate
     }
 
-    private static let timestampFormatter: DateFormatter = {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyyMMdd_HHmmss"
-        return fmt
-    }()
+    // Pinned Gregorian/POSIX: these stems are the final user-visible filenames
+    // in record-only mode, so the year must not localize into a regional calendar.
+    private static let timestampFormatter = DateFormatter.filenameStamp("yyyyMMdd_HHmmss")
 
     private static func timestamp() -> String {
         timestampFormatter.string(from: Date())

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -257,6 +257,10 @@ final class PipelineController {
                 meetingTitle: title, appName: appName,
                 mixPath: group.mix, appPath: group.app, micPath: group.mic,
                 micDelay: micDelay, participants: participants,
+                // Record-only fleet flow: a separate host reprocesses recordings
+                // captured elsewhere. Anchor the output basename on the sidecar's
+                // real meeting-start time, not this reprocessing moment.
+                meetingStartTime: sidecar?.startedAt,
                 autoSkipNaming: autoSkipNaming,
             )
             ids.append(job.id)

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -56,6 +56,13 @@ struct PipelineJob: Identifiable, Codable {
     let micDelay: TimeInterval
     let participants: [String]
     let enqueuedAt: Date
+    /// Wall-clock time the recording started (meeting start), derived from the
+    /// recorder's `recordingStart` uptime at enqueue. Used to anchor the
+    /// output-file basename so the filename reflects when the meeting happened,
+    /// not when the pipeline processed it. `nil` for reimport/orphan-recovery
+    /// jobs (no live recording) and for legacy snapshots persisted before this
+    /// field existed — callers fall back to `enqueuedAt`.
+    var meetingStartTime: Date?
     var state: JobState
     var error: String?
     var warnings: [String]
@@ -91,6 +98,7 @@ struct PipelineJob: Identifiable, Codable {
         micPath: URL?,
         micDelay: TimeInterval,
         participants: [String] = [],
+        meetingStartTime: Date? = nil,
         autoSkipNaming: Bool = false,
     ) {
         self.id = UUID()
@@ -102,6 +110,7 @@ struct PipelineJob: Identifiable, Codable {
         self.micDelay = micDelay
         self.participants = participants
         self.enqueuedAt = Date()
+        self.meetingStartTime = meetingStartTime
         self.state = .waiting
         self.error = nil
         self.warnings = []

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -23,8 +23,9 @@ extension PipelineQueue {
         let micPath: URL?
         let micDelay: TimeInterval
         let participants: [String]
-        /// Persisted-file basename, computed once from title + jobID so the
-        /// diarization and protocol stages agree on the same `\(slug)_16k.wav`.
+        /// Persisted-file basename, computed once from title + jobID + the
+        /// meeting-start time so the transcript, protocol, diarization and
+        /// audio stages all agree on the same `\(slug)` stem.
         let slug: String
     }
 
@@ -71,7 +72,9 @@ extension PipelineQueue {
             micPath: job.micPath,
             micDelay: job.micDelay,
             participants: job.participants,
-            slug: Self.namingSlug(title: job.meetingTitle, jobID: job.id),
+            // Anchor the basename on the meeting start; reimport/orphan jobs
+            // have no recorded start, so fall back to the enqueue time.
+            slug: Self.namingSlug(title: job.meetingTitle, jobID: job.id, startTime: job.meetingStartTime ?? job.enqueuedAt),
         )
 
         do {
@@ -476,7 +479,7 @@ extension PipelineQueue {
     ) async throws {
         // --- Save Transcript & Audio (always) ---
         let protocolsDir = outputDir.appendingPathComponent("protocols")
-        let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, title: ctx.title, dir: protocolsDir)
+        let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, basename: ctx.slug, dir: protocolsDir)
         logger.info("[\(ctx.shortID, privacy: .public)] transcript_saved file=\(txtPath.lastPathComponent, privacy: .private)")
 
         if let idx = jobs.firstIndex(where: { $0.id == ctx.jobID }) {
@@ -487,7 +490,7 @@ extension PipelineQueue {
         let recordingsDir = outputDir.appendingPathComponent("recordings")
         Self.copyAudioToOutput(
             mixPath: ctx.mixPath, appPath: ctx.appPath, micPath: ctx.micPath,
-            title: ctx.title, outputDir: recordingsDir,
+            basename: ctx.slug, outputDir: recordingsDir,
         )
 
         // --- Persist 16kHz audio for re-diarization (move instead of copy to avoid double I/O) ---
@@ -560,6 +563,12 @@ extension PipelineQueue {
             return
         }
         let shortID = PipelineJob.shortID(for: jobID)
+        // Reuse the basename fixed when the transcript was saved (persisted as
+        // namingSlug), so the .md shares the .txt/audio stem exactly. This runs
+        // only after a transcript exists, so namingSlug is set on every real
+        // path; the fallback just keeps generation working if the job is gone.
+        let basename = jobs.first { $0.id == jobID }?.namingSlug
+            ?? Self.namingSlug(title: title, jobID: jobID, startTime: Date())
         do {
             updateJobState(id: jobID, to: .generatingProtocol)
             startElapsedTimer()
@@ -571,7 +580,7 @@ extension PipelineQueue {
             )
             let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + transcript
             let mdPath = try ProtocolGenerator.saveProtocol(
-                fullMD, title: title, dir: protocolsDir,
+                fullMD, basename: basename, dir: protocolsDir,
             )
             logger.info("[\(shortID, privacy: .public)] protocol_saved file=\(mdPath.lastPathComponent, privacy: .private)")
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {
@@ -627,7 +636,7 @@ extension PipelineQueue {
     /// is skipped, no persistent mix is written.
     private static func copyAudioToOutput(
         mixPath: URL?, appPath: URL?, micPath: URL?,
-        title: String, outputDir: URL,
+        basename: String, outputDir: URL,
     ) {
         // Each move below renames-in-place — if two of the three URLs point at
         // the same file, the first move destroys the source for the next one.
@@ -648,11 +657,12 @@ extension PipelineQueue {
 
         let fm = FileManager.default
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
-        let slug = ProtocolGenerator.filename(title: title, ext: "").dropLast() // remove trailing "."
+        // Reuse the job's single basename so the audio copies match the
+        // transcript/protocol stems exactly (same meeting-start stamp + shortID).
         let audioPaths: [(URL, String)] = [
-            mixPath.map { ($0, "\(slug)\(RecordingFileSuffix.mix)") },
-            appPath.map { ($0, "\(slug)\(RecordingFileSuffix.app)") },
-            micPath.map { ($0, "\(slug)\(RecordingFileSuffix.mic)") },
+            mixPath.map { ($0, "\(basename)\(RecordingFileSuffix.mix)") },
+            appPath.map { ($0, "\(basename)\(RecordingFileSuffix.app)") },
+            micPath.map { ($0, "\(basename)\(RecordingFileSuffix.mic)") },
         ].compactMap(\.self)
 
         let outputDirStd = outputDir.standardizedFileURL

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -140,8 +140,8 @@ class PipelineQueue {
     /// Filesystem slug for a job's persisted artefacts. Thin alias for
     /// `SpeakerNamingStore.slug` — kept so existing call sites (`processNext`,
     /// tests) don't have to reach into the store for a pure helper.
-    static func namingSlug(title: String, jobID: UUID) -> String {
-        SpeakerNamingStore.slug(title: title, jobID: jobID)
+    static func namingSlug(title: String, jobID: UUID, startTime: Date) -> String {
+        SpeakerNamingStore.slug(title: title, jobID: jobID, startTime: startTime)
     }
 
     /// Returns naming data for a specific job ID, or the first pending job as fallback.

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -104,12 +104,15 @@ enum ProtocolGenerator {
 
     /// Save a transcript to a text file.
     ///
+    /// `basename` is the job's precomputed, meeting-start-anchored stem (shared
+    /// with the protocol and audio artifacts); the `.txt` extension is appended.
+    ///
     /// - Returns: URL of the saved file
-    static func saveTranscript(_ text: String, title: String, dir: URL) throws -> URL {
+    static func saveTranscript(_ text: String, basename: String, dir: URL) throws -> URL {
         let accessing = dir.startAccessingSecurityScopedResource()
         defer { if accessing { dir.stopAccessingSecurityScopedResource() } }
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let url = dir.appendingPathComponent(filename(title: title, ext: "txt"))
+        let url = dir.appendingPathComponent("\(basename).txt")
         try text.write(to: url, atomically: true, encoding: .utf8)
         // Transcripts contain verbatim meeting speech — restrict to owner-only.
         try FileManager.default.restrictToOwner(url)
@@ -119,12 +122,15 @@ enum ProtocolGenerator {
 
     /// Save a protocol to a Markdown file.
     ///
+    /// `basename` is the job's precomputed, meeting-start-anchored stem (shared
+    /// with the transcript and audio artifacts); the `.md` extension is appended.
+    ///
     /// - Returns: URL of the saved file
-    static func saveProtocol(_ markdown: String, title: String, dir: URL) throws -> URL {
+    static func saveProtocol(_ markdown: String, basename: String, dir: URL) throws -> URL {
         let accessing = dir.startAccessingSecurityScopedResource()
         defer { if accessing { dir.stopAccessingSecurityScopedResource() } }
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let url = dir.appendingPathComponent(filename(title: title, ext: "md"))
+        let url = dir.appendingPathComponent("\(basename).md")
         try markdown.write(to: url, atomically: true, encoding: .utf8)
         // Protocol markdown summarises the meeting — restrict to owner-only.
         try FileManager.default.restrictToOwner(url)
@@ -132,11 +138,7 @@ enum ProtocolGenerator {
         return url
     }
 
-    private static let filenameFormatter: DateFormatter = {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyyMMdd_HHmm"
-        return fmt
-    }()
+    private static let filenameFormatter = DateFormatter.filenameStamp("yyyyMMdd_HHmm")
 
     /// Sanitize a title into a safe filename slug (path-traversal safe).
     /// Falls back to `"meeting"` if no allowed characters remain.
@@ -176,11 +178,24 @@ enum ProtocolGenerator {
         return result.isEmpty ? title : result
     }
 
-    /// Generate a filename: `{yyyyMMdd_HHmm}_{slug}.{ext}`
-    static func filename(title: String, ext: String) -> String {
-        let date = filenameFormatter.string(from: Date())
+    /// Build a filesystem basename: `{yyyyMMdd_HHmm}_{slug}[_{shortID}]`.
+    ///
+    /// The timestamp is anchored on `startTime` (the meeting start) so the name
+    /// reflects when the meeting happened, not when the pipeline processed it.
+    /// The trailing `shortID` (when non-empty) is a per-job collision guard so
+    /// two same-title meetings can't clobber each other's files. Empty
+    /// components are dropped, so `shortID: ""` yields the plain
+    /// `{yyyyMMdd_HHmm}_{slug}` shape.
+    static func basename(title: String, startTime: Date, shortID: String) -> String {
+        let date = filenameFormatter.string(from: startTime)
         let slug = sanitizeSlug(title)
-        return "\(date)_\(slug).\(ext)"
+        return [date, slug, shortID].filter { !$0.isEmpty }.joined(separator: "_")
+    }
+
+    /// Generate a filename: `{yyyyMMdd_HHmm}_{slug}.{ext}`, stamped with the
+    /// current time and no collision suffix. Thin wrapper over `basename`.
+    static func filename(title: String, ext: String) -> String {
+        "\(basename(title: title, startTime: Date(), shortID: "")).\(ext)"
     }
 }
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
@@ -22,9 +22,12 @@ struct SpeakerNamingStore {
     /// rebuild — without it both jobs would resolve to the same
     /// `<title>_naming.json` and the second save would overwrite the first,
     /// then both UUIDs would map to the survivor.
-    static func slug(title: String, jobID: UUID) -> String {
-        let titleSlug = String(ProtocolGenerator.filename(title: title, ext: "").dropLast())
-        return "\(titleSlug)_\(PipelineJob.shortID(for: jobID))"
+    static func slug(title: String, jobID: UUID, startTime: Date) -> String {
+        ProtocolGenerator.basename(
+            title: title,
+            startTime: startTime,
+            shortID: PipelineJob.shortID(for: jobID),
+        )
     }
 
     private var recordingsDir: URL? {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -425,6 +425,7 @@ class WatchLoop {
             micPath: recording.micPath,
             micDelay: recording.micDelay,
             participants: participants,
+            meetingStartTime: wallClockDate(forUptime: recording.recordingStart),
         )
         pipelineQueue?.enqueue(job)
         logger.info("Enqueued pipeline job for: \(title, privacy: .private)")

--- a/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineControllerTests.swift
@@ -171,6 +171,33 @@ final class PipelineControllerTests: XCTestCase {
         XCTAssertEqual(pc.queue.jobs.count, 1, "Paired _app + _mic collapse into a single job")
     }
 
+    func testPairedReimportAnchorsMeetingStartOnSidecar() throws {
+        let pc = makeWiredController()
+        // A record-only capture reprocessed later on a separate host: paired
+        // app+mic files plus a sidecar recording the real meeting-start time.
+        let app = tmpDir.appendingPathComponent("standup_app.wav")
+        let mic = tmpDir.appendingPathComponent("standup_mic.wav")
+        FileManager.default.createFile(atPath: app.path, contents: Data("RIFF".utf8))
+        FileManager.default.createFile(atPath: mic.path, contents: Data("RIFF".utf8))
+        let meetingStart = try localDate(2026, 3, 4, 9, 15)
+        let sidecar = RecordingSidecar(
+            title: "Weekly Sync", appName: "Teams",
+            startedAt: meetingStart, stoppedAt: meetingStart.addingTimeInterval(1800),
+            participants: [], micDelaySeconds: 0,
+            mixFilename: "standup_mix.wav", appFilename: "standup_app.wav", micFilename: "standup_mic.wav",
+        )
+        try sidecar.write(toDirectory: tmpDir, basename: "standup")
+
+        pc.enqueueExistingFiles([app, mic])
+
+        let job = try XCTUnwrap(pc.queue.jobs.first)
+        XCTAssertEqual(
+            job.meetingStartTime, meetingStart,
+            "reimport must anchor the basename on the sidecar's meeting-start, not the reprocess time",
+        )
+        XCTAssertEqual(job.meetingTitle, "Weekly Sync")
+    }
+
     // MARK: - jobStatus
 
     func testJobStatusReturnsLiveJob() {

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -977,6 +977,86 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    // MARK: - One meeting-start-anchored basename per job
+
+    private func makeStraightThroughQueue() -> (PipelineQueue, MockProtocolGen) {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello world")]
+        let diar = MockDiarization()
+        diar.resultToReturn = DiarizationResult(
+            segments: [.init(start: 0, end: 5, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 5],
+            autoNames: [:],
+            embeddings: nil, // no matcher/naming pause → job runs straight to .done
+        )
+        let protocolGen = MockProtocolGen()
+        return (makeCapturingQueue(engine: engine, diar: diar, protocolGen: protocolGen), protocolGen)
+    }
+
+    /// Transcript, protocol, and both audio artifacts of one job must all land on
+    /// the identical stem, stamped with the meeting-start time and carrying the
+    /// job shortID. Fails against the old code, which stamped each save with a
+    /// fresh `Date()` (processing time) and omitted the shortID from the
+    /// transcript/protocol/mix names.
+    func testAllArtifactsShareOneMeetingStartAnchoredBasename() async throws {
+        let (q, _) = makeStraightThroughQueue()
+        let start = try localDate(2026, 3, 4, 9, 15)
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Weekly Sync", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+            meetingStartTime: start,
+        )
+        q.enqueue(job)
+        await q.processNext()
+
+        let stem = "20260304_0915_weekly_sync_\(job.shortID)"
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        let fm = FileManager.default
+        XCTAssertTrue(
+            fm.fileExists(atPath: protocolsDir.appendingPathComponent("\(stem).txt").path),
+            "transcript must use the meeting-start + shortID basename",
+        )
+        XCTAssertTrue(
+            fm.fileExists(atPath: protocolsDir.appendingPathComponent("\(stem).md").path),
+            "protocol must share the same basename",
+        )
+        XCTAssertTrue(
+            fm.fileExists(atPath: recordingsDir.appendingPathComponent("\(stem)_mix.wav").path),
+            "mix audio copy must share the same basename",
+        )
+        XCTAssertTrue(
+            fm.fileExists(atPath: recordingsDir.appendingPathComponent("\(stem)_16k.wav").path),
+            "16k audio must share the same basename",
+        )
+    }
+
+    /// A job with no recorded meeting-start (reimport / orphan recovery) must
+    /// fall back to the enqueue time for the stamp and still produce a valid,
+    /// shortID-carrying basename — never an empty stamp or a crash.
+    func testBasenameFallsBackToEnqueuedAtWhenNoMeetingStart() async throws {
+        let (q, _) = makeStraightThroughQueue()
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Reimport Test", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+            meetingStartTime: nil,
+        )
+        q.enqueue(job)
+        await q.processNext()
+
+        // enqueuedAt is captured in init, so the expected stem is deterministic.
+        let expectedStem = PipelineQueue.namingSlug(
+            title: "Reimport Test", jobID: job.id, startTime: job.enqueuedAt,
+        )
+        let txt = tmpDir.appendingPathComponent("protocols").appendingPathComponent("\(expectedStem).txt")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: txt.path),
+            "reimport job must stamp with enqueuedAt and keep the shortID, got stem: \(expectedStem)",
+        )
+    }
+
     /// An engine that doesn't produce per-utterance timestamps (emitting one
     /// segment for the whole recording) must skip diarization entirely — running
     /// it would collapse the meeting onto a single speaker — and warn the user.
@@ -3105,11 +3185,10 @@ final class PipelineQueueTests: XCTestCase {
     /// second job's `_naming.json` / `_16k.wav` overwrites the first's, and
     /// snapshot rebuild then maps the survivor's data onto both UUIDs.
     /// Embedding the job's short-id keeps each on-disk artefact distinct.
-    func test_namingSlug_differsForSameTitleDifferentJobs() {
-        let id1 = UUID()
-        let id2 = UUID()
-        let slug1 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id1)
-        let slug2 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id2)
+    func test_namingSlug_differsForSameTitleDifferentJobs() throws {
+        let start = try localDate(2026, 3, 4, 9, 15)
+        let slug1 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: UUID(), startTime: start)
+        let slug2 = PipelineQueue.namingSlug(title: "Daily Standup", jobID: UUID(), startTime: start)
         XCTAssertNotEqual(
             slug1, slug2,
             "Identical titles must produce distinct slugs when job IDs differ",
@@ -3118,16 +3197,17 @@ final class PipelineQueueTests: XCTestCase {
 
     /// Determinism: same input → same slug. Snapshot rebuild relies on this
     /// to find a job's persisted `_naming.json` after a relaunch.
-    func test_namingSlug_isDeterministicForSameJob() {
+    func test_namingSlug_isDeterministicForSameJob() throws {
         let id = UUID()
-        let first = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
-        let second = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
+        let start = try localDate(2026, 3, 4, 9, 15)
+        let first = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id, startTime: start)
+        let second = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id, startTime: start)
         XCTAssertEqual(first, second)
     }
 
-    func test_namingSlug_embedsTitleAndShortID() {
+    func test_namingSlug_embedsTitleAndShortID() throws {
         let id = UUID()
-        let slug = PipelineQueue.namingSlug(title: "Daily Standup", jobID: id)
+        let slug = try PipelineQueue.namingSlug(title: "Daily Standup", jobID: id, startTime: localDate(2026, 3, 4, 9, 15))
         XCTAssertTrue(
             slug.contains(PipelineJob.shortID(for: id)),
             "Slug must include the job short-ID for uniqueness across same-title runs",

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -73,6 +73,43 @@ final class ProtocolGeneratorTests: XCTestCase {
         XCTAssertTrue(note.contains("[Remote]"))
     }
 
+    // MARK: - Basename (meeting-start anchored)
+
+    func testBasenameUsesInjectedStartTimeNotNow() throws {
+        let name = try ProtocolGenerator.basename(
+            title: "Daily Standup",
+            startTime: localDate(2026, 7, 15, 18, 30),
+            shortID: "a1b2c3d4",
+        )
+        // Stamp reflects the meeting start (18:30), not the wall clock now.
+        XCTAssertEqual(name, "20260715_1830_daily_standup_a1b2c3d4")
+    }
+
+    func testBasenameOmitsEmptyShortID() throws {
+        let name = try ProtocolGenerator.basename(
+            title: "Daily Standup",
+            startTime: localDate(2026, 7, 15, 18, 30),
+            shortID: "",
+        )
+        // Empty shortID must not leave a trailing separator.
+        XCTAssertEqual(name, "20260715_1830_daily_standup")
+        XCTAssertFalse(name.hasSuffix("_"))
+    }
+
+    func testBasenameShortIDSuffixSurvivesReimportRoundTrip() throws {
+        // Re-importing feeds a prior basename back in as a title. The leading
+        // timestamp must be stripped (no compounding) but the trailing shortID
+        // must be preserved as slug content, not mistaken for a stamp.
+        let prior = "20260715_1830_daily_standup_a1b2c3d4"
+        let reimported = try ProtocolGenerator.basename(
+            title: prior,
+            startTime: localDate(2026, 8, 1, 9, 0),
+            shortID: "e5f6a7b8",
+        )
+        XCTAssertEqual(reimported, "20260801_0900_daily_standup_a1b2c3d4_e5f6a7b8")
+        XCTAssertFalse(reimported.contains("20260715_1830"), "old leading stamp must be stripped")
+    }
+
     // MARK: - Filename Generation
 
     func testFilenameFormat() {
@@ -194,10 +231,10 @@ final class ProtocolGeneratorTests: XCTestCase {
         let tmpDir = try makeTempDirectory(prefix: "proto_test")
 
         let text = "[00:00] Hello\n[00:05] World"
-        let url = try ProtocolGenerator.saveTranscript(text, title: "Test", dir: tmpDir)
+        let url = try ProtocolGenerator.saveTranscript(text, basename: "20260101_0000_test", dir: tmpDir)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
-        XCTAssertTrue(url.lastPathComponent.hasSuffix("_test.txt"))
+        XCTAssertEqual(url.lastPathComponent, "20260101_0000_test.txt")
 
         let loaded = try String(contentsOf: url, encoding: .utf8)
         XCTAssertEqual(loaded, text)
@@ -207,13 +244,30 @@ final class ProtocolGeneratorTests: XCTestCase {
         let tmpDir = try makeTempDirectory(prefix: "proto_test")
 
         let markdown = "# Meeting Protocol\n\n## Summary\nTest meeting."
-        let url = try ProtocolGenerator.saveProtocol(markdown, title: "Standup", dir: tmpDir)
+        let url = try ProtocolGenerator.saveProtocol(markdown, basename: "20260101_0000_standup", dir: tmpDir)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
-        XCTAssertTrue(url.lastPathComponent.hasSuffix("_standup.md"))
+        XCTAssertEqual(url.lastPathComponent, "20260101_0000_standup.md")
 
         let loaded = try String(contentsOf: url, encoding: .utf8)
         XCTAssertEqual(loaded, markdown)
+    }
+
+    /// The transcript and protocol of one job must land on the identical stem
+    /// (only the extension differs) when handed the same basename — the fix for
+    /// the old cross-artifact minute drift, where each save re-derived its own
+    /// `Date()`-stamped name.
+    func testSaveTranscriptAndProtocolShareBasename() throws {
+        let tmpDir = try makeTempDirectory(prefix: "shared_basename")
+        let base = "20260715_1830_daily_standup_a1b2c3d4"
+        let txt = try ProtocolGenerator.saveTranscript("t", basename: base, dir: tmpDir)
+        let md = try ProtocolGenerator.saveProtocol("# m", basename: base, dir: tmpDir)
+        XCTAssertEqual(txt.lastPathComponent, "\(base).txt")
+        XCTAssertEqual(md.lastPathComponent, "\(base).md")
+        XCTAssertEqual(
+            txt.deletingPathExtension().lastPathComponent,
+            md.deletingPathExtension().lastPathComponent,
+        )
     }
 
     func testSaveCreatesDirectory() throws {
@@ -222,7 +276,7 @@ final class ProtocolGeneratorTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: tmpDir.path))
 
-        let url = try ProtocolGenerator.saveTranscript("test", title: "X", dir: tmpDir)
+        let url = try ProtocolGenerator.saveTranscript("test", basename: "x", dir: tmpDir)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
@@ -438,7 +492,7 @@ final class ProtocolGeneratorTests: XCTestCase {
     /// (0600), not world-readable from the inherited umask.
     func testSaveTranscriptWritesOwnerOnlyPermissions() throws {
         let dir = try makeTempDirectory(prefix: "ProtocolGenSaveTranscript")
-        let url = try ProtocolGenerator.saveTranscript("hello world", title: "Standup", dir: dir)
+        let url = try ProtocolGenerator.saveTranscript("hello world", basename: "standup", dir: dir)
 
         let mode = try XCTUnwrap(
             FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int,
@@ -449,7 +503,7 @@ final class ProtocolGeneratorTests: XCTestCase {
     /// Protocol markdown summarises the meeting — same owner-only requirement.
     func testSaveProtocolWritesOwnerOnlyPermissions() throws {
         let dir = try makeTempDirectory(prefix: "ProtocolGenSaveProtocol")
-        let url = try ProtocolGenerator.saveProtocol("# Notes", title: "Standup", dir: dir)
+        let url = try ProtocolGenerator.saveProtocol("# Notes", basename: "standup", dir: dir)
 
         let mode = try XCTUnwrap(
             FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int,

--- a/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingStoreTests.swift
@@ -37,25 +37,38 @@ final class SpeakerNamingStoreTests: XCTestCase {
 
     // MARK: - slug
 
-    func test_slug_differsForSameTitleDifferentJobs() {
-        let slug1 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID())
-        let slug2 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID())
+    func test_slug_differsForSameTitleDifferentJobs() throws {
+        let start = try localDate(2026, 3, 4, 9, 15)
+        let slug1 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID(), startTime: start)
+        let slug2 = SpeakerNamingStore.slug(title: "Daily Standup", jobID: UUID(), startTime: start)
         XCTAssertNotEqual(slug1, slug2)
     }
 
-    func test_slug_isDeterministicForSameJob() {
+    func test_slug_isDeterministicForSameJob() throws {
         let id = UUID()
+        let start = try localDate(2026, 3, 4, 9, 15)
         XCTAssertEqual(
-            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id),
-            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id),
+            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id, startTime: start),
+            SpeakerNamingStore.slug(title: "Daily Standup", jobID: id, startTime: start),
         )
     }
 
-    func test_slug_embedsTitleAndShortID() {
+    func test_slug_embedsTitleAndShortID() throws {
         let id = UUID()
-        let slug = SpeakerNamingStore.slug(title: "Daily Standup", jobID: id)
+        let slug = try SpeakerNamingStore.slug(title: "Daily Standup", jobID: id, startTime: localDate(2026, 3, 4, 9, 15))
         XCTAssertTrue(slug.contains(PipelineJob.shortID(for: id)))
         XCTAssertTrue(slug.lowercased().contains("daily") && slug.lowercased().contains("standup"))
+    }
+
+    func test_slug_anchorsStampOnStartTime() throws {
+        let id = UUID()
+        let start = try localDate(2026, 7, 15, 18, 30)
+        let slug = SpeakerNamingStore.slug(title: "Daily Standup", jobID: id, startTime: start)
+        XCTAssertTrue(
+            slug.hasPrefix("20260715_1830_daily_standup_"),
+            "slug must be stamped with the meeting-start time, got: \(slug)",
+        )
+        XCTAssertTrue(slug.hasSuffix(PipelineJob.shortID(for: id)))
     }
 
     // MARK: - save / load round-trip
@@ -63,7 +76,7 @@ final class SpeakerNamingStoreTests: XCTestCase {
     func test_saveThenLoad_roundTripsMapping() throws {
         let store = SpeakerNamingStore(outputDir: tmpDir)
         let id = UUID()
-        let slug = SpeakerNamingStore.slug(title: "Standup", jobID: id)
+        let slug = try SpeakerNamingStore.slug(title: "Standup", jobID: id, startTime: localDate(2026, 3, 4, 9, 15))
         try store.save(makeData(jobID: id, mapping: ["SPEAKER_0": "Alice"]), slug: slug)
 
         let loaded = try XCTUnwrap(store.load(slug: slug))
@@ -113,8 +126,9 @@ final class SpeakerNamingStoreTests: XCTestCase {
         let title = "Daily Standup"
         let id1 = UUID()
         let id2 = UUID()
-        let slug1 = SpeakerNamingStore.slug(title: title, jobID: id1)
-        let slug2 = SpeakerNamingStore.slug(title: title, jobID: id2)
+        let start = try localDate(2026, 3, 4, 9, 15)
+        let slug1 = SpeakerNamingStore.slug(title: title, jobID: id1, startTime: start)
+        let slug2 = SpeakerNamingStore.slug(title: title, jobID: id2, startTime: start)
 
         try store.save(makeData(jobID: id1, title: title, mapping: ["SPEAKER_0": "Alice"]), slug: slug1)
         try store.save(makeData(jobID: id2, title: title, mapping: ["SPEAKER_0": "Bob"]), slug: slug2)

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -305,6 +305,11 @@ class MockRecorder: RecordingProvider {
     var micLevelDBFS: Double = -120
     var appLevelDBFS: Double = -120
 
+    /// Overrides the `recordingStart` uptime `stop()` reports. `nil` (default)
+    /// yields the current `systemUptime` at stop time, matching a real recorder;
+    /// set it to pin a specific meeting-start time (e.g. filename-anchoring tests).
+    var recordingStartUptime: TimeInterval?
+
     func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging _: Bool) {
         startCalled = true
         capturedAppPID = appPID
@@ -322,8 +327,37 @@ class MockRecorder: RecordingProvider {
             appPath: appPath,
             micPath: micPath,
             micDelay: 0,
-            recordingStart: ProcessInfo.processInfo.systemUptime,
+            recordingStart: recordingStartUptime ?? ProcessInfo.processInfo.systemUptime,
         )
+    }
+}
+
+/// A `MeetingDetecting` stub that never detects a meeting and reports any given
+/// meeting as inactive — so a `WatchLoop.handleMeeting(...)` ends immediately.
+/// Shared so per-test files don't each redeclare it.
+final class ImmediatelyInactiveDetector: MeetingDetecting {
+    func checkOnce() -> DetectedMeeting? {
+        nil
+    }
+
+    func isMeetingActive(_: DetectedMeeting) -> Bool {
+        false
+    }
+
+    func reset(appName _: String?) {}
+}
+
+extension XCTestCase {
+    /// Build a `Date` from local-time components in the Gregorian calendar,
+    /// matching the app's filename formatter (pinned Gregorian/POSIX, current
+    /// timezone). Using a fixed calendar keeps stamp assertions valid on
+    /// contributor machines whose regional calendar isn't Gregorian.
+    func localDate(_ y: Int, _ mo: Int, _ d: Int, _ h: Int, _ mi: Int) throws -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        var c = DateComponents()
+        c.year = y; c.month = mo; c.day = d; c.hour = h; c.minute = mi
+        return try XCTUnwrap(cal.date(from: c))
     }
 }
 

--- a/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
@@ -36,18 +36,6 @@ private final class CapturingRecorder: RecordingProvider {
     }
 }
 
-private final class ImmediatelyInactiveDetector: MeetingDetecting {
-    func checkOnce() -> DetectedMeeting? {
-        nil
-    }
-
-    func isMeetingActive(_: DetectedMeeting) -> Bool {
-        false
-    }
-
-    func reset(appName _: String?) {}
-}
-
 /// Regression coverage for the bug where `handleMeeting` (auto-watch path)
 /// never assigned `activeRecorder`, leaving `AppState`'s channel-health
 /// polling task reading nil on every tick — the red-tint indicator never

--- a/app/MeetingTranscriber/Tests/WatchLoopMeetingStartTimeTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopMeetingStartTimeTests.swift
@@ -1,0 +1,48 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class WatchLoopMeetingStartTimeTests: XCTestCase {
+    /// The enqueued job must carry the meeting-start wall-clock time derived
+    /// from the recorder's `recordingStart` uptime, not the enqueue time.
+    /// Before the fix the job had no start-time field at all and filenames were
+    /// stamped with `Date()` at save (i.e. processing time).
+    func testEnqueueAnchorsMeetingStartTimeOnRecordingStart() async throws {
+        // Recording started ~5 minutes ago (in systemUptime terms).
+        let recorder = MockRecorder()
+        recorder.mixPath = URL(fileURLWithPath: "/tmp/test_meeting_start_time.wav")
+        recorder.recordingStartUptime = ProcessInfo.processInfo.systemUptime - 300
+        let queue = PipelineQueue()
+        let loop = WatchLoop(
+            detector: ImmediatelyInactiveDetector(),
+            recorderFactory: { recorder },
+            pipelineQueue: queue,
+            pollInterval: 0.01,
+            endGracePeriod: 0.01,
+            maxDuration: 10,
+            noMic: true,
+        )
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
+
+        let meeting = DetectedMeeting(
+            pattern: .teams,
+            windowTitle: "Test Meeting | Microsoft Teams",
+            ownerName: "Microsoft Teams",
+            windowPID: 9999,
+        )
+        try await loop.handleMeeting(meeting)
+
+        let job = try XCTUnwrap(queue.jobs.first, "handleMeeting must enqueue a job")
+        let startTime = try XCTUnwrap(
+            job.meetingStartTime,
+            "enqueue must anchor meetingStartTime on the recorder's recordingStart",
+        )
+        let secondsAgo = Date().timeIntervalSince(startTime)
+        XCTAssertEqual(
+            secondsAgo, 300, accuracy: 10,
+            "meetingStartTime should reflect the recording-start uptime (~5 min ago), not the enqueue time",
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Two long-standing warts in how saved meeting files are named:

1. **Wrong timestamp + cross-artifact drift.** The `yyyyMMdd_HHmm` prefix on the transcript, protocol, and audio copies was stamped with `Date()` at each save. The protocol is saved minutes after the transcript (after the LLM call), so a single meeting's `.txt` and `.md` could end up with different minute stamps. Worse, the stamp reflected *processing* time, not *meeting* time (a recording processed at 00:23 got `..._0023_...` for an evening meeting).
2. **Silent same-minute overwrite.** The prefix is minute-resolution and the writes are atomic-overwrite. The transcript/protocol/mix filenames carried no per-job id, so two meetings with the same title in the same minute could clobber each other's files.

## Change

- Plumb the meeting-start time (already captured by the recorder as `RecordingResult.recordingStart`, a `systemUptime` interval) through to a new `PipelineJob.meetingStartTime`, converting it to wall-clock at enqueue via the existing `WatchLoop.wallClockDate`.
- Introduce a single basename builder, `ProtocolGenerator.basename(title:startTime:shortID:)`, anchored on that start time and carrying the job short-id as a collision guard. The transcript, protocol, audio copies, and diarization sidecars all now share the identical stem (the naming slug that already carried the short-id).
- Reimport / orphan-recovery jobs (no live recording) fall back to the enqueue time — except the **record-only fleet reimport**, which now anchors on the sidecar's recorded `startedAt`, so a recording captured on one host and reprocessed on another is stamped with the real meeting day, not the reprocessing day.
- Route both filename formatters (the pipeline's and the record-only recorder's) through one shared `DateFormatter.filenameStamp(_:)` pinned to Gregorian/`en_US_POSIX`, so the stamp (now the primary sort key) can't resolve `yyyy` in a regional calendar (Buddhist year, Japanese era) or localize digits — in either naming path.
- Make the meeting-start argument required on the slug builders (no `Date()` default), so a future caller can't silently regress to processing-time stamps.

Result: filenames like `20260714_1830_weekly_sync_a1b2c3d4.{txt,md}` reflect when the meeting happened, match across all of a job's artifacts, and can no longer silently overwrite a same-minute same-title meeting.

Record-only *capture* naming is unaffected (it names files from the recorder's own start-time stamp and never goes through this path).

## Tests

TDD, RED-first throughout (the pipeline and reimport tests were each confirmed to fail against the pre-change behaviour by reverting the fix):

- `basename` is stamped from the injected start time (not `Date()`) and drops an empty short-id without a trailing separator.
- the naming slug is start-time anchored.
- the transcript, protocol, and both audio artifacts of one pipeline job land on one identical meeting-start + short-id stem.
- a reimport with no meeting-start falls back to the enqueue time; a paired record-only reimport anchors on the sidecar's `startedAt`.
- the job carries the meeting-start time end to end from the recorder result through enqueue.

Full unit suite green, lint clean, `swiftlint analyze` clean, release-mode parity build passes.

## Review notes (considered, not code-changed)

- **Short-id growth on repeated bare-file reimport.** Because the short-id is now in the user-facing names, reimporting an already-processed output file (stem-as-title, no sidecar) strips the leading stamp but keeps the trailing short-id and appends a fresh one, so the name grows by ~9 chars per cycle. In practice this needs deliberate repeated reimport of output files; the common flow (process once) and the sidecar-based fleet reimport (real title, no accretion) are unaffected. Stripping a trailing hex token would risk clobbering a legitimate title that ends in 8 hex chars, so this is left as a known minor limitation.
- **`generateProtocol` basename fallback.** When the job is present in the queue (every real path — the transcript is always saved first, which sets the slug), the persisted slug is reused verbatim. The `?? Date()` fallback only fires if the job has vanished from the queue by protocol-generation time, which the pipeline's control flow doesn't allow; it's a defensive branch, not a reachable divergence.
- **`filename(title:ext:)` is now a thin wrapper** over `basename` used only by its sanitization tests. Kept intentionally as a small convenience; it delegates to `basename`, so there's no duplicated logic.
- **Sleep-skew of the start time (follow-up, not in this PR).** The meeting-start wall-clock is derived at enqueue from `ProcessInfo.systemUptime`, which doesn't advance while the machine is asleep. If a Mac sleeps mid-meeting the derived start can drift later by the sleep duration (likely Intel-only; Apple Silicon's monotonic clock appears to tick through sleep). This inaccuracy pre-exists in the record-only sidecar's `startedAt`; a follow-up could capture a `Date()` at recording start and thread it through `RecordingResult` to make it exact by construction.

## Behaviour change for existing users

Output filenames change shape: they now look like `{recordedStamp}_{title}_{jobid8}.{txt,md}` (a short job id is appended and the stamp is the meeting-start time, an earlier time than the old processing-time stamp). Nothing in-repo depends on the old shape (the automation API returns opaque paths), but external tooling that globbed the old `{stamp}_{title}` pattern (e.g. hand-built Obsidian links) will see the new shape from the first post-upgrade meeting — worth a line in the release notes.

## Notes

Related to the filename-readability request in #501, but independent of the title-source question discussed in that thread (this PR fixes only the timestamp/collision behaviour; it does not change how the meeting title is derived).

Reviewed with an additional adversarial blind-spot pass: upgrade/downgrade snapshot transitions, orphan-recovery/ledger filename dependence, sidecar cleanup, and the `recordingStart == 0` crash-recovery path were all checked and confirmed safe.
