### PR TITLE
fix(ci): guard DebugRPCServer+*.swift in e2e-ui-smoke (GitHub + is a quantifier)

### DIFF
--- a/.github/workflows/e2e-ui-smoke.yml
+++ b/.github/workflows/e2e-ui-smoke.yml
@@ -21,19 +21,18 @@ on:
       - '.github/workflows/e2e-ui-smoke.yml'
       - 'scripts/e2e-settings-smoke.sh'
       - 'scripts/build_release.sh'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+      # `*`, not `DebugRPCServer+*.swift`: GitHub filter patterns treat `+` as a
+      # regex-style "one or more of the preceding char" quantifier, so a literal
+      # `+` in a path never matches its file (`DebugRPCServer+UIPress.swift` was
+      # silently unguarded). The `*` glob covers the `+…` suffix and all splits.
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer*.swift'
       - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
       - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
   push:
     branches: [main]
     paths:
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift'
-      - 'app/MeetingTranscriber/Sources/DebugRPCServer.swift'
+      # `*`, not a literal `+` (a GitHub filter-pattern quantifier — see above).
+      - 'app/MeetingTranscriber/Sources/DebugRPCServer*.swift'
       - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
       - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
       - 'scripts/e2e-settings-smoke.sh'


### PR DESCRIPTION
## Problem

The `e2e-ui-smoke` `/ui/*` canary listed its guarded harness files as **literal** paths — including the three extension files it exists to protect:

- `DebugRPCServer+AXElement.swift`
- `DebugRPCServer+UITree.swift`
- `DebugRPCServer+UIPress.swift`

GitHub Actions filter patterns treat `+` as a **regex-style quantifier** ("one or more of the preceding character"), so a literal `+` in a path never matches its own filename. The canary was therefore silently unguarded for exactly those `/ui/*` files.

**Observed:** PR #520 changed `DebugRPCServer+UIPress.swift` and the `e2e-ui-smoke` lane did not trigger (harmless there — the change was a byte-identical allowlist-value indirection — but a real hole in the guard).

## Fix

Collapse the four `DebugRPCServer` path literals to a single `DebugRPCServer*.swift` glob in **both** the `pull_request` and `push` paths blocks. The `*` covers the `+…` suffix (and any future line-cap splits) without relying on a literal `+`.

Slightly broader than before (now also triggers on `+Metrics`/`+Screenshot`/`+V1` changes), which is correct: those share the same routing/parsing surface the `/ui/*` endpoints ride on.

## Acceptance

This PR touches `.github/workflows/e2e-ui-smoke.yml` (in its own paths), so the canary self-triggers here — proving the fixed workflow parses and runs. The `+`-glob match itself is guaranteed by the `*` semantics (`*` matches any run of non-`/` chars, covering `+UIPress`); the next PR that touches a `+` file will exercise it live.