### PR TITLE
feat(app): write the transcript before diarization runs

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -108,6 +108,30 @@ extension PipelineQueue {
         )
     }
 
+    /// Put the transcript on disk as soon as transcription produced it.
+    ///
+    /// Diarization is where this pipeline dies hardest, and a model that crashes
+    /// on a given recording crashes again next launch, because the restored job
+    /// runs the same stage over the same audio. Without this write the
+    /// transcript is persisted in no round at all and the recording is lost
+    /// however often it is retried. Stage 3 writes the same file again with the
+    /// labelled version, so on every path that reaches it this costs one extra
+    /// pass over text already in hand and leaves no trace.
+    ///
+    /// On the paths that do not reach stage 3, the draft is the point, and it
+    /// stays: an unlabelled transcript remains for a job that was cancelled or
+    /// killed mid-diarization, where previously nothing did. That is the trade,
+    /// not an oversight.
+    ///
+    /// Best effort on purpose: a job that cannot write here will report the real
+    /// problem when stage 3 tries again and does not swallow it.
+    private func saveTranscriptDraft(_ transcript: String, ctx: JobContext, outputDir: URL) {
+        _ = try? ProtocolGenerator.saveTranscript(
+            transcript, basename: ctx.slug,
+            dir: outputDir.appendingPathComponent("protocols"),
+        )
+    }
+
     /// Thin orchestrator: take the next waiting job and run it through the
     /// pipeline — transcribe → diarize → generate protocol → done.
     func processNext() async {
@@ -158,6 +182,8 @@ extension PipelineQueue {
                 triggerProcessing()
                 return
             }
+
+            saveTranscriptDraft(transcription.transcript, ctx: ctx, outputDir: outputDir)
 
             let finalTranscript = await diarize(
                 transcription, ctx: ctx, engine: engine,

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1535,6 +1535,88 @@ final class PipelineQueueTests: XCTestCase {
         )
     }
 
+    /// The transcript reaches disk before the diarization stage begins, rather
+    /// than only after it. Asked at the moment the diarizer is built, which is
+    /// that stage's first act: nothing later in it touches this directory, so
+    /// present at entry means present throughout.
+    func testTheTranscriptIsOnDiskBeforeDiarizationBegins() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [TimestampedSegment(start: 0, end: 5, text: "Readable early")]
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+
+        var draftsAtDiarizationEntry: [String] = []
+        let queue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: {
+                let names = (try? FileManager.default
+                    .contentsOfDirectory(atPath: protocolsDir.path)) ?? []
+                draftsAtDiarizationEntry = names.compactMap { name in
+                    try? String(contentsOf: protocolsDir.appendingPathComponent(name), encoding: .utf8)
+                }
+                return MockDiarization()
+            },
+            diarizationFactoryWithMode: nil,
+            protocolGeneratorFactory: { MockProtocolGen() },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            diarizeEnabled: true,
+            numSpeakers: 0,
+            micLabel: "Me",
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Long Meeting", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        await queue.processNext()
+
+        // Reading the content, not just the name: an implementation writing an
+        // empty or placeholder file would satisfy a presence check and save
+        // nothing.
+        XCTAssertTrue(
+            draftsAtDiarizationEntry.contains { $0.contains("Readable early") },
+            "the spoken text was not on disk when diarization began: \(draftsAtDiarizationEntry)",
+        )
+    }
+
+    /// The early write puts the unlabelled transcript on disk. Stage 3 has to
+    /// replace it with the labelled one, or the change would trade a readable
+    /// intermediate for a permanently worse result.
+    func testTheFinishedTranscriptIsTheLabelledOneNotTheEarlyDraft() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "First line"),
+            TimestampedSegment(start: 5, end: 10, text: "Second line"),
+        ]
+        let queue = makeCapturingQueue(
+            engine: engine, diar: MockDiarization(), protocolGen: MockProtocolGen(),
+        )
+
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Labelled Result", appName: "Teams",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        await queue.processNext()
+
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        let transcripts = try FileManager.default
+            .contentsOfDirectory(atPath: protocolsDir.path)
+            .filter { $0.hasSuffix(".txt") }
+        XCTAssertEqual(transcripts.count, 1, "the early draft was left behind as a second file")
+        let saved = try String(contentsOf: protocolsDir.appendingPathComponent(transcripts[0]), encoding: .utf8)
+        // The label is the mock diarizer's; what matters is that some label is
+        // there at all, since the early draft carries none.
+        XCTAssertTrue(
+            saved.contains("SPEAKER_"),
+            "the file kept the unlabelled draft instead of the diarized transcript: \(saved)",
+        )
+        XCTAssertFalse(saved.isEmpty)
+    }
+
     func testProcessNextEmptyTranscriptSetsError() async throws {
         let engine = MockEngine()
         engine.segmentsToReturn = [] // empty = no speech


### PR DESCRIPTION
From issue #558, which reported a finished transcription being lost. One contributing factor: the transcript is only persisted after diarization, so until then it exists nowhere but in memory.

## Why this is worth doing, and why it is not the obvious reason

The tempting justification is that a long diarization currently hides a transcript that is already finished. That effect is real and it is too small to carry the change on its own, since nothing points the user at the file until stage 3 records its path.

The reason that does carry it is that the failure repeats. Diarization is where this pipeline dies hardest, and a model that crashes on a given recording crashes again on the next launch, because the restored job runs the same stage over the same audio. Without a write beforehand the transcript is persisted in no round at all, and the recording is lost however often it is retried.

Stage 3 writes the same file again with the labelled version, so on every path that reaches it this costs one extra pass over text already in hand and leaves no trace.

## The accepted trade

On the paths that do not reach stage 3, an unlabelled transcript now remains where previously nothing did, in particular for a job cancelled mid-diarization. Keeping what was already produced seems clearly better than discarding it, but it is a visible change rather than an oversight, so it is stated here and in the code rather than left to be discovered.

## Evidence

Both tests were watched fail first, by removing the write.

The one that matters drives a diarization stage that fails outright and asserts the spoken text is on disk afterwards. It deliberately asserts the file and not the job's final state, because a sibling change stops that same failure from ending the job, and the test has to keep meaning the same thing whichever lands first.

The second asserts the transcript is on disk before the diarization stage begins, and reads its content rather than just its name, since an implementation writing an empty file would satisfy a presence check and save nothing.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

Refs #558.