### PR TITLE
fix(test): stop the fixture generator from silently downgrading its fixture

### DIFF
--- a/scripts/generate_test_audio.sh
+++ b/scripts/generate_test_audio.sh
@@ -1,21 +1,73 @@
 #!/usr/bin/env bash
 # Generate a two-speaker German test WAV for E2E transcription + diarization tests.
 #
-# Produces: app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav (~15s, 16kHz mono, ~500KB)
+# Usage: ./scripts/generate_test_audio.sh [--output <path>] [--force]
+#
+# Produces: ~17s, 16kHz mono, ~530KB of four `say` segments with 1s gaps.
 # Requires: macOS `say` command with voices Anna and Flo installed, and `sox`.
+#
+# THIS SCRIPT DOES NOT REPRODUCE THE COMMITTED FIXTURE. The checked-in
+# app/MeetingTranscriber/Tests/Fixtures/two_speakers_de.wav is 49.8s and holds a
+# longer dialogue; the two drifted apart when the fixture was regenerated with
+# different voices and the script was not carried along. Overwriting the fixture
+# with this script's output is therefore a silent downgrade, which is why the
+# default output is a temp file and the fixture path needs --force.
+#
+# What breaks if you do overwrite it (measured, not assumed): eight sibling
+# fixtures (.m4a .mp3 .mp4 .mkv .webm .ogg .opus .3gp) are derived from that WAV
+# and stay at the old duration, and FFmpegHelperTests.testMKVAndWAVProduceSimilarDuration
+# compares the two, so it fails with 17.0s vs 49.8s. Regenerating the fixture for
+# real means regenerating the whole family and re-checking every test that reads
+# it, not running this script.
 set -euo pipefail
-
-command -v sox >/dev/null 2>&1 || { echo "ERROR: sox is required. Install with: brew install sox"; exit 1; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 FIXTURE_DIR="$PROJECT_DIR/app/MeetingTranscriber/Tests/Fixtures"
-OUTPUT="$FIXTURE_DIR/two_speakers_de.wav"
+FIXTURE="$FIXTURE_DIR/two_speakers_de.wav"
+
+OUTPUT=""
+FORCE=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output) OUTPUT="${2:-}"; shift 2 ;;
+        --output=*) OUTPUT="${1#--output=}"; shift ;;
+        --force) FORCE=true; shift ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v sox >/dev/null 2>&1 || { echo "ERROR: sox is required. Install with: brew install sox"; exit 1; }
+
+# Default to a temp file: the interesting output of this script is the audio, and
+# writing it over a committed fixture that eight other fixtures are derived from
+# should be a decision, not the default.
+if [ -z "$OUTPUT" ]; then
+    OUTPUT="$(mktemp -d)/two_speakers_de.wav"
+fi
+
+if [ "$OUTPUT" = "$FIXTURE" ] && [ "$FORCE" != true ]; then
+    cat >&2 <<EOF
+ERROR: refusing to overwrite the committed fixture.
+
+  $FIXTURE
+
+That file is 49.8s and this script produces ~17s, so the write would be a silent
+downgrade. Eight sibling fixtures are derived from it and would no longer match;
+FFmpegHelperTests.testMKVAndWAVProduceSimilarDuration compares WAV against MKV and
+fails on the mismatch.
+
+Run without arguments to write to a temp file, or pass --force if you really mean
+to replace the fixture and will regenerate its siblings too.
+EOF
+    exit 1
+fi
+
 TMPDIR_AUDIO="$(mktemp -d)"
 
 trap 'rm -rf "$TMPDIR_AUDIO"' EXIT
 
-mkdir -p "$FIXTURE_DIR"
+mkdir -p "$(dirname "$OUTPUT")"
 
 echo "Generating speech segments …"
 


### PR DESCRIPTION
`scripts/generate_test_audio.sh` wrote straight over `Tests/Fixtures/two_speakers_de.wav`. The script assembles four short `say` segments (about 17s); the committed fixture is 49.8s and holds a longer dialogue. The two drifted apart when the fixture was regenerated with different voices and the script was not carried along, so running it looked like a refresh and was a downgrade.

## Measured before changing anything

One run, then the existing test:

```
fixture before: 49.768s
fixture after : 17.027s
FFmpegHelperTests.testMKVAndWAVProduceSimilarDuration
  XCTAssertEqualWithAccuracy failed: ("17.02725") is not equal to ("49.7706875") +/- ("0.5")
```

That test is the tripwire because eight sibling fixtures (`.m4a .mp3 .mp4 .mkv .webm .ogg .opus .3gp`) are derived from the same WAV and keep the old duration. Regenerating only the WAV desynchronises the family; the keyword assertions in the transcription E2E tests describe the first 15 seconds and would have survived, which is what made this quiet.

## The change

Default output is a temp file. Writing to the fixture path needs `--force` and otherwise exits 1 with an explanation. The header states what the committed file actually is and that replacing it means regenerating the whole family, so the next reader does not have to rediscover it from a red test.

Verified: default run writes to temp and leaves the fixture untouched, the fixture path without `--force` refuses and the file stays 49.8s, `--force` still writes, an unknown argument exits 2, `shellcheck` clean.

## Deliberately not done

Aligning the script's dialogue with the fixture's. Even with the right words it would not reproduce the file, since `say` output is not stable across voice and OS versions, so it would buy a resemblance rather than the guarantee the guard gives. Regenerating the fixture from the script was the other option and is the riskier one: it changes a file many tests read, to no benefit.