### PR TITLE
fix(app): guard what /ui/type types into and which window /ui/* posts to

### DIFF
--- a/app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+AXElement.swift
@@ -82,13 +82,30 @@
             AXUIElementPerformAction(element, kAXPressAction as CFString) == .success
         }
 
-        /// The app's `NSWindow` carrying the given identifier, or nil when none is
-        /// open (and always in the xctest process, where `NSApp` itself is nil).
-        /// Sits beside `axWindowElement` because the two are resolved together
-        /// whenever an endpoint needs to post events into a window rather than only
-        /// read its accessibility tree.
+        /// The app's on-screen `NSWindow` carrying the given identifier, or nil when
+        /// no visible one matches (and always in the xctest process, where `NSApp`
+        /// itself is nil). See `visibleWindow` for why visibility decides.
         static func nsWindow(forIdentifier identifier: String) -> NSWindow? {
-            NSApp?.windows.first { $0.identifier?.rawValue == identifier }
+            visibleWindow(identifier: identifier, among: NSApp?.windows ?? [])
+        }
+
+        /// The on-screen window carrying `identifier`, or nil when every match is
+        /// off-screen. Pure over the window list so it is testable without a running
+        /// application.
+        ///
+        /// Visibility is the identity signal that matters here: the accessibility
+        /// tree lists only on-screen windows, but `NSApp.windows` keeps closed ones,
+        /// so a plain first-match can pair a live AX element with a dead `NSWindow`
+        /// — focus lands on the real field, the events go nowhere, and the endpoint
+        /// still reports that it dispatched them.
+        static func visibleWindow(identifier: String, among windows: [NSWindow]) -> NSWindow? {
+            windows.first { $0.identifier?.rawValue == identifier && $0.isVisible }
+        }
+
+        /// Accessibility subrole, which distinguishes a secure text field from a
+        /// plain one (both report the `AXTextField` role).
+        static func axSubrole(_ element: AXUIElement) -> String? {
+            AXHelper.getAttribute(element, attribute: kAXSubroleAttribute as String) as? String
         }
 
         /// Make the element the focused (first-responder) control. Returns whether

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UIPress.swift
@@ -142,7 +142,9 @@
         /// window resolution; only the adapter differs.
         /// The `NSWindow` is resolved alongside the AX root so a `"click"` press has
         /// somewhere to post its mouse events. It stays optional on purpose: an AX
-        /// press works without it, so a missing window only disables clicking.
+        /// press works without it, so a missing window only disables clicking — and
+        /// "missing" now includes an identifier match that is merely off-screen,
+        /// since `nsWindow` resolves only visible windows.
         static func uiPressTarget(forWindowIdentifier identifier: String) -> (any UIPressTarget)? {
             guard let element = axWindowElement(forIdentifier: identifier) else { return nil }
             let window = nsWindow(forIdentifier: identifier)

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+UIType.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+UIType.swift
@@ -49,6 +49,8 @@
     /// record the *text* it received.
     @MainActor
     protocol UITypeTarget {
+        var uiRole: String? { get }
+        var uiSubrole: String? { get }
         var uiIdentifier: String? { get }
         var uiEnabled: Bool { get }
         var uiChildren: [any UITypeTarget] { get }
@@ -115,7 +117,7 @@
             text: String, identifier: String, in root: any UITypeTarget, maxDepth: Int,
             clear: Bool = false,
         ) -> UITypeOutcome {
-            if root.uiIdentifier == identifier {
+            if root.uiIdentifier == identifier, isTypable(root) {
                 guard root.uiEnabled else { return .disabled }
                 return .typed(root.uiType(text, clear: clear))
             }
@@ -130,6 +132,24 @@
                 }
             }
             return .notFound
+        }
+
+        /// Whether an element may receive posted keystrokes at all.
+        ///
+        /// The identifier alone must not decide: SwiftUI propagates
+        /// `.accessibilityIdentifier` to descendants when applied to a container, so
+        /// a label or group can end up carrying a field's identifier — typing into
+        /// that is at best a no-op and at worst lands in the wrong control. Checked
+        /// inside the match arm rather than before the walk, so a non-typable
+        /// carrier is skipped and the real field beneath it is still reached. A
+        /// non-matching element is therefore absent, not a conflict.
+        ///
+        /// The subrole check is what makes the "never a secure field" invariant
+        /// structural instead of a comment: a `SecureField` reports the same
+        /// `AXTextField` role as a plain one and is told apart only by its subrole.
+        static func isTypable(_ element: any UITypeTarget) -> Bool {
+            element.uiRole == kAXTextFieldRole as String
+                && element.uiSubrole != kAXSecureTextFieldSubrole as String
         }
 
         /// Resolve the accessibility root *and* the `NSWindow` for an allowed,
@@ -194,6 +214,14 @@
     private struct AXTypeSource: UITypeTarget {
         let element: AXUIElement
         let window: NSWindow
+
+        var uiRole: String? {
+            DebugRPCServer.axRole(element)
+        }
+
+        var uiSubrole: String? {
+            DebugRPCServer.axSubrole(element)
+        }
 
         var uiIdentifier: String? {
             DebugRPCServer.axIdentifier(element)

--- a/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
@@ -16,6 +16,8 @@
         /// can prove the disabled path never types.
         @MainActor
         private final class FakeTypeTarget: UITypeTarget {
+            var uiRole: String?
+            var uiSubrole: String?
             var uiIdentifier: String?
             var uiEnabled: Bool
             var uiChildren: [any UITypeTarget]
@@ -26,7 +28,10 @@
             init(
                 identifier: String? = nil, enabled: Bool = true,
                 typeReturns: Bool = true, children: [any UITypeTarget] = [],
+                role: String? = kAXTextFieldRole as String, subrole: String? = nil,
             ) {
+                uiRole = role
+                uiSubrole = subrole
                 uiIdentifier = identifier
                 uiEnabled = enabled
                 self.typeReturns = typeReturns
@@ -124,6 +129,77 @@
             )
 
             XCTAssertEqual(field.clearRequests, [false])
+        }
+
+        // MARK: - Role guard
+
+        /// Pins WHERE the check happens, not just that it happens: the carrier is
+        /// skipped and the real field beneath it still receives the text. A check
+        /// placed before the walk, or in the adapter, would abort on the carrier and
+        /// never reach the field — this is the SwiftUI identifier-propagation case
+        /// the guard exists for, so it is the behaviour worth pinning.
+        @MainActor
+        func testSkipsAnIdentifierCarryingContainerAndTypesIntoTheFieldBeneathIt() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField)
+            let carrier = FakeTypeTarget(
+                identifier: A11yID.micNameField, children: [field], role: kAXGroupRole as String,
+            )
+            let root = FakeTypeTarget(identifier: "settings", children: [carrier])
+
+            let outcome = DebugRPCServer.performType(
+                text: "Speaker A", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .typed(true))
+            XCTAssertEqual(field.typedText, ["Speaker A"], "the field beneath the carrier must receive it")
+            XCTAssertTrue(carrier.typedText.isEmpty, "the carrier itself must never be typed into")
+        }
+
+        @MainActor
+        func testRefusesAnElementThatIsNotATextField() {
+            let label = FakeTypeTarget(identifier: A11yID.micNameField, role: kAXStaticTextRole as String)
+            let root = FakeTypeTarget(identifier: "settings", children: [label])
+
+            let outcome = DebugRPCServer.performType(
+                text: "x", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .notFound, "an identifier match on a non-field must not type")
+            XCTAssertTrue(label.typedText.isEmpty)
+        }
+
+        /// Structural enforcement of the "never a secure field" invariant, which
+        /// until now lived only in a comment. A `SecureField` exposes as
+        /// `AXTextField` with the `AXSecureTextField` subrole, so the role check
+        /// alone would happily accept it.
+        @MainActor
+        func testRefusesASecureTextField() {
+            let secure = FakeTypeTarget(
+                identifier: A11yID.micNameField,
+                role: kAXTextFieldRole as String, subrole: "AXSecureTextField",
+            )
+            let root = FakeTypeTarget(identifier: "settings", children: [secure])
+
+            let outcome = DebugRPCServer.performType(
+                text: "hunter2", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .notFound, "a secure field must never receive posted keystrokes")
+            XCTAssertTrue(secure.typedText.isEmpty)
+        }
+
+        /// The guard must not reject the real target.
+        @MainActor
+        func testAcceptsAPlainTextField() {
+            let field = FakeTypeTarget(identifier: A11yID.micNameField)
+            let root = FakeTypeTarget(identifier: "settings", children: [field])
+
+            let outcome = DebugRPCServer.performType(
+                text: "ok", identifier: A11yID.micNameField, in: root, maxDepth: 10,
+            )
+
+            XCTAssertEqual(outcome, .typed(true))
+            XCTAssertEqual(field.typedText, ["ok"])
         }
 
         // MARK: - Allowlists

--- a/app/MeetingTranscriber/Tests/DebugRPCServerWindowResolutionTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerWindowResolutionTests.swift
@@ -1,0 +1,47 @@
+#if !APPSTORE
+    import AppKit
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// Covers which `NSWindow` the `/ui/*` endpoints post events into.
+    ///
+    /// The accessibility tree lists only on-screen windows, but `NSApp.windows`
+    /// keeps closed ones. Picking the first identifier match can therefore hand out
+    /// a dead window while `axFocus` acted on the live one: focus moves, the events
+    /// go nowhere, and the endpoint still reports that it dispatched them.
+    @MainActor
+    final class DebugRPCServerWindowResolutionTests: XCTestCase {
+        private func makeWindow(id: String, visible: Bool) -> NSWindow {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 120, height: 80),
+                styleMask: [.titled], backing: .buffered, defer: true,
+            )
+            window.identifier = NSUserInterfaceItemIdentifier(id)
+            if visible {
+                window.orderFront(nil)
+            }
+            return window
+        }
+
+        func testPrefersTheVisibleWindowOverAClosedOneWithTheSameIdentifier() {
+            let closed = makeWindow(id: "settings", visible: false)
+            let live = makeWindow(id: "settings", visible: true)
+
+            let resolved = DebugRPCServer.visibleWindow(identifier: "settings", among: [closed, live])
+
+            XCTAssertIdentical(resolved, live, "must resolve the on-screen window, not the lingering one")
+        }
+
+        func testYieldsNothingWhenEveryMatchIsOffScreen() {
+            let closed = makeWindow(id: "settings", visible: false)
+
+            XCTAssertNil(DebugRPCServer.visibleWindow(identifier: "settings", among: [closed]))
+        }
+
+        func testIgnoresOtherIdentifiers() {
+            let other = makeWindow(id: "speaker-naming", visible: true)
+
+            XCTAssertNil(DebugRPCServer.visibleWindow(identifier: "settings", among: [other]))
+        }
+    }
+#endif


### PR DESCRIPTION
The two follow-ups the `/ui/type` review left open. Both close a gap where the endpoint would report success while doing the wrong thing.

## The identifier alone decided what got typed into

SwiftUI propagates `.accessibilityIdentifier` to descendants when it is applied to a container, so a label or a group can end up carrying a field's identifier. Keystrokes went to whichever element carried it first.

Now the accessibility **role** must be a text field and the **subrole** must not be a secure one. The subrole half is the point: a `SecureField` reports the same `AXTextField` role as a plain one and is told apart only by its subrole, so the role check alone would have accepted it. The "never allowlist a SecureField" invariant stops being a comment and becomes something the code enforces.

**Where the check sits is load-bearing.** It is inside the match arm, not before the walk, so a carrier that inherited the identifier is skipped and the real field beneath it is still found. A test pins exactly that: moving the check to a pre-filter turns it red (verified, not assumed).

## The window could be a dead one

`NSApp.windows` retains closed windows; the accessibility tree lists only on-screen ones. A first-identifier-match could pair a live accessibility element with a dead `NSWindow` — focus lands on the real field, the events go nowhere, and the endpoint still reports it dispatched them.

Resolution now prefers the visible match, as a pure function over a window list so it is testable without a running application. `/ui/press` shares that resolution, so an off-screen match now reports it did not click rather than posting into a dead window.

## Notes

- `uiRole`/`uiSubrole` join the target protocol rather than collapsing into one `uiIsTypable`, which would push the decision into the accessibility adapter — reachable only through a live element, so the secure-field test would degrade into asserting a flag it set itself.
- A review caught that `kAXSecureTextFieldSubrole` exists in the SDK; an earlier draft hard-coded the literal with a comment claiming it did not. Verified in `AXRoleConstants.h` and corrected.

## Verification

Full suite green, SwiftLint `--strict` 0 violations, SwiftFormat at CI's pinned 0.61.1 clean, release-mode parity passed, and the placement test proven non-vacuous by deliberately mis-placing the check.