### PR TITLE
build(ci): pin SwiftFormat to 0.61.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,25 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v7
-      - name: Install tools
-        run: brew install swiftformat swiftlint
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      # SwiftFormat is version-pinned: `brew install` always pulls the latest,
+      # and 0.62.0 turned on new default rules (wrapIfStatementBodies /
+      # wrapIfExpressionBodies) that would reformat the committed codebase
+      # repo-wide. Pin to the last release whose defaults match the committed
+      # style; bump deliberately alongside a matching reformat. Uses the
+      # official prebuilt CLI binary from the GitHub release (single-file zip).
+      - name: Install SwiftFormat (pinned)
+        env:
+          SWIFTFORMAT_VERSION: "0.61.1"
+        run: |
+          curl -fsSL -o /tmp/swiftformat.zip \
+            "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
+          unzip -o -j /tmp/swiftformat.zip -d /tmp/swiftformat-bin
+          chmod +x /tmp/swiftformat-bin/swiftformat
+          xattr -dr com.apple.quarantine /tmp/swiftformat-bin/swiftformat || true
+          sudo mv /tmp/swiftformat-bin/swiftformat /usr/local/bin/swiftformat
+          swiftformat --version
       # SwiftFormat path list lives in scripts/lint.sh; calling it keeps CI and
       # local lint runs aligned. SwiftLint stays an explicit step to use the
       # github-actions-logging reporter (annotations in the PR diff).


### PR DESCRIPTION
## Problem

The `lint` job installs SwiftFormat via `brew install swiftformat`, which always pulls the latest release. SwiftFormat **0.62.x** (released 2026-07-16, after the last main merge) turned on new default rules (`wrapIfStatementBodies`, `wrapIfExpressionBodies`) and changed trailing-comma handling. These reformat the committed codebase **repo-wide** (80/351 files, including files with no pending changes).

The result: the lint gate went red on main and **every open PR** with no code change. Proof it is environmental, not any one PR: an untouched file (`SpeakerNamingView.swift`, identical to main) fails the new rules, and `main` at `301ba95e` passed lint at 17:29 under 0.61.1 but the same tree fails under 0.62.1.

## Fix

Pin SwiftFormat to **0.61.1** (the last release whose defaults match the committed style) by installing the official prebuilt CLI binary from the GitHub release, instead of letting brew float to latest. Zero source churn; the committed style is unchanged.

Verified locally: `scripts/lint.sh --format-only` reports `0/351 files require formatting` on `origin/main` with the pinned 0.61.1 binary.

## Bumping later

To adopt newer SwiftFormat formatting, raise `SWIFTFORMAT_VERSION` deliberately in a dedicated change paired with the matching repo-wide reformat, so the reformat is reviewable on its own rather than leaking into unrelated PRs.