### PR TITLE
fix(app): keep speaker-naming window visible when it loses focus

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -47,6 +47,30 @@ private struct AnimatedMenuBarIcon: View {
     }
 }
 
+/// Bridges a SwiftUI `Window` scene down to its hosting `NSWindow` so
+/// window-level AppKit properties can be configured. macOS 14 (our deployment
+/// target) has no scene-level `.windowLevel` / collection-behavior modifiers
+/// (those are macOS 15+), so a zero-size representable placed in the content's
+/// `.background` is the idiomatic way to reach the window. Mirrors the
+/// `AccessibleTextField` `NSViewRepresentable` idiom already used in the naming
+/// UI. `configure` runs once the view is attached and on subsequent updates;
+/// the window properties it sets are sticky and idempotent.
+private struct WindowAccessor: NSViewRepresentable {
+    let configure: (NSWindow) -> Void
+
+    func makeNSView(context _: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        DispatchQueue.main.async { [weak view] in
+            if let window = view?.window { configure(window) }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context _: Context) {
+        if let window = nsView.window { configure(window) }
+    }
+}
+
 @main
 struct MeetingTranscriberApp: App {
     @State private var appState = AppState(notifier: NotificationManager.shared)
@@ -160,6 +184,11 @@ struct MeetingTranscriberApp: App {
 
         Window("Name Speakers", id: "speaker-naming") {
             speakerNamingContent
+                // Pin the naming window so it stays visible + on top while the
+                // user works in other apps instead of vanishing on focus loss
+                // (issue #504). Applied via the hosting NSWindow because macOS 14
+                // has no scene-level window-level / collection-behavior modifier.
+                .background(WindowAccessor { NamingWindowPolicy.apply(to: $0) })
                 .onAppear {
                     // Close restored window if no naming data available (macOS state restoration)
                     if appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty {

--- a/app/MeetingTranscriber/Sources/NamingWindowPolicy.swift
+++ b/app/MeetingTranscriber/Sources/NamingWindowPolicy.swift
@@ -1,0 +1,40 @@
+import AppKit
+
+/// Pins the "Name Speakers" window so it stays available while the user works
+/// in other apps (issue #504).
+///
+/// The naming dialog is a "come back and finish me later" task: the user often
+/// wants to keep working elsewhere and return to it. As a menu-bar
+/// (`LSUIElement`) app we have no Dock icon to reopen a buried window, so if the
+/// window is swept off-stage by Stage Manager or displaced by a full-screen
+/// Space it reads as "gone" (issue #504). This applies the same recipe the
+/// live-captions panel uses (`LiveCaptionsWindowController`), scoped to the
+/// naming window only:
+///
+/// - `hidesOnDeactivate = false` — belt-and-braces; an `NSWindow` already
+///   defaults to `false`, but a restored/panel-backed window might not.
+/// - `level = .floating` — stays above other apps so it is always one click
+///   away (it cannot hold the *key* focus while the user types elsewhere; macOS
+///   forbids a background app from doing that).
+/// - `.canJoinAllSpaces` + `.fullScreenAuxiliary` — follows the user across
+///   Spaces and shows over full-screen apps / Stage Manager instead of being
+///   left behind on the Space it opened on.
+///
+/// `.canJoinAllSpaces` and `.fullScreenAuxiliary` each belong to a
+/// mutually-exclusive `NSWindowCollectionBehavior` group, so the conflicting
+/// members are cleared before they are unioned in — otherwise AppKit silently
+/// ignores the flags we want. SwiftUI's naming window ships with
+/// `.fullScreenNone`, which would defeat `.fullScreenAuxiliary` if left set.
+/// Unrelated flags are preserved.
+enum NamingWindowPolicy {
+    @MainActor
+    static func apply(to window: NSWindow) {
+        window.hidesOnDeactivate = false
+        window.level = .floating
+        var behavior = window.collectionBehavior
+        // Drop the other members of the two exclusive groups we set below.
+        behavior.subtract([.managed, .moveToActiveSpace, .stationary, .fullScreenPrimary, .fullScreenNone])
+        behavior.formUnion([.canJoinAllSpaces, .fullScreenAuxiliary])
+        window.collectionBehavior = behavior
+    }
+}

--- a/app/MeetingTranscriber/Tests/NamingWindowPolicyTests.swift
+++ b/app/MeetingTranscriber/Tests/NamingWindowPolicyTests.swift
@@ -1,0 +1,103 @@
+import AppKit
+@testable import MeetingTranscriber
+import XCTest
+
+/// Unit coverage for the pinning policy applied to the "Name Speakers" window
+/// so it survives app deactivation, Stage Manager, and full-screen Spaces
+/// (issue #504). Driving real scene deactivation is not possible from a
+/// pure-SPM XCTest target, so we test the pure `apply(to:)` seam against a
+/// real headless `NSWindow` instead.
+@MainActor
+final class NamingWindowPolicyTests: XCTestCase {
+    /// Build a window whose relevant properties start in the OPPOSITE of the
+    /// pinned state, so each assertion proves `apply` actually changed it (an
+    /// identity stub would leave `hidesOnDeactivate == true` and fail).
+    ///
+    /// The seeded `collectionBehavior` deliberately carries flags that are
+    /// mutually exclusive with the ones `apply` sets: `.fullScreenNone` (same
+    /// group as `.fullScreenAuxiliary`) and `.managed` (same group as
+    /// `.canJoinAllSpaces`). SwiftUI's real naming window ships with
+    /// `.fullScreenNone`, so a naive `formUnion` would leave a documented-
+    /// invalid combination. `.ignoresCycle` is an unrelated bit that must
+    /// survive untouched.
+    private func makeUnpinnedWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: true,
+        )
+        window.hidesOnDeactivate = true
+        window.level = .normal
+        window.collectionBehavior = [.managed, .fullScreenNone, .ignoresCycle]
+        return window
+    }
+
+    func testKeepsWindowVisibleWhenAppDeactivates() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        XCTAssertFalse(
+            window.hidesOnDeactivate,
+            "Naming window must not hide when the app loses focus (#504)",
+        )
+    }
+
+    func testFloatsAboveOtherAppWindows() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        XCTAssertEqual(
+            window.level, .floating,
+            "Naming window should stay on top so it is always one click away",
+        )
+    }
+
+    func testJoinsAllSpacesAndFullScreen() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        XCTAssertTrue(
+            window.collectionBehavior.contains(.canJoinAllSpaces),
+            "Naming window should follow the user across Spaces",
+        )
+        XCTAssertTrue(
+            window.collectionBehavior.contains(.fullScreenAuxiliary),
+            "Naming window should show over full-screen apps / Stage Manager",
+        )
+    }
+
+    func testClearsConflictingSpaceAndFullScreenBits() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        // `.canJoinAllSpaces` / `.fullScreenAuxiliary` are each in a
+        // mutually-exclusive group; the conflicting members must be removed,
+        // otherwise AppKit silently ignores the flags we want.
+        XCTAssertFalse(
+            window.collectionBehavior.contains(.managed),
+            "conflicting Space-participation bit must be cleared",
+        )
+        XCTAssertFalse(
+            window.collectionBehavior.contains(.fullScreenNone),
+            "conflicting full-screen bit must be cleared so .fullScreenAuxiliary takes effect",
+        )
+    }
+
+    func testPreservesUnrelatedCollectionBehaviorBits() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        XCTAssertTrue(
+            window.collectionBehavior.contains(.ignoresCycle),
+            "apply must not clobber unrelated collection-behavior flags",
+        )
+    }
+
+    /// `WindowAccessor.updateNSView` re-applies the policy on every SwiftUI
+    /// update, so applying twice must land on the same state.
+    func testIsIdempotent() {
+        let window = makeUnpinnedWindow()
+        NamingWindowPolicy.apply(to: window)
+        let afterFirst = window.collectionBehavior
+        NamingWindowPolicy.apply(to: window)
+        XCTAssertEqual(window.collectionBehavior, afterFirst)
+        XCTAssertFalse(window.hidesOnDeactivate)
+        XCTAssertEqual(window.level, .floating)
+    }
+}


### PR DESCRIPTION
## Summary

Keeps the "Name Speakers" window available while the user works in other apps, instead of it reading as "gone" the moment they click away (issue #504).

## Context

The naming dialog is a "come back and finish me later" task, but as a menu-bar (`LSUIElement`) app we have no Dock icon to reopen a window once it is buried. In local testing on macOS 26.5 the window did **not** actually close on plain focus loss (it is a normal `NSWindow` with `hidesOnDeactivate` already `false`), so the most likely real triggers are environmental: Stage Manager sweeping the window off-stage on app switch, or a full-screen Space displacing it — in both cases the window becomes effectively unreachable.

## What this does

Pins the naming window (and only that window) so it stays visible and on top, one click away, regardless of Stage Manager / Spaces:

- `hidesOnDeactivate = false`
- `level = .floating`
- `collectionBehavior`: `.canJoinAllSpaces` + `.fullScreenAuxiliary`

This is the same recipe the live-captions panel already uses. It is applied to the hosting `NSWindow` via a small `WindowAccessor: NSViewRepresentable` in the naming content's `.background` (macOS 14, our deployment target, has no scene-level window-level / collection-behavior modifier — those are macOS 15+), mirroring the existing `AccessibleTextField` representable in the naming UI. A single lifecycle-tied call site covers every open path (fresh open, state restoration, re-front) with no `NSApp.windows` identifier scan.

`.canJoinAllSpaces` and `.fullScreenAuxiliary` each belong to a mutually-exclusive collection-behavior group, so the conflicting members are cleared before they are unioned in — SwiftUI's naming window ships with `.fullScreenNone`, which would otherwise silently defeat `.fullScreenAuxiliary`.

What it deliberately does **not** do: hold the keyboard focus while the user types in another app. macOS forbids a background app from keeping key focus, so "stays in focus" here means visible + on top + reachable, not "captures your typing."

## Scope

Only the naming window is pinned; the Settings and Record-App windows are untouched.

## Testing

- `NamingWindowPolicyTests` (6 cases) against a real headless `NSWindow`, starting from the opposite (and deliberately conflicting) state so an identity stub fails: sets floating level, does not hide on deactivate, joins all Spaces + full-screen, **clears** the conflicting exclusive-group bits, preserves unrelated flags, and is idempotent (it re-applies on every SwiftUI update).
- Driving real scene deactivation is not possible from the pure-SPM XCTest target, so the wiring was verified live with a standalone repro of the exact scene shape (`MenuBarExtra` + auxiliary `Window`, `LSUIElement`, macOS 14 target): `WindowAccessor` reaches the hosting `AppKitWindow`, all four properties land, and the window survives a real app deactivation (activating Finder) still visible + floating + joining all Spaces.
- Lint clean, release-parity build clean.

## Possible follow-up

If the reporter confirms the window truly *closes* (rather than just being hidden) — e.g. the "Name Speakers" menu item disappears afterward — the cause would instead be a reflexive keystroke: after a short grace, Esc skips and Return confirms, which drains the pending job and closes the window. That is a separate keyboard-footgun to soften and is out of scope here.
