### PR TITLE
fix(test): assert only env-stable pin flags in e2e-app naming lane (#504)

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -1244,9 +1244,16 @@ run_naming_confirm() {
         naming_win="$(rpc /state | jq -c '[.windows[] | select(.id == "speaker-naming")] | .[0] // empty')"
         [ -n "$naming_win" ]
     }
+    # Assert only the environment-STABLE pin properties. `.fullScreenAuxiliary`
+    # is deliberately NOT asserted: apply() sets it and it holds on a normal
+    # desktop, but on the headless/virtual-display CI mini AppKit normalises it
+    # off (observed false there, true on a real display), so asserting it flakes.
+    # `.canJoinAllSpaces` already covers cross-Space reachability, and `floating`
+    # is the load-bearing stays-on-top property; reverting NamingWindowPolicy
+    # flips floating -> false, which still turns this lane red.
     _naming_window_pinned() {
         _naming_window || return 1
-        jq -e '.floating and .canJoinAllSpaces and .fullScreenAuxiliary' <<<"$naming_win" >/dev/null
+        jq -e '.floating and .canJoinAllSpaces' <<<"$naming_win" >/dev/null
     }
     # Phase-2 predicate (used after deactivation): present AND on-screen AND
     # floating. isVisible is the load-bearing new signal a hidesOnDeactivate
@@ -1257,7 +1264,7 @@ run_naming_confirm() {
     }
     # The window opens asynchronously (.showSpeakerNaming -> bringWindowToFront
     # on the next runloop), so poll rather than assert once.
-    log "$label: asserting speaker-naming window is pinned (floating + all-Spaces + full-screen)"
+    log "$label: asserting speaker-naming window is pinned (floating + all-Spaces)"
     poll_until 30 2 _naming_window_pinned \
         || fail "$label: speaker-naming window not pinned (#504 regression): $(rpc /state | jq -c '[.windows[] | select(.id=="speaker-naming")]')"
     log "$label: naming window pinned OK: $naming_win"


### PR DESCRIPTION
## Why

The `--naming-confirm` window-pin assertion added in #509 required `.fullScreenAuxiliary`, which turned out to be **environment-sensitive**. `NamingWindowPolicy.apply()` sets it and it holds on a real desktop (re-probed locally on the running dev app: `fullScreenAuxiliary:true`), but on the headless/virtual-display CI mini AppKit normalises it off (`fullScreenAuxiliary:false`, stable across the full 30s poll). So the post-merge e2e-app run went red at the naming lane even though the window **is** pinned: `floating`, `canJoinAllSpaces`, and `isVisible` all held on the mini.

That was my over-strict assertion, not a regression in the #508 fix.

## Change

Phase-1 asserts only the environment-stable pin properties: `floating` (load-bearing stays-on-top) + `canJoinAllSpaces` (cross-Space reachability). `.fullScreenAuxiliary` is no longer asserted (documented inline). Phase-2 (`isVisible and floating`) is unchanged.

Non-vacuous guarantee preserved: reverting `NamingWindowPolicy` flips `floating -> false`, so the lane still goes red on a real regression. Production `apply()` keeps setting `.fullScreenAuxiliary` (best-effort; harmless where AppKit drops it) — no production change.

## Verification

`bash -n` + `shellcheck` clean. `floating` + `canJoinAllSpaces` were both true on the mini (in the failing run's own JSON) and locally, so the relaxed assertion passes in both. The naming lane only runs on the mini (e2e-app.yml), so this PR is best validated with the `run-e2e` label or the post-merge main run.