### PR TITLE
fix(app): stop a second queue from running a job already in flight

### DIFF
--- a/app/MeetingTranscriber/Sources/InFlightRunRegistry.swift
+++ b/app/MeetingTranscriber/Sources/InFlightRunRegistry.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Why a run could not be claimed, or that it was.
+enum RunClaim: Equatable {
+    case claimed
+    /// This very job is already running. Whoever owns it will report under the
+    /// same job ID, so a caller can drop its copy without leaving a trace.
+    case refusedSameJob
+    /// A different job is already running this audio. Nobody will ever report
+    /// under this job's ID, so a caller owes it an answer of its own.
+    case refusedSameAudio
+}
+
+/// Process-wide record of which pipeline runs are currently executing, so a
+/// second run of the same recording cannot start while the first is still
+/// going.
+///
+/// A `PipelineQueue` guards its own re-entry with `isProcessing`, but that flag
+/// only ever covers one instance. When a replacement queue is built while the
+/// previous one is still working, the two know nothing of each other, both read
+/// the same snapshot file, and both can start the same job. Issue #558 is what
+/// that costs.
+///
+/// A claim carries two identities because either one can be the only thing two
+/// runs have in common: the job ID for a job restored from the snapshot, and the
+/// audio path for a recording that orphan recovery rebuilds under a fresh job
+/// ID. Paths are standardized so the same file reached by a different spelling
+/// is recognised as one claim, matching how the orphan scan and the processed
+/// ledger compare paths. The two are stored together rather than side by side,
+/// so a release cannot name a different path than the claim did and strand it.
+///
+/// Only the mix path counts as the audio identity. A paired import carries no
+/// mix file, so two separate enqueues of the same app plus mic pair rest on the
+/// job ID alone and would not recognise each other. Accepted: the orphan scan
+/// cannot rebuild such a group either, so the fresh-ID route that motivates the
+/// path identity does not reach them.
+///
+/// Held only in memory: a claim describes a run inside this process, so every
+/// launch legitimately starts with none. Two instances of the app running
+/// against the same data directory are therefore not covered by this at all.
+@MainActor
+final class InFlightRunRegistry {
+    static let shared = InFlightRunRegistry()
+
+    /// Claimed job IDs, each mapped to the audio path claimed with it. Jobs
+    /// without a mix file map to nil and rest on the ID alone.
+    private var claims: [UUID: String?] = [:]
+
+    /// The claimed audio paths, standardized. Callers filtering a whole batch
+    /// take this once on the main actor rather than asking per candidate, since
+    /// the scan they filter runs off it.
+    var claimedAudioPaths: Set<String> {
+        Set(claims.values.compactMap(\.self))
+    }
+
+    /// Claim a run for the caller, or say which identity is already spoken for.
+    func begin(jobID: UUID, mixPath: URL?) -> RunClaim {
+        guard claims[jobID] == nil else { return .refusedSameJob }
+        let audioKey = mixPath.map(Self.key)
+        if let audioKey, claimedAudioPaths.contains(audioKey) { return .refusedSameAudio }
+        claims[jobID] = .some(audioKey)
+        return .claimed
+    }
+
+    /// Release a claim, including whatever audio path it was made with. Safe to
+    /// call for a run that never claimed.
+    func end(jobID: UUID) {
+        claims.removeValue(forKey: jobID)
+    }
+
+    func isInFlight(jobID: UUID) -> Bool {
+        claims[jobID] != nil
+    }
+
+    func isInFlight(mixPath: URL) -> Bool {
+        claimedAudioPaths.contains(Self.key(mixPath))
+    }
+
+    private static func key(_ url: URL) -> String {
+        url.standardizedFileURL.path
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
@@ -52,6 +52,17 @@ extension PipelineQueue {
                 && !FileManager.default.fileExists(atPath: mixPath.path)
         }
 
+        // Drop what another queue is still running. This is where issue #558
+        // brought the job back: a replacement queue reads the same snapshot,
+        // finds the job recorded as active, resets it to waiting above and
+        // starts it a second time. Speaker naming is exempt because a job
+        // parked there is waiting on the user, not executing.
+        loaded.removeAll { job in
+            guard job.state != .speakerNamingPending else { return false }
+            if inFlightRuns.isInFlight(jobID: job.id) { return true }
+            return job.mixPath.map { inFlightRuns.isInFlight(mixPath: $0) } ?? false
+        }
+
         guard !loaded.isEmpty else {
             logger.info("Snapshot loaded but no recoverable jobs")
             return
@@ -105,7 +116,11 @@ extension PipelineQueue {
             await processedLedger.migrate(recordingsDir: recordingsDir)
         }
 
+        // Both reads happen here, on the main actor, before the detached hop:
+        // the registry is main-actor isolated, and reading it from inside the
+        // detached task would be a different question anyway, asked later.
         let trackedPaths = Set(jobs.compactMap { $0.mixPath?.standardizedFileURL.path })
+        let runningPaths = inFlightRuns.claimedAudioPaths
         let ledger = processedLedger
 
         // Off-main: directory scan + processed-list read + per-file
@@ -124,6 +139,7 @@ extension PipelineQueue {
                 guard let mixURL = group.mix else { return false }
                 let stdPath = mixURL.standardizedFileURL.path
                 guard !trackedPaths.contains(stdPath) else { return false }
+                guard !runningPaths.contains(stdPath) else { return false }
                 guard !processedPaths.contains(stdPath) else { return false }
                 let attrs = try? fm.attributesOfItem(atPath: mixURL.path)
                 if let created = attrs?[.creationDate] as? Date,

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -50,6 +50,42 @@ extension PipelineQueue {
         }
     }
 
+    /// Take ownership of this job's run, or give the job up when another queue
+    /// already owns it. A queue only ever guards its own re-entry, so a
+    /// replacement queue restoring this job from the shared snapshot would run
+    /// it a second time alongside the queue it replaced (issue #558). The claim
+    /// is process-wide and settles which instance owns the run.
+    ///
+    /// A job we do not own is given up rather than left waiting, since leaving
+    /// it would only re-pick it forever. How it is given up depends on who holds
+    /// it. The same job running elsewhere reports under this very ID, so that
+    /// copy goes silently: no ledger mark, no terminal record, and the snapshot
+    /// left alone, because the owner's view of this job is the current one. A
+    /// different job holding the audio reports under an ID nobody is watching
+    /// for, so this one ends in error rather than vanishing unanswered.
+    private func claimRunOrGiveUpDuplicate(_ job: PipelineJob) -> Bool {
+        switch inFlightRuns.begin(jobID: job.id, mixPath: job.mixPath) {
+        case .claimed:
+            return true
+
+        case .refusedSameJob:
+            // The owner reports under this same job ID, so this copy can go
+            // without a trace.
+            logger.info("[\(job.shortID, privacy: .public)] already running elsewhere, dropping this copy")
+            jobs.removeAll { $0.id == job.id }
+
+        case .refusedSameAudio:
+            // A different job holds the audio, so nothing will ever answer for
+            // this one. It needs a terminal state of its own, or a caller
+            // waiting on it waits forever.
+            logger.info("[\(job.shortID, privacy: .public)] audio already running under another job")
+            updateJobState(id: job.id, to: .error, error: "This recording is already being processed")
+        }
+        isProcessing = false
+        triggerProcessing()
+        return false
+    }
+
     /// The immutable per-job inputs the stages read, derived once so every
     /// stage agrees on the same basename.
     private static func makeContext(for job: PipelineJob) -> JobContext {
@@ -81,6 +117,12 @@ extension PipelineQueue {
             return
         }
         let job = jobs[index]
+        guard claimRunOrGiveUpDuplicate(job) else { return }
+        // Function scope on purpose: the run leaves through several exits,
+        // including the early return on an empty transcript and every throw.
+        // A claim that outlived one of them would lock the recording out of
+        // any later attempt for the rest of the session.
+        defer { inFlightRuns.end(jobID: job.id) }
         let ctx = Self.makeContext(for: job)
 
         do {

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -50,6 +50,24 @@ extension PipelineQueue {
         }
     }
 
+    /// The immutable per-job inputs the stages read, derived once so every
+    /// stage agrees on the same basename.
+    private static func makeContext(for job: PipelineJob) -> JobContext {
+        JobContext(
+            jobID: job.id,
+            shortID: job.shortID,
+            title: job.meetingTitle,
+            mixPath: job.mixPath,
+            appPath: job.appPath,
+            micPath: job.micPath,
+            micDelay: job.micDelay,
+            participants: job.participants,
+            // Anchor the basename on the meeting start; reimport/orphan jobs
+            // have no recorded start, so fall back to the enqueue time.
+            slug: namingSlug(title: job.meetingTitle, jobID: job.id, startTime: job.meetingStartTime ?? job.enqueuedAt),
+        )
+    }
+
     /// Thin orchestrator: take the next waiting job and run it through the
     /// pipeline — transcribe → diarize → generate protocol → done.
     func processNext() async {
@@ -63,19 +81,7 @@ extension PipelineQueue {
             return
         }
         let job = jobs[index]
-        let ctx = JobContext(
-            jobID: job.id,
-            shortID: job.shortID,
-            title: job.meetingTitle,
-            mixPath: job.mixPath,
-            appPath: job.appPath,
-            micPath: job.micPath,
-            micDelay: job.micDelay,
-            participants: job.participants,
-            // Anchor the basename on the meeting start; reimport/orphan jobs
-            // have no recorded start, so fall back to the enqueue time.
-            slug: Self.namingSlug(title: job.meetingTitle, jobID: job.id, startTime: job.meetingStartTime ?? job.enqueuedAt),
-        )
+        let ctx = Self.makeContext(for: job)
 
         do {
             // Temp directory for intermediate 16kHz files, cleaned up on any exit.

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -72,6 +72,10 @@ extension PipelineQueue {
             // The owner reports under this same job ID, so this copy can go
             // without a trace.
             logger.info("[\(job.shortID, privacy: .public)] already running elsewhere, dropping this copy")
+            // Into the event log, not just os_log: that file is how the double
+            // run was found in the first place, and a job whose story stops
+            // there without a word is the gap that made it hard to see.
+            eventLog.append(jobID: job.id, event: "duplicate_dropped", from: job.state, to: job.state)
             jobs.removeAll { $0.id == job.id }
 
         case .refusedSameAudio:

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -69,6 +69,12 @@ class PipelineQueue {
 
     let completedJobLifetime: TimeInterval
 
+    /// Process-wide claim on the runs currently executing, so a replacement
+    /// queue cannot start a job the queue it replaced is still working on.
+    /// Defaults to the shared instance; tests inject their own to stay isolated
+    /// from each other.
+    let inFlightRuns: InFlightRunRegistry
+
     /// Durable store of finished-job records for the automation API readback.
     /// nil (default) disables it; production injects one, tests opt in.
     let terminalJobStore: TerminalJobStore?
@@ -205,6 +211,7 @@ class PipelineQueue {
         stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
         terminalJobStore: TerminalJobStore? = nil,
+        inFlightRuns: InFlightRunRegistry? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
@@ -225,6 +232,7 @@ class PipelineQueue {
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.terminalJobStore = terminalJobStore
+        self.inFlightRuns = inFlightRuns ?? .shared
         naming = SpeakerNamingSession(
             namingStore: SpeakerNamingStore(outputDir: nil),
             speakerMatcherFactory: speakerMatcherFactory,
@@ -298,6 +306,7 @@ class PipelineQueue {
         stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
         terminalJobStore: TerminalJobStore? = nil,
+        inFlightRuns: InFlightRunRegistry? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
@@ -326,6 +335,7 @@ class PipelineQueue {
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.terminalJobStore = terminalJobStore
+        self.inFlightRuns = inFlightRuns ?? .shared
         naming = SpeakerNamingSession(
             namingStore: SpeakerNamingStore(outputDir: outputDir),
             speakerMatcherFactory: speakerMatcherFactory,

--- a/app/MeetingTranscriber/Tests/InFlightRunRegistryTests.swift
+++ b/app/MeetingTranscriber/Tests/InFlightRunRegistryTests.swift
@@ -1,0 +1,91 @@
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class InFlightRunRegistryTests: XCTestCase {
+    private func mixPath(_ name: String) -> URL {
+        URL(fileURLWithPath: "/tmp/\(name).wav")
+    }
+
+    func testFirstClaimSucceeds() {
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixPath("a")), .claimed)
+    }
+
+    /// The two refusals are not interchangeable: one says somebody will report
+    /// under this very job ID, the other says nobody ever will.
+    func testASecondClaimOnTheSameJobNamesTheJobAsTheReason() {
+        let registry = InFlightRunRegistry()
+        let jobID = UUID()
+        XCTAssertEqual(registry.begin(jobID: jobID, mixPath: mixPath("a")), .claimed)
+        XCTAssertEqual(registry.begin(jobID: jobID, mixPath: mixPath("a")), .refusedSameJob)
+    }
+
+    /// Orphan recovery rebuilds a dropped recording under a fresh job ID, so the
+    /// audio path is the second identity a claim has to cover.
+    func testAClaimOnAudioHeldByAnotherJobNamesTheAudioAsTheReason() {
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixPath("shared")), .claimed)
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixPath("shared")), .refusedSameAudio)
+    }
+
+    /// Paired imports carry no mix file, so those claims rest on the job ID
+    /// alone and must not collide with each other through a shared nil.
+    func testClaimsWithoutAudioDoNotBlockEachOther() {
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: nil), .claimed)
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: nil), .claimed)
+    }
+
+    func testEndingAClaimReleasesBothIdentities() {
+        let registry = InFlightRunRegistry()
+        let jobID = UUID()
+        XCTAssertEqual(registry.begin(jobID: jobID, mixPath: mixPath("a")), .claimed)
+        registry.end(jobID: jobID)
+        XCTAssertEqual(registry.begin(jobID: jobID, mixPath: mixPath("a")), .claimed)
+        registry.end(jobID: jobID)
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixPath("a")), .claimed)
+    }
+
+    /// Ending a claim the registry never had must not free somebody else's.
+    func testEndingAnUnknownClaimLeavesALiveOneAlone() {
+        let registry = InFlightRunRegistry()
+        let live = UUID()
+        XCTAssertEqual(registry.begin(jobID: live, mixPath: mixPath("a")), .claimed)
+        registry.end(jobID: UUID())
+        XCTAssertEqual(registry.begin(jobID: live, mixPath: mixPath("a")), .refusedSameJob)
+    }
+
+    /// The release names only the job, so it cannot disagree with the claim
+    /// about which audio to free. Pins that a run holding audio releases it
+    /// without the caller repeating the path.
+    func testTheReleaseFreesTheAudioWithoutBeingToldWhichItWas() {
+        let registry = InFlightRunRegistry()
+        let jobID = UUID()
+        XCTAssertEqual(registry.begin(jobID: jobID, mixPath: mixPath("held")), .claimed)
+        registry.end(jobID: jobID)
+        XCTAssertFalse(registry.isInFlight(mixPath: mixPath("held")))
+        XCTAssertTrue(registry.claimedAudioPaths.isEmpty)
+    }
+
+    /// The queue asks by identity when filtering a restored snapshot and the
+    /// orphan scan, so both lookups have to answer independently of a claim.
+    func testLookupsReportWhatIsClaimed() {
+        let registry = InFlightRunRegistry()
+        let jobID = UUID()
+        XCTAssertFalse(registry.isInFlight(jobID: jobID))
+        XCTAssertFalse(registry.isInFlight(mixPath: mixPath("a")))
+        _ = registry.begin(jobID: jobID, mixPath: mixPath("a"))
+        XCTAssertTrue(registry.isInFlight(jobID: jobID))
+        XCTAssertTrue(registry.isInFlight(mixPath: mixPath("a")))
+    }
+
+    /// The orphan scan compares standardized paths, so the registry has to
+    /// recognise the same file reached by a different spelling.
+    func testTheSameFileSpelledDifferentlyIsOneClaim() {
+        let registry = InFlightRunRegistry()
+        let claim = registry.begin(jobID: UUID(), mixPath: URL(fileURLWithPath: "/tmp/sub/../call.wav"))
+        XCTAssertEqual(claim, .claimed)
+        XCTAssertTrue(registry.isInFlight(mixPath: URL(fileURLWithPath: "/tmp/call.wav")))
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1441,6 +1441,42 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(engine.transcribeCallCount, 0, "it must not run either")
     }
 
+    /// A job given up to another queue leaves this one without a word in the
+    /// event log, and that log is how the double run in issue #558 was found in
+    /// the first place: two `waiting -> transcribing` entries under one job ID.
+    /// A story that simply stops there is exactly the gap that made the bug hard
+    /// to see, so the hand-off is recorded. Both queues append to the same file,
+    /// so the drop reads in order against the owner's entries.
+    func testGivingUpADuplicateIsRecordedInTheEventLog() async throws {
+        let registry = InFlightRunRegistry()
+        let parked = ParkedEngine()
+        parked.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "First run speaking")]
+        let first = try makeConcurrentRunQueue(engine: parked, name: "owner", inFlightRuns: registry)
+        let second = try makeConcurrentRunQueue(engine: MockEngine(), name: "loser", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Long Call", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        first.insertJobForTesting(job)
+        second.insertJobForTesting(job)
+
+        async let firstRun: Void = first.processNext()
+        await waitFor(parked.isParked, timeout: .seconds(5))
+        await second.processNext()
+        parked.release()
+        await firstRun
+
+        let log = (try? String(
+            contentsOf: tmpDir.appendingPathComponent("loser/pipeline_log.jsonl"), encoding: .utf8,
+        )) ?? ""
+        XCTAssertTrue(
+            log.contains(job.id.uuidString) && log.contains("duplicate_dropped"),
+            "the hand-off left no trace in the event log: \(log.isEmpty ? "<no log at all>" : log)",
+        )
+    }
+
     func testProcessNextEmptyTranscriptSetsError() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [] // empty = no speech

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -612,7 +612,79 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// The re-materialization point of issue #558: a queue built while its
+    /// predecessor is still working reads the same snapshot, where the job is
+    /// still recorded as active, resets it to waiting and starts it again.
+    func testLoadSnapshotSkipsAJobThatIsAlreadyRunning() throws {
+        let mixPath = tmpDir.appendingPathComponent("in_flight_mix.wav")
+        try Data("fake audio".utf8).write(to: mixPath)
+
+        var job = PipelineJob(
+            meetingTitle: "Long Call",
+            appName: "Teams",
+            mixPath: mixPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .transcribing
+        try JSONEncoder().encode([job])
+            .write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: job.id, mixPath: mixPath), .claimed, "test premise: the claim was free")
+
+        let freshQueue = PipelineQueue(logDir: tmpDir, inFlightRuns: registry)
+        freshQueue.loadSnapshot()
+
+        XCTAssertTrue(
+            freshQueue.jobs.isEmpty,
+            "restored a job another queue is still running",
+        )
+    }
+
+    /// Without the job ID in play, a restored job whose claim is free must still
+    /// come back, or the filter would quietly eat ordinary crash recovery.
+    func testLoadSnapshotStillRestoresAJobNobodyIsRunning() throws {
+        let mixPath = tmpDir.appendingPathComponent("idle_mix.wav")
+        try Data("fake audio".utf8).write(to: mixPath)
+
+        var job = PipelineJob(
+            meetingTitle: "Interrupted Call",
+            appName: "Teams",
+            mixPath: mixPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .transcribing
+        try JSONEncoder().encode([job])
+            .write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let freshQueue = PipelineQueue(logDir: tmpDir, inFlightRuns: InFlightRunRegistry())
+        freshQueue.loadSnapshot()
+
+        XCTAssertEqual(freshQueue.jobs.count, 1)
+        XCTAssertEqual(freshQueue.jobs.first?.state, .waiting)
+    }
+
     // MARK: - Orphaned Recording Recovery Tests
+
+    /// The scan reaches the same recording under a fresh job ID, so the audio
+    /// path is the only thing tying it to the run already under way.
+    func testRecoverSkipsARecordingThatIsAlreadyRunning() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260311_100000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixFile), .claimed, "test premise: the claim was free")
+
+        let freshQueue = PipelineQueue(logDir: tmpDir, inFlightRuns: registry)
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+
+        XCTAssertTrue(
+            freshQueue.jobs.isEmpty,
+            "recovered a recording another queue is still running",
+        )
+    }
 
     func testRecoverFindsUntrackedMixWav() async throws {
         let recDir = tmpDir.appendingPathComponent("recordings")
@@ -936,6 +1008,7 @@ final class PipelineQueueTests: XCTestCase {
     private func makeConcurrentRunQueue(
         engine: any TranscribingEngine, name: String,
         outputDir: URL? = nil, stagingDir: URL? = nil,
+        inFlightRuns: InFlightRunRegistry? = nil,
     ) throws -> PipelineQueue {
         let ownDir = tmpDir.appendingPathComponent(name)
         try FileManager.default.createDirectory(at: ownDir, withIntermediateDirectories: true)
@@ -952,6 +1025,12 @@ final class PipelineQueueTests: XCTestCase {
             diarizeEnabled: true,
             numSpeakers: 0,
             micLabel: "Me",
+            // A fresh registry per CALL, not per test: the concurrency tests
+            // build two queues that must not see each other's claims, or the
+            // second queue gives its job up and the test passes on an empty
+            // list without exercising anything. Hoisting this into setUp would
+            // gut them silently.
+            inFlightRuns: inFlightRuns ?? InFlightRunRegistry(),
         )
     }
 
@@ -1116,6 +1195,250 @@ final class PipelineQueueTests: XCTestCase {
             FileManager.default.fileExists(atPath: transcript?.path ?? ""),
             "the transcript was recorded but not saved",
         )
+    }
+
+    /// A replacement queue restores the same job from the shared snapshot while
+    /// the queue it replaced is still working on it. Nothing in either instance
+    /// can see the other, so both would run it. The claim they share is what
+    /// stops the second one before it starts.
+    func testSecondQueueDoesNotRunAJobTheFirstIsAlreadyRunning() async throws {
+        let registry = InFlightRunRegistry()
+        let parked = ParkedEngine()
+        parked.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "First run speaking")]
+        let secondEngine = MockEngine()
+        secondEngine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Second run speaking")]
+
+        let first = try makeConcurrentRunQueue(engine: parked, name: "first", inFlightRuns: registry)
+        let second = try makeConcurrentRunQueue(engine: secondEngine, name: "second", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Long Call",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        first.insertJobForTesting(job)
+        second.insertJobForTesting(job)
+
+        async let firstRun: Void = first.processNext()
+        await waitFor(parked.isParked, timeout: .seconds(5))
+        await second.processNext()
+
+        XCTAssertEqual(
+            secondEngine.transcribeCallCount, 0,
+            "the second queue transcribed a job the first one was already running",
+        )
+
+        parked.release()
+        await firstRun
+        XCTAssertNotEqual(
+            first.jobs.first?.state, .error,
+            "first run failed with: \(first.jobs.first?.error ?? "no error recorded")",
+        )
+    }
+
+    /// The claim has to be released when the run ends, or the job could never be
+    /// re-run: a late re-diarization, a retry, or simply the next launch.
+    func testAFinishedRunReleasesItsClaim() async throws {
+        let registry = InFlightRunRegistry()
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Hello")]
+        let queue = try makeConcurrentRunQueue(engine: engine, name: "single", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Short Call",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        await queue.processNext()
+
+        XCTAssertFalse(registry.isInFlight(jobID: job.id), "claim on the job ID outlived the run")
+        XCTAssertFalse(registry.isInFlight(mixPath: audioPath), "claim on the audio outlived the run")
+    }
+
+    /// An errored run must release its claim too, otherwise one failure locks
+    /// the recording out of every later attempt for the rest of the session.
+    func testAFailedRunReleasesItsClaim() async throws {
+        let registry = InFlightRunRegistry()
+        let engine = MockEngine()
+        engine.shouldThrow = true
+        let queue = try makeConcurrentRunQueue(engine: engine, name: "failing", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Doomed Call",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        await queue.processNext()
+
+        XCTAssertEqual(queue.jobs.first?.state, .error, "test premise: the run was supposed to fail")
+        XCTAssertFalse(registry.isInFlight(jobID: job.id), "claim survived a failed run")
+        XCTAssertFalse(registry.isInFlight(mixPath: audioPath), "claim survived a failed run")
+    }
+
+    /// Cancellation is the exit that is easiest to get wrong, because it does
+    /// not come back through the normal path. A claim left behind here would
+    /// lock the recording out of every later attempt for the rest of the
+    /// session, which is worse than the double run it prevents. Enqueued rather
+    /// than driven directly, so a real `Task` cancellation is what tears the run
+    /// down.
+    func testACancelledRunReleasesItsClaim() async throws {
+        let registry = InFlightRunRegistry()
+        let parked = ParkedEngine()
+        parked.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Interrupted")]
+        let queue = try makeConcurrentRunQueue(engine: parked, name: "cancelled", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Abandoned Call",
+            appName: "Teams",
+            mixPath: audioPath,
+            appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.enqueue(job)
+        await waitFor(parked.isParked, timeout: .seconds(5))
+        XCTAssertTrue(registry.isInFlight(jobID: job.id), "test premise: the run had claimed")
+
+        queue.cancelJob(id: job.id)
+        parked.release()
+        await waitFor(self.queueIsIdle(queue), timeout: .seconds(5))
+
+        XCTAssertFalse(registry.isInFlight(jobID: job.id), "claim survived a cancelled run")
+        XCTAssertFalse(registry.isInFlight(mixPath: audioPath), "claim survived a cancelled run")
+    }
+
+    /// True once nothing is running and nothing is left waiting.
+    private func queueIsIdle(_ queue: PipelineQueue) -> Bool {
+        !queue.isProcessing && !queue.jobs.contains { $0.state == .waiting }
+    }
+
+    /// Giving up a job someone else owns must not stall the rest of the queue.
+    /// Without the re-trigger on the refusal path, everything behind the dropped
+    /// job waits for whatever happens to poke the queue next.
+    func testARefusedJobIsDroppedAndTheQueueKeepsDraining() async throws {
+        let registry = InFlightRunRegistry()
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Mine to run")]
+        let queue = try makeConcurrentRunQueue(engine: engine, name: "draining", inFlightRuns: registry)
+
+        let ownedElsewherePath = try createTestAudioFile(in: tmpDir)
+        let ownJobPath = try createTestAudioFile(in: tmpDir)
+        let ownedElsewhere = PipelineJob(
+            meetingTitle: "Someone Else's Call", appName: "Teams",
+            mixPath: ownedElsewherePath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        let ours = PipelineJob(
+            meetingTitle: "Our Call", appName: "Teams",
+            mixPath: ownJobPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        XCTAssertEqual(
+            registry.begin(jobID: ownedElsewhere.id, mixPath: ownedElsewherePath), .claimed,
+            "test premise: the claim was free",
+        )
+
+        queue.insertJobForTesting(ownedElsewhere)
+        queue.insertJobForTesting(ours)
+        queue.triggerProcessing()
+        // Bounded rather than `awaitProcessing()`: the behaviour under test is
+        // exactly the one whose absence leaves a job waiting forever, and an
+        // unbounded wait would hang the suite instead of failing it.
+        await waitFor(self.queueIsIdle(queue), timeout: .seconds(5))
+
+        XCTAssertFalse(
+            queue.jobs.contains { $0.id == ownedElsewhere.id },
+            "the copy of a job owned elsewhere was kept",
+        )
+        XCTAssertEqual(engine.transcribeCallCount, 1, "the job behind the dropped one never ran")
+        let ourState = queue.jobs.first { $0.id == ours.id }?.state
+        XCTAssertNotEqual(ourState, .waiting)
+    }
+
+    /// The claim is released as the run unwinds, after the queue has already
+    /// armed the next one. That only works because the next run cannot begin
+    /// until this one has returned. If it ever could, a second job over the same
+    /// audio would be refused and silently dropped, so this pins the ordering.
+    func testTwoRunsOverTheSameAudioSucceedOneAfterTheOther() async throws {
+        let registry = InFlightRunRegistry()
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Same file twice")]
+        let queue = try makeConcurrentRunQueue(engine: engine, name: "sequential", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        for title in ["First Import", "Second Import"] {
+            queue.insertJobForTesting(PipelineJob(
+                meetingTitle: title, appName: "Teams",
+                mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+            ))
+        }
+        queue.triggerProcessing()
+        await waitFor(engine.transcribeCallCount == 2, timeout: .seconds(5))
+
+        XCTAssertEqual(engine.transcribeCallCount, 2, "the second run over the same audio was refused")
+    }
+
+    /// A job parked at speaker naming is waiting on the user, not executing, so
+    /// its claim is long released. Filtering it on a path some other run happens
+    /// to hold would silently discard naming the user still owes an answer to.
+    func testLoadSnapshotKeepsAPendingNamingJobWhoseAudioIsClaimed() throws {
+        let mixPath = tmpDir.appendingPathComponent("parked_mix.wav")
+        try Data("fake audio".utf8).write(to: mixPath)
+
+        var job = PipelineJob(
+            meetingTitle: "Awaiting Names", appName: "Teams",
+            mixPath: mixPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .speakerNamingPending
+        try JSONEncoder().encode([job])
+            .write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let registry = InFlightRunRegistry()
+        XCTAssertEqual(registry.begin(jobID: UUID(), mixPath: mixPath), .claimed, "test premise: the claim was free")
+
+        let freshQueue = PipelineQueue(logDir: tmpDir, inFlightRuns: registry)
+        freshQueue.loadSnapshot()
+
+        XCTAssertEqual(freshQueue.jobs.count, 1, "dropped a job that was only waiting for the user")
+    }
+
+    /// Dropping a duplicate without a trace is only right when the run that
+    /// owns it will answer under the same job ID. Submitting the same file
+    /// twice through the automation API mints a fresh ID, so nothing would ever
+    /// answer for the second one: its status lookup would keep reporting
+    /// nothing found, and a blocking submit would run to its deadline. That
+    /// job needs a terminal state instead.
+    func testAJobRefusedOverAnotherJobsAudioEndsInError() async throws {
+        let registry = InFlightRunRegistry()
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Never runs")]
+        let queue = try makeConcurrentRunQueue(engine: engine, name: "pathduplicate", inFlightRuns: registry)
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        XCTAssertEqual(
+            registry.begin(jobID: UUID(), mixPath: audioPath), .claimed,
+            "test premise: a different job took the audio first",
+        )
+
+        let job = PipelineJob(
+            meetingTitle: "Same File Again", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        queue.triggerProcessing()
+        await waitFor(self.queueIsIdle(queue), timeout: .seconds(5))
+
+        let refusedState = queue.jobs.first { $0.id == job.id }?.state
+        XCTAssertEqual(
+            refusedState, .error,
+            "the job vanished instead of reporting why it did not run",
+        )
+        XCTAssertEqual(engine.transcribeCallCount, 0, "it must not run either")
     }
 
     func testProcessNextEmptyTranscriptSetsError() async throws {


### PR DESCRIPTION
Follow-up to the working-directory fix for issue #558. That one stopped two concurrent runs of the same job from destroying each other's files. It deliberately left the double run itself in place. This closes that.

## Why a queue cannot see the problem itself

A queue guards its own re-entry with a flag, and that flag only ever covers one instance. When a replacement queue is built while the previous one is still working, neither knows the other exists, both read the same snapshot file, and both start the same job.

A process-wide claim settles which instance owns a run. It carries two identities, because either one can be the only thing two runs have in common: the job ID when the snapshot restores the same job, and the audio path when orphan recovery rebuilds the same recording under a fresh ID. Both live in one map keyed by job ID, so a release cannot name a different path than the claim did and strand it. Three places consult it: a run claims on entry and releases as it unwinds, snapshot restore drops what is already running, and the orphan scan skips audio already in hand.

## Which identity collided decides how the loser gives up

The two refusals are not interchangeable. The same job running elsewhere will report under this very ID, so that copy can go without a trace: no ledger mark, no terminal record, snapshot left alone, because the owner's view of the job is the current one.

A different job holding the audio is the opposite case, and it is reachable from the automation API: submitting the same file twice mints a fresh job ID, so nobody would ever report under the second one. Dropping it silently would leave its status lookup answering "unknown" forever, and a blocking submit running to its deadline. That job therefore ends in error instead of vanishing.

## What this deliberately does not cover

The claim lives in memory only, since it describes a run inside this process and every launch legitimately starts with none. Two runs in two app instances remain unprotected, which is exactly why the working-directory fix matters on its own.

There is also a consequence worth stating plainly: when a queue gives up a job because the same job is running elsewhere, it disappears from the queue the app is actually observing while the unobserved one finishes it. The completion notification and the output files still arrive, but nothing is visible mid-run. Silent and correct beats duplicated and destructive, so this is the better trade, but making that state visible is a separate question.

Releasing the claim on every exit is the load-bearing part. A claim that outlived a failure would lock that recording out of every later attempt for the rest of the session, which is worse than the double run it prevents. Hence the function-scope release, and tests over the successful, failed and cancelled exits.

## Evidence

Every test was watched fail before the code that satisfies it. For the release tests that meant wiring the claim first and the release afterwards, so they were seen red in between rather than passing vacuously. Each behaviour was then falsified individually by removing exactly the mechanism it guards:

- removing the release: two sequential runs over the same audio drop to one
- removing the re-trigger on the give-up path: the job behind a dropped one never runs
- removing the speaker-naming exemption: a job that was only waiting for the user is discarded
- treating an audio collision like a job collision: the second submission of the same file vanishes with no terminal state

Several tests use a bounded wait rather than an unbounded one, because the regressions above leave a job waiting forever. An unbounded wait turns that into a hung suite and a CI job timeout instead of a red line.

Also rejected: widening the existing rebuild guard to cover all live queues, which still misses a stale queue that receives new work; and collapsing to a single long-lived queue, which is the right question for the composition root and far larger than this.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

Refs #558.