### PR TITLE
refactor(app): A11yID accessibility-identifier namespace + GUI testing practice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     AppPaths.swift         # Centralized paths (ipcDir, dataDir, logSubsystem, speakersDB)
     AppSettings.swift      # @Observable settings (UserDefaults + file-based secrets)
     AXHelper.swift         # Shared accessibility API helper
+    A11yID.swift           # Single source of truth for accessibility identifiers used as automation handles (ViewInspector find + /ui/press allowlist reference the constants → compiler catches drift)
     NotificationManager.swift # macOS notifications
     KeychainHelper.swift   # Keychain CRUD (legacy/test-only, token now file-based)
     TranscriberStatus.swift # Status + MeetingInfo models
@@ -448,6 +449,55 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - Screen Recording permission required for **meeting detection** (window titles via `CGWindowListCopyWindowInfo`)
 - Audio capture (AudioTapLib) does NOT require Screen Recording — uses CATapDescription (purple dot indicator)
 - FluidAudio models are downloaded automatically on first run (~50 MB)
+
+## GUI Testing
+
+Rule: test each behavior at the cheapest layer that can falsify it.
+
+1. **Pure logic first.** Extract decision logic into a value type
+   (`BadgeKind.compute`, `LiveCaptionsGate`, `WatchLoopEndPolicy` pattern) and put
+   the bulk of assertions there.
+2. **ViewInspector** (`swift test`, every PR): exactly one wiring test per control —
+   find by an `A11yID` constant, drive (`.tap()`/`.select()`/`.increment()`), assert
+   the `AppSettings` write-back. Don't enumerate logic states through the view;
+   that's layer 1's job. (ViewInspector is reflection over undocumented SwiftUI
+   internals — keep to the boring primitives; breakage is loud since it runs on
+   every PR.)
+3. **`/state` (live RPC):** first choice for live assertions, including window/scene
+   behavior via `/state.windows` (`isVisible` after deactivate, `floating`,
+   `canJoinAllSpaces` — how #509/#511 guard the naming-window pin).
+4. **`/ui/tree` + `/ui/press`** (live, Settings window only): only for behavior that
+   exists solely in the real AppKit/AX layer. A live test earns its keep only when
+   ViewInspector cannot instantiate the failing layer (real NSWindow/NSPanel,
+   focus/activation, scene routing, the NSHostingView boundary, actual AX exposure).
+5. **Snapshots** (dev-only, `XCTSkipIf(isCI)`): pixel truth; never CI-gated.
+
+**Identifiers:** add `.accessibilityIdentifier` on demand via the shared `A11yID`
+namespace (`Sources/A11yID.swift`) — the view modifier, the ViewInspector `find`, and
+the `/ui/press` allowlist all reference the constant so the compiler catches drift.
+Interaction tests never locate by display label; `find(text:)` only when the label
+itself is the behavior under test. An identifier makes a control tree-visible;
+press-drivable *additionally* requires a `/ui/press` allowlist entry — never allowlist
+a control whose action opens a menu/popover/sheet/panel (a nested runloop wedges the
+app, see `DebugRPCServer+UIPress.swift`). Never widen the window allowlist to PII
+windows or expose control values (`DebugRPCServer+UITree.swift`).
+
+**Live assertions:** assert the `/state` effect, never the returned `pressed` flag or
+tree structure (depth/frames/child counts). Assert the env-stable, load-bearing pin
+subset (`isVisible`, `floating`, `canJoinAllSpaces`) — `fullScreenAuxiliary` proved
+env-unstable on the CI mini (#511). `e2e-ui-smoke` is a harness-liveness canary only —
+feature-level live assertions go in `test_rpc.sh` or the `e2e-app` lanes.
+
+**GUI bug found:** failing test first, at the lowest layer that reproduces it. If only
+the live scene reproduces, drive the real scene window (a minimal probe window does not
+reproduce — #504). Acceptance: revert the fix, test goes red.
+
+**Don't:** chase snapshot coverage; use `/ui/press` to arrange state (it's for testing
+the pressed control); test SwiftUI framework behavior (e.g. that `.keyboardShortcut`
+fires). **Manual-QA-only, accepted:** menu-bar dropdown interaction, modal panels
+(NSOpenPanel/NSAlert), TCC prompts, typing into fields (no `/ui/setValue` — AX-set
+doesn't fire the SwiftUI binding), drag/focus order, visual appearance beyond dev-only
+snapshots.
 
 ## E2E Architecture
 

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Single source of truth for the accessibility identifiers used as automation
+/// handles (ViewInspector `find`, the `/ui/tree` + `/ui/press` harness).
+///
+/// Referencing these constants from the SwiftUI `.accessibilityIdentifier`
+/// modifier, the ViewInspector tests, and the `/ui/press` allowlist makes the
+/// compiler catch a drifted identifier across those call sites — a raw string
+/// literal duplicated per site drifts silently. Shell drivers (`test_rpc.sh`,
+/// curl) still use the raw string; those are grep-checked.
+///
+/// Add an entry on demand when a test or the harness needs to find/drive a
+/// control — don't spray identifiers onto controls nothing drives. The string
+/// values are the stable contract (VoiceOver + tests + allowlist read them) and
+/// are heterogeneous on purpose (some kebab-case, some camelCase — they mirror
+/// the pre-existing identifiers); don't "tidy" or otherwise change a value
+/// without updating every site.
+enum A11yID {
+    // Settings — section anchors + record-only controls.
+    static let recordOnlyToggle = "recordOnlyToggle"
+    static let recordOnlyBanner = "recordOnlyBanner"
+    static let transcriptionSection = "transcriptionSection"
+    static let protocolSection = "protocolSection"
+    static let outputFolderSection = "outputFolderSection"
+    static let vadSection = "vadSection"
+    static let diarizationSection = "diarizationSection"
+    static let liveTranscriptionSection = "liveTranscriptionSection"
+    static let channelIndicatorSection = "channelIndicatorSection"
+    static let experimentalTuningDisclosure = "experimentalTuningDisclosure"
+    static let sortformerCapHint = "sortformer-cap-hint"
+
+    // Speaker-naming dialog.
+    static let confirmButton = "confirm-button"
+    static let skipButton = "skip-button"
+    static let rerunButton = "rerun-button"
+    static let rerunStepper = "rerun-stepper"
+    static let rerunModePicker = "rerun-mode-picker"
+
+    /// Per-speaker play button (`play-<label>`); the label varies at runtime.
+    static func play(_ speakerLabel: String) -> String {
+        "play-\(speakerLabel)"
+    }
+
+    /// Prefix for the per-participant name chips (`participant-name-<name>`);
+    /// the name is appended at the call site.
+    static let participantNamePrefix = "participant-name-"
+
+    static func knownName(_ name: String) -> String {
+        "known-name-\(name)"
+    }
+
+    static func knownMore(_ speakerLabel: String) -> String {
+        "known-more-\(speakerLabel)"
+    }
+
+    static func knownLess(_ speakerLabel: String) -> String {
+        "known-less-\(speakerLabel)"
+    }
+
+    // Live captions overlay.
+    static let liveCaptionBackend = "liveCaptionBackend"
+}

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
@@ -78,7 +78,7 @@
         /// would wedge the server and UI. This invariant, not the (localhost +
         /// token + env-gated + `#if !APPSTORE`) security margin, is the allowlist's
         /// real justification.
-        nonisolated static let uiPressAllowedIdentifiers: Set<String> = ["recordOnlyToggle"]
+        nonisolated static let uiPressAllowedIdentifiers: Set<String> = [A11yID.recordOnlyToggle]
 
         nonisolated static func isIdentifierAllowedForUIPress(_ identifier: String) -> Bool {
             uiPressAllowedIdentifiers.contains(identifier)

--- a/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
+++ b/app/MeetingTranscriber/Sources/LiveCaptionsOverlay.swift
@@ -45,7 +45,7 @@ struct LiveCaptionsOverlay: View {
                 Text(backend)
                     .font(.system(size: 11, weight: .semibold, design: .rounded))
                     .foregroundStyle(.white.opacity(0.45))
-                    .accessibilityIdentifier("liveCaptionBackend")
+                    .accessibilityIdentifier(A11yID.liveCaptionBackend)
             }
             ForEach(state.recentFinals.suffix(LiveCaptionsState.maxFinalsKept), id: \.self) { line in
                 row(speaker: line.speaker, text: line.text, opacity: 1.0)

--- a/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
@@ -59,7 +59,7 @@ private struct VoiceActivityDetectionSection: View {
                 }
             }
         }
-        .accessibilityIdentifier("vadSection")
+        .accessibilityIdentifier(A11yID.vadSection)
         .recordOnlyDisabled(settings.recordOnly)
     }
 }
@@ -91,6 +91,6 @@ private struct PerChannelIndicatorSection: View {
                 .help(SettingsHelp.asymmetricSilenceWarning)
             }
         }
-        .accessibilityIdentifier("channelIndicatorSection")
+        .accessibilityIdentifier(A11yID.channelIndicatorSection)
     }
 }

--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -10,7 +10,7 @@ struct GeneralSettingsView: View {
         Form {
             Section("Mode") {
                 Toggle("Record-only mode", isOn: $settings.recordOnly)
-                    .accessibilityIdentifier("recordOnlyToggle")
+                    .accessibilityIdentifier(A11yID.recordOnlyToggle)
                 if settings.recordOnly {
                     recordOnlyBanner
                 }
@@ -76,7 +76,7 @@ struct GeneralSettingsView: View {
         }
         .padding(8)
         .background(Color.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
-        .accessibilityIdentifier("recordOnlyBanner")
+        .accessibilityIdentifier(A11yID.recordOnlyBanner)
     }
 
     private func updatesSection(updateChecker: UpdateChecker) -> some View {

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -75,7 +75,7 @@ struct OutputSettingsView: View {
                     Spacer()
                 }
             }
-            .accessibilityIdentifier("outputFolderSection")
+            .accessibilityIdentifier(A11yID.outputFolderSection)
 
             Section("Protocol Generation") {
                 Picker("LLM Provider", selection: $settings.protocolProvider) {
@@ -94,7 +94,7 @@ struct OutputSettingsView: View {
 
                 promptControls
             }
-            .accessibilityIdentifier("protocolSection")
+            .accessibilityIdentifier(A11yID.protocolSection)
             .recordOnlyDisabled(settings.recordOnly)
         }
         .formStyle(.grouped)

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -49,7 +49,7 @@ struct SpeakersSettingsView: View {
     var body: some View {
         Form {
             diarizationSection
-                .accessibilityIdentifier("diarizationSection")
+                .accessibilityIdentifier(A11yID.diarizationSection)
                 .recordOnlyDisabled(settings.recordOnly)
 
             if !settings.noMic {
@@ -160,7 +160,7 @@ struct SpeakersSettingsView: View {
         } label: {
             tuningDisclosureLabel
         }
-        .accessibilityIdentifier("experimentalTuningDisclosure")
+        .accessibilityIdentifier(A11yID.experimentalTuningDisclosure)
     }
 
     private var tuningDisclosureLabel: some View {

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -69,7 +69,7 @@ struct TranscriptionSettingsView: View {
 
                 engineStatusView
             }
-            .accessibilityIdentifier("transcriptionSection")
+            .accessibilityIdentifier(A11yID.transcriptionSection)
             .recordOnlyDisabled(settings.recordOnly)
 
             liveTranscriptionSection
@@ -116,7 +116,7 @@ struct TranscriptionSettingsView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .accessibilityIdentifier("liveTranscriptionSection")
+        .accessibilityIdentifier(A11yID.liveTranscriptionSection)
         .recordOnlyDisabled(settings.recordOnly)
     }
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -174,14 +174,14 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                     in: Self.rerunCountRange(for: rerunMode),
                 )
                 .font(.caption)
-                .accessibilityIdentifier("rerun-stepper")
+                .accessibilityIdentifier(A11yID.rerunStepper)
                 rerunButton
             }
             if currentDiarizerMode != nil, rerunMode == .sortformer {
                 Text("Sortformer caps at \(DiarizerMode.sortformer.speakerCap) speakers — switch to Offline for larger meetings.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("sortformer-cap-hint")
+                    .accessibilityIdentifier(A11yID.sortformerCapHint)
             }
         }
     }
@@ -194,7 +194,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         .pickerStyle(.segmented)
         .frame(width: 200)
         .font(.caption)
-        .accessibilityIdentifier("rerun-mode-picker")
+        .accessibilityIdentifier(A11yID.rerunModePicker)
         .onChange(of: rerunMode) { _, newMode in
             rerunCount = Self.clampCount(rerunCount, for: newMode)
         }
@@ -221,7 +221,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
             }
         }
         .font(.caption)
-        .accessibilityIdentifier("rerun-button")
+        .accessibilityIdentifier(A11yID.rerunButton)
     }
 
     static func computeSpeakers(
@@ -266,7 +266,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                 }
                 .keyboardShortcut(.escape)
                 .disabled(keyboardGracePeriodActive)
-                .accessibilityIdentifier("skip-button")
+                .accessibilityIdentifier(A11yID.skipButton)
 
                 Button("Confirm") {
                     guard completedJobID != data.jobID else { return }
@@ -276,7 +276,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                 .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
                 .disabled(keyboardGracePeriodActive)
-                .accessibilityIdentifier("confirm-button")
+                .accessibilityIdentifier(A11yID.confirmButton)
             }
             .padding(.bottom, 8)
         }
@@ -356,7 +356,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                                 .foregroundStyle(.blue)
                         }
                         .buttonStyle(.plain)
-                        .accessibilityIdentifier("play-\(speaker.label)")
+                        .accessibilityIdentifier(A11yID.play(speaker.label))
                     }
 
                     Spacer()
@@ -407,7 +407,7 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
     private func participantChips(for index: Int, query: String) -> some View {
         let participants = Self.filterByQuery(names: data.participants, query: query)
         if !participants.isEmpty {
-            chipRow(names: participants, idPrefix: "participant-name-") { names[index] = $0 }
+            chipRow(names: participants, idPrefix: A11yID.participantNamePrefix) { names[index] = $0 }
         }
     }
 
@@ -433,19 +433,19 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                     .foregroundStyle(.secondary)
                 ChipFlowLayout(spacing: 4) {
                     ForEach(visible, id: \.self) { name in
-                        chipButton(label: name, identifier: "known-name-\(name)") {
+                        chipButton(label: name, identifier: A11yID.knownName(name)) {
                             names[index] = name
                         }
                     }
                     if hidden > 0 {
                         chipMoreButton(
                             label: "More (\(hidden))…",
-                            identifier: "known-more-\(speakerLabel)",
+                            identifier: A11yID.knownMore(speakerLabel),
                         ) { knownExpanded.insert(index) }
                     } else if expanded, ranked.count > Self.knownChipsCollapsedLimit {
                         chipMoreButton(
                             label: "Less",
-                            identifier: "known-less-\(speakerLabel)",
+                            identifier: A11yID.knownLess(speakerLabel),
                         ) { knownExpanded.remove(index) }
                     }
                 }

--- a/app/MeetingTranscriber/Tests/SettingsInteractionTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsInteractionTests.swift
@@ -108,7 +108,7 @@ final class SettingsInteractionTests: XCTestCase {
         // No active backend → the backend label (inside the TimelineView) is absent.
         XCTAssertThrowsError(
             try LiveCaptionsOverlay(state: state).inspect()
-                .find(viewWithAccessibilityIdentifier: "liveCaptionBackend"),
+                .find(viewWithAccessibilityIdentifier: A11yID.liveCaptionBackend),
             "with no active backend the label must not render",
         )
 
@@ -116,7 +116,7 @@ final class SettingsInteractionTests: XCTestCase {
         state.setActiveBackend("Parakeet EOU")
         XCTAssertNoThrow(
             try LiveCaptionsOverlay(state: state).inspect()
-                .find(viewWithAccessibilityIdentifier: "liveCaptionBackend"),
+                .find(viewWithAccessibilityIdentifier: A11yID.liveCaptionBackend),
             "an active backend must render the label",
         )
     }

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -546,21 +546,21 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.recordOnly = false
         let body = try makeGeneral(settings: settings).inspect()
-        XCTAssertThrowsError(try body.find(viewWithAccessibilityIdentifier: "recordOnlyBanner"))
+        XCTAssertThrowsError(try body.find(viewWithAccessibilityIdentifier: A11yID.recordOnlyBanner))
     }
 
     func testRecordOnlyBannerVisibleWhenOn() throws {
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeGeneral(settings: settings).inspect()
-        XCTAssertNoThrow(try body.find(viewWithAccessibilityIdentifier: "recordOnlyBanner"))
+        XCTAssertNoThrow(try body.find(viewWithAccessibilityIdentifier: A11yID.recordOnlyBanner))
     }
 
     func testRecordOnlyDisablesTranscriptionSection() throws {
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeTranscription(settings: settings).inspect()
-        let section = try body.find(viewWithAccessibilityIdentifier: "transcriptionSection")
+        let section = try body.find(viewWithAccessibilityIdentifier: A11yID.transcriptionSection)
         XCTAssertTrue(section.isDisabled())
     }
 
@@ -568,7 +568,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeOutput(settings: settings).inspect()
-        let section = try body.find(viewWithAccessibilityIdentifier: "protocolSection")
+        let section = try body.find(viewWithAccessibilityIdentifier: A11yID.protocolSection)
         XCTAssertTrue(section.isDisabled())
     }
 
@@ -578,7 +578,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeOutput(settings: settings).inspect()
-        let section = try body.find(viewWithAccessibilityIdentifier: "outputFolderSection")
+        let section = try body.find(viewWithAccessibilityIdentifier: A11yID.outputFolderSection)
         XCTAssertFalse(section.isDisabled())
     }
 
@@ -586,7 +586,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeSpeakers(settings: settings).inspect()
-        let section = try body.find(viewWithAccessibilityIdentifier: "diarizationSection")
+        let section = try body.find(viewWithAccessibilityIdentifier: A11yID.diarizationSection)
         XCTAssertTrue(section.isDisabled())
     }
 
@@ -594,7 +594,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.recordOnly = true
         let body = try makeAudio(settings: settings).inspect()
-        let section = try body.find(viewWithAccessibilityIdentifier: "vadSection")
+        let section = try body.find(viewWithAccessibilityIdentifier: A11yID.vadSection)
         XCTAssertTrue(section.isDisabled())
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -786,7 +786,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         let sut = SpeakerNamingView(data: makeData(), gracePeriod: 0) { _ in }
         let body = try sut.inspect()
         XCTAssertThrowsError(
-            try body.find(viewWithAccessibilityIdentifier: "rerun-mode-picker"),
+            try body.find(viewWithAccessibilityIdentifier: A11yID.rerunModePicker),
             "Mode picker must not render when currentDiarizerMode is nil",
         )
     }
@@ -799,7 +799,7 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         ) { _ in }
         let body = try sut.inspect()
         XCTAssertNoThrow(
-            try body.find(viewWithAccessibilityIdentifier: "rerun-mode-picker"),
+            try body.find(viewWithAccessibilityIdentifier: A11yID.rerunModePicker),
         )
     }
 

--- a/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
+++ b/app/MeetingTranscriber/Tests/VoiceEnrollmentViewTests.swift
@@ -176,7 +176,7 @@ final class VoiceEnrollmentViewTests: XCTestCase { // swiftlint:disable:this bal
         // SpeakerNamingView's "Re-run" button which fires `onComplete(.rerun(N))`.
         let view = makeView(initialStage: .naming(makeNamingPayload()))
         let body = try view.inspect()
-        let rerun = try body.find(viewWithAccessibilityIdentifier: "rerun-button")
+        let rerun = try body.find(viewWithAccessibilityIdentifier: A11yID.rerunButton)
         XCTAssertNoThrow(try rerun.button().tap())
     }
 


### PR DESCRIPTION
## What

Introduces `A11yID` (`Sources/A11yID.swift`) as the single source of truth for the
accessibility identifiers used as automation handles, and codifies the GUI-testing
practice in `CLAUDE.md`.

Automation-handle identifiers were raw string literals duplicated across three Swift
sites — the SwiftUI `.accessibilityIdentifier` modifier, the ViewInspector `find`
calls, and the `/ui/press` allowlist — where a value could drift between sites
silently. Now all three reference the constant, so the **compiler catches drift**
(shell drivers still use the raw string — grep-checked, noted in the file).

## Scope

- **`A11yID`** namespace: 18 static identifiers + dynamic functions (`play(_:)`,
  `knownName(_:)`, `knownMore/Less(_:)`, `participantNamePrefix`).
- Migrated every `.accessibilityIdentifier("literal")` in the 7 view files, the
  `/ui/press` allowlist (`= [A11yID.recordOnlyToggle]`), and the
  `find(viewWithAccessibilityIdentifier:)` calls in the tests.
- The string **values are unchanged** (verified byte-identical to the pre-refactor
  identifiers — an accessibility/VoiceOver + test + allowlist contract). Pure
  indirection refactor, **no behavior change**. The RPC unit-test fake-data /
  serialized-JSON assertions keep their raw strings (arbitrary representative ids,
  not find-a-real-control sites).
- **`CLAUDE.md` "GUI Testing"** section: the layer rule (cheapest layer that can
  falsify), when a live `/ui/*` test earns its keep, the identifier discipline, the
  modal-runloop / PII / value-exposure invariants, env-stable-flags-only assertion
  rule, failing-test-first regression discipline, and the manual-QA-only acceptances.

## Verification

Full suite + homebrew + App Store release builds + SwiftFormat + SwiftLint + a
clean-full-build `swiftlint analyze` (330 files) all green. A11yID string values
diffed byte-identical against origin/main.