### PR TITLE
test(app): browser-meeting detection e2e capture-proof lane (#503)

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -99,6 +99,23 @@ jobs:
         timeout-minutes: 12
         run: bash scripts/e2e-browser.sh
 
+      # Real-meeting variant (issue #503): instead of the local WebRTC fixture,
+      # two Chrome tabs join a REAL public Jitsi room (meet.ffmuc.net, no login)
+      # over a real WebRTC SFU — a genuine 2-participant meeting, not an in-page
+      # loopback. getUserMedia is overridden to a tone so no mic/TCC is needed.
+      # Reuses the bundle the step above built + signed (--no-build).
+      # Nightly/dispatch ONLY (never on labeled PRs) to keep hits on the
+      # third-party public instance rare, and continue-on-error because a
+      # Freifunk outage / UI drift is not our regression — green means the real
+      # chain works, a failure is a signal to check, not a merge blocker.
+      - name: Run browser-meeting E2E driver (real Jitsi, best-effort)
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 8
+        run: bash scripts/e2e-browser.sh --jitsi --no-build
+
       # Post-mortem: the captured app track + sidecar (copied to /tmp by the
       # driver, so the on-exit recordings sweep doesn't delete them) plus a
       # power-assertion snapshot and the audiotap log tail — the evidence for

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -1,0 +1,127 @@
+name: E2E (Browser Meeting)
+
+# Live browser-meeting detection + capture E2E (issue #503). Drives Chrome +
+# a local WebRTC-tone fixture through the power-assertion detector, answers the
+# consent prompt over RPC, and asserts the record-only _app.wav is non-silent.
+# Background: CLAUDE.md > E2E Architecture. Driver: scripts/e2e-browser.sh.
+#
+# NON-GATING CANARY: not referenced by any required check and not listed in
+# .github/tag-ruleset.json. Red is reported (no continue-on-error) but never
+# blocks a merge or a stable tag. Promote to a gate only after a couple of
+# weeks of stable nightlies.
+#
+# Runner prerequisites: the same self-hosted Mac mini as e2e-app.yml (signing
+# identity + TCC audio-capture grant), PLUS Google Chrome installed. No mic is
+# needed (the driver runs with noMic) and no Screen Recording is needed
+# (detection uses the sandbox-safe power-assertion path).
+
+on:
+  workflow_dispatch:
+  # Label-gated PR runs, same-repo branches only — identical policy to
+  # e2e-app.yml (fork PRs never reach the self-hosted runner; a label would be
+  # a standing approval and a fork run would fail without signing secrets).
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # 05:15 UTC — offset from e2e-app's 04:30 cron so the two audio lanes don't
+    # queue behind each other at the same minute (they share the one `audio`
+    # runner) and are easy to tell apart in `gh run list`.
+    - cron: '15 5 * * *'
+
+# The single `audio`-labeled runner serialises this against e2e-app.yml (only
+# one audio job runs at a time; the rest queue). cancel-in-progress stays false
+# for the same reason as e2e-app: the dev app is launched detached (`open`), so
+# a cancelled run can't clean it up — it would keep recording, hold port 9876,
+# and orphan WAVs. PR events group per PR number so a labeled PR never sits in
+# front of a nightly/dispatch run.
+concurrency:
+  group: e2e-browser-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-browser:
+    # Non-PR events (schedule/dispatch) always run. PR events run only for
+    # same-repo branches carrying the `run-e2e` label; fork PRs never reach the
+    # runner. The label-name check keeps a `labeled` event for some OTHER label
+    # from queueing a duplicate run.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'labeled' || github.event.label.name == 'run-e2e')
+      )
+    runs-on: [self-hosted, macOS, ARM64, audio]
+    # Cold build + deploy + re-sign (~70 s) + mt-cli build + one browser
+    # meeting (Chrome launch + detect + ~15 s capture + stop + assert) →
+    # ~6 min observed. 15 min gives honest margin; the driver has its own
+    # internal timeouts so a hang surfaces as a driver failure, not a job kill.
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/verify-xcode
+
+      # Same Developer ID signing path as e2e-app.yml — e2e-browser.sh shells
+      # out to e2e-app.sh --redeploy-only, which re-signs the deployed bundle.
+      # If the secret isn't set the action is a no-op and the self-signed dev
+      # cert from setup-self-hosted-runner.sh is used instead.
+      - name: Install Developer ID certificate
+        id: dev-id
+        uses: ./.github/actions/install-developer-id
+        with:
+          cert: ${{ secrets.DEVELOPER_ID_CERT }}
+          cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          keychain-name: e2e-signing.keychain-db
+          extra-partition-roles: "codesign:"
+
+      - name: Export keychain path for the driver
+        if: steps.dev-id.outputs.keychain-path != ''
+        run: echo "E2E_SIGNING_KEYCHAIN=${{ steps.dev-id.outputs.keychain-path }}" >> "$GITHUB_ENV"
+
+      - name: Pre-flight codesign smoke test
+        if: env.E2E_SIGNING_KEYCHAIN != ''
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        run: |
+          TEST_BIN=$(mktemp)
+          trap 'rm -f "$TEST_BIN"' EXIT
+          cp /usr/bin/true "$TEST_BIN"
+          if ! codesign --force --sign "$DEVELOPER_ID" --keychain "$E2E_SIGNING_KEYCHAIN" "$TEST_BIN"; then
+              echo "::error::codesign smoke test failed — likely trustd or partition-list drift on the Mini"
+              exit 1
+          fi
+
+      - name: Run browser-meeting E2E driver
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        timeout-minutes: 12
+        run: bash scripts/e2e-browser.sh
+
+      # Post-mortem: the captured app track + sidecar (copied to /tmp by the
+      # driver, so the on-exit recordings sweep doesn't delete them) plus a
+      # power-assertion snapshot and the audiotap log tail — the evidence for
+      # "did Chrome hold the assertion and did the tap capture audio?".
+      - name: Capture diagnostics
+        if: failure()
+        run: |
+          pmset -g assertions > /tmp/e2e-browser-assertions.txt 2>&1 || true
+          log show --last 5m --predicate 'subsystem == "com.meetingtranscriber.audiotap"' \
+            > /tmp/e2e-browser-audiotap.log 2>&1 || true
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-browser-diagnostics
+          path: |
+            /tmp/e2e-browser-app.wav
+            /tmp/e2e-browser-meta.json
+            /tmp/e2e-browser-assertions.txt
+            /tmp/e2e-browser-audiotap.log
+          if-no-files-found: ignore
+
+      - name: Cleanup signing keychain
+        if: always() && env.E2E_SIGNING_KEYCHAIN != ''
+        run: security delete-keychain "$E2E_SIGNING_KEYCHAIN" 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ __pycache__/
 # Local-only plans (open findings, research dumps, deferred work, history).
 # docs/plans/ stays committed for future-feature RFCs and reference docs.
 docs/plans/.local/
+scripts/fixtures/node_modules/
+scripts/fixtures/package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,8 @@ scripts/
   e2e-app.sh               # Live-recording E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
   e2e-browser.sh           # Live browser-meeting E2E driver (issue #503): deploy dev.app (watchBrowserMeetings+recordOnly+noMic+RPC), open Chrome + fixtures/webrtc-tone.html, grant consent via RPC, assert _app.wav non-silent via `mt-cli wav-verdict`
   fixtures/webrtc-tone.html  # Self-contained WebRTC-loopback + WebAudio-tone page (holds the "WebRTC has active PeerConnections" assertion + emits a tone the CATap can capture) for e2e-browser.sh
+  fixtures/jitsi-keeper.mjs  # CDP (puppeteer-core) driver for e2e-browser.sh --jitsi: two Chrome tabs join a REAL public Jitsi room (real 2-participant WebRTC SFU meeting); getUserMedia overridden to a 440 Hz tone so no mic/TCC is touched, unmuted so audio flows through the real server
+  fixtures/package.json      # puppeteer-core dep for jitsi-keeper.mjs (npm i on demand; node_modules gitignored)
   e2e-channel-health.sh    # E2E test for per-channel signal indicator (forces mic-silent state + asserts red-tint via RPC screenshot)
   e2e-settings-smoke.sh    # GitHub-hosted /ui/* canary: build homebrew .app + launch with RPC + assert GET /ui/tree surfaces recordOnlyToggle and POST /ui/press flips /state (self-pid AX; no TCC; run by e2e-ui-smoke.yml)
   e2e-silent-recording.sh  # E2E test for silent-recording detector (both channels at noise floor → in-app warning)
@@ -596,6 +598,22 @@ PRs are excluded from the self-hosted runner.
   lane is first brought up.
 - Limitation: like `e2e-app`, self-hosted mini only; the fixture's Chrome
   assertion wording is Chrome-version-dependent (the likeliest flake vector).
+- **Real-meeting variant (`--jitsi`, `scripts/fixtures/jitsi-keeper.mjs`):** the
+  synthetic fixture is an in-page `pc1↔pc2` loopback, not a real remote meeting.
+  `e2e-browser.sh --jitsi` instead drives Chrome via CDP (puppeteer-core) so two
+  tabs join a REAL public Jitsi room (`meet.ffmuc.net`, no login — `meet.jit.si`
+  requires a moderator login since 2023) — a genuine 2-participant WebRTC SFU
+  meeting; each tab's `getUserMedia` is overridden to a 440 Hz WebAudio tone, so
+  no real mic is touched (the macOS Chrome **mic-TCC** gate otherwise *hangs*
+  `getUserMedia` on a headless runner, and `--use-file-for-fake-audio-capture`
+  is buggy on macOS). Verified live on the mini: Chrome holds the assertion
+  (detection fires) and the tone flows tab-A → real server → tab-B (`recvPeak`
+  ≈ the tone), so the CATap captures real server-transported meeting audio.
+  Runs **nightly/dispatch only, never on labeled PRs**, and `continue-on-error`
+  (best-effort, depends on a third-party public instance being up — an outage is
+  not our regression). Chrome must be installed; `~/Applications` works for a
+  runner user without `/Applications` write access, and `node`/`npm` are needed
+  (puppeteer-core is `npm i`-installed on demand into `scripts/fixtures`).
 
 **Why the live-recording variant exists** (history that's easy to lose):
 - An earlier attempt at xctest-framed live recording (PR #100,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,15 +192,20 @@ tools/meeting-simulator/   # Meeting simulator tool for testing (--title sets th
 tools/mt-cli/              # Thin Swift client for DebugRPCServer (state, screenshot, open-settings, …)
   Package.swift
   Sources/
-    MTCLI.swift            # ArgumentParser entrypoint
+    MTCLI.swift            # ArgumentParser entrypoint (+ confirm-browser-consent, wav-verdict subcommands, issue #503)
     RPCClient.swift        # HTTP client; reads token from AppPaths-equivalent path
+    WavVerdict.swift       # Pure RMS non-silence analysis (windowed dBFS + activeWindowRatio); backs `mt-cli wav-verdict`
   Tests/RPCClientTests.swift
+  Tests/WavVerdictTests.swift
+  Tests/WavVerdictCommandTests.swift
   skill.md                 # Claude skill: when to use mt-cli, with examples
 scripts/
   build_release.sh         # Build self-contained .app bundle + DMG (--appstore for App Store variant)
   notarize_status.sh       # Check Apple notarization status
   run_app.sh               # Build + sign + launch menu bar app bundle (--build-only skips `open -W`)
   e2e-app.sh               # Live-recording E2E driver: build + deploy dev.app, trigger meeting-simulator, assert on RPC /state.lastJob
+  e2e-browser.sh           # Live browser-meeting E2E driver (issue #503): deploy dev.app (watchBrowserMeetings+recordOnly+noMic+RPC), open Chrome + fixtures/webrtc-tone.html, grant consent via RPC, assert _app.wav non-silent via `mt-cli wav-verdict`
+  fixtures/webrtc-tone.html  # Self-contained WebRTC-loopback + WebAudio-tone page (holds the "WebRTC has active PeerConnections" assertion + emits a tone the CATap can capture) for e2e-browser.sh
   e2e-channel-health.sh    # E2E test for per-channel signal indicator (forces mic-silent state + asserts red-tint via RPC screenshot)
   e2e-settings-smoke.sh    # GitHub-hosted /ui/* canary: build homebrew .app + launch with RPC + assert GET /ui/tree surfaces recordOnlyToggle and POST /ui/press flips /state (self-pid AX; no TCC; run by e2e-ui-smoke.yml)
   e2e-silent-recording.sh  # E2E test for silent-recording detector (both channels at noise floor → in-app warning)
@@ -234,6 +239,7 @@ Casks/meeting-transcriber@beta.rb # Homebrew Cask formula (pre-release)
   pr-labels.yml            # Automatic PR labeling
   e2e.yml                  # E2E — fixture-based xctest on self-hosted Mac (dispatch + main push + label-gated PR runs via `run-e2e`)
   e2e-app.yml              # E2E — deployed dev .app + live recording + RPC-driven assertion (dispatch + push to main + nightly + label-gated PR runs via `run-e2e`)
+  e2e-browser.yml          # E2E — browser-meeting detection + capture (issue #503): Chrome + WebRTC-tone fixture → power-assertion detect → RPC consent → non-silent _app.wav; NON-GATING canary on the self-hosted mini (dispatch + nightly + label-gated PR runs via `run-e2e`)
   e2e-cpu-load.yml         # E2E — idle + in-meeting CPU/RAM measurement of the deployed app (dispatch + nightly trend cron, RESULT artifact)
   appstore.yml             # App Store variant smoke test: build + launch-check (main push + nightly + dispatch)
   e2e-ui-smoke.yml         # E2E — GitHub-hosted /ui/* self-pid AX canary: build homebrew .app, drive GET /ui/tree + POST /ui/press, assert (guards the non-contractual self-pid path against macOS drift; no TCC → runs off the mini; paths-filtered PR + main push + nightly + dispatch)
@@ -433,7 +439,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 
 **Debug RPC server (dev-only):**
 - `DebugRPCServer` is an embedded HTTP server bound to `127.0.0.1:9876` that exposes app state, screenshots, and scene actions for shell-driven inspection. Whole file is `#if !APPSTORE`. Two enable paths: persistent `Settings → Advanced → Local Automation API` toggle (key `debugRPCEnabled`, off by default), or per-session `MEETINGTRANSCRIBER_DEBUG_RPC=1` env var (force-starts at launch). `AppState.applyDebugRPCSetting()` reconciles the running server with both signals at startup and on toggle changes.
-- Debug / inspection endpoints (no stability contract): `GET /state` (pipeline + speaker DB + engine state JSON; `engines.*.modelState` lets driver scripts wait for model preload), `GET /healthz`, `GET /metrics` (cumulative CPU/RAM/instructions self-report via `proc_pid_rusage` — diff two snapshots for window averages; process-only, child processes excluded; consumed by `scripts/e2e-cpu-load.sh`), `GET /screenshot` (PNG of the largest visible window), `GET /ui/tree` (read-only accessibility tree of an allowlisted window as JSON — `?window=settings` by default; walks the app's own self-pid `AXUIElement` tree in-process — which surfaces SwiftUI's `.accessibilityIdentifier`s, unlike the `NSView.accessibilityChildren()` walk — and needs no Accessibility TCC grant since self-inspection is exempt; lets a driver assert on UI structure instead of pixel-diffing a screenshot; PII windows stay off the allowlist), `POST /ui/press` (drive a real UI action: presses the control with the given accessibility `identifier` in an allowlisted window via in-process `AXUIElementPerformAction(kAXPressAction)` on the self-pid tree — no TCC grant, runs on the main actor; body `{window, identifier}`; the pressable set is a reviewed per-identifier allowlist, not "any control in the window", so a token-holder can't trigger arbitrary or modal-opening controls; 200 `{"pressed":<bool>}` / 404 allowlisted id absent from tree / 409 present-but-disabled / 403 disallowed window or identifier / 503 window not open; the driver asserts the resulting state via `GET /state`, not the returned flag), `POST /action/openSettings`, `POST /action/closeSettings`.
+- Debug / inspection endpoints (no stability contract): `GET /state` (pipeline + speaker DB + engine state JSON; `engines.*.modelState` lets driver scripts wait for model preload), `GET /healthz`, `GET /metrics` (cumulative CPU/RAM/instructions self-report via `proc_pid_rusage` — diff two snapshots for window averages; process-only, child processes excluded; consumed by `scripts/e2e-cpu-load.sh`), `GET /screenshot` (PNG of the largest visible window), `GET /ui/tree` (read-only accessibility tree of an allowlisted window as JSON — `?window=settings` by default; walks the app's own self-pid `AXUIElement` tree in-process — which surfaces SwiftUI's `.accessibilityIdentifier`s, unlike the `NSView.accessibilityChildren()` walk — and needs no Accessibility TCC grant since self-inspection is exempt; lets a driver assert on UI structure instead of pixel-diffing a screenshot; PII windows stay off the allowlist), `POST /action/confirmBrowserConsent` (resolve a parked browser-meeting consent prompt without a clickable notification, issue #503; body `{granted:bool}` → `{"resolved":true}` if a prompt was waiting, `{"resolved":false}` no-op otherwise; resolves inline via the lock-guarded `ConsentPromptCoordinator`, no main-actor hop — used by `scripts/e2e-browser.sh` via `mt-cli confirm-browser-consent`), `POST /ui/press` (drive a real UI action: presses the control with the given accessibility `identifier` in an allowlisted window via in-process `AXUIElementPerformAction(kAXPressAction)` on the self-pid tree — no TCC grant, runs on the main actor; body `{window, identifier}`; the pressable set is a reviewed per-identifier allowlist, not "any control in the window", so a token-holder can't trigger arbitrary or modal-opening controls; 200 `{"pressed":<bool>}` / 404 allowlisted id absent from tree / 409 present-but-disabled / 403 disallowed window or identifier / 503 window not open; the driver asserts the resulting state via `GET /state`, not the returned flag), `POST /action/openSettings`, `POST /action/closeSettings`.
 - Versioned automation API under `/v1` (carries a stability contract, kept off the debug `/action/*` surface): `POST /v1/transcribe` (blocking one-call: 200 terminal / 202 still-running / 400), `POST /v1/jobs` + `GET /v1/jobs/<id>` (enqueue + poll), `GET`/`POST /v1/jobs/<id>/naming` + `POST /v1/jobs/<id>/naming/skip` (speaker naming; 409 on wrong state, 404 unknown id). The two POST enqueue routes honour an `Idempotency-Key` header. Finished-job readback survives the 60s queue reaping + an app restart via `TerminalJobStore`. Full reference: `docs/automation-api.md`. Routing in `DebugRPCServer+V1.swift`.
 - Two-layer auth: 32-byte hex bearer token at `~/Library/Application Support/MeetingTranscriber/.rpc-token` (chmod 0600) + reject on any non-empty browser `Origin` header.
 - Action endpoints post `Notification.Name.showSettings` / `.closeSettings` that the `@main` scene observes and routes to `bringWindowToFront(id: "settings")` / `closeWindow(id: "settings")` — same path the menu bar uses.
@@ -561,6 +567,35 @@ PRs are excluded from the self-hosted runner.
 - Limitations: needs one-time runner setup (see below); can't run on
   GitHub-hosted runners — only on a self-hosted Mac with an interactive
   GUI session and a stable code-signing identity.
+
+**Browser-meeting E2E (`e2e-browser.yml`, `scripts/e2e-browser.sh`)**
+- Proves the issue #503 chain end-to-end without a real meeting service:
+  deploys the dev `.app` (`watchBrowserMeetings` + `recordOnly` + `noMic` +
+  RPC, reusing `e2e-app.sh --redeploy-only` for build/sign), opens Chrome with
+  the self-contained `scripts/fixtures/webrtc-tone.html` (an in-page pc1↔pc2
+  WebRTC loopback carrying a 440 Hz WebAudio tone), then answers the parked
+  consent prompt over RPC (`mt-cli confirm-browser-consent`) instead of a
+  click, records ~15 s, quits Chrome to end the meeting, and asserts the
+  record-only `_app.wav` is non-silent (`mt-cli wav-verdict`).
+- The consent prompt normally requires a click; the debug-RPC
+  `POST /action/confirmBrowserConsent` resolves the parked
+  `ConsentPromptCoordinator` continuation so the whole flow runs headless.
+  `askToRecord` parks and blocks the watch loop regardless of notification
+  permission, so the RPC resolve works even when notifications are denied.
+- Detection uses the sandbox-safe power-assertion path (no Screen Recording),
+  so it needs no extra TCC beyond e2e-app's; the only new runner prerequisite
+  is Google Chrome installed. No mic (`noMic`).
+- The signal the driver polls is `confirm-browser-consent` returning
+  `{"resolved":true}` (a prompt has parked) — detection alone can't be read
+  from `watchState` (it stays `"watching"` both before detection and while
+  deferring for consent). After granting, it polls `watchState == "recording"`.
+- NON-GATING canary: reports red but is not a required check and not in
+  `tag-ruleset.json`. The assertion-hold (does a loopback PeerConnection hold
+  "WebRTC has active PeerConnections") and tap-capture (does the CATap record
+  Chrome's shared-audio-service output) are verified live on the mini when the
+  lane is first brought up.
+- Limitation: like `e2e-app`, self-hosted mini only; the fixture's Chrome
+  assertion wording is Chrome-version-dependent (the likeliest flake vector).
 
 **Why the live-recording variant exists** (history that's easy to lose):
 - An earlier attempt at xctest-framed live recording (PR #100,

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -18,6 +18,12 @@ protocol AppNotifying {
     @MainActor
     func askToRecord(title: String, body: String) async -> Bool
 
+    /// Resolve a parked `askToRecord` prompt programmatically (the debug-RPC
+    /// consent hook, issue #503); returns whether one was waiting. Lives on the
+    /// same seam as `askToRecord` so park + resolve share it. Defaults to false
+    /// (no prompt) for notifiers without a real coordinator.
+    func resolveBrowserConsent(granted: Bool) -> Bool
+
     #if !APPSTORE
         /// Recently posted notifications, oldest first, for the debug RPC
         /// `/state.notifications` snapshot. Defaults to empty — only the
@@ -43,7 +49,13 @@ extension AppNotifying {
     func askToRecord(title _: String, body _: String) async -> Bool {
         false
     }
+
     // swiftlint:enable async_without_await
+
+    /// No prompt to resolve by default — only `NotificationManager` parks one.
+    func resolveBrowserConsent(granted _: Bool) -> Bool {
+        false
+    }
 }
 
 // MARK: - AppState
@@ -310,6 +322,13 @@ final class AppState {
                     }
                 }
             }
+            // Answers a parked browser-meeting consent prompt (issue #503) so an
+            // e2e driver can confirm recording without a clickable notification.
+            // Rides the injected `notifier` seam — the same one `askToRecord`
+            // parks in (WatchLoop+Consent) — so park + resolve stay symmetric.
+            let confirmBrowserConsent: (Bool) -> Bool = { [weak self] granted in
+                self?.notifier.resolveBrowserConsent(granted: granted) ?? false
+            }
             // RPC counterpart to the NSOpenPanel "Open from Recording" flow.
             // Validates the file exists (RPC layer returns 400 on `false`),
             // then routes through the same `enqueueFiles` entry point the
@@ -354,6 +373,7 @@ final class AppState {
                 snapshot: snapshot,
                 speakerActions: makeSpeakerDBActions(),
                 skipNaming: skipNaming,
+                confirmBrowserConsent: confirmBrowserConsent,
                 enqueueFile: enqueueFile,
                 enqueueFiles: enqueueFilesRPC,
                 enqueueReturningIDs: enqueueReturningIDs,

--- a/app/MeetingTranscriber/Sources/ConsentPromptCoordinator.swift
+++ b/app/MeetingTranscriber/Sources/ConsentPromptCoordinator.swift
@@ -65,4 +65,27 @@ final class ConsentPromptCoordinator: @unchecked Sendable {
         timeoutTask?.cancel()
         continuation?.resume(returning: granted)
     }
+
+    /// Resolve every currently-pending prompt at once with `granted`, returning
+    /// whether at least one was waiting. The debug-RPC consent hook (issue #503)
+    /// has no prompt id — "resolve whatever is parked" is the only sensible
+    /// semantics for a test hook, and a `false` no-op when nothing waits lets the
+    /// driver poll until a prompt actually parks. The drain happens under the
+    /// lock so two racing callers can't double-resume the same continuation.
+    @discardableResult
+    func resolvePending(granted: Bool) -> Bool {
+        lock.lock()
+        let continuations = Array(pending.values)
+        let timeoutTasks = Array(timeouts.values)
+        pending.removeAll()
+        timeouts.removeAll()
+        lock.unlock()
+        for task in timeoutTasks {
+            task.cancel()
+        }
+        for continuation in continuations {
+            continuation.resume(returning: granted)
+        }
+        return !continuations.isEmpty
+    }
 }

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -67,6 +67,11 @@
         private let snapshot: () -> RPCStateSnapshot
         private let speakerActions: SpeakerDBActions
         private let skipNaming: () -> Void
+        /// Resolves a parked browser-meeting consent prompt (issue #503) with the
+        /// posted `granted` value; returns whether a prompt was actually waiting.
+        /// Lets the e2e driver answer the ask-before-recording prompt without a
+        /// clickable macOS notification.
+        private let confirmBrowserConsent: (Bool) -> Bool
         /// Enqueues a previously-recorded file into the pipeline — same path
         /// `processAudioFiles` (NSOpenPanel) takes. Returns `false` if the
         /// caller's path is missing or doesn't exist on disk; the RPC layer
@@ -100,6 +105,7 @@
             snapshot: @escaping () -> RPCStateSnapshot,
             speakerActions: SpeakerDBActions = .noop,
             skipNaming: @escaping () -> Void = {},
+            confirmBrowserConsent: @escaping (Bool) -> Bool = { _ in false },
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
             enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
@@ -114,6 +120,7 @@
             self.snapshot = snapshot
             self.speakerActions = speakerActions
             self.skipNaming = skipNaming
+            self.confirmBrowserConsent = confirmBrowserConsent
             self.enqueueFile = enqueueFile
             self.enqueueFiles = enqueueFiles
             self.enqueueReturningIDs = enqueueReturningIDs
@@ -373,6 +380,9 @@
                 skipNaming()
                 return HTTPResponse.ok()
 
+            case ("POST", "/action/confirmBrowserConsent"):
+                return routeConfirmBrowserConsent(body: request.body)
+
             case ("POST", "/action/enqueueFile"):
                 // Enqueues a previously-recorded audio file into the pipeline
                 // — the same code path NSOpenPanel hits via "Open from
@@ -415,6 +425,23 @@
             default:
                 return HTTPResponse.notFound()
             }
+        }
+
+        /// Resolve a parked browser-meeting consent prompt (issue #503) without a
+        /// clickable macOS notification — the e2e driver posts `{"granted":bool}`.
+        /// Threading: unlike the scene actions (openSettings etc.) which hop to
+        /// the main actor via `Notification.Name`, this only touches the
+        /// lock-guarded `ConsentPromptCoordinator`, so it resolves inline — don't
+        /// "unify" it onto the main-actor path. 400 on undecodable body;
+        /// `{"resolved":true}` if a prompt was waiting, `{"resolved":false}`
+        /// (no-op) if none was, so the driver can poll until true.
+        private func routeConfirmBrowserConsent(body: Data) -> HTTPResponse {
+            guard let p = try? JSONDecoder().decode(ConsentPayload.self, from: body)
+            else { return HTTPResponse.badRequest() }
+            let resolved = confirmBrowserConsent(p.granted)
+            return HTTPResponse.ok(
+                body: Data(#"{"resolved":\#(resolved)}"#.utf8), contentType: "application/json",
+            )
         }
 
         // MARK: - Speaker DB action helpers
@@ -473,6 +500,10 @@
 
         private struct EnqueueFilePayload: Decodable {
             let path: String
+        }
+
+        private struct ConsentPayload: Decodable {
+            let granted: Bool
         }
 
         /// Map the action outcome to an HTTP response. `notFound` → 404,

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -178,6 +178,16 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         }
     }
 
+    /// Resolve a parked browser-consent prompt programmatically (the debug-RPC
+    /// `confirmBrowserConsent` hook, issue #503) — an automated e2e driver can't
+    /// click the macOS notification, so it answers the parked prompt through
+    /// this instead. Returns whether a prompt was actually waiting. Touches only
+    /// the lock-guarded coordinator, so it's safe from any thread with no
+    /// MainActor hop (unlike the scene actions).
+    func resolveBrowserConsent(granted: Bool) -> Bool {
+        consentCoordinator.resolvePending(granted: granted)
+    }
+
     /// Post the actionable consent notification (the thin UNUserNotificationCenter
     /// adapter — the decision itself is driven by `didReceive` / the coordinator
     /// timeout, whichever resolves first).

--- a/app/MeetingTranscriber/Tests/ConsentPromptCoordinatorTests.swift
+++ b/app/MeetingTranscriber/Tests/ConsentPromptCoordinatorTests.swift
@@ -52,6 +52,65 @@ final class ConsentPromptCoordinatorTests: XCTestCase {
         coord.resolve(id: "never-awaited", granted: true)
     }
 
+    // MARK: - resolvePending (the RPC consent hook — resolve without a prompt id)
+
+    func testResolvePendingWithNoPromptsReturnsFalse() {
+        // The RPC test hook has no prompt id and polls: "nothing waiting yet" is
+        // a false no-op, not an error, so the driver can retry.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        XCTAssertFalse(coord.resolvePending(granted: true))
+    }
+
+    func testResolvePendingResolvesSingleParkedPrompt() async {
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "a") {} }
+        await yieldUntilParked()
+        let resolved = coord.resolvePending(granted: true)
+        XCTAssertTrue(resolved)
+        let result = await task.value
+        XCTAssertTrue(result)
+    }
+
+    func testResolvePendingResolvesAllParkedPrompts() async {
+        // Defensive n>1 case: with no ids to target, "resolve everything waiting"
+        // is the only sane semantics — no zombie continuations left to time out.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let t1 = Task { await coord.awaitDecision(id: "a") {} }
+        let t2 = Task { await coord.awaitDecision(id: "b") {} }
+        await yieldUntilParked()
+        let resolved = coord.resolvePending(granted: false)
+        XCTAssertTrue(resolved)
+        let r1 = await t1.value
+        let r2 = await t2.value
+        XCTAssertFalse(r1)
+        XCTAssertFalse(r2)
+    }
+
+    func testResolvePendingAfterResolveByIdIsNoOp() async {
+        // A prompt already answered by id leaves nothing pending.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "a") {} }
+        await yieldUntilParked()
+        coord.resolve(id: "a", granted: true)
+        let result = await task.value
+        XCTAssertTrue(result)
+        XCTAssertFalse(coord.resolvePending(granted: false))
+    }
+
+    func testConcurrentResolvePendingResolvesEachOnce() async {
+        // Two racing resolvePending calls must not double-resume a continuation
+        // (that would crash) — the drain-under-lock lets exactly one see it.
+        let coord = ConsentPromptCoordinator(timeout: 60, sleep: neverSleep)
+        let task = Task { await coord.awaitDecision(id: "a") {} }
+        await yieldUntilParked()
+        async let a = Task.detached { coord.resolvePending(granted: true) }.value
+        async let b = Task.detached { coord.resolvePending(granted: true) }.value
+        let (ra, rb) = await (a, b)
+        XCTAssertNotEqual(ra, rb, "exactly one racing resolvePending should see the pending prompt")
+        let result = await task.value
+        XCTAssertTrue(result)
+    }
+
     /// Sleep briefly so the awaiting task registers its continuation inside
     /// `withCheckedContinuation` before the test resolves it.
     private func yieldUntilParked() async {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -31,7 +31,11 @@
 
         private func startServer(
             snapshot: RPCStateSnapshot = .empty,
+            // NB: keep after `enqueueFile` — Swift's forward-scan binds an
+            // unlabeled trailing closure to the FIRST function-type param, and
+            // the enqueueFile tests rely on that being enqueueFile.
             enqueueFile: @escaping (URL) -> Bool = { _ in false },
+            confirmBrowserConsent: @escaping (Bool) -> Bool = { _ in false },
             enqueueFiles: @escaping ([URL]) -> Int = { _ in 0 },
             enqueueReturningIDs: @escaping ([URL]) -> [UUID] = { _ in [] },
             jobStatus: @escaping (UUID) -> JobStatusDTO? = { _ in nil },
@@ -44,6 +48,7 @@
                 port: 0,
                 token: Self.testToken,
                 snapshot: { snapshot },
+                confirmBrowserConsent: confirmBrowserConsent,
                 enqueueFile: enqueueFile,
                 enqueueFiles: enqueueFiles,
                 enqueueReturningIDs: enqueueReturningIDs,
@@ -239,6 +244,58 @@
                 for: request("GET", base.appendingPathComponent("screenshot"), headers: authHeader),
             )
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 503)
+        }
+
+        // MARK: - /action/confirmBrowserConsent (issue #503)
+
+        func testConfirmBrowserConsentUndecodableBodyReturns400() async throws {
+            let base = try await startServer()
+            var req = request("POST", base.appendingPathComponent("action/confirmBrowserConsent"), headers: authHeader)
+            req.httpBody = Data("{}".utf8) // missing "granted"
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testConfirmBrowserConsentNoParkedPromptReturnsResolvedFalse() async throws {
+            // Closure returns false (nothing parked) → 200 {"resolved":false} so
+            // the driver keeps polling until a prompt actually parks.
+            let noPrompt: (Bool) -> Bool = { _ in false }
+            let base = try await startServer(confirmBrowserConsent: noPrompt)
+            var req = request("POST", base.appendingPathComponent("action/confirmBrowserConsent"), headers: authHeader)
+            req.httpBody = Data(#"{"granted":true}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual(String(data: data, encoding: .utf8), #"{"resolved":false}"#)
+        }
+
+        func testConfirmBrowserConsentResolvesAndForwardsGranted() async throws {
+            // Records each granted value the closure sees, as an array so the box
+            // holds a non-optional Bool and "not yet called" is just empty.
+            actor GrantBox {
+                private(set) var grants: [Bool] = []
+                func record(_ granted: Bool) {
+                    grants.append(granted)
+                }
+            }
+            let box = GrantBox()
+            let confirm: (Bool) -> Bool = { granted in
+                Task { await box.record(granted) }
+                return true
+            }
+            let base = try await startServer(confirmBrowserConsent: confirm)
+            var req = request("POST", base.appendingPathComponent("action/confirmBrowserConsent"), headers: authHeader)
+            req.httpBody = Data(#"{"granted":true}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            XCTAssertEqual(String(data: data, encoding: .utf8), #"{"resolved":true}"#)
+
+            var grants: [Bool] = []
+            for _ in 0 ..< 20 {
+                grants = await box.grants
+                if !grants.isEmpty { break }
+                try await Task.sleep(for: .milliseconds(25))
+            }
+            XCTAssertEqual(grants, [true], "the posted granted value must reach the closure")
         }
 
         // MARK: - /action/enqueueFile

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -220,10 +220,28 @@ log "RPC up"
 
 # --- drive the browser meeting --------------------------------------------
 
+_watch_state() { rpc /state | jq -r '.watchState // ""'; }
+
+# Best-effort diagnostics when detection doesn't fire — the next CI run then
+# shows whether the app was watching, whether Chrome was in the watched set,
+# and whether the WebRTC assertion was actually present. Never fails the script.
+_dump_detection_diag() {
+    log "DIAG: watchState=$(_watch_state)"
+    log "DIAG: /state.settings.detection = $(rpc /state | jq -c '.settings.detection // {}' 2>/dev/null)"
+    log "DIAG: effective watchBrowserMeetings std=$(snapshot_default "$BUNDLE_ID" watchBrowserMeetings) ctr=$([ -f "$_CONTAINER_PLIST" ] && snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
+    log "DIAG: effective autoWatch std=$(snapshot_default "$BUNDLE_ID" autoWatch)"
+    log "DIAG: pmset WebRTC assertions:"
+    pmset -g assertions 2>/dev/null | grep -iE "webrtc|peerconnection|Google Chrome" || log "DIAG:   (none)"
+}
+
 log "Launching Chrome with the WebRTC-tone fixture"
+# --password-store=basic keeps Chrome off the macOS keychain (an in-memory
+# store instead), so its first launch never pops a blocking "Chrome wants to
+# use the keychain" modal that a headless runner has no one to dismiss.
 open -na "$CHROME_APP" --args \
     --user-data-dir="$CHROME_PROFILE" \
     --no-first-run --no-default-browser-check \
+    --password-store=basic \
     --autoplay-policy=no-user-gesture-required \
     "$FIXTURE_URL"
 
@@ -237,12 +255,13 @@ _grant_consent() {
     assert_app_alive
     "$MTCLI" confirm-browser-consent --granted 2>/dev/null | jq -e '.resolved == true' >/dev/null 2>&1
 }
-poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent \
-    || fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
+poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent || {
+    _dump_detection_diag
+    fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
+}
 log "Consent granted over RPC"
 
 log "Waiting for recording to start (watchState == recording)"
-_watch_state() { rpc /state | jq -r '.watchState // ""'; }
 _is_recording() { [ "$(_watch_state)" = "recording" ]; }
 poll_until "$DETECT_TIMEOUT_S" 2 _is_recording \
     || fail "watchState never reached 'recording' after consent"

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Live browser-meeting E2E driver for the Meeting Transcriber dev app (issue #503).
+#
+# Proves the browser-detection + capture chain end-to-end, WITHOUT a real
+# meeting service, account, or second participant:
+#
+#   Chrome + local WebRTC-tone fixture
+#     → PowerAssertionDetector (assertion "WebRTC has active PeerConnections")
+#     → consent gate (watchState stays "watching", a prompt parks)
+#     → RPC confirmBrowserConsent (stands in for the un-clickable notification)
+#     → record-only capture (noMic)
+#     → sidecar + _app.wav
+#     → ASSERT: _app.wav is NOT silent (the CATap actually tapped Chrome audio)
+#
+# Runs on the same self-hosted Mac mini as e2e-app.sh. Detection uses the
+# power-assertion path (no Screen Recording needed) and consent is answered
+# over RPC (no clickable notification needed), so it works headless. Chrome
+# must be installed; no mic is needed (noMic) and TCC audio-capture grants are
+# the same ones e2e-app.sh relies on.
+#
+# See CLAUDE.md > E2E architecture, and scripts/setup-self-hosted-runner.sh.
+
+set -euo pipefail
+
+# --- args -----------------------------------------------------------------
+
+NO_BUILD=false     # skip build/deploy/re-sign — use ~/Applications bundle as-is
+KEEP_APP=false     # leave the dev app running on exit
+KEEP_CHROME=false  # leave the fixture Chrome instance open on exit
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-build)    NO_BUILD=true ;;
+        --keep-app)    KEEP_APP=true ;;
+        --keep-chrome) KEEP_CHROME=true ;;
+        -h|--help)
+            cat <<'HELP'
+Usage: e2e-browser.sh [--no-build] [--keep-app] [--keep-chrome]
+
+  --no-build     Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
+  --keep-app     Leave the dev app running on exit (default: quit it).
+  --keep-chrome  Leave the fixture Chrome instance open on exit (default: quit it).
+HELP
+            exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --- paths ----------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_BUNDLE_DEPLOY="$HOME/Applications/MeetingTranscriber-Dev.app"
+MTCLI_PKG="$ROOT/tools/mt-cli"
+MTCLI="$MTCLI_PKG/.build/release/mt-cli"
+FIXTURE="$ROOT/scripts/fixtures/webrtc-tone.html"
+FIXTURE_URL="file://$FIXTURE"
+RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+RPC_BASE="http://127.0.0.1:9876"
+RECORDINGS_DIR="$HOME/Downloads/MeetingTranscriber/recordings"
+# Resolve Chrome from an explicit override, then the user Applications dir, then
+# the system one. A self-hosted runner whose user can't write /Applications
+# (no passwordless sudo) installs Chrome under ~/Applications, so check there too.
+CHROME_APP="${CHROME_APP:-}"
+if [ -z "$CHROME_APP" ]; then
+    for candidate in "$HOME/Applications/Google Chrome.app" "/Applications/Google Chrome.app"; do
+        [ -d "$candidate" ] && CHROME_APP="$candidate" && break
+    done
+fi
+# `find -newer` marker so cleanup + artifact search only touch THIS run's files.
+RUN_MARKER="/tmp/e2e-browser-marker.$$"
+# Isolated Chrome profile so the fixture instance is distinct from any user
+# Chrome and can be quit by argv match without touching the user's windows.
+CHROME_PROFILE="$(mktemp -d /tmp/e2e-browser-chrome.XXXXXX)"
+
+_CONTAINER_PLIST="$HOME/Library/Containers/com.meetingtranscriber.dev/Data/Library/Preferences/com.meetingtranscriber.dev.plist"
+BUNDLE_ID="com.meetingtranscriber.dev"
+
+# --- timing budgets -------------------------------------------------------
+
+RPC_READY_TIMEOUT_S=30   # dev-app cold start (model preload etc.)
+DETECT_TIMEOUT_S=90      # Chrome launch + assertion + detector poll + prompt park
+RECORD_SECONDS=15        # how long to let the tone record
+STOP_TIMEOUT_S=120       # Chrome quit → assertion drop → endGrace → recorder finalize
+SIDECAR_TIMEOUT_S=30     # sidecar + _app.wav appear on disk after stop
+
+# --- helpers --------------------------------------------------------------
+
+log()  { printf '[e2e-browser] %s\n' "$*"; }
+fail() { printf '[e2e-browser] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# shellcheck source=lib/e2e-helpers.sh
+source "$SCRIPT_DIR/lib/e2e-helpers.sh"
+
+require_command() { command -v "$1" >/dev/null || fail "missing command: $1"; }
+
+RPC_TOKEN=""
+# Transient-tolerant GET so poll loops under `set -e` keep going on a hiccup.
+rpc() {
+    curl --silent --show-error --max-time 15 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE$1" 2>/dev/null || true
+}
+
+# Quit only the fixture Chrome instance (its argv carries our profile dir) —
+# never the user's own Chrome windows.
+quit_chrome() { pkill -f "$CHROME_PROFILE" 2>/dev/null || true; }
+
+# Write a dev default to BOTH the standard domain and the app's container
+# plist (if present) — macOS routes the dev .app's reads to the container when
+# it exists, so a standard-domain-only write is silently a no-op there. Mirrors
+# e2e-app.sh's `_set_dev_default`.
+_set_dev_bool() {
+    local key="$1" value="$2"
+    defaults write "$BUNDLE_ID" "$key" -bool "$value" 2>/dev/null || true
+    [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
+}
+
+# Per-domain snapshots of the behaviour toggles this lane flips, so cleanup
+# restores EACH domain to exactly its own prior value (empty → delete).
+_PRE_BROWSER_STD=""; _PRE_BROWSER_CTR=""
+_PRE_RECORDONLY_STD=""; _PRE_RECORDONLY_CTR=""
+_PRE_NOMIC_STD=""; _PRE_NOMIC_CTR=""
+
+# --- preflight ------------------------------------------------------------
+
+require_command curl
+require_command jq
+require_command swift
+require_command open
+
+[ -f "$FIXTURE" ] || fail "fixture not found: $FIXTURE"
+[ -n "$CHROME_APP" ] && [ -d "$CHROME_APP" ] \
+    || fail "Google Chrome not found in ~/Applications or /Applications — install it on the runner (or set CHROME_APP)"
+
+# noMic sidesteps the mic capture path, so a virtual input device isn't
+# required (unlike e2e-app.sh). Warn if absent, don't fail.
+if ! system_profiler SPAudioDataType 2>/dev/null | grep -A4 "Default Input" | grep -q "Input Channels"; then
+    log "WARNING: no default audio input device — fine under noMic, but check output routing exists for Chrome"
+fi
+
+# Always quit a stale instance so the UserDefaults below take effect on launch
+# and the old RPC server doesn't shadow the new one.
+quit_running_app
+
+if [ "$NO_BUILD" = false ]; then
+    # Reuse e2e-app.sh's full build/deploy/re-sign machinery (Developer ID or
+    # self-signed dev cert, keychain re-assertion) — it rebuilds + deploys the
+    # canonical bundle and exits, leaving nothing running.
+    log "Building + deploying dev bundle via e2e-app.sh --redeploy-only"
+    "$SCRIPT_DIR/e2e-app.sh" --redeploy-only || fail "build/deploy failed"
+else
+    [ -d "$DEV_BUNDLE_DEPLOY" ] || fail "--no-build given but $DEV_BUNDLE_DEPLOY doesn't exist"
+    log "Skipping build/deploy — using existing $DEV_BUNDLE_DEPLOY"
+fi
+
+# Build mt-cli (release) for confirm-browser-consent + wav-verdict.
+if [ ! -x "$MTCLI" ]; then
+    log "Building mt-cli"
+    (cd "$MTCLI_PKG" && swift build -c release) || fail "mt-cli build failed"
+fi
+
+# --- settings -------------------------------------------------------------
+
+# Snapshot the behaviour toggles per domain before flipping them.
+_PRE_BROWSER_STD="$(snapshot_default "$BUNDLE_ID" watchBrowserMeetings)"
+_PRE_RECORDONLY_STD="$(snapshot_default "$BUNDLE_ID" recordOnly)"
+_PRE_NOMIC_STD="$(snapshot_default "$BUNDLE_ID" noMic)"
+if [ -f "$_CONTAINER_PLIST" ]; then
+    _PRE_BROWSER_CTR="$(snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
+    _PRE_RECORDONLY_CTR="$(snapshot_default "$_CONTAINER_PLIST" recordOnly)"
+    _PRE_NOMIC_CTR="$(snapshot_default "$_CONTAINER_PLIST" noMic)"
+fi
+
+# debugRPCEnabled + autoWatch are set-and-leave (like e2e-app.sh — harmless on).
+defaults write "$BUNDLE_ID" debugRPCEnabled -bool true
+defaults write "$BUNDLE_ID" autoWatch -bool true
+_set_dev_bool watchBrowserMeetings true   # append "Google Chrome" to watchApps
+_set_dev_bool recordOnly true             # sidecar + WAVs, skip transcription/protocol
+_set_dev_bool noMic true                  # app-track only; no mic needed for the proof
+
+mkdir -p "$RECORDINGS_DIR"
+touch "$RUN_MARKER"
+
+# --- launch + cleanup trap ------------------------------------------------
+
+log "Launching $DEV_BUNDLE_DEPLOY"
+open "$DEV_BUNDLE_DEPLOY"
+
+_ON_EXIT_RAN=""
+on_exit() {
+    [ -n "$_ON_EXIT_RAN" ] && return 0
+    _ON_EXIT_RAN=1
+    [ "$KEEP_CHROME" = false ] && quit_chrome
+    [ "$KEEP_APP" = false ] && quit_running_app || true
+    # Restore the behaviour toggles per domain (empty snapshot → delete).
+    restore_bool_default "$BUNDLE_ID" watchBrowserMeetings "$_PRE_BROWSER_STD"
+    restore_bool_default "$BUNDLE_ID" recordOnly "$_PRE_RECORDONLY_STD"
+    restore_bool_default "$BUNDLE_ID" noMic "$_PRE_NOMIC_STD"
+    if [ -f "$_CONTAINER_PLIST" ]; then
+        restore_bool_default "$_CONTAINER_PLIST" watchBrowserMeetings "$_PRE_BROWSER_CTR"
+        restore_bool_default "$_CONTAINER_PLIST" recordOnly "$_PRE_RECORDONLY_CTR"
+        restore_bool_default "$_CONTAINER_PLIST" noMic "$_PRE_NOMIC_CTR"
+    fi
+    # Marker-bounded artifact cleanup — CI only (dev + prod share the recordings
+    # dir locally; see feedback memory no_destructive_fs_on_real_dirs).
+    sweep_run_artifacts "$RECORDINGS_DIR" "$RUN_MARKER"
+    rm -f "$RUN_MARKER"
+    rm -rf "$CHROME_PROFILE"
+}
+trap on_exit EXIT
+trap 'on_exit; exit 130' INT
+trap 'on_exit; exit 143' TERM
+
+log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
+_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
+log "RPC up"
+
+# --- drive the browser meeting --------------------------------------------
+
+log "Launching Chrome with the WebRTC-tone fixture"
+open -na "$CHROME_APP" --args \
+    --user-data-dir="$CHROME_PROFILE" \
+    --no-first-run --no-default-browser-check \
+    --autoplay-policy=no-user-gesture-required \
+    "$FIXTURE_URL"
+
+# Detection + consent in one poll: confirm-browser-consent returns
+# {"resolved":false} until the consent prompt actually parks (i.e. the browser
+# meeting was detected and the watch loop is blocked awaiting consent), then
+# {"resolved":true} once we grant it. Polling until true is race-free against
+# however long Chrome takes to hold the assertion.
+log "Waiting up to ${DETECT_TIMEOUT_S}s for detection + granting consent over RPC"
+_grant_consent() {
+    assert_app_alive
+    "$MTCLI" confirm-browser-consent --granted 2>/dev/null | jq -e '.resolved == true' >/dev/null 2>&1
+}
+poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent \
+    || fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
+log "Consent granted over RPC"
+
+log "Waiting for recording to start (watchState == recording)"
+_watch_state() { rpc /state | jq -r '.watchState // ""'; }
+_is_recording() { [ "$(_watch_state)" = "recording" ]; }
+poll_until "$DETECT_TIMEOUT_S" 2 _is_recording \
+    || fail "watchState never reached 'recording' after consent"
+log "Recording started; capturing ${RECORD_SECONDS}s of tone"
+sleep "$RECORD_SECONDS"
+
+log "Quitting Chrome to end the meeting"
+quit_chrome
+
+log "Waiting up to ${STOP_TIMEOUT_S}s for recording to stop"
+_not_recording() { [ "$(_watch_state)" != "recording" ]; }
+poll_until "$STOP_TIMEOUT_S" 2 _not_recording \
+    || fail "watchState stayed 'recording' after Chrome quit — meeting-end not detected"
+
+# --- assert: a non-silent app track was captured --------------------------
+
+log "Waiting up to ${SIDECAR_TIMEOUT_S}s for the record-only sidecar"
+SIDECAR=""
+_find_sidecar() {
+    SIDECAR="$(find "$RECORDINGS_DIR" -name '*_meta.json' -newer "$RUN_MARKER" 2>/dev/null | head -1)"
+    [ -n "$SIDECAR" ]
+}
+poll_until "$SIDECAR_TIMEOUT_S" 1 _find_sidecar || fail "no record-only sidecar written under $RECORDINGS_DIR"
+log "Sidecar: $SIDECAR"
+
+APP_WAV="${SIDECAR%_meta.json}_app.wav"
+[ -f "$APP_WAV" ] || fail "no _app.wav next to the sidecar ($APP_WAV)"
+
+# Preserve the captured track + sidecar OUTSIDE the recordings dir so the
+# on-exit sweep (CI-gated) doesn't delete them before CI uploads them for
+# post-mortem — the whole point of this lane is "was there audio?".
+cp "$APP_WAV" /tmp/e2e-browser-app.wav 2>/dev/null || true
+cp "$SIDECAR" /tmp/e2e-browser-meta.json 2>/dev/null || true
+
+log "Verdict on the captured app track:"
+"$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs -50 --min-active-ratio 0.5 \
+    || fail "app track is silent — the CATap did not capture Chrome's browser-meeting audio"
+
+log "PASS: browser detection → RPC consent → non-silent CATap capture of the app track"

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -235,13 +235,14 @@ _dump_detection_diag() {
 }
 
 log "Launching Chrome with the WebRTC-tone fixture"
-# --password-store=basic keeps Chrome off the macOS keychain (an in-memory
-# store instead), so its first launch never pops a blocking "Chrome wants to
-# use the keychain" modal that a headless runner has no one to dismiss.
+# Keep Chrome off the macOS Keychain so its first launch never pops a blocking
+# "Chrome wants to use the keychain" modal a headless runner can't dismiss.
+# --use-mock-keychain is the macOS flag (Chrome uses a mock Keychain for its
+# Safe Storage); --password-store=basic is its Linux counterpart, harmless here.
 open -na "$CHROME_APP" --args \
     --user-data-dir="$CHROME_PROFILE" \
     --no-first-run --no-default-browser-check \
-    --password-store=basic \
+    --use-mock-keychain --password-store=basic \
     --autoplay-policy=no-user-gesture-required \
     "$FIXTURE_URL"
 
@@ -297,7 +298,9 @@ cp "$APP_WAV" /tmp/e2e-browser-app.wav 2>/dev/null || true
 cp "$SIDECAR" /tmp/e2e-browser-meta.json 2>/dev/null || true
 
 log "Verdict on the captured app track:"
-"$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs -50 --min-active-ratio 0.5 \
+# `=` form is required for the negative threshold: ArgumentParser reads a bare
+# `-50` after `--threshold-dbfs` as another flag and errors out.
+"$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs=-50 --min-active-ratio=0.5 \
     || fail "app track is silent — the CATap did not capture Chrome's browser-meeting audio"
 
 log "PASS: browser detection → RPC consent → non-silent CATap capture of the app track"

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -27,19 +27,28 @@ set -euo pipefail
 NO_BUILD=false     # skip build/deploy/re-sign — use ~/Applications bundle as-is
 KEEP_APP=false     # leave the dev app running on exit
 KEEP_CHROME=false  # leave the fixture Chrome instance open on exit
+MODE=fixture       # meeting source: fixture (in-page loopback) | jitsi (real SFU)
+JITSI_HOST=meet.ffmuc.net  # real public Jitsi (no login) for --jitsi mode
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --no-build)    NO_BUILD=true ;;
         --keep-app)    KEEP_APP=true ;;
         --keep-chrome) KEEP_CHROME=true ;;
+        --jitsi)       MODE=jitsi ;;
+        --jitsi-host)  shift; JITSI_HOST="$1" ;;
         -h|--help)
             cat <<'HELP'
-Usage: e2e-browser.sh [--no-build] [--keep-app] [--keep-chrome]
+Usage: e2e-browser.sh [--no-build] [--keep-app] [--keep-chrome] [--jitsi [--jitsi-host HOST]]
 
   --no-build     Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
   --keep-app     Leave the dev app running on exit (default: quit it).
   --keep-chrome  Leave the fixture Chrome instance open on exit (default: quit it).
+  --jitsi        Real-meeting mode: instead of the local WebRTC fixture, join a real
+                 public Jitsi room with two Chrome tabs (real 2-participant WebRTC SFU
+                 meeting; getUserMedia overridden to a tone so no mic/TCC is needed).
+                 Best-effort — depends on a third-party public Jitsi being reachable.
+  --jitsi-host   Jitsi host for --jitsi (default meet.ffmuc.net, a no-login public instance).
 HELP
             exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
@@ -56,6 +65,10 @@ MTCLI_PKG="$ROOT/tools/mt-cli"
 MTCLI="$MTCLI_PKG/.build/release/mt-cli"
 FIXTURE="$ROOT/scripts/fixtures/webrtc-tone.html"
 FIXTURE_URL="file://$FIXTURE"
+FIXTURES_DIR="$ROOT/scripts/fixtures"
+KEEPER="$FIXTURES_DIR/jitsi-keeper.mjs"
+CDP_PORT=9222
+KEEPER_PID=""
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 RPC_BASE="http://127.0.0.1:9876"
 RECORDINGS_DIR="$HOME/Downloads/MeetingTranscriber/recordings"
@@ -130,9 +143,23 @@ require_command jq
 require_command swift
 require_command open
 
-[ -f "$FIXTURE" ] || fail "fixture not found: $FIXTURE"
 [ -n "$CHROME_APP" ] && [ -d "$CHROME_APP" ] \
     || fail "Google Chrome not found in ~/Applications or /Applications — install it on the runner (or set CHROME_APP)"
+
+if [ "$MODE" = fixture ]; then
+    [ -f "$FIXTURE" ] || fail "fixture not found: $FIXTURE"
+else
+    # --jitsi: drive Chrome via CDP with puppeteer-core (node). Install it on
+    # demand into scripts/fixtures (node_modules is gitignored).
+    require_command node
+    require_command npm
+    [ -f "$KEEPER" ] || fail "jitsi keeper not found: $KEEPER"
+    if [ ! -d "$FIXTURES_DIR/node_modules/puppeteer-core" ]; then
+        log "Installing puppeteer-core for the jitsi keeper"
+        ( cd "$FIXTURES_DIR" && npm install --no-audit --no-fund >/dev/null 2>&1 ) \
+            || fail "npm install puppeteer-core failed"
+    fi
+fi
 
 # noMic sidesteps the mic capture path, so a virtual input device isn't
 # required (unlike e2e-app.sh). Warn if absent, don't fail.
@@ -192,6 +219,7 @@ _ON_EXIT_RAN=""
 on_exit() {
     [ -n "$_ON_EXIT_RAN" ] && return 0
     _ON_EXIT_RAN=1
+    [ -n "$KEEPER_PID" ] && kill "$KEEPER_PID" 2>/dev/null || true
     [ "$KEEP_CHROME" = false ] && quit_chrome
     [ "$KEEP_APP" = false ] && quit_running_app || true
     # Restore the behaviour toggles per domain (empty snapshot → delete).
@@ -234,17 +262,26 @@ _dump_detection_diag() {
     pmset -g assertions 2>/dev/null | grep -iE "webrtc|peerconnection|Google Chrome" || log "DIAG:   (none)"
 }
 
-log "Launching Chrome with the WebRTC-tone fixture"
 # Keep Chrome off the macOS Keychain so its first launch never pops a blocking
 # "Chrome wants to use the keychain" modal a headless runner can't dismiss.
 # --use-mock-keychain is the macOS flag (Chrome uses a mock Keychain for its
 # Safe Storage); --password-store=basic is its Linux counterpart, harmless here.
-open -na "$CHROME_APP" --args \
-    --user-data-dir="$CHROME_PROFILE" \
-    --no-first-run --no-default-browser-check \
-    --use-mock-keychain --password-store=basic \
-    --autoplay-policy=no-user-gesture-required \
-    "$FIXTURE_URL"
+CHROME_FLAGS=(--user-data-dir="$CHROME_PROFILE" --no-first-run --no-default-browser-check
+    --use-mock-keychain --password-store=basic --autoplay-policy=no-user-gesture-required)
+if [ "$MODE" = fixture ]; then
+    log "Launching Chrome with the WebRTC-tone fixture"
+    open -na "$CHROME_APP" --args "${CHROME_FLAGS[@]}" "$FIXTURE_URL"
+else
+    # --jitsi: launch Chrome with a CDP port, then the keeper joins a real Jitsi
+    # room with two tabs (real 2-participant WebRTC SFU meeting). A unique room
+    # per run avoids colliding with anyone else on the public instance.
+    JITSI_ROOM="MtE2e$(date +%s)$$"
+    log "Launching Chrome (CDP) + joining real Jitsi room $JITSI_HOST/$JITSI_ROOM"
+    open -na "$CHROME_APP" --args "${CHROME_FLAGS[@]}" --remote-debugging-port="$CDP_PORT" "about:blank"
+    sleep 5
+    node "$KEEPER" --host "$JITSI_HOST" --room "$JITSI_ROOM" --keep 120 --port "$CDP_PORT" &
+    KEEPER_PID=$!
+fi
 
 # Detection + consent in one poll: confirm-browser-consent returns
 # {"resolved":false} until the consent prompt actually parks (i.e. the browser

--- a/scripts/fixtures/jitsi-keeper.mjs
+++ b/scripts/fixtures/jitsi-keeper.mjs
@@ -1,0 +1,76 @@
+// Real-meeting audio source for the browser-detection e2e (issue #503): joins a
+// real Jitsi room with TWO tabs in one Chrome so it is a genuine 2-participant
+// meeting over a real WebRTC SFU (not the in-page pc1<->pc2 fixture). Each tab's
+// getUserMedia is overridden to a 440 Hz WebAudio-oscillator stream, so:
+//   - no real microphone is touched (sidesteps the macOS Chrome mic-TCC gate
+//     that hangs getUserMedia on a headless runner), and
+//   - each tab sends the tone to the SFU, which relays it to the other tab,
+//     which plays it out -> Chrome's output carries real server-transported
+//     meeting audio for the app's CATap to capture.
+// Chrome must already be running with --remote-debugging-port; this connects via
+// CDP (puppeteer-core), joins, unmutes, prints readiness, and keeps the tabs in
+// the meeting for --keep seconds, then exits (the driver quits Chrome to end it).
+//
+// Usage: node jitsi-keeper.mjs --host meet.ffmuc.net --room <name> --keep 90 --port 9222
+import puppeteer from "puppeteer-core";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+const HOST = arg("host", "meet.ffmuc.net");
+const ROOM = arg("room", "MtE2eRoom");
+const KEEP = parseInt(arg("keep", "90"), 10);
+const PORT = arg("port", "9222");
+
+const OVERRIDE = () => {
+  const AC = window.AudioContext || window.webkitAudioContext;
+  navigator.mediaDevices.getUserMedia = async () => {
+    const ctx = new AC();
+    const osc = ctx.createOscillator();
+    osc.frequency.value = 440;
+    const gain = ctx.createGain();
+    gain.gain.value = 0.3;
+    const dst = ctx.createMediaStreamDestination();
+    osc.connect(gain).connect(dst);
+    osc.start();
+    window.__toneCtx = ctx; // keep alive
+    return dst.stream;
+  };
+};
+
+const browser = await puppeteer.connect({ browserURL: `http://127.0.0.1:${PORT}`, defaultViewport: null });
+
+async function joinTab(name) {
+  const page = await browser.newPage();
+  await page.evaluateOnNewDocument(OVERRIDE);
+  const url = `https://${HOST}/${ROOM}`
+    + "#config.prejoinConfig.enabled=false"
+    + "&config.startWithVideoMuted=true"
+    + `&userInfo.displayName=%22${name}%22`;
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 45000 }).catch((e) => console.log(name, "goto", e.message));
+  return page;
+}
+
+const a = await joinTab("e2e-a");
+await new Promise((r) => setTimeout(r, 5000));
+const b = await joinTab("e2e-b");
+await new Promise((r) => setTimeout(r, 9000));
+
+// Unmute both so the tone is actually transmitted (Jitsi may start muted).
+for (let k = 0; k < 3; k++) {
+  for (const p of [a, b]) {
+    await p.evaluate(() => { try { if (window.APP?.conference?.isLocalAudioMuted?.()) window.APP.conference.muteAudio(false); } catch (e) {} }).catch(() => {});
+  }
+  await new Promise((r) => setTimeout(r, 1500));
+}
+
+const status = await a.evaluate(() => {
+  try { return { members: window.APP?.conference?.membersCount, muted: window.APP?.conference?.isLocalAudioMuted?.() }; } catch (e) { return { err: String(e).slice(0, 60) }; }
+});
+console.log("KEEPER_JOINED " + JSON.stringify(status));
+
+await new Promise((r) => setTimeout(r, KEEP * 1000));
+await browser.disconnect();
+console.log("KEEPER_DONE");

--- a/scripts/fixtures/package.json
+++ b/scripts/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "e2e-jitsi-keeper",
+  "private": true,
+  "type": "module",
+  "description": "CDP driver deps for the real-Jitsi browser-meeting e2e (issue #503). Install with `npm i` in this dir; node_modules is gitignored.",
+  "dependencies": {
+    "puppeteer-core": "^24.0.0"
+  }
+}

--- a/scripts/fixtures/webrtc-tone.html
+++ b/scripts/fixtures/webrtc-tone.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>WebRTC + Tone Fixture (issue #503)</title>
+</head>
+<body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; font-size: 1.4rem">
+  <h1 id="status">starting…</h1>
+  <button id="start" style="font-size: 1.4rem; padding: 1rem 2rem">Start (if muted)</button>
+  <pre id="log" style="font-size: 0.9rem; color: #555"></pre>
+  <script>
+    // Self-contained e2e fixture for browser-meeting detection + capture.
+    // No Zoom / account / second participant / network needed:
+    //   1. A continuous 440 Hz tone rendered to the output device — this is
+    //      what the CATapDescription tap must record non-silently.
+    //   2. An in-page pc1 <-> pc2 WebRTC loopback carrying that tone as a
+    //      real media track, so Chrome holds the "WebRTC has active
+    //      PeerConnections" power assertion that PowerAssertionDetector
+    //      matches (a real active PeerConnection with a track guarantees the
+    //      assertion regardless of whether a bare RTCPeerConnection would).
+    const logEl = document.getElementById('log');
+    const statusEl = document.getElementById('status');
+    const log = (m) => { logEl.textContent += m + '\n'; };
+    const setStatus = (s) => { statusEl.textContent = s; };
+
+    let started = false;
+    async function start() {
+      if (started) return;
+      started = true;
+      try {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        await ctx.resume();
+
+        const osc = ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.value = 440;
+        const gain = ctx.createGain();
+        gain.gain.value = 0.3;
+        osc.connect(gain);
+        gain.connect(ctx.destination);              // → output device → CATap
+        const streamDest = ctx.createMediaStreamDestination();
+        gain.connect(streamDest);                   // → WebRTC track
+        osc.start();
+
+        const pc1 = new RTCPeerConnection();
+        const pc2 = new RTCPeerConnection();
+        pc1.onicecandidate = (e) => { if (e.candidate) pc2.addIceCandidate(e.candidate); };
+        pc2.onicecandidate = (e) => { if (e.candidate) pc1.addIceCandidate(e.candidate); };
+        pc2.ontrack = () => log('pc2: received track');
+        pc1.onconnectionstatechange = () => {
+          log('pc1 connectionState: ' + pc1.connectionState);
+          if (pc1.connectionState === 'connected') setStatus('connected: tone + WebRTC active');
+        };
+        streamDest.stream.getTracks().forEach((t) => pc1.addTrack(t, streamDest.stream));
+
+        const offer = await pc1.createOffer();
+        await pc1.setLocalDescription(offer);
+        await pc2.setRemoteDescription(offer);
+        const answer = await pc2.createAnswer();
+        await pc2.setLocalDescription(answer);
+        await pc1.setRemoteDescription(answer);
+
+        window.__fixtureReady = true;             // pollable readiness flag
+        setStatus('tone playing + WebRTC negotiating');
+        log('AudioContext state: ' + ctx.state);
+      } catch (e) {
+        setStatus('error');
+        log('error: ' + e);
+      }
+    }
+
+    document.getElementById('start').addEventListener('click', start);
+    // Autostart: works when Chrome is launched with
+    // --autoplay-policy=no-user-gesture-required (the e2e driver does this).
+    // The button is a manual fallback when opened by hand.
+    window.addEventListener('load', () => { start(); });
+  </script>
+</body>
+</html>

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -8,7 +8,7 @@ struct MTCLI: AsyncParsableCommand {
         abstract: "Thin client for the Meeting Transcriber debug RPC server.",
         subcommands: [
             State.self, Healthz.self, Screenshot.self, UITree.self, UIPress.self,
-            OpenSettings.self, CloseSettings.self,
+            OpenSettings.self, CloseSettings.self, ConfirmBrowserConsent.self,
             SeedSpeaker.self, RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
         ],
     )
@@ -62,6 +62,25 @@ struct CloseSettings: AsyncParsableCommand {
         let client = try RPCClient.loadDefault()
         let data = try await client.post("/action/closeSettings", json: [:])
         FileHandle.standardOutput.write(data)
+    }
+}
+
+struct ConfirmBrowserConsent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "confirm-browser-consent",
+        abstract: "Answer a parked browser-meeting consent prompt (issue #503). "
+            + "Prints the server's {\"resolved\":bool} JSON; resolved:false means "
+            + "no prompt was waiting yet, so poll until true.",
+    )
+
+    @Flag(inversion: .prefixedNo, help: "Grant recording (default) or --no-granted to decline.")
+    var granted = true
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        let data = try await client.post("/action/confirmBrowserConsent", json: ["granted": granted])
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
     }
 }
 

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import AVFoundation
 import Foundation
 
 @main
@@ -10,6 +11,7 @@ struct MTCLI: AsyncParsableCommand {
             State.self, Healthz.self, Screenshot.self, UITree.self, UIPress.self,
             OpenSettings.self, CloseSettings.self, ConfirmBrowserConsent.self,
             SeedSpeaker.self, RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
+            WavVerdictCommand.self,
         ],
     )
 }
@@ -81,6 +83,71 @@ struct ConfirmBrowserConsent: AsyncParsableCommand {
         let data = try await client.post("/action/confirmBrowserConsent", json: ["granted": granted])
         FileHandle.standardOutput.write(data)
         FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+}
+
+// Sync ParsableCommand (not Async) — the analysis + file load are synchronous,
+// so a `run() async` would be an async_without_await. ArgumentParser dispatches
+// a sync subcommand of an async root fine.
+struct WavVerdictCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "wav-verdict",
+        abstract: "Analyze an audio file's loudness (issue #503 capture proof). "
+            + "Prints a JSON verdict; exits 0 when non-silent AND active-window "
+            + "ratio >= --min-active-ratio, 1 otherwise.",
+    )
+
+    @Argument(help: "Path to the WAV/audio file to analyze.")
+    var path: String
+
+    @Option(name: .long, help: "dBFS threshold below which a window is silent. Default -50.")
+    var thresholdDbfs: Double = -50
+
+    @Option(name: .long, help: "Minimum fraction of active windows to pass. Default 0.5.")
+    var minActiveRatio: Double = 0.5
+
+    @Option(name: .long, help: "Analysis window length in seconds. Default 0.5.")
+    var windowSeconds: Double = 0.5
+
+    func run() throws {
+        let (samples, sampleRate) = try Self.loadSamples(path: path)
+        let verdict = WavVerdict.analyze(
+            samples: samples, sampleRate: sampleRate,
+            windowSeconds: windowSeconds, thresholdDBFS: thresholdDbfs,
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try FileHandle.standardOutput.write(encoder.encode(verdict))
+        FileHandle.standardOutput.write(Data("\n".utf8))
+        // Non-zero exit if silent or too few active windows, so a driver can
+        // gate on the exit code alone.
+        if verdict.isSilent || verdict.activeWindowRatio < minActiveRatio {
+            throw ExitCode(1)
+        }
+    }
+
+    /// Load an audio file as mono Float32 samples via AVAudioFile, averaging any
+    /// channels down to mono. Thin I/O layer — the verdict logic stays pure.
+    static func loadSamples(path: String) throws -> (samples: [Float], sampleRate: Double) {
+        let file = try AVAudioFile(forReading: URL(fileURLWithPath: path))
+        let format = file.processingFormat
+        let frameCount = AVAudioFrameCount(file.length)
+        guard frameCount > 0, let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            return ([], format.sampleRate)
+        }
+        try file.read(into: buffer)
+        guard let channelData = buffer.floatChannelData else { return ([], format.sampleRate) }
+        let channels = Int(format.channelCount)
+        let frames = Int(buffer.frameLength)
+        var mono = [Float](repeating: 0, count: frames)
+        for frame in 0 ..< frames {
+            var sum: Float = 0
+            for channel in 0 ..< channels {
+                sum += channelData[channel][frame]
+            }
+            mono[frame] = sum / Float(channels)
+        }
+        return (mono, format.sampleRate)
     }
 }
 

--- a/tools/mt-cli/Sources/WavVerdict.swift
+++ b/tools/mt-cli/Sources/WavVerdict.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Pure RMS-based "is this WAV non-silent?" analysis. Splits the samples into
+/// non-overlapping windows, reports overall + peak-window loudness and the
+/// fraction of windows above the threshold, plus a silence verdict. No file
+/// I/O — the `wav-verdict` subcommand loads samples via AVAudioFile and hands
+/// them here, so the decision logic stays deterministically unit-testable.
+///
+/// `activeWindowRatio` is what distinguishes a genuine continuous recording
+/// from a "1 s blip then silence" regression: a driver asserting a sustained
+/// tone checks both `!isSilent` and `activeWindowRatio` above a floor.
+struct WavVerdict: Codable, Equatable {
+    let overallRMSdBFS: Double
+    let peakWindowRMSdBFS: Double
+    let activeWindowRatio: Double
+    let windowCount: Int
+    let isSilent: Bool
+
+    /// Loudness reported instead of -inf for digital silence, so the verdict
+    /// stays JSON-encodable (JSON has no infinity).
+    static let silenceFloorDBFS = -120.0
+
+    static func analyze(
+        samples: [Float],
+        sampleRate: Double,
+        windowSeconds: Double = 0.5,
+        thresholdDBFS: Double = -50,
+    ) -> Self {
+        let windowSize = max(1, Int(windowSeconds * sampleRate))
+        // Even a clip shorter than one window is analyzed as a single window.
+        let windows = stride(from: 0, to: max(samples.count, 1), by: windowSize).map { start -> Double in
+            let end = min(start + windowSize, samples.count)
+            return dBFS(rmsOf: samples[start ..< end])
+        }
+        let peak = windows.max() ?? silenceFloorDBFS
+        // Plain loop rather than filter().count / count(where:) — the latter
+        // trip the SwiftFormat preferCountWhere vs SwiftLint trailing_closure
+        // disagreement.
+        var activeCount = 0
+        for windowDBFS in windows where windowDBFS > thresholdDBFS {
+            activeCount += 1
+        }
+        let ratio = windows.isEmpty ? 0 : Double(activeCount) / Double(windows.count)
+        return Self(
+            overallRMSdBFS: dBFS(rmsOf: samples[...]),
+            peakWindowRMSdBFS: peak,
+            activeWindowRatio: ratio,
+            windowCount: windows.count,
+            // Silent iff no window is loud enough — the peak decides it.
+            isSilent: peak < thresholdDBFS,
+        )
+    }
+
+    private static func dBFS(rmsOf samples: ArraySlice<Float>) -> Double {
+        guard !samples.isEmpty else { return silenceFloorDBFS }
+        var sumSquares = 0.0
+        for sample in samples {
+            sumSquares += Double(sample) * Double(sample)
+        }
+        let rms = (sumSquares / Double(samples.count)).squareRoot()
+        guard rms > 0 else { return silenceFloorDBFS }
+        return max(silenceFloorDBFS, 20 * Foundation.log10(rms))
+    }
+}

--- a/tools/mt-cli/Tests/RPCClientTests.swift
+++ b/tools/mt-cli/Tests/RPCClientTests.swift
@@ -148,6 +148,78 @@ final class RPCClientTests: XCTestCase {
 
         XCTAssertEqual(captured.value, "GET /ui/tree?window=settings HTTP/1.1")
     }
+
+    /// The confirm-browser-consent command posts a Bool payload; it must
+    /// serialize as a JSON boolean (`true`), not the integer `1`, so the
+    /// server's `ConsentPayload { granted: Bool }` decodes it. Captures the
+    /// request body off a fake server and asserts the exact bytes.
+    func testPostSerializesBoolPayloadAsJSONBoolean() async throws {
+        let listener = try NWListener(using: .tcp, on: .any)
+        let held = SilentConnectionHolder()
+        let captured = RequestLineBox()
+        listener.newConnectionHandler = { connection in
+            held.add(connection)
+            connection.start(queue: .global())
+            // URLSession delivers the POST body in a TCP segment after the
+            // headers, so accumulate until the full Content-Length body arrives.
+            drainRequestBody(connection, into: captured)
+        }
+
+        let portReady = XCTestExpectation(description: "listener bound")
+        let assignedPort = OSPortBox()
+        listener.stateUpdateHandler = { state in
+            if case .ready = state, let port = listener.port?.rawValue {
+                assignedPort.set(port)
+                portReady.fulfill()
+            }
+        }
+        listener.start(queue: .global())
+        defer { listener.cancel() }
+
+        await fulfillment(of: [portReady], timeout: 2)
+        let port = try XCTUnwrap(assignedPort.value)
+        guard let baseURL = URL(string: "http://127.0.0.1:\(port)") else {
+            XCTFail("could not build URL")
+            return
+        }
+        let client = RPCClient(baseURL: baseURL, token: "test-token")
+
+        _ = try await client.post("/action/confirmBrowserConsent", json: ["granted": true])
+
+        XCTAssertEqual(captured.value, #"{"granted":true}"#)
+    }
+}
+
+/// Recursively receive from `connection`, accumulating bytes until the full
+/// HTTP request body (per Content-Length) has arrived, then store the body in
+/// `box` and reply 200. URLSession splits headers and body across TCP segments,
+/// so a single receive can't see the POST body.
+private func drainRequestBody(_ connection: NWConnection, into box: RequestLineBox, acc: Data = Data()) {
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, _ in
+        var buffer = acc
+        if let data { buffer.append(data) }
+        // Failable decode: a partial UTF-8 sequence at a TCP segment boundary
+        // yields nil, so keep accumulating rather than corrupting the body.
+        guard let text = String(bytes: buffer, encoding: .utf8) else {
+            drainRequestBody(connection, into: box, acc: buffer)
+            return
+        }
+        if let sep = text.range(of: "\r\n\r\n") {
+            let header = String(text[..<sep.lowerBound])
+            let body = String(text[sep.upperBound...])
+            let expected = header
+                .split(separator: "\r\n")
+                .first { $0.lowercased().hasPrefix("content-length:") }
+                .flatMap { Int($0.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)) } ?? 0
+            if body.utf8.count >= expected {
+                box.set(body)
+                let resp = Data("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+                connection.send(content: resp, completion: .contentProcessed { _ in connection.cancel() })
+                return
+            }
+        }
+        drainRequestBody(connection, into: box, acc: buffer)
+    }
 }
 
 /// Thread-safe single-shot box for the request line captured by the fake

--- a/tools/mt-cli/Tests/WavVerdictCommandTests.swift
+++ b/tools/mt-cli/Tests/WavVerdictCommandTests.swift
@@ -1,0 +1,64 @@
+import AVFoundation
+@testable import mt_cli
+import XCTest
+
+/// Covers the thin AVAudioFile I/O layer of the `wav-verdict` command. Writes a
+/// real WAV via AVAudioFile (no `sox` dependency) and reads it back through
+/// `loadSamples`, then confirms the pure verdict agrees.
+final class WavVerdictCommandTests: XCTestCase {
+    private func writeToneWav(url: URL, freq: Double, seconds: Double, sampleRate: Double, amplitude: Float) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: false,
+        ) else {
+            throw XCTSkip("could not build audio format")
+        }
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let frames = AVAudioFrameCount(seconds * sampleRate)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else {
+            throw XCTSkip("could not allocate buffer")
+        }
+        buffer.frameLength = frames
+        guard let channel = buffer.floatChannelData?[0] else {
+            throw XCTSkip("no float channel data")
+        }
+        for i in 0 ..< Int(frames) {
+            channel[i] = amplitude * sin(2 * Float.pi * Float(freq) * Float(i) / Float(sampleRate))
+        }
+        try file.write(from: buffer)
+    }
+
+    func testLoadSamplesReadsBackWrittenTone() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wav-verdict-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writeToneWav(url: url, freq: 440, seconds: 1, sampleRate: 16000, amplitude: 0.3)
+
+        let (samples, sampleRate) = try WavVerdictCommand.loadSamples(path: url.path)
+        XCTAssertEqual(sampleRate, 16000, accuracy: 1)
+        // AVAudioFile WAV round-trips can drop a few hundred frames and the
+        // amount is macOS-version-sensitive, so assert a lower bound, not the
+        // exact 16000 — the verdict, not the sample count, is the contract.
+        XCTAssertGreaterThan(samples.count, 15000)
+
+        let verdict = WavVerdict.analyze(samples: samples, sampleRate: sampleRate)
+        XCTAssertFalse(verdict.isSilent, "a 0.3-amplitude tone must read back non-silent")
+        XCTAssertEqual(verdict.activeWindowRatio, 1.0, accuracy: 0.001)
+    }
+
+    func testLoadSamplesOnSilentWavIsSilent() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wav-verdict-silent-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writeToneWav(url: url, freq: 440, seconds: 1, sampleRate: 16000, amplitude: 0)
+
+        let (samples, sampleRate) = try WavVerdictCommand.loadSamples(path: url.path)
+        let verdict = WavVerdict.analyze(samples: samples, sampleRate: sampleRate)
+        XCTAssertTrue(verdict.isSilent)
+    }
+
+    func testLoadSamplesMissingFileThrows() {
+        XCTAssertThrowsError(
+            try WavVerdictCommand.loadSamples(path: "/tmp/definitely-missing-\(UUID().uuidString).wav"),
+        )
+    }
+}

--- a/tools/mt-cli/Tests/WavVerdictTests.swift
+++ b/tools/mt-cli/Tests/WavVerdictTests.swift
@@ -1,0 +1,69 @@
+@testable import mt_cli
+import XCTest
+
+final class WavVerdictTests: XCTestCase {
+    private let sampleRate = 16000.0
+
+    // MARK: - Synthetic sample generators (no file I/O)
+
+    /// A sine whose windowed RMS sits at `rmsDBFS` (rms = amp / sqrt(2)).
+    private func sine(rmsDBFS: Double, seconds: Double, freq: Double = 440) -> [Float] {
+        let amp = pow(10, rmsDBFS / 20) * 2.0.squareRoot()
+        let count = Int(seconds * sampleRate)
+        return (0 ..< count).map { Float(amp * sin(2 * Double.pi * freq * Double($0) / sampleRate)) }
+    }
+
+    /// A constant DC level whose RMS is exactly `dBFS` (rms = |value|).
+    private func constant(dBFS: Double, seconds: Double) -> [Float] {
+        let value = Float(pow(10, dBFS / 20))
+        return [Float](repeating: value, count: Int(seconds * sampleRate))
+    }
+
+    // MARK: - Tests
+
+    func testPureSilenceIsSilent() {
+        let v = WavVerdict.analyze(samples: [Float](repeating: 0, count: 16000), sampleRate: sampleRate)
+        XCTAssertTrue(v.isSilent)
+        XCTAssertEqual(v.activeWindowRatio, 0)
+        XCTAssertEqual(v.peakWindowRMSdBFS, WavVerdict.silenceFloorDBFS)
+    }
+
+    func testVeryQuietSignalIsSilent() {
+        // -90 dBFS is real signal but well below the -50 threshold → silent.
+        let v = WavVerdict.analyze(samples: constant(dBFS: -90, seconds: 1), sampleRate: sampleRate)
+        XCTAssertTrue(v.isSilent)
+        XCTAssertEqual(v.activeWindowRatio, 0)
+        XCTAssertEqual(v.peakWindowRMSdBFS, -90, accuracy: 0.5)
+    }
+
+    func testSustainedToneIsNotSilentWithFullActiveRatio() {
+        let v = WavVerdict.analyze(samples: sine(rmsDBFS: -20, seconds: 1), sampleRate: sampleRate)
+        XCTAssertFalse(v.isSilent)
+        XCTAssertEqual(v.activeWindowRatio, 1.0, accuracy: 0.001)
+        XCTAssertEqual(v.peakWindowRMSdBFS, -20, accuracy: 1.0)
+    }
+
+    func testBriefToneInLongSilenceHasLowActiveRatio() {
+        // 1 s tone + 9 s silence: peak is loud (not silent), but only ~10% of
+        // the 0.5 s windows are active — the guard against a "1 s blip" pass.
+        var samples = sine(rmsDBFS: -20, seconds: 1)
+        samples += [Float](repeating: 0, count: Int(9 * sampleRate))
+        let v = WavVerdict.analyze(samples: samples, sampleRate: sampleRate)
+        XCTAssertFalse(v.isSilent)
+        XCTAssertEqual(v.windowCount, 20)
+        XCTAssertEqual(v.activeWindowRatio, 0.1, accuracy: 0.05)
+    }
+
+    func testClipShorterThanOneWindowIsAnalyzedAsOneWindow() {
+        // 100 samples, window is 8000 — must not crash or divide by zero.
+        let v = WavVerdict.analyze(samples: sine(rmsDBFS: -10, seconds: 0.006), sampleRate: sampleRate)
+        XCTAssertEqual(v.windowCount, 1)
+        XCTAssertFalse(v.isSilent)
+    }
+
+    func testEmptySamplesAreSilent() {
+        let v = WavVerdict.analyze(samples: [], sampleRate: sampleRate)
+        XCTAssertTrue(v.isSilent)
+        XCTAssertEqual(v.peakWindowRMSdBFS, WavVerdict.silenceFloorDBFS)
+    }
+}


### PR DESCRIPTION
## What

Adds an end-to-end **capture-proof lane** for the browser-meeting detection feature (issue #503), plus the RPC + tooling it needs. It proves the full chain works without a real meeting service, account, or second participant:

```
Chrome + local WebRTC-tone fixture
  → PowerAssertionDetector ("WebRTC has active PeerConnections")
  → consent gate (watchState stays "watching", a prompt parks)
  → RPC confirmBrowserConsent (stands in for the un-clickable notification)
  → record-only capture (noMic)
  → sidecar + _app.wav
  → ASSERT: _app.wav is NOT silent (the CATap actually tapped Chrome audio)
```

This closes the one open question the detection PR couldn't answer on its own: **does the CATapDescription tap actually record a browser meeting's audio non-silently?** The blocker was the ask-first consent notification — it can't be clicked headless. A debug-RPC hook resolves the parked consent prompt programmatically instead.

> Stacked on `feat/issue-503-browser-detection` (PR #523) because the lane exercises that feature. GitHub retargets this PR to `main` once #523 merges.

## Commits

1. `ConsentPromptCoordinator.resolvePending(granted:)` — drains every parked continuation under the lock (the RPC hook has no prompt id; returns whether one was waiting so a driver can poll until a prompt parks).
2. Debug-RPC `POST /action/confirmBrowserConsent {granted}` → `NotificationManager.resolveBrowserConsent` → coordinator. Resolves inline (only touches the lock-guarded coordinator, no main-actor hop). Wired through the injected `AppNotifying` seam — the same one `askToRecord` parks in — so park + resolve stay symmetric and mockable.
3. `mt-cli confirm-browser-consent [--granted|--no-granted]`.
4. `WavVerdict` — pure windowed-RMS non-silence analysis (`activeWindowRatio` guards against a "1 s blip then silence" false pass).
5. `mt-cli wav-verdict <file>` — thin AVAudioFile loader over `WavVerdict`; exits 0 when non-silent AND the active-window ratio clears the floor.
6. `scripts/fixtures/webrtc-tone.html` — self-contained in-page pc1↔pc2 WebRTC loopback carrying a 440 Hz WebAudio tone (holds the assertion for detection + emits a tone as the capture target).
7. `scripts/e2e-browser.sh` — the driver (reuses `e2e-app.sh --redeploy-only` for build/sign and the shared e2e helpers).
8. `.github/workflows/e2e-browser.yml` — non-gating canary lane on the self-hosted mini.
9. Docs.

## Notes

- **Non-gating canary**: reports red but is not a required check and not in `tag-ruleset.json`, so it never blocks a merge or a stable tag.
- Detection uses the sandbox-safe power-assertion path (no Screen Recording) and consent is answered over RPC (no clickable notification), so the lane runs headless. The only new runner prerequisite is Google Chrome installed; no mic (`noMic`).
- **Verified green on the Mac mini.** Both live unknowns confirmed: the loopback PeerConnection holds `"WebRTC has active PeerConnections"` (detection fires in ~5 s), and the CATap captures Chrome's shared-audio-service output non-silently (`activeWindowRatio 0.94`, `peakWindowRMSdBFS -13.5` = the fixture's 440 Hz tone). This is the first end-to-end proof that a browser meeting is actually recorded.
- Two mechanical driver fixes came out of the mini bring-up: Chrome needs `--use-mock-keychain` (the macOS flag) so a headless runner never hits its keychain modal, and `mt-cli wav-verdict` must be called with the `=` form for the negative threshold (`--threshold-dbfs=-50`), since ArgumentParser reads a bare `-50` as a flag. Runner prerequisite: Chrome installed (works from `~/Applications` on a runner whose user can't write `/Applications`).

## Real-meeting variant (`--jitsi`)

The fixture above is an in-page `pc1↔pc2` loopback — it proves the mechanism but isn't a real remote meeting. `e2e-browser.sh --jitsi` adds a real-service variant: two Chrome tabs join a **real public Jitsi room** (`meet.ffmuc.net`, no login — the account-free option since `meet.jit.si` added moderator login in 2023) over a real WebRTC SFU, driven via CDP (`puppeteer-core`, `scripts/fixtures/jitsi-keeper.mjs`). Each tab's `getUserMedia` is overridden to a 440 Hz tone, so no real mic is touched — this sidesteps the macOS Chrome **mic-TCC** gate that otherwise *hangs* `getUserMedia` on a headless runner. The tone flows tab-A → real server → tab-B, so Chrome plays real server-transported meeting audio for the CATap.

Verified live on the mini: Chrome holds `"WebRTC has active PeerConnections"` (detection fires) and the received-audio peak matches the tone. Wired as a **nightly/dispatch-only, `continue-on-error`** step (never on labeled PRs), since it depends on a third-party public instance being up — green means the real chain works; a failure is a signal to check, not a merge blocker.

## Test plan

- Full app suite + mt-cli tests green; app + mt-cli release builds green.
- SwiftFormat (pinned 0.61.1) + `swiftlint lint --strict` clean.
- New coverage: `resolvePending` (0/1/n prompts, concurrent-resolve race), the RPC endpoint (400 / resolved:false / resolved:true + forwarded granted), `mt-cli` request shape, `WavVerdict` (silence / quiet / sustained tone / brief-blip / sub-window / empty), and the AVAudioFile round-trip.
- The `e2e-browser` lane itself is **green on the mini** (detection → RPC consent → 15 s record → non-silent `_app.wav` verdict).
