### PR TITLE
refactor(app): NotificationManager behind a port for testable consent behavior (#503)

### DIFF
--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -49,35 +49,39 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         }
     #endif
 
-    override init() {
+    /// The notification center behind a port (so posting + registration are
+    /// testable against a fake) and the "can we deliver?" check (a real app
+    /// bundle is required — `Bundle.main.bundleIdentifier` is nil in `swift
+    /// test`). Both injected; production uses the real system center + the bundle
+    /// check, tests inject a fake scheduler and flip `canDeliver`.
+    private let scheduler: any NotificationScheduling
+    private let canDeliver: @Sendable () -> Bool
+
+    init(
+        scheduler: any NotificationScheduling = SystemNotificationScheduler(),
+        canDeliver: @escaping @Sendable () -> Bool = { Bundle.main.bundleIdentifier != nil },
+    ) {
+        self.scheduler = scheduler
+        self.canDeliver = canDeliver
         super.init()
     }
 
     /// Set up delegate and request permission. Must be called after the app bundle is loaded.
     func setUp() {
         guard !isSetUp else { return }
-        // UNUserNotificationCenter crashes without a proper app bundle
-        guard Bundle.main.bundleIdentifier != nil else {
-            logger.warning("Skipping setup — no app bundle")
+        // UNUserNotificationCenter crashes without a proper app bundle.
+        guard canDeliver() else {
+            logger.warning("Skipping setup — notifications not deliverable")
             return
         }
         isSetUp = true
-
-        let center = UNUserNotificationCenter.current()
-        center.delegate = self
-        center.setNotificationCategories([Self.makeConsentCategory()])
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if let error {
-                logger.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
-            }
-            if !granted {
-                logger.warning("Notification permission denied")
-            }
-        }
+        scheduler.setDelegate(self)
+        scheduler.setCategories([Self.makeConsentCategory()])
+        scheduler.requestAuthorization()
     }
 
     func notify(title: String, body: String) {
-        let deliverable = isSetUp && Bundle.main.bundleIdentifier != nil
+        let deliverable = isSetUp && canDeliver()
 
         #if !APPSTORE
             // Record before the delivery guard so the app's *decision* to notify
@@ -90,18 +94,25 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
         guard deliverable else { return }
 
+        scheduler.add(UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: Self.makeNotificationContent(title: title, body: body),
+            trigger: nil,
+        ))
+    }
+
+    /// Pure builder for a notification's `UNMutableNotificationContent` (title,
+    /// body, sound, and optional category). Split out so the content mapping is
+    /// unit-testable without a real notification center.
+    static func makeNotificationContent(
+        title: String, body: String, categoryID: String? = nil,
+    ) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
-
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil,
-        )
-
-        UNUserNotificationCenter.current().add(request)
+        if let categoryID { content.categoryIdentifier = categoryID }
+        return content
     }
 
     /// Pure function: determines notification content for a state transition.
@@ -171,7 +182,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     /// prompt, and false on timeout/ignore/dismiss.
     @MainActor
     func askToRecord(title: String, body: String) async -> Bool {
-        guard isSetUp, Bundle.main.bundleIdentifier != nil else { return false }
+        guard isSetUp, canDeliver() else { return false }
         let id = UUID().uuidString
         return await consentCoordinator.awaitDecision(id: id) { [self] in
             postConsentNotification(id: id, title: title, body: body)
@@ -188,26 +199,35 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         consentCoordinator.resolvePending(granted: granted)
     }
 
-    /// Post the actionable consent notification (the thin UNUserNotificationCenter
-    /// adapter — the decision itself is driven by `didReceive` / the coordinator
-    /// timeout, whichever resolves first).
+    /// Post the actionable consent notification (the request-building is the pure
+    /// `makeNotificationContent`; only the `scheduler.add` is I/O). The decision
+    /// itself is driven by `didReceive` / the coordinator timeout, whichever
+    /// resolves first.
     private func postConsentNotification(id: String, title: String, body: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = .default
-        content.categoryIdentifier = Self.consentCategoryID
-        UNUserNotificationCenter.current().add(
-            UNNotificationRequest(identifier: id, content: content, trigger: nil),
+        scheduler.add(UNNotificationRequest(
+            identifier: id,
+            content: Self.makeNotificationContent(title: title, body: body, categoryID: Self.consentCategoryID),
+            trigger: nil,
+        ))
+    }
+
+    /// Resolve a parked consent prompt from a notification response's primitives.
+    /// The delegate callback unwraps the framework `UNNotificationResponse` (which
+    /// has no public initialiser) into these, so the id + grant mapping stays
+    /// unit-testable without constructing a real response.
+    func resolveConsent(responseIdentifier: String, actionIdentifier: String) {
+        consentCoordinator.resolve(
+            id: responseIdentifier,
+            granted: Self.consentGranted(for: actionIdentifier),
         )
     }
 
     // Handle a tapped consent action (or a dismiss) → resolve the prompt.
     // swiftlint:disable:next async_without_await
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        consentCoordinator.resolve(
-            id: response.notification.request.identifier,
-            granted: Self.consentGranted(for: response.actionIdentifier),
+        resolveConsent(
+            responseIdentifier: response.notification.request.identifier,
+            actionIdentifier: response.actionIdentifier,
         )
     }
 

--- a/app/MeetingTranscriber/Sources/NotificationScheduling.swift
+++ b/app/MeetingTranscriber/Sources/NotificationScheduling.swift
@@ -1,0 +1,48 @@
+import os.log
+import UserNotifications
+
+/// Port over the slice of `UNUserNotificationCenter` that `NotificationManager`
+/// uses (add / register categories / set delegate / request permission), so its
+/// posting + registration behaviour is testable against a fake. The real center
+/// needs a proper app bundle and can't run in `swift test`, which is exactly why
+/// the behaviour has to be driven through this seam.
+///
+/// The concrete `SystemNotificationScheduler` is the thin, deliberately-untested
+/// adapter — its pass-throughs are exercised by the e2e-app lane's real
+/// notifications, which unit coverage can't reach.
+protocol NotificationScheduling: AnyObject, Sendable {
+    func add(_ request: UNNotificationRequest)
+    func setCategories(_ categories: Set<UNNotificationCategory>)
+    func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?)
+    func requestAuthorization()
+}
+
+/// Real adapter: forwards to `UNUserNotificationCenter.current()`. Sendable (its
+/// only state is a `Logger`), so its `requestAuthorization` completion — a
+/// `@Sendable` closure — can reference it.
+final class SystemNotificationScheduler: NotificationScheduling, Sendable {
+    private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "NotificationScheduler")
+
+    func add(_ request: UNNotificationRequest) {
+        UNUserNotificationCenter.current().add(request)
+    }
+
+    func setCategories(_ categories: Set<UNNotificationCategory>) {
+        UNUserNotificationCenter.current().setNotificationCategories(categories)
+    }
+
+    func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {
+        UNUserNotificationCenter.current().delegate = delegate
+    }
+
+    func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                self.logger.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
+            }
+            if !granted {
+                self.logger.warning("Notification permission denied")
+            }
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
@@ -1,0 +1,173 @@
+@testable import MeetingTranscriber
+import UserNotifications
+import XCTest
+
+/// Fake `NotificationScheduling` recording what `NotificationManager` posts /
+/// registers, so the posting + consent behaviour is testable without a real
+/// `UNUserNotificationCenter` (which needs an app bundle absent in `swift test`).
+private final class FakeNotificationScheduler: NotificationScheduling, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _added: [UNNotificationRequest] = []
+    private(set) var categories: Set<UNNotificationCategory> = []
+    private(set) weak var delegate: (any UNUserNotificationCenterDelegate)?
+    private(set) var authRequested = false
+
+    var added: [UNNotificationRequest] {
+        lock.lock(); defer { lock.unlock() }; return _added
+    }
+
+    func add(_ request: UNNotificationRequest) {
+        lock.lock(); _added.append(request); lock.unlock()
+    }
+
+    func setCategories(_ categories: Set<UNNotificationCategory>) {
+        self.categories = categories
+    }
+
+    func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {
+        self.delegate = delegate
+    }
+
+    func requestAuthorization() {
+        authRequested = true
+    }
+}
+
+/// Mutable deliverability so a test can flip `canDeliver` to false *after*
+/// `setUp()` has already succeeded — the only way to exercise the `canDeliver`
+/// conjunct of `notify`'s deliver guard independently of the `isSetUp` conjunct.
+private final class DeliverabilityBox: @unchecked Sendable {
+    var value: Bool
+    init(_ value: Bool) {
+        self.value = value
+    }
+}
+
+@MainActor
+final class NotificationManagerSchedulingTests: XCTestCase {
+    private func makeManager(deliverable: Bool = true) -> (NotificationManager, FakeNotificationScheduler) {
+        let (manager, fake, _) = makeManagerWithBox(deliverable: deliverable)
+        return (manager, fake)
+    }
+
+    private func makeManagerWithBox(
+        deliverable: Bool = true,
+    ) -> (NotificationManager, FakeNotificationScheduler, DeliverabilityBox) {
+        let fake = FakeNotificationScheduler()
+        let box = DeliverabilityBox(deliverable)
+        let canDeliver: @Sendable () -> Bool = { box.value }
+        let manager = NotificationManager(scheduler: fake, canDeliver: canDeliver)
+        return (manager, fake, box)
+    }
+
+    // MARK: - setUp
+
+    func testSetUpRegistersDelegateCategoryAndRequestsAuth() {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        XCTAssertTrue(manager.isSetUp)
+        XCTAssertIdentical(fake.delegate, manager)
+        XCTAssertTrue(fake.authRequested)
+        XCTAssertEqual(fake.categories.map(\.identifier), [NotificationManager.consentCategoryID])
+    }
+
+    func testSetUpSkippedWhenNotDeliverable() {
+        let (manager, fake) = makeManager(deliverable: false)
+        manager.setUp()
+        XCTAssertFalse(manager.isSetUp)
+        XCTAssertFalse(fake.authRequested)
+        XCTAssertNil(fake.delegate)
+        XCTAssertTrue(fake.categories.isEmpty)
+    }
+
+    // MARK: - notify
+
+    func testNotifyPostsRequestWithMappedContent() {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        manager.notify(title: "Meeting Detected", body: "Recording: Standup (Teams)")
+        XCTAssertEqual(fake.added.count, 1)
+        XCTAssertEqual(fake.added.first?.content.title, "Meeting Detected")
+        XCTAssertEqual(fake.added.first?.content.body, "Recording: Standup (Teams)")
+        #if !APPSTORE
+            // The ring-buffer entry must be flagged delivered — RPC/e2e consumers
+            // asserting a user-VISIBLE warning gate on this flag.
+            XCTAssertEqual(manager.recentNotifications.map(\.delivered), [true])
+        #endif
+    }
+
+    func testNotifyDoesNotPostWhenNotSetUp() {
+        let (manager, fake) = makeManager()
+        // setUp never called → not deliverable regardless of canDeliver.
+        manager.notify(title: "Meeting Detected", body: "x")
+        XCTAssertTrue(fake.added.isEmpty)
+    }
+
+    func testNotifyDoesNotPostWhenSetUpButNotDeliverable() {
+        // setUp succeeds (deliverable), then the environment loses deliverability:
+        // isSetUp stays true, so this isolates the canDeliver conjunct of notify.
+        let (manager, fake, box) = makeManagerWithBox()
+        manager.setUp()
+        XCTAssertTrue(manager.isSetUp)
+        box.value = false
+        manager.notify(title: "Meeting Detected", body: "x")
+        XCTAssertTrue(fake.added.isEmpty)
+    }
+
+    // MARK: - askToRecord consent flow (issue #503)
+
+    /// Awaits the consent notification the manager posts on park, then returns it.
+    /// `fake.added` is a synchronous lock-guarded read, so the yield-based
+    /// `waitFor` overload drains the parked `askToRecord` Task without sleeping.
+    private func firstPostedRequest(from fake: FakeNotificationScheduler) async -> UNNotificationRequest? {
+        await waitFor(!fake.added.isEmpty)
+        return fake.added.first
+    }
+
+    func testAskToRecordPostsConsentNotificationAndRecordActionGrants() async {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        let task = Task { await manager.askToRecord(title: "Record browser meeting?", body: "A meeting is active.") }
+
+        guard let posted = await firstPostedRequest(from: fake) else {
+            XCTFail("no consent notification posted")
+            return
+        }
+        XCTAssertEqual(posted.content.categoryIdentifier, NotificationManager.consentCategoryID)
+        XCTAssertEqual(posted.content.title, "Record browser meeting?")
+        XCTAssertEqual(posted.content.body, "A meeting is active.")
+
+        manager.resolveConsent(responseIdentifier: posted.identifier, actionIdentifier: NotificationManager.recordActionID)
+        let granted = await task.value
+        XCTAssertTrue(granted)
+    }
+
+    func testAskToRecordIgnoreActionDeclines() async {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        let task = Task { await manager.askToRecord(title: "Record browser meeting?", body: "A meeting is active.") }
+
+        guard let posted = await firstPostedRequest(from: fake) else {
+            XCTFail("no consent notification posted")
+            return
+        }
+        manager.resolveConsent(responseIdentifier: posted.identifier, actionIdentifier: NotificationManager.ignoreActionID)
+        let granted = await task.value
+        XCTAssertFalse(granted)
+    }
+
+    // MARK: - pure content builder
+
+    func testMakeNotificationContentMapsFields() {
+        let content = NotificationManager.makeNotificationContent(title: "T", body: "B", categoryID: "CAT")
+        XCTAssertEqual(content.title, "T")
+        XCTAssertEqual(content.body, "B")
+        XCTAssertEqual(content.categoryIdentifier, "CAT")
+        XCTAssertEqual(content.sound, .default)
+    }
+
+    func testMakeNotificationContentWithoutCategoryLeavesItEmpty() {
+        let content = NotificationManager.makeNotificationContent(title: "T", body: "B")
+        XCTAssertEqual(content.categoryIdentifier, "")
+    }
+}


### PR DESCRIPTION
## What

Puts `UNUserNotificationCenter` behind a **port** so `NotificationManager`'s posting / registration / consent-prompt behaviour is actually **tested against a fake**, instead of being unit-untestable framework glue. This raises the coverage Codecov flagged on the consent-notification code (18 uncovered lines in `NotificationManager.swift`), but the real win is behavioural tests, not the percentage.

The untested lines were the thin `UNUserNotificationCenter` adapter — `swift test` has no app bundle (`Bundle.main.bundleIdentifier` is nil, so the delivery guards return early) and `UNNotificationResponse`/`UNNotification` have no public initialiser, so those paths couldn't run in unit tests at all.

## How (ports & adapters)

- **`NotificationScheduling` protocol** (port) over the slice of `UNUserNotificationCenter` the class uses (`add` / `setCategories` / `setDelegate` / `requestAuthorization`), with a thin real `SystemNotificationScheduler` adapter. Injected into `NotificationManager` (default = the real one).
- **Deliverability injected** as `canDeliver: () -> Bool` (default: the bundle check) — the reason tests couldn't reach the delivery path. Tests flip it to `true`.
- **Pure `makeNotificationContent(title:body:categoryID:)`** — the content mapping, split out so it's testable without a center.
- **Pure `resolveConsent(responseIdentifier:actionIdentifier:)`** — the delegate unwraps the framework `UNNotificationResponse` into primitives and forwards to this, so the id + grant mapping is testable without constructing a response.

## Result

With a fake scheduler, the tests now assert real behaviour: `setUp` registers the delegate + consent category + requests auth; `notify` posts a request with the mapped content (and posts nothing when not deliverable); `askToRecord` posts the consent notification and the **Record** action grants / **Ignore** declines; the content builder maps its fields. Only the trivial concrete `SystemNotificationScheduler` stays untested — its pass-throughs are exercised by the real notifications in the `e2e-app` lane, which unit coverage can't reach.

## Notes

- Stacked on `feat/e2e-browser-meetings` (PR #525) so it has the full consent-notification code (introduced in #523, extended in #525) to refactor. Merges after that stack; keeps #523/#525 untouched (no rebase cascade).
- Behaviour-preserving: the existing `NotificationManagerTests` (21) pass unchanged; production still wires `NotificationManager.shared` with the real scheduler.
