### PR TITLE
fix(app): mic track is silent whenever another app activates voice processing (discrete channel layout downmix)

### DIFF
--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -220,6 +220,19 @@ public class MicCaptureHandler: @unchecked Sendable {
                 standardFormatWithSampleRate: fileSampleRate, channels: 1,
             )! // swiftlint:disable:this force_unwrapping
             converter = AVAudioConverter(from: tapFormat, to: outputFormat)
+            // AVAudioConverter's IMPLICIT downmix writes SILENCE — with no
+            // error — when the input carries a discrete channel layout, which
+            // is exactly what a mic array reports. The built-in mic switches to
+            // a 3ch discrete array the moment another app activates voice
+            // processing (any WeChat / FaceTime / Teams call), so the mic track
+            // of a real call recorded 50 minutes of digital silence while the
+            // app track was fine. Selecting a channel explicitly restores it.
+            if let map = MicChannelMap.downmixMap(for: tapFormat) {
+                converter?.channelMap = map
+                logger.info(
+                    "Mic: discrete/multichannel layout — selecting channel 0 explicitly (implicit downmix yields silence)",
+                )
+            }
             logger.info(
                 "Mic: converting \(Int(tapFormat.sampleRate))Hz/\(tapFormat.channelCount)ch → \(Int(self.fileSampleRate))Hz/1ch",
             )

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -211,26 +211,11 @@ public class MicCaptureHandler: @unchecked Sendable {
 
         converter = nil
         resampleRatio = fileSampleRate / tapFormat.sampleRate
-        // Convert to 16 kHz mono whenever the tap isn't already there — this
-        // covers resampling AND downmixing a multi-channel input device. Since
-        // the tap now matches the node's real channel count (issue #379), a
-        // 2ch device is captured as 2ch and folded to the mono WAV here.
-        if tapFormat.sampleRate != fileSampleRate || tapFormat.channelCount != 1 {
-            let outputFormat = AVAudioFormat(
-                standardFormatWithSampleRate: fileSampleRate, channels: 1,
-            )! // swiftlint:disable:this force_unwrapping
-            converter = AVAudioConverter(from: tapFormat, to: outputFormat)
-            // AVAudioConverter's IMPLICIT downmix writes SILENCE — with no
-            // error — when the input carries a discrete channel layout, which
-            // is exactly what a mic array reports. The built-in mic switches to
-            // a 3ch discrete array the moment another app activates voice
-            // processing (any WeChat / FaceTime / Teams call), so the mic track
-            // of a real call recorded 50 minutes of digital silence while the
-            // app track was fine. Selecting a channel explicitly restores it.
-            if let map = MicChannelMap.downmixMap(for: tapFormat) {
-                converter?.channelMap = map
+        if let setup = MicConverterFactory.make(tapFormat: tapFormat, fileSampleRate: fileSampleRate) {
+            converter = setup.converter
+            if let channel = setup.selectedChannel {
                 logger.info(
-                    "Mic: discrete/multichannel layout — selecting channel 0 explicitly (implicit downmix yields silence)",
+                    "Mic: layout has no usable implicit downmix — selecting channel \(channel) explicitly",
                 )
             }
             logger.info(

--- a/tools/audiotap/Sources/MicChannelMap.swift
+++ b/tools/audiotap/Sources/MicChannelMap.swift
@@ -1,0 +1,48 @@
+import AVFoundation
+
+/// Decides when a multi-channel mic input needs an EXPLICIT converter
+/// `channelMap` instead of `AVAudioConverter`'s implicit downmix.
+///
+/// Why this exists: `AVAudioConverter` silently produces **silence** (all-zero
+/// downmix matrix, `convert` returns success, no error) when the input format
+/// carries a *discrete* channel layout — the layout a microphone array reports.
+/// The built-in mic switches from 1ch to a 3ch discrete array as soon as any
+/// other app activates voice processing (a WeChat / FaceTime / Teams call), so
+/// the mic track of a real call is written as digital silence while the app
+/// track records normally. Measured on macOS 26.1: discrete 2ch/3ch/4ch → peak
+/// 0.0; the same conversion with `channelMap = [0]` → the input signal intact.
+///
+/// Standard mono/stereo layouts downmix correctly and are left alone, so a
+/// normal stereo interface keeps both channels folded together as before.
+public enum MicChannelMap {
+    /// High 16 bits of a layout tag hold the tag "family"; the low 16 hold the
+    /// channel count for count-parameterised tags such as `DiscreteInOrder`.
+    private static let tagFamilyMask: AudioChannelLayoutTag = 0xFFFF_0000
+
+    private static func family(of tag: AudioChannelLayoutTag) -> AudioChannelLayoutTag {
+        tag & tagFamilyMask
+    }
+
+    /// `[0]` when `format` needs an explicit single-channel selection, `nil`
+    /// when the implicit downmix is trustworthy (mono, or a standard layout
+    /// with an inferable downmix matrix).
+    public static func downmixMap(for format: AVAudioFormat) -> [NSNumber]? {
+        guard format.channelCount > 1 else { return nil }
+
+        guard let layout = format.channelLayout else {
+            // No layout at all: only mono/stereo have an inferable downmix.
+            return format.channelCount > 2 ? [0] : nil
+        }
+
+        let tagFamily = family(of: layout.layoutTag)
+        let discreteFamily = family(of: kAudioChannelLayoutTag_DiscreteInOrder)
+        let unknownFamily = family(of: kAudioChannelLayoutTag_Unknown)
+
+        if tagFamily == discreteFamily || tagFamily == unknownFamily {
+            return [0]
+        }
+        // Any other named layout above stereo has no meaningful mono fold for a
+        // mic capture either — prefer one real channel over a guess.
+        return format.channelCount > 2 ? [0] : nil
+    }
+}

--- a/tools/audiotap/Sources/MicChannelMap.swift
+++ b/tools/audiotap/Sources/MicChannelMap.swift
@@ -4,45 +4,49 @@ import AVFoundation
 /// `channelMap` instead of `AVAudioConverter`'s implicit downmix.
 ///
 /// Why this exists: `AVAudioConverter` silently produces **silence** (all-zero
-/// downmix matrix, `convert` returns success, no error) when the input format
-/// carries a *discrete* channel layout — the layout a microphone array reports.
-/// The built-in mic switches from 1ch to a 3ch discrete array as soon as any
-/// other app activates voice processing (a WeChat / FaceTime / Teams call), so
-/// the mic track of a real call is written as digital silence while the app
-/// track records normally. Measured on macOS 26.1: discrete 2ch/3ch/4ch → peak
-/// 0.0; the same conversion with `channelMap = [0]` → the input signal intact.
+/// downmix matrix, `convert` returns success, no error) for most layouts a real
+/// capture device reports. The built-in mic switches from 1ch to a 3ch discrete
+/// array as soon as another app activates voice processing (a WeChat /
+/// FaceTime / Teams call), so the mic track of a whole call is written as
+/// digital silence while the app track records normally.
 ///
-/// Standard mono/stereo layouts downmix correctly and are left alone, so a
-/// normal stereo interface keeps both channels folded together as before.
+/// The set of layouts the implicit path folds correctly is much smaller than
+/// "everything that is not discrete". Measured on macOS 26.5.2, 48 kHz → 16 kHz
+/// mono, 0.5-amplitude sine on *every* input channel:
+///
+///     mono; stereo with no layout; kAudioChannelLayoutTag_Stereo    0.5  ok
+///     DiscreteInOrder 2ch / 3ch / 4ch                               0.0  silent
+///     StereoHeadphones, MatrixStereo, MidSide, XY, Binaural         0.0  silent
+///
+/// `MidSide` and `XY` are microphone-pair configurations, so the silent set is
+/// not exotic. The policy is therefore an ALLOWLIST: only layouts measured to
+/// fold correctly stay on the implicit path, everything else selects one real
+/// channel. A named surround layout loses its correct fold that way, but no mic
+/// input reports one, and one audible channel beats a silent track.
+///
+/// For a mic array channel 0 is taken as-is rather than averaging the elements,
+/// which would risk comb filtering from the inter-element delay.
 public enum MicChannelMap {
-    /// High 16 bits of a layout tag hold the tag "family"; the low 16 hold the
-    /// channel count for count-parameterised tags such as `DiscreteInOrder`.
-    private static let tagFamilyMask: AudioChannelLayoutTag = 0xFFFF_0000
-
-    private static func family(of tag: AudioChannelLayoutTag) -> AudioChannelLayoutTag {
-        tag & tagFamilyMask
-    }
+    // `AVAudioConverter.channelMap` takes `[NSNumber]`, and `nil` here means
+    // "leave the converter's own downmix alone" rather than "map no channels",
+    // so both of these rules are unavoidable at this boundary.
+    // swiftlint:disable discouraged_optional_collection legacy_objc_type
 
     /// `[0]` when `format` needs an explicit single-channel selection, `nil`
-    /// when the implicit downmix is trustworthy (mono, or a standard layout
-    /// with an inferable downmix matrix).
+    /// when the implicit downmix is trustworthy.
     public static func downmixMap(for format: AVAudioFormat) -> [NSNumber]? {
         guard format.channelCount > 1 else { return nil }
 
         guard let layout = format.channelLayout else {
-            // No layout at all: only mono/stereo have an inferable downmix.
-            return format.channelCount > 2 ? [0] : nil
+            // Plain stereo carries no layout object and folds L+R correctly.
+            return format.channelCount == 2 ? nil : [0]
         }
 
-        let tagFamily = family(of: layout.layoutTag)
-        let discreteFamily = family(of: kAudioChannelLayoutTag_DiscreteInOrder)
-        let unknownFamily = family(of: kAudioChannelLayoutTag_Unknown)
-
-        if tagFamily == discreteFamily || tagFamily == unknownFamily {
-            return [0]
+        if format.channelCount == 2, layout.layoutTag == kAudioChannelLayoutTag_Stereo {
+            return nil
         }
-        // Any other named layout above stereo has no meaningful mono fold for a
-        // mic capture either — prefer one real channel over a guess.
-        return format.channelCount > 2 ? [0] : nil
+        return [0]
     }
+
+    // swiftlint:enable discouraged_optional_collection legacy_objc_type
 }

--- a/tools/audiotap/Sources/MicConverterFactory.swift
+++ b/tools/audiotap/Sources/MicConverterFactory.swift
@@ -1,0 +1,44 @@
+@preconcurrency import AVFoundation
+
+/// The tap → WAV converter for one mic capture, plus whether an explicit
+/// channel selection had to be applied (for logging).
+public struct MicConverterSetup {
+    public let converter: AVAudioConverter
+    /// Non-nil when `MicChannelMap` required an explicit single-channel
+    /// selection because the implicit downmix would have written silence.
+    public let selectedChannel: Int?
+}
+
+/// Builds the converter that folds the mic tap format to the 16 kHz mono WAV.
+///
+/// Separated from `MicCaptureHandler` so the channel-map decision is testable
+/// without an audio device: the handler only reaches this code with a live
+/// engine, yet the failure it guards against (a discrete layout downmixing to
+/// digital silence) is a pure property of the format.
+public enum MicConverterFactory {
+    /// `nil` when the tap already matches the file format and no conversion is
+    /// needed. Otherwise a converter configured for this tap format, with an
+    /// explicit `channelMap` whenever the implicit downmix cannot be trusted.
+    public static func make(tapFormat: AVAudioFormat, fileSampleRate: Double) -> MicConverterSetup? {
+        // Convert whenever the tap isn't already at the file format — this
+        // covers resampling AND downmixing a multi-channel input device. Since
+        // the tap matches the node's real channel count (issue #379), a 2ch
+        // device is captured as 2ch and folded to the mono WAV here.
+        guard tapFormat.sampleRate != fileSampleRate || tapFormat.channelCount != 1 else { return nil }
+        guard let outputFormat = AVAudioFormat(standardFormatWithSampleRate: fileSampleRate, channels: 1),
+              let converter = AVAudioConverter(from: tapFormat, to: outputFormat)
+        else { return nil }
+
+        // AVAudioConverter's IMPLICIT downmix writes SILENCE — with no error —
+        // for every layout but plain stereo, and a mic array reports exactly
+        // such a layout. The built-in mic switches to a 3ch discrete array the
+        // moment another app activates voice processing (any WeChat / FaceTime
+        // / Teams call), so the mic track of a real call recorded 50 minutes of
+        // digital silence while the app track was fine. See `MicChannelMap`.
+        guard let map = MicChannelMap.downmixMap(for: tapFormat) else {
+            return MicConverterSetup(converter: converter, selectedChannel: nil)
+        }
+        converter.channelMap = map
+        return MicConverterSetup(converter: converter, selectedChannel: map.first?.intValue)
+    }
+}

--- a/tools/audiotap/Sources/TapFormatResolver.swift
+++ b/tools/audiotap/Sources/TapFormatResolver.swift
@@ -13,7 +13,12 @@ public enum TapFormatResolver {
     /// it always matches the bus (issue #379 — a mismatched channel count made
     /// installTapOnBus raise) AND it works for any channel count, whereas
     /// `standardFormatWithSampleRate:channels:` returns nil for >2 channels
-    /// (no inferable layout). The converter downmixes it to the mono WAV.
+    /// (no inferable layout).
+    ///
+    /// The channel layout rides along verbatim, which matters downstream: for
+    /// anything but plain stereo `AVAudioConverter`'s implicit downmix writes
+    /// silence, so `MicConverterFactory` has to select a channel explicitly.
+    /// Do not assume the converter folds this format to mono on its own.
     public static func tapFormat(forHardware hwFormat: AVAudioFormat) -> AVAudioFormat? {
         guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else { return nil }
         return hwFormat

--- a/tools/audiotap/Tests/MicChannelMapTests.swift
+++ b/tools/audiotap/Tests/MicChannelMapTests.swift
@@ -1,0 +1,86 @@
+@testable import AudioTapLib
+import AVFoundation
+import XCTest
+
+final class MicChannelMapTests: XCTestCase {
+    private func discreteFormat(channels: AVAudioChannelCount) throws -> AVAudioFormat {
+        let tag = kAudioChannelLayoutTag_DiscreteInOrder | UInt32(channels)
+        let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: tag))
+        return AVAudioFormat(standardFormatWithSampleRate: 48000, channelLayout: layout)
+    }
+
+    // MARK: - Policy
+
+    func testMonoNeedsNoMap() throws {
+        let mono = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
+        XCTAssertNil(MicChannelMap.downmixMap(for: mono))
+    }
+
+    func testStandardStereoKeepsImplicitDownmix() throws {
+        // Standard stereo folds L+R correctly — don't throw away a channel.
+        let stereo = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 2))
+        XCTAssertNil(MicChannelMap.downmixMap(for: stereo))
+    }
+
+    func testDiscreteStereoNeedsExplicitMap() throws {
+        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 2)), [0])
+    }
+
+    func testDiscreteMicArrayNeedsExplicitMap() throws {
+        // The built-in mic in voice-processing mode: 3ch discrete.
+        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 3)), [0])
+        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 4)), [0])
+    }
+
+    // MARK: - The behaviour the policy exists for
+
+    /// Pins the actual AVAudioConverter defect: a discrete multichannel input
+    /// downmixes to silence implicitly, and to real audio with the map. If a
+    /// future macOS fixes the implicit path, the first assertion fails and this
+    /// workaround can be revisited.
+    func testImplicitDownmixIsSilentAndMapRestoresAudio() throws {
+        for channels in [2, 3, 4] as [AVAudioChannelCount] {
+            let inFormat = try discreteFormat(channels: channels)
+            XCTAssertEqual(
+                try convertPeak(from: inFormat, channelMap: nil), 0, accuracy: 0.0001,
+                "discrete \(channels)ch implicit downmix is expected to yield silence",
+            )
+            XCTAssertEqual(
+                try convertPeak(from: inFormat, channelMap: MicChannelMap.downmixMap(for: inFormat)), 0.5,
+                accuracy: 0.01, "explicit channel map must preserve the signal (\(channels)ch)",
+            )
+        }
+    }
+
+    /// Feeds one buffer of a 0.5-amplitude sine on every channel through the
+    /// same conversion MicCaptureHandler performs; returns the output peak.
+    private func convertPeak(from inFormat: AVAudioFormat, channelMap: [NSNumber]?) throws -> Float {
+        let outFormat = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1))
+        let converter = try XCTUnwrap(AVAudioConverter(from: inFormat, to: outFormat))
+        if let channelMap { converter.channelMap = channelMap }
+
+        let frames: AVAudioFrameCount = 4800
+        let inBuf = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: inFormat, frameCapacity: frames))
+        inBuf.frameLength = frames
+        for channel in 0 ..< Int(inFormat.channelCount) {
+            let samples = try XCTUnwrap(inBuf.floatChannelData)[channel]
+            for frame in 0 ..< Int(frames) {
+                samples[frame] = 0.5 * sinf(2 * .pi * 440 * Float(frame) / 48000)
+            }
+        }
+
+        let outBuf = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: 1600))
+        var error: NSError?
+        var fed = false
+        converter.convert(to: outBuf, error: &error) { _, status in
+            if fed { status.pointee = .noDataNow; return nil }
+            fed = true
+            status.pointee = .haveData
+            return inBuf
+        }
+        if let error { throw error }
+
+        let samples = try XCTUnwrap(outBuf.floatChannelData)[0]
+        return (0 ..< Int(outBuf.frameLength)).reduce(Float(0)) { max($0, abs(samples[$1])) }
+    }
+}

--- a/tools/audiotap/Tests/MicChannelMapTests.swift
+++ b/tools/audiotap/Tests/MicChannelMapTests.swift
@@ -3,10 +3,23 @@ import AVFoundation
 import XCTest
 
 final class MicChannelMapTests: XCTestCase {
-    private func discreteFormat(channels: AVAudioChannelCount) throws -> AVAudioFormat {
-        let tag = kAudioChannelLayoutTag_DiscreteInOrder | UInt32(channels)
+    /// 2ch layouts whose implicit downmix was measured to yield silence.
+    /// `MidSide` and `XY` are what a stereo microphone pair reports.
+    private static let silentStereoTags: [AudioChannelLayoutTag] = [
+        kAudioChannelLayoutTag_StereoHeadphones,
+        kAudioChannelLayoutTag_MatrixStereo,
+        kAudioChannelLayoutTag_MidSide,
+        kAudioChannelLayoutTag_XY,
+        kAudioChannelLayoutTag_Binaural,
+    ]
+
+    private func taggedFormat(_ tag: AudioChannelLayoutTag) throws -> AVAudioFormat {
         let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: tag))
         return AVAudioFormat(standardFormatWithSampleRate: 48000, channelLayout: layout)
+    }
+
+    private func discreteFormat(channels: AVAudioChannelCount) throws -> AVAudioFormat {
+        try taggedFormat(kAudioChannelLayoutTag_DiscreteInOrder | UInt32(channels))
     }
 
     // MARK: - Policy
@@ -23,13 +36,33 @@ final class MicChannelMapTests: XCTestCase {
     }
 
     func testDiscreteStereoNeedsExplicitMap() throws {
-        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 2)), [0])
+        let discreteStereo = try discreteFormat(channels: 2)
+        XCTAssertEqual(MicChannelMap.downmixMap(for: discreteStereo), [0])
     }
 
     func testDiscreteMicArrayNeedsExplicitMap() throws {
         // The built-in mic in voice-processing mode: 3ch discrete.
-        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 3)), [0])
-        XCTAssertEqual(MicChannelMap.downmixMap(for: try discreteFormat(channels: 4)), [0])
+        let threeChannel = try discreteFormat(channels: 3)
+        let fourChannel = try discreteFormat(channels: 4)
+        XCTAssertEqual(MicChannelMap.downmixMap(for: threeChannel), [0])
+        XCTAssertEqual(MicChannelMap.downmixMap(for: fourChannel), [0])
+    }
+
+    func testNamedStereoVariantsNeedExplicitMap() throws {
+        // Every 2ch layout except the plain Stereo tag downmixes to silence,
+        // including the two microphone-pair configurations (MidSide, XY).
+        for tag in Self.silentStereoTags {
+            let format = try taggedFormat(tag)
+            XCTAssertEqual(
+                MicChannelMap.downmixMap(for: format), [0],
+                "layout tag \(String(format: "0x%06X", tag)) must not stay on the implicit path",
+            )
+        }
+    }
+
+    func testPlainStereoTagKeepsImplicitDownmix() throws {
+        let stereo = try taggedFormat(kAudioChannelLayoutTag_Stereo)
+        XCTAssertNil(MicChannelMap.downmixMap(for: stereo))
     }
 
     // MARK: - The behaviour the policy exists for
@@ -41,19 +74,38 @@ final class MicChannelMapTests: XCTestCase {
     func testImplicitDownmixIsSilentAndMapRestoresAudio() throws {
         for channels in [2, 3, 4] as [AVAudioChannelCount] {
             let inFormat = try discreteFormat(channels: channels)
-            XCTAssertEqual(
-                try convertPeak(from: inFormat, channelMap: nil), 0, accuracy: 0.0001,
-                "discrete \(channels)ch implicit downmix is expected to yield silence",
-            )
-            XCTAssertEqual(
-                try convertPeak(from: inFormat, channelMap: MicChannelMap.downmixMap(for: inFormat)), 0.5,
-                accuracy: 0.01, "explicit channel map must preserve the signal (\(channels)ch)",
-            )
+            try assertImplicitSilentAndMapAudible(inFormat, label: "discrete \(channels)ch")
+        }
+        for tag in Self.silentStereoTags {
+            let inFormat = try taggedFormat(tag)
+            try assertImplicitSilentAndMapAudible(inFormat, label: String(format: "tag 0x%06X", tag))
         }
     }
 
-    /// Feeds one buffer of a 0.5-amplitude sine on every channel through the
-    /// same conversion MicCaptureHandler performs; returns the output peak.
+    /// The plain Stereo tag is the one layout the allowlist keeps on the
+    /// implicit path, so its fold has to stay correct for that to be safe.
+    func testPlainStereoStillFoldsCorrectlyWithoutAMap() throws {
+        let stereo = try taggedFormat(kAudioChannelLayoutTag_Stereo)
+        let peak = try convertPeak(from: stereo, channelMap: nil)
+        XCTAssertEqual(peak, 0.5, accuracy: 0.01)
+    }
+
+    private func assertImplicitSilentAndMapAudible(
+        _ inFormat: AVAudioFormat, label: String, file: StaticString = #filePath, line: UInt = #line,
+    ) throws {
+        let implicitPeak = try convertPeak(from: inFormat, channelMap: nil)
+        XCTAssertEqual(
+            implicitPeak, 0, accuracy: 0.0001,
+            "\(label): implicit downmix is expected to yield silence", file: file, line: line,
+        )
+        let mappedPeak = try convertPeak(from: inFormat, channelMap: MicChannelMap.downmixMap(for: inFormat))
+        XCTAssertEqual(
+            mappedPeak, 0.5, accuracy: 0.01,
+            "\(label): explicit channel map must preserve the signal", file: file, line: line,
+        )
+    }
+
+    // swiftlint:disable:next discouraged_optional_collection legacy_objc_type
     private func convertPeak(from inFormat: AVAudioFormat, channelMap: [NSNumber]?) throws -> Float {
         let outFormat = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1))
         let converter = try XCTUnwrap(AVAudioConverter(from: inFormat, to: outFormat))

--- a/tools/audiotap/Tests/MicConverterFactoryTests.swift
+++ b/tools/audiotap/Tests/MicConverterFactoryTests.swift
@@ -1,0 +1,75 @@
+@testable import AudioTapLib
+import AVFoundation
+import XCTest
+
+/// Covers the seam the silent-mic bug actually lived at: `MicChannelMap` can be
+/// perfectly correct and the mic track still records silence if the converter
+/// the capture path builds never gets the map applied. These tests drive the
+/// factory the handler uses, so dropping the `channelMap` assignment fails them
+/// even though every `MicChannelMapTests` case still passes.
+final class MicConverterFactoryTests: XCTestCase {
+    private let fileRate: Double = 16000
+
+    private func taggedFormat(_ tag: AudioChannelLayoutTag) throws -> AVAudioFormat {
+        let layout = try XCTUnwrap(AVAudioChannelLayout(layoutTag: tag))
+        return AVAudioFormat(standardFormatWithSampleRate: 48000, channelLayout: layout)
+    }
+
+    /// The device state a WeChat / FaceTime / Teams call puts the built-in mic
+    /// into: 48 kHz, 3 channels, discrete layout.
+    private func voiceProcessingMicFormat() throws -> AVAudioFormat {
+        try taggedFormat(kAudioChannelLayoutTag_DiscreteInOrder | 3)
+    }
+
+    func testNoConverterWhenTapAlreadyMatchesTheFile() throws {
+        let matching = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: fileRate, channels: 1))
+        XCTAssertNil(MicConverterFactory.make(tapFormat: matching, fileSampleRate: fileRate))
+    }
+
+    func testMicArrayConverterCarriesAnExplicitChannelMap() throws {
+        let tapFormat = try voiceProcessingMicFormat()
+        let setup = try XCTUnwrap(MicConverterFactory.make(tapFormat: tapFormat, fileSampleRate: fileRate))
+        XCTAssertEqual(setup.converter.channelMap, [0])
+        XCTAssertEqual(setup.selectedChannel, 0)
+    }
+
+    func testPlainStereoConverterKeepsTheImplicitFold() throws {
+        let stereo = try taggedFormat(kAudioChannelLayoutTag_Stereo)
+        let setup = try XCTUnwrap(MicConverterFactory.make(tapFormat: stereo, fileSampleRate: fileRate))
+        XCTAssertNil(setup.selectedChannel)
+    }
+
+    /// The end the user notices: audio in, audio out. Without the explicit map
+    /// this converter writes digital zeros for the whole call.
+    func testMicArrayConverterProducesAudioRatherThanSilence() throws {
+        let tapFormat = try voiceProcessingMicFormat()
+        let setup = try XCTUnwrap(MicConverterFactory.make(tapFormat: tapFormat, fileSampleRate: fileRate))
+
+        let frames: AVAudioFrameCount = 4800
+        let inBuf = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: tapFormat, frameCapacity: frames))
+        inBuf.frameLength = frames
+        for channel in 0 ..< Int(tapFormat.channelCount) {
+            let samples = try XCTUnwrap(inBuf.floatChannelData)[channel]
+            for frame in 0 ..< Int(frames) {
+                samples[frame] = 0.5 * sinf(2 * .pi * 440 * Float(frame) / 48000)
+            }
+        }
+
+        let outBuf = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: setup.converter.outputFormat, frameCapacity: 1600),
+        )
+        var error: NSError?
+        var fed = false
+        setup.converter.convert(to: outBuf, error: &error) { _, status in
+            if fed { status.pointee = .noDataNow; return nil }
+            fed = true
+            status.pointee = .haveData
+            return inBuf
+        }
+        XCTAssertNil(error)
+
+        let samples = try XCTUnwrap(outBuf.floatChannelData)[0]
+        let peak = (0 ..< Int(outBuf.frameLength)).reduce(Float(0)) { max($0, abs(samples[$1])) }
+        XCTAssertEqual(peak, 0.5, accuracy: 0.01, "the capture path must not write digital silence")
+    }
+}


### PR DESCRIPTION
## Symptom

The **mic track of a real call is digital silence**, while the app track records normally. Nothing is logged as an error — the only downstream sign is a transcript full of Whisper's silence hallucinations ("Thank you." repeated).

Observed on a 50-minute WeChat video call (macOS 26.1, MacBook Air, built-in mic):

```
21:29:18  Mic hardware format: 48000.0 Hz, 3ch      ← call starts, device flips 1ch → 3ch
21:29:24  Mic: filled 1 silent frames for a device-restart gap
   …      App audio RMS: -24…-33 dBFS    (fine)
   …      Mic RMS:       -48…-62 dBFS    (nothing)
22:19:23  Mic hardware format: 48000.0 Hz, 1ch      ← call ends, device back to 1ch
```

`ffmpeg silencedetect -70dB` on the resulting `_mic.wav`: **one unbroken silent region, 0 → 3005.1 s** of a 3022 s recording. It records audio again only in the last ~17 seconds, i.e. after the call released the device.

## Root cause

`AVAudioConverter`'s **implicit** downmix matrix is all-zero when the input format carries a *discrete* channel layout. `convert(to:error:)` returns success, sets no error, and writes silence.

A discrete layout is exactly what a microphone array reports — and the built-in mic switches from 1ch to a **3ch discrete array** as soon as any other app activates voice processing (any WeChat / FaceTime / Teams / Zoom call). `MicCaptureHandler` taps at the hardware format (correct, since #379) and relies on the converter to fold it to the 16 kHz mono WAV, so from the moment a call starts every sample written is zero.

Measured directly (48 kHz → 16 kHz mono, 0.5-amplitude sine on **every** input channel, so a correct downmix must yield ≈ 0.5):

| input format | peak out | |
|---|---|---|
| 1ch | 0.500 | ok |
| standard stereo | 0.500 | ok |
| discrete 2ch | **0.000** | silent |
| discrete 3ch | **0.000** | silent |
| discrete 4ch | **0.000** | silent |
| discrete 3ch, `channelMap = [0]` | 0.500 | ok |
| discrete 4ch, `channelMap = [0]` | 0.500 | ok |

## Fix

`MicChannelMap.downmixMap(for:)` decides when an explicit `converter.channelMap` is required:

- **mono** → no map (nothing to fold),
- **standard stereo** → no map, the implicit L+R fold is correct and keeps both channels,
- **discrete / unknown layout, or >2ch with no meaningful mono fold** → `[0]`, one real channel instead of silence.

For a mic array, channel 0 is the primary element, so selecting it is the sensible choice; averaging array elements would risk comb filtering from the inter-element delay.

`MicChannelMapTests` pins both halves: the policy, and the underlying converter behaviour itself (implicit → silence, explicit map → signal). If a future macOS fixes the implicit path, the pinning assertion fails and this workaround can be revisited deliberately rather than silently.

## A note on verification

The measurements above were produced by running the exact conversion path in a standalone Swift program on the affected machine — that evidence is solid. **The XCTest target itself I could not run**: this machine has Command Line Tools only (no Xcode), so `swift test` cannot resolve `XCTest`. Please treat the test file as unverified until CI runs it; I'd appreciate the workflow being approved on this PR.

Related: #547 (a second silent-capture failure, on the app-audio side, from a missing usage-description key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
