### PR TITLE
Diagnostics + guidance for a silent app-audio track (#524)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ Suffix constants live as static lets: the audio-file suffixes on `RecordingFileS
 
 - AudioTapLib (CATapDescription) requires macOS 14.2+ — compiled as SPM library, no separate binary needed
 - Screen Recording permission required for **meeting detection** (window titles via `CGWindowListCopyWindowInfo`)
-- Audio capture (AudioTapLib) does NOT require Screen Recording — uses CATapDescription (purple dot indicator)
+- Audio capture (CATapDescription process tap) is TCC-gated: it needs either the `NSAudioCaptureUsageDescription` "Audio Recording" grant or, as a fallback, the Screen Recording grant. With neither, the tap returns `noErr` but captures silence, with no error and nothing logged (issue #524; measured on macOS 26, see the process-tap TCC-gate notes). This corrects an earlier "does not require Screen Recording" claim.
 - FluidAudio models are downloaded automatically on first run (~50 MB)
 
 ## GUI Testing

--- a/app/MeetingTranscriber/Sources/ChannelHealthController.swift
+++ b/app/MeetingTranscriber/Sources/ChannelHealthController.swift
@@ -191,7 +191,9 @@ final class ChannelHealthController {
         switch channel {
         case .app:
             "The app-audio channel went silent while the mic is still carrying audio. "
-                + "Check the meeting app's audio settings or system audio permission."
+                + "Enable Meeting Transcriber under System Settings → Privacy & Security → "
+                + "Screen & System Audio Recording, and check whether a third-party audio tool "
+                + "(SoundSource, Audio Hijack, Loopback, Krisp) is intercepting the meeting app's audio."
 
         case .mic:
             "The microphone went silent while the app audio is still recording. "

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -57,6 +57,16 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         XCTAssertTrue(micMessage.lowercased().contains("microphone"))
     }
 
+    func testAppSilenceMessagePointsAtPermissionAndAudioTools() {
+        // A silent far side is most often a missing Screen & System Audio
+        // Recording grant (the tap needs it) or a third-party audio utility
+        // intercepting the meeting app's output (issue #524). Name both so the
+        // notification is actionable instead of a dead end.
+        let message = ChannelHealthController.asymmetricSilenceMessage(for: .app)
+        XCTAssertTrue(message.contains("Screen & System Audio Recording"))
+        XCTAssertTrue(message.contains("SoundSource"))
+    }
+
     // MARK: - Production scenario: user mutes their mic mid-meeting
 
     func testMutedMicWithAppSpeechFiresMicSilent() {

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -281,11 +281,15 @@ public class AppAudioCapture: @unchecked Sendable {
                 userInfo: [NSLocalizedDescriptionKey: "Cannot get default output device UID"],
             )
         }
-        logger.info("System output device: \(systemOutputUID)")
+        // Transport type is logged unconditionally (not personal data, unlike
+        // the device name/UID): a "Virtual"/"Aggregate" transport is the first
+        // sign that a third-party audio tool has interposed on the output and
+        // the process tap may capture silence (issue #524).
+        let transport = getDefaultOutputDeviceTransportType() ?? "?"
+        logger.info("System output device: \(systemOutputUID) transport=\(transport, privacy: .public)")
 
         if debugLogging {
             let deviceName = getDefaultOutputDeviceName() ?? "?"
-            let transport = getDefaultOutputDeviceTransportType() ?? "?"
             let deviceRate = getDefaultOutputDeviceSampleRate() ?? 0
             logger.info(
                 "[debug] Default output device: name=\(deviceName, privacy: .public) uid=\(systemOutputUID, privacy: .public) transport=\(transport, privacy: .public) rate=\(deviceRate, privacy: .public)",
@@ -314,10 +318,10 @@ public class AppAudioCapture: @unchecked Sendable {
             )
         }
         tapID = newTapID
-        logger.info("Created process tap: \(self.tapID)")
+        let tapRate = Self.queryTapSampleRate(tapID: tapID)
+        logger.info("Created process tap: \(self.tapID) rate=\(tapRate, privacy: .public) Hz")
 
         if debugLogging {
-            let tapRate = Self.queryTapSampleRate(tapID: tapID)
             logger.info(
                 "[debug] Tap format: rate=\(tapRate, privacy: .public) Hz, tapID=\(self.tapID, privacy: .public)",
             )

--- a/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Timeline.swift
@@ -26,6 +26,19 @@ extension MicCaptureHandler {
         Self.writeSilence(frames: silence, to: outputFile)
     }
 
+    /// A steady clock skew (mic crystal a little slower than the mach clock)
+    /// back-fills a handful of frames every few seconds. Logging each one buries
+    /// the export in noise, so only fills at or above this duration get a line.
+    static let gapFillLogMinSeconds = 0.05
+
+    /// Whether a gap fill of `frames` at `sampleRate` is large enough to log.
+    /// Sub-threshold fills are the harmless clock-skew slivers; at or above it
+    /// the gap is long enough to be a genuine restart worth one line. Pure so it
+    /// can be unit-tested without touching a file or an engine.
+    static func shouldLogGapFill(frames: Int, sampleRate: Double) -> Bool {
+        Double(frames) >= sampleRate * gapFillLogMinSeconds
+    }
+
     /// Write `frames` zeroed frames to `file` in its processing format. Static
     /// (engine-free) so it can be unit-tested directly against an `AVAudioFile`
     /// without any engine setup.
@@ -41,7 +54,9 @@ extension MicCaptureHandler {
         }
         do {
             try file.write(from: silentBuffer)
-            logger.info("Mic: filled \(frames) silent frames for a device-restart gap")
+            if shouldLogGapFill(frames: frames, sampleRate: file.processingFormat.sampleRate) {
+                logger.info("Mic: inserted \(frames) silent frames to keep the track aligned to wall-clock")
+            }
         } catch {
             logger.warning("Mic timeline gap-fill write error: \(error.localizedDescription, privacy: .public)")
         }

--- a/tools/audiotap/Tests/MicCaptureHandlerTimelineTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerTimelineTests.swift
@@ -61,4 +61,26 @@ final class MicCaptureHandlerTimelineTests: XCTestCase {
 
         XCTAssertEqual(file.length, 0, "no gap, no write")
     }
+
+    // A mic whose sample clock runs a little slower than the mach clock
+    // back-fills a few frames of silence roughly every 5 s. Those sub-50ms
+    // slivers are load-bearing (they keep the track wall-clock aligned) but
+    // logging each one flooded the diagnostic export (2427 of 2590 lines in
+    // the issue #524 log), and the "device-restart gap" wording sent triage
+    // the wrong way. Only fills long enough to be a real gap should be logged.
+    func testTinyClockSkewFillsAreNotLogged() {
+        XCTAssertFalse(MicCaptureHandler.shouldLogGapFill(frames: 10, sampleRate: speechSampleRate))
+        XCTAssertFalse(MicCaptureHandler.shouldLogGapFill(frames: 799, sampleRate: speechSampleRate))
+    }
+
+    func testRealGapFillsAreLogged() {
+        XCTAssertTrue(MicCaptureHandler.shouldLogGapFill(frames: 800, sampleRate: speechSampleRate))
+        XCTAssertTrue(MicCaptureHandler.shouldLogGapFill(frames: 14400, sampleRate: speechSampleRate))
+    }
+
+    func testGapFillLogThresholdScalesWithSampleRate() {
+        // 50 ms at 48 kHz is 2400 frames.
+        XCTAssertFalse(MicCaptureHandler.shouldLogGapFill(frames: 2399, sampleRate: 48000))
+        XCTAssertTrue(MicCaptureHandler.shouldLogGapFill(frames: 2400, sampleRate: 48000))
+    }
 }


### PR DESCRIPTION
## Why

Follow-up hardening from the issue #524 investigation ("App Sound not recording (only my mic)"). The reporter's app-audio track was silent while the mic recorded fine. Root cause is a missing process-tap authorization on RC6 (already fixed on main by the `NSAudioCaptureUsageDescription` add and the record-time Screen Recording request); a third-party audio interposer (SoundSource et al.) is a secondary suspect.

Diagnosing it was harder than it should have been: the default diagnostic export could not show whether an interposer had rerouted the output, the far-side-silent notification pointed nowhere actionable, and 94% of the log was one misleading line. These changes make the *next* such report self-diagnosing. No production audio behaviour changes.

## What

- **feat(audiotap): log output-device transport and tap rate at info level** — a `Virtual`/`Aggregate` transport is the first sign an interposer has taken the output, so a process tap can return `noErr` yet capture silence. Previously only visible under Verbose Audio Logging. Transport type and the numeric tap rate are not personal data (device name/UID stay redacted), so they log unconditionally; the values are computed once and reused by the existing `[debug]` lines.
- **fix(audiotap): stop the mic gap-fill from flooding the log** — a mic clock running slightly slower than the mach clock back-fills sub-millisecond silence slivers every few seconds; logging each one produced 2427 of 2590 lines in one report, and the "device-restart gap" wording misdirected triage. Now gated on a pure, sample-rate-scaled 50 ms threshold and reworded. Gap-fill behaviour itself is unchanged.
- **feat(app): point the silent-app-channel warning at permissions and tools** — the far-side-silent notification now names the exact settings pane to enable and the common interposers (SoundSource, Audio Hijack, Loopback, Krisp) instead of a dead-end "check audio settings".
- **docs: correct the Critical Note on the process tap's permission gate** — the note claimed audio capture "does NOT require Screen Recording"; measurement shows the tap is TCC-gated (Audio Recording grant, or Screen Recording as fallback) and captures silence with `noErr` and no log when it has neither. That is the leading explanation for #524, and the old note contradicted the in-app guidance this branch adds.

## Testing

- New unit tests: `shouldLogGapFill` threshold (below/at/above, sample-rate scaling) and the actionable-warning content.
- `swift test` green for the audiotap suite and the app ChannelHealth suite; app module compiles clean.
- Formatting verified against the CI-pinned SwiftFormat 0.61.1; SwiftLint `--strict` clean on the changed files.
- Independent correctness review: no logic/boundary/concurrency/privacy issues; tests confirmed non-vacuous.

## Follow-ups (not in this PR)

- Two older pane-path strings (`AdvancedSettingsView`, `AppAudioCapture+TapError`) still say "Screen Recording"; the pane is "Screen & System Audio Recording" on current macOS. Worth unifying behind one shared constant later.
