### PR TITLE
feat(app): automate text entry via POST /ui/type

### DIFF
--- a/.github/workflows/e2e-ui-smoke.yml
+++ b/.github/workflows/e2e-ui-smoke.yml
@@ -28,6 +28,10 @@ on:
       - 'app/MeetingTranscriber/Sources/DebugRPCServer*.swift'
       - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
       - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
+      # The injectors the /ui/* harness actuates through — as load-bearing for
+      # this lane as the endpoints themselves, so a change to them must trigger it.
+      - 'app/MeetingTranscriber/Sources/KeyboardInjection.swift'
+      - 'app/MeetingTranscriber/Sources/MouseInjection.swift'
   push:
     branches: [main]
     paths:
@@ -35,6 +39,10 @@ on:
       - 'app/MeetingTranscriber/Sources/DebugRPCServer*.swift'
       - 'app/MeetingTranscriber/Sources/HTTPRequest.swift'
       - 'app/MeetingTranscriber/Sources/HTTPResponse.swift'
+      # The injectors the /ui/* harness actuates through — as load-bearing for
+      # this lane as the endpoints themselves, so a change to them must trigger it.
+      - 'app/MeetingTranscriber/Sources/KeyboardInjection.swift'
+      - 'app/MeetingTranscriber/Sources/MouseInjection.swift'
       - 'scripts/e2e-settings-smoke.sh'
       - 'scripts/build_release.sh'
       - '.github/workflows/e2e-ui-smoke.yml'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ Rule: test each behavior at the cheapest layer that can falsify it.
 3. **`/state` (live RPC):** first choice for live assertions, including window/scene
    behavior via `/state.windows` (`isVisible` after deactivate, `floating`,
    `canJoinAllSpaces` — how #509/#511 guard the naming-window pin).
-4. **`/ui/tree` + `/ui/press`** (live, Settings window only): only for behavior that
+4. **`/ui/tree` + `/ui/press` + `/ui/type`** (live, Settings window only): only for behavior that
    exists solely in the real AppKit/AX layer. A live test earns its keep only when
    ViewInspector cannot instantiate the failing layer (real NSWindow/NSPanel,
    focus/activation, scene routing, the NSHostingView boundary, actual AX exposure).
@@ -263,9 +263,16 @@ reproduce — #504). Acceptance: revert the fix, test goes red.
 **Don't:** chase snapshot coverage; use `/ui/press` to arrange state (it's for testing
 the pressed control); test SwiftUI framework behavior (e.g. that `.keyboardShortcut`
 fires). **Manual-QA-only, accepted:** menu-bar dropdown interaction, modal panels
-(NSOpenPanel/NSAlert), TCC prompts, typing into fields (no `/ui/setValue` — AX-set
-doesn't fire the SwiftUI binding), drag/focus order, visual appearance beyond dev-only
+(NSOpenPanel/NSAlert), TCC prompts, drag/focus order, visual appearance beyond dev-only
 snapshots.
+
+**Typing** is automatable via `POST /ui/type` (allowlisted plain text fields only —
+never a `SecureField`). It posts real key events, because an AX set-value does *not*
+fire the SwiftUI binding; that asymmetry is why there is no `/ui/setValue`. Pass
+`clear: true` to replace rather than append, or the assertion depends on the field's
+prior contents. Reaching a control outside the General tab needs a tab switch first,
+and only `POST /ui/press` with `"via": "click"` performs one — the AX press reports
+success on a sidebar row without selecting it.
 
 ## E2E Architecture
 

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -31,6 +31,23 @@ enum A11yID {
     static let experimentalTuningDisclosure = "experimentalTuningDisclosure"
     static let sortformerCapHint = "sortformer-cap-hint"
 
+    /// Mic speaker-name field (Settings → Speakers). The `/ui/type` allowlist's
+    /// only entry: a plain, non-secret text field whose write-back is readable in
+    /// `/state`, which is what makes it a usable text-entry probe.
+    static let micNameField = "micNameField"
+
+    /// Settings sidebar row for one tab (`settings-tab-<rawValue>`). The detail
+    /// pane renders only the selected tab, so a control in another tab is absent
+    /// from the accessibility tree until its row is selected — a driver switches
+    /// tabs through these before driving anything outside General.
+    static func settingsTab(_ rawValue: String) -> String {
+        "settings-tab-\(rawValue)"
+    }
+
+    /// The one tab row the `/ui/press` allowlist admits. A named constant rather
+    /// than a literal at the allowlist, so the identifier has a single home.
+    static let settingsTabSpeakers = settingsTab("speakers")
+
     // Speaker-naming dialog.
     static let confirmButton = "confirm-button"
     static let skipButton = "skip-button"

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift
@@ -1,10 +1,11 @@
 #if !APPSTORE
     // `@preconcurrency`: ApplicationServices AX globals lack Sendable annotations
     // (same gap AXHelper/Permissions guard).
+    import AppKit
     @preconcurrency import ApplicationServices
 
     /// Shared HIServices accessibility plumbing for the in-process `/ui/*`
-    /// endpoints (`/ui/tree`, `/ui/press`). Reads the app's OWN accessibility tree
+    /// `/ui/*` endpoints. Reads the app's OWN accessibility tree
     /// via `AXUIElementCreateApplication(getpid())`.
     ///
     /// Why the AX C API and not `NSView.accessibilityChildren()`: SwiftUI builds
@@ -79,6 +80,25 @@
         /// `MainActor`); `DebugRPCServer`'s isolation enforces that.
         static func axPress(_ element: AXUIElement) -> Bool {
             AXUIElementPerformAction(element, kAXPressAction as CFString) == .success
+        }
+
+        /// The app's `NSWindow` carrying the given identifier, or nil when none is
+        /// open (and always in the xctest process, where `NSApp` itself is nil).
+        /// Sits beside `axWindowElement` because the two are resolved together
+        /// whenever an endpoint needs to post events into a window rather than only
+        /// read its accessibility tree.
+        static func nsWindow(forIdentifier identifier: String) -> NSWindow? {
+            NSApp?.windows.first { $0.identifier?.rawValue == identifier }
+        }
+
+        /// Make the element the focused (first-responder) control. Returns whether
+        /// HIServices accepted it. Unlike `kAXValueAttribute` — which does not fire
+        /// a SwiftUI binding, see `KeyboardInjection` — setting focus on a
+        /// view-backed element maps to `makeFirstResponder:`, which is exactly what
+        /// `/ui/type` needs before posting key events. Main-actor for the same
+        /// reason as `axPress`.
+        static func axFocus(_ element: AXUIElement) -> Bool {
+            AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, kCFBooleanTrue) == .success
         }
 
         /// The app's window with the given `AXIdentifier` (our `NSWindow`

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
@@ -1,4 +1,5 @@
 #if !APPSTORE
+    import AppKit
     @preconcurrency import ApplicationServices
     import Foundation
 
@@ -7,6 +8,18 @@
     struct UIPressPayload: Codable {
         let window: String?
         let identifier: String
+        /// How to actuate the control; omitted means `.ax`. Typed rather than a
+        /// raw string so an unknown value fails decoding into the existing 400 arm
+        /// instead of silently falling back to an AX press and reporting success.
+        let via: UIPressVia?
+    }
+
+    /// How `/ui/press` actuates a control. `click` exists because some SwiftUI
+    /// controls accept the AX press and report success without acting on it — a
+    /// `List(selection:)` row is the known case (see `MouseInjection`).
+    enum UIPressVia: String, Codable {
+        case ax
+        case click
     }
 
     /// The outcome of resolving and pressing a control inside a window's
@@ -33,6 +46,16 @@
         var uiChildren: [any UIPressTarget] { get }
         /// Fire the element's AX press action. Returns whether it reported running.
         func uiPress() -> Bool
+        /// Post a real mouse click at the element's frame. Returns whether it ran.
+        func uiClick() -> Bool
+    }
+
+    /// Click defaults to unsupported so in-memory fakes (and any target without a
+    /// window to post into) keep working without implementing it.
+    extension UIPressTarget {
+        func uiClick() -> Bool {
+            false
+        }
     }
 
     /// `POST /ui/press` — drive a real UI action (button/toggle press) against an
@@ -78,7 +101,15 @@
         /// would wedge the server and UI. This invariant, not the (localhost +
         /// token + env-gated + `#if !APPSTORE`) security margin, is the allowlist's
         /// real justification.
-        nonisolated static let uiPressAllowedIdentifiers: Set<String> = [A11yID.recordOnlyToggle]
+        /// The Settings sidebar rows are safe under the invariant above: selecting
+        /// one swaps the detail pane, it opens nothing modal. They are needed
+        /// because a control outside the General tab is absent from the
+        /// accessibility tree until its tab is selected, and they only actuate
+        /// via `"click"` (the AX press reports success without selecting).
+        nonisolated static let uiPressAllowedIdentifiers: Set<String> = [
+            A11yID.recordOnlyToggle,
+            A11yID.settingsTabSpeakers,
+        ]
 
         nonisolated static func isIdentifierAllowedForUIPress(_ identifier: String) -> Bool {
             uiPressAllowedIdentifiers.contains(identifier)
@@ -90,15 +121,17 @@
         /// `.notFound`. Identifiers are assumed unique per window, so first match
         /// wins. Pure over `UIPressTarget`, so it is unit-testable with a fake.
         static func performPress(
-            identifier: String, in root: any UIPressTarget, maxDepth: Int,
+            identifier: String, in root: any UIPressTarget, maxDepth: Int, via: UIPressVia? = nil,
         ) -> UIPressOutcome {
             if root.uiIdentifier == identifier {
                 guard root.uiEnabled else { return .disabled }
-                return .pressed(root.uiPress())
+                return .pressed(via == .click ? root.uiClick() : root.uiPress())
             }
             guard maxDepth > 0 else { return .notFound }
             for child in root.uiChildren {
-                let outcome = performPress(identifier: identifier, in: child, maxDepth: maxDepth - 1)
+                let outcome = performPress(
+                    identifier: identifier, in: child, maxDepth: maxDepth - 1, via: via,
+                )
                 if outcome != .notFound { return outcome }
             }
             return .notFound
@@ -107,8 +140,13 @@
         /// Resolve the accessibility root for an allowed, currently-open window,
         /// or nil when no matching open window exists. Shares `/ui/tree`'s self-pid
         /// window resolution; only the adapter differs.
+        /// The `NSWindow` is resolved alongside the AX root so a `"click"` press has
+        /// somewhere to post its mouse events. It stays optional on purpose: an AX
+        /// press works without it, so a missing window only disables clicking.
         static func uiPressTarget(forWindowIdentifier identifier: String) -> (any UIPressTarget)? {
-            axWindowElement(forIdentifier: identifier).map { AXPressSource(element: $0) }
+            guard let element = axWindowElement(forIdentifier: identifier) else { return nil }
+            let window = nsWindow(forIdentifier: identifier)
+            return AXPressSource(element: element, window: window)
         }
 
         /// Map a press outcome to its HTTP response. Pure so the 200/404/409
@@ -144,6 +182,7 @@
             }
             return Self.response(for: Self.performPress(
                 identifier: payload.identifier, in: root, maxDepth: Self.uiPressMaxDepth,
+                via: payload.via,
             ))
         }
     }
@@ -154,6 +193,9 @@
     @MainActor
     private struct AXPressSource: UIPressTarget {
         let element: AXUIElement
+        /// Nil when no `NSWindow` matched (headless harness): AX press still works,
+        /// `"click"` reports false rather than pretending it acted.
+        let window: NSWindow?
 
         var uiIdentifier: String? {
             DebugRPCServer.axIdentifier(element)
@@ -164,11 +206,18 @@
         }
 
         var uiChildren: [any UIPressTarget] {
-            DebugRPCServer.axChildren(element).map { Self(element: $0) }
+            DebugRPCServer.axChildren(element).map { Self(element: $0, window: window) }
         }
 
         func uiPress() -> Bool {
             DebugRPCServer.axPress(element)
+        }
+
+        func uiClick() -> Bool {
+            guard let window else { return false }
+            let frame = DebugRPCServer.axFrame(element)
+            guard !frame.isEmpty else { return false }
+            return MouseInjection.click(atAXPoint: CGPoint(x: frame.midX, y: frame.midY), in: window)
         }
     }
 #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UITree.swift
@@ -56,6 +56,19 @@
     /// TCC grant (self-inspection is exempt). The older
     /// `NSView.accessibilityChildren()` walk returned an empty SwiftUI tree.
     extension DebugRPCServer {
+        /// Routing for the whole `/ui/*` debug surface (tree, press, type), so
+        /// `route()` stays inside its length budget and the related endpoints sit
+        /// together — the same split `routeV1` uses for `/v1`. Returns nil when the
+        /// request is not a `/ui/*` call, so `route()` falls through to its table.
+        func routeUI(_ request: HTTPRequest, path: String) -> HTTPResponse? {
+            // The raw target (with the query) is parsed inside `uiTreeResponse` to
+            // read `?window=x`.
+            if request.method == "GET", path == "/ui/tree" { return uiTreeResponse(target: request.path) }
+            if request.method == "POST", path == "/ui/press" { return uiPressResponse(body: request.body) }
+            if request.method == "POST", path == "/ui/type" { return uiTypeResponse(body: request.body) }
+            return nil
+        }
+
         /// SwiftUI scene identifiers exposed to `GET /ui/tree`. Deliberately only
         /// the Settings window for now — `speaker-naming`, `record-app`, and the
         /// live-captions panel stay off the list because they surface PII /

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UIType.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UIType.swift
@@ -1,0 +1,223 @@
+#if !APPSTORE
+    import AppKit
+    @preconcurrency import ApplicationServices
+
+    /// Request body for `POST /ui/type`: the accessibility `identifier` of the
+    /// field to type into, the `text` to enter, and the `window` it lives in
+    /// (defaults to `settings`).
+    struct UITypePayload: Codable {
+        let window: String?
+        let identifier: String
+        let text: String
+        /// Replace the field's contents (select-all first) instead of typing at
+        /// the cursor. Defaults to false — appending is what "type" means and is
+        /// the non-destructive choice — but a driver asserting an exact value
+        /// wants `true`, otherwise the result depends on the field's prior state.
+        ///
+        /// Known limitation: `clear` with an EMPTY `text` does not empty the
+        /// field. Select-all only selects; the replacement happens because the
+        /// following keystroke overwrites the selection, so with nothing typed the
+        /// old text survives. Emptying a field would need a delete keystroke,
+        /// which this endpoint does not send.
+        let clear: Bool
+
+        /// Hand-rolled so `clear` can be omitted by the caller yet stay a plain
+        /// `Bool` here — an optional flag would push a `?? false` onto every use
+        /// site and reads as a third state the endpoint does not have.
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            window = try container.decodeIfPresent(String.self, forKey: .window)
+            identifier = try container.decode(String.self, forKey: .identifier)
+            text = try container.decode(String.self, forKey: .text)
+            clear = try container.decodeIfPresent(Bool.self, forKey: .clear) ?? false
+        }
+    }
+
+    /// The outcome of resolving a field and typing into it. `typed` carries
+    /// whether focus + injection ran; the driver asserts on the *effect* via
+    /// `/state`, not on this boolean.
+    enum UITypeOutcome: Equatable {
+        case typed(Bool)
+        case notFound
+        case disabled
+    }
+
+    /// Minimal actionable view of one accessibility element for text entry:
+    /// enough to locate a field by `identifier`, decide whether it accepts input,
+    /// and type into it. Separate from `UIPressTarget` because the concerns
+    /// differ (focus + key events vs a press action) and a fake must be able to
+    /// record the *text* it received.
+    @MainActor
+    protocol UITypeTarget {
+        var uiIdentifier: String? { get }
+        var uiEnabled: Bool { get }
+        var uiChildren: [any UITypeTarget] { get }
+        /// Focus the element and enter `text`, optionally replacing what is there.
+        /// Returns whether it ran.
+        func uiType(_ text: String, clear: Bool) -> Bool
+    }
+
+    /// `POST /ui/type` — enter text into an allowlisted field, so a driver can
+    /// automate the one GUI acceptance that had no automated path: typing into a
+    /// field, then asserting the resulting `AppSettings` write-back via
+    /// `GET /state`.
+    ///
+    /// The field is located in the app's own self-pid `AXUIElement` tree (same
+    /// plumbing and no-TCC rationale as `/ui/tree` and `/ui/press`), focused via
+    /// `axFocus`, and filled by `KeyboardInjection` posting real key events. An
+    /// accessibility set-value would be the obvious implementation and is the
+    /// wrong one: it does not fire the SwiftUI binding, which is why no
+    /// `/ui/setValue` exists.
+    extension DebugRPCServer {
+        /// Windows a type may target. Same allowlist rationale as `/ui/press`:
+        /// only the Settings window. PII windows (`speaker-naming`, the
+        /// live-captions panel) stay off.
+        nonisolated static let uiTypeAllowedWindowIDs: Set<String> = ["settings"]
+
+        /// Window used when the request omits `window`.
+        nonisolated static let defaultUITypeWindow = "settings"
+
+        /// Recursion cap — shares `/ui/tree`'s bound.
+        nonisolated static let uiTypeMaxDepth = uiTreeMaxDepth
+
+        nonisolated static func isWindowAllowedForUIType(identifier: String?) -> Bool {
+            isWindowAllowed(identifier, in: uiTypeAllowedWindowIDs)
+        }
+
+        /// Fields a type may target, by accessibility identifier. Deliberately
+        /// narrow, and narrower than `/ui/press`'s: text entry writes attacker-
+        /// chosen content into a persisted setting, so without an allowlist a
+        /// token-holder could rewrite any current-or-future field in the window
+        /// (an endpoint URL, an output path).
+        ///
+        /// INVARIANT — never allowlist a secure field (`SecureField`, API keys,
+        /// tokens). Posting into one is both a credential-handling hazard and
+        /// unreliable (macOS Secure Event Input exists precisely to block
+        /// synthetic input there). Plain, non-secret text fields only.
+        nonisolated static let uiTypeAllowedIdentifiers: Set<String> = [A11yID.micNameField]
+
+        /// Upper bound on a single request's text. Each character is posted as a
+        /// key-event pair synchronously on the main actor and drives a settings
+        /// write, so an unbounded string (the body cap alone allows ~64k) would
+        /// freeze the UI and stall the server for the whole run.
+        nonisolated static let uiTypeMaxTextLength = 512
+
+        nonisolated static func isIdentifierAllowedForUIType(_ identifier: String) -> Bool {
+            uiTypeAllowedIdentifiers.contains(identifier)
+        }
+
+        /// Depth-first search for the first element whose identifier matches, then
+        /// act on it: `.disabled` (found but not accepting input, never typed
+        /// into), `.typed` (found, enabled, filled), or `.notFound`. Identifiers
+        /// are assumed unique per window, so first match wins. Pure over
+        /// `UITypeTarget`, so it is unit-testable with a fake.
+        static func performType(
+            text: String, identifier: String, in root: any UITypeTarget, maxDepth: Int,
+            clear: Bool = false,
+        ) -> UITypeOutcome {
+            if root.uiIdentifier == identifier {
+                guard root.uiEnabled else { return .disabled }
+                return .typed(root.uiType(text, clear: clear))
+            }
+            guard maxDepth > 0 else { return .notFound }
+            for child in root.uiChildren {
+                let outcome = performType(
+                    text: text, identifier: identifier, in: child, maxDepth: maxDepth - 1,
+                    clear: clear,
+                )
+                if outcome != .notFound {
+                    return outcome
+                }
+            }
+            return .notFound
+        }
+
+        /// Resolve the accessibility root *and* the `NSWindow` for an allowed,
+        /// currently-open window, or nil when either is missing. Typing needs both:
+        /// the AX element to focus the field, the window to post key events to.
+        /// Both are absent in the headless xctest process, so both are guarded.
+        static func uiTypeTarget(forWindowIdentifier identifier: String) -> (any UITypeTarget)? {
+            guard let element = axWindowElement(forIdentifier: identifier),
+                  let window = nsWindow(forIdentifier: identifier)
+            else { return nil }
+            return AXTypeSource(element: element, window: window)
+        }
+
+        /// Map a type outcome to its HTTP response. Pure so the 200/404/409 arms —
+        /// unreachable through `route()` in the headless test harness, which has no
+        /// live window to resolve — are unit-testable directly.
+        ///
+        /// Named rather than overloading `response(for:)`: `UIPressOutcome` and
+        /// `UITypeOutcome` share case names, so an overload would make existing
+        /// bare-case call sites (`response(for: .notFound)`) ambiguous.
+        nonisolated static func uiTypeResponse(for outcome: UITypeOutcome) -> HTTPResponse {
+            switch outcome {
+            case .notFound:
+                HTTPResponse.notFound()
+
+            case .disabled:
+                HTTPResponse.conflict()
+
+            case let .typed(accepted):
+                HTTPResponse.ok(body: Data(#"{"typed":\#(accepted)}"#.utf8), contentType: "application/json")
+            }
+        }
+
+        /// `POST /ui/type` handler. 400 undecodable body / empty identifier, 403
+        /// window or identifier off its allowlist, 503 allowed window not open,
+        /// 404 identifier absent, 409 present-but-disabled, 200 typed
+        /// (`{"typed":<bool>}`).
+        func uiTypeResponse(body: Data) -> HTTPResponse {
+            guard let payload = try? JSONDecoder().decode(UITypePayload.self, from: body),
+                  !payload.identifier.isEmpty,
+                  payload.text.count <= Self.uiTypeMaxTextLength
+            else { return HTTPResponse.badRequest() }
+            let windowID = payload.window ?? Self.defaultUITypeWindow
+            guard Self.isWindowAllowedForUIType(identifier: windowID),
+                  Self.isIdentifierAllowedForUIType(payload.identifier)
+            else { return HTTPResponse.forbidden() }
+            guard let root = Self.uiTypeTarget(forWindowIdentifier: windowID) else {
+                return HTTPResponse.serviceUnavailable("no window\n")
+            }
+            return Self.uiTypeResponse(for: Self.performType(
+                text: payload.text, identifier: payload.identifier, in: root,
+                maxDepth: Self.uiTypeMaxDepth, clear: payload.clear,
+            ))
+        }
+    }
+
+    /// Adapter bridging one self-pid `AXUIElement` (plus its hosting `NSWindow`)
+    /// to `UITypeTarget` (mirrors `AXPressSource` in `+UIPress.swift`).
+    @MainActor
+    private struct AXTypeSource: UITypeTarget {
+        let element: AXUIElement
+        let window: NSWindow
+
+        var uiIdentifier: String? {
+            DebugRPCServer.axIdentifier(element)
+        }
+
+        var uiEnabled: Bool {
+            DebugRPCServer.axEnabled(element)
+        }
+
+        var uiChildren: [any UITypeTarget] {
+            DebugRPCServer.axChildren(element).map { Self(element: $0, window: window) }
+        }
+
+        func uiType(_ text: String, clear: Bool) -> Bool {
+            guard DebugRPCServer.axFocus(element) else { return false }
+            // Focusing a text field selects its contents, so the caret has to be
+            // placed deliberately either way: keep the selection to replace it, or
+            // collapse it to the end to append. Leaving it implicit makes the same
+            // request replace or append depending on prior focus state. A refused
+            // action is reported rather than silently doing the other thing.
+            let positioned = clear
+                ? KeyboardInjection.selectAll(in: window)
+                : KeyboardInjection.moveToEnd(in: window)
+            guard positioned else { return false }
+            KeyboardInjection.type(text, into: window)
+            return true
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -340,18 +340,8 @@
                 return await routeV1(request, path: pathWithoutQuery)
             }
 
-            // Read-only accessibility-tree inspection. Debug surface (no
-            // stability contract). The raw target (with the query) is parsed
-            // inside `uiTreeResponse` to read `?window=x`.
-            if request.method == "GET", pathWithoutQuery == "/ui/tree" {
-                return uiTreeResponse(target: request.path)
-            }
-
-            // Drive a real UI action against an allowlisted window. Debug surface
-            // (no stability contract), like `/ui/tree`.
-            if request.method == "POST", pathWithoutQuery == "/ui/press" {
-                return uiPressResponse(body: request.body)
-            }
+            // Debug `/ui/*` surface (tree, press, type) — no stability contract.
+            if let uiResponse = routeUI(request, path: pathWithoutQuery) { return uiResponse }
 
             switch (request.method, request.path) {
             case ("GET", "/state"):

--- a/app/MeetingTranscriber/Sources/KeyboardInjection.swift
+++ b/app/MeetingTranscriber/Sources/KeyboardInjection.swift
@@ -1,0 +1,86 @@
+#if !APPSTORE
+    import AppKit
+
+    /// Types text into the app's own UI by posting real key events, backing
+    /// `POST /ui/type`.
+    ///
+    /// Why posted events and not an accessibility set-value: writing
+    /// `kAXValueAttribute` updates the control's accessibility value without going
+    /// through `keyDown:` → `interpretKeyEvents:` → `insertText:`, so a SwiftUI
+    /// `TextField`'s binding never observes it and the setting is never written.
+    /// That is why the harness deliberately exposes no `/ui/setValue`. A posted key
+    /// event travels the real responder chain, so the binding does update.
+    /// `KeyboardInjectionTests` pins that behaviour.
+    ///
+    /// Delivery is `NSWindow.sendEvent` rather than `NSApp.postEvent` so it routes
+    /// straight to the window's first responder and stays usable where `NSApp` is
+    /// absent (the xctest process). The events never leave the process: no
+    /// WindowServer HID path, hence no Accessibility/PostEvent TCC grant, and
+    /// Secure Event Input cannot block them. Secure fields are out of scope by
+    /// design — the `/ui/type` allowlist admits plain text fields only.
+    @MainActor
+    enum KeyboardInjection {
+        /// Post one key-down/key-up pair carrying `characters` to `window`'s first
+        /// responder.
+        ///
+        /// `keyCode` is left at 0 for every character: text insertion reads the
+        /// event's `characters`, so a per-character virtual keycode would mean
+        /// carrying a keyboard-layout table for no behavioural gain. Callers that
+        /// need real key semantics (arrows, Tab, anything the responder switches on
+        /// by code) must build those events with their proper keycodes instead.
+        private static func post(
+            characters: String, modifiers: NSEvent.ModifierFlags, in window: NSWindow,
+        ) {
+            for phase in [NSEvent.EventType.keyDown, .keyUp] {
+                guard let event = NSEvent.keyEvent(
+                    with: phase,
+                    location: .zero,
+                    modifierFlags: modifiers,
+                    timestamp: ProcessInfo.processInfo.systemUptime,
+                    windowNumber: window.windowNumber,
+                    context: nil,
+                    characters: characters,
+                    charactersIgnoringModifiers: characters,
+                    isARepeat: false,
+                    keyCode: 0,
+                ) else { continue }
+                window.sendEvent(event)
+            }
+        }
+
+        /// Type `text` into `window`'s first responder, one key pair per character.
+        /// The caller focuses the target field first.
+        static func type(_ text: String, into window: NSWindow) {
+            for character in text {
+                post(characters: String(character), modifiers: [], in: window)
+            }
+        }
+
+        /// Select the focused field's contents, so a caller can replace them
+        /// instead of appending at the cursor. Returns whether the responder
+        /// accepted the action.
+        ///
+        /// Sends `selectAll:` down `window`'s own responder chain rather than
+        /// posting Cmd-A. A command-modified key event is dispatched as a key
+        /// EQUIVALENT: it resolves through the main menu against `NSApp.keyWindow`,
+        /// so it silently does nothing when there is no matching menu item
+        /// (measured: the field then appends instead of replacing) and can land in
+        /// a different window when `window` is not key. The responder action is
+        /// scoped to the window we were handed.
+        static func selectAll(in window: NSWindow) -> Bool {
+            window.firstResponder?.tryToPerform(#selector(NSText.selectAll(_:)), with: nil) ?? false
+        }
+
+        /// Collapse the selection to the end of the field's contents.
+        ///
+        /// Required for a deterministic append: AppKit selects a text field's whole
+        /// contents when it becomes first responder, so typing straight after a
+        /// focus change REPLACES them. Without this the same request appends or
+        /// replaces depending on whether the field happened to be focused already —
+        /// measured, and the reason this is not left to the caller.
+        static func moveToEnd(in window: NSWindow) -> Bool {
+            window.firstResponder?
+                .tryToPerform(#selector(NSResponder.moveToEndOfDocument(_:)), with: nil) ?? false
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/MouseInjection.swift
+++ b/app/MeetingTranscriber/Sources/MouseInjection.swift
@@ -1,0 +1,90 @@
+#if !APPSTORE
+    import AppKit
+
+    /// Clicks a point in the app's own UI by posting real mouse events, backing
+    /// `POST /ui/press` with `"via":"click"`.
+    ///
+    /// Why a synthetic click when an AX press action exists: some SwiftUI controls
+    /// accept `kAXPressAction` and report success without the action taking effect.
+    /// A `List(selection:)` row is the case that forced this — the identifier lands
+    /// on the row's `AXStaticText`, pressing it returns `true`, and the selection
+    /// does not change. A posted mouse event goes through real hit-testing, which
+    /// is the path that actually drives selection.
+    ///
+    /// Delivery is `NSApplication.postEvent(_:atStart:)`, so the events never
+    /// leave the process: no WindowServer HID path, hence no
+    /// Accessibility/PostEvent TCC grant, and no cursor warp (the pointer does not
+    /// move, so a click cannot be stolen from whatever the user is doing).
+    ///
+    /// It must be the event QUEUE and not `NSWindow.sendEvent`: a mouse-down on a
+    /// row-tracking control (`NSTableView`, which backs SwiftUI `List`) enters a
+    /// modal tracking loop that pulls the matching mouse-up off the queue. Direct
+    /// `sendEvent` delivery bypasses the queue, so the tracking loop waits forever
+    /// for a mouse-up that is only delivered after it returns — verified live: it
+    /// wedges the app's main thread and the RPC server stops answering. Posting
+    /// both events and returning lets the run loop feed the tracking loop.
+    @MainActor
+    enum MouseInjection {
+        /// Convert an accessibility point (global, top-left origin, y down) to
+        /// Cocoa screen coordinates (global, bottom-left origin, y up).
+        ///
+        /// Both spaces are anchored on the primary screen — the one whose Cocoa
+        /// origin is (0, 0) and against whose top edge AX measures — so the flip
+        /// is `primaryHeight - y`. Pure, so the arithmetic is unit-testable
+        /// without a screen.
+        static func cocoaScreenPoint(fromAXPoint point: CGPoint, primaryScreenHeight: CGFloat) -> CGPoint {
+            CGPoint(x: point.x, y: primaryScreenHeight - point.y)
+        }
+
+        /// Post a click at `axPoint` (an accessibility frame point) to `window`.
+        /// Returns false when the point cannot be mapped into the window, when the
+        /// screen list is empty, or when either event cannot be built.
+        ///
+        /// Both events are constructed BEFORE either is posted. Posting a mouse-down
+        /// whose mouse-up never follows leaves the tracking loop waiting for an up
+        /// that cannot arrive, which wedges the main thread exactly as described
+        /// above, so a half-built pair must never be delivered.
+        static func click(atAXPoint axPoint: CGPoint, in window: NSWindow) -> Bool {
+            guard let app = NSApp, let primary = NSScreen.screens.first else { return false }
+            let screenPoint = cocoaScreenPoint(
+                fromAXPoint: axPoint, primaryScreenHeight: primary.frame.height,
+            )
+            // Hit-testing, not the validated identifier, decides what a click lands
+            // on. Refusing points outside the window keeps a stale frame (window
+            // moved or scrolled since the accessibility read) from clicking
+            // something else entirely.
+            guard window.frame.contains(screenPoint) else { return false }
+            // A synthetic click on an inactive app is delivered but not acted on:
+            // measured against the running app, the sidebar selection did not change
+            // and the endpoint still answered `{"pressed":true}`. Making the window
+            // key first is what turns the post into an actual hit-test.
+            if !window.isKeyWindow {
+                app.activate(ignoringOtherApps: true)
+                window.makeKeyAndOrderFront(nil)
+            }
+            let windowPoint = window.convertPoint(fromScreen: screenPoint)
+            guard let down = mouseEvent(.leftMouseDown, at: windowPoint, in: window),
+                  let up = mouseEvent(.leftMouseUp, at: windowPoint, in: window)
+            else { return false }
+            app.postEvent(down, atStart: false)
+            app.postEvent(up, atStart: false)
+            return true
+        }
+
+        private static func mouseEvent(
+            _ type: NSEvent.EventType, at point: CGPoint, in window: NSWindow,
+        ) -> NSEvent? {
+            NSEvent.mouseEvent(
+                with: type,
+                location: point,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 1,
+                pressure: type == .leftMouseDown ? 1 : 0,
+            )
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/MouseInjection.swift
+++ b/app/MeetingTranscriber/Sources/MouseInjection.swift
@@ -44,16 +44,30 @@
         /// whose mouse-up never follows leaves the tracking loop waiting for an up
         /// that cannot arrive, which wedges the main thread exactly as described
         /// above, so a half-built pair must never be delivered.
+        /// Resolve an accessibility point into `window`'s own coordinate space, or
+        /// nil when it falls outside the window.
+        ///
+        /// Split out of `click` because this is the part that can be subtly wrong —
+        /// a bad flip mirrors the click and a stale frame lands it on whatever moved
+        /// into that spot — and it is the only part testable without a running
+        /// `NSApplication`. Hit-testing, not the validated identifier, decides what a
+        /// click actually hits, so refusing out-of-window points is a guard, not a
+        /// convenience.
+        static func windowPoint(
+            forAXPoint axPoint: CGPoint, in window: NSWindow, primaryScreenHeight: CGFloat,
+        ) -> CGPoint? {
+            let screenPoint = cocoaScreenPoint(
+                fromAXPoint: axPoint, primaryScreenHeight: primaryScreenHeight,
+            )
+            guard window.frame.contains(screenPoint) else { return nil }
+            return window.convertPoint(fromScreen: screenPoint)
+        }
+
         static func click(atAXPoint axPoint: CGPoint, in window: NSWindow) -> Bool {
             guard let app = NSApp, let primary = NSScreen.screens.first else { return false }
-            let screenPoint = cocoaScreenPoint(
-                fromAXPoint: axPoint, primaryScreenHeight: primary.frame.height,
-            )
-            // Hit-testing, not the validated identifier, decides what a click lands
-            // on. Refusing points outside the window keeps a stale frame (window
-            // moved or scrolled since the accessibility read) from clicking
-            // something else entirely.
-            guard window.frame.contains(screenPoint) else { return false }
+            guard let windowPoint = windowPoint(
+                forAXPoint: axPoint, in: window, primaryScreenHeight: primary.frame.height,
+            ) else { return false }
             // A synthetic click on an inactive app is delivered but not acted on:
             // measured against the running app, the sidebar selection did not change
             // and the endpoint still answered `{"pressed":true}`. Making the window
@@ -62,7 +76,6 @@
                 app.activate(ignoringOtherApps: true)
                 window.makeKeyAndOrderFront(nil)
             }
-            let windowPoint = window.convertPoint(fromScreen: screenPoint)
             guard let down = mouseEvent(.leftMouseDown, at: windowPoint, in: window),
                   let up = mouseEvent(.leftMouseUp, at: windowPoint, in: window)
             else { return false }

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -60,6 +60,7 @@ struct SpeakersSettingsView: View {
                         TextField("Me", text: $settings.micName)
                             .frame(width: 160)
                             .multilineTextAlignment(.trailing)
+                            .accessibilityIdentifier(A11yID.micNameField)
                     }
                     Text("Your name for dual-source mode. Leave empty to diarize mic track (multi-person room).")
                         .font(.caption)

--- a/app/MeetingTranscriber/Sources/SettingsView.swift
+++ b/app/MeetingTranscriber/Sources/SettingsView.swift
@@ -31,6 +31,7 @@ struct SettingsView: View {
             List(SettingsTab.allCases, selection: $selection) { tab in
                 Label(tab.label, systemImage: tab.systemImage)
                     .tag(tab)
+                    .accessibilityIdentifier(A11yID.settingsTab(tab.rawValue))
             }
             .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 240)
         } detail: {

--- a/app/MeetingTranscriber/Tests/DebugRPCServerUIPressTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUIPressTests.swift
@@ -20,6 +20,7 @@
             var uiChildren: [any UIPressTarget]
             let pressReturns: Bool
             private(set) var pressCallCount = 0
+            private(set) var clickCallCount = 0
 
             init(
                 identifier: String? = nil, enabled: Bool = true,
@@ -35,6 +36,53 @@
                 pressCallCount += 1
                 return pressReturns
             }
+
+            func uiClick() -> Bool {
+                clickCallCount += 1
+                return pressReturns
+            }
+        }
+
+        // MARK: - Actuation selector (`via`)
+
+        /// `"click"` must take the mouse path, not the AX press: the whole point is
+        /// that some controls report a successful press without acting on it.
+        @MainActor
+        func testViaClickUsesTheMousePathInsteadOfTheAXPress() {
+            let target = FakePressTarget(identifier: A11yID.settingsTabSpeakers)
+            let root = FakePressTarget(identifier: "settings", children: [target])
+
+            let outcome = DebugRPCServer.performPress(
+                identifier: A11yID.settingsTabSpeakers, in: root, maxDepth: 10, via: .click,
+            )
+
+            XCTAssertEqual(outcome, .pressed(true))
+            XCTAssertEqual(target.clickCallCount, 1)
+            XCTAssertEqual(target.pressCallCount, 0, "click must not also fire the AX press")
+        }
+
+        /// Omitting `via` keeps the pre-existing AX behaviour.
+        @MainActor
+        func testOmittedViaDefaultsToTheAXPress() {
+            let target = FakePressTarget(identifier: A11yID.recordOnlyToggle)
+            let root = FakePressTarget(identifier: "settings", children: [target])
+
+            _ = DebugRPCServer.performPress(
+                identifier: A11yID.recordOnlyToggle, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(target.pressCallCount, 1)
+            XCTAssertEqual(target.clickCallCount, 0)
+        }
+
+        /// An unknown actuation must fail decoding into the 400 arm rather than
+        /// silently degrading to an AX press and reporting success.
+        @MainActor
+        func testUnknownViaIsRejected() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let body = #"{"identifier":"recordOnlyToggle","via":"tap"}"#
+
+            XCTAssertEqual(server.uiPressResponse(body: Data(body.utf8)).status, 400)
         }
 
         // MARK: - performPress (pure search + dispatch)

--- a/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
@@ -1,4 +1,5 @@
 #if !APPSTORE
+    import AppKit
     @testable import MeetingTranscriber
     import XCTest
 
@@ -171,6 +172,75 @@
             let body = Data(#"{"identifier":"micNameField","text":"x","clear":true}"#.utf8)
 
             XCTAssertTrue(try JSONDecoder().decode(UITypePayload.self, from: body).clear)
+        }
+
+        // MARK: - Routing
+
+        /// `/ui/type` reaches its handler through `routeUI`, so these go through
+        /// `route()` rather than calling the handler directly: the dispatch branch
+        /// is exactly what a duplicate or mis-ordered route would break.
+        private func authed(_ body: String) -> HTTPRequest {
+            HTTPRequest(
+                method: "POST", path: "/ui/type",
+                headers: ["authorization": "Bearer \(Self.testToken)"],
+                body: Data(body.utf8),
+            )
+        }
+
+        @MainActor
+        func testRouteReachesTheTypeHandler() async {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+
+            // 403 proves the request reached the handler's allowlist check; an
+            // unrouted path would 404 instead.
+            let response = await server.route(authed(#"{"identifier":"openAIApiKeyField","text":"x"}"#))
+
+            XCTAssertEqual(response.status, 403)
+        }
+
+        @MainActor
+        func testRouteRejectsMalformedTypeBody() async {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+
+            let response = await server.route(authed("not json"))
+
+            XCTAssertEqual(response.status, 400)
+        }
+
+        /// Text past the cap is refused before any window work. The cap exists so a
+        /// single request cannot occupy the main actor typing tens of thousands of
+        /// characters, which would stall the UI and the server with it.
+        @MainActor
+        func testRouteRejectsOversizedText() async {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let tooLong = String(repeating: "x", count: DebugRPCServer.uiTypeMaxTextLength + 1)
+
+            let response = await server.route(authed(#"{"identifier":"micNameField","text":"\#(tooLong)"}"#))
+
+            XCTAssertEqual(response.status, 400)
+        }
+
+        @MainActor
+        func testTextAtTheCapIsAccepted() async {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+            let atCap = String(repeating: "x", count: DebugRPCServer.uiTypeMaxTextLength)
+
+            let response = await server.route(authed(#"{"identifier":"micNameField","text":"\#(atCap)"}"#))
+
+            // 503: allowed and correctly sized, but this process has no live window.
+            XCTAssertEqual(response.status, 503, "the cap must be inclusive")
+        }
+
+        // MARK: - Headless resolution
+
+        /// Fail closed: with no running application there is no window to focus or
+        /// post into, so resolution yields nothing rather than a half-usable target.
+        @MainActor
+        func testTargetResolutionYieldsNothingWithoutAnApplication() {
+            XCTAssertNil(NSApp, "precondition: xctest has no NSApplication")
+
+            XCTAssertNil(DebugRPCServer.uiTypeTarget(forWindowIdentifier: "settings"))
+            XCTAssertNil(DebugRPCServer.nsWindow(forIdentifier: "settings"))
         }
 
         // MARK: - Payload validation

--- a/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
@@ -1,0 +1,202 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Unit tests for the `POST /ui/type` text-entry endpoint. The pure
+    /// depth-first search / dispatch / payload decode / allowlist / response
+    /// mapping are exercised with an in-memory target; the AppKit half (AX focus
+    /// plus the posted key events actually reaching the field) is covered at the
+    /// mechanism layer by `KeyboardInjectionTests`, mirroring how `/ui/press`
+    /// splits its pure search from the live press.
+    final class DebugRPCServerUITypeTests: XCTestCase {
+        private static let testToken = "testtoken1234"
+
+        /// In-memory `UITypeTarget` recording what it was asked to type, so a test
+        /// can prove the disabled path never types.
+        @MainActor
+        private final class FakeTypeTarget: UITypeTarget {
+            var uiIdentifier: String?
+            var uiEnabled: Bool
+            var uiChildren: [any UITypeTarget]
+            let typeReturns: Bool
+            private(set) var typedText: [String] = []
+            private(set) var clearRequests: [Bool] = []
+
+            init(
+                identifier: String? = nil, enabled: Bool = true,
+                typeReturns: Bool = true, children: [any UITypeTarget] = [],
+            ) {
+                uiIdentifier = identifier
+                uiEnabled = enabled
+                self.typeReturns = typeReturns
+                uiChildren = children
+            }
+
+            func uiType(_ text: String, clear: Bool) -> Bool {
+                typedText.append(text)
+                clearRequests.append(clear)
+                return typeReturns
+            }
+        }
+
+        // MARK: - performType (pure search + dispatch)
+
+        @MainActor
+        func testPerformTypeDeliversTextToEnabledMatch() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField)
+            let root = FakeTypeTarget(identifier: "settings", children: [field])
+
+            let outcome = DebugRPCServer.performType(
+                text: "Speaker A", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .typed(true))
+            XCTAssertEqual(field.typedText, ["Speaker A"], "the matched field must receive the text exactly once")
+        }
+
+        /// A disabled field is never typed into: the endpoint reports the conflict
+        /// instead of silently dropping keystrokes into a control the user could
+        /// not have typed into either.
+        @MainActor
+        func testPerformTypeSkipsDisabledMatch() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField, enabled: false)
+            let root = FakeTypeTarget(identifier: "settings", children: [field])
+
+            let outcome = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .disabled)
+            XCTAssertTrue(field.typedText.isEmpty, "a disabled field must never be typed into")
+        }
+
+        @MainActor
+        func testPerformTypeReportsMissingIdentifier() {
+            let root = FakeTypeTarget(identifier: "settings", children: [FakeTypeTarget(identifier: "other")])
+
+            let outcome = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .notFound)
+        }
+
+        /// The depth cap bounds the walk: a field deeper than `maxDepth` is not
+        /// reached, so a pathological tree cannot hang the handler.
+        @MainActor
+        func testPerformTypeRespectsDepthCap() {
+            let deep = FakeTypeTarget(identifier: A11yID.micNameField)
+            let root = FakeTypeTarget(identifier: "settings", children: [
+                FakeTypeTarget(identifier: "a", children: [FakeTypeTarget(identifier: "b", children: [deep])]),
+            ])
+
+            let outcome = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 1,
+            )
+
+            XCTAssertEqual(outcome, .notFound)
+            XCTAssertTrue(deep.typedText.isEmpty)
+        }
+
+        /// `clear` reaches the field: a driver asserting an exact value needs the
+        /// replace path, otherwise the result depends on the field's prior text.
+        @MainActor
+        func testPerformTypeForwardsClearRequest() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField)
+            let root = FakeTypeTarget(identifier: "settings", children: [field])
+
+            _ = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 10, clear: true,
+            )
+
+            XCTAssertEqual(field.clearRequests, [true])
+        }
+
+        /// Appending is the default, so a bare request never destroys existing text.
+        @MainActor
+        func testPerformTypeDefaultsToAppending() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField)
+            let root = FakeTypeTarget(identifier: "settings", children: [field])
+
+            _ = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(field.clearRequests, [false])
+        }
+
+        // MARK: - Allowlists
+
+        /// The allowlist is the endpoint's real guard: without it any current or
+        /// future field in the window could be written to over HTTP.
+        func testOnlyAllowlistedIdentifiersMayBeTyped() {
+            XCTAssertTrue(DebugRPCServer.isIdentifierAllowedForUIType(A11yID.micNameField))
+            XCTAssertFalse(DebugRPCServer.isIdentifierAllowedForUIType(A11yID.recordOnlyToggle))
+            XCTAssertFalse(DebugRPCServer.isIdentifierAllowedForUIType("openAIApiKeyField"))
+        }
+
+        func testOnlySettingsWindowMayBeTyped() {
+            XCTAssertTrue(DebugRPCServer.isWindowAllowedForUIType(identifier: "settings"))
+            XCTAssertFalse(DebugRPCServer.isWindowAllowedForUIType(identifier: "speaker-naming"))
+        }
+
+        // MARK: - Response mapping
+
+        func testResponseMapsOutcomesToStatusCodes() {
+            XCTAssertEqual(DebugRPCServer.uiTypeResponse(for: UITypeOutcome.notFound).status, 404)
+            XCTAssertEqual(DebugRPCServer.uiTypeResponse(for: UITypeOutcome.disabled).status, 409)
+            XCTAssertEqual(DebugRPCServer.uiTypeResponse(for: UITypeOutcome.typed(true)).status, 200)
+        }
+
+        func testTypedResponseCarriesTheWireShape() throws {
+            let response = DebugRPCServer.uiTypeResponse(for: UITypeOutcome.typed(true))
+            let body = try XCTUnwrap(String(data: response.body, encoding: .utf8))
+            XCTAssertTrue(body.contains("\"typed\":true"), "driver reads {\"typed\":<bool>}; got \(body)")
+        }
+
+        // MARK: - Payload decoding
+
+        /// The hand-rolled decoder must default `clear` to append, so an omitted
+        /// flag never silently replaces a field's contents.
+        func testOmittedClearDecodesAsAppend() throws {
+            let body = Data(#"{"identifier":"micNameField","text":"x"}"#.utf8)
+
+            let payload = try JSONDecoder().decode(UITypePayload.self, from: body)
+
+            XCTAssertFalse(payload.clear)
+            XCTAssertNil(payload.window, "an omitted window falls back to the default at the call site")
+        }
+
+        func testExplicitClearDecodes() throws {
+            let body = Data(#"{"identifier":"micNameField","text":"x","clear":true}"#.utf8)
+
+            XCTAssertTrue(try JSONDecoder().decode(UITypePayload.self, from: body).clear)
+        }
+
+        // MARK: - Payload validation
+
+        @MainActor
+        func testRejectsUndecodableOrEmptyPayloads() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+
+            XCTAssertEqual(server.uiTypeResponse(body: Data("not json".utf8)).status, 400)
+            XCTAssertEqual(
+                server.uiTypeResponse(body: Data(#"{"identifier":"","text":"x"}"#.utf8)).status, 400,
+                "an empty identifier has no target",
+            )
+        }
+
+        /// Off-allowlist requests are rejected before any window lookup, so the
+        /// 403 holds even in the headless test harness where no window exists.
+        @MainActor
+        func testRejectsOffAllowlistRequests() {
+            let server = DebugRPCServer(port: 0, token: Self.testToken) { .empty }
+
+            let body = #"{"identifier":"openAIApiKeyField","text":"secret"}"#
+            XCTAssertEqual(server.uiTypeResponse(body: Data(body.utf8)).status, 403)
+
+            let wrongWindow = #"{"window":"speaker-naming","identifier":"micNameField","text":"x"}"#
+            XCTAssertEqual(server.uiTypeResponse(body: Data(wrongWindow.utf8)).status, 403)
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/KeyboardInjectionTests.swift
+++ b/app/MeetingTranscriber/Tests/KeyboardInjectionTests.swift
@@ -1,0 +1,137 @@
+#if !APPSTORE
+    import AppKit
+    @testable import MeetingTranscriber
+    import SwiftUI
+    import XCTest
+
+    /// Layer-1 cover for the mechanism `POST /ui/type` is built on: posting key
+    /// events through a window's responder chain updates a SwiftUI `TextField`'s
+    /// binding.
+    ///
+    /// This is the load-bearing platform assumption of the endpoint, and it is
+    /// specifically *not* the obvious one: setting the accessibility value
+    /// (`kAXValueAttribute`) does **not** fire the binding, which is why the
+    /// harness exposes no `/ui/setValue`. A posted key event goes through
+    /// `keyDown:` → `insertText:`, which the binding does observe. If a future
+    /// macOS release breaks that, this test goes red with a precise cause rather
+    /// than leaving the endpoint silently inert.
+    @MainActor
+    final class KeyboardInjectionTests: XCTestCase {
+        /// Reference box the SwiftUI binding writes back to, so the test reads the
+        /// typed value without reaching into SwiftUI's private state.
+        private final class Box { var value = "" }
+
+        private struct Probe: View {
+            let box: Box
+            var body: some View {
+                TextField("", text: Binding(get: { box.value }, set: { box.value = $0 }))
+            }
+        }
+
+        /// Pump the run loop until `condition` holds or the deadline passes, so
+        /// the test waits on the state it actually needs instead of a fixed sleep.
+        private func pump(timeout: TimeInterval = 5, until condition: () -> Bool) {
+            let deadline = Date().addingTimeInterval(timeout)
+            while !condition(), Date() < deadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+            }
+        }
+
+        private func firstTextInput(in view: NSView) -> NSView? {
+            if view is NSTextField || view is NSTextView {
+                return view
+            }
+            for sub in view.subviews {
+                if let found = firstTextInput(in: sub) {
+                    return found
+                }
+            }
+            return nil
+        }
+
+        /// Host the probe field in a key window and focus it, mirroring what
+        /// `/ui/type` does via `axFocus` before injecting.
+        private func makeFocusedProbe() throws -> (Box, NSWindow) {
+            let box = Box()
+            let hosting = NSHostingView(rootView: Probe(box: box))
+            hosting.frame = NSRect(x: 0, y: 0, width: 200, height: 30)
+            let window = NSWindow(
+                contentRect: hosting.frame, styleMask: [.titled], backing: .buffered, defer: false,
+            )
+            window.contentView = hosting
+            window.makeKeyAndOrderFront(nil)
+
+            // SwiftUI builds its backing NSView tree on a later run-loop turn.
+            pump { hosting.subviews.isEmpty == false && self.firstTextInput(in: hosting) != nil }
+            let field = try XCTUnwrap(firstTextInput(in: hosting), "SwiftUI TextField never materialised a text view")
+            XCTAssertTrue(window.makeFirstResponder(field), "field must accept first responder before typing")
+            return (box, window)
+        }
+
+        func testPostedKeyEventsUpdateTextFieldBinding() throws {
+            let (box, window) = try makeFocusedProbe()
+
+            KeyboardInjection.type("hi", into: window)
+            pump { box.value == "hi" }
+
+            XCTAssertEqual(box.value, "hi", "posted key events must drive the SwiftUI binding")
+        }
+
+        /// Refocusing a populated field selects its contents, so typing straight
+        /// after a focus change REPLACES them. `/ui/type` calls `axFocus` before
+        /// every injection, so without deliberate caret placement the same request
+        /// would append or replace depending on whether the field happened to be
+        /// focused already. This pins the platform half of that; `moveToEnd` is
+        /// what makes the endpoint deterministic.
+        func testRefocusSelectsContentsSoRawTypingReplaces() throws {
+            let (box, window) = try makeFocusedProbe()
+            KeyboardInjection.type("abc", into: window)
+            pump { box.value == "abc" }
+
+            try refocusField(in: window)
+            KeyboardInjection.type("X", into: window)
+            pump { box.value != "abc" }
+
+            XCTAssertEqual(box.value, "X", "a refocused field starts fully selected")
+        }
+
+        /// The append path: collapsing the selection first keeps existing text.
+        func testMoveToEndAppendsInsteadOfReplacing() throws {
+            let (box, window) = try makeFocusedProbe()
+            KeyboardInjection.type("abc", into: window)
+            pump { box.value == "abc" }
+
+            try refocusField(in: window)
+            XCTAssertTrue(KeyboardInjection.moveToEnd(in: window), "responder must accept moveToEndOfDocument:")
+            KeyboardInjection.type("X", into: window)
+            pump { box.value != "abc" }
+
+            XCTAssertEqual(box.value, "abcX", "collapsing the selection to the end must append")
+        }
+
+        /// Drop and re-take focus, the way a second `/ui/type` request does.
+        private func refocusField(in window: NSWindow) throws {
+            XCTAssertTrue(window.makeFirstResponder(nil))
+            let contentView = try XCTUnwrap(window.contentView)
+            let field = try XCTUnwrap(firstTextInput(in: contentView))
+            XCTAssertTrue(window.makeFirstResponder(field))
+        }
+
+        /// `clear` must genuinely replace. This pins the reason `selectAll` sends a
+        /// responder action instead of posting Cmd-A: a Cmd-A key equivalent needs
+        /// a matching main-menu item, which this window (and the xctest process)
+        /// does not have, so it silently no-ops and the field APPENDS — measured as
+        /// "abcX" before the fix.
+        func testSelectAllReplacesInsteadOfAppending() throws {
+            let (box, window) = try makeFocusedProbe()
+            KeyboardInjection.type("abc", into: window)
+            pump { box.value == "abc" }
+
+            XCTAssertTrue(KeyboardInjection.selectAll(in: window), "responder must accept selectAll:")
+            KeyboardInjection.type("X", into: window)
+            pump { box.value == "X" }
+
+            XCTAssertEqual(box.value, "X", "select-all then typing must replace, not append")
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
+++ b/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
@@ -1,0 +1,32 @@
+#if !APPSTORE
+    import AppKit
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers the coordinate flip `POST /ui/press` with `"via":"click"` depends on:
+    /// accessibility frames are global with a TOP-left origin, `NSEvent` mouse
+    /// locations are global with a BOTTOM-left origin. Getting this wrong sends the
+    /// click to a mirrored position, which looks like "the click did nothing".
+    final class MouseInjectionTests: XCTestCase {
+        @MainActor
+        func testFlipsAccessibilityYIntoCocoaScreenSpace() {
+            let point = MouseInjection.cocoaScreenPoint(
+                fromAXPoint: CGPoint(x: 100, y: 200), primaryScreenHeight: 1000,
+            )
+
+            XCTAssertEqual(point.x, 100, "x is shared by both spaces and must not move")
+            XCTAssertEqual(point.y, 800, "y must be measured from the bottom instead of the top")
+        }
+
+        /// The flip is its own inverse, so a round trip lands back on the original
+        /// point — the property that makes a wrong screen height obvious.
+        @MainActor
+        func testFlipIsSelfInverse() {
+            let original = CGPoint(x: 42, y: 137)
+            let once = MouseInjection.cocoaScreenPoint(fromAXPoint: original, primaryScreenHeight: 900)
+            let twice = MouseInjection.cocoaScreenPoint(fromAXPoint: once, primaryScreenHeight: 900)
+
+            XCTAssertEqual(twice.y, original.y)
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
+++ b/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
@@ -18,6 +18,58 @@
             XCTAssertEqual(point.y, 800, "y must be measured from the bottom instead of the top")
         }
 
+        // MARK: - windowPoint (the decision `click` delegates to)
+
+        /// A window at a known frame: AX y is measured from the screen top, the
+        /// window frame from the bottom, so this pins the whole chain rather than
+        /// the arithmetic alone.
+        @MainActor
+        private func makeWindow(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat) -> NSWindow {
+            NSWindow(
+                contentRect: NSRect(x: x, y: y, width: width, height: height),
+                styleMask: [.titled], backing: .buffered, defer: true,
+            )
+        }
+
+        @MainActor
+        func testResolvesAnAXPointInsideTheWindow() throws {
+            // Screen 1000 tall; window occupies Cocoa y 400...600, i.e. AX y 400...600.
+            let window = makeWindow(x: 100, y: 400, width: 200, height: 200)
+
+            let point = try XCTUnwrap(MouseInjection.windowPoint(
+                forAXPoint: CGPoint(x: 150, y: 500), in: window, primaryScreenHeight: 1000,
+            ))
+
+            // AX y 500 -> Cocoa y 500 -> 100 above the window's bottom edge.
+            XCTAssertEqual(point.x, 50, "x is window-relative")
+            XCTAssertEqual(point.y, 100, "y is measured from the window's bottom edge")
+        }
+
+        /// The guard that matters: a point outside the window is refused rather than
+        /// clicked. Without it a stale accessibility frame — the window moved or the
+        /// sidebar scrolled since the read — would click whatever now sits there.
+        @MainActor
+        func testRefusesAnAXPointOutsideTheWindow() {
+            let window = makeWindow(x: 100, y: 400, width: 200, height: 200)
+
+            XCTAssertNil(MouseInjection.windowPoint(
+                forAXPoint: CGPoint(x: 150, y: 900), in: window, primaryScreenHeight: 1000,
+            ), "a point below the window must not resolve")
+            XCTAssertNil(MouseInjection.windowPoint(
+                forAXPoint: CGPoint(x: 900, y: 500), in: window, primaryScreenHeight: 1000,
+            ), "a point right of the window must not resolve")
+        }
+
+        /// Fail closed: with no running application there is nothing to post to, so
+        /// the caller is told the click did not happen instead of assuming it did.
+        @MainActor
+        func testClickReportsFailureWithoutAnApplication() {
+            XCTAssertNil(NSApp, "precondition: xctest has no NSApplication")
+            let window = makeWindow(x: 0, y: 0, width: 100, height: 100)
+
+            XCTAssertFalse(MouseInjection.click(atAXPoint: CGPoint(x: 10, y: 10), in: window))
+        }
+
         /// The flip is its own inverse, so a round trip lands back on the original
         /// point — the property that makes a wrong screen height obvious.
         @MainActor

--- a/scripts/e2e-settings-smoke.sh
+++ b/scripts/e2e-settings-smoke.sh
@@ -129,5 +129,58 @@ done
 ok "recordOnly flipped $before -> $after"
 if press; then ok "restored"; else echo "    (restore press failed — harmless on the ephemeral runner)"; fi
 
+step "POST /ui/press via=click selects a sidebar row (the AX press cannot)"
+field_in_tree() {
+    curl -sf --max-time 15 "${AUTH[@]}" "$BASE/ui/tree?window=settings" | grep -c micNameField || true
+}
+# SwiftUI renders only the selected tab, so the Speakers field is absent until the
+# row is selected. That absence is the assertion: it proves the click did something
+# an AX press provably cannot, rather than trusting the returned flag.
+[ "$(field_in_tree)" = "0" ] \
+    || fail "micNameField already in the tree before switching tabs — cannot prove the click did it"
+curl -sf --max-time 15 "${AUTH[@]}" -X POST "$BASE/ui/press" \
+    -H 'Content-Type: application/json' \
+    -d '{"window":"settings","identifier":"settings-tab-speakers","via":"click"}' -o /dev/null \
+    || fail "ui/press via=click failed"
+present=0
+for _ in $(seq 1 8); do
+    present=$(field_in_tree)
+    [ "$present" != "0" ] && break
+    sleep 1
+done
+[ "$present" != "0" ] \
+    || fail "Speakers tab did not become selected => synthetic click did not hit-test on this runner"
+ok "click switched tabs (micNameField now in the tree)"
+
+step "POST /ui/type writes through to AppSettings"
+read_mic_name() {
+    curl -sf --max-time 15 "${AUTH[@]}" "$BASE/state" \
+        | python3 -c "import json,sys; print(json.load(sys.stdin)['settings']['recording']['micName'])"
+}
+original_mic=$(read_mic_name) || fail "could not read micName"
+probe="UiTypeSmoke"
+curl -sf --max-time 15 "${AUTH[@]}" -X POST "$BASE/ui/type" \
+    -H 'Content-Type: application/json' \
+    -d "{\"identifier\":\"micNameField\",\"text\":\"$probe\",\"clear\":true}" -o /dev/null \
+    || fail "ui/type failed"
+typed=""
+for _ in $(seq 1 8); do
+    typed=$(read_mic_name) || fail "could not read micName after typing"
+    [ "$typed" = "$probe" ] && break
+    sleep 1
+done
+# Exact match, not "contains": clear must replace, and a partial match would hide
+# the append-vs-replace ambiguity this endpoint exists to remove.
+[ "$typed" = "$probe" ] \
+    || fail "micName is '$typed', expected '$probe' => posted key events did not drive the SwiftUI binding"
+ok "micName written via posted key events: '$typed'"
+
+# Restore so a re-run starts from the same state as a fresh runner.
+curl -sf --max-time 15 "${AUTH[@]}" -X POST "$BASE/ui/type" \
+    -H 'Content-Type: application/json' \
+    -d "{\"identifier\":\"micNameField\",\"text\":\"$original_mic\",\"clear\":true}" -o /dev/null \
+    && ok "restored micName to '$original_mic'" \
+    || echo "    (restore failed — harmless on the ephemeral runner)"
+
 echo
 echo "UI-SMOKE PASSED — self-pid /ui/* harness works on this runner"


### PR DESCRIPTION
## Summary

Closes one of the GUI acceptances listed as **manual-QA-only**: typing into fields.

The guidance treats typing as un-automatable because setting the accessibility value does not fire a SwiftUI binding (hence no `/ui/setValue`). That holds only for the **AX value attribute**. A posted **key event** travels the real `keyDown:` → `insertText:` responder chain, which the binding does observe.

Two capabilities, one per commit:

1. **`/ui/press` gains `"via":"click"`** — posts a real mouse click at the element's frame. Needed because SwiftUI renders only the selected Settings tab, so controls outside General are absent from the accessibility tree until their sidebar row is selected, and the AX press does not select those rows.
2. **`POST /ui/type`** — locates a field by identifier in the app's own self-pid AX tree, focuses it via the new `axFocus`, and fills it with posted key events.

Both are in-process, so no Accessibility/PostEvent TCC grant is required.

## Verified end to end against the running app

| Step | Result |
|---|---|
| `POST /ui/press {"identifier":"settings-tab-speakers","via":"click"}` | Speakers tab selected; `micNameField` appears in `/ui/tree` (was absent) |
| `POST /ui/type {"identifier":"micNameField","text":"Speaker B","clear":true}` | `{"typed":true}` |
| `GET /state` | `settings.recording.micName == "Speaker B"` |

Non-vacuous: typing a second value changed the result rather than leaving it, and the assertion reads the real `AppSettings` write-back, not a UI-local echo.

## Findings worth keeping (all observed, not theorised)

- **The AX press flag can lie.** Pressing a `List(selection:)` row returns `{"pressed":true}` and changes nothing. A concrete instance of the existing rule "assert the `/state` effect, never the returned flag".
- **Queue, not direct delivery.** A mouse-down on a row-tracking control enters a modal tracking loop that pulls the matching mouse-up off the event queue. `NSWindow.sendEvent` bypasses the queue, so the loop waits forever and wedges the main thread, taking the RPC server with it. `NSApplication.postEvent` is what works.
- **Coordinate spaces differ.** AX frames are global top-left-origin; `NSEvent` locations are global bottom-left-origin. The flip is pure and unit-tested; getting it wrong just looks like "the click did nothing".

## Guards

The `/ui/type` identifier allowlist admits exactly one plain field, deliberately tighter than `/ui/press`: text entry writes caller-chosen content into a persisted setting, so an unguarded endpoint would let a token-holder rewrite an endpoint URL or an output path. Documented invariant: never allowlist a secure field.

## Verification

Full suite (2324 tests) green, `swiftlint analyze --strict` 0 violations across 344 files, release-mode parity check passed, lint clean.