### PR TITLE
fix(app): anchor meeting-start on wall-clock Date captured at recording start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 **Recording:**
 - `DualSourceRecorder` uses `AudioTapLib.AudioCaptureSession` directly (no subprocess). App imports the library via SPM local package dependency.
-- `DualSourceRecorder` captures `recordingStartTime` in `start()`, not in `stop()`.
+- `DualSourceRecorder` captures `recordingStartDate` (wall-clock `Date`) in `start()`, not in `stop()`. It is captured directly, not derived from `systemUptime`, which freezes during sleep and would skew the meeting-start anchor for a meeting spanning a sleep.
 - Grace period minimum is 1 second (enforced in `AppSettings.endGrace` setter).
 
 **Detection:**
@@ -431,7 +431,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 **Record-only mode:**
 - When `AppSettings.recordOnly` is true, `WatchLoop.enqueueRecording()` moves the dual-source WAVs into `<settings.effectiveOutputDir>/recordings/` and writes a `<basename>_meta.json` `RecordingSidecar` next to them, skipping the entire post-processing pipeline (VAD, transcription, diarization, protocol generation). Both call sites — auto-detected meetings (`handleMeeting`) and manual recordings (`stopManualRecording`) — flow through the same branch. The destination is wrapped in `startAccessingSecurityScopedResource()` to honour user-picked Output Folder bookmarks (relevant for the App Store sandboxed build).
-- Sidecar JSON contains: `version` (currently `RecordingSidecar.currentVersion = 1`), `title`, `appName`, `startedAt`/`stoppedAt` (ISO 8601, reconstructed from `recordingStart` uptime), `participants`, `micDelaySeconds`, `files` (basenames only). Optional `app` / `mic` filenames are omitted when nil. Suffix constants live as static lets: the audio-file suffixes on `RecordingFileSuffix` (`mix = "_mix.wav"`, `app`, `mic`, and the raw-temp `appRaw`/`legacyAppRaw`), and the sidecar suffix on `RecordingSidecar.filenameSuffix = "_meta.json"`.
+- Sidecar JSON contains: `version` (currently `RecordingSidecar.currentVersion = 1`), `title`, `appName`, `startedAt`/`stoppedAt` (ISO 8601; `startedAt` is the recorder's `recordingStartDate` captured at start, `stoppedAt` is `Date()` at stop), `participants`, `micDelaySeconds`, `files` (basenames only). Optional `app` / `mic` filenames are omitted when nil. Suffix constants live as static lets: the audio-file suffixes on `RecordingFileSuffix` (`mix = "_mix.wav"`, `app`, `mic`, and the raw-temp `appRaw`/`legacyAppRaw`), and the sidecar suffix on `RecordingSidecar.filenameSuffix = "_meta.json"`.
 - Intended for fleet topologies where macOS clients capture and a separate machine (e.g. Linux GPU host) processes the audio via Syncthing or similar.
 - Menu bar: the small red dot is rendered as a **persistent overlay** (`MenuBarIcon.image(..., recordOnlyOverlay:)`) on top of *whatever* primary badge `BadgeKind.compute(...)` would otherwise show — idle, recording, transcribing, etc. — so the mode is always visible. Permission overlay (red exclamation) takes precedence when both apply, since a permission problem actually breaks recording. Settings tabs dim Transcription / Protocol / VAD / Diarization sections via `View.recordOnlyDisabled(_:)` and show a banner in the General tab pointing at the active output dir.
 - Sidecar write failures notify the user via `NotificationManager` (injected as `any AppNotifying` on `WatchLoop`) since record-only does not transition state to `.error`.

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -15,7 +15,10 @@ struct RecordingResult {
     let appPath: URL?
     let micPath: URL?
     let micDelay: TimeInterval
-    let recordingStart: TimeInterval // ProcessInfo.systemUptime
+    /// Wall-clock time recording started, captured directly in `start()`.
+    /// Not derived from `systemUptime` (which doesn't advance during sleep, so
+    /// a meeting spanning a sleep would skew the anchor) — this is exact.
+    let recordingStartDate: Date
 }
 
 /// The format `buildRecording` should expect the app track to arrive in, passed
@@ -70,7 +73,7 @@ class DualSourceRecorder: RecordingProvider {
     // Type-erased storage to avoid @available on stored properties
     private var _captureSession: AnyObject?
     private(set) var isRecording = false
-    private(set) var recordingStartTime: TimeInterval = 0
+    private(set) var recordingStartDate: Date = .distantPast
     private var startTimestamp: String?
 
     var appLevelDBFS: Double {
@@ -198,7 +201,7 @@ class DualSourceRecorder: RecordingProvider {
             from: result,
             recordingsDir: recDir,
             timestamp: stem,
-            recordingStart: 0,
+            recordingStartDate: .distantPast,
             format: CaptureFormat(
                 requestedChannels: channels,
                 requestedRate: rate,
@@ -308,7 +311,7 @@ class DualSourceRecorder: RecordingProvider {
         captureSession = session
 
         isRecording = true
-        recordingStartTime = ProcessInfo.processInfo.systemUptime
+        recordingStartDate = Date()
 
         logger.info("Recording started: PID \(appPID), \(self.recordRate) Hz, \(self.appChannels)ch")
     }
@@ -324,7 +327,6 @@ class DualSourceRecorder: RecordingProvider {
             throw RecorderError.unsupportedOS
         }
 
-        let recordingStart = recordingStartTime
         isRecording = false
 
         // Stop capture session and get result
@@ -345,7 +347,7 @@ class DualSourceRecorder: RecordingProvider {
             from: captureResult,
             recordingsDir: Self.recordingsDir,
             timestamp: ts,
-            recordingStart: recordingStart,
+            recordingStartDate: recordingStartDate,
             format: CaptureFormat(requestedChannels: 1, requestedRate: targetRate, targetRate: targetRate),
         )
     }
@@ -359,7 +361,7 @@ class DualSourceRecorder: RecordingProvider {
         from captureResult: AudioCaptureResult,
         recordingsDir recDir: URL,
         timestamp ts: String,
-        recordingStart: TimeInterval,
+        recordingStartDate: Date,
         format: CaptureFormat,
     ) throws -> RecordingResult {
         let micDelay = captureResult.micDelay
@@ -495,7 +497,7 @@ class DualSourceRecorder: RecordingProvider {
             appPath: appPath,
             micPath: micPath,
             micDelay: micDelay,
-            recordingStart: recordingStart,
+            recordingStartDate: recordingStartDate,
         )
     }
 

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -56,9 +56,10 @@ struct PipelineJob: Identifiable, Codable {
     let micDelay: TimeInterval
     let participants: [String]
     let enqueuedAt: Date
-    /// Wall-clock time the recording started (meeting start), derived from the
-    /// recorder's `recordingStart` uptime at enqueue. Used to anchor the
-    /// output-file basename so the filename reflects when the meeting happened,
+    /// Wall-clock time the recording started (meeting start), captured directly
+    /// by the recorder at start (`RecordingResult.recordingStartDate`), not
+    /// derived from `systemUptime` (which freezes during sleep). Used to anchor
+    /// the output-file basename so the filename reflects when the meeting happened,
     /// not when the pipeline processed it. `nil` for reimport/orphan-recovery
     /// jobs (no live recording) and for legacy snapshots persisted before this
     /// field existed — callers fall back to `enqueuedAt`.

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -425,17 +425,10 @@ class WatchLoop {
             micPath: recording.micPath,
             micDelay: recording.micDelay,
             participants: participants,
-            meetingStartTime: wallClockDate(forUptime: recording.recordingStart),
+            meetingStartTime: recording.recordingStartDate,
         )
         pipelineQueue?.enqueue(job)
         logger.info("Enqueued pipeline job for: \(title, privacy: .private)")
-    }
-
-    /// Convert a `ProcessInfo.systemUptime`-based timestamp captured at recording
-    /// start into a wall-clock `Date` by anchoring against "now" (also systemUptime).
-    private func wallClockDate(forUptime uptime: TimeInterval, now: Date = Date()) -> Date {
-        let elapsed = ProcessInfo.processInfo.systemUptime - uptime
-        return now.addingTimeInterval(-elapsed)
     }
 
     private func writeRecordOnlySidecar(
@@ -444,8 +437,12 @@ class WatchLoop {
         recording: RecordingResult,
         participants: [String],
     ) {
-        let stoppedAt = Date()
-        let startedAt = wallClockDate(forUptime: recording.recordingStart, now: stoppedAt)
+        let startedAt = recording.recordingStartDate
+        // Guard the sidecar's startedAt <= stoppedAt invariant against a
+        // backward wall-clock step between start and stop (e.g. NTP correcting a
+        // fast clock): never emit a negative interval for downstream fleet
+        // consumers that compute a duration from the pair.
+        let stoppedAt = max(Date(), startedAt)
 
         let mixName = recording.mixPath.lastPathComponent
         let basename = RecordingFileSuffix.stripSuffix(from: mixName)?.stem

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -81,14 +81,14 @@ final class DualSourceRecorderTests: XCTestCase {
             appPath: URL(fileURLWithPath: "/tmp/app.wav"),
             micPath: URL(fileURLWithPath: "/tmp/mic.wav"),
             micDelay: 0.15,
-            recordingStart: 1000.0,
+            recordingStartDate: Date(timeIntervalSince1970: 1000),
         )
 
         XCTAssertEqual(result.mixPath.lastPathComponent, "mix.wav")
         XCTAssertEqual(result.appPath?.lastPathComponent, "app.wav")
         XCTAssertEqual(result.micPath?.lastPathComponent, "mic.wav")
         XCTAssertEqual(result.micDelay, 0.15)
-        XCTAssertEqual(result.recordingStart, 1000.0)
+        XCTAssertEqual(result.recordingStartDate, Date(timeIntervalSince1970: 1000))
     }
 
     func testRecordingResultNoTracks() {
@@ -97,7 +97,7 @@ final class DualSourceRecorderTests: XCTestCase {
             appPath: nil,
             micPath: nil,
             micDelay: 0,
-            recordingStart: 0,
+            recordingStartDate: .distantPast,
         )
 
         XCTAssertNil(result.appPath)
@@ -341,7 +341,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 from: result,
                 recordingsDir: dir,
                 timestamp: "20260311_100000",
-                recordingStart: 1000,
+                recordingStartDate: Date(timeIntervalSince1970: 1000),
                 format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
             ),
         ) { error in
@@ -364,7 +364,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 appAudioFileURL: appTmp, micAudioFileURL: nil,
                 actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
             ),
-            recordingsDir: dir, timestamp: "20260311_120000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_120000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
         )
 
@@ -388,7 +388,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 appAudioFileURL: appTmp, micAudioFileURL: micWav,
                 actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
             ),
-            recordingsDir: dir, timestamp: "20260311_130000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_130000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
         )
 
@@ -411,7 +411,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 appAudioFileURL: appTmp, micAudioFileURL: micWav,
                 actualSampleRate: 48000, actualChannels: 2, micDelay: 0.1,
             ),
-            recordingsDir: dir, timestamp: "20260311_140000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_140000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
         )
 
@@ -443,7 +443,7 @@ final class DualSourceRecorderTests: XCTestCase {
                     appAudioFileURL: appTmp, micAudioFileURL: badMic,
                     actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
                 ),
-                recordingsDir: dir, timestamp: "20260311_160000", recordingStart: 1000,
+                recordingsDir: dir, timestamp: "20260311_160000", recordingStartDate: Date(timeIntervalSince1970: 1000),
                 format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
             ),
         )
@@ -467,7 +467,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 appAudioFileURL: appTmp, micAudioFileURL: nil,
                 actualSampleRate: 48000, actualChannels: 1, micDelay: 0,
             ),
-            recordingsDir: dir, timestamp: "20260311_150000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_150000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 2, requestedRate: 48000, targetRate: 16000),
         )
 
@@ -488,7 +488,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 actualSampleRate: 48000, actualChannels: 2, micDelay: 0,
             ),
             // Requested 44.1 kHz but the device delivered 48 kHz.
-            recordingsDir: dir, timestamp: "20260311_160000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_160000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 2, requestedRate: 44100, targetRate: 16000),
         )
 
@@ -515,7 +515,7 @@ final class DualSourceRecorderTests: XCTestCase {
                 appAudioFileURL: appTmp, micAudioFileURL: micWav,
                 actualSampleRate: 16000, actualChannels: 1, micDelay: 0,
             ),
-            recordingsDir: dir, timestamp: "20260311_180000", recordingStart: 1000,
+            recordingsDir: dir, timestamp: "20260311_180000", recordingStartDate: Date(timeIntervalSince1970: 1000),
             format: CaptureFormat(requestedChannels: 1, requestedRate: 16000, targetRate: 16000),
         )
 

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -305,10 +305,10 @@ class MockRecorder: RecordingProvider {
     var micLevelDBFS: Double = -120
     var appLevelDBFS: Double = -120
 
-    /// Overrides the `recordingStart` uptime `stop()` reports. `nil` (default)
-    /// yields the current `systemUptime` at stop time, matching a real recorder;
-    /// set it to pin a specific meeting-start time (e.g. filename-anchoring tests).
-    var recordingStartUptime: TimeInterval?
+    /// Overrides the `recordingStartDate` `stop()` reports. `nil` (default)
+    /// yields `Date()` at stop time, matching a real recorder; set it to pin a
+    /// specific meeting-start time (e.g. filename-anchoring tests).
+    var recordingStartDate: Date?
 
     func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging _: Bool) {
         startCalled = true
@@ -327,7 +327,7 @@ class MockRecorder: RecordingProvider {
             appPath: appPath,
             micPath: micPath,
             micDelay: 0,
-            recordingStart: recordingStartUptime ?? ProcessInfo.processInfo.systemUptime,
+            recordingStartDate: recordingStartDate ?? Date(),
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopActiveRecorderTests.swift
@@ -31,7 +31,7 @@ private final class CapturingRecorder: RecordingProvider {
             appPath: nil,
             micPath: nil,
             micDelay: 0,
-            recordingStart: ProcessInfo.processInfo.systemUptime,
+            recordingStartDate: Date(),
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/WatchLoopMeetingStartTimeTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopMeetingStartTimeTests.swift
@@ -3,15 +3,18 @@ import XCTest
 
 @MainActor
 final class WatchLoopMeetingStartTimeTests: XCTestCase {
-    /// The enqueued job must carry the meeting-start wall-clock time derived
-    /// from the recorder's `recordingStart` uptime, not the enqueue time.
-    /// Before the fix the job had no start-time field at all and filenames were
-    /// stamped with `Date()` at save (i.e. processing time).
-    func testEnqueueAnchorsMeetingStartTimeOnRecordingStart() async throws {
-        // Recording started ~5 minutes ago (in systemUptime terms).
+    /// The enqueued job must carry the exact wall-clock `Date` the recorder
+    /// captured at recording start, passed through verbatim — no derivation
+    /// from `systemUptime`. The previous implementation reconstructed the start
+    /// via `Date() - (systemUptime_now - recordingStartUptime)`, which skews for
+    /// any meeting spanning a sleep (uptime freezes while asleep). Injecting a
+    /// fixed absolute instant the uptime math would never reproduce pins that:
+    /// pass-through yields exactly this instant; the old round-trip yields ~now.
+    func testEnqueueAnchorsMeetingStartTimeOnRecorderStartDate() async throws {
+        let fixedStart = Date(timeIntervalSince1970: 1_600_000_000) // 2020-09-13, far from "now"
         let recorder = MockRecorder()
         recorder.mixPath = URL(fileURLWithPath: "/tmp/test_meeting_start_time.wav")
-        recorder.recordingStartUptime = ProcessInfo.processInfo.systemUptime - 300
+        recorder.recordingStartDate = fixedStart
         let queue = PipelineQueue()
         let loop = WatchLoop(
             detector: ImmediatelyInactiveDetector(),
@@ -37,12 +40,11 @@ final class WatchLoopMeetingStartTimeTests: XCTestCase {
         let job = try XCTUnwrap(queue.jobs.first, "handleMeeting must enqueue a job")
         let startTime = try XCTUnwrap(
             job.meetingStartTime,
-            "enqueue must anchor meetingStartTime on the recorder's recordingStart",
+            "enqueue must anchor meetingStartTime on the recorder's recordingStartDate",
         )
-        let secondsAgo = Date().timeIntervalSince(startTime)
         XCTAssertEqual(
-            secondsAgo, 300, accuracy: 10,
-            "meetingStartTime should reflect the recording-start uptime (~5 min ago), not the enqueue time",
+            startTime, fixedStart,
+            "meetingStartTime must be the recorder's captured start Date verbatim, not derived from uptime",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -328,6 +328,7 @@ final class WatchLoopTests: XCTestCase {
         title: String = "Standup",
         appName: String = "Microsoft Teams",
         notifier: any AppNotifying = SilentNotifier(),
+        recordingStartDate: Date? = nil,
     ) async throws -> WatchLoop {
         let (loop, recorder) = makeTestWatchLoop(
             pipelineQueue: queue,
@@ -338,6 +339,7 @@ final class WatchLoopTests: XCTestCase {
         recorder.mixPath = recorderMix
         recorder.appPath = recorderApp
         recorder.micPath = recorderMic
+        recorder.recordingStartDate = recordingStartDate
         try await loop.startManualRecording(pid: 42, appName: appName, title: title)
         loop.stopManualRecording()
         return loop
@@ -394,6 +396,37 @@ final class WatchLoopTests: XCTestCase {
         // startedAt must precede stoppedAt — we don't pin exact wall-clock
         // values because the manual-recording flow records its own startTime.
         XCTAssertLessThanOrEqual(sidecar.startedAt, sidecar.stoppedAt)
+    }
+
+    /// A backward wall-clock step during the meeting (e.g. NTP correcting a fast
+    /// clock) can make the recorder's captured start `Date` later than the
+    /// `Date()` read at stop. The sidecar must still satisfy
+    /// `startedAt <= stoppedAt` so a downstream fleet consumer never computes a
+    /// negative duration or rejects the JSON as malformed.
+    func test_recordOnly_sidecarStartedAtNeverAfterStoppedAt_onBackwardClockStep() async throws {
+        let queue = PipelineQueue()
+        let tmp = try makeTempDirectory(prefix: "recordOnlyClock")
+        let mixURL = tmp.appendingPathComponent("20260503_120000_mix.wav")
+        try Data().write(to: mixURL)
+        let destDir = tmp.appendingPathComponent("dest", isDirectory: true)
+
+        // Recorder reports a start one hour ahead of the Date() read at stop.
+        _ = try await runManualRecordOnlyRecording(
+            recorderMix: mixURL,
+            outputDir: destDir,
+            queue: queue,
+            recordingStartDate: Date(timeIntervalSinceNow: 3600),
+        )
+
+        let sidecarURL = destDir.appendingPathComponent("20260503_120000_meta.json")
+        let data = try Data(contentsOf: sidecarURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let sidecar = try decoder.decode(RecordingSidecar.self, from: data)
+        XCTAssertLessThanOrEqual(
+            sidecar.startedAt, sidecar.stoppedAt,
+            "sidecar interval must never invert even when the wall clock steps backward mid-recording",
+        )
     }
 
     func test_recordOnly_sidecarWriteFailure_setsLastErrorAndNotifies() async throws {


### PR DESCRIPTION
## Problem

Output filenames are stamped with the meeting-start time (via `PipelineJob.meetingStartTime`). That anchor was reconstructed from `ProcessInfo.systemUptime`: the recorder stored an uptime at start, and `WatchLoop` derived a wall-clock `Date` at enqueue as `Date() - (uptime_now - uptime_start)`.

`systemUptime` does not advance while the machine is asleep. So a meeting that spans a sleep (join, close the lid, wake, keep talking, stop) had its start skewed **later** than the true start, by the sleep duration. The resulting filename prefix (`yyyyMMdd_HHmm`) and the record-only sidecar `startedAt` were both wrong for exactly the common "meeting across a laptop sleep" case.

## Fix

Capture `Date()` directly in `DualSourceRecorder.start()` and thread it through `RecordingResult.recordingStartDate`, passed to the job verbatim. The wall-clock truth is now recorded at the source instead of being reconstructed downstream from a monotonic clock that stalls during sleep.

- Removes the now-dead `wallClockDate(forUptime:now:)` helper; both former consumers (pipeline enqueue and the record-only sidecar) read the single `recordingStartDate` field.
- The record-only sidecar clamps `stoppedAt` to `max(Date(), startedAt)`. Passing the captured start through verbatim drops the old derivation's implicit `startedAt <= stoppedAt` guarantee, so a backward wall-clock step (NTP correcting a fast clock) mid-recording can no longer emit a negative interval to downstream fleet consumers.

## Tests

- `WatchLoopMeetingStartTimeTests`: injects a fixed absolute instant the old uptime math could never reproduce and asserts the enqueued `meetingStartTime` is that instant verbatim (fails against an identity stub that stamps `Date()`).
- `WatchLoopTests`: pins the sidecar `startedAt <= stoppedAt` ordering invariant under a backward clock step.

## Scope note

The two remaining `systemUptime` uses are correct and intentionally untouched: `ClaudeCLIProtocolGenerator` measures an elapsed timeout duration (monotonic is right there), and `TimelineAnchor` uses host-time deltas for intra-track audio alignment. Neither reconstructs a wall clock.
