### PR TITLE
ci: add GitHub-hosted /ui/* self-pid AX canary lane

### DIFF
--- a/.github/workflows/e2e-ui-smoke.yml
+++ b/.github/workflows/e2e-ui-smoke.yml
@@ -14,15 +14,19 @@ name: E2E — UI Smoke (self-pid /ui/* canary)
 on:
   workflow_dispatch:
   pull_request:
-    # Self-validate only PRs that touch the harness or this lane; unrelated PRs
-    # aren't burdened with a full release build on the macos-26 runner budget.
+    # Self-validate only PRs that touch the harness, its request/response + routing
+    # layer, the build path it drives, or this lane. Unrelated PRs aren't burdened
+    # with a full release build on the macos-26 runner budget.
     paths:
       - '.github/workflows/e2e-ui-smoke.yml'
       - 'scripts/e2e-settings-smoke.sh'
+      - 'scripts/build_release.sh'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+      - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
+      - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
   push:
     branches: [main]
     paths:
@@ -30,7 +34,10 @@ on:
       - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
       - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+      - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
+      - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
       - 'scripts/e2e-settings-smoke.sh'
+      - 'scripts/build_release.sh'
       - '.github/workflows/e2e-ui-smoke.yml'
   schedule:
     # 04:00 UTC — after quality-and-safety (03:00) and appstore (03:30), before
@@ -43,6 +50,10 @@ on:
 concurrency:
   group: ui-smoke-${{ github.ref }}
   cancel-in-progress: true
+
+# Least privilege: the job only reads the repo and uploads an artifact; no writes.
+permissions:
+  contents: read
 
 jobs:
   smoke:

--- a/.github/workflows/e2e-ui-smoke.yml
+++ b/.github/workflows/e2e-ui-smoke.yml
@@ -1,0 +1,65 @@
+name: E2E — UI Smoke (self-pid /ui/* canary)
+
+# Canary for the in-process /ui/* accessibility harness. Builds the Homebrew
+# .app, launches it with the debug RPC on a GitHub-hosted runner, and asserts the
+# self-pid AXUIElement path still works: GET /ui/tree surfaces a SwiftUI
+# identifier and POST /ui/press flips /state. That path rests on three
+# non-contractual macOS behaviors (see DebugRPCServer+AXElement.swift); this lane
+# makes an OS update that breaks any of them fail loudly and attributably.
+#
+# Runs on GitHub-hosted macOS (not the self-hosted Mac): the harness needs no TCC
+# grant (self-inspection is exempt), so it doesn't depend on the mini's manual
+# permission grants — which is the whole point of proving it here.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # Self-validate only PRs that touch the harness or this lane; unrelated PRs
+    # aren't burdened with a full release build on the macos-26 runner budget.
+    paths:
+      - '.github/workflows/e2e-ui-smoke.yml'
+      - 'scripts/e2e-settings-smoke.sh'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+  push:
+    branches: [main]
+    paths:
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+      - 'scripts/e2e-settings-smoke.sh'
+      - '.github/workflows/e2e-ui-smoke.yml'
+  schedule:
+    # 04:00 UTC — after quality-and-safety (03:00) and appstore (03:30), before
+    # e2e-app (04:30), so nightly failures are easy to disambiguate in `gh run list`.
+    # The nightly run is the real reason this lane exists: it catches macOS drift
+    # breaking the non-contractual self-pid AX path even when no code changed.
+    - cron: '0 4 * * *'
+
+# Two runs would race on the build dir and the launched app process.
+concurrency:
+  group: ui-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/verify-xcode
+
+      - name: UI smoke — drive /ui/* against the live app
+        run: ./scripts/e2e-settings-smoke.sh
+
+      - name: Upload crash reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-smoke-crash-reports
+          path: ~/Library/Logs/DiagnosticReports/MeetingTranscriber-*.ips
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,7 @@ scripts/
   run_app.sh               # Build + sign + launch menu bar app bundle (--build-only skips `open -W`)
   e2e-app.sh               # Live-recording E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
   e2e-channel-health.sh    # E2E test for per-channel signal indicator (forces mic-silent state + asserts red-tint via RPC screenshot)
+  e2e-settings-smoke.sh    # GitHub-hosted /ui/* canary: build homebrew .app + launch with RPC + assert GET /ui/tree surfaces recordOnlyToggle and POST /ui/press flips /state (self-pid AX; no TCC; run by e2e-ui-smoke.yml)
   e2e-silent-recording.sh  # E2E test for silent-recording detector (both channels at noise floor → in-app warning)
   e2e-live-captions.sh     # E2E driver asserting on in-flight liveCaptions.recentFinals RPC state (complements e2e-app.sh)
   e2e-cpu-load.sh          # E2E resource measurement: idle + recording-without-captions + recording-with-live-captions CPU/RAM of the deployed app via RPC /metrics deltas (logs trends, gates only a generous idle-CPU catastrophe bound)
@@ -232,6 +233,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly + label-gated PR runs via `run-e2e`)
   e2e-cpu-load.yml         # E2E — idle + in-meeting CPU/RAM measurement of the deployed app (dispatch + nightly trend cron, RESULT artifact)
   appstore.yml             # App Store variant smoke test: build + launch-check (main push + nightly + dispatch)
+  e2e-ui-smoke.yml         # E2E — GitHub-hosted /ui/* self-pid AX canary: build homebrew .app, drive GET /ui/tree + POST /ui/press, assert (guards the non-contractual self-pid path against macOS drift; no TCC → runs off the mini; paths-filtered PR + main push + nightly + dispatch)
   build-perf-tracking.yml  # Weekly build performance trend analysis (flags regressions vs 28-day baseline)
   quality-and-safety.yml   # TSan/ASan matrix + WER/DER quality regression (main + nightly + dispatch + label-gated PR runs via `run-quality`)
   dependabot-auto-merge.yml # Auto-merge Dependabot patch/minor and github-actions bumps

--- a/scripts/e2e-settings-smoke.sh
+++ b/scripts/e2e-settings-smoke.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# GitHub-hosted canary for the in-process /ui/* accessibility harness.
+#
+# Builds the Homebrew .app (the RPC server + /ui/* are `#if !APPSTORE`), launches
+# it with the debug RPC, opens Settings, and asserts the self-pid AXUIElement path
+# still works: `GET /ui/tree` surfaces a SwiftUI `.accessibilityIdentifier`, and
+# `POST /ui/press` flips the observed `/state`. That path rests on three
+# non-contractual macOS behaviors (lazy AX materialization, self-pid TCC exemption,
+# self-pid direct dispatch — see DebugRPCServer+AXElement.swift); this canary makes
+# an OS update that breaks any of them fail loudly and attributably.
+#
+# It needs NO Accessibility/mic/screen-recording TCC grant (self-inspection is
+# exempt; it only reads/presses Settings, never records), which is exactly what
+# lets it run on an ephemeral GitHub-hosted runner instead of the self-hosted Mac.
+#
+# Usage: ./scripts/e2e-settings-smoke.sh    (exit 0 pass, non-zero on first failure)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPM_DIR="$REPO_ROOT/app/MeetingTranscriber"
+APP="$SPM_DIR/.build/release/MeetingTranscriber.app"
+TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+BASE="http://127.0.0.1:9876"
+
+step() { printf "\n\033[1;34m==> %s\033[0m\n" "$1"; }
+ok()   { printf "    \033[0;32m✓\033[0m %s\n" "$1"; }
+fail() { printf "    \033[0;31m✗\033[0m %s\n" "$1"; exit 1; }
+
+# `-x` (exact name) so we never touch a developer's MeetingTranscriber-Dev while
+# this runs locally; the release bundle's process is exactly "MeetingTranscriber".
+step "Build Homebrew .app (ad-hoc signed)"
+pkill -x MeetingTranscriber 2>/dev/null || true
+sleep 1
+"$REPO_ROOT/scripts/build_release.sh" --no-notarize >/dev/null
+[ -d "$APP" ] || fail "no app bundle at $APP"
+ok "built $APP"
+
+step "Launch with MEETINGTRANSCRIBER_DEBUG_RPC=1"
+trap 'pkill -x MeetingTranscriber 2>/dev/null || true' EXIT
+MEETINGTRANSCRIBER_DEBUG_RPC=1 open -gj "$APP"
+for _ in $(seq 1 60); do
+    [ -s "$TOKEN_FILE" ] && lsof -i :9876 >/dev/null 2>&1 && break
+    sleep 0.5
+done
+[ -s "$TOKEN_FILE" ] || fail "RPC token never appeared — the app didn't start the RPC server"
+lsof -i :9876 >/dev/null 2>&1 || fail "nothing bound :9876 within 30s"
+TOKEN=$(cat "$TOKEN_FILE")
+AUTH=(-H "Authorization: Bearer $TOKEN")
+curl -sf "${AUTH[@]}" -o /dev/null "$BASE/healthz" || fail "RPC not reachable on :9876"
+ok "RPC listening + authenticated"
+
+step "Open Settings"
+curl -sf "${AUTH[@]}" -X POST "$BASE/action/openSettings" -o /dev/null || fail "openSettings failed"
+sleep 2
+
+step "GET /ui/tree surfaces the SwiftUI identifier (self-pid AX works on this runner)"
+code=$(curl -s -o /tmp/ui-tree.json -w '%{http_code}' "${AUTH[@]}" "$BASE/ui/tree?window=settings")
+[ "$code" = "200" ] \
+    || fail "/ui/tree returned $code (503 => the Settings window did not render on this runner)"
+python3 -c "
+import json,sys
+t=json.load(open('/tmp/ui-tree.json'))
+ids=[]
+def w(n):
+    if n.get('identifier'): ids.append(n['identifier'])
+    for c in n.get('children',[]): w(c)
+w(t)
+assert 'recordOnlyToggle' in ids, \
+    f'recordOnlyToggle absent (ids={sorted(set(ids))}) => self-pid AX not surfacing SwiftUI identifiers here'
+print('    tree identifiers:', sorted(set(ids)))
+" || fail "/ui/tree did not surface recordOnlyToggle"
+ok "recordOnlyToggle present in the accessibility tree"
+
+step "POST /ui/press flips the observed state (in-process press fires on this runner)"
+read_record_only() {
+    curl -sf "${AUTH[@]}" "$BASE/state" \
+        | python3 -c "import json,sys; print(json.load(sys.stdin)['settings']['recording']['recordOnly'])"
+}
+press() {
+    curl -sf "${AUTH[@]}" -X POST "$BASE/ui/press" \
+        -H 'Content-Type: application/json' \
+        -d '{"window":"settings","identifier":"recordOnlyToggle"}' -o /dev/null
+}
+before=$(read_record_only)
+[ -n "$before" ] || fail "could not read settings.recording.recordOnly"
+press || fail "ui/press recordOnlyToggle failed"
+sleep 1
+after=$(read_record_only)
+[ "$before" != "$after" ] \
+    || fail "recordOnly did not flip ($before -> $after) => in-process AX press did not fire on this runner"
+ok "recordOnly flipped $before -> $after"
+press || true  # restore original state
+ok "restored"
+
+echo
+echo "UI-SMOKE PASSED — self-pid /ui/* harness works on this runner"

--- a/scripts/e2e-settings-smoke.sh
+++ b/scripts/e2e-settings-smoke.sh
@@ -23,22 +23,28 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP="$REPO_ROOT/.build/release/MeetingTranscriber.app"
 TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 BASE="http://127.0.0.1:9876"
+TREE_JSON="$(mktemp)"
 
 step() { printf "\n\033[1;34m==> %s\033[0m\n" "$1"; }
 ok()   { printf "    \033[0;32m✓\033[0m %s\n" "$1"; }
 fail() { printf "    \033[0;31m✗\033[0m %s\n" "$1"; exit 1; }
 
-# `-x` (exact name) so we never touch a developer's MeetingTranscriber-Dev while
-# this runs locally; the release bundle's process is exactly "MeetingTranscriber".
+# Kill only THIS release bundle's process, matched by its unique bundle path.
+# Both the release and a developer's MeetingTranscriber-Dev bundle share the
+# executable name "MeetingTranscriber" (only the .app dir differs), so `pkill -x`
+# would hit both; `-f "$APP"` disambiguates so running this locally never touches
+# a running Dev app.
+kill_app() { pkill -f "$APP" 2>/dev/null || true; }
+trap 'kill_app; rm -f "$TREE_JSON"' EXIT
+
 step "Build Homebrew .app (ad-hoc signed)"
-pkill -x MeetingTranscriber 2>/dev/null || true
+kill_app
 sleep 1
 "$REPO_ROOT/scripts/build_release.sh" --no-notarize >/dev/null
 [ -d "$APP" ] || fail "no app bundle at $APP"
 ok "built $APP"
 
 step "Launch with MEETINGTRANSCRIBER_DEBUG_RPC=1"
-trap 'pkill -x MeetingTranscriber 2>/dev/null || true' EXIT
 MEETINGTRANSCRIBER_DEBUG_RPC=1 open -gj "$APP"
 for _ in $(seq 1 60); do
     [ -s "$TOKEN_FILE" ] && lsof -i :9876 >/dev/null 2>&1 && break
@@ -48,51 +54,80 @@ done
 lsof -i :9876 >/dev/null 2>&1 || fail "nothing bound :9876 within 30s"
 TOKEN=$(cat "$TOKEN_FILE")
 AUTH=(-H "Authorization: Bearer $TOKEN")
-curl -sf "${AUTH[@]}" -o /dev/null "$BASE/healthz" || fail "RPC not reachable on :9876"
+curl -sf --max-time 15 "${AUTH[@]}" -o /dev/null "$BASE/healthz" || fail "RPC not reachable on :9876"
 ok "RPC listening + authenticated"
 
 step "Open Settings"
-curl -sf "${AUTH[@]}" -X POST "$BASE/action/openSettings" -o /dev/null || fail "openSettings failed"
-sleep 2
+curl -sf --max-time 15 "${AUTH[@]}" -X POST "$BASE/action/openSettings" -o /dev/null || fail "openSettings failed"
 
-step "GET /ui/tree surfaces the SwiftUI identifier (self-pid AX works on this runner)"
-code=$(curl -s -o /tmp/ui-tree.json -w '%{http_code}' "${AUTH[@]}" "$BASE/ui/tree?window=settings")
-[ "$code" = "200" ] \
-    || fail "/ui/tree returned $code (503 => the Settings window did not render on this runner)"
-python3 -c "
-import json,sys
-t=json.load(open('/tmp/ui-tree.json'))
-ids=[]
-def w(n):
-    if n.get('identifier'): ids.append(n['identifier'])
-    for c in n.get('children',[]): w(c)
-w(t)
-assert 'recordOnlyToggle' in ids, \
-    f'recordOnlyToggle absent (ids={sorted(set(ids))}) => self-pid AX not surfacing SwiftUI identifiers here'
+# The Settings window renders and its AX subtree materializes lazily, and launch
+# fires a CoreML model warm-up that can saturate a cold runner — so poll for the
+# identifier rather than guessing a fixed sleep (would flake on the nightly cron).
+step "GET /ui/tree surfaces recordOnlyToggle (poll: window + AX tree materialize lazily)"
+last_code=""
+ui_tree_has_toggle() {
+    last_code=$(curl -s --max-time 15 -o "$TREE_JSON" -w '%{http_code}' \
+        "${AUTH[@]}" "$BASE/ui/tree?window=settings" || true)
+    [ "$last_code" = "200" ] || return 1
+    python3 - "$TREE_JSON" <<'PY'
+import json, sys
+try:
+    tree = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+ids = []
+def walk(n):
+    if n.get('identifier'):
+        ids.append(n['identifier'])
+    for c in n.get('children', []):
+        walk(c)
+walk(tree)
+sys.exit(0 if 'recordOnlyToggle' in ids else 1)
+PY
+}
+found=false
+for _ in $(seq 1 30); do
+    if ui_tree_has_toggle; then found=true; break; fi
+    sleep 1
+done
+[ "$found" = true ] || fail "/ui/tree never surfaced recordOnlyToggle within 30s (last HTTP ${last_code:-none}): \
+503 => Settings window didn't render; 200 => AX subtree not materialized / self-pid AX not surfacing identifiers here"
+python3 - "$TREE_JSON" <<'PY'
+import json, sys
+tree = json.load(open(sys.argv[1]))
+ids = []
+def walk(n):
+    if n.get('identifier'):
+        ids.append(n['identifier'])
+    for c in n.get('children', []):
+        walk(c)
+walk(tree)
 print('    tree identifiers:', sorted(set(ids)))
-" || fail "/ui/tree did not surface recordOnlyToggle"
+PY
 ok "recordOnlyToggle present in the accessibility tree"
 
 step "POST /ui/press flips the observed state (in-process press fires on this runner)"
 read_record_only() {
-    curl -sf "${AUTH[@]}" "$BASE/state" \
+    curl -sf --max-time 15 "${AUTH[@]}" "$BASE/state" \
         | python3 -c "import json,sys; print(json.load(sys.stdin)['settings']['recording']['recordOnly'])"
 }
 press() {
-    curl -sf "${AUTH[@]}" -X POST "$BASE/ui/press" \
+    curl -sf --max-time 15 "${AUTH[@]}" -X POST "$BASE/ui/press" \
         -H 'Content-Type: application/json' \
         -d '{"window":"settings","identifier":"recordOnlyToggle"}' -o /dev/null
 }
-before=$(read_record_only)
-[ -n "$before" ] || fail "could not read settings.recording.recordOnly"
+before=$(read_record_only) || fail "could not read /state (app not responding — crashed after openSettings?)"
 press || fail "ui/press recordOnlyToggle failed"
-sleep 1
-after=$(read_record_only)
+after="$before"
+for _ in $(seq 1 5); do
+    after=$(read_record_only) || fail "could not read /state after press"
+    [ "$after" != "$before" ] && break
+    sleep 1
+done
 [ "$before" != "$after" ] \
     || fail "recordOnly did not flip ($before -> $after) => in-process AX press did not fire on this runner"
 ok "recordOnly flipped $before -> $after"
-press || true  # restore original state
-ok "restored"
+if press; then ok "restored"; else echo "    (restore press failed — harmless on the ephemeral runner)"; fi
 
 echo
 echo "UI-SMOKE PASSED — self-pid /ui/* harness works on this runner"

--- a/scripts/e2e-settings-smoke.sh
+++ b/scripts/e2e-settings-smoke.sh
@@ -18,8 +18,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SPM_DIR="$REPO_ROOT/app/MeetingTranscriber"
-APP="$SPM_DIR/.build/release/MeetingTranscriber.app"
+# build_release.sh assembles the bundle at the repo-root .build/release (it moves
+# the .app back there after staging the DMG), NOT the SPM package's .build.
+APP="$REPO_ROOT/.build/release/MeetingTranscriber.app"
 TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 BASE="http://127.0.0.1:9876"
 


### PR DESCRIPTION
## What

Adds a CI canary for the in-process `/ui/*` accessibility harness (merged in #517).
Until now the only thing exercising `GET /ui/tree` / `POST /ui/press` was the
**manual** `scripts/test_rpc.sh` — nothing in CI. The self-pid `AXUIElement` path
rests on three non-contractual macOS behaviors (lazy AX materialization, self-pid
TCC exemption, self-pid direct dispatch), so an OS update could silently break both
endpoints with no signal.

- `scripts/e2e-settings-smoke.sh` — build the Homebrew `.app` (RPC is `#if !APPSTORE`),
  launch it with the debug RPC, open Settings, assert: `GET /ui/tree` surfaces
  `recordOnlyToggle` **and** `POST /ui/press` flips `settings.recording.recordOnly`
  in `/state`.
- `.github/workflows/e2e-ui-smoke.yml` — runs it on a **GitHub-hosted** `macos-26`
  runner (paths-filtered PRs + push to main + nightly cron + dispatch).

## Why GitHub-hosted (not the mini)

The harness needs **no** Accessibility/mic/screen-recording TCC grant (self-inspection
is exempt; it only reads/presses Settings, never records). So it doesn't depend on the
self-hosted mini's manual permission grants — and running it here also proves that
TCC-free claim.

## PoC note — this PR's own run is the test

The open question Fable's SOTA review flagged: does a GitHub-hosted runner provide a
sufficient GUI (window server) for the Settings window to render and the self-pid AX
tree to populate? This PR triggers the lane on itself (paths match), so **this PR's
`e2e-ui-smoke` check answers it**:
- **green** → the canary is viable; it guards the harness from here on.
- **`/ui/tree` 503 / `recordOnlyToggle` absent / press doesn't flip** → the runner's
  GUI/AX context is insufficient; fall back to running the canary on the mini
  (self-hosted) — still a canary, just not GitHub-hosted. The script's failure
  messages say which of the three it was.

Nightly is the real reason it exists: catch macOS drift breaking the non-contractual
path even when no code changes.