### PR TITLE
docs: clarify meeting detection needs no Screen Recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Suffix constants live as static lets: the audio-file suffixes on `RecordingFileS
 ## Critical Notes
 
 - AudioTapLib (CATapDescription) requires macOS 14.2+ — compiled as SPM library, no separate binary needed
-- Screen Recording permission required for **meeting detection** (window titles via `CGWindowListCopyWindowInfo`)
+- **Meeting detection** needs no Screen Recording: the watch loop auto-detects via `PowerAssertionDetector` (IOKit power assertions). The grant only sharpens the meeting *title* (`CGWindowListCopyWindowInfo`, real title vs. a placeholder) and gates the audio-tap TCC fallback below. The window-title `MeetingDetector` that would require it is not the production detector (issue #562).
 - Audio capture (CATapDescription process tap) is TCC-gated: it needs either the `NSAudioCaptureUsageDescription` "Audio Recording" grant or, as a fallback, the Screen Recording grant. With neither, the tap returns `noErr` but captures silence, with no error and nothing logged (issue #524; measured on macOS 26, see the process-tap TCC-gate notes). This corrects an earlier "does not require Screen Recording" claim.
 - FluidAudio models are downloaded automatically on first run (~50 MB)
 

--- a/app/MeetingTranscriber/Sources/MeetingDetector.swift
+++ b/app/MeetingTranscriber/Sources/MeetingDetector.swift
@@ -3,8 +3,14 @@ import Foundation
 
 /// Polls window list to detect active meeting windows.
 ///
-/// Uses CGWindowListCopyWindowInfo to read on-screen windows.
-/// Requires Screen Recording permission.
+/// Uses CGWindowListCopyWindowInfo to read on-screen windows, which needs
+/// Screen Recording permission.
+///
+/// Not the production detector: the watch loop auto-detects via
+/// `PowerAssertionDetector` (IOKit power assertions), which fires without
+/// Screen Recording. The grant only sharpens the meeting title (a real title
+/// with it, a placeholder without) and gates the audio-tap TCC fallback
+/// (issue #524), so a detection failure is never a Screen Recording problem.
 @Observable
 class MeetingDetector: MeetingDetecting {
     private let patterns: [AppMeetingPattern]


### PR DESCRIPTION
Closes the documentation half of #562.

## What
An external reporter (#562) independently diagnosed why Zoom auto-detection failed in v0.5.1 and, along the way, hit a misleading doc: both the `MeetingDetector` docstring and the CLAUDE.md Critical Note claimed **Screen Recording is required for meeting detection**. That sent them down a TCC / Homebrew-quarantine rabbit hole before they read the source.

It is not accurate for the production path:

- Auto-detection runs `PowerAssertionDetector` (IOKit power assertions) via `WatchingController.defaultDetectors`, which fires **without** Screen Recording.
- The window-title `MeetingDetector` (the class carrying the "Requires Screen Recording permission" docstring) is not instantiated in the production detection path at all.
- Screen Recording is still relevant, just not for detection firing: it sharpens the meeting *title* (`CGWindowListCopyWindowInfo`, real title vs. a placeholder) and is a TCC fallback gate for the audio tap itself (#524).

## Changes
- `MeetingDetector.swift`: docstring now states this is not the production detector and spells out what Screen Recording actually affects.
- `CLAUDE.md` Critical Note: corrected the same claim.

## Not in scope
The underlying Zoom detection miss (Zoom names its in-call assertion with Apple's placeholder `"Describe Activity Type"`, so the old keyword match never fired) was already fixed via the `assertionTypes` fallback in `v0.6.0-rc6`. That is a release-notes item for the next stable, tracked separately.

Docs-only, no behavior change. Both claims were verified against `main` by an independent review before this PR.