### PR TITLE
fix(app): add missing NSAudioCaptureUsageDescription for the process tap

### DIFF
--- a/app/MeetingTranscriber/Sources/Info.plist
+++ b/app/MeetingTranscriber/Sources/Info.plist
@@ -24,6 +24,8 @@
     <string>AppIcon</string>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Meeting Transcriber records the meeting app’s own audio (the other participants) via a Core Audio process tap.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Meeting Transcriber needs microphone access to record meeting audio for transcription.</string>
     <key>NSScreenCaptureUsageDescription</key>


### PR DESCRIPTION
## Problem

On macOS 26.1, the app-audio track of every recording is digital silence (-120 dBFS flat), while the mic track records fine. Nothing in the diagnostics points at a cause: `AudioHardwareCreateProcessTap` succeeds, the aggregate device is created, buffers flow (`totalBytes` grows), and no error is logged.

## Root cause

`Info.plist` ships no `NSAudioCaptureUsageDescription`. Without that key, macOS **silently** denies the process-tap TCC authorization:

- no permission prompt is shown,
- no `kTCCServiceAudioCapture` row is created in the TCC database,
- the tap delivers zero-filled buffers instead of failing.

So the failure mode is indistinguishable from "the meeting app produced no audio" — which is exactly what our diagnostics showed (`App audio RMS (5s): -120.0 dBFS` every 5 s for the whole meeting).

## Fix

Add `NSAudioCaptureUsageDescription` to `Sources/Info.plist`. With the key present, macOS grants `kTCCServiceAudioCapture` at first tap creation (verified: the TCC row appears stamped at the exact second recording starts) and real app audio flows immediately (`App audio RMS (5s): -24.6 dBFS` in the same test setup).

## Verification

- Before: simulator meeting (`tools/meeting-simulator` playing the bundled two-speaker fixture) → `_app.wav` mean/max volume -91.0 dB (ffmpeg volumedetect), RMS log -120 dBFS, no TCC row.
- After (same machine, `tccutil reset AudioCapture` first): same simulator run → app track -26.7 dB mean / -5.9 dB max, `kTCCServiceAudioCapture` auth_value=2 created at recording start.
- macOS 26.1 (Tahoe), Apple Silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
