### PR TITLE
fix(app)!: make the browser-consent prompt survive Focus modes (new bundle identifier, #543)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__/
 docs/plans/.local/
 scripts/fixtures/node_modules/
 scripts/fixtures/package-lock.json
+
+# Developer ID provisioning profiles (account artifacts, like the signing cert)
+signing/

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -165,7 +165,7 @@ final class AppSettings {
 
     /// PoC: when on, mic-channel audio is also fed to a live `StreamingTranscriber`
     /// during recording. Partial / finalised captions are logged via os_log on
-    /// subsystem `com.meetingtranscriber.app`, category `LiveTranscription` — no
+    /// subsystem `com.meetingtranscriber`, category `LiveTranscription` — no
     /// caption-bar UI yet. Only effective when the active engine is Parakeet;
     /// other engines silently no-op. Default: off.
     var liveTranscriptionEnabled: Bool {

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -174,7 +174,13 @@ final class AppState {
     // function reference instead of re-solving the dependency's init.
 
     private static func makeDefaultSettings() -> AppSettings {
-        AppSettings()
+        // Runs before the first read of `.standard`: the bundle identifier
+        // changed, UserDefaults is scoped per identifier, and an existing
+        // user's settings sit in the old domain until this copies them across.
+        // This is the only production construction of `AppSettings` — tests
+        // inject their own, so none of them touch the real domains.
+        LegacyDefaultsMigration.run(into: .standard)
+        return AppSettings()
     }
 
     private static func makeUpdateChecker() -> UpdateChecker {

--- a/app/MeetingTranscriber/Sources/Bundle+AppVersion.swift
+++ b/app/MeetingTranscriber/Sources/Bundle+AppVersion.swift
@@ -13,4 +13,15 @@ extension Bundle {
     var gitCommitHash: String {
         infoDictionary?["GitCommitHash"] as? String ?? "dev"
     }
+
+    /// The bundle identifier, or `"?"` outside an app bundle (`swift test`).
+    ///
+    /// Surfaced in Settings → Advanced → About because the identifier decides
+    /// which settings domain, TCC grants and notification registration the
+    /// running app actually uses — so "which build am I looking at" is not
+    /// answerable from the version alone, and a release/dev mix-up otherwise
+    /// only shows up as permissions or preferences inexplicably missing.
+    var bundleID: String {
+        bundleIdentifier ?? "?"
+    }
 }

--- a/app/MeetingTranscriber/Sources/Info.plist
+++ b/app/MeetingTranscriber/Sources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>com.meetingtranscriber.app</string>
+    <string>app.meetingtranscriber</string>
     <key>CFBundleName</key>
     <string>Meeting Transcriber</string>
     <key>CFBundleDisplayName</key>

--- a/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
+++ b/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
@@ -17,8 +17,23 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LegacyD
 /// identifier's preferences. That variant has no installed base under the old
 /// identifier, so there is nothing to carry over.
 enum LegacyDefaultsMigration {
-    /// The identifier the app shipped under until the rename.
-    static let defaultLegacyDomain = "com.meetingtranscriber.app"
+    /// What each current identifier was called before the rename.
+    ///
+    /// A table rather than one constant, because the release and dev builds
+    /// each have their own history: pointing both at the release domain made
+    /// the dev build inherit the release user's settings on first launch, which
+    /// is exactly the separation the dev identity exists to keep.
+    private static let legacyDomains = [
+        "app.meetingtranscriber": "com.meetingtranscriber.app",
+        "app.meetingtranscriber.dev": "com.meetingtranscriber.dev",
+    ]
+
+    /// The pre-rename domain for a current identifier, or nil when there is
+    /// none. Unknown identifiers get nothing: guessing a domain for one could
+    /// only import settings that were never ours.
+    static func legacyDomain(for bundleID: String) -> String? {
+        legacyDomains[bundleID]
+    }
 
     /// Set once the copy has run, so a later launch never re-applies it.
     static let markerKey = "migratedFromLegacyBundleIdentifier"
@@ -60,11 +75,20 @@ enum LegacyDefaultsMigration {
         return dict
     }
 
-    /// Reads the legacy domain, applies `plan`, and records that it ran. Marks
-    /// itself done even when there was nothing to copy, so the fresh-install
-    /// case stops re-reading a domain that will never appear.
-    static func run(into defaults: UserDefaults, legacyDomain: String = defaultLegacyDomain) {
+    /// Reads the legacy domain belonging to the running identifier, applies
+    /// `plan`, and records that it ran. Marks itself done even when there was
+    /// nothing to copy, so the fresh-install case stops re-reading a domain
+    /// that will never appear.
+    ///
+    /// `legacyDomain` is resolved from the running bundle identifier, so the
+    /// dev build reads the old dev domain rather than the release user's.
+    /// Tests pass it explicitly; outside an app bundle there is no identifier
+    /// and nothing to migrate.
+    static func run(into defaults: UserDefaults, legacyDomain: String? = nil) {
         guard !defaults.bool(forKey: markerKey) else { return }
+        guard let legacyDomain = legacyDomain
+            ?? Bundle.main.bundleIdentifier.flatMap(self.legacyDomain(for:))
+        else { return }
 
         let legacy = mergedLegacy(
             standard: defaults.persistentDomain(forName: legacyDomain) ?? [:],

--- a/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
+++ b/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
@@ -1,0 +1,61 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LegacyDefaultsMigration")
+
+/// One-shot carry-over of the user's settings from the pre-rename bundle
+/// identifier. UserDefaults is scoped per identifier, so the move to
+/// `app.meetingtranscriber` would otherwise reset every preference on update.
+///
+/// Copies the legacy *persistent domain* wholesale rather than an explicit key
+/// list: `AppSettings` reads ~50 keys as string literals spread through its
+/// initialiser, so a curated list would silently drift out of date and drop
+/// exactly the settings nobody remembered to add. The persistent domain is the
+/// old app's own plist — global and system-wide domains are not part of it.
+///
+/// Does nothing in the sandboxed App Store build, which cannot read another
+/// identifier's preferences. That variant has no installed base under the old
+/// identifier, so there is nothing to carry over.
+enum LegacyDefaultsMigration {
+    /// The identifier the app shipped under until the rename.
+    static let defaultLegacyDomain = "com.meetingtranscriber.app"
+
+    /// Set once the copy has run, so a later launch never re-applies it.
+    static let markerKey = "migratedFromLegacyBundleIdentifier"
+
+    /// Which key/value pairs to write into the current domain.
+    ///
+    /// - A key already present under the new identifier is the user's newer
+    ///   intent and is left alone.
+    /// - Runs exactly once: after that, a value the user reset back to its
+    ///   default must not be resurrected from the legacy plist.
+    static func plan(
+        legacy: [String: Any],
+        existing: Set<String>,
+        alreadyMigrated: Bool,
+    ) -> [String: Any] {
+        guard !alreadyMigrated else { return [:] }
+        return legacy.filter { key, _ in
+            key != markerKey && !existing.contains(key)
+        }
+    }
+
+    /// Reads the legacy domain, applies `plan`, and records that it ran. Marks
+    /// itself done even when there was nothing to copy, so the fresh-install
+    /// case stops re-reading a domain that will never appear.
+    static func run(into defaults: UserDefaults, legacyDomain: String = defaultLegacyDomain) {
+        guard !defaults.bool(forKey: markerKey) else { return }
+
+        let legacy = defaults.persistentDomain(forName: legacyDomain) ?? [:]
+        let existing = Set(legacy.keys.filter { defaults.object(forKey: $0) != nil })
+        let pending = plan(legacy: legacy, existing: existing, alreadyMigrated: false)
+
+        for (key, value) in pending {
+            defaults.set(value, forKey: key)
+        }
+        defaults.set(true, forKey: markerKey)
+        if !pending.isEmpty {
+            logger.info("Carried \(pending.count, privacy: .public) settings over from the previous bundle identifier")
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
+++ b/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
@@ -23,19 +23,13 @@ enum LegacyDefaultsMigration {
     /// Set once the copy has run, so a later launch never re-applies it.
     static let markerKey = "migratedFromLegacyBundleIdentifier"
 
-    /// Which key/value pairs to write into the current domain.
+    /// Which key/value pairs to write into the current domain: everything from
+    /// the legacy domain except the marker and except keys already set under the
+    /// new identifier, which are the user's newer intent.
     ///
-    /// - A key already present under the new identifier is the user's newer
-    ///   intent and is left alone.
-    /// - Runs exactly once: after that, a value the user reset back to its
-    ///   default must not be resurrected from the legacy plist.
-    static func plan(
-        legacy: [String: Any],
-        existing: Set<String>,
-        alreadyMigrated: Bool,
-    ) -> [String: Any] {
-        guard !alreadyMigrated else { return [:] }
-        return legacy.filter { key, _ in
+    /// Running at most once is `run`'s concern, not this function's.
+    static func plan(legacy: [String: Any], existing: Set<String>) -> [String: Any] {
+        legacy.filter { key, _ in
             key != markerKey && !existing.contains(key)
         }
     }
@@ -48,7 +42,7 @@ enum LegacyDefaultsMigration {
 
         let legacy = defaults.persistentDomain(forName: legacyDomain) ?? [:]
         let existing = Set(legacy.keys.filter { defaults.object(forKey: $0) != nil })
-        let pending = plan(legacy: legacy, existing: existing, alreadyMigrated: false)
+        let pending = plan(legacy: legacy, existing: existing)
 
         for (key, value) in pending {
             defaults.set(value, forKey: key)

--- a/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
+++ b/app/MeetingTranscriber/Sources/LegacyDefaultsMigration.swift
@@ -7,8 +7,8 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LegacyD
 /// identifier. UserDefaults is scoped per identifier, so the move to
 /// `app.meetingtranscriber` would otherwise reset every preference on update.
 ///
-/// Copies the legacy *persistent domain* wholesale rather than an explicit key
-/// list: `AppSettings` reads ~50 keys as string literals spread through its
+/// Copies the legacy domain wholesale rather than an explicit key list:
+/// `AppSettings` reads ~50 keys as string literals spread through its
 /// initialiser, so a curated list would silently drift out of date and drop
 /// exactly the settings nobody remembered to add. The persistent domain is the
 /// old app's own plist — global and system-wide domains are not part of it.
@@ -34,13 +34,42 @@ enum LegacyDefaultsMigration {
         }
     }
 
+    /// The two places a bundle identifier's preferences can physically live,
+    /// merged into what the old app actually read.
+    ///
+    /// If a container exists for an identifier, macOS redirects that app's
+    /// UserDefaults access into it — including for a binary that is not
+    /// sandboxed, which is why `defaults read` on the standard domain can
+    /// disagree with what the app sees. The container therefore wins where both
+    /// define a key. Normal installs have no container and only pass `standard`.
+    static func mergedLegacy(standard: [String: Any], container: [String: Any]) -> [String: Any] {
+        standard.merging(container) { _, fromContainer in fromContainer }
+    }
+
+    /// The container preferences for a bundle identifier, empty when it has no
+    /// container — the normal case, and indistinguishable here from a container
+    /// we cannot read (the sandboxed build): both mean "nothing to merge".
+    static func containerDefaults(for bundleID: String) -> [String: Any] {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Containers/\(bundleID)")
+            .appendingPathComponent("Data/Library/Preferences/\(bundleID).plist")
+        guard let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let dict = plist as? [String: Any]
+        else { return [:] }
+        return dict
+    }
+
     /// Reads the legacy domain, applies `plan`, and records that it ran. Marks
     /// itself done even when there was nothing to copy, so the fresh-install
     /// case stops re-reading a domain that will never appear.
     static func run(into defaults: UserDefaults, legacyDomain: String = defaultLegacyDomain) {
         guard !defaults.bool(forKey: markerKey) else { return }
 
-        let legacy = defaults.persistentDomain(forName: legacyDomain) ?? [:]
+        let legacy = mergedLegacy(
+            standard: defaults.persistentDomain(forName: legacyDomain) ?? [:],
+            container: containerDefaults(for: legacyDomain),
+        )
         let existing = Set(legacy.keys.filter { defaults.object(forKey: $0) != nil })
         let pending = plan(legacy: legacy, existing: existing)
 

--- a/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
+++ b/app/MeetingTranscriber/Sources/LiveTranscriptionController.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "LiveTra
 
 /// Wires the per-channel caption pipelines to both audio sinks of a
 /// `DualSourceRecorder`. Logs partial/final captions via os_log on subsystem
-/// `com.meetingtranscriber.app`, category `LiveTranscription`, and feeds them
+/// `com.meetingtranscriber`, category `LiveTranscription`, and feeds them
 /// into the observable `LiveCaptionsState` that backs the caption-bar overlay.
 ///
 /// Scope:

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -102,15 +102,24 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     }
 
     /// Pure builder for a notification's `UNMutableNotificationContent` (title,
-    /// body, sound, and optional category). Split out so the content mapping is
-    /// unit-testable without a real notification center.
+    /// body, sound, optional category, interruption level). Split out so the
+    /// content mapping is unit-testable without a real notification center.
+    ///
+    /// `interruptionLevel` defaults to `.active` — a banner that auto-dismisses
+    /// and is suppressed under Focus, which is right for anything the user can
+    /// read whenever they get round to it. Only the consent prompt overrides it;
+    /// see `postConsentNotification`.
     static func makeNotificationContent(
-        title: String, body: String, categoryID: String? = nil,
+        title: String,
+        body: String,
+        categoryID: String? = nil,
+        interruptionLevel: UNNotificationInterruptionLevel = .active,
     ) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
+        content.interruptionLevel = interruptionLevel
         if let categoryID { content.categoryIdentifier = categoryID }
         return content
     }
@@ -230,7 +239,18 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     private func postConsentNotification(id: String, title: String, body: String) {
         scheduler.add(UNNotificationRequest(
             identifier: id,
-            content: Self.makeNotificationContent(title: title, body: body, categoryID: Self.consentCategoryID),
+            content: Self.makeNotificationContent(
+                title: title,
+                body: body,
+                categoryID: Self.consentCategoryID,
+                // The one notification the app posts that asks a question with a
+                // deadline. At `.active` it is a banner: gone in seconds, and
+                // suppressed outright by any Focus mode, so it expires unseen and
+                // browser meetings silently never record. `.timeSensitive` is the
+                // only level that breaks through Focus, and it needs the matching
+                // entitlement in Entitlements/*.entitlements to do so.
+                interruptionLevel: .timeSensitive,
+            ),
             trigger: nil,
         ))
     }

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -126,6 +126,8 @@ struct AdvancedSettingsView: View {
             Section("About") {
                 LabeledContent("Version", value: Self.versionString)
                     .textSelection(.enabled)
+                LabeledContent("Identifier", value: Bundle.main.bundleID)
+                    .textSelection(.enabled)
                 LabeledContent("Build Date", value: Self.buildDate)
                     .textSelection(.enabled)
                 LabeledContent("ffmpeg") {

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -169,7 +169,7 @@ struct TranscriptionSettingsView: View {
             + "Caption text is **not** logged by default — enable "
             + "\"Verbose Diagnostic Logging\" in Advanced to see "
             + "partials + finals in Console.app (subsystem "
-            + "com.meetingtranscriber.app, category LiveTranscription). "
+            + "com.meetingtranscriber, category LiveTranscription). "
             + "Engine changes take effect on the next recording — "
             + "switching mid-recording is not supported."
     }

--- a/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
+++ b/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
@@ -40,6 +40,40 @@ final class LegacyDefaultsMigrationTests: XCTestCase {
         XCTAssertEqual(plan["autoWatch"] as? Bool, true)
     }
 
+    // MARK: - container redirect
+
+    /// When a container exists for a bundle identifier, macOS redirects the
+    /// app's UserDefaults reads into it — even for a binary that is not
+    /// sandboxed. So the values the old app actually saw may live in the
+    /// container plist rather than the standard one, and the container has to
+    /// win where both define a key. Reading only the standard domain would
+    /// migrate stale values, or none, without any sign that it happened.
+    func testContainerValuesWinOverTheStandardDomain() {
+        let merged = LegacyDefaultsMigration.mergedLegacy(
+            standard: ["whisperLanguage": "de", "autoWatch": false],
+            container: ["whisperLanguage": "en"],
+        )
+        XCTAssertEqual(merged["whisperLanguage"] as? String, "en")
+        XCTAssertEqual(merged["autoWatch"] as? Bool, false)
+    }
+
+    /// The common case: no container, so nothing to merge.
+    func testStandardDomainSurvivesWithoutAContainer() {
+        let merged = LegacyDefaultsMigration.mergedLegacy(
+            standard: ["whisperLanguage": "de"],
+            container: [:],
+        )
+        XCTAssertEqual(merged["whisperLanguage"] as? String, "de")
+    }
+
+    func testContainerOnlyKeysAreCarriedOver() {
+        let merged = LegacyDefaultsMigration.mergedLegacy(
+            standard: [:],
+            container: ["micName": "Me"],
+        )
+        XCTAssertEqual(merged["micName"] as? String, "Me")
+    }
+
     // MARK: - end to end against real defaults domains
 
     func testRunCopiesAcrossDomainsAndIsIdempotent() throws {

--- a/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
+++ b/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
@@ -1,0 +1,87 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The bundle identifier moved from `com.meetingtranscriber.app` to
+/// `app.meetingtranscriber`, and UserDefaults is scoped per identifier — so
+/// without this migration every existing user silently loses every setting on
+/// the update. The decision of *what* to copy is the part worth testing; the
+/// read/write of the two domains is a thin wrapper around Foundation.
+final class LegacyDefaultsMigrationTests: XCTestCase {
+    func testCopiesLegacyKeysWhenNothingMigratedYet() {
+        let plan = LegacyDefaultsMigration.plan(
+            legacy: ["whisperLanguage": "de", "autoWatch": true],
+            existing: [],
+            alreadyMigrated: false,
+        )
+        XCTAssertEqual(plan["whisperLanguage"] as? String, "de")
+        XCTAssertEqual(plan["autoWatch"] as? Bool, true)
+    }
+
+    /// A value the user already set under the new identifier is the newer
+    /// intent and must win — otherwise a stale legacy plist would keep
+    /// overwriting it.
+    func testKeysAlreadySetUnderTheNewIdentifierAreNotOverwritten() {
+        let plan = LegacyDefaultsMigration.plan(
+            legacy: ["whisperLanguage": "de", "autoWatch": true],
+            existing: ["whisperLanguage"],
+            alreadyMigrated: false,
+        )
+        XCTAssertNil(plan["whisperLanguage"])
+        XCTAssertEqual(plan["autoWatch"] as? Bool, true)
+    }
+
+    /// Runs once. Otherwise a user who deliberately reset a setting back to its
+    /// default would have the legacy value restored on the next launch.
+    func testNothingIsCopiedOnceTheMigrationHasRun() {
+        let plan = LegacyDefaultsMigration.plan(
+            legacy: ["whisperLanguage": "de"],
+            existing: [],
+            alreadyMigrated: true,
+        )
+        XCTAssertTrue(plan.isEmpty)
+    }
+
+    func testEmptyLegacyDomainProducesNothingToDo() {
+        let plan = LegacyDefaultsMigration.plan(legacy: [:], existing: [], alreadyMigrated: false)
+        XCTAssertTrue(plan.isEmpty)
+    }
+
+    /// The marker itself lives in the legacy domain too once a user has run a
+    /// migrated build and then an older one; copying it across would mark the
+    /// new domain as migrated without having copied anything.
+    func testTheMigrationMarkerIsNeverCopied() {
+        let plan = LegacyDefaultsMigration.plan(
+            legacy: [LegacyDefaultsMigration.markerKey: true, "autoWatch": true],
+            existing: [],
+            alreadyMigrated: false,
+        )
+        XCTAssertNil(plan[LegacyDefaultsMigration.markerKey])
+        XCTAssertEqual(plan["autoWatch"] as? Bool, true)
+    }
+
+    // MARK: - end to end against real defaults domains
+
+    func testRunCopiesAcrossDomainsAndIsIdempotent() throws {
+        let legacyName = "app.meetingtranscriber.test.legacy.\(UUID().uuidString)"
+        let currentName = "app.meetingtranscriber.test.current.\(UUID().uuidString)"
+        let legacy = try XCTUnwrap(UserDefaults(suiteName: legacyName))
+        let current = try XCTUnwrap(UserDefaults(suiteName: currentName))
+        defer {
+            legacy.removePersistentDomain(forName: legacyName)
+            current.removePersistentDomain(forName: currentName)
+        }
+        legacy.set("de", forKey: "whisperLanguage")
+        legacy.set(true, forKey: "autoWatch")
+
+        LegacyDefaultsMigration.run(into: current, legacyDomain: legacyName)
+        XCTAssertEqual(current.string(forKey: "whisperLanguage"), "de")
+        XCTAssertTrue(current.bool(forKey: "autoWatch"))
+        XCTAssertTrue(current.bool(forKey: LegacyDefaultsMigration.markerKey))
+
+        // Second run must be inert even though the legacy domain still exists:
+        // the user's later choice under the new identifier has to survive.
+        current.set("en", forKey: "whisperLanguage")
+        LegacyDefaultsMigration.run(into: current, legacyDomain: legacyName)
+        XCTAssertEqual(current.string(forKey: "whisperLanguage"), "en")
+    }
+}

--- a/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
+++ b/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
@@ -7,11 +7,10 @@ import XCTest
 /// the update. The decision of *what* to copy is the part worth testing; the
 /// read/write of the two domains is a thin wrapper around Foundation.
 final class LegacyDefaultsMigrationTests: XCTestCase {
-    func testCopiesLegacyKeysWhenNothingMigratedYet() {
+    func testCopiesLegacyKeys() {
         let plan = LegacyDefaultsMigration.plan(
             legacy: ["whisperLanguage": "de", "autoWatch": true],
             existing: [],
-            alreadyMigrated: false,
         )
         XCTAssertEqual(plan["whisperLanguage"] as? String, "de")
         XCTAssertEqual(plan["autoWatch"] as? Bool, true)
@@ -24,26 +23,9 @@ final class LegacyDefaultsMigrationTests: XCTestCase {
         let plan = LegacyDefaultsMigration.plan(
             legacy: ["whisperLanguage": "de", "autoWatch": true],
             existing: ["whisperLanguage"],
-            alreadyMigrated: false,
         )
         XCTAssertNil(plan["whisperLanguage"])
         XCTAssertEqual(plan["autoWatch"] as? Bool, true)
-    }
-
-    /// Runs once. Otherwise a user who deliberately reset a setting back to its
-    /// default would have the legacy value restored on the next launch.
-    func testNothingIsCopiedOnceTheMigrationHasRun() {
-        let plan = LegacyDefaultsMigration.plan(
-            legacy: ["whisperLanguage": "de"],
-            existing: [],
-            alreadyMigrated: true,
-        )
-        XCTAssertTrue(plan.isEmpty)
-    }
-
-    func testEmptyLegacyDomainProducesNothingToDo() {
-        let plan = LegacyDefaultsMigration.plan(legacy: [:], existing: [], alreadyMigrated: false)
-        XCTAssertTrue(plan.isEmpty)
     }
 
     /// The marker itself lives in the legacy domain too once a user has run a
@@ -53,7 +35,6 @@ final class LegacyDefaultsMigrationTests: XCTestCase {
         let plan = LegacyDefaultsMigration.plan(
             legacy: [LegacyDefaultsMigration.markerKey: true, "autoWatch": true],
             existing: [],
-            alreadyMigrated: false,
         )
         XCTAssertNil(plan[LegacyDefaultsMigration.markerKey])
         XCTAssertEqual(plan["autoWatch"] as? Bool, true)

--- a/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
+++ b/app/MeetingTranscriber/Tests/LegacyDefaultsMigrationTests.swift
@@ -40,6 +40,29 @@ final class LegacyDefaultsMigrationTests: XCTestCase {
         XCTAssertEqual(plan["autoWatch"] as? Bool, true)
     }
 
+    // MARK: - which legacy domain belongs to which identifier
+
+    /// The release build reads the release domain, and the dev build reads the
+    /// dev one. A single hardcoded legacy domain made the dev build inherit the
+    /// *release* user's settings on first launch, which defeats the separate
+    /// identity the dev build exists for.
+    func testEachIdentifierMapsToItsOwnLegacyDomain() {
+        XCTAssertEqual(
+            LegacyDefaultsMigration.legacyDomain(for: "app.meetingtranscriber"),
+            "com.meetingtranscriber.app",
+        )
+        XCTAssertEqual(
+            LegacyDefaultsMigration.legacyDomain(for: "app.meetingtranscriber.dev"),
+            "com.meetingtranscriber.dev",
+        )
+    }
+
+    /// An identifier we never shipped under has nothing to carry over, and
+    /// guessing a domain for it could only import a stranger's settings.
+    func testUnknownIdentifierHasNoLegacyDomain() {
+        XCTAssertNil(LegacyDefaultsMigration.legacyDomain(for: "com.example.other"))
+    }
+
     // MARK: - container redirect
 
     /// When a container exists for a bundle identifier, macOS redirects the

--- a/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
@@ -125,6 +125,38 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertFalse(granted)
     }
 
+    // MARK: - interruption level (issue #543)
+
+    /// The consent prompt asks a question that expires after
+    /// `consentPromptTimeout`. At the default `.active` level macOS renders it
+    /// as a banner, which auto-dismisses in seconds and is suppressed entirely
+    /// under any Focus mode — so the question is never seen, times out as a
+    /// decline, and browser meetings silently never record. `.timeSensitive` is
+    /// the only level that breaks through Focus.
+    func testConsentPromptIsTimeSensitive() async {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        let task = Task { await manager.askToRecord(title: "Record browser meeting?", body: "A meeting is active.") }
+
+        guard let posted = await firstPostedRequest(from: fake) else {
+            XCTFail("no consent notification posted")
+            return
+        }
+        XCTAssertEqual(posted.content.interruptionLevel, .timeSensitive)
+
+        manager.resolveConsent(responseIdentifier: posted.identifier, actionIdentifier: NotificationManager.ignoreActionID)
+        _ = await task.value
+    }
+
+    /// Only the consent prompt. A transcript-ready or permission-problem notice
+    /// has no deadline and must not break through the user's Focus.
+    func testOrdinaryNotificationsStayActiveLevel() {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        manager.notify(title: "Protocol Ready", body: "x")
+        XCTAssertEqual(fake.added.first?.content.interruptionLevel, .active)
+    }
+
     // MARK: - pure content builder
 
     func testMakeNotificationContentMapsFields() {

--- a/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
@@ -105,6 +105,13 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertEqual(posted.content.categoryIdentifier, NotificationManager.consentCategoryID)
         XCTAssertEqual(posted.content.title, "Record browser meeting?")
         XCTAssertEqual(posted.content.body, "A meeting is active.")
+        // The prompt asks a question that expires after `consentPromptTimeout`.
+        // At the default `.active` level macOS renders it as a banner, which any
+        // Focus mode suppresses outright — so the question is never seen, times
+        // out as a decline, and browser meetings silently never record.
+        // `.timeSensitive` is the only level that breaks through Focus
+        // (issue #543).
+        XCTAssertEqual(posted.content.interruptionLevel, .timeSensitive)
 
         manager.resolveConsent(responseIdentifier: posted.identifier, actionIdentifier: NotificationManager.recordActionID)
         let granted = await task.value
@@ -125,38 +132,6 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertFalse(granted)
     }
 
-    // MARK: - interruption level (issue #543)
-
-    /// The consent prompt asks a question that expires after
-    /// `consentPromptTimeout`. At the default `.active` level macOS renders it
-    /// as a banner, which auto-dismisses in seconds and is suppressed entirely
-    /// under any Focus mode — so the question is never seen, times out as a
-    /// decline, and browser meetings silently never record. `.timeSensitive` is
-    /// the only level that breaks through Focus.
-    func testConsentPromptIsTimeSensitive() async {
-        let (manager, fake) = makeManager()
-        manager.setUp()
-        let task = Task { await manager.askToRecord(title: "Record browser meeting?", body: "A meeting is active.") }
-
-        guard let posted = await firstPostedRequest(from: fake) else {
-            XCTFail("no consent notification posted")
-            return
-        }
-        XCTAssertEqual(posted.content.interruptionLevel, .timeSensitive)
-
-        manager.resolveConsent(responseIdentifier: posted.identifier, actionIdentifier: NotificationManager.ignoreActionID)
-        _ = await task.value
-    }
-
-    /// Only the consent prompt. A transcript-ready or permission-problem notice
-    /// has no deadline and must not break through the user's Focus.
-    func testOrdinaryNotificationsStayActiveLevel() {
-        let (manager, fake) = makeManager()
-        manager.setUp()
-        manager.notify(title: "Protocol Ready", body: "x")
-        XCTAssertEqual(fake.added.first?.content.interruptionLevel, .active)
-    }
-
     // MARK: - pure content builder
 
     func testMakeNotificationContentMapsFields() {
@@ -165,6 +140,10 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertEqual(content.body, "B")
         XCTAssertEqual(content.categoryIdentifier, "CAT")
         XCTAssertEqual(content.sound, .default)
+        // Only the consent prompt overrides this. A transcript-ready or
+        // permission-problem notice has no deadline and must not break through
+        // the user's Focus, so the default has to stay `.active`.
+        XCTAssertEqual(content.interruptionLevel, .active)
     }
 
     func testMakeNotificationContentWithoutCategoryLeavesItEmpty() {

--- a/app/MeetingTranscriber/Tests/SettingsAboutSectionTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsAboutSectionTests.swift
@@ -1,0 +1,62 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+/// The About section of Settings → Advanced. Split out of `SettingsViewTests`
+/// when adding the identifier row took that file past the 600-line cap; the
+/// section is self-contained, so it makes a natural seam.
+@MainActor
+final class SettingsAboutSectionTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var defaults: UserDefaults!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var testSuiteName: String!
+
+    /// Per-test isolated UserDefaults suite — same pattern as the sibling
+    /// settings suites. Avoids `swift test --parallel` plist races and keeps a
+    /// killed test process from leaking into the dev app's `.standard` plist.
+    override func setUp() async throws {
+        try await super.setUp()
+        testSuiteName = "SettingsAboutSectionTests-\(getpid())-\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: testSuiteName) else {
+            XCTFail("Could not create test UserDefaults suite")
+            return
+        }
+        defaults = suite
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: testSuiteName)
+        defaults = nil
+        testSuiteName = nil
+        try await super.tearDown()
+    }
+
+    private func makeAdvanced() -> AdvancedSettingsView {
+        AdvancedSettingsView(settings: AppSettings(defaults: defaults))
+    }
+
+    func testAboutSectionExists() throws {
+        let body = try makeAdvanced().inspect()
+        XCTAssertNoThrow(try body.find(text: "Version"))
+    }
+
+    func testAboutSectionShowsBuildDate() throws {
+        let body = try makeAdvanced().inspect()
+        XCTAssertNoThrow(try body.find(text: "Build Date"))
+    }
+
+    /// The identifier decides which settings domain, TCC grants and notification
+    /// registration the running app uses, so "which build is this" is not
+    /// answerable from the version alone — a dev/release mix-up otherwise shows
+    /// up only as permissions or preferences inexplicably missing.
+    func testAboutSectionShowsBundleIdentifier() throws {
+        let body = try makeAdvanced().inspect()
+        XCTAssertNoThrow(try body.find(text: "Identifier"))
+    }
+
+    func testAboutSectionShowsFfmpegStatus() throws {
+        let body = try makeAdvanced().inspect()
+        XCTAssertNoThrow(try body.find(text: "ffmpeg"))
+    }
+}

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -502,21 +502,6 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertNoThrow(try body.find(text: "Accessibility"))
     }
 
-    func testAboutSectionExists() throws {
-        let body = try makeAdvanced().inspect()
-        XCTAssertNoThrow(try body.find(text: "Version"))
-    }
-
-    func testAboutSectionShowsBuildDate() throws {
-        let body = try makeAdvanced().inspect()
-        XCTAssertNoThrow(try body.find(text: "Build Date"))
-    }
-
-    func testAboutSectionShowsFfmpegStatus() throws {
-        let body = try makeAdvanced().inspect()
-        XCTAssertNoThrow(try body.find(text: "ffmpeg"))
-    }
-
     #if !APPSTORE
         func testDebugRPCToggleExists() throws {
             let body = try makeAdvanced().inspect()

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -148,6 +148,14 @@ if [ "$NOTARIZE" = true ]; then
             codesign --force --sign "$DEVELOPER_ID" --options runtime --timestamp "$lib"
         done
 
+    # Embed the provisioning profile (when available) and derive the
+    # entitlements it authorises — see scripts/lib/signing.sh for why the
+    # time-sensitive key must never be added without one.
+    # shellcheck source=lib/signing.sh
+    source "$SCRIPT_DIR/lib/signing.sh"
+    BUNDLE_ID_FOR_SIGNING="com.meetingtranscriber.app"
+    ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$ENTITLEMENTS" "$BUNDLE_ID_FOR_SIGNING")"
+
     # Sign the main app binary with entitlements
     codesign --force --sign "$DEVELOPER_ID" \
         --options runtime --timestamp --entitlements "$ENTITLEMENTS" \

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -153,7 +153,7 @@ if [ "$NOTARIZE" = true ]; then
     # time-sensitive key must never be added without one.
     # shellcheck source=lib/signing.sh
     source "$SCRIPT_DIR/lib/signing.sh"
-    BUNDLE_ID_FOR_SIGNING="com.meetingtranscriber.app"
+    BUNDLE_ID_FOR_SIGNING="app.meetingtranscriber"
     ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$ENTITLEMENTS" "$BUNDLE_ID_FOR_SIGNING")"
 
     # Sign the main app binary with entitlements

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -153,12 +153,15 @@ if [ "$NOTARIZE" = true ]; then
     # time-sensitive key must never be added without one.
     # shellcheck source=lib/signing.sh
     source "$SCRIPT_DIR/lib/signing.sh"
-    BUNDLE_ID_FOR_SIGNING="app.meetingtranscriber"
-    ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$ENTITLEMENTS" "$BUNDLE_ID_FOR_SIGNING")"
+    # shellcheck source=lib/bundle-ids.sh
+    source "$SCRIPT_DIR/lib/bundle-ids.sh"
+    prepare_signing "$APP_BUNDLE" "$ENTITLEMENTS" "$RELEASE_BUNDLE_ID" "$DEVELOPER_ID"
 
-    # Sign the main app binary with entitlements
-    codesign --force --sign "$DEVELOPER_ID" \
-        --options runtime --timestamp --entitlements "$ENTITLEMENTS" \
+    # Sign the main app binary with entitlements. The identity comes from
+    # prepare_signing: when a profile is embedded it must be one the profile
+    # authorises, or macOS refuses to launch the app.
+    codesign --force --sign "$SIGNING_IDENTITY" \
+        --options runtime --timestamp --entitlements "$SIGNING_ENTITLEMENTS" \
         "$APP_BUNDLE"
     echo "  Signed with Developer ID for notarization"
     verify_signing "$APP_BUNDLE"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -161,6 +161,7 @@ if [ "$NOTARIZE" = true ]; then
         --options runtime --timestamp --entitlements "$ENTITLEMENTS" \
         "$APP_BUNDLE"
     echo "  Signed with Developer ID for notarization"
+    verify_signing "$APP_BUNDLE"
 
     # When --staple is set, notarize and staple the .app itself so Gatekeeper
     # does not need to contact Apple online when the app is launched (cask

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -374,18 +374,18 @@ fi
 # explicit "Start Watching" menu click would — necessary because that
 # menu isn't reachable over SSH. `debugRPCEnabled` brings the RPC up at
 # launch instead of after a Settings toggle.
-defaults write com.meetingtranscriber.dev debugRPCEnabled -bool true
-defaults write com.meetingtranscriber.dev autoWatch -bool true
+defaults write app.meetingtranscriber.dev debugRPCEnabled -bool true
+defaults write app.meetingtranscriber.dev autoWatch -bool true
 
 if [ "$RECORD_ONLY" = true ]; then
     log "Enabling record-only mode (no transcript/protocol generation)"
-    defaults write com.meetingtranscriber.dev recordOnly -bool true
+    defaults write app.meetingtranscriber.dev recordOnly -bool true
     mkdir -p "$RECORDINGS_DIR"
     touch "$RECORD_ONLY_MARKER"
 else
     # Reset stale toggle from a previous --record-only run on the same host
     # so a plain `--two-meetings` invocation isn't silently still in record-only.
-    defaults delete com.meetingtranscriber.dev recordOnly 2>/dev/null || true
+    defaults delete app.meetingtranscriber.dev recordOnly 2>/dev/null || true
 fi
 
 # Optional diarizer-mode override. `MTT_DIARIZER_MODE=sortformer` flips the
@@ -394,16 +394,16 @@ fi
 # actually lights up the naming dialog in production-chain. Always cleared
 # on exit so subsequent runs return to the default `.offline` mode.
 #
-# `defaults write com.meetingtranscriber.dev` from outside writes to the
+# `defaults write app.meetingtranscriber.dev` from outside writes to the
 # *standard* preferences domain. The dev .app's bundle has a pre-existing
-# container at `~/Library/Containers/com.meetingtranscriber.dev/...` —
+# container at `~/Library/Containers/app.meetingtranscriber.dev/...` —
 # from a prior App Store-variant build or interactive use — and macOS
 # routes the app's UserDefaults reads to that container regardless of
 # whether the current binary is sandboxed. A naïve `defaults write` is
 # silently a no-op there. Write to both: container if it exists (covers
 # this runner) AND standard domain (covers a clean runner where the
 # container hasn't been created yet).
-_CONTAINER_PLIST="$HOME/Library/Containers/com.meetingtranscriber.dev/Data/Library/Preferences/com.meetingtranscriber.dev.plist"
+_CONTAINER_PLIST="$HOME/Library/Containers/app.meetingtranscriber.dev/Data/Library/Preferences/app.meetingtranscriber.dev.plist"
 _set_dev_default() {
     local key="$1" value="$2" type="${3:-string}"
     # `numSpeakers` is read as `defaults.object(forKey:) as? Int`, so it must be
@@ -411,22 +411,22 @@ _set_dev_default() {
     # and silently fall back to the auto-detect sentinel (0).
     case "$type" in
         bool)
-            defaults write com.meetingtranscriber.dev "$key" -bool "$value" 2>/dev/null || true
+            defaults write app.meetingtranscriber.dev "$key" -bool "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
             ;;
         int)
-            defaults write com.meetingtranscriber.dev "$key" -int "$value" 2>/dev/null || true
+            defaults write app.meetingtranscriber.dev "$key" -int "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -int "$value" 2>/dev/null || true
             ;;
         *)
-            defaults write com.meetingtranscriber.dev "$key" "$value" 2>/dev/null || true
+            defaults write app.meetingtranscriber.dev "$key" "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" "$value" 2>/dev/null || true
             ;;
     esac
 }
 _delete_dev_default() {
     local key="$1"
-    defaults delete com.meetingtranscriber.dev "$key" 2>/dev/null || true
+    defaults delete app.meetingtranscriber.dev "$key" 2>/dev/null || true
     [ -f "$_CONTAINER_PLIST" ] && defaults delete "$_CONTAINER_PLIST" "$key" 2>/dev/null || true
 }
 if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
@@ -566,15 +566,15 @@ _naming_confirm_cleanup() {
     # Restore each domain to exactly its own snapshot. The shared restore_*_default
     # helpers translate `defaults read`'s 1/0 into the -bool true/false tokens and
     # write -int for numSpeakers (a raw 1/0 into `-bool` errors; see the helpers).
-    restore_bool_default com.meetingtranscriber.dev diarize "$_NC_PRE_DIARIZE_STD"
-    restore_int_default com.meetingtranscriber.dev numSpeakers "$_NC_PRE_NUMSPK_STD"
+    restore_bool_default app.meetingtranscriber.dev diarize "$_NC_PRE_DIARIZE_STD"
+    restore_int_default app.meetingtranscriber.dev numSpeakers "$_NC_PRE_NUMSPK_STD"
     if [ -f "$_CONTAINER_PLIST" ]; then
         restore_bool_default "$_CONTAINER_PLIST" diarize "$_NC_PRE_DIARIZE_CTR"
         restore_int_default "$_CONTAINER_PLIST" numSpeakers "$_NC_PRE_NUMSPK_CTR"
     fi
     local now_diarize now_num
-    now_diarize="$(read_dev_default_effective com.meetingtranscriber.dev "$_CONTAINER_PLIST" diarize)"
-    now_num="$(read_dev_default_effective com.meetingtranscriber.dev "$_CONTAINER_PLIST" numSpeakers)"
+    now_diarize="$(read_dev_default_effective app.meetingtranscriber.dev "$_CONTAINER_PLIST" diarize)"
+    now_num="$(read_dev_default_effective app.meetingtranscriber.dev "$_CONTAINER_PLIST" numSpeakers)"
     log "[naming-confirm] settings restored (effective diarize='$now_diarize' numSpeakers='$now_num')"
 }
 
@@ -585,8 +585,8 @@ if [ "$NAMING_CONFIRM" = true ]; then
     log "Enabling naming-confirm lane (diarize on, expected speakers = 2)"
     # Snapshot BOTH domains (standard + container) BEFORE overriding so cleanup
     # restores each domain to exactly its own pre-lane state.
-    _NC_PRE_DIARIZE_STD="$(snapshot_default com.meetingtranscriber.dev diarize)"
-    _NC_PRE_NUMSPK_STD="$(snapshot_default com.meetingtranscriber.dev numSpeakers)"
+    _NC_PRE_DIARIZE_STD="$(snapshot_default app.meetingtranscriber.dev diarize)"
+    _NC_PRE_NUMSPK_STD="$(snapshot_default app.meetingtranscriber.dev numSpeakers)"
     if [ -f "$_CONTAINER_PLIST" ]; then
         _NC_PRE_DIARIZE_CTR="$(snapshot_default "$_CONTAINER_PLIST" diarize)"
         _NC_PRE_NUMSPK_CTR="$(snapshot_default "$_CONTAINER_PLIST" numSpeakers)"
@@ -662,7 +662,7 @@ on_exit() {
     _ON_EXIT_RAN=1
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
     if [ "$RECORD_ONLY" = true ]; then
-        defaults delete com.meetingtranscriber.dev recordOnly 2>/dev/null || true
+        defaults delete app.meetingtranscriber.dev recordOnly 2>/dev/null || true
         # Marker-bounded cleanup: only files created since `touch $MARKER`
         # at launch — never touches pre-existing user data. See feedback
         # memory `no_destructive_fs_on_real_dirs`. Skipped under

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -374,18 +374,18 @@ fi
 # explicit "Start Watching" menu click would — necessary because that
 # menu isn't reachable over SSH. `debugRPCEnabled` brings the RPC up at
 # launch instead of after a Settings toggle.
-defaults write app.meetingtranscriber.dev debugRPCEnabled -bool true
-defaults write app.meetingtranscriber.dev autoWatch -bool true
+defaults write "$DEV_BUNDLE_ID" debugRPCEnabled -bool true
+defaults write "$DEV_BUNDLE_ID" autoWatch -bool true
 
 if [ "$RECORD_ONLY" = true ]; then
     log "Enabling record-only mode (no transcript/protocol generation)"
-    defaults write app.meetingtranscriber.dev recordOnly -bool true
+    defaults write "$DEV_BUNDLE_ID" recordOnly -bool true
     mkdir -p "$RECORDINGS_DIR"
     touch "$RECORD_ONLY_MARKER"
 else
     # Reset stale toggle from a previous --record-only run on the same host
     # so a plain `--two-meetings` invocation isn't silently still in record-only.
-    defaults delete app.meetingtranscriber.dev recordOnly 2>/dev/null || true
+    defaults delete "$DEV_BUNDLE_ID" recordOnly 2>/dev/null || true
 fi
 
 # Optional diarizer-mode override. `MTT_DIARIZER_MODE=sortformer` flips the
@@ -394,16 +394,16 @@ fi
 # actually lights up the naming dialog in production-chain. Always cleared
 # on exit so subsequent runs return to the default `.offline` mode.
 #
-# `defaults write app.meetingtranscriber.dev` from outside writes to the
+# `defaults write $DEV_BUNDLE_ID` from outside writes to the
 # *standard* preferences domain. The dev .app's bundle has a pre-existing
-# container at `~/Library/Containers/app.meetingtranscriber.dev/...` —
+# container at `~/Library/Containers/$DEV_BUNDLE_ID/...` —
 # from a prior App Store-variant build or interactive use — and macOS
 # routes the app's UserDefaults reads to that container regardless of
 # whether the current binary is sandboxed. A naïve `defaults write` is
 # silently a no-op there. Write to both: container if it exists (covers
 # this runner) AND standard domain (covers a clean runner where the
 # container hasn't been created yet).
-_CONTAINER_PLIST="$HOME/Library/Containers/app.meetingtranscriber.dev/Data/Library/Preferences/app.meetingtranscriber.dev.plist"
+_CONTAINER_PLIST="$(dev_container_plist)"
 _set_dev_default() {
     local key="$1" value="$2" type="${3:-string}"
     # `numSpeakers` is read as `defaults.object(forKey:) as? Int`, so it must be
@@ -411,22 +411,22 @@ _set_dev_default() {
     # and silently fall back to the auto-detect sentinel (0).
     case "$type" in
         bool)
-            defaults write app.meetingtranscriber.dev "$key" -bool "$value" 2>/dev/null || true
+            defaults write "$DEV_BUNDLE_ID" "$key" -bool "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
             ;;
         int)
-            defaults write app.meetingtranscriber.dev "$key" -int "$value" 2>/dev/null || true
+            defaults write "$DEV_BUNDLE_ID" "$key" -int "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -int "$value" 2>/dev/null || true
             ;;
         *)
-            defaults write app.meetingtranscriber.dev "$key" "$value" 2>/dev/null || true
+            defaults write "$DEV_BUNDLE_ID" "$key" "$value" 2>/dev/null || true
             [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" "$value" 2>/dev/null || true
             ;;
     esac
 }
 _delete_dev_default() {
     local key="$1"
-    defaults delete app.meetingtranscriber.dev "$key" 2>/dev/null || true
+    defaults delete "$DEV_BUNDLE_ID" "$key" 2>/dev/null || true
     [ -f "$_CONTAINER_PLIST" ] && defaults delete "$_CONTAINER_PLIST" "$key" 2>/dev/null || true
 }
 if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
@@ -566,15 +566,15 @@ _naming_confirm_cleanup() {
     # Restore each domain to exactly its own snapshot. The shared restore_*_default
     # helpers translate `defaults read`'s 1/0 into the -bool true/false tokens and
     # write -int for numSpeakers (a raw 1/0 into `-bool` errors; see the helpers).
-    restore_bool_default app.meetingtranscriber.dev diarize "$_NC_PRE_DIARIZE_STD"
-    restore_int_default app.meetingtranscriber.dev numSpeakers "$_NC_PRE_NUMSPK_STD"
+    restore_bool_default "$DEV_BUNDLE_ID" diarize "$_NC_PRE_DIARIZE_STD"
+    restore_int_default "$DEV_BUNDLE_ID" numSpeakers "$_NC_PRE_NUMSPK_STD"
     if [ -f "$_CONTAINER_PLIST" ]; then
         restore_bool_default "$_CONTAINER_PLIST" diarize "$_NC_PRE_DIARIZE_CTR"
         restore_int_default "$_CONTAINER_PLIST" numSpeakers "$_NC_PRE_NUMSPK_CTR"
     fi
     local now_diarize now_num
-    now_diarize="$(read_dev_default_effective app.meetingtranscriber.dev "$_CONTAINER_PLIST" diarize)"
-    now_num="$(read_dev_default_effective app.meetingtranscriber.dev "$_CONTAINER_PLIST" numSpeakers)"
+    now_diarize="$(read_dev_default_effective "$DEV_BUNDLE_ID" "$_CONTAINER_PLIST" diarize)"
+    now_num="$(read_dev_default_effective "$DEV_BUNDLE_ID" "$_CONTAINER_PLIST" numSpeakers)"
     log "[naming-confirm] settings restored (effective diarize='$now_diarize' numSpeakers='$now_num')"
 }
 
@@ -585,8 +585,8 @@ if [ "$NAMING_CONFIRM" = true ]; then
     log "Enabling naming-confirm lane (diarize on, expected speakers = 2)"
     # Snapshot BOTH domains (standard + container) BEFORE overriding so cleanup
     # restores each domain to exactly its own pre-lane state.
-    _NC_PRE_DIARIZE_STD="$(snapshot_default app.meetingtranscriber.dev diarize)"
-    _NC_PRE_NUMSPK_STD="$(snapshot_default app.meetingtranscriber.dev numSpeakers)"
+    _NC_PRE_DIARIZE_STD="$(snapshot_default "$DEV_BUNDLE_ID" diarize)"
+    _NC_PRE_NUMSPK_STD="$(snapshot_default "$DEV_BUNDLE_ID" numSpeakers)"
     if [ -f "$_CONTAINER_PLIST" ]; then
         _NC_PRE_DIARIZE_CTR="$(snapshot_default "$_CONTAINER_PLIST" diarize)"
         _NC_PRE_NUMSPK_CTR="$(snapshot_default "$_CONTAINER_PLIST" numSpeakers)"
@@ -662,7 +662,7 @@ on_exit() {
     _ON_EXIT_RAN=1
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
     if [ "$RECORD_ONLY" = true ]; then
-        defaults delete app.meetingtranscriber.dev recordOnly 2>/dev/null || true
+        defaults delete "$DEV_BUNDLE_ID" recordOnly 2>/dev/null || true
         # Marker-bounded cleanup: only files created since `touch $MARKER`
         # at launch — never touches pre-existing user data. See feedback
         # memory `no_destructive_fs_on_real_dirs`. Skipped under

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -87,8 +87,10 @@ RUN_MARKER="/tmp/e2e-browser-marker.$$"
 # Chrome and can be quit by argv match without touching the user's windows.
 CHROME_PROFILE="$(mktemp -d /tmp/e2e-browser-chrome.XXXXXX)"
 
-_CONTAINER_PLIST="$HOME/Library/Containers/app.meetingtranscriber.dev/Data/Library/Preferences/app.meetingtranscriber.dev.plist"
-BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$ROOT/scripts/lib/bundle-ids.sh"
+BUNDLE_ID="$DEV_BUNDLE_ID"
+_CONTAINER_PLIST="$(dev_container_plist)"
 
 # --- timing budgets -------------------------------------------------------
 
@@ -105,6 +107,10 @@ fail() { printf '[e2e-browser] FAIL: %s\n' "$*" >&2; exit 1; }
 
 # shellcheck source=lib/e2e-helpers.sh
 source "$SCRIPT_DIR/lib/e2e-helpers.sh"
+# For bundle_has_time_sensitive: the entitlement assertion below shares the
+# library's definition of the check and of the key itself.
+# shellcheck source=lib/signing.sh
+source "$SCRIPT_DIR/lib/signing.sh"
 
 require_command() { command -v "$1" >/dev/null || fail "missing command: $1"; }
 
@@ -345,6 +351,8 @@ poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent || {
     _dump_detection_diag
     fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
 }
+log "Consent granted over RPC"
+
 # The consent prompt only breaks through a Focus mode if the deployed bundle
 # actually carries the time-sensitive entitlement (issue #543). That is a
 # signing-time property no runtime assertion can see, and a build or re-sign
@@ -358,16 +366,13 @@ poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent || {
 # Focus while every other check stayed green.
 if [ -f "$DEV_BUNDLE_DEPLOY/Contents/embedded.provisionprofile" ]; then
     log "Profile embedded — checking the time-sensitive entitlement came with it"
-    codesign -d --entitlements :- "$DEV_BUNDLE_DEPLOY" 2>/dev/null \
-        | grep -q "com.apple.developer.usernotifications.time-sensitive" \
+    bundle_has_time_sensitive "$DEV_BUNDLE_DEPLOY" \
         || fail "the deployed bundle embeds a provisioning profile but is missing the
        time-sensitive entitlement, so the consent prompt cannot break through
        Focus. Check prepare_signing in scripts/lib/signing.sh."
 else
     log "No provisioning profile in the deployed bundle — skipping the time-sensitive check"
 fi
-
-log "Consent granted over RPC"
 
 # Answering over RPC resolves the parked continuation directly, so on its own it
 # proves nothing about the notification a real user depends on. The pre-flight

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -427,9 +427,16 @@ cp "$APP_WAV" /tmp/e2e-browser-app.wav 2>/dev/null || true
 cp "$SIDECAR" /tmp/e2e-browser-meta.json 2>/dev/null || true
 
 log "Verdict on the captured app track:"
+# Gate on SECONDS of audio, not on the fraction of the file that is audible.
+# The recording keeps running after Chrome quits (grace period, then
+# finalisation) and that tail varies run to run, so a ratio floor is really a
+# threshold on recording length: measured here, the captured tone was identical
+# across runs (31 active windows every time) while the ratio swung across a 0.5
+# floor purely because one recording came out a second longer.
+#
 # `=` form is required for the negative threshold: ArgumentParser reads a bare
 # `-50` after `--threshold-dbfs` as another flag and errors out.
-"$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs=-50 --min-active-ratio=0.5 \
-    || fail "app track is silent — the CATap did not capture Chrome's browser-meeting audio"
+"$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs=-50 --min-active-seconds=5 \
+    || fail "the CATap did not capture enough of Chrome's browser-meeting audio (reason above)"
 
 log "PASS: browser detection → RPC consent → non-silent CATap capture of the app track"

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -87,8 +87,8 @@ RUN_MARKER="/tmp/e2e-browser-marker.$$"
 # Chrome and can be quit by argv match without touching the user's windows.
 CHROME_PROFILE="$(mktemp -d /tmp/e2e-browser-chrome.XXXXXX)"
 
-_CONTAINER_PLIST="$HOME/Library/Containers/com.meetingtranscriber.dev/Data/Library/Preferences/com.meetingtranscriber.dev.plist"
-BUNDLE_ID="com.meetingtranscriber.dev"
+_CONTAINER_PLIST="$HOME/Library/Containers/app.meetingtranscriber.dev/Data/Library/Preferences/app.meetingtranscriber.dev.plist"
+BUNDLE_ID="app.meetingtranscriber.dev"
 
 # --- timing budgets -------------------------------------------------------
 

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -345,6 +345,28 @@ poll_until "$DETECT_TIMEOUT_S" 2 _grant_consent || {
     _dump_detection_diag
     fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
 }
+# The consent prompt only breaks through a Focus mode if the deployed bundle
+# actually carries the time-sensitive entitlement (issue #543). That is a
+# signing-time property no runtime assertion can see, and a build or re-sign
+# change could drop it silently — after which the feature would keep passing
+# every test while being invisible to any user with Do Not Disturb on.
+# Only meaningful once a provisioning profile authorises the entitlement: a
+# bundle signed with it but no profile does not launch at all, so the key is
+# added conditionally (scripts/lib/signing.sh). Assert the PAIRING rather than
+# the key: a profile present without the entitlement means the signing step
+# silently stopped deriving it, which would leave the prompt suppressed under
+# Focus while every other check stayed green.
+if [ -f "$DEV_BUNDLE_DEPLOY/Contents/embedded.provisionprofile" ]; then
+    log "Profile embedded — checking the time-sensitive entitlement came with it"
+    codesign -d --entitlements :- "$DEV_BUNDLE_DEPLOY" 2>/dev/null \
+        | grep -q "com.apple.developer.usernotifications.time-sensitive" \
+        || fail "the deployed bundle embeds a provisioning profile but is missing the
+       time-sensitive entitlement, so the consent prompt cannot break through
+       Focus. Check prepare_signing in scripts/lib/signing.sh."
+else
+    log "No provisioning profile in the deployed bundle — skipping the time-sensitive check"
+fi
+
 log "Consent granted over RPC"
 
 # Answering over RPC resolves the parked continuation directly, so on its own it

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -78,7 +78,7 @@ DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="com.meetingtranscriber.dev"
+BUNDLE_ID="app.meetingtranscriber.dev"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -78,7 +78,9 @@ DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$ROOT/scripts/lib/bundle-ids.sh"
+BUNDLE_ID="$DEV_BUNDLE_ID"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -58,7 +58,9 @@ SIMULATOR_BIN="$SIMULATOR_PKG/.build/release/meeting-simulator"
 DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$ROOT/scripts/lib/bundle-ids.sh"
+BUNDLE_ID="$DEV_BUNDLE_ID"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -58,7 +58,7 @@ SIMULATOR_BIN="$SIMULATOR_PKG/.build/release/meeting-simulator"
 DEFAULT_FIXTURE="$ROOT/app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav"
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="com.meetingtranscriber.dev"
+BUNDLE_ID="app.meetingtranscriber.dev"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/e2e-settings-smoke.sh
+++ b/scripts/e2e-settings-smoke.sh
@@ -37,7 +37,7 @@ fail() { printf "    \033[0;31m✗\033[0m %s\n" "$1"; exit 1; }
 kill_app() { pkill -f "$APP" 2>/dev/null || true; }
 trap 'kill_app; rm -f "$TREE_JSON"' EXIT
 
-# This drives the RELEASE bundle, which shares the `com.meetingtranscriber.app`
+# This drives the RELEASE bundle, which shares the `app.meetingtranscriber`
 # defaults domain with an installed copy — so the run mutates the REAL settings of
 # whoever executes it. Each step restores what it changed, but a run that dies in
 # between leaves them changed, and `recordOnly` stuck ON means the next real meeting
@@ -45,7 +45,7 @@ trap 'kill_app; rm -f "$TREE_JSON"' EXIT
 # machine does, so local runs must opt in knowingly.
 if [ -z "${CI:-}" ] && [ "${MT_SMOKE_ALLOW_LOCAL:-}" != "1" ]; then
     printf "\033[0;31m✗\033[0m %s\n" \
-        "refusing to run outside CI: this toggles recordOnly and rewrites micName in your REAL settings (com.meetingtranscriber.app)." >&2
+        "refusing to run outside CI: this toggles recordOnly and rewrites micName in your REAL settings (app.meetingtranscriber)." >&2
     printf "  %s\n" "Re-run with MT_SMOKE_ALLOW_LOCAL=1 if you accept that a crashed run can leave them changed." >&2
     exit 1
 fi

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -64,7 +64,7 @@ MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
 # in the same CI workflow, e2e-app.sh's release build is reused via
 # `--no-build` rather than rebuilt in debug mode.
 SIM="$ROOT/tools/meeting-simulator/.build/release/meeting-simulator"
-BUNDLE_ID="com.meetingtranscriber.dev"
+BUNDLE_ID="app.meetingtranscriber.dev"
 REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 # Anchor for the EXIT-trap artifact sweep: created before any recording, so
 # every file this run produces is newer than it (see sweep_run_artifacts).

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -64,7 +64,9 @@ MTCLI="$ROOT/tools/mt-cli/.build/debug/mt-cli"
 # in the same CI workflow, e2e-app.sh's release build is reused via
 # `--no-build` rather than rebuilt in debug mode.
 SIM="$ROOT/tools/meeting-simulator/.build/release/meeting-simulator"
-BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$ROOT/scripts/lib/bundle-ids.sh"
+BUNDLE_ID="$DEV_BUNDLE_ID"
 REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 # Anchor for the EXIT-trap artifact sweep: created before any recording, so
 # every file this run produces is newer than it (see sweep_run_artifacts).

--- a/scripts/e2e-soak.sh
+++ b/scripts/e2e-soak.sh
@@ -81,7 +81,9 @@ RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 # initializer argument. e2e-app.sh asserts against this same directory.
 REC_DIR="$HOME/Downloads/MeetingTranscriber/recordings"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$ROOT/scripts/lib/bundle-ids.sh"
+BUNDLE_ID="$DEV_BUNDLE_ID"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/e2e-soak.sh
+++ b/scripts/e2e-soak.sh
@@ -81,7 +81,7 @@ RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 # initializer argument. e2e-app.sh asserts against this same directory.
 REC_DIR="$HOME/Downloads/MeetingTranscriber/recordings"
 RPC_BASE="http://127.0.0.1:9876"
-BUNDLE_ID="com.meetingtranscriber.dev"
+BUNDLE_ID="app.meetingtranscriber.dev"
 
 [ -n "$SIMULATOR_FIXTURE" ] || SIMULATOR_FIXTURE="$DEFAULT_FIXTURE"
 

--- a/scripts/lib/bundle-ids.sh
+++ b/scripts/lib/bundle-ids.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Single source of truth for the app's bundle identifiers.
+#
+# Read out of Info.plist rather than restated, because a second copy of an
+# identifier has no way to notice when the first one changes — and every way it
+# then fails is silent:
+#   * `defaults write <old-id>` still succeeds, into a domain nothing reads, so
+#     an e2e lane's toggles never take and the run fails as an opaque timeout;
+#   * the signing helper finds no `signing/<new-id>.provisionprofile`, takes its
+#     no-profile path, and ships a build without its restricted entitlement
+#     while reporting success.
+# PlistBuddy exits non-zero on a missing key, so with `set -e` a drifted or
+# renamed key is loud instead.
+#
+# Source this, don't execute it.
+
+_BUNDLE_IDS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+RELEASE_BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+    "$_BUNDLE_IDS_ROOT/app/MeetingTranscriber/Sources/Info.plist")"
+
+# The dev build carries its own identity so it never shares TCC grants,
+# settings or a notification registration with an installed release. Derived
+# from the release identifier so the two can only ever move together.
+DEV_BUNDLE_ID="$RELEASE_BUNDLE_ID.dev"
+
+# `defaults write <id>` from outside a running app can be redirected into the
+# app's container, so callers that read a dev default back have to check both
+# locations. One definition of where that container plist lives.
+dev_container_plist() {
+    local bundle_id="${1:-$DEV_BUNDLE_ID}"
+    printf '%s' "$HOME/Library/Containers/$bundle_id/Data/Library/Preferences/$bundle_id.plist"
+}

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -5,7 +5,7 @@
 #   quit_running_app
 #   bootout_stale_launchctl
 #   wait_for_rpc "$MTCLI"
-#   restore_bool_default com.meetingtranscriber.dev autoWatch "$SAVED"
+#   restore_bool_default app.meetingtranscriber.dev autoWatch "$SAVED"
 #
 # This file has no shebang and no `set -e` — it inherits the caller's.
 
@@ -21,7 +21,7 @@
 # graceful and never sends SIGTERM/SIGKILL when the process has
 # already exited.
 quit_running_app() {
-    local bundle_id="${1:-com.meetingtranscriber.dev}"
+    local bundle_id="${1:-app.meetingtranscriber.dev}"
     # Default pattern matches the dev bundle. Release-bundle callers
     # (e.g. test_rpc.sh against the homebrew-cask binary) override by
     # passing a second arg.
@@ -51,7 +51,7 @@ quit_running_app() {
     return 1
 }
 
-# Boot out stale launchctl entries for `com.meetingtranscriber.dev.*`.
+# Boot out stale launchctl entries for `app.meetingtranscriber.dev.*`.
 # A previous run that exited ungracefully can leave per-PID service
 # registrations in `gui/<uid>` even after the process is dead, which
 # in turn can hold per-bundle TCC state or block re-launches. Safe to
@@ -62,7 +62,7 @@ bootout_stale_launchctl() {
     # (e.g. an SSH session without a `gui/<uid>` domain) so callers
     # outside an EXIT trap aren't taken down by a best-effort cleanup.
     { launchctl list 2>/dev/null \
-        | awk '$3 ~ /com\.meetingtranscriber\.dev/ {print $3}' \
+        | awk '$3 ~ /app\.meetingtranscriber\.dev/ {print $3}' \
         | while read -r srv; do
             launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
         done

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -5,9 +5,14 @@
 #   quit_running_app
 #   bootout_stale_launchctl
 #   wait_for_rpc "$MTCLI"
-#   restore_bool_default app.meetingtranscriber.dev autoWatch "$SAVED"
+#   restore_bool_default "$DEV_BUNDLE_ID" autoWatch "$SAVED"
 #
 # This file has no shebang and no `set -e` — it inherits the caller's.
+# Sourcing it also gives the caller $RELEASE_BUNDLE_ID / $DEV_BUNDLE_ID, so no
+# driver has to restate an identifier that only Info.plist should own.
+
+# shellcheck source=bundle-ids.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bundle-ids.sh"
 
 # Graceful AppleScript quit → SIGTERM → SIGKILL ladder. Returns 0 when
 # the process is gone, 1 if it survived even SIGKILL (unusual; means
@@ -21,7 +26,7 @@
 # graceful and never sends SIGTERM/SIGKILL when the process has
 # already exited.
 quit_running_app() {
-    local bundle_id="${1:-app.meetingtranscriber.dev}"
+    local bundle_id="${1:-$DEV_BUNDLE_ID}"
     # Default pattern matches the dev bundle. Release-bundle callers
     # (e.g. test_rpc.sh against the homebrew-cask binary) override by
     # passing a second arg.
@@ -51,7 +56,7 @@ quit_running_app() {
     return 1
 }
 
-# Boot out stale launchctl entries for `app.meetingtranscriber.dev.*`.
+# Boot out stale launchctl entries for `$DEV_BUNDLE_ID.*`.
 # A previous run that exited ungracefully can leave per-PID service
 # registrations in `gui/<uid>` even after the process is dead, which
 # in turn can hold per-bundle TCC state or block re-launches. Safe to
@@ -62,7 +67,7 @@ bootout_stale_launchctl() {
     # (e.g. an SSH session without a `gui/<uid>` domain) so callers
     # outside an EXIT trap aren't taken down by a best-effort cleanup.
     { launchctl list 2>/dev/null \
-        | awk '$3 ~ /app\.meetingtranscriber\.dev/ {print $3}' \
+        | awk -v id="$DEV_BUNDLE_ID" 'index($3, id) == 1 {print $3}' \
         | while read -r srv; do
             launchctl bootout "gui/$(id -u)/$srv" 2>/dev/null || true
         done

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -33,10 +33,18 @@ PROFILE_DIR="${PROFILE_DIR:-$_SIGNING_LIB_ROOT/signing}"
 TIME_SENSITIVE_KEY="com.apple.developer.usernotifications.time-sensitive"
 
 # profile_for <bundle-id> → path, or empty when none is available.
+#
+# "No profile" is a normal outcome, not a failure, so this must return 0 either
+# way: an `&&`-terminated body would hand back the failed test's status, and a
+# caller's `profile="$(profile_for "$id")"` under `set -e` would then abort the
+# whole build with no output at all. Every machine without the account's
+# profiles takes this path.
 profile_for() {
     local bundle_id="$1"
     local candidate="$PROFILE_DIR/${bundle_id}.provisionprofile"
-    [ -f "$candidate" ] && printf '%s' "$candidate"
+    if [ -f "$candidate" ]; then
+        printf '%s' "$candidate"
+    fi
 }
 
 # prepare_signing <app-bundle> <base-entitlements> <bundle-id> [fallback-identity]

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -30,35 +30,6 @@
 _SIGNING_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PROFILE_DIR="${PROFILE_DIR:-$_SIGNING_LIB_ROOT/signing}"
 
-# signing_identity_for <bundle-id> <fallback-identity>
-#
-# A profile authorises specific CERTIFICATES. Signing with one it does not list
-# makes macOS reject the launch outright once the entitlement is really present
-# ("Launchd job spawn failed" — measured). Developer ID distribution profiles
-# list the Developer ID Application certificate, so when a profile applies, that
-# is the identity to use rather than whatever `security find-identity` returns
-# first.
-#
-# A separate function rather than a variable set inside prepare_signing: that one
-# runs in a command substitution, so anything it assigns dies with the subshell.
-signing_identity_for() {
-    local bundle_id="$1" fallback="$2"
-    if [ -z "$(profile_for "$bundle_id")" ]; then
-        printf '%s' "$fallback"
-        return 0
-    fi
-    local devid
-    devid="$(security find-identity -v -p codesigning \
-        | grep "Developer ID Application" | head -1 | awk '{print $2}')"
-    if [ -n "$devid" ]; then
-        printf '%s' "$devid"
-    else
-        echo "  WARNING: a profile applies but no Developer ID Application certificate was found;" >&2
-        echo "  the signature will not be covered by it and the app may refuse to launch." >&2
-        printf '%s' "$fallback"
-    fi
-}
-
 TIME_SENSITIVE_KEY="com.apple.developer.usernotifications.time-sensitive"
 
 # profile_for <bundle-id> → path, or empty when none is available.
@@ -68,16 +39,26 @@ profile_for() {
     [ -f "$candidate" ] && printf '%s' "$candidate"
 }
 
-# prepare_signing <app-bundle> <base-entitlements> <bundle-id>
+# prepare_signing <app-bundle> <base-entitlements> <bundle-id> [fallback-identity]
 #
-# Embeds the matching profile when there is one and prints the entitlements path
-# to sign with: either a temporary copy carrying the time-sensitive key, or the
-# base file unchanged. Always prints exactly one path on stdout; progress goes to
-# stderr so the caller can capture the path.
+# Embeds the matching profile when there is one, then sets two globals for the
+# caller to sign with:
+#   SIGNING_ENTITLEMENTS — the base file, or a derived copy carrying the
+#                          time-sensitive key when a profile authorises it
+#   SIGNING_IDENTITY     — the identity that profile covers, else the fallback
+#
+# Globals rather than stdout: this function MUTATES the bundle (it copies the
+# profile in, or removes a stale one), and a `$( )` call site would hide that
+# side effect inside a subshell — plus returning two values through stdout is
+# what previously forced a second function and a second keychain query.
+#
+# shellcheck disable=SC2034  # SIGNING_ENTITLEMENTS/SIGNING_IDENTITY are read by callers
 prepare_signing() {
-    local bundle="$1" base_entitlements="$2" bundle_id="$3"
+    local bundle="$1" base_entitlements="$2" bundle_id="$3" fallback="${4:-}"
     local profile
     profile="$(profile_for "$bundle_id")"
+
+    SIGNING_IDENTITY="$fallback"
 
     if [ -z "$profile" ]; then
         # Drop a profile left behind by an earlier build: the bundle is
@@ -85,28 +66,44 @@ prepare_signing() {
         # this build look provisioned when it is not, and would make
         # verify_signing warn about a profile nobody asked for.
         rm -f "$bundle/Contents/embedded.provisionprofile"
-        echo "  No provisioning profile for $bundle_id — signing without $TIME_SENSITIVE_KEY." >&2
-        echo "  (The consent prompt will not break through Focus in this build; see issue #543.)" >&2
-        printf '%s' "$base_entitlements"
+        echo "  No provisioning profile for $bundle_id — signing without $TIME_SENSITIVE_KEY."
+        echo "  (The consent prompt will not break through Focus in this build; see issue #543.)"
+        SIGNING_ENTITLEMENTS="$base_entitlements"
         return 0
     fi
 
     cp "$profile" "$bundle/Contents/embedded.provisionprofile"
-    echo "  Embedded provisioning profile for $bundle_id" >&2
+    echo "  Embedded provisioning profile for $bundle_id"
 
+    # A profile authorises specific CERTIFICATES. Signing with one it does not
+    # list makes macOS reject the launch outright once the entitlement is really
+    # present ("Launchd job spawn failed" — measured). Developer ID distribution
+    # profiles list the Developer ID Application certificate, so prefer that
+    # over whatever `security find-identity` happens to return first.
+    local devid
+    devid="$(security find-identity -v -p codesigning 2>/dev/null \
+        | grep "Developer ID Application" | head -1 | awk '{print $2}')" || true
+    if [ -n "$devid" ]; then
+        SIGNING_IDENTITY="$devid"
+    else
+        echo "  WARNING: a profile applies but no Developer ID Application certificate was found;"
+        echo "  the signature will not be covered by it and the app may refuse to launch."
+    fi
 
     # Derive the entitlements rather than keeping a second near-duplicate file,
-    # so the base list stays the single source of truth.
-    local derived
-    derived="$(mktemp -t entitlements).plist"
+    # so the base list stays the single source of truth. Written beside the
+    # bundle instead of into TMPDIR: it is a build artifact, gets overwritten by
+    # the next build, and goes away with the build directory rather than piling
+    # up one file per build forever.
+    local derived="${bundle%.app}-entitlements.plist"
     cp "$base_entitlements" "$derived"
     # plutil reads dots in a key as KEY PATH separators, so the literal key has
     # to arrive escaped or the insert silently fails and the build reports a key
     # it never added.
     plutil -insert "${TIME_SENSITIVE_KEY//./\\.}" -bool true "$derived" \
         || { echo "  ERROR: could not add $TIME_SENSITIVE_KEY to the entitlements" >&2; return 1; }
-    echo "  Requesting $TIME_SENSITIVE_KEY" >&2
-    printf '%s' "$derived"
+    echo "  Requesting $TIME_SENSITIVE_KEY"
+    SIGNING_ENTITLEMENTS="$derived"
 }
 
 # verify_signing <app-bundle>
@@ -124,14 +121,24 @@ verify_signing() {
     local bundle="$1"
     [ -f "$bundle/Contents/embedded.provisionprofile" ] || return 0
 
-    if codesign -d --entitlements :- "$bundle" 2>/dev/null | grep -q "$TIME_SENSITIVE_KEY"; then
-        echo "  Verified $TIME_SENSITIVE_KEY survived signing" >&2
+    if bundle_has_time_sensitive "$bundle"; then
+        echo "  Verified $TIME_SENSITIVE_KEY survived signing"
         return 0
     fi
 
-    echo "  WARNING: the profile is embedded but codesign dropped $TIME_SENSITIVE_KEY." >&2
-    echo "  The profile does not grant it — enable the Time Sensitive Notifications" >&2
-    echo "  capability on this App ID and re-issue the profile. Until then the" >&2
-    echo "  consent prompt cannot break through Focus (issue #543)." >&2
+    echo "  WARNING: the profile is embedded but codesign dropped $TIME_SENSITIVE_KEY."
+    echo "  The profile does not grant it — enable the Time Sensitive Notifications"
+    echo "  capability on this App ID and re-issue the profile. Until then the"
+    echo "  consent prompt cannot break through Focus (issue #543)."
     return 0
+}
+
+# bundle_has_time_sensitive <app-bundle>
+#
+# True when the SIGNATURE actually carries the key. Separate from
+# verify_signing so a caller that must fail on a missing key (an e2e lane
+# asserting the prompt can break through Focus) shares this one definition of
+# the check and of the key itself, instead of re-spelling both.
+bundle_has_time_sensitive() {
+    codesign -d --entitlements :- "$1" 2>/dev/null | grep -q "$TIME_SENSITIVE_KEY"
 }

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -30,6 +30,35 @@
 _SIGNING_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PROFILE_DIR="${PROFILE_DIR:-$_SIGNING_LIB_ROOT/signing}"
 
+# signing_identity_for <bundle-id> <fallback-identity>
+#
+# A profile authorises specific CERTIFICATES. Signing with one it does not list
+# makes macOS reject the launch outright once the entitlement is really present
+# ("Launchd job spawn failed" — measured). Developer ID distribution profiles
+# list the Developer ID Application certificate, so when a profile applies, that
+# is the identity to use rather than whatever `security find-identity` returns
+# first.
+#
+# A separate function rather than a variable set inside prepare_signing: that one
+# runs in a command substitution, so anything it assigns dies with the subshell.
+signing_identity_for() {
+    local bundle_id="$1" fallback="$2"
+    if [ -z "$(profile_for "$bundle_id")" ]; then
+        printf '%s' "$fallback"
+        return 0
+    fi
+    local devid
+    devid="$(security find-identity -v -p codesigning \
+        | grep "Developer ID Application" | head -1 | awk '{print $2}')"
+    if [ -n "$devid" ]; then
+        printf '%s' "$devid"
+    else
+        echo "  WARNING: a profile applies but no Developer ID Application certificate was found;" >&2
+        echo "  the signature will not be covered by it and the app may refuse to launch." >&2
+        printf '%s' "$fallback"
+    fi
+}
+
 TIME_SENSITIVE_KEY="com.apple.developer.usernotifications.time-sensitive"
 
 # profile_for <bundle-id> → path, or empty when none is available.
@@ -51,6 +80,11 @@ prepare_signing() {
     profile="$(profile_for "$bundle_id")"
 
     if [ -z "$profile" ]; then
+        # Drop a profile left behind by an earlier build: the bundle is
+        # reassembled in place, so a stale embedded.provisionprofile would make
+        # this build look provisioned when it is not, and would make
+        # verify_signing warn about a profile nobody asked for.
+        rm -f "$bundle/Contents/embedded.provisionprofile"
         echo "  No provisioning profile for $bundle_id — signing without $TIME_SENSITIVE_KEY." >&2
         echo "  (The consent prompt will not break through Focus in this build; see issue #543.)" >&2
         printf '%s' "$base_entitlements"
@@ -60,12 +94,44 @@ prepare_signing() {
     cp "$profile" "$bundle/Contents/embedded.provisionprofile"
     echo "  Embedded provisioning profile for $bundle_id" >&2
 
+
     # Derive the entitlements rather than keeping a second near-duplicate file,
     # so the base list stays the single source of truth.
     local derived
     derived="$(mktemp -t entitlements).plist"
     cp "$base_entitlements" "$derived"
-    plutil -insert "$TIME_SENSITIVE_KEY" -bool true "$derived" >/dev/null
-    echo "  Added $TIME_SENSITIVE_KEY" >&2
+    # plutil reads dots in a key as KEY PATH separators, so the literal key has
+    # to arrive escaped or the insert silently fails and the build reports a key
+    # it never added.
+    plutil -insert "${TIME_SENSITIVE_KEY//./\\.}" -bool true "$derived" \
+        || { echo "  ERROR: could not add $TIME_SENSITIVE_KEY to the entitlements" >&2; return 1; }
+    echo "  Requesting $TIME_SENSITIVE_KEY" >&2
     printf '%s' "$derived"
+}
+
+# verify_signing <app-bundle>
+#
+# Call AFTER codesign. Requesting the entitlement is not the same as getting it:
+# when a profile is embedded, codesign validates entitlements against it and
+# silently DROPS any the profile does not grant. Measured: with a profile that
+# lacks the Time Sensitive Notifications capability, the key vanishes from the
+# signature, the build reports success, and the consent prompt stays suppressed
+# under Focus with nothing anywhere saying so.
+#
+# (Without any profile the same key instead makes the app refuse to launch, which
+# is why prepare_signing only requests it when a profile is present.)
+verify_signing() {
+    local bundle="$1"
+    [ -f "$bundle/Contents/embedded.provisionprofile" ] || return 0
+
+    if codesign -d --entitlements :- "$bundle" 2>/dev/null | grep -q "$TIME_SENSITIVE_KEY"; then
+        echo "  Verified $TIME_SENSITIVE_KEY survived signing" >&2
+        return 0
+    fi
+
+    echo "  WARNING: the profile is embedded but codesign dropped $TIME_SENSITIVE_KEY." >&2
+    echo "  The profile does not grant it — enable the Time Sensitive Notifications" >&2
+    echo "  capability on this App ID and re-issue the profile. Until then the" >&2
+    echo "  consent prompt cannot break through Focus (issue #543)." >&2
+    return 0
 }

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Shared signing helper: embed a provisioning profile and, only then, add the
+# entitlements that profile authorises.
+#
+# Why this exists (issue #543): the browser-meeting consent prompt asks a
+# question that expires. At the default interruption level macOS renders it as a
+# banner, which any Focus mode suppresses outright, so the question is never seen
+# and browser meetings silently never record. `.timeSensitive` is the only level
+# that breaks through Focus, and it requires
+# `com.apple.developer.usernotifications.time-sensitive`.
+#
+# That entitlement is RESTRICTED. Measured, not assumed: signing a bundle with it
+# but no provisioning profile makes macOS refuse to launch the app outright
+# ("Launchd job spawn failed", POSIX 163) — with a local Apple Development cert
+# AND with Developer ID plus hardened runtime, i.e. exactly how a release is
+# signed. Adding the key unconditionally would ship a brick.
+#
+# So the key is added ONLY when a profile that authorises it is present, and the
+# no-profile path is byte-identical to the previous behaviour. Contributors and
+# CI without profiles keep building working apps; the prompt just stays at the
+# old interruption level for them.
+#
+# Profiles are Developer ID distribution profiles from the Apple Developer
+# portal, one per bundle id. They are gitignored: they are account artifacts, and
+# the same reasoning that keeps the signing certificate out of the repo applies.
+# Point PROFILE_DIR somewhere else if you keep them elsewhere.
+
+# Derived from this file's own location, so it does not depend on which caller
+# happens to define TRANSCRIBER_ROOT.
+_SIGNING_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROFILE_DIR="${PROFILE_DIR:-$_SIGNING_LIB_ROOT/signing}"
+
+TIME_SENSITIVE_KEY="com.apple.developer.usernotifications.time-sensitive"
+
+# profile_for <bundle-id> → path, or empty when none is available.
+profile_for() {
+    local bundle_id="$1"
+    local candidate="$PROFILE_DIR/${bundle_id}.provisionprofile"
+    [ -f "$candidate" ] && printf '%s' "$candidate"
+}
+
+# prepare_signing <app-bundle> <base-entitlements> <bundle-id>
+#
+# Embeds the matching profile when there is one and prints the entitlements path
+# to sign with: either a temporary copy carrying the time-sensitive key, or the
+# base file unchanged. Always prints exactly one path on stdout; progress goes to
+# stderr so the caller can capture the path.
+prepare_signing() {
+    local bundle="$1" base_entitlements="$2" bundle_id="$3"
+    local profile
+    profile="$(profile_for "$bundle_id")"
+
+    if [ -z "$profile" ]; then
+        echo "  No provisioning profile for $bundle_id — signing without $TIME_SENSITIVE_KEY." >&2
+        echo "  (The consent prompt will not break through Focus in this build; see issue #543.)" >&2
+        printf '%s' "$base_entitlements"
+        return 0
+    fi
+
+    cp "$profile" "$bundle/Contents/embedded.provisionprofile"
+    echo "  Embedded provisioning profile for $bundle_id" >&2
+
+    # Derive the entitlements rather than keeping a second near-duplicate file,
+    # so the base list stays the single source of truth.
+    local derived
+    derived="$(mktemp -t entitlements).plist"
+    cp "$base_entitlements" "$derived"
+    plutil -insert "$TIME_SENSITIVE_KEY" -bool true "$derived" >/dev/null
+    echo "  Added $TIME_SENSITIVE_KEY" >&2
+    printf '%s' "$derived"
+}

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -28,10 +28,8 @@ APP_BUNDLE="$SPM_DIR/.build/MeetingTranscriber-Dev.app"
 APP_MACOS="$APP_BUNDLE/Contents/MacOS"
 APP_BINARY="$APP_MACOS/MeetingTranscriber"
 INFO_PLIST="$SPM_DIR/Sources/Info.plist"
-# Separate identity from the release build so the two never share TCC grants,
-# settings or a notification registration. Single source of truth for this
-# script and the e2e drivers that read the dev bundle's defaults domain.
-DEV_BUNDLE_ID="app.meetingtranscriber.dev"
+# shellcheck source=lib/bundle-ids.sh
+source "$SCRIPT_DIR/lib/bundle-ids.sh"
 
 # Always rebuild to pick up code changes
 echo "Building Meeting Transcriber app..."
@@ -48,11 +46,7 @@ swift build "${SWIFT_BUILD_FLAGS[@]}"
 
 # Assemble .app bundle
 mkdir -p "$APP_MACOS"
-# Use dev bundle identifier to keep permissions separate from release.
-# Assigned rather than text-substituted: a sed on the release identifier fails
-# silently the moment that identifier changes, and the dev bundle would then
-# inherit the release one — sharing its TCC grants and settings, which is the
-# exact opposite of the point.
+# Use the dev bundle identifier to keep permissions separate from release.
 cp "$INFO_PLIST" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $DEV_BUNDLE_ID" "$APP_BUNDLE/Contents/Info.plist"
 
@@ -76,11 +70,10 @@ SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}
 # time-sensitive consent prompt (issue #543).
 # shellcheck source=lib/signing.sh
 source "$SCRIPT_DIR/lib/signing.sh"
-ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "$DEV_BUNDLE_ID")"
-SIGN_HASH="$(signing_identity_for "$DEV_BUNDLE_ID" "$SIGN_HASH")"
-if [ -n "$SIGN_HASH" ]; then
-    codesign --force --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
-        echo "  Signed with: $SIGN_HASH (+ entitlements)"
+prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "$DEV_BUNDLE_ID" "$SIGN_HASH"
+if [ -n "$SIGNING_IDENTITY" ]; then
+    codesign --force --sign "$SIGNING_IDENTITY" --entitlements "$SIGNING_ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
+        echo "  Signed with: $SIGNING_IDENTITY (+ entitlements)"
 fi
 verify_signing "$APP_BUNDLE"
 

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -28,6 +28,10 @@ APP_BUNDLE="$SPM_DIR/.build/MeetingTranscriber-Dev.app"
 APP_MACOS="$APP_BUNDLE/Contents/MacOS"
 APP_BINARY="$APP_MACOS/MeetingTranscriber"
 INFO_PLIST="$SPM_DIR/Sources/Info.plist"
+# Separate identity from the release build so the two never share TCC grants,
+# settings or a notification registration. Single source of truth for this
+# script and the e2e drivers that read the dev bundle's defaults domain.
+DEV_BUNDLE_ID="app.meetingtranscriber.dev"
 
 # Always rebuild to pick up code changes
 echo "Building Meeting Transcriber app..."
@@ -44,9 +48,13 @@ swift build "${SWIFT_BUILD_FLAGS[@]}"
 
 # Assemble .app bundle
 mkdir -p "$APP_MACOS"
-# Use dev bundle identifier to keep permissions separate from release
-sed 's/com\.meetingtranscriber\.app/com.meetingtranscriber.dev/' \
-    "$INFO_PLIST" > "$APP_BUNDLE/Contents/Info.plist"
+# Use dev bundle identifier to keep permissions separate from release.
+# Assigned rather than text-substituted: a sed on the release identifier fails
+# silently the moment that identifier changes, and the dev bundle would then
+# inherit the release one — sharing its TCC grants and settings, which is the
+# exact opposite of the point.
+cp "$INFO_PLIST" "$APP_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $DEV_BUNDLE_ID" "$APP_BUNDLE/Contents/Info.plist"
 
 # Inject version from VERSION file
 APP_VERSION=$(cat "$TRANSCRIBER_ROOT/VERSION" | tr -d '[:space:]')
@@ -68,8 +76,8 @@ SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}
 # time-sensitive consent prompt (issue #543).
 # shellcheck source=lib/signing.sh
 source "$SCRIPT_DIR/lib/signing.sh"
-ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "com.meetingtranscriber.dev")"
-SIGN_HASH="$(signing_identity_for "com.meetingtranscriber.dev" "$SIGN_HASH")"
+ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "$DEV_BUNDLE_ID")"
+SIGN_HASH="$(signing_identity_for "$DEV_BUNDLE_ID" "$SIGN_HASH")"
 if [ -n "$SIGN_HASH" ]; then
     codesign --force --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
         echo "  Signed with: $SIGN_HASH (+ entitlements)"

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -62,9 +62,16 @@ cp "$BUILD_BINARY" "$APP_BINARY"
 # Code-sign so macOS keeps Screen Recording permission across rebuilds.
 # Uses SHA-1 hash to avoid "ambiguous identity" errors with duplicate names.
 SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}')
+# Sign WITH the Homebrew entitlements, the same set build_release.sh uses.
+# Without them the dev build carries no entitlements at all, so anything gated on
+# one behaves differently here than in a release build — notably the
+# time-sensitive consent prompt (issue #543).
+# shellcheck source=lib/signing.sh
+source "$SCRIPT_DIR/lib/signing.sh"
+ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "com.meetingtranscriber.dev")"
 if [ -n "$SIGN_HASH" ]; then
-    codesign --force --sign "$SIGN_HASH" "$APP_BUNDLE" 2>/dev/null && \
-        echo "  Signed with: $SIGN_HASH"
+    codesign --force --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
+        echo "  Signed with: $SIGN_HASH (+ entitlements)"
 fi
 
 if [ "$BUILD_ONLY" = true ]; then

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -69,10 +69,12 @@ SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}
 # shellcheck source=lib/signing.sh
 source "$SCRIPT_DIR/lib/signing.sh"
 ENTITLEMENTS="$(prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "com.meetingtranscriber.dev")"
+SIGN_HASH="$(signing_identity_for "com.meetingtranscriber.dev" "$SIGN_HASH")"
 if [ -n "$SIGN_HASH" ]; then
     codesign --force --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
         echo "  Signed with: $SIGN_HASH (+ entitlements)"
 fi
+verify_signing "$APP_BUNDLE"
 
 if [ "$BUILD_ONLY" = true ]; then
     echo "Bundle ready: $APP_BUNDLE"

--- a/scripts/tests/test_signing_no_profile.sh
+++ b/scripts/tests/test_signing_no_profile.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression test for scripts/lib/signing.sh on the path where no provisioning
+# profile exists — which is every machine except the one that holds the
+# account's profiles: the CI Mac mini, and every contributor.
+#
+# Bug history:
+#   `profile_for` ended in `[ -f "$candidate" ] && printf ...`, so with no
+#   profile the function's exit status was the failed test, i.e. 1. Under
+#   `set -e` the caller's `profile="$(profile_for "$id")"` assignment then
+#   aborted the whole script with no output at all — `run_app.sh` died straight
+#   after "Build complete!" and the bundle was never assembled or signed.
+#
+# The library's own header promises the no-profile path is byte-identical to the
+# previous behaviour, so this pins exactly that: prepare_signing succeeds, hands
+# back the base entitlements unchanged, and leaves the fallback identity alone.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$2"; then
+        printf 'PASS\n'
+    else
+        printf 'FAIL\n'
+        FAILED=1
+    fi
+}
+
+# Runs prepare_signing in a subshell with `set -e` (as its callers do) against a
+# PROFILE_DIR that is empty, and echoes the two globals it is contracted to set.
+_prepare_without_profile() {
+    local workdir="$1"
+    (
+        set -euo pipefail
+        PROFILE_DIR="$workdir/profiles"
+        # shellcheck source=../lib/signing.sh
+        source "$REPO_ROOT/scripts/lib/signing.sh"
+        prepare_signing "$workdir/Some.app" "$workdir/base.entitlements" \
+            "com.example.absent" "FALLBACKHASH" >/dev/null
+        printf '%s\n%s\n' "$SIGNING_ENTITLEMENTS" "$SIGNING_IDENTITY"
+    )
+}
+
+test_survives_missing_profile() {
+    local workdir out status
+    workdir="$(mktemp -d)"
+    mkdir -p "$workdir/Some.app/Contents" "$workdir/profiles"
+    printf '<plist/>' > "$workdir/base.entitlements"
+
+    local expected_entitlements="$workdir/base.entitlements"
+    out="$(_prepare_without_profile "$workdir")"
+    status=$?
+    rm -rf "$workdir"
+    if [ "$status" -ne 0 ]; then
+        echo "  prepare_signing aborted (exit $status) with no profile present" >&2
+        return 1
+    fi
+    local entitlements identity
+    entitlements="$(printf '%s' "$out" | sed -n 1p)"
+    identity="$(printf '%s' "$out" | sed -n 2p)"
+
+    if [ "$entitlements" != "$expected_entitlements" ]; then
+        echo "  expected the base entitlements unchanged, got: $entitlements" >&2
+        return 1
+    fi
+    if [ "$identity" != "FALLBACKHASH" ]; then
+        echo "  expected the caller's fallback identity, got: $identity" >&2
+        return 1
+    fi
+}
+
+echo "Testing scripts/lib/signing.sh (no provisioning profile)"
+echo
+run_test "prepare_signing succeeds and passes the base entitlements through" \
+    test_survives_missing_profile
+echo
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "Some tests FAILED."
+fi
+exit "$FAILED"

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -93,8 +93,8 @@ struct WavVerdictCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wav-verdict",
         abstract: "Analyze an audio file's loudness (issue #503 capture proof). "
-            + "Prints a JSON verdict; exits 0 when non-silent AND active-window "
-            + "ratio >= --min-active-ratio, 1 otherwise.",
+            + "Prints a JSON verdict; exits 0 when non-silent AND at least "
+            + "--min-active-seconds of audio is above the threshold, 1 otherwise.",
     )
 
     @Argument(help: "Path to the WAV/audio file to analyze.")
@@ -103,8 +103,12 @@ struct WavVerdictCommand: ParsableCommand {
     @Option(name: .long, help: "dBFS threshold below which a window is silent. Default -50.")
     var thresholdDbfs: Double = -50
 
-    @Option(name: .long, help: "Minimum fraction of active windows to pass. Default 0.5.")
-    var minActiveRatio: Double = 0.5
+    /// Seconds rather than a fraction of the file: every recording carries
+    /// trailing silence (grace period, then finalisation) whose length varies
+    /// run to run, so a ratio floor gates on how long the recording happened to
+    /// be rather than on how much audio was captured.
+    @Option(name: .long, help: "Minimum seconds of audio above the threshold to pass. Default 3.")
+    var minActiveSeconds: Double = 3
 
     @Option(name: .long, help: "Analysis window length in seconds. Default 0.5.")
     var windowSeconds: Double = 0.5
@@ -119,9 +123,21 @@ struct WavVerdictCommand: ParsableCommand {
         encoder.outputFormatting = [.sortedKeys]
         try FileHandle.standardOutput.write(encoder.encode(verdict))
         FileHandle.standardOutput.write(Data("\n".utf8))
-        // Non-zero exit if silent or too few active windows, so a driver can
-        // gate on the exit code alone.
-        if verdict.isSilent || verdict.activeWindowRatio < minActiveRatio {
+        // Non-zero exit if silent or too little audio, so a driver can gate on
+        // the exit code alone. Which of the two failed goes to stderr: they
+        // mean different things, and a caller reporting "silent" for a file
+        // whose own verdict says `isSilent: false` sends the reader hunting in
+        // the wrong place.
+        if verdict.isSilent {
+            FileHandle.standardError.write(Data(
+                "silent: no window above \(thresholdDbfs) dBFS\n".utf8,
+            ))
+            throw ExitCode(1)
+        }
+        if verdict.activeSeconds < minActiveSeconds {
+            let reason = "too little audio: \(verdict.activeSeconds)s above "
+                + "\(thresholdDbfs) dBFS, need \(minActiveSeconds)s\n"
+            FileHandle.standardError.write(Data(reason.utf8))
             throw ExitCode(1)
         }
     }

--- a/tools/mt-cli/Sources/WavVerdict.swift
+++ b/tools/mt-cli/Sources/WavVerdict.swift
@@ -6,13 +6,19 @@ import Foundation
 /// I/O — the `wav-verdict` subcommand loads samples via AVAudioFile and hands
 /// them here, so the decision logic stays deterministically unit-testable.
 ///
-/// `activeWindowRatio` is what distinguishes a genuine continuous recording
-/// from a "1 s blip then silence" regression: a driver asserting a sustained
-/// tone checks both `!isSilent` and `activeWindowRatio` above a floor.
+/// `activeSeconds` is what distinguishes a genuine capture from a "1 s blip
+/// then silence" regression, and it is what a driver should gate on: how much
+/// real audio was recorded does not shrink because the recording ran longer.
+/// `activeWindowRatio` is the same count as a fraction — informative, but it
+/// moves with the trailing silence every recording has (grace period, then
+/// finalisation), so a floor on it is a threshold on recording length wearing a
+/// disguise.
 struct WavVerdict: Codable, Equatable {
     let overallRMSdBFS: Double
     let peakWindowRMSdBFS: Double
     let activeWindowRatio: Double
+    /// Total duration of the windows above the threshold.
+    let activeSeconds: Double
     let windowCount: Int
     let isSilent: Bool
 
@@ -45,6 +51,7 @@ struct WavVerdict: Codable, Equatable {
             overallRMSdBFS: dBFS(rmsOf: samples[...]),
             peakWindowRMSdBFS: peak,
             activeWindowRatio: ratio,
+            activeSeconds: Double(activeCount) * windowSeconds,
             windowCount: windows.count,
             // Silent iff no window is loud enough — the peak decides it.
             isSilent: peak < thresholdDBFS,

--- a/tools/mt-cli/Tests/WavVerdictTests.swift
+++ b/tools/mt-cli/Tests/WavVerdictTests.swift
@@ -66,4 +66,38 @@ final class WavVerdictTests: XCTestCase {
         XCTAssertTrue(v.isSilent)
         XCTAssertEqual(v.peakWindowRMSdBFS, WavVerdict.silenceFloorDBFS)
     }
+
+    // MARK: - activeSeconds
+
+    func testActiveSecondsCountsOnlyTheAudiblePart() {
+        var samples = sine(rmsDBFS: -20, seconds: 3)
+        samples += [Float](repeating: 0, count: Int(7 * sampleRate))
+        let v = WavVerdict.analyze(samples: samples, sampleRate: sampleRate)
+        XCTAssertEqual(v.activeSeconds, 3, accuracy: 0.6)
+    }
+
+    /// The property a capture proof actually needs: how much real audio was
+    /// recorded does not shrink because the recording ran longer. Measured on
+    /// the browser-meeting lane, where the tone was identical across runs (31
+    /// active windows every time) but the recording length varied — the ratio
+    /// swung from 0.508 to 0.463 across a fixed 0.5 floor and flipped a passing
+    /// run to failing without anything about the captured audio changing.
+    func testTrailingSilenceShrinksTheRatioButNotActiveSeconds() {
+        let tone = sine(rmsDBFS: -20, seconds: 3)
+        let short = WavVerdict.analyze(
+            samples: tone + [Float](repeating: 0, count: Int(3 * sampleRate)),
+            sampleRate: sampleRate,
+        )
+        let long = WavVerdict.analyze(
+            samples: tone + [Float](repeating: 0, count: Int(9 * sampleRate)),
+            sampleRate: sampleRate,
+        )
+        XCTAssertEqual(short.activeSeconds, long.activeSeconds, accuracy: 0.001)
+        XCTAssertGreaterThan(short.activeWindowRatio, long.activeWindowRatio)
+    }
+
+    func testSilenceHasNoActiveSeconds() {
+        let v = WavVerdict.analyze(samples: [Float](repeating: 0, count: 16000), sampleRate: sampleRate)
+        XCTAssertEqual(v.activeSeconds, 0)
+    }
 }


### PR DESCRIPTION
Makes the browser-meeting consent prompt survive a Focus mode. Refs #543 (finding 1).

## The problem

The prompt that asks "record this browser meeting?" is a user notification with a deadline: unanswered, it expires after 60 s and the expiry counts as a decline, followed by a cooldown and a re-prompt. At the default `.active` interruption level macOS renders it as a banner, and any Focus mode suppresses banners outright. So for a user with Do Not Disturb on, browser-meeting recording is silently and permanently dead — it detects, it asks, the question is never seen.

`.timeSensitive` is the level Apple designed for exactly this, and it needs `com.apple.developer.usernotifications.time-sensitive`.

## Why this also renames the bundle identifier

Two independent reasons, both measured rather than assumed.

**The entitlement is restricted, and the old identifier could never carry it.** `com.meetingtranscriber.app` cannot be registered as an App ID: it is actively held by another team. Apple returns the same "not available" error for foreign and for own identifiers, so that was resolved by registering a throwaway `.app` identifier (proving the suffix is not reserved) and by re-registering a deleted one (excluding "we deleted it once" as the explanation). No App ID means no provisioning profile, and without a profile the release build cannot carry the entitlement at all.

**macOS binds notification capability to the identifier at first registration.** The dev bundle, carrying a verified time-sensitive entitlement in its signature and with authorization granted, still had its prompt suppressed by Do Not Disturb. The same binary under a fresh identifier broke through, labelled `TIME SENSITIVE` by the system, with macOS asking whether to keep time-sensitive delivery on. Adding the entitlement to an already-registered identifier does not change what macOS recorded for it.

`app.meetingtranscriber` is the correct reverse-DNS form of the domain we own. The dev identifier moves with it so both keep one naming scheme.

## Cost for existing users, and what covers it

- **Settings** are scoped per identifier, so they would reset on update: engine choice, language, watched apps, output folder, diarization tuning. A one-shot migration copies the old domain across. It never overwrites a key already set under the new identifier and runs once, so a value the user deliberately reset is not resurrected. It reads both places a domain can physically live. When a container exists for an identifier, macOS redirects that app's UserDefaults access into `~/Library/Containers/<id>/…` — including for a binary that is not sandboxed, the same redirect that forces the e2e drivers to write both locations. Reading only the standard plist would migrate stale values, or none, and lose the settings anyway. The container wins where both define a key, because that is what the old app read.
- **TCC grants do not carry over.** The microphone prompt reappears and screen recording has to be re-enabled by hand. The permission health check surfaces both, so it is not a silent failure.
- **Application Support data is unaffected** — `AppPaths.dataDir` is a fixed path, so voice profiles, prompts, recordings and the RPC token stay put. The ML models live outside the identifier too (`~/Documents/huggingface`, `~/Library/Application Support/FluidAudio`), so nothing is re-downloaded.
- **A stored OpenAI API key stays findable** — `KeychainHelper` scopes items by a fixed service string, not the bundle identifier. Only the keychain item's access control is tied to the code signature, so macOS may ask once for access; allowing it is permanent. No code can avoid that prompt, since reading the item is what triggers it.

## Also in here

**A build bug this branch introduced, found by running it somewhere without a provisioning profile.** `profile_for` ended in `[ -f "$c" ] && printf …`, so with no profile it returned the failed test's status, and under `set -e` the caller's assignment took the whole script down with no output: `run_app.sh` died right after "Build complete!", never assembled or signed the bundle. That is every machine except the one holding the account's profiles — the CI mini and every contributor. It was invisible locally, where a profile exists. Fixed with a regression test that pins the promise the library header makes.

**One source of truth for the identifiers.** The rename had to touch about thirty literals across eleven scripts, which is the actual finding: each copy could silently disagree with `Info.plist`, and every way it then fails is quiet. A `defaults write` against a stale identifier still succeeds, into a domain nothing reads, so an e2e lane's toggles never take and the run fails as an opaque timeout. One copy had already gone wrong on this branch — an awk pattern holding the identifier as an escaped regex was missed by the rename sweep, so the launchctl cleanup would have matched nothing forever. `scripts/lib/bundle-ids.sh` now reads the release identifier out of `Info.plist` and derives the dev one, leaving one literal in the repo. PlistBuddy exits non-zero on a missing key, so drift is loud.

**`prepare_signing` sets variables instead of printing a path.** It mutates the bundle, and a command substitution both hid that side effect in a subshell and forced a second function plus a second keychain query (0.45 s each) to return the identity. It also reserved a `mktemp` path and wrote to a different one, leaking two files per build.

**The identifier is now shown in Settings → Advanced → About**, selectable next to the version. Which identifier is running decides the settings domain, the TCC grants and the notification registration, so "which build is this" was not answerable from the version alone — and a mix-up surfaces only as permissions or preferences inexplicably missing.

**The browser-meeting lane was passing for the wrong reason.** It gates on the captured audio and failed here with "app track is silent" printed one line under its own verdict saying `isSilent: false`. The runs settle it: the captured tone was identical every time — 31 active windows in all three, peak level matching to five decimals — while the ratio read 0.508, 0.508 and 0.463. Only the denominator moved, because one recording came out about a second longer, and the floor sat at 0.5. The lane had been passing by 0.008. A ratio is the wrong invariant: every recording keeps running after the meeting ends, and that tail varies, so a floor on the audible fraction is a threshold on recording length in disguise. It now gates on seconds of audio, which is unchanged by the tail and stricter against the one-second blip it exists to catch (one second against a five-second floor). The command also reports which of the two conditions failed, since reporting "silent" for a file whose verdict says otherwise sends the reader hunting in the wrong place.

**A dead diagnostic hint.** Settings → Transcribe told users to filter Console.app by subsystem `com.meetingtranscriber.app`, which never matches: the app logs under `com.meetingtranscriber`. Pre-existing and unrelated to the rename, so it lands as its own commit.

## The runner needed a one-time manual grant

The dev identifier changed, so the Mac mini's existing microphone and screen-recording grants no longer applied — TCC keys a grant to the identifier and the signing certificate, and neither the grant nor the notification registration carries across a rename. The bundle was deployed there under the new identifier, signed with the same Developer ID certificate CI uses, and the permissions were granted by hand in the GUI session.

Worth knowing for the next time: the deploy path is shared, so any run on `main` redeploys the old identifier over it. The grant itself survives that (it is not keyed to the path), but the app has to be present under the new identifier for the System Settings entry to be addable at all. Screen recording can be added manually by path; the microphone cannot — that list only accepts what the app itself requested, so the prompt has to be answered live.

## Verification

- Full test suite green (the dev-only menu-bar snapshot tests deviate on this machine both with and without these changes)
- `swiftlint --strict` clean, SwiftFormat clean on the changed files
- Release-mode parity green for both variants, including the App Store build
- Both script tests green
- All four self-hosted lanes green on the runner after its grant: `e2e`, `e2e-app`, `e2e-browser`, `e2e-crash-recovery`
- Live: dev build under the new identifier, entitlement verified present in the signature after codesign, prompt observed breaking through Do Not Disturb
- Live: the migration run against real domains on a machine that has both — all 30 keys of the legacy domain carried over, the only differences being values changed afterwards under the new identifier

## Deliberately not in scope

- The tap repo's cask does not list the preferences plists under `zap trash:`, and after the rename there are two orphans instead of one. Pre-existing, and the cask that ships is the tap's copy, not this repo's.
- Findings 3 to 6 of #543 are untouched, including the parked prompt blocking the watch loop for up to 60 s.
