### PR TITLE
feat(app): add clickable help badges to settings options

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
@@ -21,22 +21,7 @@ struct AudioSettingsView: View {
                 }
             }
 
-            Section("Voice Activity Detection") {
-                Toggle("Voice Activity Detection (VAD)", isOn: $settings.vadEnabled)
-                    .help("Remove silence before transcription for better results")
-
-                if settings.vadEnabled {
-                    HStack {
-                        Text("Threshold:")
-                        Slider(value: $settings.vadThreshold, in: 0.3 ... 0.9, step: 0.05)
-                        Text(String(format: "%.2f", settings.vadThreshold))
-                            .monospacedDigit()
-                            .frame(width: 35)
-                    }
-                }
-            }
-            .accessibilityIdentifier("vadSection")
-            .recordOnlyDisabled(settings.recordOnly)
+            VoiceActivityDetectionSection(settings: settings)
 
             PerChannelIndicatorSection(settings: settings)
         }
@@ -53,25 +38,47 @@ struct AudioSettingsView: View {
     }
 }
 
+private struct VoiceActivityDetectionSection: View {
+    @Bindable var settings: AppSettings
+
+    var body: some View {
+        Section("Voice Activity Detection") {
+            HelpfulToggle(
+                title: "Voice Activity Detection (VAD)",
+                help: SettingsHelp.vad,
+                isOn: $settings.vadEnabled,
+            )
+
+            if settings.vadEnabled {
+                HStack {
+                    Text("Threshold:")
+                    Slider(value: $settings.vadThreshold, in: 0.3 ... 0.9, step: 0.05)
+                    Text(String(format: "%.2f", settings.vadThreshold))
+                        .monospacedDigit()
+                        .frame(width: 35)
+                }
+            }
+        }
+        .accessibilityIdentifier("vadSection")
+        .recordOnlyDisabled(settings.recordOnly)
+    }
+}
+
 private struct PerChannelIndicatorSection: View {
     @Bindable var settings: AppSettings
 
-    private static let toggleHelp =
-        "Turn the menu bar red when one capture channel goes silent while the other still carries audio. " +
-        "Catches asymmetric capture failures (muted mic, dropped app-audio tap) in real time."
-
-    private static let sliderHelp =
-        "Continuous asymmetric silence required before the indicator and notification fire. " +
-        "Short enough to surface a dead channel during a meeting, long enough to ignore speaking pauses."
-
     var body: some View {
         Section("Per-Channel Indicator") {
-            Toggle("Detect Silent Capture Channel", isOn: $settings.perChannelIndicatorEnabled)
-                .help(Self.toggleHelp)
+            HelpfulToggle(
+                title: "Detect Silent Capture Channel",
+                help: SettingsHelp.silentCaptureChannel,
+                isOn: $settings.perChannelIndicatorEnabled,
+            )
 
             if settings.perChannelIndicatorEnabled {
                 HStack {
                     Text("Warn after:")
+                    HelpBadge(text: SettingsHelp.asymmetricSilenceWarning)
                     Slider(
                         value: $settings.asymmetricSilenceWarningSeconds,
                         in: 30 ... 300,
@@ -81,7 +88,7 @@ private struct PerChannelIndicatorSection: View {
                         .monospacedDigit()
                         .frame(width: 40)
                 }
-                .help(Self.sliderHelp)
+                .help(SettingsHelp.asymmetricSilenceWarning)
             }
         }
         .accessibilityIdentifier("channelIndicatorSection")

--- a/app/MeetingTranscriber/Sources/Settings/HelpBadge.swift
+++ b/app/MeetingTranscriber/Sources/Settings/HelpBadge.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// A small, clickable ⓘ that explains a settings option in a popover.
+///
+/// The bare `.help()` tooltips used elsewhere are invisible until hovered, so
+/// non-expert users never discover them (issue #505). This gives an option a
+/// visible affordance while still exposing the same text as a hover tooltip and
+/// to VoiceOver.
+///
+/// Place it as a sibling of the option's label, not inside an interactive
+/// control's label (see ``HelpfulToggle`` for why). For a plain row:
+/// ```swift
+/// HStack(spacing: 4) {
+///     Text("Warn after:")
+///     HelpBadge(text: SettingsHelp.someOption)
+///     Slider(value: $seconds, in: 30 ... 300)
+/// }
+/// ```
+/// For a toggle row, use ``HelpfulToggle``, which wires the badge in safely.
+struct HelpBadge: View {
+    let text: String
+    @State private var showing = false
+
+    var body: some View {
+        Button {
+            showing.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.borderless)
+        // Show on hover (no click needed); the Button keeps click working for
+        // touch / keyboard / VoiceOver, which a hover-only affordance can't reach.
+        .onHover { showing = $0 }
+        // `.help` still feeds the full text to VoiceOver (AXHelp) and is the
+        // ViewInspector hook the tests match on (popover content isn't inspectable).
+        .help(text)
+        .accessibilityLabel("Help")
+        // Keep the hint terse and action-describing (per HIG); the full
+        // explanation is surfaced by the popover on activation/hover.
+        .accessibilityHint("Shows an explanation of this setting")
+        .popover(isPresented: $showing, arrowEdge: .trailing) {
+            Text(text)
+                .font(.callout)
+                // fixedSize forces the text to take its full multi-line height;
+                // without it the popover proposes a single line and truncates.
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(width: 280, alignment: .leading)
+                .padding()
+        }
+    }
+}
+
+/// A settings `Toggle` with a trailing switch and an inline ``HelpBadge`` next
+/// to its label.
+///
+/// The badge is a *sibling* of the toggle, not nested inside the toggle's label.
+/// Nesting an interactive control in a `Toggle` label folds the button into the
+/// toggle's single accessibility element, so VoiceOver can't focus the badge
+/// separately (and on some macOS versions the toggle's label hit region can also
+/// intercept the tap). Keeping it a sibling (mirroring the existing
+/// `TuningHelpIcon` placement) keeps the badge separately focusable with its own
+/// hit target.
+struct HelpfulToggle: View {
+    let title: String
+    let help: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            // The hidden Toggle label carries the accessibility name; this
+            // visible copy is decorative, so keep it out of the a11y tree to
+            // avoid announcing the title twice.
+            Text(title)
+                .accessibilityHidden(true)
+            HelpBadge(text: help)
+            Spacer()
+            Toggle(title, isOn: $isOn)
+                .labelsHidden()
+        }
+        // Row-wide hover tooltip preserves the pre-badge behaviour for people
+        // used to hovering the control; the badge stays the visible, clickable
+        // affordance for everyone else.
+        .help(help)
+    }
+}

--- a/app/MeetingTranscriber/Sources/Settings/SettingsHelp.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SettingsHelp.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Short, plain-English explanations for settings options, surfaced via ``HelpBadge``.
+///
+/// Kept out of the view bodies so those stay lint- and type-check-friendly
+/// (no inline string literals inflating SwiftUI expression type-checking), and
+/// so the help copy is auditable in one place.
+enum SettingsHelp {
+    static let vad =
+        "Voice Activity Detection trims silent stretches out of the recording before " +
+        "transcription, which speeds up processing and can improve accuracy. Enable it " +
+        "for long or pause-heavy recordings; disable it if you notice speech being cut off."
+
+    static let silentCaptureChannel =
+        "Turns the menu bar red when one capture channel goes silent while the other " +
+        "still carries audio, for example a muted microphone or a dropped app-audio tap. " +
+        "It catches these one-sided capture failures live, during a meeting."
+
+    static let asymmetricSilenceWarning =
+        "How long one channel must stay silent, while the other keeps producing audio, " +
+        "before the indicator and notification fire. Lower reacts faster to a dead channel; " +
+        "higher ignores natural speaking pauses."
+}

--- a/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
+++ b/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
@@ -1,0 +1,168 @@
+import AppKit
+@testable import MeetingTranscriber
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@MainActor
+final class HelpBadgeTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var defaults: UserDefaults!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var testSuiteName: String!
+
+    /// Per-test isolated UserDefaults suite (same pattern as SettingsViewTests).
+    /// Avoids `swift test --parallel` plist races and prevents leaking into the
+    /// dev app's `.standard` plist.
+    override func setUp() async throws {
+        try await super.setUp()
+        testSuiteName = "HelpBadgeTests-\(getpid())-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: testSuiteName) else {
+            XCTFail("Could not create test UserDefaults suite")
+            return
+        }
+        defaults = suite
+    }
+
+    override func tearDown() async throws {
+        defaults?.removePersistentDomain(forName: testSuiteName)
+        defaults = nil
+        testSuiteName = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func iconNames(for badge: HelpBadge) throws -> [String] {
+        let images = try badge.inspect().findAll(ViewType.Image.self)
+        return images.compactMap { try? $0.actualImage().name() }
+    }
+
+    private func infoBadgeCount(in view: AudioSettingsView) throws -> Int {
+        let images = try view.inspect().findAll(ViewType.Image.self)
+        return images.compactMap { try? $0.actualImage().name() }.count { $0 == "info.circle" }
+    }
+
+    // MARK: - Badge rendering
+
+    func testRendersInfoCircleIcon() throws {
+        XCTAssertTrue(try iconNames(for: HelpBadge(text: "Explains the thing")).contains("info.circle"))
+    }
+
+    func testBadgeIsATappableButtonCarryingTheHelpText() throws {
+        // The badge is a real Button carrying the help string. NOTE: ViewInspector
+        // 0.10.3 cannot inspect native `.popover` content, so `find(text:)` here
+        // matches the `.help()` tooltip modifier, not the popover Text. This is a
+        // declarative check; it does not exercise tap -> popover presentation.
+        let sut = HelpBadge(text: "Explains the thing")
+        XCTAssertNoThrow(try sut.inspect().find(ViewType.Button.self))
+        XCTAssertNoThrow(try sut.inspect().find(text: "Explains the thing"))
+    }
+
+    // MARK: - Behavioural (hosted)
+
+    /// Clicking the badge presents the popover. This is the only test that
+    /// exercises the tap -> popover path and the popover's content builder;
+    /// ViewInspector 0.10.3 can't reach native `.popover` content, so it hosts
+    /// the view in a real NSWindow (the popover is an AppKit window).
+    func testClickingBadgePresentsPopover() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false,
+        )
+        defer { window.orderOut(nil) }
+        window.contentView = NSHostingView(rootView: HelpBadge(text: "hello"))
+        window.orderFront(nil)
+        window.layoutIfNeeded()
+
+        func buttons(in view: NSView) -> [NSButton] {
+            ((view as? NSButton).map { [$0] } ?? []) + view.subviews.flatMap(buttons(in:))
+        }
+        func visiblePopoverWindows() -> Int {
+            NSApp.windows.count { String(describing: type(of: $0)).contains("Popover") && $0.isVisible }
+        }
+
+        let content = try XCTUnwrap(window.contentView)
+        let badge = try XCTUnwrap(buttons(in: content).first, "no NSButton hosted for the badge")
+        let before = visiblePopoverWindows()
+        badge.performClick(nil)
+
+        // Popover presentation is async; pump the run loop until it appears.
+        let deadline = Date(timeIntervalSinceNow: 2)
+        while visiblePopoverWindows() == before, Date() < deadline {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+        XCTAssertEqual(visiblePopoverWindows(), before + 1, "clicking the badge should present its popover")
+    }
+
+    // MARK: - HelpfulToggle
+
+    /// The badge must be a sibling of the toggle (own hit target, separately
+    /// focusable), so both a HelpBadge and the Toggle live in the same row.
+    func testHelpfulToggleRendersLabelBadgeAndToggle() throws {
+        let body = try HelpfulToggle(title: "My Option", help: "the help text", isOn: .constant(false)).inspect()
+        XCTAssertNoThrow(try body.find(text: "My Option"))
+        XCTAssertNoThrow(try body.find(ViewType.Toggle.self))
+        // The help param must reach the badge (found via its `.help()` tooltip;
+        // popover content is not inspectable), not just render some badge.
+        XCTAssertNoThrow(try body.find(text: "the help text"))
+        let names = body.findAll(ViewType.Image.self).compactMap { try? $0.actualImage().name() }
+        XCTAssertTrue(names.contains("info.circle"))
+    }
+
+    /// The badge must be a SIBLING of the Toggle, never nested inside its label:
+    /// nesting folds it into the toggle's single accessibility element, so
+    /// VoiceOver cannot focus the badge. This is the one zero-scaffolding
+    /// automated guard for that regression (red if the badge moves into the
+    /// Toggle's label, green while it stays a sibling).
+    func testHelpfulToggleKeepsBadgeOutsideToggleSubtree() throws {
+        let toggle = try HelpfulToggle(title: "T", help: "h", isOn: .constant(false))
+            .inspect().find(ViewType.Toggle.self)
+        XCTAssertThrowsError(
+            try toggle.find(ViewType.Button.self),
+            "the help badge must not live inside the Toggle's label",
+        )
+    }
+
+    // MARK: - Catalog
+
+    func testHelpCatalogStringsAreNonEmpty() {
+        XCTAssertFalse(SettingsHelp.vad.isEmpty)
+        XCTAssertFalse(SettingsHelp.silentCaptureChannel.isEmpty)
+        XCTAssertFalse(SettingsHelp.asymmetricSilenceWarning.isEmpty)
+    }
+
+    // MARK: - Adoption in AudioSettingsView (issue #505)
+
+    /// VAD toggle + Detect Silent Capture Channel toggle + Warn-after row each
+    /// carry a clickable info badge. All three rows are visible with defaults
+    /// (perChannelIndicatorEnabled defaults to true → warn-after row shown).
+    func testAudioTabShowsHelpBadgesForNamedOptions() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.perChannelIndicatorEnabled = true
+        XCTAssertEqual(try infoBadgeCount(in: AudioSettingsView(settings: settings)), 3)
+    }
+
+    /// The warn-after badge lives on the conditional slider row, so it drops
+    /// out with the row when per-channel detection is off.
+    func testWarnAfterHelpBadgeHiddenWhenDetectionOff() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.perChannelIndicatorEnabled = false
+        XCTAssertEqual(try infoBadgeCount(in: AudioSettingsView(settings: settings)), 2)
+    }
+
+    /// Each option must carry ITS help string (not merely some badge), so a
+    /// swapped/empty SettingsHelp constant is caught; the count checks alone
+    /// would not notice. The catalog strings are found via each badge's
+    /// `.help()` tooltip (ViewInspector can't inspect popover content).
+    func testAudioTabWiresEachOptionsHelpText() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.perChannelIndicatorEnabled = true
+        let body = try AudioSettingsView(settings: settings).inspect()
+        XCTAssertNoThrow(try body.find(text: SettingsHelp.vad))
+        XCTAssertNoThrow(try body.find(text: SettingsHelp.silentCaptureChannel))
+        XCTAssertNoThrow(try body.find(text: SettingsHelp.asymmetricSilenceWarning))
+    }
+}


### PR DESCRIPTION
## Summary

Adds clickable ⓘ help badges to settings options so non-experts can tell what each control actually does (fixes #505). The existing help was a bare `.help()` hover tooltip, invisible until hovered, so the reporter never found it.

## What's new

- **`HelpBadge`** — a reusable `info.circle` that shows a short explanation in a popover **on hover or click** (click is kept for touch / keyboard / VoiceOver; the full text is also exposed as a VoiceOver AXHelp string). The popover text wraps rather than truncating.
- **`HelpfulToggle`** — a settings toggle with the badge placed as a *sibling* of the switch, not nested in the toggle's label. Nesting an interactive control in a `Toggle` label lets macOS route badge taps to the toggle (flipping it, or swallowing the tap so the popover never opens) and fold the button into the toggle's single accessibility element. The sibling placement mirrors the existing `TuningHelpIcon`.
- **`SettingsHelp`** — a central catalog for the help copy, kept out of the view bodies (SwiftUI expression type-check budget).

## Scope

A thin slice: adopts the badge on the three options named in the issue (VAD, Detect Silent Capture Channel, Warn after), all in the Audio tab. Later tabs can adopt `HelpBadge`/`HelpfulToggle` cheaply.

The app already uses `info.circle` for its informational caption footnotes, so the glyph stays consistent (permission / how-to popovers use `questionmark.circle`).

## Out of scope (follow-ups)

- Rolling the badges out to the other settings tabs (mostly copywriting).
- Migrating the hover-only `TuningHelpIcon` (Speakers tab) to `HelpBadge`.

## Testing

- New `HelpBadgeTests` (ViewInspector): badge renders `info.circle`; the badge is a Button carrying the help string; `HelpfulToggle` renders label + badge + toggle; each Audio option carries its own `SettingsHelp` string; badge count tracks the visible rows.
- **Structural guard** (`testHelpfulToggleKeepsBadgeOutsideToggleSubtree`): asserts the badge never nests inside the Toggle's label — the automated guard against the accessibility-folding regression. Verified red on the nested shape, green on the sibling shape.
- **Hosted behavioural test** (`testClickingBadgePresentsPopover`): hosts the badge in an NSWindow and clicks it, asserting the popover presents. This exercises the tap → popover path that ViewInspector 0.10.3 can't reach declaratively (it can't inspect native `.popover` content), and lifts `HelpBadge.swift` line coverage to ~97% — the one remaining line is the `@State` default initializer, an uncoverable SwiftUI artifact. It's a new NSWindow-hosting pattern for this repo; it should run on CI's UI-capable runners and is skippable by name if it ever flakes (as `MenuBarIconSnapshotTests` is).
- Lint clean, release-parity build clean, unit + view tests green. Also rendered the real rows to an image and drove the popover/hover live in the dev app to confirm the layout (badge next to the label, switch right-aligned as a separate element).
