### PR TITLE
test(app): prove posted key events drive a SwiftUI TextField binding

### DIFF
--- a/app/MeetingTranscriber/Tests/KeyboardInjectionPoCTests.swift
+++ b/app/MeetingTranscriber/Tests/KeyboardInjectionPoCTests.swift
@@ -1,0 +1,110 @@
+#if !APPSTORE
+    import AppKit
+    @testable import MeetingTranscriber
+    import SwiftUI
+    import XCTest
+
+    /// PoC for the e2e "last mile": prove that a *posted key event* updates a
+    /// SwiftUI `TextField`'s binding, unlike an AX set-value (which the `/ui`
+    /// harness deliberately does not expose, because AX-set does not fire the
+    /// SwiftUI binding). If this is green, the same mechanism is what a future
+    /// in-process `/ui/type` endpoint would use to automate the "typing into
+    /// fields" acceptance that is currently manual-QA-only.
+    ///
+    /// The injector is intentionally test-local (not production visibility
+    /// widening): slice 1 only establishes the mechanism.
+    @MainActor
+    final class KeyboardInjectionPoCTests: XCTestCase {
+        /// Reference box the SwiftUI binding writes back to, so the test can read
+        /// the post-typing value without reaching into SwiftUI's private state.
+        private final class Box { var value = "" }
+
+        private struct Probe: View {
+            let box: Box
+            var body: some View {
+                TextField("", text: Binding(get: { box.value }, set: { box.value = $0 }))
+            }
+        }
+
+        /// Hosts the probe in a real key window, focuses the field, injects the
+        /// characters as posted key events, and returns the window so the caller
+        /// can pump the run loop before asserting.
+        private func makeHostedProbe(_ box: Box) -> NSWindow {
+            let hosting = NSHostingView(rootView: Probe(box: box))
+            hosting.frame = NSRect(x: 0, y: 0, width: 200, height: 30)
+            let window = NSWindow(
+                contentRect: hosting.frame,
+                styleMask: [.titled], backing: .buffered, defer: false,
+            )
+            window.contentView = hosting
+            window.makeKeyAndOrderFront(nil)
+            return window
+        }
+
+        func testPostedKeyEventUpdatesTextFieldBinding() {
+            let box = Box()
+            let window = makeHostedProbe(box)
+
+            // Give SwiftUI a run-loop turn to build its NSView tree + field editor.
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+            KeyboardInjector.focusFirstTextField(in: window)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+            KeyboardInjector.type("hi", into: window)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+            XCTAssertEqual(box.value, "hi", "posted key events should drive the SwiftUI binding")
+        }
+    }
+
+    /// Minimal in-process key-event injector (test-local). Focuses the first
+    /// text view in a window and posts real key-down/up events through the
+    /// responder chain via `NSWindow.sendEvent` (no `NSApp` dependency, so it
+    /// works in the xctest process where `NSApp` is nil).
+    @MainActor
+    enum KeyboardInjector {
+        /// Depth-first search for the field editor's backing text view and make
+        /// it first responder.
+        static func focusFirstTextField(in window: NSWindow) {
+            guard let root = window.contentView else { return }
+            if let field = firstTextInput(in: root) {
+                window.makeFirstResponder(field)
+            }
+        }
+
+        private static func firstTextInput(in view: NSView) -> NSView? {
+            if view is NSTextField || view is NSTextView {
+                return view
+            }
+            for sub in view.subviews {
+                if let found = firstTextInput(in: sub) {
+                    return found
+                }
+            }
+            return nil
+        }
+
+        /// Post each character as a key-down + key-up `NSEvent` routed to the
+        /// window's first responder.
+        static func type(_ text: String, into window: NSWindow) {
+            for scalarString in text.map({ String($0) }) {
+                for down in [true, false] {
+                    guard let event = NSEvent.keyEvent(
+                        with: down ? .keyDown : .keyUp,
+                        location: .zero,
+                        modifierFlags: [],
+                        timestamp: ProcessInfo.processInfo.systemUptime,
+                        windowNumber: window.windowNumber,
+                        context: nil,
+                        characters: scalarString,
+                        charactersIgnoringModifiers: scalarString,
+                        isARepeat: false,
+                        keyCode: 0,
+                    ) else { continue }
+                    window.sendEvent(event)
+                }
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

Thin PoC that closes one of the E2E "last mile" gaps: **typing into fields**, currently listed as manual-QA-only.

The GUI Testing guidance treats typing as un-automatable because AX set-value does not fire the SwiftUI binding (hence no `/ui/setValue`). That is only true for the **AX value attribute**. A real **posted key event** goes through the `keyDown:` -> `insertText:` responder chain that the binding observes, so it **does** update the binding.

This proves the mechanism:
- Host a `TextField` (bound to a reference box) in a key `NSWindow`.
- Focus the field, post per-character `NSEvent`s via `NSWindow.sendEvent`.
- Assert the bound value updated.

It runs in the **plain xctest process** (no `NSApp`, no TCC, no self-hosted runner) because `sendEvent` routes to the first responder directly.

## Why it is non-vacuous

Verified by stubbing the injector to a no-op: the assertion goes red (bound value stays empty). Only the posted events turn it green.

## Scope

- Test-only. The injector is deliberately test-local (no production visibility widening).
- One positive test; a fragile AX-negative test was intentionally left out.

## Follow-up (not in this PR)

Wire the same `NSEvent` injection into the in-process `/ui` debug surface as a `/ui/type` endpoint, then a live test types into a real Settings field and asserts the `AppSettings` write-back via `/state`. That turns the mechanism into end-to-end coverage of the manual "typing" acceptance. Drag/focus-order and the `NSOpenPanel`/`NSAlert` seams are the natural next steps after that.