### PR TITLE
Unify the Screen Recording pane path behind one versioned constant

### DIFF
--- a/app/MeetingTranscriber/Sources/ChannelHealthController.swift
+++ b/app/MeetingTranscriber/Sources/ChannelHealthController.swift
@@ -1,3 +1,4 @@
+import AudioTapLib
 import Foundation
 import Observation
 
@@ -191,8 +192,8 @@ final class ChannelHealthController {
         switch channel {
         case .app:
             "The app-audio channel went silent while the mic is still carrying audio. "
-                + "Enable Meeting Transcriber under System Settings → Privacy & Security → "
-                + "Screen & System Audio Recording, and check whether a third-party audio tool "
+                + "Enable Meeting Transcriber under \(SystemSettingsPaths.screenRecording), "
+                + "and check whether a third-party audio tool "
                 + "(SoundSource, Audio Hijack, Loopback, Krisp) is intercepting the meeting app's audio."
 
         case .mic:

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import AudioTapLib
 import AVFoundation
 import os.log
 import SwiftUI
@@ -37,7 +38,7 @@ struct AdvancedSettingsView: View {
                     label: "Screen Recording",
                     detail: Self.screenRecordingDetail,
                     granted: screenRecordingOK,
-                    help: "System Settings → Privacy & Security → Screen Recording → enable Meeting Transcriber",
+                    help: "\(SystemSettingsPaths.screenRecording) → enable Meeting Transcriber",
                     settingsURL: PrivacyPane.screenCapture.url,
                 )
                 PermissionRow(

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -1,3 +1,4 @@
+import AudioTapLib
 @testable import MeetingTranscriber
 import XCTest
 
@@ -63,7 +64,7 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         // intercepting the meeting app's output (issue #524). Name both so the
         // notification is actionable instead of a dead end.
         let message = ChannelHealthController.asymmetricSilenceMessage(for: .app)
-        XCTAssertTrue(message.contains("Screen & System Audio Recording"))
+        XCTAssertTrue(message.contains(SystemSettingsPaths.screenRecording))
         XCTAssertTrue(message.contains("SoundSource"))
     }
 

--- a/tools/audiotap/Sources/AppAudioCapture+TapError.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+TapError.swift
@@ -12,8 +12,7 @@ extension AppAudioCapture {
         switch status {
         case -12988:
             "OSStatus -12988: likely missing permission. " +
-                "Check System Settings → Privacy & Security → Screen Recording " +
-                "and enable Meeting Transcriber."
+                "Check \(SystemSettingsPaths.screenRecording) and enable Meeting Transcriber."
 
         case -10851:
             "OSStatus -10851 (kAudioUnitErr_InvalidProperty): " +

--- a/tools/audiotap/Sources/SystemSettingsPaths.swift
+++ b/tools/audiotap/Sources/SystemSettingsPaths.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// User-facing macOS System Settings navigation paths, kept in one place so the
+/// tap-error hint, the permission UI, and the channel-health notification all
+/// name the pane identically. macOS 15 (Sequoia) renamed the "Screen Recording"
+/// pane to "Screen & System Audio Recording"; the app supports macOS 14.2+, so
+/// the correct label depends on the running OS.
+public enum SystemSettingsPaths {
+    /// Path to the pane that gates screen capture and system-audio recording —
+    /// the permission the CATapDescription process tap needs (or falls back to).
+    /// Callers add their own lead-in / trailing action text.
+    public static var screenRecording: String {
+        let sequoiaOrLater = if #available(macOS 15, *) {
+            true
+        } else {
+            false
+        }
+        return screenRecordingPath(sequoiaOrLater: sequoiaOrLater)
+    }
+
+    /// Pure form of ``screenRecording`` so both OS branches are unit-testable
+    /// without faking the running OS version.
+    static func screenRecordingPath(sequoiaOrLater: Bool) -> String {
+        let pane = sequoiaOrLater ? "Screen & System Audio Recording" : "Screen Recording"
+        return "System Settings → Privacy & Security → \(pane)"
+    }
+}

--- a/tools/audiotap/Tests/SystemSettingsPathsTests.swift
+++ b/tools/audiotap/Tests/SystemSettingsPathsTests.swift
@@ -1,0 +1,30 @@
+@testable import AudioTapLib
+import XCTest
+
+/// The pane name is version-dependent (macOS 15 renamed "Screen Recording" to
+/// "Screen & System Audio Recording") and shared by the tap-error hint, the
+/// permission UI, and the channel-health notification, so it is worth pinning.
+final class SystemSettingsPathsTests: XCTestCase {
+    func testScreenRecordingPathUsesSequoiaPaneName() {
+        XCTAssertEqual(
+            SystemSettingsPaths.screenRecordingPath(sequoiaOrLater: true),
+            "System Settings → Privacy & Security → Screen & System Audio Recording",
+        )
+    }
+
+    func testScreenRecordingPathUsesLegacyPaneNameBeforeSequoia() {
+        XCTAssertEqual(
+            SystemSettingsPaths.screenRecordingPath(sequoiaOrLater: false),
+            "System Settings → Privacy & Security → Screen Recording",
+        )
+    }
+
+    func testScreenRecordingResolvesToAKnownPane() {
+        // The OS-resolved value must match one of the two version branches.
+        let resolved = SystemSettingsPaths.screenRecording
+        XCTAssertTrue(
+            resolved == SystemSettingsPaths.screenRecordingPath(sequoiaOrLater: true)
+                || resolved == SystemSettingsPaths.screenRecordingPath(sequoiaOrLater: false),
+        )
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to #559. The System Settings pane that gates the process tap was spelled out as a literal in three places, and they had drifted: the tap-error hint and the Advanced Settings help said "Screen Recording", while #559's new notification said "Screen & System Audio Recording". macOS 15 (Sequoia) renamed that pane, and the app supports 14.2+, so neither literal was correct on both OS versions.

## What

- **refactor(audiotap): add a versioned `SystemSettingsPaths` constant** — `SystemSettingsPaths.screenRecording` resolves the pane name by OS (`if #available(macOS 15, *)`), backed by a pure `screenRecordingPath(sequoiaOrLater:)` so both branches are unit-testable. Placed in AudioTapLib because it is the shared lower layer both packages reach and it already emits this hint in `describeTapError` (which now uses it). Moving it up into the app would strand that call site, since audiotap cannot import the app.
- **refactor(app): adopt the constant** in the Advanced Settings permission help and the silent-app-channel notification, so all three sites name the pane identically and correctly on both macOS 14 and 15+. The notification test asserts against the constant, so it stays green regardless of the runner's OS.

No functional change beyond the displayed pane name becoming OS-correct.

## Testing

- New `SystemSettingsPathsTests` pins both OS branches; `swift test` green for audiotap (7) and the app SettingsView + ChannelHealth suites (89), 0 failures.
- Formatting verified against the CI-pinned SwiftFormat 0.61.1; SwiftLint `--strict` clean on the changed files.
- Independent simplify + correctness review: verdict "keep the constant in audiotap"; both passes caught an incomplete migration (a dead import + unconverted literal in AdvancedSettingsView) which is fixed in this branch.

## Out of scope

- `PermissionHealthCheck` uses a bare "Screen Recording" *label* (not the full breadcrumb) in one message; left as-is. Row labels in the Settings UI likewise stay "Screen Recording" as short permission names.
