### PR TITLE
fix(app): make cancelling a job stop the recording coming back

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -405,6 +405,14 @@ class PipelineQueue {
 
     /// Cancel a job. Removes the job + cleans up sidecar files if naming was
     /// pending. Done/error jobs are not affected.
+    ///
+    /// The recording is marked processed, so the cancel holds. Without that,
+    /// orphan recovery offers it again, and not only on the next launch:
+    /// switching watching on rebuilds the queue and rebuilding scans for
+    /// orphans, so the job the user just stopped came back within the session,
+    /// relabelled as a recovered recording. Cancelling that copy only re-armed
+    /// the loop. Re-importing the file by hand stays the way back and never
+    /// consults the ledger.
     func cancelJob(id: UUID) {
         guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
         let state = jobs[index].state
@@ -414,6 +422,9 @@ class PipelineQueue {
         // too — otherwise a job cancelled mid-stage leaks these entries.
         stageStartByJob.removeValue(forKey: id)
         jobAudioSeconds.removeValue(forKey: id)
+        if state != .done, state != .error {
+            processedLedger.markProcessed(mixPath: jobs[index].mixPath)
+        }
         switch state {
         case .waiting:
             jobs.remove(at: index)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -664,6 +664,64 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(freshQueue.jobs.first?.state, .waiting)
     }
 
+    // MARK: - Cancelling a job
+
+    /// Cancelling is the most explicit "stop this" the app offers, yet the
+    /// recording used to stay eligible for orphan recovery. Since the queue is
+    /// rebuilt whenever watching is switched on, and rebuilding scans for
+    /// orphans, the cancelled recording came back within the same session,
+    /// relabelled as a recovered one so it did not even look like the thing that
+    /// was stopped. Cancelling the copy only re-armed the loop.
+    func testCancellingAJobStopsItComingBackAsAnOrphan() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260311_120000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+
+        let queue = PipelineQueue(logDir: tmpDir)
+        let job = PipelineJob(
+            meetingTitle: "Stopped By Hand", appName: "Teams",
+            mixPath: mixFile, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+
+        queue.cancelJob(id: job.id)
+
+        let rebuilt = PipelineQueue(logDir: tmpDir)
+        await rebuilt.recoverOrphanedRecordings(recordingsDir: recDir)
+        XCTAssertTrue(
+            rebuilt.jobs.isEmpty,
+            "the cancelled recording was offered again as a recovered one",
+        )
+    }
+
+    /// Cancelling a job that is mid-run has to settle it the same way. This is
+    /// the expensive case: the recording that comes back is the one that was
+    /// costing minutes of compute when it was stopped.
+    func testCancellingAJobInFlightStopsItComingBackAsAnOrphan() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260311_130000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+
+        let queue = PipelineQueue(logDir: tmpDir)
+        var job = PipelineJob(
+            meetingTitle: "Stopped Mid Run", appName: "Teams",
+            mixPath: mixFile, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        job.state = .transcribing
+        queue.insertJobForTesting(job)
+
+        queue.cancelJob(id: job.id)
+
+        let rebuilt = PipelineQueue(logDir: tmpDir)
+        await rebuilt.recoverOrphanedRecordings(recordingsDir: recDir)
+        XCTAssertTrue(
+            rebuilt.jobs.isEmpty,
+            "the cancelled recording was offered again as a recovered one",
+        )
+    }
+
     // MARK: - Orphaned Recording Recovery Tests
 
     /// The scan reaches the same recording under a fresh job ID, so the audio


### PR DESCRIPTION
Follow-up to the ledger documentation PR, which noted this asymmetry but deliberately left it open because it changes visible behaviour. This is that change, on its own so it can be judged or dropped on its own merits.

## What was wrong

Cancelling is the most explicit "stop this" the app offers, and it was the only job-ending action that left no permanent mark. Dismissing an errored job marks the recording as handled; cancelling a running one did not, so the recording stayed eligible for orphan recovery and came back.

The part that makes this worth changing is that "came back" does not mean "on the next launch". Switching watching on rebuilds the pipeline queue, and rebuilding scans for orphans. So: stop an hour-long transcription, toggle watching, and minutes later it is running again, titled "Recovered Recording" so it does not even look like the thing that was stopped. Cancelling that copy only re-arms the loop.

The difference between the two paths turns out to be an accident rather than a decision: cancelling bypasses the dismissal path in order to reap stage-timing bookkeeping, and the ledger write was simply not carried across. Nothing in the code argues for the distinction.

## The cost, accepted rather than hidden

The ledger entry is permanent, so someone who cancels meaning "not now" loses the automatic way back. That was weighed and taken, because the automatic way back was not usable as a feature: it only fires within 24 hours of the recording being made, at moments nobody controls, and nothing in the app tells the user it exists. Nobody can be relying on it deliberately.

Re-importing the file by hand remains the way back, and that path never consults the ledger. The audio itself is never deleted by cancelling.

If "cancel but keep it for later" turns out to be a real need, it deserves a visible pause or requeue action rather than continuing to arrive as a side effect.

## Evidence

Both tests were watched fail first. They cover the two cases that differ in cost: a job cancelled while still waiting, and one cancelled mid-run, which is the expensive one since it was consuming compute when it was stopped. Both assert at the layer the user notices, that a rebuilt queue's orphan scan leaves the recording alone, rather than at the ledger.

The six existing cancellation tests still pass unchanged, including the one pinning that cancelling an already-finished job does nothing.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.

Refs #558.