### PR TITLE
fix(app): make the release actually deliver the entitlement, and let users grant Screen Recording

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,35 @@ jobs:
           cert: ${{ secrets.DEVELOPER_ID_CERT }}
           cert-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
 
+      # The time-sensitive notification entitlement is RESTRICTED: codesign only
+      # keeps it when a provisioning profile that grants it is embedded, and
+      # silently drops it otherwise while still reporting success. Profiles are
+      # account artifacts and gitignored, so without this step a release ships
+      # with the entitlement missing and the browser-consent prompt stays
+      # suppressed under Focus for every user — the exact bug it fixes.
+      # Absent secret: prepare_signing takes its no-profile path and the build
+      # still succeeds, so a fork release is not blocked by it.
+      - name: Install provisioning profile
+        if: matrix.variant == 'homebrew'
+        env:
+          PROFILE_B64: ${{ secrets.RELEASE_PROVISIONING_PROFILE }}
+        run: |
+          # Guarded here rather than in `if:` — the secrets context is not
+          # dependable in step conditions, and the repo already gates
+          # DEVELOPER_ID this way.
+          if [ -z "${PROFILE_B64:-}" ]; then
+            echo "No RELEASE_PROVISIONING_PROFILE secret — building without the entitlement."
+            exit 0
+          fi
+          # shellcheck source=scripts/lib/signing.sh
+          source scripts/lib/signing.sh
+          # shellcheck source=scripts/lib/bundle-ids.sh
+          source scripts/lib/bundle-ids.sh
+          mkdir -p "$PROFILE_DIR"
+          printf '%s' "$PROFILE_B64" \
+            | base64 --decode > "$PROFILE_DIR/${RELEASE_BUNDLE_ID}.provisionprofile"
+          echo "Installed profile for $RELEASE_BUNDLE_ID"
+
       - name: Build .app and DMG
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
@@ -94,6 +123,32 @@ jobs:
             ./scripts/build_release.sh $STAPLE_FLAG ${BUILD_VERSION:-}
           else
             ./scripts/build_release.sh ${{ matrix.build-flags }} --no-notarize ${BUILD_VERSION:-}
+          fi
+
+      # Assert on the SHIPPED signature, not on the profile: a profile that
+      # grants the key is necessary but not sufficient, and every other way the
+      # entitlement gets dropped (unset DEVELOPER_ID, a plist edit that breaks,
+      # a signing path that never reaches prepare_signing) is invisible to a
+      # check on the input. verify_signing only warns, deliberately, so
+      # contributor builds keep working — the release lane is the one caller
+      # that has to fail.
+      - name: Verify the release carries the time-sensitive entitlement
+        if: matrix.variant == 'homebrew'
+        env:
+          PROFILE_B64: ${{ secrets.RELEASE_PROVISIONING_PROFILE }}
+        run: |
+          if [ -z "${PROFILE_B64:-}" ]; then
+            echo "No profile was installed — nothing to verify."
+            exit 0
+          fi
+          # shellcheck source=scripts/lib/signing.sh
+          source scripts/lib/signing.sh
+          APP_BUNDLE=".build/release/MeetingTranscriber.app"
+          if bundle_has_time_sensitive "$APP_BUNDLE"; then
+            echo "Signature carries $TIME_SENSITIVE_KEY"
+          else
+            echo "::error::the built app is missing $TIME_SENSITIVE_KEY — the consent prompt would stay suppressed under Focus"
+            exit 1
           fi
 
       - name: Get version

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -24,6 +24,43 @@ enum Permissions {
         return granted
     }
 
+    /// Take a one-shot flag: true when this caller is the first to claim it.
+    /// Shared by the prompt guards below, which would otherwise each hand-roll
+    /// the same test-and-set in a slightly different shape.
+    private static func claimFirst(_ lock: OSAllocatedUnfairLock<Bool>) -> Bool {
+        lock.withLock { claimed in
+            defer { claimed = true }
+            return !claimed
+        }
+    }
+
+    private static let screenRecordingPromptLock = OSAllocatedUnfairLock(initialState: false)
+
+    /// Ask macOS for Screen Recording, at most once per session.
+    ///
+    /// `CGRequestScreenCaptureAccess` is the only call that registers the app in
+    /// the Screen Recording list; `CGPreflightScreenCaptureAccess` reports
+    /// status and registers nothing. Until the app is in that list there is
+    /// nothing for the user to switch on, and the "Open System Settings" link
+    /// opens a pane the app is absent from.
+    ///
+    /// Unlike the microphone, this cannot grant in place: macOS offers only
+    /// Deny or Open System Settings, the toggle stays there, and the grant takes
+    /// effect on the next launch. So the win is turning "find the bundle inside
+    /// a hidden folder" into "flip the switch that is already there".
+    ///
+    /// The already-granted check comes first so a session that starts granted
+    /// does not burn the one-shot flag: if the grant is revoked mid-session, the
+    /// next watch start still asks.
+    static func ensureScreenRecordingAccess() {
+        guard !CGPreflightScreenCaptureAccess() else { return }
+        guard claimFirst(screenRecordingPromptLock) else { return }
+
+        if !CGRequestScreenCaptureAccess() {
+            logger.warning("permission_denied resource=screen_recording status=user_denied_prompt")
+        }
+    }
+
     static func ensureMicrophoneAccess() async -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         if status == .authorized { return true }

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -47,6 +47,22 @@ final class WatchingController {
     /// surfaces a permission problem through its own `permissionChecker`).
     private let ensureMicAccess: () async -> Bool
 
+    /// Screen-Recording request, fired at watch start. Injectable so tests skip
+    /// the real TCC prompt.
+    ///
+    /// Asking is what registers the app in the Screen Recording list at all —
+    /// preflighting never does — and until it is listed there is nothing for
+    /// the user to switch on. It sits here, next to the microphone gate, rather
+    /// than in the health check: that runs on every activation, so the request
+    /// would keep arriving while the user is trying to work, and a checker
+    /// causing a system prompt is a side effect nothing can inject around.
+    ///
+    /// The result is ignored, like the microphone gate: the permission only
+    /// improves the detected meeting's title (`PowerAssertionDetector` falls
+    /// back to a placeholder), so watching proceeds either way and the health
+    /// check reports the state.
+    private let requestScreenRecording: () -> Void
+
     /// Meeting detector factory for the auto-detect path. Injectable so tests can
     /// supply a deterministic detector instead of the IOKit-backed
     /// `PowerAssertionDetector`.
@@ -66,6 +82,7 @@ final class WatchingController {
         permissions: PermissionsController,
         liveTranscription: LiveTranscriptionCoordinator,
         ensureMicAccess: @escaping () async -> Bool = { await Permissions.ensureMicrophoneAccess() },
+        requestScreenRecording: @escaping () -> Void = { Permissions.ensureScreenRecordingAccess() },
         makeDetector: (() -> any MeetingDetecting)? = nil,
     ) {
         self.settings = settings
@@ -75,6 +92,7 @@ final class WatchingController {
         self.permissions = permissions
         self.liveTranscription = liveTranscription
         self.ensureMicAccess = ensureMicAccess
+        self.requestScreenRecording = requestScreenRecording
         // Tests inject a deterministic detector; production defaults to one
         // filtered by the "Apps to Watch" toggles, re-read at each watch start.
         self.makeDetector = makeDetector ?? { [settings] in
@@ -123,6 +141,7 @@ final class WatchingController {
             startTask = Task { @MainActor in
                 defer { startTask = nil }
                 _ = await ensureMicAccess()
+                requestScreenRecording()
 
                 syncEngines?()
                 pipeline.rebuild()

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -28,6 +28,7 @@ final class WatchingControllerTests: XCTestCase {
     /// default detector never matches a window so no recording starts.
     private func makeController(
         ensureMicAccess: @escaping () async -> Bool = { true },
+        requestScreenRecording: @escaping () -> Void = {},
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
     ) -> WatchingController {
         let settings = AppSettings()
@@ -54,8 +55,30 @@ final class WatchingControllerTests: XCTestCase {
             permissions: permissions,
             liveTranscription: liveTranscription,
             ensureMicAccess: ensureMicAccess,
+            requestScreenRecording: requestScreenRecording,
             makeDetector: makeDetector,
         )
+    }
+
+    // MARK: - requestScreenRecording seam
+
+    /// Asking is what registers the app in the Screen Recording list, and until
+    /// it is listed there is no switch for the user to turn on. It belongs at
+    /// watch start, where the window-title lookup that needs it happens — not
+    /// in the health check, which runs on every activation and would re-ask a
+    /// user who is trying to work.
+    func testToggleWatchingRequestsScreenRecording() async {
+        var requested = false
+        // Not trailing-closure: a trailing closure binds to the last param
+        // (`makeDetector`), not `requestScreenRecording`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(requestScreenRecording: { requested = true })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(requested)
+
+        XCTAssertTrue(requested, "toggleWatching must ask for Screen Recording")
     }
 
     // MARK: - ensureMicAccess seam


### PR DESCRIPTION
Two things that have to be true before the next release, both found while getting the bundle-identifier rename onto the CI runner.

## The release would have shipped without the entitlement

The time-sensitive notification entitlement is restricted: `codesign` keeps it only when an embedded provisioning profile grants it, and drops it silently otherwise while still reporting success. Profiles are account artifacts and gitignored, so `release.yml` had none. Every release would therefore have carried the whole browser-consent fix without its effect — the prompt would have stayed suppressed under Focus for every user, which is exactly the bug the entitlement is there to fix.

The profile now comes from a repository secret, the same way the signing certificate already does. Identifier, profile directory and entitlement key all come from `scripts/lib/bundle-ids.sh` and `scripts/lib/signing.sh` rather than being spelled again here — a second copy is exactly the failure those libraries exist to prevent, and the drift is silent: the signing helper finds no profile, takes its no-profile path, and ships without the entitlement while reporting success.

The build then has to prove it worked. Checking that the *profile* grants the key only proves an input; what has to hold is that the *shipped signature* carries it, and every other way it gets dropped (no `DEVELOPER_ID`, a plist edit that breaks, a signing path that never reaches `prepare_signing`) is invisible from the input side. A post-build step asserts it via `bundle_has_time_sensitive`, which exists for this and whose own comment asks callers to share it instead of re-spelling the key. `verify_signing` only warns, deliberately, so contributor builds keep working — the release lane is the one caller that must fail.

A missing secret degrades to the existing no-profile path rather than failing, so a fork build still succeeds. The guard is inside the script rather than in `if:`, since the secrets context is not dependable in step conditions and the repo already gates `DEVELOPER_ID` the same way.

## Users had no reasonable way to grant Screen Recording

The app only ever called `CGPreflightScreenCaptureAccess`, which reports status and registers nothing. macOS lists an app under Screen Recording once it has *requested* the permission, so the app never appeared in that list at all: the health check reported the permission missing, "Open System Settings" opened a pane the app was absent from, and the only way through was typing the bundle path into a file picker whose parent folders are hidden.

That was the real flow on the CI runner after the identifier changed, and it is what every user would have met on the next update, since a new identifier starts with no grants.

`CGRequestScreenCaptureAccess` puts the app in the list and shows the system prompt. Worth being precise about what it does not do: it cannot grant in place. macOS offers only Deny or Open System Settings and the toggle stays there, unlike the microphone, whose prompt really does grant. The win is turning "find the bundle inside a hidden folder" into "flip the switch that is already there".

It fires at watch start, next to the microphone gate and through the same kind of injectable seam, with a test asserting it. Two reasons it does not live in the permission health check, where it started: that check runs at startup and on every activation, so a read-only checker would acquire a system-mutating side effect nothing can inject around, and every `PermissionsControllerTests` case would really call `CGRequestScreenCaptureAccess`. And on the merits — `MeetingDetector`, the only user of this permission, is not instantiated in production at all. Production runs `PowerAssertionDetector`, which needs it solely to read a window title and already falls back to a placeholder. Prompting at launch would have put a system alert in front of every ungranted user for a cosmetically nicer meeting title, before they had switched watching on.

The already-granted check comes before the once-per-session flag is claimed, so a session that starts granted does not burn it — otherwise a grant revoked mid-session would never be re-requested. Its sibling `ensureAccessibilityAccess` already did it in that order; both now share one `claimFirst` helper instead of two hand-rolled test-and-sets in the same file.

## Verification

- Full test suite green; a seam test pins that watch start asks for the permission
- `swiftlint --strict` clean; SwiftFormat clean on the added lines (the two files it still reports are pre-existing single-line `if` bodies that only the newer local SwiftFormat rewrites — CI pins 0.61.1)
- Release-mode parity green
- The workflow YAML parses, and the base64 round-trip plus the entitlement check were run against the real profile
- Reviewed for reuse, simplification and altitude; the findings are in the last two commits (wrong home for the prompt, a one-shot flag claimed too early, a pure function whose tests could not fail, and three literals the signing libraries already own)

## Not covered here

- Whether the shipped release actually carries the entitlement can only be confirmed by inspecting a real release artifact, since the profile lives in a secret and not in the repo. Worth checking `codesign -d --entitlements :-` on the first DMG built after this lands.
- A grant still takes effect on the next launch; nothing here changes that.
