### PR TITLE
docs(app): say what the processed ledger actually records

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
@@ -88,7 +88,8 @@ extension PipelineQueue {
 
     /// Scan `recordingsDir` for `*_mix.wav` files not tracked by any loaded job.
     /// Creates recovery jobs for untracked recordings younger than `maxAge`.
-    /// Skips files that were already successfully processed (tracked in processed_recordings.json).
+    /// Skips files the pipeline is already finished with, successfully or not
+    /// (tracked in processed_recordings.json).
     ///
     /// The directory scan + per-file `attributesOfItem` calls run on a
     /// detached task — startup callers don't block the UI on a potentially

--- a/app/MeetingTranscriber/Sources/ProcessedRecordingsLedger.swift
+++ b/app/MeetingTranscriber/Sources/ProcessedRecordingsLedger.swift
@@ -3,8 +3,15 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "ProcessedRecordingsLedger")
 
-/// File-backed ledger of mix-file paths that completed the pipeline
-/// successfully, backing `PipelineQueue`'s orphan-recovery skip list.
+/// File-backed ledger of mix-file paths the pipeline is finished with, backing
+/// `PipelineQueue`'s orphan-recovery skip list.
+///
+/// Finished, not succeeded. A recording lands here once its job reached any
+/// terminal state, and also when the user dismisses it. Recording the failures
+/// is the point: one that fails deterministically, say a silent capture that
+/// yields an empty transcript, would otherwise be re-picked as an orphan on
+/// every launch and fail again, with a notification each time. Re-importing by
+/// hand is the intended retry and never consults this list.
 ///
 /// Pure persistence over one JSON file (`processed_recordings.json` in
 /// `logDir`): a JSON array of standardized file paths (`[String]`), written
@@ -24,8 +31,8 @@ struct ProcessedRecordingsLedger {
         logDir.appendingPathComponent("processed_recordings.json")
     }
 
-    /// Load the set of mix paths that completed successfully. Returns an empty
-    /// set when the file is missing or unreadable/corrupt.
+    /// Load the set of mix paths the pipeline is finished with. Returns an
+    /// empty set when the file is missing or unreadable/corrupt.
     func load() -> Set<String> {
         guard let data = try? Data(contentsOf: path),
               let paths = try? JSONDecoder().decode([String].self, from: data) else {
@@ -34,7 +41,7 @@ struct ProcessedRecordingsLedger {
         return Set(paths)
     }
 
-    /// Record that a job's mix file was successfully processed. Nil mixPath
+    /// Record that the pipeline is finished with a job's mix file. Nil mixPath
     /// (paired imports without a `_mix.wav` source) is a no-op — there's no
     /// path to track for orphan recovery.
     func markProcessed(mixPath: URL?) {

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -560,6 +560,58 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertTrue(freshQueue.jobs.isEmpty)
     }
 
+    // MARK: - Processed ledger on unhappy outcomes
+
+    /// Marking a failed recording as processed looks wrong at first glance and
+    /// is deliberate: a recording that fails deterministically, say a silent one
+    /// that yields an empty transcript, would otherwise be re-picked as an
+    /// orphan on every launch and fail again, with a notification each time.
+    /// Re-importing it by hand is the intended retry and never consults this
+    /// list. Pinned because the doc comment used to claim the opposite, which is
+    /// an invitation to "fix" it.
+    func testAFailedRecordingIsMarkedProcessed() {
+        let mixPath = tmpDir.appendingPathComponent("failed_mix.wav")
+        let queue = PipelineQueue(logDir: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Silent Meeting", appName: "Teams",
+            mixPath: mixPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+
+        queue.updateJobState(id: job.id, to: .error, error: "Empty transcript")
+
+        XCTAssertTrue(
+            ProcessedRecordingsLedger(logDir: tmpDir).load()
+                .contains(mixPath.standardizedFileURL.path),
+            "a failed recording was left to be re-picked on every launch",
+        )
+    }
+
+    /// The consequence of the above, at the layer the user notices: the failed
+    /// recording does not come back as a recovered orphan.
+    func testOrphanRecoverySkipsARecordingThatAlreadyFailed() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260311_100000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+
+        let failing = PipelineQueue(logDir: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Silent Meeting", appName: "Teams",
+            mixPath: mixFile, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        failing.insertJobForTesting(job)
+        failing.updateJobState(id: job.id, to: .error, error: "Empty transcript")
+
+        let nextLaunch = PipelineQueue(logDir: tmpDir)
+        await nextLaunch.recoverOrphanedRecordings(recordingsDir: recDir)
+
+        XCTAssertTrue(
+            nextLaunch.jobs.isEmpty,
+            "the failed recording came back as an orphan and would fail again",
+        )
+    }
+
     // MARK: - Orphaned Recording Recovery Tests
 
     func testRecoverFindsUntrackedMixWav() async throws {


### PR DESCRIPTION
Last of the loose ends from issue #558, and the smallest. The issue noted that a recording is marked processed when its job reaches any terminal state, failure included, while the ledger's own documentation claimed it held recordings that "completed the pipeline successfully". The reporter read that as a contradiction, which is fair, because the documentation was simply wrong.

## The behaviour is deliberate, so the fix is the wording

A recording that fails deterministically, say a silent capture that yields an empty transcript, would otherwise be re-picked as an orphan on every launch and fail again, with a notification each time. The ledger entry is what stops that. Re-importing the file by hand is the intended retry, and that path never consults the ledger, so nothing is permanently locked out.

The danger of the old wording was concrete: a reader who trusted it would have taken the failure case for a bug and removed the protection. So the wording is corrected in all three places, and the behaviour is now pinned by tests rather than only described, at both layers that matter: the entry is written, and the next launch's orphan scan leaves the recording alone.

Both tests were falsified against the exact "fix" the old comment invited, marking only on success. Both go red.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

## Still open, and it needs a decision rather than a patch

Dismissing a job marks the ledger, but cancelling one does not. So an explicitly cancelled recording comes back as a recovered orphan on the next launch, which reads as the cancel not having stuck. Making cancel mark the ledger too would settle the asymmetry, but it changes visible behaviour and there is a defensible reading in the other direction: someone who cancels a wedged job may well want it offered again. That is left out of this change on purpose.

Refs #558.