### PR TITLE
fix(app): use the real meeting window title, not the Teams Calendar tab

### DIFF
--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -305,6 +305,18 @@ jobs:
         timeout-minutes: 12
         run: bash scripts/e2e-app.sh --no-build --naming-confirm
 
+      # Title-source lane (issue #501): run the simulator with a window title
+      # equal to the app name (no usable meeting-window title), then assert the
+      # detected meeting title is the clean "MeetingSimulator Call" placeholder,
+      # not the raw IOKit assertion name. Fails against the pre-fix detector,
+      # so it guards the real deployed detection → title-selection chain.
+      # `--no-build` reuses the bundle the earlier lanes built + signed.
+      - name: Run title-source placeholder E2E (issue #501)
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 8
+        run: bash scripts/e2e-app.sh --no-build --title-source
+
       # Crash-recovery lane (issue #379 part 3, PR #385/#386): start a meeting,
       # SIGKILL the app mid-recording (no stop() → orphaned _app16k_raw.tmp +
       # unfinalized _mic.wav, no _mix.wav survive), relaunch, and assert the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ tools/audiotap/            # AudioTapLib — CATapDescription-based app audio ca
     StreamingMonoResamplerTests.swift
     TapFormatResolverTests.swift
     TimelineAnchorTests.swift
-tools/meeting-simulator/   # Meeting simulator tool for testing
+tools/meeting-simulator/   # Meeting simulator tool for testing (--title sets the window title the app's title lookup sees → drives the detected meeting title)
   Package.swift
   Sources/main.swift
 tools/mt-cli/              # Thin Swift client for DebugRPCServer (state, screenshot, open-settings, …)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     WavHeaderRepair.swift     # Repairs unfinalized WAV files from crash-interrupted recordings (RIFF/data chunk size fix)
     MeetingDetecting.swift # MeetingDetecting protocol + DetectedMeeting model
     MeetingDetector.swift  # Window title matching (counts each pattern once per poll)
+    MeetingTitleMatcher.swift  # Shared compiled idle/meeting title classifier per AppMeetingPattern (used by MeetingDetector + PowerAssertionDetector title lookup)
     FFmpegHelper.swift     # ffmpeg CLI detection + audio extraction for MKV/WebM/OGG
     AudioMixer.swift       # Multi-format audio loading (WAV/MP3/M4A/MP4 via AVAsset fallback, MKV/WebM/OGG via ffmpeg) + mixing to 16kHz mono
     LiveAudioResampler.swift # Streams live LiveAudioBuffer through AVAudioConverter → 16 kHz mono Float32 (feeds StreamingTranscriber)

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -1,8 +1,5 @@
 import CoreGraphics
 import Foundation
-import os.log
-
-private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "MeetingDetector")
 
 /// Polls window list to detect active meeting windows.
 ///
@@ -16,9 +13,9 @@ class MeetingDetector: MeetingDetecting {
     private var cooldownUntil: [String: Date] = [:]
     private let cooldownDuration: TimeInterval = 5 // brief cooldown to avoid re-detecting the same meeting
 
-    /// Pre-compiled regex for each pattern to avoid re-compilation on every poll.
-    private let compiledMeetingPatterns: [String: [NSRegularExpression]]
-    private let compiledIdlePatterns: [String: [NSRegularExpression]]
+    /// Pre-compiled title matcher per app (idle/meeting regexes), so titles are
+    /// classified without re-compiling regexes on every poll.
+    private let matchers: [String: MeetingTitleMatcher]
 
     /// Closure that provides the window list. Defaults to CGWindowListCopyWindowInfo.
     /// Override in tests to inject mock window data.
@@ -27,29 +24,12 @@ class MeetingDetector: MeetingDetecting {
     init(patterns: [AppMeetingPattern], confirmationCount: Int = 2) {
         self.patterns = patterns
         self.confirmationCount = confirmationCount
-
-        var meeting: [String: [NSRegularExpression]] = [:]
-        var idle: [String: [NSRegularExpression]] = [:]
-        for p in patterns {
-            meeting[p.appName] = p.meetingPatterns.compactMap { pattern in
-                do {
-                    return try NSRegularExpression(pattern: pattern)
-                } catch {
-                    logger.error("Invalid meeting regex for \(p.appName): \(pattern) — \(error.localizedDescription, privacy: .public)")
-                    return nil
-                }
-            }
-            idle[p.appName] = p.idlePatterns.compactMap { pattern in
-                do {
-                    return try NSRegularExpression(pattern: pattern)
-                } catch {
-                    logger.error("Invalid idle regex for \(p.appName): \(pattern) — \(error.localizedDescription, privacy: .public)")
-                    return nil
-                }
-            }
+        // reduce(into:) (last-wins), not Dictionary(uniqueKeysWithValues:),
+        // which traps on a duplicate appName. The pre-extraction loop tolerated
+        // duplicates silently; keep that (matches PowerAssertionDetector).
+        matchers = patterns.reduce(into: [:]) { dict, pattern in
+            dict[pattern.appName] = MeetingTitleMatcher(pattern: pattern)
         }
-        self.compiledMeetingPatterns = meeting
-        self.compiledIdlePatterns = idle
     }
 
     /// Single poll: check all windows against all patterns.
@@ -142,22 +122,11 @@ class MeetingDetector: MeetingDetecting {
             }
         }
 
-        // Skip idle patterns (pre-compiled)
-        let range = NSRange(title.startIndex..., in: title)
-        if let idleRegexes = compiledIdlePatterns[pattern.appName] {
-            for regex in idleRegexes where regex.firstMatch(in: title, range: range) != nil {
-                return nil
-            }
-        }
-
-        // Match meeting patterns (pre-compiled)
-        if let meetingRegexes = compiledMeetingPatterns[pattern.appName] {
-            for regex in meetingRegexes where regex.firstMatch(in: title, range: range) != nil {
-                return title
-            }
-        }
-
-        return nil
+        // Skip idle-tab titles before meeting classification (a Calendar-tab
+        // title matches both), then require a meeting-pattern match.
+        guard let matcher = matchers[pattern.appName] else { return nil }
+        if matcher.isIdleTitle(title) { return nil }
+        return matcher.isMeetingTitle(title) ? title : nil
     }
 
     /// Default window list provider using CGWindowListCopyWindowInfo.

--- a/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
@@ -1,0 +1,58 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "MeetingTitleMatcher")
+
+/// Compiled idle/meeting title semantics for one `AppMeetingPattern`.
+///
+/// Both meeting detectors classify window titles the same way — an idle-tab
+/// title (Teams' Calendar/Chat/… tabs) is not a meeting, a title matching the
+/// app's meeting patterns is. `MeetingDetector` used to own this logic;
+/// `PowerAssertionDetector` re-implemented a weaker version that skipped the
+/// idle check entirely (letting the Calendar tab leak in as the meeting title).
+/// Sharing the compiled matcher keeps the two in lock-step. Regexes are
+/// compiled once; invalid patterns are logged and dropped.
+struct MeetingTitleMatcher {
+    let appName: String
+    let ownerNames: [String]
+    private let idleRegexes: [NSRegularExpression]
+    private let meetingRegexes: [NSRegularExpression]
+
+    init(pattern: AppMeetingPattern) {
+        appName = pattern.appName
+        ownerNames = pattern.ownerNames
+        idleRegexes = Self.compile(pattern.idlePatterns, kind: "idle", appName: pattern.appName)
+        meetingRegexes = Self.compile(pattern.meetingPatterns, kind: "meeting", appName: pattern.appName)
+    }
+
+    /// True when `title` matches one of the app's idle-tab patterns (e.g. Teams'
+    /// `Calendar | …`). Must be checked *before* `isMeetingTitle`: a Calendar-tab
+    /// title also matches the Teams meeting regex, so meeting classification
+    /// alone would misclassify it as a real meeting.
+    func isIdleTitle(_ title: String) -> Bool {
+        Self.anyMatch(idleRegexes, title)
+    }
+
+    /// True when `title` matches one of the app's meeting-window patterns.
+    func isMeetingTitle(_ title: String) -> Bool {
+        Self.anyMatch(meetingRegexes, title)
+    }
+
+    private static func anyMatch(_ regexes: [NSRegularExpression], _ title: String) -> Bool {
+        let range = NSRange(title.startIndex..., in: title)
+        return regexes.contains { $0.firstMatch(in: title, range: range) != nil }
+    }
+
+    private static func compile(_ patterns: [String], kind: String, appName: String) -> [NSRegularExpression] {
+        patterns.compactMap { pattern in
+            do {
+                return try NSRegularExpression(pattern: pattern)
+            } catch {
+                logger.error(
+                    "Invalid \(kind, privacy: .public) regex for \(appName, privacy: .public): \(pattern, privacy: .public) — \(error.localizedDescription, privacy: .public)",
+                )
+                return nil
+            }
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
@@ -38,6 +38,38 @@ struct MeetingTitleMatcher {
         Self.anyMatch(meetingRegexes, title)
     }
 
+    /// Pick the best usable window title for this app from a `CGWindowList`
+    /// snapshot. Skips windows whose owner isn't ours, and titles that are
+    /// empty, equal to the app name, or idle-tab titles. Then, tiered:
+    /// 1. the first surviving title that matches a meeting pattern (the call
+    ///    window — for a 1:1 Teams call that is the other person's name);
+    /// 2. else the first surviving (non-idle) title, so an unrecognised-but-real
+    ///    title still surfaces rather than being over-filtered;
+    /// 3. else `nil` — the caller substitutes a clean placeholder.
+    /// No minimum-size gate here: a snapshot missing `kCGWindowBounds` must not
+    /// degrade a real title to the placeholder (title source only).
+    /// Idle-skip takes priority over the meeting match by design: never leaking
+    /// a Teams tab title is the goal, so a real meeting whose subject happens to
+    /// equal a tab name (e.g. a call literally titled "Files") degrades to the
+    /// placeholder. The opposite priority would re-leak the Calendar tab. This
+    /// matches `MeetingDetector`'s long-standing idle-before-meeting order.
+    func selectWindowTitle(from windows: [[String: Any]]) -> String? {
+        var firstNonIdle: String?
+        for window in windows {
+            guard let owner = window["kCGWindowOwnerName"] as? String,
+                  ownerNames.contains(owner),
+                  let title = window["kCGWindowName"] as? String,
+                  !title.isEmpty,
+                  title != appName,
+                  !isIdleTitle(title) else {
+                continue
+            }
+            if isMeetingTitle(title) { return title }
+            if firstNonIdle == nil { firstNonIdle = title }
+        }
+        return firstNonIdle
+    }
+
     private static func anyMatch(_ regexes: [NSRegularExpression], _ title: String) -> Bool {
         let range = NSRange(title.startIndex..., in: title)
         return regexes.contains { $0.firstMatch(in: title, range: range) != nil }

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -155,7 +155,7 @@ class PowerAssertionDetector: MeetingDetecting {
                     ownerNames: [match.processName],
                     meetingPatterns: [],
                 )
-                let title = lookupWindowTitle(appName: appName) ?? match.assertName
+                let title = lookupWindowTitle(appName: appName) ?? Self.placeholderTitle(appName: appName)
                 return DetectedMeeting(
                     pattern: meetingPattern,
                     windowTitle: title,
@@ -200,6 +200,14 @@ class PowerAssertionDetector: MeetingDetecting {
     }
 
     // MARK: - Window Title Lookup
+
+    /// Clean fallback title when no usable window title is found (e.g. Screen
+    /// Recording denied, or the app exposes only idle windows). Preferred over
+    /// the raw assertion name, which is often an internal placeholder
+    /// (Zoom's "Describe Activity Type") or a status string.
+    static func placeholderTitle(appName: String) -> String {
+        "\(appName) Call"
+    }
 
     /// Look up the actual meeting-window title for a detected app via
     /// CGWindowListCopyWindowInfo. Prefers a meeting-pattern window (a 1:1 call

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -89,12 +89,29 @@ class PowerAssertionDetector: MeetingDetecting {
     /// Override in tests to inject mock data.
     var windowListProvider: () -> [[String: Any]] = MeetingDetector.systemWindowList
 
+    /// Compiled title matcher per watched app, so the window-title lookup
+    /// classifies titles the same way `MeetingDetector` does (idle-tab titles
+    /// skipped, meeting-pattern titles preferred).
+    private let matchers: [String: MeetingTitleMatcher]
+
     init(
         patterns: [AssertionPattern] = PowerAssertionDetector.defaultPatterns,
         confirmationCount: Int = 2,
     ) {
         self.patterns = patterns
         self.confirmationCount = confirmationCount
+        matchers = patterns.reduce(into: [:]) { dict, pattern in
+            guard let meetingPattern = AppMeetingPattern.forAppName(pattern.appName) else {
+                // Drift guard: a watched assertion app with no matching
+                // AppMeetingPattern would silently title every meeting with the
+                // placeholder. Surface it (a consistency test also pins this).
+                logger.error(
+                    "No AppMeetingPattern for watched app \(pattern.appName, privacy: .public); its meeting titles fall back to the placeholder",
+                )
+                return
+            }
+            dict[pattern.appName] = MeetingTitleMatcher(pattern: meetingPattern)
+        }
     }
 
     func checkOnce() -> DetectedMeeting? {
@@ -184,23 +201,13 @@ class PowerAssertionDetector: MeetingDetecting {
 
     // MARK: - Window Title Lookup
 
-    /// Look up the actual window title for a detected meeting app via CGWindowListCopyWindowInfo.
-    /// Returns the first non-empty, non-idle window title matching the app's owner names.
+    /// Look up the actual meeting-window title for a detected app via
+    /// CGWindowListCopyWindowInfo. Prefers a meeting-pattern window (a 1:1 call
+    /// window carries the other person's name), skips idle-tab titles (Teams'
+    /// Calendar tab etc.), and returns nil when nothing usable is found so the
+    /// caller can substitute a placeholder instead of the raw assertion name.
     private func lookupWindowTitle(appName: String) -> String? {
-        guard let meetingPattern = AppMeetingPattern.forAppName(appName) else { return nil }
-        let windows = windowListProvider()
-
-        for window in windows {
-            guard let owner = window["kCGWindowOwnerName"] as? String,
-                  meetingPattern.ownerNames.contains(owner),
-                  let title = window["kCGWindowName"] as? String,
-                  !title.isEmpty,
-                  title != appName else {
-                continue
-            }
-            return title
-        }
-        return nil
+        matchers[appName]?.selectWindowTitle(from: windowListProvider())
     }
 
     // MARK: - Private

--- a/app/MeetingTranscriber/Tests/MeetingTitleMatcherTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingTitleMatcherTests.swift
@@ -1,0 +1,34 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class MeetingTitleMatcherTests: XCTestCase {
+    private let teams = MeetingTitleMatcher(pattern: .teams)
+
+    func test_isIdleTitle_matchesTeamsIdleTabs() {
+        XCTAssertTrue(teams.isIdleTitle("Calendar | Contoso | user@contoso.com | Microsoft Teams"))
+        XCTAssertTrue(teams.isIdleTitle("Microsoft Teams"))
+        XCTAssertTrue(teams.isIdleTitle("Chat | Contoso"))
+        XCTAssertFalse(teams.isIdleTitle("Sprint Review | Microsoft Teams"))
+        XCTAssertFalse(teams.isIdleTitle("Jane Doe | Microsoft Teams"))
+    }
+
+    func test_isMeetingTitle_matchesRealMeetingWindows() {
+        XCTAssertTrue(teams.isMeetingTitle("Sprint Review | Microsoft Teams"))
+        // The Calendar-tab title ALSO matches the meeting regex — this is exactly
+        // why idle titles must be excluded *before* meeting classification.
+        XCTAssertTrue(teams.isMeetingTitle("Calendar | Contoso | Microsoft Teams"))
+        XCTAssertTrue(MeetingTitleMatcher(pattern: .zoom).isMeetingTitle("Zoom Meeting"))
+        XCTAssertFalse(teams.isMeetingTitle("Home"))
+        XCTAssertFalse(teams.isMeetingTitle(""))
+    }
+
+    func test_invalidRegexIsDroppedNotCrashed() {
+        let bad = AppMeetingPattern(
+            appName: "X", ownerNames: ["X"],
+            meetingPatterns: ["[unterminated"], idlePatterns: ["(also bad"],
+        )
+        let matcher = MeetingTitleMatcher(pattern: bad)
+        XCTAssertFalse(matcher.isMeetingTitle("anything"))
+        XCTAssertFalse(matcher.isIdleTitle("anything"))
+    }
+}

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -3,23 +3,22 @@ import XCTest
 
 // MARK: - Test Helpers
 
-private func makeAssertionDict(
+/// Builds a single-app IOKit power-assertion dictionary in the shape
+/// `PowerAssertionDetector.assertionProvider` yields. Internal (not private) so
+/// PowerAssertionDetectorTitleTests can reuse it instead of re-declaring it.
+func makeAssertionDict(
     pid: Int32,
     processName: String,
     assertName: String,
     assertType: String = "PreventUserIdleDisplaySleep",
 ) -> [Int32: [[String: Any]]] {
-    [
-        pid: [
-            [
-                "Process Name": processName,
-                "AssertName": assertName,
-                "AssertType": assertType,
-                "AssertPID": pid,
-                "AssertLevel": 255,
-            ],
-        ],
-    ]
+    [pid: [[
+        "Process Name": processName,
+        "AssertName": assertName,
+        "AssertType": assertType,
+        "AssertPID": pid,
+        "AssertLevel": 255,
+    ]]]
 }
 
 private func makeDetector(confirmationCount: Int = 1) -> PowerAssertionDetector {
@@ -402,28 +401,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNotNil(detector.checkOnce())
     }
 
-    // MARK: - Window Title Lookup
-
-    func testWindowTitleUsedWhenFound() {
-        let detector = makeDetector()
-        detector.assertionProvider = {
-            makeAssertionDict(
-                pid: 1438,
-                processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress",
-            )
-        }
-        detector.windowListProvider = {
-            [[
-                "kCGWindowOwnerName": "Microsoft Teams",
-                "kCGWindowName": "Sprint Review | Microsoft Teams",
-                "kCGWindowOwnerPID": Int32(1438),
-            ]]
-        }
-        let result = detector.checkOnce()
-        XCTAssertNotNil(result)
-        XCTAssertEqual(result?.windowTitle, "Sprint Review | Microsoft Teams")
-    }
+    // MARK: - Window Title Lookup (further title cases in PowerAssertionDetectorTitleTests)
 
     func testAssertionNameUsedWhenNoWindowFound() {
         let detector = makeDetector()
@@ -439,41 +417,6 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let result = detector.checkOnce()
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
-    }
-
-    func testWindowTitleSkipsEmptyAndAppNameOnly() {
-        let detector = makeDetector()
-        detector.assertionProvider = {
-            makeAssertionDict(
-                pid: 1438,
-                processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress",
-            )
-        }
-        detector.windowListProvider = {
-            [
-                // Empty title — should be skipped
-                [
-                    "kCGWindowOwnerName": "Microsoft Teams",
-                    "kCGWindowName": "",
-                    "kCGWindowOwnerPID": Int32(1438),
-                ],
-                // Title equals app name — should be skipped
-                [
-                    "kCGWindowOwnerName": "Microsoft Teams",
-                    "kCGWindowName": "Microsoft Teams",
-                    "kCGWindowOwnerPID": Int32(1438),
-                ],
-                // Real meeting title
-                [
-                    "kCGWindowOwnerName": "Microsoft Teams",
-                    "kCGWindowName": "Daily Standup | Microsoft Teams",
-                    "kCGWindowOwnerPID": Int32(1438),
-                ],
-            ]
-        }
-        let result = detector.checkOnce()
-        XCTAssertEqual(result?.windowTitle, "Daily Standup | Microsoft Teams")
     }
 
     // MARK: - Reset Without App Name

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTests.swift
@@ -48,7 +48,9 @@ final class PowerAssertionDetectorTests: XCTestCase {
         let result = detector.checkOnce()
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.pattern.appName, "Microsoft Teams")
-        XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
+        // No window title available (empty list) → clean placeholder, not the
+        // raw assertion name.
+        XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call")
         XCTAssertEqual(result?.ownerName, "MSTeams")
         XCTAssertEqual(result?.windowPID, 1438)
     }
@@ -401,23 +403,7 @@ final class PowerAssertionDetectorTests: XCTestCase {
         XCTAssertNotNil(detector.checkOnce())
     }
 
-    // MARK: - Window Title Lookup (further title cases in PowerAssertionDetectorTitleTests)
-
-    func testAssertionNameUsedWhenNoWindowFound() {
-        let detector = makeDetector()
-        detector.assertionProvider = {
-            makeAssertionDict(
-                pid: 1438,
-                processName: "MSTeams",
-                assertName: "Microsoft Teams Call in progress",
-            )
-        }
-        // No matching windows
-        detector.windowListProvider = { [] }
-        let result = detector.checkOnce()
-        XCTAssertNotNil(result)
-        XCTAssertEqual(result?.windowTitle, "Microsoft Teams Call in progress")
-    }
+    // Window-title lookup + placeholder fallback: PowerAssertionDetectorTitleTests.
 
     // MARK: - Reset Without App Name
 

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
@@ -1,0 +1,108 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Title-selection behaviour of `PowerAssertionDetector`: it must prefer the
+/// real meeting window's title, skip Teams' idle-tab titles, and (once the
+/// placeholder ships) never leak the raw assertion name. Split out of
+/// `PowerAssertionDetectorTests` (that file is at the `type_body_length` cap).
+final class PowerAssertionDetectorTitleTests: XCTestCase {
+    private func win(owner: String, title: String?, pid: Int32 = 1438) -> [String: Any] {
+        var w: [String: Any] = ["kCGWindowOwnerName": owner, "kCGWindowOwnerPID": pid]
+        if let title { w["kCGWindowName"] = title }
+        return w
+    }
+
+    private func teamsDetector(windows: @escaping () -> [[String: Any]]) -> PowerAssertionDetector {
+        let detector = PowerAssertionDetector(confirmationCount: 1)
+        detector.assertionProvider = {
+            [1438: [[
+                "Process Name": "MSTeams",
+                "AssertName": "Microsoft Teams Call in progress",
+                "AssertType": "PreventUserIdleDisplaySleep",
+                "AssertPID": Int32(1438),
+                "AssertLevel": 255,
+            ]]]
+        }
+        detector.windowListProvider = windows
+        return detector
+    }
+
+    private func zoomDetector(windows: @escaping () -> [[String: Any]]) -> PowerAssertionDetector {
+        let detector = PowerAssertionDetector(confirmationCount: 1)
+        detector.assertionProvider = {
+            [2020: [[
+                "Process Name": "zoom.us",
+                "AssertName": "Zoom Video Communication",
+                "AssertType": "PreventUserIdleDisplaySleep",
+                "AssertPID": Int32(2020),
+                "AssertLevel": 255,
+            ]]]
+        }
+        detector.windowListProvider = windows
+        return detector
+    }
+
+    // MARK: - Moved from PowerAssertionDetectorTests (Window Title Lookup)
+
+    func testWindowTitleUsedWhenFound() {
+        let detector = teamsDetector { [self.win(owner: "Microsoft Teams", title: "Sprint Review | Microsoft Teams")] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Sprint Review | Microsoft Teams")
+    }
+
+    func testWindowTitleSkipsEmptyAndAppNameOnly() {
+        let detector = teamsDetector {
+            [
+                self.win(owner: "Microsoft Teams", title: ""),
+                self.win(owner: "Microsoft Teams", title: "Microsoft Teams"),
+                self.win(owner: "Microsoft Teams", title: "Daily Standup | Microsoft Teams"),
+            ]
+        }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Daily Standup | Microsoft Teams")
+    }
+
+    // MARK: - Idle-skip + meeting-pattern preference (this commit)
+
+    func testSkipsIdleCalendarPrefersMeetingWindow() {
+        // The Calendar-tab window is first AND matches the Teams meeting regex —
+        // the exact case the old code got wrong (it returned the first match).
+        let detector = teamsDetector {
+            [
+                self.win(owner: "Microsoft Teams", title: "Calendar | Contoso | user@contoso.com | Microsoft Teams"),
+                self.win(owner: "Microsoft Teams", title: "Sprint Review | Microsoft Teams"),
+            ]
+        }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Sprint Review | Microsoft Teams")
+    }
+
+    @MainActor
+    func testOneToOneCallTitleCleansToCallerName() {
+        let detector = teamsDetector { [self.win(owner: "Microsoft Teams", title: "Jane Doe | Microsoft Teams")] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Jane Doe | Microsoft Teams")
+        // The suffix is stripped downstream in WatchLoop → filename "Jane Doe".
+        XCTAssertEqual(WatchLoop.cleanTitle("Jane Doe | Microsoft Teams"), "Jane Doe")
+    }
+
+    func testZoomMeetingWindowUsed() {
+        // Zoom's in-call window is literally titled "Zoom Meeting" (a meeting
+        // pattern) — it must get the real title, not a placeholder.
+        let detector = zoomDetector { [self.win(owner: "zoom.us", title: "Zoom Meeting")] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Zoom Meeting")
+    }
+
+    func testNonIdleNonMeetingTitleKeptAsTier2() {
+        // Neither idle nor a meeting-pattern match: preserve today's behaviour
+        // (surface it) rather than over-filter to a placeholder.
+        let detector = teamsDetector { [self.win(owner: "Microsoft Teams", title: "Some Popup")] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Some Popup")
+    }
+
+    func testFirstMeetingWindowWinsInProviderOrder() {
+        let detector = teamsDetector {
+            [
+                self.win(owner: "Microsoft Teams", title: "A | Microsoft Teams"),
+                self.win(owner: "Microsoft Teams", title: "B | Microsoft Teams"),
+            ]
+        }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "A | Microsoft Teams")
+    }
+}

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
@@ -105,4 +105,29 @@ final class PowerAssertionDetectorTitleTests: XCTestCase {
         }
         XCTAssertEqual(detector.checkOnce()?.windowTitle, "A | Microsoft Teams")
     }
+
+    // MARK: - Placeholder fallback (this commit)
+
+    func testIdleOnlyWindowsFallBackToPlaceholder() {
+        // Only the Calendar tab is open (idle) — no real meeting window. The
+        // title must not be the Calendar tab nor the raw assertion name.
+        let detector = teamsDetector {
+            [self.win(owner: "Microsoft Teams", title: "Calendar | Contoso | user@contoso.com | Microsoft Teams")]
+        }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Microsoft Teams Call")
+    }
+
+    func testEmptyWindowListFallsBackToPlaceholder() {
+        // Replaces the old assertion-name fallback: no windows (e.g. Screen
+        // Recording denied) must yield a clean placeholder, not the assertName.
+        let detector = teamsDetector { [] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Microsoft Teams Call")
+    }
+
+    func testMissingWindowNameFallsBackToPlaceholder() {
+        // Field case: Screen Recording denied → kCGWindowName absent; the raw
+        // Zoom assertion name ("Describe Activity Type" in the wild) must not leak.
+        let detector = zoomDetector { [self.win(owner: "zoom.us", title: nil)] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Zoom Call")
+    }
 }

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorTitleTests.swift
@@ -15,13 +15,7 @@ final class PowerAssertionDetectorTitleTests: XCTestCase {
     private func teamsDetector(windows: @escaping () -> [[String: Any]]) -> PowerAssertionDetector {
         let detector = PowerAssertionDetector(confirmationCount: 1)
         detector.assertionProvider = {
-            [1438: [[
-                "Process Name": "MSTeams",
-                "AssertName": "Microsoft Teams Call in progress",
-                "AssertType": "PreventUserIdleDisplaySleep",
-                "AssertPID": Int32(1438),
-                "AssertLevel": 255,
-            ]]]
+            makeAssertionDict(pid: 1438, processName: "MSTeams", assertName: "Microsoft Teams Call in progress")
         }
         detector.windowListProvider = windows
         return detector
@@ -30,13 +24,7 @@ final class PowerAssertionDetectorTitleTests: XCTestCase {
     private func zoomDetector(windows: @escaping () -> [[String: Any]]) -> PowerAssertionDetector {
         let detector = PowerAssertionDetector(confirmationCount: 1)
         detector.assertionProvider = {
-            [2020: [[
-                "Process Name": "zoom.us",
-                "AssertName": "Zoom Video Communication",
-                "AssertType": "PreventUserIdleDisplaySleep",
-                "AssertPID": Int32(2020),
-                "AssertLevel": 255,
-            ]]]
+            makeAssertionDict(pid: 2020, processName: "zoom.us", assertName: "Zoom Video Communication")
         }
         detector.windowListProvider = windows
         return detector
@@ -74,12 +62,12 @@ final class PowerAssertionDetectorTitleTests: XCTestCase {
         XCTAssertEqual(detector.checkOnce()?.windowTitle, "Sprint Review | Microsoft Teams")
     }
 
-    @MainActor
-    func testOneToOneCallTitleCleansToCallerName() {
+    func testOneToOneCallUsesTheCallerWindowTitle() {
+        // A 1:1 Teams call window is titled with the other person's name; that
+        // becomes the meeting title. The " | Microsoft Teams" suffix is stripped
+        // downstream by WatchLoop.cleanTitle (covered in WatchLoopTests) → "Jane Doe".
         let detector = teamsDetector { [self.win(owner: "Microsoft Teams", title: "Jane Doe | Microsoft Teams")] }
         XCTAssertEqual(detector.checkOnce()?.windowTitle, "Jane Doe | Microsoft Teams")
-        // The suffix is stripped downstream in WatchLoop → filename "Jane Doe".
-        XCTAssertEqual(WatchLoop.cleanTitle("Jane Doe | Microsoft Teams"), "Jane Doe")
     }
 
     func testZoomMeetingWindowUsed() {
@@ -129,5 +117,37 @@ final class PowerAssertionDetectorTitleTests: XCTestCase {
         // Zoom assertion name ("Describe Activity Type" in the wild) must not leak.
         let detector = zoomDetector { [self.win(owner: "zoom.us", title: nil)] }
         XCTAssertEqual(detector.checkOnce()?.windowTitle, "Zoom Call")
+    }
+
+    // MARK: - Pattern-table drift guard
+
+    func testEveryWatchedAssertionAppHasAMeetingPattern() {
+        // The title matcher is built by joining the assertion-pattern table to
+        // the meeting-pattern table on appName. If an app is added to one but
+        // not the other, its titles silently become the placeholder forever —
+        // this pins the two tables together so the drift fails here, not in the field.
+        for pattern in PowerAssertionDetector.defaultPatterns {
+            XCTAssertNotNil(
+                AppMeetingPattern.forAppName(pattern.appName),
+                "\(pattern.appName) has no AppMeetingPattern; its meeting titles would always be the placeholder",
+            )
+        }
+    }
+
+    func testWatchedAppWithoutMeetingPatternFallsBackToPlaceholder() {
+        // The drift the consistency test guards against, exercised: a watched
+        // assertion app with no matching AppMeetingPattern gets no title matcher
+        // (init logs + skips it), so its window title can't be looked up and the
+        // detector substitutes the "<app> Call" placeholder rather than leaking a
+        // window/assertion string. Also covers the synthesized-pattern fallback.
+        let detector = PowerAssertionDetector(
+            patterns: [.init(appName: "Unknown App", processNames: ["unknownproc"], keywords: ["unknownmeeting"])],
+            confirmationCount: 1,
+        )
+        detector.assertionProvider = {
+            makeAssertionDict(pid: 999, processName: "unknownproc", assertName: "unknownmeeting in progress")
+        }
+        detector.windowListProvider = { [self.win(owner: "unknownproc", title: "Some Window", pid: 999)] }
+        XCTAssertEqual(detector.checkOnce()?.windowTitle, "Unknown App Call")
     }
 }

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -36,6 +36,7 @@ MIC_DEVICE_CHANGE=false  # build the issue #379 fault-injection seam + assert th
 CRASH_RECOVERY=false     # kill mid-recording + assert the orphan is recovered into the pipeline on relaunch (issue #379 part 3)
 REDEPLOY_ONLY=false      # rebuild + redeploy the canonical (non-fault) bundle and exit — restores a clean bundle after --mic-device-change
 NAMING_CONFIRM=false     # drive the speaker-naming CONFIRM path end-to-end via POST /v1/jobs/<id>/naming (see run_naming_confirm)
+TITLE_SOURCE=false       # drive the window-title lookup with a no-usable-title case + assert the clean placeholder (issue #501 title source)
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -52,6 +53,7 @@ while [ $# -gt 0 ]; do
         --crash-recovery)   CRASH_RECOVERY=true ;;
         --redeploy-only)    REDEPLOY_ONLY=true ;;
         --naming-confirm)   NAMING_CONFIRM=true ;;
+        --title-source)     TITLE_SOURCE=true ;;
         -h|--help)
             cat <<'HELP'
 Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
@@ -119,6 +121,12 @@ Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
                        pollutes the persistent speaker DB; that snapshot/restore
                        is $GITHUB_ACTIONS-gated, so a LOCAL run enrolls voices
                        into your real speaker DB (a warning is printed).
+  --title-source       Issue #501: run meeting-simulator with a window title equal
+                       to the app name (no usable meeting-window title), then assert
+                       the detected meeting title is the clean "MeetingSimulator Call"
+                       placeholder — not the raw IOKit assertion name. Fails against
+                       the pre-fix detector, so it proves the deployed
+                       detection → title-selection chain end-to-end.
   --fixture            Audio fixture for meeting-simulator. Default: two_speakers_de.wav.
 HELP
             exit 0
@@ -1361,6 +1369,31 @@ run_naming_confirm() {
     log "$label: shared fixture intact after the lane ✅"
 }
 
+# Title-source lane (issue #501): drive the app's window-title lookup with a
+# title that is NOT usable — the window title equals the app name, which the
+# lookup skips — so PowerAssertionDetector finds no meeting-window title and
+# must fall back to the clean "<app> Call" placeholder. Pre-fix the detector
+# leaked the raw IOKit assertion name ("Simulator Meeting Call in progress")
+# instead, so this assertion fails against the old code (non-vacuous). Proves
+# the real deployed detection → title-selection → job-title chain, which the
+# unit tests can only exercise through injected seams.
+run_title_source() {
+    local label="[title-source]"
+    log "$label: starting meeting-simulator --title MeetingSimulator (no usable window title) → $SIMULATOR_FIXTURE"
+    "$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" --title "MeetingSimulator" >/tmp/e2e-app-sim.log 2>&1 &
+    SIM_PID=$!
+
+    _poll_for_new_lastjob_terminal "$label" ignore-recovered
+    [ "$POLL_LJ_STATE" = "done" ] || fail "$label: lastJob.state == \"$POLL_LJ_STATE\", expected \"done\""
+
+    local meeting_title
+    meeting_title="$(rpc /state | jq -r '.lastJob.meetingTitle // empty')"
+    log "$label: lastJob.meetingTitle = \"$meeting_title\""
+    [ "$meeting_title" = "MeetingSimulator Call" ] \
+        || fail "$label: meetingTitle == \"$meeting_title\", expected \"MeetingSimulator Call\". The window title equalled the app name, so the title lookup should return nil and the detector substitute the placeholder; a leaked assertion name or window title means the title-source fix regressed."
+    log "$label: PASS — no usable window title fell back to the clean placeholder ✅"
+}
+
 if [ "$REIMPORT_LATEST" = true ]; then
     # Skip the live-record phase and reuse a WAV produced by an earlier
     # `--record-only --keep-recordings` run on this host. Picks the
@@ -1424,6 +1457,8 @@ elif [ "$CRASH_RECOVERY" = true ]; then
     run_crash_recovery
 elif [ "$NAMING_CONFIRM" = true ]; then
     run_naming_confirm
+elif [ "$TITLE_SOURCE" = true ]; then
+    run_title_source
 elif [ "$TWO_MEETINGS" = true ]; then
     run_one_meeting "[1/2]"
     log "Sleeping ${INTER_MEETING_COOLDOWN_S}s for WatchLoop cooldown before meeting 2"

--- a/tools/meeting-simulator/Sources/main.swift
+++ b/tools/meeting-simulator/Sources/main.swift
@@ -23,8 +23,14 @@ struct MeetingSimulator: ParsableCommand {
     @Argument(help: "Path to fixture WAV. Defaults to the repo's two_speakers_de.wav.")
     var audioPath: String?
 
-    @Argument(help: "Window title. Must match a MeetingDetector pattern for auto-detect to fire.")
-    var windowTitle: String = "Simulator Meeting | MeetingSimulator"
+    @Option(name: .long, help: """
+    Window title the simulated meeting window shows. Detection fires off the
+    power assertion regardless; this title is what the app's title lookup sees,
+    so it drives the resulting meeting title / output filename. Default matches
+    the MeetingSimulator meeting pattern. Set to "MeetingSimulator" (the app
+    name) to exercise the no-usable-title placeholder path.
+    """)
+    var title: String = "Simulator Meeting | MeetingSimulator"
 
     @Flag(help: """
     Play the fixture at volume=0 so the audio device stays active but produces
@@ -48,11 +54,11 @@ struct MeetingSimulator: ParsableCommand {
 
     func run() {
         let fixturePath = audioPath ?? Self.findFixture()
-        let title = windowTitle
+        let windowTitle = title
         let silentMode = silent
         let dur = duration
         MainActor.assumeIsolated {
-            runSimulator(fixturePath: fixturePath, windowTitle: title, silent: silentMode, duration: dur)
+            runSimulator(fixturePath: fixturePath, windowTitle: windowTitle, silent: silentMode, duration: dur)
         }
     }
 


### PR DESCRIPTION
## Problem

Saved meeting files came out named like `20260715_0023_calendar__company__emailslug`. There is no calendar-matching feature — that string is literally the Teams main window's title while it sits on the **Calendar tab** (`Calendar | Company | you@company.com`). Production meeting detection (`PowerAssertionDetector`) fires on a power assertion and then grabbed the *first* Teams window title it found, never skipping Teams' idle-tab titles — despite its own docstring promising a "non-idle" title. So the Calendar tab leaked in as the meeting title.

(The timestamp/format half of #501 shipped separately; this PR fixes the title source.)

## Change

- Extract the idle/meeting title classification that `MeetingDetector` already owned into a shared `MeetingTitleMatcher`, and route `PowerAssertionDetector`'s title lookup through it — so the two detectors classify titles identically instead of the assertion detector re-implementing a weaker version that skipped the idle check.
- The lookup now skips idle-tab titles (Calendar / Chat / …), then prefers a **meeting-pattern window** (a 1:1 Teams call window is titled with the other person's name → that becomes the title, the caller-name fallback the requester asked for, for free), else the first non-idle title.
- When no usable title exists (Screen Recording denied → no window name; or only idle windows open), fall back to a clean **`<app> Call`** placeholder instead of the raw IOKit assertion name (often junk like Zoom's `Describe Activity Type`).

Result: scheduled meetings get the real meeting name, 1:1 calls get the caller's name, and the worst case is `Microsoft Teams Call` rather than `calendar__company__emailslug`. Zoom keeps its real `Zoom Meeting` title.

## Tests (TDD, RED-first)

- `MeetingTitleMatcher`: idle/meeting classification, including the trap that a Calendar-tab title matches **both** the idle regex and the Teams meeting regex (so idle must be checked first); invalid regexes are dropped, not crashed.
- `PowerAssertionDetector` title selection, driven end-to-end via injected assertions + window lists: a Calendar window in front of a real meeting window now picks the meeting window (fails against the old first-match code); a 1:1 title cleans to the caller name; Zoom's `Zoom Meeting` keeps its real title; empty / idle-only / missing-window-name all yield the placeholder; provider-order determinism.
- A consistency test pins the assertion-pattern ↔ meeting-pattern tables together, so a future app added to one table but not the other fails in CI rather than silently titling every meeting with the placeholder.
- `MeetingDetector`'s existing tests are unchanged — the extraction is behaviour-preserving.
- A live-recording e2e lane (`e2e-app.sh --title-source`) drives the deployed app via `meeting-simulator --title MeetingSimulator` (a window title equal to the app name → no usable meeting-window title) and asserts the detected meeting title is the clean `MeetingSimulator Call` placeholder, not the raw assertion name. Fails against the pre-fix detector, so it guards the real detection → title-selection chain that the unit tests can only reach through injected seams. `meeting-simulator`'s window title is now a named `--title` option.

Full unit suite green, lint clean, `swiftlint analyze` clean, release-mode parity build passes.

## Notes

Addresses the original complaint in #501. The requester confirmed on the issue that readable titles plus the (already-shipped) meeting-start timestamp fully solve their use case; they also mentioned a purely optional, explicitly non-blocking nice-to-have (a toggle to drop the time component from the filename), which is deliberately out of scope here.
