### PR TITLE
fix(build): drop the deprecated string form from the cask requirement

### DIFF
--- a/Casks/meeting-transcriber.rb
+++ b/Casks/meeting-transcriber.rb
@@ -7,7 +7,7 @@ cask "meeting-transcriber" do
   desc "Auto-transcribe and summarize meetings"
   homepage "https://github.com/pasrom/meeting-transcriber"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   conflicts_with cask: "meeting-transcriber@beta"
 

--- a/Casks/meeting-transcriber@beta.rb
+++ b/Casks/meeting-transcriber@beta.rb
@@ -7,7 +7,7 @@ cask "meeting-transcriber@beta" do
   desc "Auto-transcribe and summarize meetings (pre-release)"
   homepage "https://github.com/pasrom/meeting-transcriber"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   conflicts_with cask: "meeting-transcriber"
 


### PR DESCRIPTION
Homebrew 6.0.x deprecates `depends_on macos: ">= :sonoma"` and prints a warning on every operation that touches the cask, telling users to report it to this tap. It fires today on a plain `brew upgrade`.

The bare symbol means the same thing on modern brew. Verified against the live cask before changing anything here: with `depends_on macos: :sonoma`, `brew info --cask meeting-transcriber` still reports `Required: macOS >= 14` and the warning is gone.

Note these two files are only templates. The casks users actually install live in the tap repo, and the release workflow rewrites just the version and sha256 lines there, so the same one-line change has to land in the tap to silence the warning. This keeps the template from re-introducing it when it seeds a cask file the tap does not have yet.