### PR TITLE
fix(ci): keep the soak's meeting alive for the whole sampling window

### DIFF
--- a/scripts/e2e-soak.sh
+++ b/scripts/e2e-soak.sh
@@ -239,8 +239,14 @@ sleep "$SETTLE_TIMEOUT_S"
 # the meeting window open for the full duration without an hour of sound coming
 # out of the runner. The soak measures the resident process, not transcription
 # quality, so silence costs nothing here.
-log "Starting meeting-simulator for ${SOAK_MINUTES} minutes"
-"$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" --silent --duration "$((SOAK_MINUTES * 60))" >/dev/null 2>&1 &
+# `--minutes` means minutes of MEASURED soak, so the meeting has to outlast the
+# ramp settle too. Without that the sampling window runs past the meeting's end
+# and the closing samples measure an idle app: the footprint drops once
+# recording stops, which drags the fitted slope down and can mask the very leak
+# this lane exists to find.
+MEETING_SECONDS=$((RECORDING_SETTLE_S + SOAK_MINUTES * 60))
+log "Starting meeting-simulator for ${MEETING_SECONDS}s (${SOAK_MINUTES}min measured + ${RECORDING_SETTLE_S}s ramp)"
+"$SIMULATOR_BIN" "$SIMULATOR_FIXTURE" --silent --duration "$MEETING_SECONDS" >/dev/null 2>&1 &
 SIM_PID=$!
 
 _is_recording() {


### PR DESCRIPTION
The soak lane's meeting ran for `--minutes`, but sampling only starts after the ramp settle — so the measuring window overran the meeting's end by exactly that settle, and the closing samples measured an **idle** app.

Not cosmetic: the footprint moves when recording stops, so a late sample drags the fitted slope whichever way teardown happens to push memory.

**Measured, not theorised.** The first validation run on the runner produced 51, 51, 51, **179** MB — flat for the entire recording, then one sample that landed during WAV finalisation, fitting to **1152 MB/hour** and tripping the catastrophe bound on a healthy app.

The same run also settled the lane's open question: `Recording landed after the soak: capture survived the full session` — the closing assertion works, so record-only and the corrected recordings path are both confirmed.

## On how this slipped through

This fix was supposed to ship with the lane. The earlier attempt was a text replacement whose pattern did not match the file, so it silently did nothing — and `bash -n` cannot see a no-op edit. This one asserts the target exists before replacing, and asserts the result is present afterwards.