### PR TITLE
build(ci): make pinned SwiftFormat win PATH over runner default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,32 @@ jobs:
       # repo-wide. Pin to the last release whose defaults match the committed
       # style; bump deliberately alongside a matching reformat. Uses the
       # official prebuilt CLI binary from the GitHub release (single-file zip).
+      #
+      # The runner image pre-installs a newer SwiftFormat on the Homebrew path,
+      # which precedes /usr/local/bin, so `mv`-ing the pin there is shadowed.
+      # Prepend the pin dir via $GITHUB_PATH (front of PATH for later steps).
       - name: Install SwiftFormat (pinned)
         env:
           SWIFTFORMAT_VERSION: "0.61.1"
         run: |
-          curl -fsSL -o /tmp/swiftformat.zip \
+          curl -fsSL -o "$RUNNER_TEMP/swiftformat.zip" \
             "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
-          unzip -o -j /tmp/swiftformat.zip -d /tmp/swiftformat-bin
-          chmod +x /tmp/swiftformat-bin/swiftformat
-          xattr -dr com.apple.quarantine /tmp/swiftformat-bin/swiftformat || true
-          sudo mv /tmp/swiftformat-bin/swiftformat /usr/local/bin/swiftformat
-          swiftformat --version
+          unzip -o -j "$RUNNER_TEMP/swiftformat.zip" -d "$RUNNER_TEMP/swiftformat-bin"
+          chmod +x "$RUNNER_TEMP/swiftformat-bin/swiftformat"
+          xattr -dr com.apple.quarantine "$RUNNER_TEMP/swiftformat-bin/swiftformat" || true
+          echo "$RUNNER_TEMP/swiftformat-bin" >> "$GITHUB_PATH"
+      # Hard-fail loudly if the pin is ever shadowed by a pre-installed
+      # SwiftFormat again, instead of silently reformatting the codebase.
+      - name: Verify SwiftFormat version
+        env:
+          SWIFTFORMAT_VERSION: "0.61.1"
+        run: |
+          got="$(swiftformat --version)"
+          echo "swiftformat resolves to: $(command -v swiftformat) ($got)"
+          if [ "$got" != "$SWIFTFORMAT_VERSION" ]; then
+            echo "::error::Expected pinned SwiftFormat $SWIFTFORMAT_VERSION but got $got (shadowed by a pre-installed binary)."
+            exit 1
+          fi
       # SwiftFormat path list lives in scripts/lint.sh; calling it keeps CI and
       # local lint runs aligned. SwiftLint stays an explicit step to use the
       # github-actions-logging reporter (annotations in the PR diff).


### PR DESCRIPTION
## Problem

Follow-up to the SwiftFormat 0.61.1 pin (#513). That pin `mv`d the pinned binary into `/usr/local/bin`, but the GitHub macOS runner image **pre-installs a newer SwiftFormat on the Homebrew bin path**, which precedes `/usr/local/bin` in `PATH`. So the bare `swiftformat` call in `scripts/lint.sh` resolved to the pre-installed 0.62.1 and still reformatted the codebase repo-wide (80/351 files) — even though the install step reported success and printed `0.62.1`.

This is why #513's lint went green on its own PR but the same pin failed to take effect on a follow-up PR: PATH resolution was non-deterministic across runner images.

## Fix

- Prepend the pin directory to `$GITHUB_PATH` so the pinned 0.61.1 binary wins over any pre-installed SwiftFormat for all later steps (this is the documented way to override a runner tool).
- Add a dedicated **version-assert step** that hard-fails with a clear `::error::` if a pre-installed binary ever shadows the pin again, instead of silently reformatting the codebase and surfacing as a confusing 80-file lint failure.

Installs into `$RUNNER_TEMP` instead of `/usr/local/bin` (no `sudo` needed).