### PR TITLE
fix(test): gate the live transcript on German, not on the fixture's script

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -223,14 +223,14 @@ RECORD_ONLY_MARKER="/tmp/e2e-app-record-only-marker.$$"
 # speaks "Meeting", but neither this list nor the xctest set includes it: it is
 # the one English word, so requiring only German words proves the German
 # fixture actually transcribed rather than an English hallucination.
-# Threshold is 2-of-5, below the xctest's 3-of-5: the live-capture path
-# (BlackHole → CATap → dual-track merge) is lossier than the xctest's
-# direct-engine path, so 2 leaves margin against capture variance while still
-# decisively rejecting garbage (which matches 0). Applied only when the
-# simulator plays the known fixture (and not the mic-device-change survival
-# lane); a custom --fixture keeps only the >100-byte size check.
-DEFAULT_FIXTURE_KEYWORDS=(willkommen Projekt Status Entwicklung Zeitplan)
-DEFAULT_FIXTURE_KEYWORDS_MIN=2
+# The check itself lives in lib/e2e-helpers.sh as `transcript_is_german` and
+# keys on common German words, NOT on the fixture's script. Recording starts
+# only once the app has DETECTED the meeting, so the opening seconds are never
+# captured and which sentences land shifts run to run; a script-derived list
+# therefore measured recording-start timing, not transcription quality.
+# Applied only when the simulator plays the known fixture (and not the
+# mic-device-change survival lane); a custom --fixture keeps only the
+# >100-byte size check.
 IS_DEFAULT_FIXTURE=false
 [ "$SIMULATOR_FIXTURE" = "$DEFAULT_FIXTURE" ] && IS_DEFAULT_FIXTURE=true
 
@@ -819,28 +819,17 @@ _poll_for_new_lastjob_terminal() {
     POLL_LJ_STATE="$lj_state"
 }
 
-# Assert the transcript contains at least DEFAULT_FIXTURE_KEYWORDS_MIN of the
-# expected German content words (case-insensitive). Guards the live-recording
-# lanes against a transcript that clears the >100-byte size check but is
-# actually garbage — wrong-language hallucination, silent-capture noise, or an
-# empty-ish file — none of which contain the fixture's spoken words. Logs which
-# keywords matched so a near-miss is diagnosable straight from the CI log.
-# Accumulates hit/miss as strings (not arrays) to stay safe under `set -u` on
-# the runner's bash regardless of version.
-assert_transcript_keywords() {
+# Fail the lane unless the transcript reads as German. Guards the
+# live-recording lanes against a transcript that clears the >100-byte size
+# check but is actually garbage — wrong-language hallucination, silent-capture
+# noise, or an empty-ish file. Logs which words matched so a near-miss is
+# diagnosable straight from the CI log.
+assert_transcript_is_german() {
     local label="$1" transcript_path="$2"
-    local matched=0 hit="" miss="" kw
-    for kw in "${DEFAULT_FIXTURE_KEYWORDS[@]}"; do
-        if grep -qi -- "$kw" "$transcript_path"; then
-            matched=$(( matched + 1 )); hit="$hit $kw"
-        else
-            miss="$miss $kw"
-        fi
-    done
-    if [ "$matched" -lt "$DEFAULT_FIXTURE_KEYWORDS_MIN" ]; then
-        fail "$label: transcript matched only $matched/${#DEFAULT_FIXTURE_KEYWORDS[@]} expected German fixture keywords (need >= $DEFAULT_FIXTURE_KEYWORDS_MIN) — likely garbage or wrong-language despite passing the >100-byte size check. matched=[${hit# }] missing=[${miss# }]. Preview:"$'\n'"$(head -c 500 "$transcript_path")"
+    if ! transcript_is_german "$transcript_path"; then
+        fail "$label: transcript does not read as German — matched only $GERMAN_MARKER_MATCHED/${#GERMAN_MARKER_WORDS[@]} common German words (need >= $GERMAN_MARKER_WORDS_MIN), so it is likely an English hallucination or garbage despite passing the >100-byte size check. matched=[$GERMAN_MARKER_HITS]. Preview:"$'\n'"$(head -c 500 "$transcript_path")"
     fi
-    log "$label: transcript content OK — matched $matched/${#DEFAULT_FIXTURE_KEYWORDS[@]} keywords [${hit# }]"
+    log "$label: transcript content OK — matched $GERMAN_MARKER_MATCHED/${#GERMAN_MARKER_WORDS[@]} German words [$GERMAN_MARKER_HITS]"
 }
 
 run_one_meeting() {
@@ -887,7 +876,7 @@ run_one_meeting() {
         # false regression that masks the real survival signal, so skip it.
         log "$label: mic-device-change survival lane — skipping content keyword assertion"
     elif [ "$IS_DEFAULT_FIXTURE" = true ]; then
-        assert_transcript_keywords "$label" "$transcript_path"
+        assert_transcript_is_german "$label" "$transcript_path"
     else
         # Custom --fixture: unknown spoken content, so keep only the size check.
         log "$label: custom fixture — skipping content keyword assertion (size check only)"

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -259,3 +259,39 @@ sweep_run_artifacts() {
         find "$rec_dir" -type f -newer "$marker" -delete 2>/dev/null || true
     fi
 }
+
+# Common German words, matched whole. Function words rather than words from the
+# fixture's script, because the live lane cannot choose which part of the
+# meeting it records: the app starts recording only once it has DETECTED the
+# meeting, so the opening seconds are never captured and the remaining slice
+# shifts run to run. Measured over 13 runs, a content-word list drawn from the
+# script matched exactly [Status Entwicklung] twelve times and [Entwicklung]
+# once — a ceiling of 2 against a floor of 2, so the gate was one dropped word
+# from red while nothing was wrong with the recording.
+#
+# What the gate is actually for is unchanged: catching an English hallucination
+# or garbage that got past the size check. Any German speech carries several of
+# these; English carries none.
+# Kept broad on purpose: the margin comes from the list being long enough that
+# any few German sentences hit several, not from a low threshold.
+GERMAN_MARKER_WORDS=(
+    und die der den das ein ist sind nicht noch mit für haben wir ich
+)
+GERMAN_MARKER_WORDS_MIN=3
+
+# True when the transcript reads as German. Word-boundary matching (`-w`) is
+# load-bearing: with substring matching, English "submit"/"listed"/"sound"
+# contain mit/ist/und and fluent English would pass the very check meant to
+# reject it.
+transcript_is_german() {
+    local transcript_path="$1"
+    local matched=0 hit="" word
+    for word in "${GERMAN_MARKER_WORDS[@]}"; do
+        if grep -qiw -- "$word" "$transcript_path" 2>/dev/null; then
+            matched=$(( matched + 1 )); hit="$hit $word"
+        fi
+    done
+    GERMAN_MARKER_HITS="${hit# }"
+    GERMAN_MARKER_MATCHED="$matched"
+    [ "$matched" -ge "$GERMAN_MARKER_WORDS_MIN" ]
+}

--- a/scripts/tests/test_transcript_is_german.sh
+++ b/scripts/tests/test_transcript_is_german.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Regression test for the e2e transcript language gate.
+#
+# The gate exists to reject an English hallucination or garbage that slipped
+# past the >100-byte size check. It has to do that while accepting whatever
+# slice of the meeting the live lane happened to capture: recording starts only
+# once the app has DETECTED the meeting, so the opening seconds are never in the
+# transcript, and which sentences land varies run to run.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/e2e-helpers.sh
+source "$ROOT/scripts/lib/e2e-helpers.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASSED=0
+
+check() {
+    local name="$1" expected="$2" body="$3"
+    local file="$TMP/${name}.txt"
+    printf '%s\n' "$body" > "$file"
+    local actual=pass
+    transcript_is_german "$file" >/dev/null 2>&1 || actual=fail
+    if [ "$actual" = "$expected" ]; then
+        echo "$name ... PASS"
+        PASSED=$(( PASSED + 1 ))
+    else
+        echo "$name ... FAIL (expected $expected, got $actual)"
+        exit 1
+    fi
+}
+
+# What the live lane actually produces. Taken from a real CI transcript: the
+# capture starts mid-meeting, so none of the fixture's opening words are in it.
+# The old content-keyword gate scored this 1/5 against a floor of 2 and failed
+# the lane, with nothing wrong in the recording or the transcription.
+check live_capture_slice pass \
+"[00:00] S1: Ich kann berichten, dass die Entwicklung gut voranschreitet.
+[00:10] S1: Wir haben letzte Woche drei wichtige Features abgeschlossen.
+[00:21] S1: Ja, wir haben noch ein Problem mit der Datenbankanbindung."
+
+# The other slice, containing the fixture's scripted sentences.
+check fixture_opening_slice pass \
+"[00:00] S1: Guten Tag, willkommen zum Projekt Meeting.
+[00:04] S2: Danke. Ich möchte den aktuellen Status berichten.
+[00:09] S2: Die Entwicklung läuft nach Plan. Wir sind im Zeitplan."
+
+# The failure this gate is for: the engine ran on the wrong language and
+# produced fluent English.
+check english_hallucination fail \
+"[00:00] S1: I can report that development is progressing well.
+[00:10] S1: We completed three important features last week.
+[00:21] S1: There is still a problem with the database connection."
+
+# Substring matching would score this as German: 'submit' contains 'mit',
+# 'listed' contains 'ist', 'sound' contains 'und', 'diet' contains 'die'.
+check english_containing_german_substrings fail \
+"[00:00] S1: Please submit the listed items and the sound diet plan.
+[00:10] S1: The auditor understood the founder was under a bundle."
+
+check garbage fail "[00:00] S1: ▓▒░ ┤├ ╪╪╪ ░▒▓"
+
+check empty_ish fail "[00:00] S1:"
+
+echo "All $PASSED tests passed."


### PR DESCRIPTION
The live-recording lane went red today with nothing wrong: the recording was fine and the transcript was fluent, correctly-diarized German. Only the content check failed. Looking into why turned up a gate that had been passing by its last inch since it was written.

## What the numbers say

The lane asserted that the transcript contained at least 2 of 5 content words taken from the fixture's script (`willkommen Projekt Status Entwicklung Zeitplan`). Across 13 lane-runs today:

```
12 x  matched [Status Entwicklung]   = 2 of 5   green
 1 x  matched [Entwicklung]          = 1 of 5   red
```

A ceiling of 2 against a floor of 2. `willkommen`, `Projekt` and `Zeitplan` never matched once.

## Why those three can never match

The app starts recording only once it has **detected** the meeting, while the simulator begins playing immediately. The opening seconds are therefore never captured, and those three words live in the opening. Which sentences land in the recorded slice shifts from run to run, which is exactly why the count oscillates between 1 and 2.

So the check was measuring recording-start timing, not transcription quality — and it could only ever report the two words that happen to recur later in the fixture.

Worth being precise: this is structural, not a defect. An app cannot record audio from before it knew there was a meeting.

## What the gate does now

Its purpose is unchanged — catch an English hallucination or garbage that got past the >100-byte size check. It now keys on common German words, which any German speech carries several of and English carries none, and which do not depend on which slice was recorded.

Word-boundary matching is load-bearing rather than tidiness. With substring matching, English `submit`, `listed`, `sound` and `diet` contain *mit*, *ist*, *und* and *die*, so fluent English would pass the very check meant to reject it. A test pins that case; removing the `-w` flag turns it red, which I verified rather than assumed.

The check moved into `lib/e2e-helpers.sh` so it is sourceable and testable — the driver is not.

## Verification

- `scripts/tests/test_transcript_is_german.sh` covers six cases: a real captured slice from a CI transcript, the fixture's opening slice, an English hallucination, the substring trap, garbage, and an empty-ish file
- Confirmed not vacuous: with `-w` removed the substring case flips to green, i.e. the suite detects the weakening
- `bash -n` clean on both changed scripts; shellcheck reports nothing new (the one `SC2148` on the helper library predates this and is by design — the file documents that it inherits the caller's shell)
- No dangling references to the removed constants

## Deliberately unchanged

- The xctest keyword lists in `ParakeetE2ETests` / `WhisperKitE2ETests`. Those feed the whole fixture straight to the engine, so all five words are reachable and 3-of-5 is a real assertion there.
- `scripts/generate_test_audio.sh` produces four short sentences while the committed fixture is 49.8 s, so the generator no longer reproduces the fixture. Out of scope here, but worth knowing before anyone regenerates it.
