### PR TITLE
feat(app): detect and record browser meetings (issue #503)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     AppSettings.swift      # @Observable settings (UserDefaults + file-based secrets)
     AXHelper.swift         # Shared accessibility API helper
     A11yID.swift           # Single source of truth for accessibility identifiers used as automation handles (ViewInspector find + /ui/press allowlist reference the constants → compiler catches drift)
-    NotificationManager.swift # macOS notifications
+    NotificationManager.swift # macOS notifications (+ actionable browser-consent prompt, issue #503)
+    ConsentPromptCoordinator.swift  # Pure async yes/no prompt coordinator (register→resolve-once by answer or injected-clock timeout, race-safe); NotificationManager wires UNUserNotificationCenter to it (issue #503)
     KeychainHelper.swift   # Keychain CRUD (legacy/test-only, token now file-based)
     TranscriberStatus.swift # Status + MeetingInfo models
     TranscribingEngine.swift # TranscribingEngine protocol + mergeDualSourceSegments default impl
@@ -83,6 +84,7 @@ app/MeetingTranscriber/    # Swift macOS menu bar app (SPM)
     OpenAIProtocolGenerator.swift # OpenAI-compatible API protocol generation (Ollama, LM Studio, etc.)
     WatchLoop.swift        # @MainActor watch loop: detect → record → enqueue PipelineJob
     WatchLoopEndPolicy.swift  # Pure decision logic for WatchLoop.waitForMeetingEnd (grace-period / max-duration)
+    BrowserConsentPolicy.swift  # Pure decision logic for the browser-meeting "ask before recording" prompt (per-app decline cooldown, issue #503)
     WatchLoopState.swift   # Value-type snapshot of WatchLoop's observable fields (for tests and RPC)
     WatchingController.swift  # @Observable controller owning WatchLoop lifecycle (wired by AppState)
     ManualRecordingMonitorPolicy.swift  # Pure decision logic for manual recording stop conditions (process-died vs max-duration)
@@ -397,6 +399,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 **Detection:**
 - `MeetingDetecting` protocol abstracts detection strategies. Two implementations: `MeetingDetector` (window title matching via `CGWindowListCopyWindowInfo`) and `PowerAssertionDetector` (IOKit power assertions — sandbox-safe, no Screen Recording permission needed).
 - `MeetingDetector` counts each pattern once per poll — prevents over-counting when multiple windows match the same app.
+- **Browser meetings (issue #503):** `PowerAssertionDetector` also carries a `Google Chrome` pattern that matches the `NoIdleSleepAssertion` named `"WebRTC has active PeerConnections"` (keyword `webrtc`/`peerconnection`, not the assertion type — Chrome holds the same type for plain media playback), so Google Meet / Whereby / web Zoom-Teams-Webex are detected without window titles. It is opt-in via `AppSettings.watchBrowserMeetings` (default off, appends `"Google Chrome"` to `watchApps`). Because the WebRTC signal isn't meeting-exclusive, browser meetings are gated behind a consent prompt (`AppMeetingPattern.requiresRecordingConsent` → `WatchLoop.consentProvider` → `NotificationManager.askToRecord`, a `BROWSER_MEETING_CONSENT` notification with Record/Ignore actions) instead of auto-starting; a decline suppresses re-prompts for a cooldown (`BrowserConsentPolicy`). Audio capture reuses the existing multi-PID tap (Chrome is multi-process like Electron); capturing only the meeting tab vs. all Chrome audio is a known follow-up.
 
 **Diarization:**
 - `FluidDiarizer` uses FluidAudio (CoreML/ANE) for on-device speaker diarization — no HuggingFace token needed. Two modes: `.offline` (default) and `.sortformer` (overlap-aware, via `SortformerDiarizer`). Selected via `AppSettings.diarizerMode`.

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -19,6 +19,7 @@ import Foundation
 enum A11yID {
     // Settings — section anchors + record-only controls.
     static let recordOnlyToggle = "recordOnlyToggle"
+    static let watchBrowserToggle = "watchBrowserToggle"
     static let recordOnlyBanner = "recordOnlyBanner"
     static let transcriptionSection = "transcriptionSection"
     static let protocolSection = "protocolSection"

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -112,6 +112,13 @@ final class AppSettings {
         didSet { defaults.set(watchWebex, forKey: "watchWebex") }
     }
 
+    /// Watch for browser-based meetings (Google Chrome / WebRTC), issue #503.
+    /// Off by default — opt-in, and browser meetings prompt before recording
+    /// (the WebRTC signal isn't meeting-exclusive), unlike native auto-start.
+    var watchBrowserMeetings: Bool {
+        didSet { defaults.set(watchBrowserMeetings, forKey: "watchBrowserMeetings") }
+    }
+
     /// Auto-start watching on app launch.
     var autoWatch: Bool {
         didSet { defaults.set(autoWatch, forKey: "autoWatch") }
@@ -457,6 +464,7 @@ final class AppSettings {
         if watchTeams { apps.append("Microsoft Teams") }
         if watchZoom { apps.append("Zoom") }
         if watchWebex { apps.append("Webex") }
+        if watchBrowserMeetings { apps.append(AppMeetingPattern.chromeBrowser.appName) }
         return apps
     }
 
@@ -468,6 +476,7 @@ final class AppSettings {
         watchTeams = defaults.object(forKey: "watchTeams") as? Bool ?? true
         watchZoom = defaults.object(forKey: "watchZoom") as? Bool ?? true
         watchWebex = defaults.object(forKey: "watchWebex") as? Bool ?? true
+        watchBrowserMeetings = defaults.object(forKey: "watchBrowserMeetings") as? Bool ?? false
         autoWatch = defaults.object(forKey: "autoWatch") as? Bool ?? false
 
         pollInterval = defaults.object(forKey: "pollInterval") as? Double ?? 3.0

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -12,6 +12,12 @@ import os.log
 protocol AppNotifying {
     func notify(title: String, body: String)
 
+    /// Ask the user whether to record a just-detected browser meeting (issue
+    /// #503); true = record. `@MainActor` — the real prompt is UI. Defaults to
+    /// false so a notifier without a prompt never records silently.
+    @MainActor
+    func askToRecord(title: String, body: String) async -> Bool
+
     #if !APPSTORE
         /// Recently posted notifications, oldest first, for the debug RPC
         /// `/state.notifications` snapshot. Defaults to empty — only the
@@ -29,6 +35,16 @@ protocol AppNotifying {
         }
     }
 #endif
+
+extension AppNotifying {
+    // swiftlint:disable async_without_await
+    /// Deny by default — only `NotificationManager` shows a real prompt.
+    @MainActor
+    func askToRecord(title _: String, body _: String) async -> Bool {
+        false
+    }
+    // swiftlint:enable async_without_await
+}
 
 // MARK: - AppState
 

--- a/app/MeetingTranscriber/Sources/BrowserConsentPolicy.swift
+++ b/app/MeetingTranscriber/Sources/BrowserConsentPolicy.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure decision logic for the browser-meeting "ask before recording" prompt
+/// (issue #503). Native meeting apps auto-start; browser meetings prompt, and a
+/// declined prompt must not re-appear on every poll while the user stays in the
+/// call. This is the *prompt* policy — distinct from `PowerAssertionDetector`'s
+/// 5 s detection debounce (`cooldownDuration`), which only entprellt detection.
+///
+/// The WebRTC power assertion keeps firing for the whole call, so `checkOnce()`
+/// re-detects the same meeting every few seconds; the policy is asked *before*
+/// prompting so a decline suppresses re-prompts for `cooldown` seconds instead
+/// of spamming. Value type with an injected `now` so it is deterministically
+/// testable (pattern: `WatchLoopEndPolicy`, `ManualRecordingMonitorPolicy`).
+struct BrowserConsentPolicy {
+    /// How long after a decline the same app stays suppressed from re-prompting.
+    /// Independent of `NotificationManager.consentPromptTimeout` (how long an
+    /// unanswered prompt stays open) — they share a default value but are
+    /// separate knobs.
+    let cooldown: TimeInterval
+    /// Per-app instant until which prompting is suppressed after a decline.
+    private var suppressedUntil: [String: Date] = [:]
+
+    enum Decision: Equatable {
+        /// No active suppression — prompt the user.
+        case ask
+        /// A recent decline still suppresses this app until the given instant.
+        case suppressed(until: Date)
+    }
+
+    init(cooldown: TimeInterval = 60) {
+        self.cooldown = cooldown
+    }
+
+    /// Whether to prompt for `app` at `now`, or stay quiet after a recent decline.
+    func decision(app: String, now: Date) -> Decision {
+        if let until = suppressedUntil[app], now < until {
+            return .suppressed(until: until)
+        }
+        return .ask
+    }
+
+    /// Record that the user declined (or the prompt timed out) — suppress
+    /// re-prompts for this app for `cooldown` seconds.
+    mutating func recordDecline(app: String, now: Date) {
+        suppressedUntil[app] = now.addingTimeInterval(cooldown)
+    }
+}

--- a/app/MeetingTranscriber/Sources/ConsentPromptCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/ConsentPromptCoordinator.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Coordinates an async yes/no prompt (issue #503): register a pending decision
+/// for an id, then resolve it exactly once — by an external answer or a timeout,
+/// whichever comes first (race-safe, remove-on-resolve). Pure: no
+/// UI / UNUserNotificationCenter dependency, and the timeout clock is injected,
+/// so the park / resolve / timeout / race logic is deterministically unit-testable.
+/// `NotificationManager` wires the raw `UNUserNotificationCenter` add + delegate
+/// to this (that thin glue stays the only untested part — Apple's framework isn't
+/// ours to test).
+///
+/// `@unchecked Sendable`: `pending`/`timeouts` are guarded by `lock`, since the
+/// notification delegate and the timeout task resolve from arbitrary queues.
+final class ConsentPromptCoordinator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending: [String: CheckedContinuation<Bool, Never>] = [:]
+    private var timeouts: [String: Task<Void, Never>] = [:]
+
+    private let timeout: TimeInterval
+    /// Sleep primitive for the timeout. Defaults to `Task.sleep`; tests inject a
+    /// controllable one (instant to force a timeout, or long to let a resolve win).
+    private let sleep: @Sendable (TimeInterval) async -> Void
+
+    init(
+        timeout: TimeInterval = 60,
+        sleep: @escaping @Sendable (TimeInterval) async -> Void = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        },
+    ) {
+        self.timeout = timeout
+        self.sleep = sleep
+    }
+
+    /// Await the decision for `id`. `onParked` runs once the continuation is
+    /// registered (the caller posts the notification there, so a fast answer
+    /// can't race ahead of registration). Resolves via `resolve(id:granted:)`
+    /// or, if unanswered, `false` after the timeout.
+    func awaitDecision(id: String, onParked: @Sendable () -> Void) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let sleep = self.sleep
+            let timeout = self.timeout
+            let timeoutTask = Task { [weak self] in
+                await sleep(timeout)
+                guard !Task.isCancelled else { return }
+                self?.resolve(id: id, granted: false)
+            }
+
+            lock.lock()
+            pending[id] = continuation
+            timeouts[id] = timeoutTask
+            lock.unlock()
+
+            onParked()
+        }
+    }
+
+    /// Resolve `id` exactly once — the first caller (answer or timeout) wins and
+    /// removes it; later calls no-op. Cancels the timeout task so it doesn't
+    /// linger once an answer arrives.
+    func resolve(id: String, granted: Bool) {
+        lock.lock()
+        let continuation = pending.removeValue(forKey: id)
+        let timeoutTask = timeouts.removeValue(forKey: id)
+        lock.unlock()
+        timeoutTask?.cancel()
+        continuation?.resume(returning: granted)
+    }
+}

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -8,6 +8,12 @@ struct AppMeetingPattern: Equatable {
     let idlePatterns: [String]
     let minWindowWidth: CGFloat
     let minWindowHeight: CGFloat
+    /// When true, a detected meeting for this app must be confirmed by the user
+    /// before recording starts, instead of auto-recording. Browser meetings set
+    /// this (issue #503): the WebRTC power assertion that detects them fires for
+    /// any WebRTC use, not just meetings, so a prompt is the false-positive
+    /// filter. Native desktop clients leave it false and keep auto-start.
+    let requiresRecordingConsent: Bool
 
     init(
         appName: String,
@@ -16,6 +22,7 @@ struct AppMeetingPattern: Equatable {
         idlePatterns: [String] = [],
         minWindowWidth: CGFloat = 200,
         minWindowHeight: CGFloat = 200,
+        requiresRecordingConsent: Bool = false,
     ) {
         self.appName = appName
         self.ownerNames = ownerNames
@@ -23,6 +30,7 @@ struct AppMeetingPattern: Equatable {
         self.idlePatterns = idlePatterns
         self.minWindowWidth = minWindowWidth
         self.minWindowHeight = minWindowHeight
+        self.requiresRecordingConsent = requiresRecordingConsent
     }
 }
 
@@ -90,7 +98,20 @@ extension AppMeetingPattern {
         minWindowHeight: 100,
     )
 
-    static let all: [AppMeetingPattern] = [teams, zoom, webex, simulator]
+    /// Browser-based meetings (Google Meet, Whereby, web Zoom/Teams/Webex) run
+    /// inside Chrome, which the native-app patterns above miss (issue #503).
+    /// Detection is by the WebRTC power assertion (see `PowerAssertionDetector`),
+    /// not window titles — Chrome's window title only reflects the active tab.
+    /// `requiresRecordingConsent` routes it through a prompt instead of
+    /// auto-start; `meetingPatterns` is empty (no title-based detection in the PoC).
+    static let chromeBrowser = AppMeetingPattern(
+        appName: "Google Chrome",
+        ownerNames: ["Google Chrome"],
+        meetingPatterns: [],
+        requiresRecordingConsent: true,
+    )
+
+    static let all: [AppMeetingPattern] = [teams, zoom, webex, simulator, chromeBrowser]
 
     static let byName: [String: AppMeetingPattern] = {
         var dict: [String: AppMeetingPattern] = [:]

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -17,6 +17,26 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
     private(set) var isSetUp = false
 
+    // MARK: - Browser meeting consent prompt (issue #503)
+
+    /// Notification category + action identifiers for the "record this browser
+    /// meeting?" prompt. The category is registered in `setUp()`; the action
+    /// identifier the user taps maps to a Bool via `consentGranted(for:)`.
+    static let consentCategoryID = "BROWSER_MEETING_CONSENT"
+    static let recordActionID = "BROWSER_MEETING_RECORD"
+    static let ignoreActionID = "BROWSER_MEETING_IGNORE"
+    /// An unanswered prompt counts as "ignore" after this long, so a missed
+    /// prompt doesn't block the watch loop indefinitely. Independent of
+    /// `BrowserConsentPolicy.cooldown` (post-decline re-prompt suppression),
+    /// which happens to share this value — the two are separate knobs, don't
+    /// unify them.
+    static let consentPromptTimeout: TimeInterval = 60
+
+    /// Owns the consent prompt's register/resolve/timeout/race logic (unit-tested
+    /// in `ConsentPromptCoordinatorTests`); this class only wires the
+    /// UNUserNotificationCenter add + delegate callback to it.
+    private let consentCoordinator = ConsentPromptCoordinator(timeout: NotificationManager.consentPromptTimeout)
+
     #if !APPSTORE
         /// Bounded in-memory log of every notification posted through
         /// `notify(...)`, read by the dev-only debug RPC `/state.notifications`
@@ -45,6 +65,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
         let center = UNUserNotificationCenter.current()
         center.delegate = self
+        center.setNotificationCategories([Self.makeConsentCategory()])
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
                 logger.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
@@ -122,6 +143,62 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         if let content = Self.notificationContent(for: newState, status: status) {
             notify(title: content.title, body: content.body)
         }
+    }
+
+    // MARK: - Consent prompt (issue #503)
+
+    /// The "record this browser meeting?" category with Record / Ignore actions.
+    static func makeConsentCategory() -> UNNotificationCategory {
+        let record = UNNotificationAction(identifier: recordActionID, title: "Record", options: [.foreground])
+        let ignore = UNNotificationAction(identifier: ignoreActionID, title: "Ignore", options: [])
+        return UNNotificationCategory(
+            identifier: consentCategoryID,
+            actions: [record, ignore],
+            intentIdentifiers: [],
+            options: [],
+        )
+    }
+
+    /// Pure mapping: only the explicit Record action grants consent. Ignore, a
+    /// swipe-away dismiss, and the default body tap all decline.
+    static func consentGranted(for actionIdentifier: String) -> Bool {
+        actionIdentifier == recordActionID
+    }
+
+    /// Post an actionable "record this browser meeting?" prompt and await the
+    /// user's choice (issue #503). Returns false when notifications can't be
+    /// delivered (no bundle / not set up) so we never record without a visible
+    /// prompt, and false on timeout/ignore/dismiss.
+    @MainActor
+    func askToRecord(title: String, body: String) async -> Bool {
+        guard isSetUp, Bundle.main.bundleIdentifier != nil else { return false }
+        let id = UUID().uuidString
+        return await consentCoordinator.awaitDecision(id: id) { [self] in
+            postConsentNotification(id: id, title: title, body: body)
+        }
+    }
+
+    /// Post the actionable consent notification (the thin UNUserNotificationCenter
+    /// adapter — the decision itself is driven by `didReceive` / the coordinator
+    /// timeout, whichever resolves first).
+    private func postConsentNotification(id: String, title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.categoryIdentifier = Self.consentCategoryID
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: id, content: content, trigger: nil),
+        )
+    }
+
+    // Handle a tapped consent action (or a dismiss) → resolve the prompt.
+    // swiftlint:disable:next async_without_await
+    func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        consentCoordinator.resolve(
+            id: response.notification.request.identifier,
+            granted: Self.consentGranted(for: response.actionIdentifier),
+        )
     }
 
     // Show notifications even when app is in foreground

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -55,6 +55,18 @@ class PowerAssertionDetector: MeetingDetecting {
             processNames: ["meeting-simulator"],
             keywords: ["simulator meeting"],
         ),
+        // Browser meetings (issue #503): Chrome holds a "NoIdleSleepAssertion"
+        // named "WebRTC has active PeerConnections" during any WebRTC call
+        // (Google Meet, Whereby, web Zoom/Teams/Webex). Keyword-only, no
+        // assertionTypes: Chrome holds the same assertion type for plain media
+        // playback (YouTube), so matching the type would fire on every video —
+        // the WebRTC name is the meeting-specific signal. Opt-in: only watched
+        // when the browser toggle adds "Google Chrome" to watchApps.
+        AssertionPattern(
+            appName: AppMeetingPattern.chromeBrowser.appName,
+            processNames: ["Google Chrome"],
+            keywords: ["webrtc", "peerconnection"],
+        ),
     ]
 
     /// The `defaultPatterns` subset to watch given the user's "Apps to Watch"

--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -20,6 +20,11 @@ struct GeneralSettingsView: View {
                 Toggle("Microsoft Teams", isOn: $settings.watchTeams)
                 Toggle("Zoom", isOn: $settings.watchZoom)
                 Toggle("Webex", isOn: $settings.watchWebex)
+                Toggle("Browser Web Meetings (Google Chrome)", isOn: $settings.watchBrowserMeetings)
+                    .accessibilityIdentifier(A11yID.watchBrowserToggle)
+                Text("Detects meetings in Chrome (Google Meet, Whereby, web Zoom/Teams). Asks before recording.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Detection") {

--- a/app/MeetingTranscriber/Sources/WatchLoop+Consent.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop+Consent.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Browser-meeting recording-consent gate (issue #503), split out of `WatchLoop`
+/// to keep its body under the line-length cap. Only patterns with
+/// `requiresRecordingConsent` reach it; native meetings auto-start unchanged.
+extension WatchLoop {
+    /// Whether to skip recording this detected meeting because it needs consent
+    /// and the user declined (or a recent decline still suppresses the prompt).
+    /// Resets the detector on a skip so it re-detects after its debounce.
+    func shouldDeferForConsent(_ meeting: DetectedMeeting) async -> Bool {
+        guard meeting.pattern.requiresRecordingConsent else { return false }
+        if await grantRecordingConsent(for: meeting) { return false }
+        detector.reset(appName: meeting.pattern.appName)
+        return true
+    }
+
+    /// Prompt (via the notifier) unless a recent decline still suppresses it,
+    /// then confirm the call is still active before starting — minutes can pass
+    /// between prompt and click. True only when recording should start.
+    private func grantRecordingConsent(for meeting: DetectedMeeting) async -> Bool {
+        let app = meeting.pattern.appName
+        guard case .ask = consentPolicy.decision(app: app, now: nowProvider()) else {
+            return false // still in decline cooldown → don't prompt, don't record
+        }
+        let granted = await notifier.askToRecord(
+            title: "Record browser meeting?",
+            body: "A meeting is active in \(app).",
+        )
+        guard granted else {
+            consentPolicy.recordDecline(app: app, now: nowProvider())
+            return false
+        }
+        // The prompt is async; re-check the call didn't end while it was open.
+        return detector.isMeetingActive(meeting)
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -83,6 +83,10 @@ class WatchLoop {
     /// spawning a real subprocess.
     let pidAliveCheck: (pid_t) -> Bool
 
+    /// Suppresses re-prompting after a browser-meeting decline (issue #503).
+    /// Internal so the consent gate can live in `WatchLoop+Consent.swift`.
+    var consentPolicy: BrowserConsentPolicy
+
     private var watchTask: Task<Void, Never>?
 
     /// Hook called when state changes (for UI updates, notifications, etc.)
@@ -108,6 +112,7 @@ class WatchLoop {
             try await Task.sleep(for: .seconds(interval))
         },
         pidAliveCheck: @escaping (pid_t) -> Bool = { kill($0, 0) == 0 },
+        consentPolicy: BrowserConsentPolicy = BrowserConsentPolicy(),
     ) {
         self.detector = detector
         self.recorderFactory = recorderFactory
@@ -124,6 +129,7 @@ class WatchLoop {
         self.nowProvider = nowProvider
         self.sleepProvider = sleepProvider
         self.pidAliveCheck = pidAliveCheck
+        self.consentPolicy = consentPolicy
     }
 
     nonisolated static var defaultOutputDir: URL {
@@ -280,6 +286,12 @@ class WatchLoop {
     private func watchLoop() async {
         while !Task.isCancelled {
             if let meeting = detector.checkOnce() {
+                // Browser meetings (issue #503) ask before recording; native
+                // meetings skip this (flag false). See WatchLoop+Consent.swift.
+                if await shouldDeferForConsent(meeting) {
+                    try? await sleepProvider(pollInterval)
+                    continue
+                }
                 do {
                     try await handleMeeting(meeting)
                 } catch {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -164,6 +164,27 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(settings.watchApps, [])
     }
 
+    // MARK: - watchBrowserMeetings (issue #503)
+
+    func testWatchBrowserMeetingsDefaultsOff() {
+        XCTAssertFalse(settings.watchBrowserMeetings)
+        XCTAssertFalse(
+            settings.watchApps.contains("Google Chrome"),
+            "browser watching is opt-in, so Chrome must not be watched by default",
+        )
+    }
+
+    func testWatchBrowserMeetingsAppendsChromeToWatchApps() {
+        settings.watchBrowserMeetings = true
+        XCTAssertEqual(settings.watchApps, ["Microsoft Teams", "Zoom", "Webex", "Google Chrome"])
+    }
+
+    func testWatchBrowserMeetingsPersists() {
+        settings.watchBrowserMeetings = true
+        let fresh = AppSettings(defaults: defaults)
+        XCTAssertTrue(fresh.watchBrowserMeetings)
+    }
+
     // MARK: - Claude CLI
 
     #if !APPSTORE

--- a/app/MeetingTranscriber/Tests/BrowserConsentPolicyTests.swift
+++ b/app/MeetingTranscriber/Tests/BrowserConsentPolicyTests.swift
@@ -1,0 +1,46 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class BrowserConsentPolicyTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    func testFirstContactAsks() {
+        let policy = BrowserConsentPolicy()
+        XCTAssertEqual(policy.decision(app: "Google Chrome", now: t0), .ask)
+    }
+
+    func testDeclineSuppressesWithinCooldown() {
+        var policy = BrowserConsentPolicy(cooldown: 60)
+        policy.recordDecline(app: "Google Chrome", now: t0)
+        // Still inside the 60 s window → suppressed until t0+60.
+        XCTAssertEqual(
+            policy.decision(app: "Google Chrome", now: t0.addingTimeInterval(59)),
+            .suppressed(until: t0.addingTimeInterval(60)),
+        )
+    }
+
+    func testAsksAgainAtCooldownBoundary() {
+        var policy = BrowserConsentPolicy(cooldown: 60)
+        policy.recordDecline(app: "Google Chrome", now: t0)
+        // At exactly t0+60 the window has elapsed → ask again.
+        XCTAssertEqual(policy.decision(app: "Google Chrome", now: t0.addingTimeInterval(60)), .ask)
+        XCTAssertEqual(policy.decision(app: "Google Chrome", now: t0.addingTimeInterval(120)), .ask)
+    }
+
+    func testCooldownIsPerApp() {
+        var policy = BrowserConsentPolicy(cooldown: 60)
+        policy.recordDecline(app: "Google Chrome", now: t0)
+        // A decline for one app does not suppress another.
+        XCTAssertEqual(policy.decision(app: "Microsoft Edge", now: t0.addingTimeInterval(1)), .ask)
+    }
+
+    func testCustomCooldownRespected() {
+        var policy = BrowserConsentPolicy(cooldown: 10)
+        policy.recordDecline(app: "Google Chrome", now: t0)
+        XCTAssertEqual(
+            policy.decision(app: "Google Chrome", now: t0.addingTimeInterval(9)),
+            .suppressed(until: t0.addingTimeInterval(10)),
+        )
+        XCTAssertEqual(policy.decision(app: "Google Chrome", now: t0.addingTimeInterval(10)), .ask)
+    }
+}

--- a/app/MeetingTranscriber/Tests/ConsentPromptCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/ConsentPromptCoordinatorTests.swift
@@ -1,0 +1,60 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class ConsentPromptCoordinatorTests: XCTestCase {
+    /// A timeout sleep that effectively never returns, so the timeout can't win
+    /// and the test drives resolution explicitly.
+    private let neverSleep: @Sendable (TimeInterval) async -> Void = { _ in
+        try? await Task.sleep(nanoseconds: 60_000_000_000)
+    }
+
+    func testResolvesToGrantedAnswer() async {
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "a") {} }
+        await yieldUntilParked()
+        coord.resolve(id: "a", granted: true)
+        let result = await task.value
+        XCTAssertTrue(result)
+    }
+
+    func testResolvesToDeniedAnswer() async {
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "b") {} }
+        await yieldUntilParked()
+        coord.resolve(id: "b", granted: false)
+        let result = await task.value
+        XCTAssertFalse(result)
+    }
+
+    func testUnansweredPromptTimesOutToDeny() async {
+        // A short real timeout: an unanswered prompt resolves to "don't record".
+        let coord = ConsentPromptCoordinator(timeout: 0.02)
+        let result = await coord.awaitDecision(id: "c") {}
+        XCTAssertFalse(result)
+    }
+
+    func testSecondResolveIsIgnored() async {
+        // Race-safety: the first resolver wins; a second resolve (e.g. the
+        // timeout firing just after an answer) must not double-resume the
+        // continuation — that would crash.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "d") {} }
+        await yieldUntilParked()
+        coord.resolve(id: "d", granted: true)
+        coord.resolve(id: "d", granted: false)
+        let result = await task.value
+        XCTAssertTrue(result)
+    }
+
+    func testResolveForUnknownIdIsNoOp() {
+        // Resolving an id that was never awaited must not crash.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        coord.resolve(id: "never-awaited", granted: true)
+    }
+
+    /// Sleep briefly so the awaiting task registers its continuation inside
+    /// `withCheckedContinuation` before the test resolves it.
+    private func yieldUntilParked() async {
+        try? await Task.sleep(nanoseconds: 30_000_000)
+    }
+}

--- a/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
@@ -45,8 +45,9 @@ final class MeetingPatternsTests: XCTestCase {
         XCTAssertFalse(AppMeetingPattern.webex.ownerNames.isEmpty)
     }
 
-    func testAllPatternsContainsFour() {
-        XCTAssertEqual(AppMeetingPattern.all.count, 4)
+    func testAllPatternsContainsFive() {
+        // teams, zoom, webex, simulator, chromeBrowser (issue #503)
+        XCTAssertEqual(AppMeetingPattern.all.count, 5)
     }
 
     func testByNameLookup() {

--- a/app/MeetingTranscriber/Tests/MeetingPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingPatternsTests.swift
@@ -21,7 +21,28 @@ final class AppMeetingPatternTests: XCTestCase {
     // MARK: - All Patterns
 
     func testAllPatternsCount() {
-        XCTAssertEqual(AppMeetingPattern.all.count, 4)
+        XCTAssertEqual(AppMeetingPattern.all.count, 5)
+    }
+
+    // MARK: - Chrome Browser Pattern (issue #503)
+
+    func testForAppNameReturnsChromeBrowser() {
+        let pattern = AppMeetingPattern.forAppName("Google Chrome")
+        XCTAssertEqual(pattern?.appName, "Google Chrome")
+        XCTAssertTrue(pattern?.ownerNames.contains("Google Chrome") ?? false)
+    }
+
+    func testChromeBrowserRequiresRecordingConsent() {
+        XCTAssertTrue(AppMeetingPattern.chromeBrowser.requiresRecordingConsent)
+    }
+
+    func testNativePatternsDoNotRequireRecordingConsent() {
+        // Native desktop meeting apps keep their auto-start behaviour; only
+        // browser meetings gate behind a prompt.
+        XCTAssertFalse(AppMeetingPattern.teams.requiresRecordingConsent)
+        XCTAssertFalse(AppMeetingPattern.zoom.requiresRecordingConsent)
+        XCTAssertFalse(AppMeetingPattern.webex.requiresRecordingConsent)
+        XCTAssertFalse(AppMeetingPattern.simulator.requiresRecordingConsent)
     }
 
     // MARK: - Simulator Pattern

--- a/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
@@ -1,4 +1,5 @@
 @testable import MeetingTranscriber
+import UserNotifications
 import XCTest
 
 final class NotificationManagerTests: XCTestCase {
@@ -182,6 +183,45 @@ final class NotificationManagerTests: XCTestCase {
                 "Expected no notification for state \(state)",
             )
         }
+    }
+
+    // MARK: - Browser consent prompt (issue #503)
+
+    func testConsentGrantedOnlyForRecordAction() {
+        XCTAssertTrue(NotificationManager.consentGranted(for: NotificationManager.recordActionID))
+    }
+
+    func testConsentDeclinedForIgnoreDismissAndDefault() {
+        XCTAssertFalse(NotificationManager.consentGranted(for: NotificationManager.ignoreActionID))
+        XCTAssertFalse(NotificationManager.consentGranted(for: UNNotificationDismissActionIdentifier))
+        XCTAssertFalse(NotificationManager.consentGranted(for: UNNotificationDefaultActionIdentifier))
+        XCTAssertFalse(NotificationManager.consentGranted(for: "something-else"))
+    }
+
+    func testConsentCategoryHasRecordAndIgnoreActions() {
+        let category = NotificationManager.makeConsentCategory()
+        XCTAssertEqual(category.identifier, NotificationManager.consentCategoryID)
+        XCTAssertEqual(
+            category.actions.map(\.identifier),
+            [NotificationManager.recordActionID, NotificationManager.ignoreActionID],
+        )
+        XCTAssertEqual(category.actions.map(\.title), ["Record", "Ignore"])
+    }
+
+    func testAskToRecordDeclinesWhenNotSetUp() async {
+        // No app bundle / setUp never ran → we can't show a prompt, so default
+        // to "don't record" rather than recording without asking.
+        let manager = NotificationManager()
+        let granted = await manager.askToRecord(title: "Browser meeting", body: "Record?")
+        XCTAssertFalse(granted)
+    }
+
+    func testDefaultNotifierDeniesConsent() async {
+        // The AppNotifying default (a notifier with no real prompt, e.g.
+        // SilentNotifier) denies consent, so a browser meeting never records
+        // without a visible prompt.
+        let granted = await SilentNotifier().askToRecord(title: "Browser meeting", body: "Record?")
+        XCTAssertFalse(granted)
     }
 
     // MARK: - Helpers

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -49,8 +49,10 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
         }
         let meeting = detector.checkOnce()
         XCTAssertEqual(meeting?.pattern.appName, "Google Chrome")
-        XCTAssertTrue(meeting?.pattern.requiresRecordingConsent ?? false,
-                      "a detected browser meeting must carry the consent flag")
+        XCTAssertTrue(
+            meeting?.pattern.requiresRecordingConsent ?? false,
+            "a detected browser meeting must carry the consent flag",
+        )
     }
 
     func testChromeMediaPlaybackIsNotDetectedAsMeeting() {
@@ -149,5 +151,33 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
         }
         _ = detector.checkOnce()
         XCTAssertNotNil(detector.checkOnce(), "Zoom on → a Zoom call must fire")
+    }
+
+    @MainActor
+    func testDefaultDetectorWiresBrowserToggle() throws {
+        // End-to-end wiring (issue #503): the watchBrowserMeetings toggle must
+        // flow through watchApps → patterns(watching:) → the default detector,
+        // so a Chrome WebRTC call fires only when the toggle is on.
+        func detector(browserOn: Bool) throws -> PowerAssertionDetector {
+            let suite = "BrowserWatchWiring-\(browserOn)-\(getpid())-\(UUID().uuidString)"
+            let settings = try AppSettings(defaults: XCTUnwrap(UserDefaults(suiteName: suite)))
+            settings.watchBrowserMeetings = browserOn
+            let d = try XCTUnwrap(
+                WatchingController.defaultDetector(settings: settings) as? PowerAssertionDetector,
+            )
+            d.windowListProvider = { [] }
+            d.assertionProvider = {
+                assertionDict(processName: "Google Chrome", assertName: "WebRTC has active PeerConnections")
+            }
+            return d
+        }
+
+        let on = try detector(browserOn: true)
+        _ = on.checkOnce()
+        XCTAssertNotNil(on.checkOnce(), "browser toggle on → a Chrome WebRTC call must fire")
+
+        let off = try detector(browserOn: false)
+        _ = off.checkOnce()
+        XCTAssertNil(off.checkOnce(), "browser toggle off → a Chrome WebRTC call must be ignored")
     }
 }

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -15,11 +15,71 @@ private func assertionDict(processName: String, assertName: String) -> [Int32: [
 /// type_body_length cap) since this is a distinct concern.
 final class PowerAssertionDetectorPatternsTests: XCTestCase {
     func testPatternsWatchingAllKeepsEveryPattern() {
-        // All toggles on (the default) → every default pattern, unchanged.
+        // Every user-facing app watched (natives + browser) → every default pattern.
         let names = PowerAssertionDetector
-            .patterns(watching: ["Microsoft Teams", "Zoom", "Webex"])
+            .patterns(watching: ["Microsoft Teams", "Zoom", "Webex", "Google Chrome"])
             .map(\.appName)
         XCTAssertEqual(Set(names), Set(PowerAssertionDetector.defaultPatterns.map(\.appName)))
+    }
+
+    // MARK: - Browser (Chrome / WebRTC) pattern — issue #503
+
+    func testBrowserPatternIsOptInViaWatching() {
+        // The Chrome browser pattern ships in defaults but is only watched when
+        // the browser toggle adds "Google Chrome" to watchApps — off by default,
+        // so the native-only selection must not include it.
+        XCTAssertFalse(
+            PowerAssertionDetector.patterns(watching: ["Microsoft Teams", "Zoom", "Webex"])
+                .map(\.appName).contains("Google Chrome"),
+        )
+        XCTAssertTrue(
+            PowerAssertionDetector.patterns(watching: ["Google Chrome"])
+                .map(\.appName).contains("Google Chrome"),
+        )
+    }
+
+    func testChromeWebRTCCallIsDetected() {
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Google Chrome"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            assertionDict(processName: "Google Chrome", assertName: "WebRTC has active PeerConnections")
+        }
+        let meeting = detector.checkOnce()
+        XCTAssertEqual(meeting?.pattern.appName, "Google Chrome")
+        XCTAssertTrue(meeting?.pattern.requiresRecordingConsent ?? false,
+                      "a detected browser meeting must carry the consent flag")
+    }
+
+    func testChromeMediaPlaybackIsNotDetectedAsMeeting() {
+        // A Chrome tab playing audio/video (e.g. YouTube) also holds a
+        // display-sleep assertion, but its name has no WebRTC marker — the
+        // keyword match must reject it so we don't prompt on every video.
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Google Chrome"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            assertionDict(processName: "Google Chrome", assertName: "Playing audio")
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testNonChromeWebRTCAssertionIsNotDetected() {
+        // The pattern matches by exact process name; a different process holding
+        // a WebRTC-named assertion must not fire the Chrome browser pattern.
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Google Chrome"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            assertionDict(processName: "firefox", assertName: "WebRTC has active PeerConnections")
+        }
+        XCTAssertNil(detector.checkOnce())
     }
 
     func testPatternsWatchingSubsetDropsUnselectedApps() {

--- a/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
@@ -1,0 +1,136 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The `WatchLoop` consent gate for browser meetings (issue #503): meetings
+/// whose pattern requires consent prompt before recording instead of
+/// auto-starting, and a decline must not re-prompt on every poll. Driven
+/// through the real `start()`/`watchLoop()` path so the gate is exercised in
+/// place, not via a widened-visibility hook.
+@MainActor
+final class WatchLoopBrowserConsentTests: XCTestCase {
+    /// Detector that always reports one meeting, active.
+    private final class FixedDetector: MeetingDetecting {
+        let meeting: DetectedMeeting
+        init(_ meeting: DetectedMeeting) {
+            self.meeting = meeting
+        }
+
+        func checkOnce() -> DetectedMeeting? {
+            meeting
+        }
+
+        func isMeetingActive(_: DetectedMeeting) -> Bool {
+            true
+        }
+
+        func reset(appName _: String?) {}
+    }
+
+    /// Counting consent responder — an `AppNotifying` whose `askToRecord` the
+    /// `WatchLoop` consent gate calls. Records how often the user was prompted.
+    private final class ConsentSpy: AppNotifying {
+        private(set) var calls = 0
+        let response: Bool
+        init(response: Bool) {
+            self.response = response
+        }
+
+        func notify(title _: String, body _: String) {}
+
+        // swiftlint:disable async_without_await
+        @MainActor
+        func askToRecord(title _: String, body _: String) async -> Bool {
+            calls += 1
+            return response
+        }
+        // swiftlint:enable async_without_await
+    }
+
+    private func browserMeeting() -> DetectedMeeting {
+        DetectedMeeting(
+            pattern: .chromeBrowser,
+            windowTitle: "Google Chrome Call",
+            ownerName: "Google Chrome",
+            windowPID: 5632,
+        )
+    }
+
+    private func nativeMeeting() -> DetectedMeeting {
+        DetectedMeeting(
+            pattern: .zoom,
+            windowTitle: "Zoom Meeting",
+            ownerName: "zoom.us",
+            windowPID: 4321,
+        )
+    }
+
+    private func makeLoop(
+        detector: any MeetingDetecting,
+        spy: ConsentSpy,
+        consentPolicy: BrowserConsentPolicy = BrowserConsentPolicy(),
+    ) -> (WatchLoop, MockRecorder) {
+        let recorder = MockRecorder()
+        recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix_\(UUID().uuidString).wav")
+        let loop = WatchLoop(
+            detector: detector,
+            recorderFactory: { recorder },
+            pollInterval: 0.05,
+            endGracePeriod: 0.05,
+            notifier: spy,
+            consentPolicy: consentPolicy,
+        )
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
+        }
+        return (loop, recorder)
+    }
+
+    func testBrowserMeetingRecordsWhenConsentGranted() async {
+        let spy = ConsentSpy(response: true)
+        let (loop, recorder) = makeLoop(detector: FixedDetector(browserMeeting()), spy: spy)
+        loop.start()
+        await waitFor(recorder.startCalled)
+        XCTAssertTrue(recorder.startCalled, "granted consent must start recording")
+        XCTAssertGreaterThanOrEqual(spy.calls, 1, "the user must have been prompted")
+        loop.stop()
+    }
+
+    func testBrowserMeetingNotRecordedWhenConsentDenied() async {
+        let spy = ConsentSpy(response: false)
+        let (loop, recorder) = makeLoop(detector: FixedDetector(browserMeeting()), spy: spy)
+        loop.start()
+        // Well within the default 60 s decline cooldown: several polls happen,
+        // but the prompt must fire once and recording must never start.
+        await waitFor(spy.calls >= 1)
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertFalse(recorder.startCalled, "declined consent must not record")
+        XCTAssertEqual(spy.calls, 1, "a decline must suppress re-prompts within the cooldown")
+        loop.stop()
+    }
+
+    func testNativeMeetingNeverPromptsAndAutoStarts() async {
+        let spy = ConsentSpy(response: false) // would block recording IF consulted
+        let (loop, recorder) = makeLoop(detector: FixedDetector(nativeMeeting()), spy: spy)
+        loop.start()
+        await waitFor(recorder.startCalled)
+        XCTAssertTrue(recorder.startCalled, "native meetings keep auto-start")
+        XCTAssertEqual(spy.calls, 0, "native meetings must never consult the consent prompt")
+        loop.stop()
+    }
+
+    func testDeclinedBrowserMeetingRePromptsAfterCooldown() async {
+        let spy = ConsentSpy(response: false)
+        let (loop, recorder) = makeLoop(
+            detector: FixedDetector(browserMeeting()),
+            spy: spy,
+            consentPolicy: BrowserConsentPolicy(cooldown: 0.15),
+        )
+        loop.start()
+        // With a 0.15 s cooldown and 0.05 s polls, a decline suppresses a few
+        // polls, then the prompt re-appears — so calls climb past one over time.
+        await waitFor(spy.calls >= 2, timeout: .seconds(2))
+        XCTAssertGreaterThanOrEqual(spy.calls, 2, "prompt must re-appear once the cooldown elapses")
+        XCTAssertFalse(recorder.startCalled)
+        loop.stop()
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in detection and consent-gated recording of browser-based meetings
(Google Meet, Whereby, web Zoom/Teams/Webex) that run inside Google Chrome,
which the native-app detection misses. Closes #503.

## How

- **Detection via the WebRTC power assertion.** Chrome holds a
  `NoIdleSleepAssertion` named `"WebRTC has active PeerConnections"` during any
  WebRTC call — a robust, tab-focus-independent, platform-agnostic meeting
  signal (verified live against the real Chrome client). A new `Google Chrome`
  `AssertionPattern` in `PowerAssertionDetector` matches it by the
  `webrtc`/`peerconnection` keyword, deliberately **not** the assertion type:
  Chrome holds the same `NoIdleSleepAssertion` type for plain media playback, so
  a type match would fire on every YouTube video.

- **Opt-in, reusing the existing toggle mechanism.**
  `AppSettings.watchBrowserMeetings` (default off) appends `"Google Chrome"` to
  `watchApps`, so the existing `PowerAssertionDetector.patterns(watching:)`
  filter includes the browser pattern only when the user opts in — no new
  detection plumbing. Settings → General → Apps to Watch gains a "Browser Web
  Meetings (Google Chrome)" toggle.

- **Ask before recording.** The WebRTC signal isn't meeting-exclusive (any
  WebRTC use fires it), so browser meetings don't auto-start like native ones.
  `AppMeetingPattern.requiresRecordingConsent` routes them through a consent
  prompt (`WatchLoop.consentProvider` → an actionable `NotificationManager`
  notification with Record / Ignore actions). A decline suppresses re-prompts
  for a cooldown (`BrowserConsentPolicy`) so the prompt doesn't reappear every
  poll while the call continues. Native meetings are untouched (flag false →
  auto-start unchanged).

## Scope

This is a thin first slice. **In:** Chrome detection + consent gate + toggle.
**Out (follow-ups):**
- Audio-capture hardening for Chrome. The existing multi-PID tap already handles
  Chromium multi-process apps (Teams 2.x is Electron), but Chrome's audio
  service is shared across tabs, so a tap captures all Chrome audio, not just
  the meeting tab.
- Other browsers (Edge / Brave / Arc / Safari / Firefox — each needs its own
  process name / assertion signature verified).
- Meeting-title enrichment and an e2e lane.

## Testing

Pure logic is unit-tested end to end:
- pattern flag + Chrome `AppMeetingPattern`;
- WebRTC-vs-media-playback matching, non-Chrome rejection, and opt-in filtering;
- `BrowserConsentPolicy` decline cooldown (per-app, boundary, consent-clears);
- the `WatchLoop` consent gate driven through the real watch loop: granted
  records, denied doesn't and re-prompts only after the cooldown, and a native
  meeting never consults the prompt and still auto-starts;
- the notification action → consent mapping;
- settings roundtrip + the full toggle → `watchApps` → default detector wiring
  (a Chrome WebRTC call fires only when the toggle is on).

## Prompt UX

The consent prompt is a macOS notification with actions. It sits behind an
injected `consentProvider` seam, so swapping it for a menu-bar or floating-panel
prompt later is isolated to one place.
