### PR TITLE
feat(app): expose home-dir-redacted title labels in GET /ui/tree

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift
@@ -3,15 +3,17 @@
     import Foundation
 
     /// One node of the serialized accessibility tree — the Codable wire shape of
-    /// `GET /ui/tree`. Structure and our developer-assigned identifiers only
-    /// (role / identifier / frame / enabled) plus the recursive children.
+    /// `GET /ui/tree`: role / identifier / title / frame / enabled plus the
+    /// recursive children.
     ///
-    /// The endpoint's contract is deliberately "structure, not content": neither
-    /// a control's `title`/`label` nor its `value` is exposed, because both can
-    /// carry user-visible content (a mic name, an endpoint URL, a path) that the
-    /// window allowlist alone doesn't scrub. Drivers assert on `identifier`
-    /// (which the app sets, never user input) and `enabled`; add labels/values
-    /// later behind field-level gating if a use case needs them.
+    /// `title` is the control's label — a static string for most controls
+    /// ("Record Only", "Microphone Name"). It is home-directory redacted so a
+    /// displayed path can't leak the account name; the Settings window is the
+    /// only allowlisted window and its content is already exposed via
+    /// `/screenshot`, so labels here don't widen the surface. A control's
+    /// `value` (a text field's typed contents — mic name, endpoint URL) is
+    /// deliberately NOT exposed: that is user-entered content, and drivers
+    /// assert on `identifier` (app-set, never user input) and `enabled` anyway.
     struct UITreeNode: Codable, Equatable {
         struct Frame: Codable, Equatable {
             let x: Double
@@ -22,6 +24,7 @@
 
         let role: String?
         let identifier: String?
+        let title: String?
         let frame: Frame
         let enabled: Bool
         let children: [Self]
@@ -35,6 +38,7 @@
     protocol UITreeNodeSource {
         var uiRole: String? { get }
         var uiIdentifier: String? { get }
+        var uiTitle: String? { get }
         var uiFrame: CGRect { get }
         var uiEnabled: Bool { get }
         var uiChildren: [any UITreeNodeSource] { get }
@@ -73,6 +77,17 @@
             HTTPRequest.queryValues(target: target, key: "window").first ?? defaultUITreeWindow
         }
 
+        /// Replace a home-directory prefix in a title/label with `~` so a
+        /// displayed folder or URL can't leak the account name. Anchored on the
+        /// path separator (`home + "/"`) so a longer sibling like
+        /// `/Users/romantic` is never mangled; a bare home path collapses to `~`.
+        /// Pure so it is unit-testable; the adapter passes `NSHomeDirectory()`.
+        nonisolated static func redactUITreeString(_ value: String?, homeDirectory: String) -> String? {
+            guard let value, !homeDirectory.isEmpty else { return value }
+            let abbreviated = value.replacingOccurrences(of: homeDirectory + "/", with: "~/")
+            return abbreviated == homeDirectory ? "~" : abbreviated
+        }
+
         /// Recursively convert an accessibility source into the Codable wire
         /// shape, capping recursion at `maxDepth` levels of descendants.
         static func buildUITree(from source: any UITreeNodeSource, maxDepth: Int) -> UITreeNode {
@@ -83,6 +98,7 @@
             return UITreeNode(
                 role: source.uiRole,
                 identifier: source.uiIdentifier,
+                title: source.uiTitle,
                 frame: .init(
                     x: Double(frame.origin.x), y: Double(frame.origin.y),
                     width: Double(frame.size.width), height: Double(frame.size.height),
@@ -125,8 +141,9 @@
     /// Adapter bridging one AppKit accessibility element to `UITreeNodeSource`.
     /// Only children conforming to the umbrella `NSAccessibility` protocol are
     /// followed; an element exposing just the base element protocol is dropped
-    /// (it carries no `accessibilityChildren` anyway). Reads only structural
-    /// attributes — no title/label or value (see `UITreeNode`).
+    /// (it carries no `accessibilityChildren` anyway). Reads role / identifier /
+    /// title / frame / enabled; the title is home-directory redacted and the
+    /// control's `value` is deliberately not read (see `UITreeNode`).
     @MainActor
     private struct AXElementSource: UITreeNodeSource {
         let element: any NSAccessibilityProtocol
@@ -138,6 +155,11 @@
         var uiIdentifier: String? {
             guard let identifier = element.accessibilityIdentifier(), !identifier.isEmpty else { return nil }
             return identifier
+        }
+
+        var uiTitle: String? {
+            let title = element.accessibilityTitle() ?? element.accessibilityLabel()
+            return DebugRPCServer.redactUITreeString(title, homeDirectory: NSHomeDirectory())
         }
 
         var uiFrame: CGRect {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerUITreeTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUITreeTests.swift
@@ -3,8 +3,8 @@
     import XCTest
 
     /// Unit tests for the read-only `GET /ui/tree` accessibility-tree endpoint.
-    /// The pure builder / param-parser / allowlist are exercised with an
-    /// in-memory source; the AppKit walk (the 200 path) is validated live by
+    /// The pure builder / param-parser / allowlist / redaction are exercised with
+    /// an in-memory source; the AppKit walk (the 200 path) is validated live by
     /// `scripts/test_rpc.sh`, mirroring how `/screenshot` is tested.
     final class DebugRPCServerUITreeTests: XCTestCase {
         private static let testToken = "testtoken1234"
@@ -15,17 +15,19 @@
         private final class FakeSource: UITreeNodeSource {
             var uiRole: String?
             var uiIdentifier: String?
+            var uiTitle: String?
             var uiFrame: CGRect
             var uiEnabled: Bool
             var uiChildren: [any UITreeNodeSource]
 
             init(
-                role: String? = nil, identifier: String? = nil,
+                role: String? = nil, identifier: String? = nil, title: String? = nil,
                 frame: CGRect = .zero, enabled: Bool = true,
                 children: [any UITreeNodeSource] = [],
             ) {
                 uiRole = role
                 uiIdentifier = identifier
+                uiTitle = title
                 uiFrame = frame
                 uiEnabled = enabled
                 uiChildren = children
@@ -37,11 +39,11 @@
         @MainActor
         func testBuildUITreeMapsFieldsAndChildren() {
             let child = FakeSource(
-                role: "AXCheckBox", identifier: "recordOnlyToggle",
+                role: "AXCheckBox", identifier: "recordOnlyToggle", title: "Record Only",
                 frame: CGRect(x: 10, y: 20, width: 30, height: 40), enabled: false,
             )
             let root = FakeSource(
-                role: "AXWindow", identifier: nil,
+                role: "AXWindow", identifier: nil, title: "Settings",
                 frame: CGRect(x: 0, y: 0, width: 800, height: 600),
                 enabled: true, children: [child],
             )
@@ -50,6 +52,7 @@
 
             XCTAssertEqual(tree.role, "AXWindow")
             XCTAssertNil(tree.identifier)
+            XCTAssertEqual(tree.title, "Settings")
             XCTAssertEqual(tree.frame.width, 800)
             XCTAssertTrue(tree.enabled)
             XCTAssertEqual(tree.children.count, 1)
@@ -57,6 +60,7 @@
             let mapped = tree.children[0]
             XCTAssertEqual(mapped.role, "AXCheckBox")
             XCTAssertEqual(mapped.identifier, "recordOnlyToggle")
+            XCTAssertEqual(mapped.title, "Record Only")
             XCTAssertEqual(mapped.frame.x, 10)
             XCTAssertEqual(mapped.frame.height, 40)
             XCTAssertFalse(mapped.enabled)
@@ -116,6 +120,33 @@
             XCTAssertFalse(DebugRPCServer.isWindowAllowedForUITree(identifier: "live-captions"))
             XCTAssertFalse(DebugRPCServer.isWindowAllowedForUITree(identifier: ""))
             XCTAssertFalse(DebugRPCServer.isWindowAllowedForUITree(identifier: nil))
+        }
+
+        // MARK: - redaction (pure)
+
+        func testRedactUITreeStringAbbreviatesHomeAtPathBoundary() {
+            XCTAssertEqual(
+                DebugRPCServer.redactUITreeString("/Users/roman/Documents/out.md", homeDirectory: "/Users/roman"),
+                "~/Documents/out.md",
+            )
+            // A displayed path mid-string is abbreviated too.
+            XCTAssertEqual(
+                DebugRPCServer.redactUITreeString("Saving to /Users/roman/x", homeDirectory: "/Users/roman"),
+                "Saving to ~/x",
+            )
+            // The bare home path collapses to "~".
+            XCTAssertEqual(DebugRPCServer.redactUITreeString("/Users/roman", homeDirectory: "/Users/roman"), "~")
+            // A longer sibling must NOT be mangled (path-boundary guard).
+            XCTAssertEqual(
+                DebugRPCServer.redactUITreeString("/Users/romantic/file", homeDirectory: "/Users/roman"),
+                "/Users/romantic/file",
+            )
+            XCTAssertNil(DebugRPCServer.redactUITreeString(nil, homeDirectory: "/Users/roman"))
+            XCTAssertEqual(
+                DebugRPCServer.redactUITreeString("/Users/roman/x", homeDirectory: ""),
+                "/Users/roman/x",
+                "an empty home directory must leave the string untouched",
+            )
         }
 
         // MARK: - route


### PR DESCRIPTION
## What

Brings `title` (the control's accessibility label) back into `GET /ui/tree`.
Slice 1 (#515) shipped the endpoint with `title` omitted after code review
flagged that the home-directory redaction didn't cover every label. This adds
it back deliberately, with the redaction bug fixed.

## Why it's safe to expose title now

- The **Settings** window is the only allowlisted window, and its content is
  **already exposed via `/screenshot`** over the same token-gated RPC —
  surfacing its labels as text doesn't widen the surface.
- `title` is the control's **label** (mostly static: "Record Only",
  "Microphone Name"), home-directory redacted so a displayed folder path can't
  leak the account name.
- A control's **`value` stays omitted** — that's user-entered content (mic
  name, endpoint URL). The "no user-entered content" line holds; only labels
  come back.

## Redaction bug fix

The slice-1 redaction did a plain substring replace, so `/Users/romantic`
became `~tic` when home was `/Users/roman` (one of the reasons dropping title
was the safe call then). It's now anchored on the path separator (`home + "/"`),
abbreviating a displayed path to `~` without mangling a longer sibling, and
collapsing a bare home path to `~`. A unit test guards the boundary.

## Testing

- Unit tests: title mapping through the builder + the boundary-anchored
  redaction (including the `/Users/romantic` guard).
- Full suite green; Homebrew + App Store variant builds green.
- The live tree (with labels) is exercised by `scripts/test_rpc.sh` as before.
