### PR TITLE
fix(app): keep the transcript when diarization loses its audio

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -107,7 +107,7 @@ extension PipelineQueue {
                 return
             }
 
-            let finalTranscript = try await diarize(
+            let finalTranscript = await diarize(
                 transcription, ctx: ctx, engine: engine,
                 workDir: workDir, outputDir: outputDir,
             )
@@ -222,10 +222,15 @@ extension PipelineQueue {
     /// diarization is disabled, unavailable, or fails. Drives the speaker-naming
     /// dialog loop and persists naming data + recognition forensics as side
     /// effects.
+    /// Cannot throw, and that is the point: every failure inside is caught and
+    /// downgraded to a warning, so a diarization problem costs the speaker
+    /// labels and never the transcript. Keeping that in the signature means the
+    /// compiler, not a comment, refuses the next throwing call added outside the
+    /// block.
     private func diarize(
         _ transcription: TranscriptionOutput, ctx: JobContext,
         engine: any TranscribingEngine, workDir: URL, outputDir: URL,
-    ) async throws -> String {
+    ) async -> String {
         var finalTranscript = transcription.transcript
 
         guard diarizeEnabled, let diarizationFactory else { return finalTranscript }
@@ -250,9 +255,14 @@ extension PipelineQueue {
 
         updateJobState(id: ctx.jobID, to: .diarizing)
         startElapsedTimer()
-        let mix16k = try await ensureMixAudio(workDir: workDir, ctx: ctx)
-
         do {
+            // Inside the block on purpose: preparing the mix is part of
+            // diarizing, and this catch is what keeps a diarization problem from
+            // costing more than the speaker labels. Outside it, a missing or
+            // unreadable source here failed the whole job, discarding a
+            // transcript that was already finished. Stage 3 tolerates a missing
+            // mix, so there is nothing further downstream that needs it.
+            let mix16k = try await ensureMixAudio(workDir: workDir, ctx: ctx)
             let speakerCount = numSpeakers > 0 ? numSpeakers : nil
             let run = try await runDiarization(
                 diarizeProcess: diarizeProcess, useDualTrack: transcription.isDualSource,

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1014,6 +1014,58 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// Preparing the mix for diarization sits outside the block that treats a
+    /// diarization failure as a warning, so a file problem there fails the whole
+    /// job instead of costing only the speaker labels. The transcript is already
+    /// finished at that point and stage 3 tolerates a missing mix, so losing it
+    /// buys nothing.
+    ///
+    /// Only a paired source can reach that failure: a single-source job already
+    /// wrote the 16 kHz mix during transcription, so the step returns early. The
+    /// sources are removed once transcription has consumed them, which is the
+    /// state a concurrent run or a user tidying a folder can produce.
+    func testDiarizationLosingItsAudioCostsOnlySpeakerLabels() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Recorded fine")]
+        let job = try makeDualSourceJob(title: "Vanishing Sources")
+
+        // The diarizer is built between transcription and mix preparation, so
+        // building it is where the sources can be taken away: a concurrent run
+        // relocating staged audio, or somebody tidying the folder mid-job.
+        let diar = MockDiarization()
+        let removeEverySource = {
+            for path in [job.appPath, job.micPath, job.mixPath].compactMap(\.self) {
+                try? FileManager.default.removeItem(at: path)
+            }
+        }
+        let queue = makeCapturingQueue(
+            engine: engine,
+            diar: diar,
+            protocolGen: MockProtocolGen(),
+            beforeDiarizing: removeEverySource,
+        )
+
+        queue.insertJobForTesting(job)
+        await queue.processNext()
+
+        let finished = queue.jobs.first { $0.id == job.id }
+        XCTAssertEqual(
+            finished?.state, .done,
+            "job ended in \(String(describing: finished?.state)): \(finished?.error ?? "no error recorded")",
+        )
+        XCTAssertTrue(
+            finished?.warnings.contains { $0.contains("Diarization") } ?? false,
+            "the lost diarization was not reported as a warning",
+        )
+        // The point of the whole change: the finished transcript is kept.
+        let transcript = finished?.transcriptPath
+        XCTAssertNotNil(transcript, "no transcript was written")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: transcript?.path ?? ""),
+            "the transcript was recorded but not saved",
+        )
+    }
+
     func testProcessNextEmptyTranscriptSetsError() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [] // empty = no speech
@@ -1064,10 +1116,14 @@ final class PipelineQueueTests: XCTestCase {
         protocolGen: MockProtocolGen,
         micLabel: String = "Me",
         stagingDir: URL? = nil,
+        beforeDiarizing: (() -> Void)? = nil,
     ) -> PipelineQueue {
         PipelineQueue(
             engine: engine,
-            diarizationFactory: { diar },
+            diarizationFactory: {
+                beforeDiarizing?()
+                return diar
+            },
             diarizationFactoryWithMode: nil,
             protocolGeneratorFactory: { protocolGen },
             outputDir: tmpDir,


### PR DESCRIPTION
Third defect from issue #558. Preparing the 16 kHz mix for diarization sat outside the block that treats a diarization failure as a warning, so a file problem there failed the entire job and threw away a transcript that was already finished.

## Why the cost was wrong

By the time this step runs, transcription has completed and produced a non-empty transcript, which is where nearly all the compute went. Discarding it buys nothing: stage 3 already tolerates a missing mix, and nothing downstream of this particular failure needs one, because speaker naming is only ever parked when diarization actually produced speakers.

Moving the call inside the block makes a diarization problem cost the speaker labels and a warning, which is exactly what every other diarization failure already costs.

With that move, nothing in the stage can throw any more, so its signature no longer claims it can. That part is deliberate rather than tidying: the compiler now refuses the next throwing call someone adds outside the block, where a comment would only have asked politely.

## Reachability

Only a paired source can reach this failure. A single-source job wrote its 16 kHz mix during transcription and the preparation step returns early, and because each run now owns its working directory, no sibling run can take that file away.

## Evidence

The test drives a paired job whose sources are removed between transcription and diarization, which is a state a concurrent run relocating staged audio or a user tidying a folder can produce. It was watched fail first, with the real error the pipeline reports (`com.apple.coreaudio.avfaudio error 2003334207`), and it pins three things rather than one: the job reaches `done`, the warning is recorded, and the transcript exists on disk. Reverting the fix turns all three red.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

## Known follow-ups, deliberately not in this change

- **The speaker labels are recoverable.** Dual-track diarization reads the per-track 16 kHz files, not the mix, so in the only topology that can hit this failure the labels did not strictly have to die. The mix serves the output-folder sidecar and the naming dialog's playback. Preparing it lazily would downgrade the cost further, from "no speaker labels" to "no sidecar". This change is the minimal correct downgrade; that one is a larger rework of the stage.
- **Orphaned sidecars.** On this path stage 3 now runs where the job previously died, so the per-track 16 kHz files and the segments JSON are persisted into the output folder with no consumer, since naming is never parked. The same already happens when diarization proper fails; this widens its reach.
- **Cancellation.** The block's catch is untyped, so a cancellation landing inside it is downgraded to a warning instead of ending the job. That was already true for diarization proper; this adds the mix-preparation window to it.

Refs #558.