### PR TITLE
feat(app): detect Google Meet calls in Chromium browsers

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
@@ -34,6 +34,7 @@
                 watchTeams: watchTeams,
                 watchZoom: watchZoom,
                 watchWebex: watchWebex,
+                watchMeet: watchMeet,
                 autoWatch: autoWatch,
                 pollIntervalSeconds: pollInterval,
             )

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -112,6 +112,13 @@ final class AppSettings {
         didSet { defaults.set(watchWebex, forKey: "watchWebex") }
     }
 
+    /// Google Meet in a Chromium browser (Chrome, Brave, Edge). Detection needs
+    /// Screen Recording permission: the browser's WebRTC power assertion is
+    /// only trusted when an in-call Meet tab title confirms it.
+    var watchMeet: Bool {
+        didSet { defaults.set(watchMeet, forKey: "watchMeet") }
+    }
+
     /// Auto-start watching on app launch.
     var autoWatch: Bool {
         didSet { defaults.set(autoWatch, forKey: "autoWatch") }
@@ -457,6 +464,7 @@ final class AppSettings {
         if watchTeams { apps.append("Microsoft Teams") }
         if watchZoom { apps.append("Zoom") }
         if watchWebex { apps.append("Webex") }
+        if watchMeet { apps.append("Google Meet") }
         return apps
     }
 
@@ -468,6 +476,7 @@ final class AppSettings {
         watchTeams = defaults.object(forKey: "watchTeams") as? Bool ?? true
         watchZoom = defaults.object(forKey: "watchZoom") as? Bool ?? true
         watchWebex = defaults.object(forKey: "watchWebex") as? Bool ?? true
+        watchMeet = defaults.object(forKey: "watchMeet") as? Bool ?? true
         autoWatch = defaults.object(forKey: "autoWatch") as? Bool ?? false
 
         pollInterval = defaults.object(forKey: "pollInterval") as? Double ?? 3.0

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -8,6 +8,11 @@ struct AppMeetingPattern: Equatable {
     let idlePatterns: [String]
     let minWindowWidth: CGFloat
     let minWindowHeight: CGFloat
+    /// Only titles matching `meetingPatterns` count as usable window titles —
+    /// no first-non-idle fallback. Required for browser-hosted meetings (Google
+    /// Meet), where the owner is a general-purpose browser and any unrelated
+    /// tab title would otherwise pass as "the meeting window".
+    let strictTitleMatch: Bool
 
     init(
         appName: String,
@@ -16,6 +21,7 @@ struct AppMeetingPattern: Equatable {
         idlePatterns: [String] = [],
         minWindowWidth: CGFloat = 200,
         minWindowHeight: CGFloat = 200,
+        strictTitleMatch: Bool = false,
     ) {
         self.appName = appName
         self.ownerNames = ownerNames
@@ -23,6 +29,7 @@ struct AppMeetingPattern: Equatable {
         self.idlePatterns = idlePatterns
         self.minWindowWidth = minWindowWidth
         self.minWindowHeight = minWindowHeight
+        self.strictTitleMatch = strictTitleMatch
     }
 }
 
@@ -78,6 +85,24 @@ extension AppMeetingPattern {
         ],
     )
 
+    /// Google Meet runs in a Chromium browser, not a dedicated app. The owner is
+    /// the browser process; an in-call tab is titled "Meet – <code or name>"
+    /// (the landing page is just "Google Meet"). `strictTitleMatch` because any
+    /// other tab title in the same browser must never pass as the meeting.
+    /// The browser window title may carry a profile/browser suffix, so the
+    /// meeting regex is anchored at the start only.
+    static let meet = AppMeetingPattern(
+        appName: "Google Meet",
+        ownerNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium"],
+        meetingPatterns: [
+            #"^Meet\s+[–—-]\s+\S+"#,
+        ],
+        idlePatterns: [
+            #"^Google Meet\b"#,
+        ],
+        strictTitleMatch: true,
+    )
+
     /// Debug simulator for testing the full pipeline without a real meeting app.
     /// Run: cd tools/meeting-simulator && swift run
     static let simulator = AppMeetingPattern(
@@ -90,7 +115,7 @@ extension AppMeetingPattern {
         minWindowHeight: 100,
     )
 
-    static let all: [AppMeetingPattern] = [teams, zoom, webex, simulator]
+    static let all: [AppMeetingPattern] = [teams, zoom, webex, meet, simulator]
 
     static let byName: [String: AppMeetingPattern] = {
         var dict: [String: AppMeetingPattern] = [:]

--- a/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTitleMatcher.swift
@@ -15,12 +15,17 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Meeting
 struct MeetingTitleMatcher {
     let appName: String
     let ownerNames: [String]
+    /// Mirrors `AppMeetingPattern.strictTitleMatch`: when set, only
+    /// meeting-pattern titles are usable — `selectWindowTitle` never falls back
+    /// to the first non-idle title (a browser's unrelated tabs would leak in).
+    let strictTitleMatch: Bool
     private let idleRegexes: [NSRegularExpression]
     private let meetingRegexes: [NSRegularExpression]
 
     init(pattern: AppMeetingPattern) {
         appName = pattern.appName
         ownerNames = pattern.ownerNames
+        strictTitleMatch = pattern.strictTitleMatch
         idleRegexes = Self.compile(pattern.idlePatterns, kind: "idle", appName: pattern.appName)
         meetingRegexes = Self.compile(pattern.meetingPatterns, kind: "meeting", appName: pattern.appName)
     }
@@ -65,7 +70,7 @@ struct MeetingTitleMatcher {
                 continue
             }
             if isMeetingTitle(title) { return title }
-            if firstNonIdle == nil { firstNonIdle = title }
+            if firstNonIdle == nil, !strictTitleMatch { firstNonIdle = title }
         }
         return firstNonIdle
     }

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -24,12 +24,26 @@ class PowerAssertionDetector: MeetingDetecting {
         /// Teams, whose WebView holds a display-sleep "Video Wake Lock" even with
         /// no call in progress, so it must stay keyword-only.
         let assertionTypes: [String]
+        /// A matched assertion counts only when the app's window-title lookup
+        /// also finds a meeting-pattern window. Required for browser-hosted
+        /// meetings (Google Meet): the browser's WebRTC assertion fires for any
+        /// site using camera/mic, so the assertion alone must never trigger a
+        /// recording of the whole browser. Needs Screen Recording permission
+        /// (window titles) — without it these patterns simply never fire.
+        let requiresWindowConfirmation: Bool
 
-        init(appName: String, processNames: [String], keywords: [String], assertionTypes: [String] = []) {
+        init(
+            appName: String,
+            processNames: [String],
+            keywords: [String],
+            assertionTypes: [String] = [],
+            requiresWindowConfirmation: Bool = false,
+        ) {
             self.appName = appName
             self.processNames = processNames
             self.keywords = keywords
             self.assertionTypes = assertionTypes
+            self.requiresWindowConfirmation = requiresWindowConfirmation
         }
     }
 
@@ -49,6 +63,12 @@ class PowerAssertionDetector: MeetingDetecting {
             appName: "Webex",
             processNames: ["Webex", "Cisco Webex Meetings", "Meeting Center"],
             keywords: ["webex"],
+        ),
+        AssertionPattern(
+            appName: "Google Meet",
+            processNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium"],
+            keywords: ["webrtc"],
+            requiresWindowConfirmation: true,
         ),
         AssertionPattern(
             appName: AppMeetingPattern.simulator.appName,
@@ -137,6 +157,13 @@ class PowerAssertionDetector: MeetingDetecting {
                     guard !hitsThisRound.contains(pattern.appName) else { continue }
 
                     if matchAssertion(processName: processName, assertName: assertName, assertType: assertType, pattern: pattern) {
+                        // Browser-hosted meetings: the assertion alone is ambiguous
+                        // (any WebRTC site holds it), so require a meeting-pattern
+                        // window title before counting the hit.
+                        if pattern.requiresWindowConfirmation,
+                           lookupWindowTitle(appName: pattern.appName) == nil {
+                            continue
+                        }
                         hitsThisRound.insert(pattern.appName)
                         firstMatch[pattern.appName] = (pid, processName, assertName)
                         consecutiveHits[pattern.appName, default: 0] += 1

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -251,12 +251,13 @@
                 let watchTeams: Bool
                 let watchZoom: Bool
                 let watchWebex: Bool
+                let watchMeet: Bool
                 let autoWatch: Bool
                 let pollIntervalSeconds: Double
 
                 static let empty = Self(
                     watchTeams: false, watchZoom: false, watchWebex: false,
-                    autoWatch: false, pollIntervalSeconds: 0,
+                    watchMeet: false, autoWatch: false, pollIntervalSeconds: 0,
                 )
             }
 

--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -20,6 +20,7 @@ struct GeneralSettingsView: View {
                 Toggle("Microsoft Teams", isOn: $settings.watchTeams)
                 Toggle("Zoom", isOn: $settings.watchZoom)
                 Toggle("Webex", isOn: $settings.watchWebex)
+                Toggle("Google Meet (Chrome, Brave, Edge)", isOn: $settings.watchMeet)
             }
 
             Section("Detection") {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -149,18 +149,19 @@ final class AppSettingsTests: XCTestCase {
     // MARK: - watchApps
 
     func testWatchAppsAllEnabled() {
-        XCTAssertEqual(settings.watchApps, ["Microsoft Teams", "Zoom", "Webex"])
+        XCTAssertEqual(settings.watchApps, ["Microsoft Teams", "Zoom", "Webex", "Google Meet"])
     }
 
     func testWatchAppsSingleDisabled() {
         settings.watchZoom = false
-        XCTAssertEqual(settings.watchApps, ["Microsoft Teams", "Webex"])
+        XCTAssertEqual(settings.watchApps, ["Microsoft Teams", "Webex", "Google Meet"])
     }
 
     func testWatchAppsAllDisabled() {
         settings.watchTeams = false
         settings.watchZoom = false
         settings.watchWebex = false
+        settings.watchMeet = false
         XCTAssertEqual(settings.watchApps, [])
     }
 

--- a/app/MeetingTranscriber/Tests/GoogleMeetDetectionTests.swift
+++ b/app/MeetingTranscriber/Tests/GoogleMeetDetectionTests.swift
@@ -1,0 +1,166 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Google Meet detection: a Chromium browser's WebRTC power assertion is only
+/// trusted when an in-call Meet tab title confirms it (`requiresWindowConfirmation`
+/// + `strictTitleMatch`). Split into its own file — `PowerAssertionDetectorTests`
+/// is at the `type_body_length` cap.
+final class GoogleMeetDetectionTests: XCTestCase {
+    private func win(owner: String, title: String?, pid: Int32 = 4242) -> [String: Any] {
+        var w: [String: Any] = ["kCGWindowOwnerName": owner, "kCGWindowOwnerPID": pid]
+        if let title { w["kCGWindowName"] = title }
+        return w
+    }
+
+    private func meetDetector(
+        processName: String = "Brave Browser",
+        windows: @escaping () -> [[String: Any]],
+    ) -> PowerAssertionDetector {
+        let detector = PowerAssertionDetector(confirmationCount: 1)
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 4242,
+                processName: processName,
+                assertName: "WebRTC has active PeerConnections",
+                assertType: "PreventUserIdleSystemSleep",
+            )
+        }
+        detector.windowListProvider = windows
+        return detector
+    }
+
+    // MARK: - Detection
+
+    func testDetectsMeetCallInBrave() {
+        let detector = meetDetector {
+            [self.win(owner: "Brave Browser", title: "Meet – abc-defg-hij")]
+        }
+        let result = detector.checkOnce()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.pattern.appName, "Google Meet")
+        XCTAssertEqual(result?.windowTitle, "Meet – abc-defg-hij")
+        XCTAssertEqual(result?.ownerName, "Brave Browser")
+        XCTAssertEqual(result?.windowPID, 4242)
+    }
+
+    func testDetectsMeetCallInChrome() {
+        let detector = meetDetector(processName: "Google Chrome") {
+            [self.win(owner: "Google Chrome", title: "Meet – Weekly Sync")]
+        }
+        XCTAssertEqual(detector.checkOnce()?.pattern.appName, "Google Meet")
+    }
+
+    func testDetectsMeetTitleWithBrowserSuffix() {
+        // The window title may carry a profile/browser suffix — the meeting
+        // regex is anchored at the start only.
+        let detector = meetDetector {
+            [self.win(owner: "Brave Browser", title: "Meet – abc-defg-hij - Brave")]
+        }
+        XCTAssertNotNil(detector.checkOnce())
+    }
+
+    // MARK: - Assertion alone must not fire
+
+    func testIgnoresWebRTCAssertionWithoutMeetWindow() {
+        // Any WebRTC site (Discord web, Whereby, …) holds the same assertion —
+        // without an in-call Meet tab title the browser must NOT be recorded.
+        let detector = meetDetector {
+            [self.win(owner: "Brave Browser", title: "Some Video Chat — Whereby")]
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresWebRTCAssertionWithEmptyWindowList() {
+        // No Screen Recording permission → no window titles → never fires.
+        let detector = meetDetector { [] }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresMeetLandingPage() {
+        // The Meet landing page tab ("Google Meet") is idle, not a call.
+        let detector = meetDetector {
+            [self.win(owner: "Brave Browser", title: "Google Meet")]
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    func testIgnoresNonWebRTCBrowserAssertion() {
+        // A browser playing media (YouTube etc.) with a Meet tab open in the
+        // background must not fire: the assertion keyword doesn't match.
+        let detector = PowerAssertionDetector(confirmationCount: 1)
+        detector.assertionProvider = {
+            makeAssertionDict(
+                pid: 4242,
+                processName: "Brave Browser",
+                assertName: "Playing audio",
+                assertType: "PreventUserIdleSystemSleep",
+            )
+        }
+        detector.windowListProvider = {
+            [self.win(owner: "Brave Browser", title: "Meet – abc-defg-hij")]
+        }
+        XCTAssertNil(detector.checkOnce())
+    }
+
+    // MARK: - Strict title matching (no non-idle fallback for browsers)
+
+    func testStrictMatcherNeverFallsBackToUnrelatedTabTitle() {
+        let matcher = MeetingTitleMatcher(pattern: .meet)
+        let title = matcher.selectWindowTitle(from: [
+            win(owner: "Brave Browser", title: "GitHub - pasrom/meeting-transcriber"),
+            win(owner: "Brave Browser", title: "Gmail"),
+        ])
+        XCTAssertNil(title, "a browser's unrelated tab titles must never pass as the meeting")
+    }
+
+    func testStrictMatcherPrefersMeetingTitleAmongTabs() {
+        let matcher = MeetingTitleMatcher(pattern: .meet)
+        let title = matcher.selectWindowTitle(from: [
+            win(owner: "Brave Browser", title: "GitHub - pasrom/meeting-transcriber"),
+            win(owner: "Brave Browser", title: "Meet – abc-defg-hij"),
+        ])
+        XCTAssertEqual(title, "Meet – abc-defg-hij")
+    }
+
+    func testNonStrictMatcherKeepsNonIdleFallback() {
+        // Teams keeps the tier-2 fallback: an unrecognised-but-real title still
+        // surfaces rather than being over-filtered.
+        let matcher = MeetingTitleMatcher(pattern: .teams)
+        let title = matcher.selectWindowTitle(from: [
+            win(owner: "Microsoft Teams", title: "Some unrecognised window"),
+        ])
+        XCTAssertEqual(title, "Some unrecognised window")
+    }
+
+    // MARK: - isMeetingActive
+
+    func testMeetStaysActiveWhileAssertionHeldEvenIfTabUnfocused() throws {
+        // Mid-call the user switches to another tab: the Meet title disappears
+        // from the window list but the WebRTC assertion persists — the meeting
+        // must stay active (recording continues).
+        let detector = meetDetector {
+            [self.win(owner: "Brave Browser", title: "Meet – abc-defg-hij")]
+        }
+        let meeting = try XCTUnwrap(detector.checkOnce())
+
+        detector.windowListProvider = {
+            [self.win(owner: "Brave Browser", title: "GitHub - pull requests")]
+        }
+        XCTAssertTrue(detector.isMeetingActive(meeting))
+
+        detector.assertionProvider = { [:] }
+        XCTAssertFalse(detector.isMeetingActive(meeting))
+    }
+
+    // MARK: - Apps to Watch filtering
+
+    func testMeetPatternDroppedWhenNotWatched() {
+        let names = PowerAssertionDetector.patterns(watching: ["Zoom"]).map(\.appName)
+        XCTAssertFalse(names.contains("Google Meet"))
+    }
+
+    func testMeetPatternKeptWhenWatched() {
+        let names = PowerAssertionDetector.patterns(watching: ["Google Meet"]).map(\.appName)
+        XCTAssertTrue(names.contains("Google Meet"))
+    }
+}

--- a/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingDetectorTests.swift
@@ -45,14 +45,15 @@ final class MeetingPatternsTests: XCTestCase {
         XCTAssertFalse(AppMeetingPattern.webex.ownerNames.isEmpty)
     }
 
-    func testAllPatternsContainsFour() {
-        XCTAssertEqual(AppMeetingPattern.all.count, 4)
+    func testAllPatternsContainsFive() {
+        XCTAssertEqual(AppMeetingPattern.all.count, 5)
     }
 
     func testByNameLookup() {
         XCTAssertNotNil(AppMeetingPattern.byName["microsoft teams"])
         XCTAssertNotNil(AppMeetingPattern.byName["zoom"])
         XCTAssertNotNil(AppMeetingPattern.byName["webex"])
+        XCTAssertNotNil(AppMeetingPattern.byName["google meet"])
         XCTAssertNil(AppMeetingPattern.byName["slack"])
     }
 }

--- a/app/MeetingTranscriber/Tests/MeetingPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingPatternsTests.swift
@@ -21,7 +21,7 @@ final class AppMeetingPatternTests: XCTestCase {
     // MARK: - All Patterns
 
     func testAllPatternsCount() {
-        XCTAssertEqual(AppMeetingPattern.all.count, 4)
+        XCTAssertEqual(AppMeetingPattern.all.count, 5)
     }
 
     // MARK: - Simulator Pattern

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -17,7 +17,7 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
     func testPatternsWatchingAllKeepsEveryPattern() {
         // All toggles on (the default) → every default pattern, unchanged.
         let names = PowerAssertionDetector
-            .patterns(watching: ["Microsoft Teams", "Zoom", "Webex"])
+            .patterns(watching: ["Microsoft Teams", "Zoom", "Webex", "Google Meet"])
             .map(\.appName)
         XCTAssertEqual(Set(names), Set(PowerAssertionDetector.defaultPatterns.map(\.appName)))
     }

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -221,6 +221,7 @@
 
             let allowlist: Set = [
                 "detection.watchTeams", "detection.watchZoom", "detection.watchWebex",
+                "detection.watchMeet",
                 "detection.autoWatch", "detection.pollIntervalSeconds",
                 "recording.endGraceSeconds", "recording.noMic", "recording.recordOnly",
                 "recording.micDeviceUID", "recording.micName",


### PR DESCRIPTION
## Summary

Adds auto-detection for Google Meet calls running in a Chromium browser (Chrome, Brave, Edge, Chromium), alongside the existing Teams/Zoom/Webex detection.

Meet has no dedicated app, so no app-specific power assertion exists. Detection therefore requires **two signals** before the browser is recorded:

1. The browser process holds a WebRTC power assertion (`WebRTC has active PeerConnections`). Any site using camera/mic holds the same one, so the assertion alone must never fire — implemented as `AssertionPattern.requiresWindowConfirmation`.
2. An in-call Meet tab title (`Meet – <code or name>`) confirms it. Title matching for browser-hosted patterns is **strict** (`AppMeetingPattern.strictTitleMatch`): `selectWindowTitle` gets no first-non-idle fallback, since any unrelated tab title would otherwise pass as "the meeting".

Recording the browser's root PID captures Meet audio because `resolveTapPIDs` already expands to every PID under the app bundle (same mechanism as Electron apps). Mid-call tab switches keep the meeting alive: `isMeetingActive` checks the assertion only, so the recording survives the Meet tab losing focus.

## Changes

- `AppMeetingPattern`: new `strictTitleMatch` field + `.meet` pattern (in-call regex anchored at start only, so profile/browser title suffixes still match; `^Google Meet\b` landing page is idle)
- `MeetingTitleMatcher`: honors `strictTitleMatch` in `selectWindowTitle`
- `PowerAssertionDetector`: new `requiresWindowConfirmation` on `AssertionPattern` + Google Meet pattern (keyword `webrtc`)
- `AppSettings`: `watchMeet` toggle (default on) wired into `watchApps`
- General settings: new "Google Meet (Chrome, Brave, Edge)" toggle in Apps to Watch
- RPC settings snapshot: `detection.watchMeet`

## Limitations

- Needs Screen Recording permission (window titles). Without it the Meet pattern simply never fires — the two-signal gate fails closed rather than recording the whole browser.
- Initial detection requires the in-call Meet tab to be the active tab in some browser window during the confirmation polls (window titles only expose the active tab). In practice you just joined the call, so it is.

## Testing

- 12 new unit tests in `GoogleMeetDetectionTests.swift`: detection in Brave/Chrome, browser-suffix titles, WebRTC assertion without a Meet tab (must not fire), Meet landing page (idle, must not fire), non-WebRTC browser assertions with a Meet tab open (must not fire), strict-vs-non-strict title selection, mid-call tab switch keeps the meeting active, Apps-to-Watch filtering
- Updated the pattern-count/allowlist pins (`AppMeetingPattern.all`, RPC settings key allowlist, `watchApps` expectations)
- Full suite green locally: 2222 tests, 0 failures (skipping model-download E2E + snapshot lanes)
- Verified end-to-end against a real Google Meet call in Chrome on macOS 26: auto-detect → dual-source recording → transcription/diarization → protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)