### PR TITLE
test(app): CI regression net for speaker-naming window pinning (#504)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -1,5 +1,23 @@
 #if !APPSTORE
+    import AppKit
     import Foundation
+
+    extension RPCStateSnapshot.WindowInfo {
+        /// Project an `NSWindow`'s pinning-relevant properties for the RPC
+        /// snapshot. `id` is passed in (the caller already resolved it from the
+        /// window identifier) so this stays a pure value mapping.
+        @MainActor
+        init(window: NSWindow, id: String) {
+            let behavior = window.collectionBehavior
+            self.init(
+                id: id,
+                isVisible: window.isVisible,
+                floating: window.level == .floating,
+                canJoinAllSpaces: behavior.contains(.canJoinAllSpaces),
+                fullScreenAuxiliary: behavior.contains(.fullScreenAuxiliary),
+            )
+        }
+    }
 
     extension PermissionStatus {
         /// Stable wire string for the RPC `/state.permissionHealth` snapshot.
@@ -73,7 +91,24 @@
                 settings: settings.rpcSettingsSnapshot(),
                 badge: currentBadge,
                 updateStatus: updateStatusSnapshot(),
+                windows: windowsSnapshot(),
             )
+        }
+
+        /// Project the pinning-relevant properties of each named scene window.
+        /// Only windows carrying a scene identifier (settings, speaker-naming,
+        /// record-app) are included; transient/system windows are skipped.
+        /// Extracted (like the other `*Snapshot` helpers) to keep the
+        /// `rpcStateSnapshot` literal under the type-check budget.
+        private func windowsSnapshot() -> [RPCStateSnapshot.WindowInfo] {
+            // `NSApp` is an implicitly-unwrapped optional that is nil in an
+            // xctest process (no NSApplication is created), so guard it — the
+            // RPC snapshot is built on the main actor from unit tests too.
+            guard let app = NSApp else { return [] }
+            return app.windows.compactMap { window in
+                guard let id = window.identifier?.rawValue else { return nil }
+                return RPCStateSnapshot.WindowInfo(window: window, id: id)
+            }
         }
 
         /// Snapshot the update-checker status. Extracted (like the other

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -67,6 +67,28 @@
         /// update *preferences* — mirroring the `permissionHealth` status family.
         /// Contains no secrets.
         let updateStatus: UpdateStatus
+        /// Pinning-relevant properties of each named scene window (settings,
+        /// speaker-naming, record-app). Lets the e2e-app naming-confirm lane
+        /// assert the speaker-naming window is pinned — floating + joins all
+        /// Spaces + shows over full-screen apps — so it stays reachable when the
+        /// user switches apps (issue #504). Asserting on these properties, not
+        /// mere visibility, is what makes the regression net non-vacuous: an
+        /// un-pinned window also stays visible on deactivation.
+        let windows: [WindowInfo]
+
+        struct WindowInfo: Codable {
+            /// The scene identifier (e.g. "speaker-naming", "settings").
+            let id: String
+            /// Whether the window is on-screen. On deactivation this stays true
+            /// only if `hidesOnDeactivate` is false — so it is the signal that
+            /// catches a "window hides when the app loses focus" regression.
+            let isVisible: Bool
+            /// `level == .floating` — the load-bearing pin property (stays on
+            /// top / above other apps).
+            let floating: Bool
+            let canJoinAllSpaces: Bool
+            let fullScreenAuxiliary: Bool
+        }
 
         struct UpdateStatus: Codable {
             /// True when a release newer than the running version was found.
@@ -362,6 +384,7 @@
             settings: Settings = .empty,
             badge: BadgeKind = .inactive,
             updateStatus: UpdateStatus = .empty,
+            windows: [WindowInfo] = [],
         ) {
             self.pipeline = pipeline
             self.speakerDB = speakerDB
@@ -377,6 +400,7 @@
             self.settings = settings
             self.badge = badge
             self.updateStatus = updateStatus
+            self.windows = windows
         }
 
         func jsonData() throws -> Data {

--- a/app/MeetingTranscriber/Tests/RPCWindowSnapshotTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCWindowSnapshotTests.swift
@@ -1,0 +1,71 @@
+#if !APPSTORE
+    import AppKit
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the `windows` field of the RPC `/state` snapshot: it projects each
+    /// named scene window's pinning-relevant properties (level / collection
+    /// behavior / visibility) so the e2e-app naming-confirm lane can assert the
+    /// speaker-naming window is pinned (issue #504) without screenshot OCR.
+    ///
+    /// The load-bearing property is `floating` (+ the Space flags): an un-pinned
+    /// `NSWindow` stays *visible* on deactivation too, so a visibility-only check
+    /// would be vacuous. Reverting `NamingWindowPolicy` flips `floating` to false
+    /// here, which is what turns the lane red.
+    @MainActor
+    final class RPCWindowSnapshotTests: XCTestCase {
+        private func makeWindow() -> NSWindow {
+            NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+                styleMask: [.titled], backing: .buffered, defer: true,
+            )
+        }
+
+        func testWindowInfoReflectsPinnedState() {
+            let window = makeWindow()
+            NamingWindowPolicy.apply(to: window)
+            let info = RPCStateSnapshot.WindowInfo(window: window, id: "speaker-naming")
+            XCTAssertEqual(info.id, "speaker-naming")
+            XCTAssertTrue(info.floating)
+            XCTAssertTrue(info.canJoinAllSpaces)
+            XCTAssertTrue(info.fullScreenAuxiliary)
+        }
+
+        /// Non-vacuous guard: an un-pinned window reports `floating == false`,
+        /// so a reverted `NamingWindowPolicy` would flip the lane assertion red.
+        func testWindowInfoReportsUnpinnedWindowAsNotFloating() {
+            let window = makeWindow()
+            let info = RPCStateSnapshot.WindowInfo(window: window, id: "settings")
+            XCTAssertFalse(info.floating)
+            XCTAssertFalse(info.canJoinAllSpaces)
+            XCTAssertFalse(info.fullScreenAuxiliary)
+        }
+
+        /// The exact wire shape the e2e `jq` filter reads.
+        func testWindowsSerialiseIntoSnapshotJSON() throws {
+            let info = RPCStateSnapshot.WindowInfo(
+                id: "speaker-naming",
+                isVisible: true,
+                floating: true,
+                canJoinAllSpaces: true,
+                fullScreenAuxiliary: true,
+            )
+            XCTAssertTrue(info.isVisible)
+            let snapshot = RPCStateSnapshot(
+                pipeline: .init(
+                    isProcessing: false,
+                    activeJobCount: 0,
+                    waitingJobCount: 0,
+                    pendingNamingJobCount: 0,
+                ),
+                speakerDB: .init(count: 0, recentNames: [], knownSpeakerNames: []),
+                pendingNamingJobs: [],
+                windows: [info],
+            )
+            let json = try XCTUnwrap(String(data: snapshot.jsonData(), encoding: .utf8))
+            XCTAssertTrue(json.contains("\"id\" : \"speaker-naming\""), json)
+            XCTAssertTrue(json.contains("\"floating\" : true"), json)
+            XCTAssertTrue(json.contains("\"isVisible\" : true"), json)
+        }
+    }
+#endif

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -1220,6 +1220,57 @@ run_naming_confirm() {
     [ "${pending_count:-0}" -ge 2 ] 2>/dev/null \
         || fail "$label: naming dialog speakerCount=$pending_count, expected >= 2 (numSpeakers=2 on a 2-speaker fixture)"
 
+    # --- #504 regression net: the speaker-naming window must be PINNED --------
+    # It floats + joins all Spaces + shows over full-screen apps so it stays
+    # reachable when the user switches apps, instead of being swept away by
+    # Stage Manager or a full-screen Space. Assert on the window PROPERTIES, not
+    # mere visibility: an un-pinned NSWindow also stays visible on deactivation,
+    # so a visibility-only check would stay green even with the fix reverted
+    # (vacuous). Reverting NamingWindowPolicy flips floating -> false here, which
+    # is what turns this lane red.
+    local naming_win=""
+    # Capture the speaker-naming window's RPC projection into $naming_win;
+    # non-zero if the window is not present.
+    _naming_window() {
+        assert_app_alive
+        naming_win="$(rpc /state | jq -c '[.windows[] | select(.id == "speaker-naming")] | .[0] // empty')"
+        [ -n "$naming_win" ]
+    }
+    _naming_window_pinned() {
+        _naming_window || return 1
+        jq -e '.floating and .canJoinAllSpaces and .fullScreenAuxiliary' <<<"$naming_win" >/dev/null
+    }
+    # Phase-2 predicate (used after deactivation): present AND on-screen AND
+    # floating. isVisible is the load-bearing new signal a hidesOnDeactivate
+    # regression would flip.
+    _naming_window_visible_pinned() {
+        _naming_window || return 1
+        jq -e '.isVisible and .floating' <<<"$naming_win" >/dev/null
+    }
+    # The window opens asynchronously (.showSpeakerNaming -> bringWindowToFront
+    # on the next runloop), so poll rather than assert once.
+    log "$label: asserting speaker-naming window is pinned (floating + all-Spaces + full-screen)"
+    poll_until 30 2 _naming_window_pinned \
+        || fail "$label: speaker-naming window not pinned (#504 regression): $(rpc /state | jq -c '[.windows[] | select(.id=="speaker-naming")]')"
+    log "$label: naming window pinned OK: $naming_win"
+
+    # And it must SURVIVE the app losing focus: bring another app to the front,
+    # then re-assert. The pin flags are focus-invariant, so the load-bearing new
+    # signal here is isVisible: a "window hides when the app loses focus"
+    # regression (e.g. hidesOnDeactivate flipped back on) flips isVisible to
+    # false only AFTER deactivation, which phase 1 (app still active) cannot see.
+    # RPC + the naming confirm are localhost HTTP, so leaving our menu-bar app
+    # in the background does not block the rest of the lane.
+    osascript -e 'tell application "Finder" to activate' >/dev/null 2>&1 || true
+    sleep 2
+    # Poll rather than single-shot: a transient localhost RPC hiccup at this one
+    # instant would otherwise fail the lane with a misleading "regression"
+    # message. A genuine hide-on-deactivate regression stays red the whole window.
+    poll_until 20 2 _naming_window_visible_pinned \
+        || fail "$label: speaker-naming window not visible + pinned after the app was deactivated (#504 regression): $(rpc /state | jq -c '.windows')"
+    log "$label: naming window still visible + pinned after deactivating the app"
+    # -------------------------------------------------------------------------
+
     # Read the naming choice: raw labels + auto-name suggestions + speaking time.
     local naming speaker_count
     naming="$(curl --silent --show-error --max-time 10 \


### PR DESCRIPTION
## Summary

Adds a CI regression net so the speaker-naming window can't silently lose its pinning (issue #504, fixed in #508). The fix keeps that window floating + joining all Spaces + showing over full-screen apps so it stays reachable when the user switches apps; nothing in CI would have caught a future revert.

## Why not just "assert the window is still visible"

An un-pinned `NSWindow` also stays visible when the app is deactivated (that was the empirical finding while investigating #504). So a visibility-only check would stay green even with the pin reverted, i.e. vacuous. The regression net therefore asserts on the window's **properties**, which is what actually changes: reverting `NamingWindowPolicy` flips `floating` back to false and the lane goes red.

## Changes

- **`RPCStateSnapshot` / `AppState+RPC`**: a new `windows` array in the debug RPC `/state` snapshot, projecting each named scene window's `id`, `isVisible`, `floating`, `canJoinAllSpaces`, `fullScreenAuxiliary`. The `NSWindow` -> `WindowInfo` mapping is a pure `@MainActor` value seam. Debug-only (`#if !APPSTORE`), same as the rest of the RPC surface.
- **`scripts/e2e-app.sh`** (`--naming-confirm` lane): after a job parks at speaker-naming, poll `/state.windows` and assert the window is pinned (floating + all-Spaces + full-screen). Then activate Finder to deactivate the app and re-assert the window is still present and still visible + floating. `isVisible` read *after* deactivation is the one signal a `hidesOnDeactivate` regression would flip (phase 1, with the app still active, can't see it).

## Testing

- `RPCWindowSnapshotTests` (3): a pinned window maps to `floating == true` + both Space flags; an un-pinned window maps to `floating == false` (the non-vacuous guard); the JSON serialises to the exact shape the e2e `jq` reads.
- Verified the `/state.windows` observable live end-to-end (no fixtures, no artifacts): opened the Settings window via RPC and confirmed it surfaces as `{"id":"settings","isVisible":true,"floating":false,"canJoinAllSpaces":false,...}` — i.e. the observable reflects real scene-window state, and an un-pinned window reports `floating:false`.
- `bash -n` + `shellcheck` clean on the script, lint clean, release-parity build clean.

## How it runs

The naming-confirm lane is part of `e2e-app.yml` (self-hosted Mac, GUI session). It runs on `workflow_dispatch`, push to main, nightly, and label-gated PRs (`run-e2e`). It does not run on ordinary PRs.
