### PR TITLE
fix(app): stop concurrent pipeline runs from destroying each other's work

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -79,8 +79,14 @@ extension PipelineQueue {
 
         do {
             // Temp directory for intermediate 16kHz files, cleaned up on any exit.
+            // The run suffix is what makes the `defer` below safe: keyed on the
+            // job ID alone, two runs of the same job would share this directory,
+            // and whichever failed first would delete the other's intermediate
+            // files mid-flight, losing a finished transcription (issue #558).
+            // The suffix scopes the directory, and therefore the cleanup, to the
+            // run that created it.
             let workDir = FileManager.default.temporaryDirectory
-                .appendingPathComponent("pipeline_\(ctx.jobID.uuidString)")
+                .appendingPathComponent("pipeline_\(ctx.jobID.uuidString)_\(UUID().uuidString)")
             try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
             defer { try? FileManager.default.removeItem(at: workDir) }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -687,6 +687,15 @@ extension PipelineQueue {
             case .move:
                 break
             }
+            // The policy decides from path shape alone, so a source another run
+            // of this job already relocated still reads as `.move`. Falling
+            // through would delete that run's destination copy and then fail the
+            // move on the missing source, and since staging audio is moved
+            // rather than copied, no copy would remain anywhere.
+            guard fm.fileExists(atPath: src.path) else {
+                logger.info("Audio already relocated, skipping: \(name, privacy: .private)")
+                continue
+            }
             do {
                 if fm.fileExists(atPath: dst.path) { try fm.removeItem(at: dst) }
                 try fm.moveItem(at: src, to: dst)

--- a/app/MeetingTranscriber/Tests/ParkedEngine.swift
+++ b/app/MeetingTranscriber/Tests/ParkedEngine.swift
@@ -24,17 +24,25 @@ final class ParkedEngine: TranscribingEngine {
     private(set) var isParked = false
 
     private var parkedContinuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
 
     func loadModel() {}
 
     func transcribeSegments(audioPath _: URL) async -> [TimestampedSegment] {
         isParked = true
-        await withCheckedContinuation { parkedContinuation = $0 }
+        // Parking only when the release has not already happened keeps the two
+        // orderings equivalent. Otherwise a run that arrives here after the
+        // caller gave up waiting would park with nobody left to release it, and
+        // the suite would hang rather than fail.
+        if !isReleased {
+            await withCheckedContinuation { parkedContinuation = $0 }
+        }
         return segmentsToReturn
     }
 
-    /// Let the parked run continue.
+    /// Let the parked run continue, whether or not it has parked yet.
     func release() {
+        isReleased = true
         parkedContinuation?.resume()
         parkedContinuation = nil
     }

--- a/app/MeetingTranscriber/Tests/ParkedEngine.swift
+++ b/app/MeetingTranscriber/Tests/ParkedEngine.swift
@@ -1,0 +1,41 @@
+import Foundation
+@testable import MeetingTranscriber
+
+/// Transcription engine that parks inside `transcribeSegments` until the test
+/// releases it. Lets a test hold one pipeline run mid-stage, past the point
+/// where it has written its intermediate 16 kHz files, while a second run of
+/// the same job is driven to completion. That is the only way to observe how
+/// two concurrent runs treat each other's working files.
+///
+/// Callers wait for `isParked` via `waitFor` rather than a second continuation,
+/// so a run that regresses and never reaches transcription fails the test on
+/// the timeout instead of hanging the suite.
+///
+/// Kept out of `TestHelpers.swift` so that file stays under its length limit.
+@MainActor
+final class ParkedEngine: TranscribingEngine {
+    var modelState: EngineModelState = .loaded
+    var downloadProgress: Double = 1.0
+    var transcriptionProgress: Double = 1.0
+    var providesTimestamps = true
+    var segmentsToReturn: [TimestampedSegment] = []
+
+    /// True once a run has entered `transcribeSegments` and suspended there.
+    private(set) var isParked = false
+
+    private var parkedContinuation: CheckedContinuation<Void, Never>?
+
+    func loadModel() {}
+
+    func transcribeSegments(audioPath _: URL) async -> [TimestampedSegment] {
+        isParked = true
+        await withCheckedContinuation { parkedContinuation = $0 }
+        return segmentsToReturn
+    }
+
+    /// Let the parked run continue.
+    func release() {
+        parkedContinuation?.resume()
+        parkedContinuation = nil
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -883,6 +883,7 @@ final class PipelineQueueTests: XCTestCase {
     /// share.
     private func makeConcurrentRunQueue(
         engine: any TranscribingEngine, name: String,
+        outputDir: URL? = nil, stagingDir: URL? = nil,
     ) throws -> PipelineQueue {
         let ownDir = tmpDir.appendingPathComponent(name)
         try FileManager.default.createDirectory(at: ownDir, withIntermediateDirectories: true)
@@ -891,8 +892,11 @@ final class PipelineQueueTests: XCTestCase {
             diarizationFactory: { MockDiarization() },
             diarizationFactoryWithMode: nil,
             protocolGeneratorFactory: { MockProtocolGen() },
-            outputDir: ownDir,
+            outputDir: outputDir ?? ownDir,
             logDir: ownDir,
+            // Default keeps sources outside staging, i.e. user-picked imports
+            // the pipeline leaves alone; pass one to exercise the relocation.
+            stagingDir: stagingDir ?? AppPaths.recordingsDir,
             diarizeEnabled: true,
             numSpeakers: 0,
             micLabel: "Me",
@@ -943,6 +947,70 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertNotEqual(
             first.jobs.first?.state, .error,
             "first run failed with: \(first.jobs.first?.error ?? "no error recorded")",
+        )
+    }
+
+    /// Two runs that both reach the end now both try to relocate the same
+    /// staging audio. The relocation deletes an existing destination before
+    /// moving onto it, and the policy that picks `.move` only looks at path
+    /// shape, never at whether the source still exists. So the second finisher
+    /// deletes the recording the first one persisted and then fails its move
+    /// into a swallowed warning, leaving no copy anywhere: staging was emptied
+    /// by the first run, because audio is moved out of it, not copied.
+    func testSecondFinishingRunDoesNotDeleteThePersistedRecording() async throws {
+        let stagingDir = tmpDir.appendingPathComponent("staging")
+        let sharedOutputDir = tmpDir.appendingPathComponent("shared-output")
+        for dir in [stagingDir, sharedOutputDir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        let parked = ParkedEngine()
+        parked.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "First run speaking")]
+        let secondEngine = MockEngine()
+        secondEngine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Second run speaking")]
+
+        let first = try makeConcurrentRunQueue(
+            engine: parked, name: "first-persist",
+            outputDir: sharedOutputDir, stagingDir: stagingDir,
+        )
+        let second = try makeConcurrentRunQueue(
+            engine: secondEngine, name: "second-persist",
+            outputDir: sharedOutputDir, stagingDir: stagingDir,
+        )
+
+        // Source inside the staging dir, so the persistence policy relocates it.
+        let stagedAudio = stagingDir.appendingPathComponent("meeting_mix.wav")
+        let sourceAudio = try createTestAudioFile(in: tmpDir)
+        try FileManager.default.copyItem(at: sourceAudio, to: stagedAudio)
+        let job = PipelineJob(
+            meetingTitle: "Long Call",
+            appName: "Teams",
+            mixPath: stagedAudio,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        first.insertJobForTesting(job)
+        second.insertJobForTesting(job)
+
+        async let firstRun: Void = first.processNext()
+        await waitFor(parked.isParked, timeout: .seconds(5))
+        // The second run finishes first and relocates the audio.
+        await second.processNext()
+        let recordingsDir = sharedOutputDir.appendingPathComponent("recordings")
+        let persisted = try FileManager.default
+            .contentsOfDirectory(atPath: recordingsDir.path)
+            .filter { $0.hasSuffix(RecordingFileSuffix.mix) }
+        XCTAssertEqual(persisted.count, 1, "second run did not persist the recording")
+
+        // Now let the first run finish on top of it.
+        parked.release()
+        await firstRun
+
+        let survivors = try FileManager.default
+            .contentsOfDirectory(atPath: recordingsDir.path)
+            .filter { $0.hasSuffix(RecordingFileSuffix.mix) }
+        XCTAssertEqual(
+            survivors, persisted,
+            "the finished run deleted the recording the other run had already persisted",
         )
     }
 

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -838,6 +838,114 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(engine.transcribeCallCount > 0)
     }
 
+    // MARK: - Concurrent runs of the same job (issue #558)
+
+    /// A work directory derived from the job ID alone is shared by every run of
+    /// that job, so a second run walks into the first run's intermediate files.
+    /// This pins the collision half: a `pipeline_<jobID>` directory that already
+    /// holds a `mix_16k.wav` must not fail the run that arrives second.
+    /// `AudioMixer.resampleFile` copies when the source is already 16 kHz mono,
+    /// and `copyItem` onto an existing destination throws Cocoa 516.
+    func testRunIsNotFailedByAnotherRunsWorkDirectory() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Second run speaking"),
+        ]
+        let (pQueue, _) = makeMockProcessingQueue(engine: engine)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Collision",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+
+        // Stand in for a concurrent run of the same job that already resampled.
+        let otherRunDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pipeline_\(job.id.uuidString)")
+        try FileManager.default.createDirectory(at: otherRunDir, withIntermediateDirectories: true)
+        try Data().write(to: otherRunDir.appendingPathComponent("mix_16k.wav"))
+        defer { try? FileManager.default.removeItem(at: otherRunDir) }
+
+        pQueue.enqueue(job)
+        await pQueue.processNext()
+
+        XCTAssertNotEqual(
+            pQueue.jobs.first?.state, .error,
+            "job failed with: \(pQueue.jobs.first?.error ?? "no error recorded")",
+        )
+        XCTAssertTrue(engine.transcribeCallCount > 0, "transcription never ran")
+    }
+
+    /// A queue wired for the concurrent-run tests: its own log and output
+    /// directory, so the temp working directory is the only thing two of these
+    /// share.
+    private func makeConcurrentRunQueue(
+        engine: any TranscribingEngine, name: String,
+    ) throws -> PipelineQueue {
+        let ownDir = tmpDir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: ownDir, withIntermediateDirectories: true)
+        return PipelineQueue(
+            engine: engine,
+            diarizationFactory: { MockDiarization() },
+            diarizationFactoryWithMode: nil,
+            protocolGeneratorFactory: { MockProtocolGen() },
+            outputDir: ownDir,
+            logDir: ownDir,
+            diarizeEnabled: true,
+            numSpeakers: 0,
+            micLabel: "Me",
+        )
+    }
+
+    /// The destruction half: with a shared working directory, the run that
+    /// fails first takes the other run's intermediate files down with it via
+    /// its cleanup, and the surviving run then dies reaching for a file that is
+    /// gone, after transcription has already succeeded. That is the hour of
+    /// meeting content issue #558 reports losing.
+    func testConcurrentRunDoesNotDestroyTheOtherRunsWorkingFiles() async throws {
+        let parked = ParkedEngine()
+        parked.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "First run speaking")]
+        let secondEngine = MockEngine()
+        secondEngine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Second run speaking")]
+
+        let first = try makeConcurrentRunQueue(engine: parked, name: "first")
+        let second = try makeConcurrentRunQueue(engine: secondEngine, name: "second")
+
+        // The same job value in both queues: a struct copy carries the same id,
+        // which is what a snapshot restore into a replacement queue produces.
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Long Call",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        first.insertJobForTesting(job)
+        second.insertJobForTesting(job)
+
+        async let firstRun: Void = first.processNext()
+        await waitFor(parked.isParked, timeout: .seconds(5))
+        // The first run now holds finished intermediate files. Drive the second
+        // run to completion on top of them.
+        await second.processNext()
+        parked.release()
+        await firstRun
+
+        // Pins the premise: if the second run ever stops reaching the point
+        // where it writes into the working directory, this test would go green
+        // without exercising anything.
+        XCTAssertNotEqual(
+            second.jobs.first?.state, .error,
+            "second run failed with: \(second.jobs.first?.error ?? "no error recorded")",
+        )
+        XCTAssertNotEqual(
+            first.jobs.first?.state, .error,
+            "first run failed with: \(first.jobs.first?.error ?? "no error recorded")",
+        )
+    }
+
     func testProcessNextEmptyTranscriptSetsError() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [] // empty = no speech


### PR DESCRIPTION
Two runs of the same pipeline job shared one temp working directory, and the cleanup of whichever run failed first deleted the other run's files mid-flight. Issue #558 reports the outcome: a 60-minute transcription that had already completed was lost, and the job died reporting that its source file did not exist when in truth the destination directory was gone.

## What changes

**The working directory now belongs to the run that created it.** It was derived from the job ID alone, so every run of a job shared it, while the `defer` removed it unconditionally. A per-run identifier scopes both the directory and its cleanup to one run.

**A finished run no longer deletes audio another run already persisted.** Relocating a job's audio picks its action from path shape alone, so a source that another run already moved still reads as "move me". That branch deletes an existing destination before moving onto it, then fails on the missing source into a swallowed warning, and since staging audio is moved rather than copied, no copy would remain anywhere. This was unreachable while both runs of a doubled job died early; making each run own its working directory is what lets both reach this stage, so the guard belongs with the change that exposes it.

## What this does not do

It does not stop a job from running twice. It stops the second run from destroying the first one's work. The double-run cause itself is a separate concern, and a related guard on the queue rebuild path is already on `main` but is in no released tag.

Also worth knowing: a crash mid-run now leaks its working directory rather than having it reclaimed by the job's next run. These live in the system temp directory and are purged there. In exchange, a leftover directory from a crashed run no longer fails the job's next attempt.

## Evidence

Both fixes were written test-first and each test was watched fail against the unfixed code, with the failures matching the reported incident:

- The destruction test fails with `The file "..." doesn't exist`, the same misleading message from the issue, where the missing thing is actually the directory.
- The collision test fails with `couldn't be copied ... because an item with the same name already exists`, the Cocoa 516 the second run hit.
- The persistence test fails by finding an empty recordings directory where the other run's `_mix.wav` had just been written.

The concurrency tests drive two real queues over one job value, holding the first run inside transcription while the second runs to completion, rather than asserting on directory names. A test double parks the first run and is safe against either ordering, so a regression fails the suite instead of hanging it.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

Refs #558.