### PR TITLE
docs: reconcile GUI-testing doc with shipped test reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,8 +458,9 @@ Rule: test each behavior at the cheapest layer that can falsify it.
    (`BadgeKind.compute`, `LiveCaptionsGate`, `WatchLoopEndPolicy` pattern) and put
    the bulk of assertions there.
 2. **ViewInspector** (`swift test`, every PR): exactly one wiring test per control —
-   find by an `A11yID` constant, drive (`.tap()`/`.select()`/`.increment()`), assert
-   the `AppSettings` write-back. Don't enumerate logic states through the view;
+   find by its `A11yID` constant (or by label, for `Picker`/`Stepper`, which expose
+   no findable one — see Identifiers), drive (`.tap()`/`.select()`/`.increment()`),
+   assert the `AppSettings` write-back. Don't enumerate logic states through the view;
    that's layer 1's job. (ViewInspector is reflection over undocumented SwiftUI
    internals — keep to the boring primitives; breakage is loud since it runs on
    every PR.)
@@ -475,8 +476,13 @@ Rule: test each behavior at the cheapest layer that can falsify it.
 **Identifiers:** add `.accessibilityIdentifier` on demand via the shared `A11yID`
 namespace (`Sources/A11yID.swift`) — the view modifier, the ViewInspector `find`, and
 the `/ui/press` allowlist all reference the constant so the compiler catches drift.
-Interaction tests never locate by display label; `find(text:)` only when the label
-itself is the behavior under test. An identifier makes a control tree-visible;
+Interaction tests locate by the `A11yID` constant wherever a control exposes a
+findable one. Accepted exception: SwiftUI `Picker` and `Stepper` don't surface a
+ViewInspector-findable `.accessibilityIdentifier`, so those are located by label or
+document-order index (see `SettingsInteractionTests`) — the one sanctioned fallback,
+not a licence to skip identifiers where they work. `find(text:)` for a bare label
+only when the label itself is the behavior under test. An identifier makes a control
+tree-visible;
 press-drivable *additionally* requires a `/ui/press` allowlist entry — never allowlist
 a control whose action opens a menu/popover/sheet/panel (a nested runloop wedges the
 app, see `DebugRPCServer+UIPress.swift`). Never widen the window allowlist to PII

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -7,7 +7,8 @@ import Foundation
 /// modifier, the ViewInspector tests, and the `/ui/press` allowlist makes the
 /// compiler catch a drifted identifier across those call sites — a raw string
 /// literal duplicated per site drifts silently. Shell drivers (`test_rpc.sh`,
-/// curl) still use the raw string; those are grep-checked.
+/// curl) use the raw string value and are not compiler-checked — keep them in
+/// sync by hand when a value changes.
 ///
 /// Add an entry on demand when a test or the harness needs to find/drive a
 /// control — don't spray identifiers onto controls nothing drives. The string


### PR DESCRIPTION
Follow-up to an independent audit of the GUI-testability arc (#515–#521). The audit confirmed the arc is complete and the harness matches its docs, with two doc-vs-code inconsistencies worth correcting.

## 1. Picker/Stepper label-locating (the real contradiction)

`CLAUDE.md ## GUI Testing` codified "interaction tests **never locate by display label**" — but SwiftUI `Picker` and `Stepper` expose no ViewInspector-findable `.accessibilityIdentifier`, so `SettingsInteractionTests` (the arc's own exemplar, shipped in #519) locates them by label / document-order index. The flagship doc contradicted the flagship tests.

Fix: codify label/index locating for `Picker`/`Stepper` as the one sanctioned fallback, while keeping the `A11yID`-constant rule for every control that does expose a findable identifier.

## 2. A11yID "grep-checked" overstatement

The `A11yID.swift` header claimed shell drivers (`test_rpc.sh`, curl) using the raw identifier string are "grep-checked". No automated grep exists — it's a manual practice. Corrected to say so plainly.

## Scope

Docs only (one markdown section + one code comment). No behavior change. Verified with the CI-pinned SwiftFormat 0.61.1 (`0/1 require formatting`) and SwiftLint (clean) on the touched Swift file. Given it's doc-only remediation of an audit finding, I judged the full simplify/code-review agent passes disproportionate and did a manual proofread instead.

Deliberately **not** done from the audit (both defensible as-is): recording the two dropped Slice-3 items (`openNamingWindow`, UI-driven naming-confirm) — they follow from the settings-only PII allowlist and the naming-confirm path is already E2E-covered via the `/v1`-driven `e2e-app.sh --naming-confirm` lane; and adding `A11yID.swift`/`GeneralSettingsView.swift` to the `e2e-ui-smoke` paths — the busy settings file would trigger a heavy macos-26 build on every edit to catch only a rare identifier removal.