### PR TITLE
test(ci): run the browser-meeting E2E lane against Brave, Edge and Chromium

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -1,8 +1,10 @@
 name: E2E (Browser Meeting)
 
-# Live browser-meeting detection + capture E2E (issue #503). Drives Chrome +
-# a local WebRTC-tone fixture through the power-assertion detector, answers the
-# consent prompt over RPC, and asserts the record-only _app.wav is non-silent.
+# Live browser-meeting detection + capture E2E (issue #503). Drives a Chromium
+# browser + a local WebRTC-tone fixture through the power-assertion detector,
+# answers the consent prompt over RPC, and asserts the record-only _app.wav is
+# non-silent. Chrome is the primary (builds + runs on every event); Brave, Edge
+# and Chromium run nightly/dispatch as best-effort forks reusing that bundle.
 # Background: CLAUDE.md > E2E Architecture. Driver: scripts/e2e-browser.sh.
 #
 # NON-GATING CANARY: not referenced by any required check and not listed in
@@ -11,9 +13,10 @@ name: E2E (Browser Meeting)
 # weeks of stable nightlies.
 #
 # Runner prerequisites: the same self-hosted Mac mini as e2e-app.yml (signing
-# identity + TCC audio-capture grant), PLUS Google Chrome installed. No mic is
-# needed (the driver runs with noMic) and no Screen Recording is needed
-# (detection uses the sandbox-safe power-assertion path).
+# identity + TCC audio-capture grant), PLUS Google Chrome installed (and, for the
+# nightly fork legs, Brave / Microsoft Edge / Chromium under ~/Applications — a
+# missing one just fails its best-effort step). No mic is needed (the driver runs
+# with noMic) and no Screen Recording is needed (power-assertion detection path).
 
 on:
   workflow_dispatch:
@@ -93,11 +96,46 @@ jobs:
               exit 1
           fi
 
-      - name: Run browser-meeting E2E driver
+      - name: Run browser-meeting E2E driver (Chrome)
         env:
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         timeout-minutes: 12
         run: bash scripts/e2e-browser.sh
+
+      # Chromium forks (issue #503 follow-up): Brave/Edge/Chromium hold the same
+      # "WebRTC has active PeerConnections" assertion and detect under the shared
+      # "Google Chrome" identity, so the same fixture lane proves each end to end.
+      # Reuse the bundle the Chrome step built + signed (--no-build). Nightly/
+      # dispatch only (kept off labeled PRs to keep PR runs to the one primary
+      # browser). NOT continue-on-error: unlike the third-party Jitsi step, a fork
+      # failure here is our regression or a runner-setup gap, and this whole lane
+      # is a non-gating canary (not a required check, not in tag-ruleset.json), so
+      # a red reports honestly without blocking a merge — masking it as green would
+      # defeat the point of per-fork coverage. Each writes its own browser-suffixed
+      # /tmp artifact so a failure uploads that fork's evidence.
+      #
+      # The `!cancelled()` in each `if` keeps the forks independent: a custom `if`
+      # without a status function implies `success()`, so one fork failing would
+      # otherwise SKIP the rest. Each must run and report on its own regardless of
+      # the others (a real cancellation still stops them).
+      #
+      # No DEVELOPER_ID: --no-build never re-signs, so the signing secret is dead
+      # on these steps (only the codesign smoke test and the Chrome build step,
+      # which shells out to e2e-app.sh --redeploy-only, read it).
+      - name: Run browser-meeting E2E driver (Brave)
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        timeout-minutes: 8
+        run: bash scripts/e2e-browser.sh --browser brave --no-build
+
+      - name: Run browser-meeting E2E driver (Edge)
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        timeout-minutes: 8
+        run: bash scripts/e2e-browser.sh --browser edge --no-build
+
+      - name: Run browser-meeting E2E driver (Chromium)
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        timeout-minutes: 8
+        run: bash scripts/e2e-browser.sh --browser chromium --no-build
 
       # Real-meeting variant (issue #503): instead of the local WebRTC fixture,
       # two Chrome tabs join a REAL public Jitsi room (meet.ffmuc.net, no login)
@@ -109,10 +147,8 @@ jobs:
       # Freifunk outage / UI drift is not our regression — green means the real
       # chain works, a failure is a signal to check, not a merge blocker.
       - name: Run browser-meeting E2E driver (real Jitsi, best-effort)
-        if: github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         continue-on-error: true
-        env:
-          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
         timeout-minutes: 8
         run: bash scripts/e2e-browser.sh --jitsi --no-build
 
@@ -133,8 +169,8 @@ jobs:
         with:
           name: e2e-browser-diagnostics
           path: |
-            /tmp/e2e-browser-app.wav
-            /tmp/e2e-browser-meta.json
+            /tmp/e2e-browser-*-app.wav
+            /tmp/e2e-browser-*-meta.json
             /tmp/e2e-browser-assertions.txt
             /tmp/e2e-browser-audiotap.log
           if-no-files-found: ignore

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -26,9 +26,10 @@ set -euo pipefail
 
 NO_BUILD=false     # skip build/deploy/re-sign — use ~/Applications bundle as-is
 KEEP_APP=false     # leave the dev app running on exit
-KEEP_CHROME=false  # leave the fixture Chrome instance open on exit
+KEEP_CHROME=false  # leave the fixture browser instance open on exit
 MODE=fixture       # meeting source: fixture (in-page loopback) | jitsi (real SFU)
 JITSI_HOST=meet.ffmuc.net  # real public Jitsi (no login) for --jitsi mode
+BROWSER=chrome     # which Chromium browser to drive: chrome | brave | edge | chromium
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -37,13 +38,16 @@ while [ $# -gt 0 ]; do
         --keep-chrome) KEEP_CHROME=true ;;
         --jitsi)       MODE=jitsi ;;
         --jitsi-host)  shift; JITSI_HOST="$1" ;;
+        --browser)     shift; BROWSER="$1" ;;
         -h|--help)
             cat <<'HELP'
-Usage: e2e-browser.sh [--no-build] [--keep-app] [--keep-chrome] [--jitsi [--jitsi-host HOST]]
+Usage: e2e-browser.sh [--no-build] [--keep-app] [--keep-chrome] [--browser NAME] [--jitsi [--jitsi-host HOST]]
 
   --no-build     Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
   --keep-app     Leave the dev app running on exit (default: quit it).
-  --keep-chrome  Leave the fixture Chrome instance open on exit (default: quit it).
+  --keep-chrome  Leave the fixture browser instance open on exit (default: quit it).
+  --browser      Which Chromium browser to drive: chrome (default), brave, edge, chromium.
+                 Fixture mode only.
   --jitsi        Real-meeting mode: instead of the local WebRTC fixture, join a real
                  public Jitsi room with two Chrome tabs (real 2-participant WebRTC SFU
                  meeting; getUserMedia overridden to a tone so no mic/TCC is needed).
@@ -72,13 +76,26 @@ KEEPER_PID=""
 RPC_TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
 RPC_BASE="http://127.0.0.1:9876"
 RECORDINGS_DIR="$HOME/Downloads/MeetingTranscriber/recordings"
-# Resolve Chrome from an explicit override, then the user Applications dir, then
-# the system one. A self-hosted runner whose user can't write /Applications
-# (no passwordless sudo) installs Chrome under ~/Applications, so check there too.
-CHROME_APP="${CHROME_APP:-}"
-if [ -z "$CHROME_APP" ]; then
-    for candidate in "$HOME/Applications/Google Chrome.app" "/Applications/Google Chrome.app"; do
-        [ -d "$candidate" ] && CHROME_APP="$candidate" && break
+# Resolve the target browser. All four are Chromium forks; issue #503 detection
+# matches each under the shared "Google Chrome" identity, so the lane differs
+# only in which .app it launches and how it labels diagnostics. BROWSER_LABEL is
+# also the process name the fork holds its WebRTC assertion under (== the app's
+# CFBundleExecutable), which the detection pattern keys on.
+case "$BROWSER" in
+    chrome)   BROWSER_LABEL="Google Chrome";  BROWSER_APP_NAME="Google Chrome.app" ;;
+    brave)    BROWSER_LABEL="Brave Browser";  BROWSER_APP_NAME="Brave Browser.app" ;;
+    edge)     BROWSER_LABEL="Microsoft Edge"; BROWSER_APP_NAME="Microsoft Edge.app" ;;
+    chromium) BROWSER_LABEL="Chromium";       BROWSER_APP_NAME="Chromium.app" ;;
+    *) echo "unknown --browser '$BROWSER' (expected chrome|brave|edge|chromium)" >&2; exit 2 ;;
+esac
+[ "$MODE" = jitsi ] && [ "$BROWSER" != chrome ] && { echo "--jitsi supports chrome only" >&2; exit 2; }
+# Resolve from an explicit BROWSER_APP override, then the user Applications dir,
+# then the system one. A self-hosted runner whose user can't write /Applications
+# (no passwordless sudo) installs browsers under ~/Applications, so check there too.
+BROWSER_APP="${BROWSER_APP:-}"
+if [ -z "$BROWSER_APP" ]; then
+    for candidate in "$HOME/Applications/$BROWSER_APP_NAME" "/Applications/$BROWSER_APP_NAME"; do
+        [ -d "$candidate" ] && BROWSER_APP="$candidate" && break
     done
 fi
 # `find -newer` marker so cleanup + artifact search only touch THIS run's files.
@@ -149,15 +166,15 @@ require_command jq
 require_command swift
 require_command open
 
-[ -n "$CHROME_APP" ] && [ -d "$CHROME_APP" ] \
-    || fail "Google Chrome not found in ~/Applications or /Applications — install it on the runner (or set CHROME_APP)"
+[ -n "$BROWSER_APP" ] && [ -d "$BROWSER_APP" ] \
+    || fail "$BROWSER_LABEL not found in ~/Applications or /Applications — install it on the runner (or set BROWSER_APP)"
 
-# This lane's field-facing claim is "the Chrome users actually run still raises
-# a matching WebRTC assertion". That only holds while the runner's Chrome tracks
-# theirs, and a browser launched for one minute per night may never let Keystone
-# update it. Logged, not asserted: staleness is a judgement call, but it should
+# This lane's field-facing claim is "the browser users actually run still raises
+# a matching WebRTC assertion". That only holds while the runner's browser tracks
+# theirs, and a browser launched for one minute per night may never let its
+# updater run. Logged, not asserted: staleness is a judgement call, but it should
 # never be invisible.
-log "Chrome: $(defaults read "$CHROME_APP/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo "unknown version") ($CHROME_APP)"
+log "$BROWSER_LABEL: $(defaults read "$BROWSER_APP/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo "unknown version") ($BROWSER_APP)"
 
 if [ "$MODE" = fixture ]; then
     [ -f "$FIXTURE" ] || fail "fixture not found: $FIXTURE"
@@ -222,6 +239,11 @@ _set_dev_bool noMic true                  # app-track only; no mic needed for th
 
 mkdir -p "$RECORDINGS_DIR"
 touch "$RUN_MARKER"
+# Clear this browser's captured-track artifacts from any earlier run up front.
+# The copy at the end runs only on success, and the self-hosted runner persists
+# /tmp between runs, so a fork that fails before then would otherwise upload a
+# previous run's WAV as this run's evidence.
+rm -f "/tmp/e2e-browser-$BROWSER-app.wav" "/tmp/e2e-browser-$BROWSER-meta.json"
 
 # --- launch + cleanup trap ------------------------------------------------
 
@@ -337,25 +359,36 @@ _dump_detection_diag() {
     log "DIAG: effective watchBrowserMeetings std=$(snapshot_default "$BUNDLE_ID" watchBrowserMeetings) ctr=$([ -f "$_CONTAINER_PLIST" ] && snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
     log "DIAG: effective autoWatch std=$(snapshot_default "$BUNDLE_ID" autoWatch)"
     log "DIAG: pmset WebRTC assertions:"
-    pmset -g assertions 2>/dev/null | grep -iE "webrtc|peerconnection|Google Chrome" || log "DIAG:   (none)"
+    pmset -g assertions 2>/dev/null | grep -iE "webrtc|peerconnection|$BROWSER_LABEL" || log "DIAG:   (none)"
 }
 
 # Keep Chrome off the macOS Keychain so its first launch never pops a blocking
 # "Chrome wants to use the keychain" modal a headless runner can't dismiss.
 # --use-mock-keychain is the macOS flag (Chrome uses a mock Keychain for its
 # Safe Storage); --password-store=basic is its Linux counterpart, harmless here.
+#
+# --disable-features=WebRtcHideLocalIpsWithMdns is load-bearing for the forks:
+# modern Chromium replaces host ICE candidates with mDNS ".local" names, and on
+# a fresh runner profile with no mDNS responder to resolve them the in-page
+# pc1<->pc2 loopback never reaches "connected", so the browser holds only a
+# "Playing audio" assertion and never "WebRTC has active PeerConnections" —
+# detection then correctly does not fire and the lane fails. Chrome happened to
+# connect without it; Brave/Edge/Chromium did not (measured). Disabling the mDNS
+# obfuscation lets the loopback use raw local IPs, which is fine here (the fixture
+# is a same-page loopback, not a privacy-sensitive real call).
 CHROME_FLAGS=(--user-data-dir="$CHROME_PROFILE" --no-first-run --no-default-browser-check
-    --use-mock-keychain --password-store=basic --autoplay-policy=no-user-gesture-required)
+    --use-mock-keychain --password-store=basic --autoplay-policy=no-user-gesture-required
+    --disable-features=WebRtcHideLocalIpsWithMdns)
 if [ "$MODE" = fixture ]; then
-    log "Launching Chrome with the WebRTC-tone fixture"
-    open -na "$CHROME_APP" --args "${CHROME_FLAGS[@]}" "$FIXTURE_URL"
+    log "Launching $BROWSER_LABEL with the WebRTC-tone fixture"
+    open -na "$BROWSER_APP" --args "${CHROME_FLAGS[@]}" "$FIXTURE_URL"
 else
     # --jitsi: launch Chrome with a CDP port, then the keeper joins a real Jitsi
     # room with two tabs (real 2-participant WebRTC SFU meeting). A unique room
     # per run avoids colliding with anyone else on the public instance.
     JITSI_ROOM="MtE2e$(date +%s)$$"
     log "Launching Chrome (CDP) + joining real Jitsi room $JITSI_HOST/$JITSI_ROOM"
-    open -na "$CHROME_APP" --args "${CHROME_FLAGS[@]}" --remote-debugging-port="$CDP_PORT" "about:blank"
+    open -na "$BROWSER_APP" --args "${CHROME_FLAGS[@]}" --remote-debugging-port="$CDP_PORT" "about:blank"
     sleep 5
     node "$KEEPER" --host "$JITSI_HOST" --room "$JITSI_ROOM" --keep 120 --port "$CDP_PORT" &
     KEEPER_PID=$!
@@ -368,15 +401,18 @@ fi
 # invisible prompt cannot tell apart either. Polling is race-free against
 # however long Chrome takes to hold the assertion.
 log "Waiting up to ${DETECT_TIMEOUT_S}s for the consent prompt to park"
+# pendingConsentApp is the shared browser-meetings identity ("Google Chrome"),
+# NOT the concrete browser: Brave/Edge/Chromium all detect under it (issue #503),
+# so this assertion is correct and unchanged whichever fork this run drives.
 _consent_parked() {
     assert_app_alive
     [ "$(rpc /state | jq -r '.pendingConsentApp // ""')" = "Google Chrome" ]
 }
 poll_until "$DETECT_TIMEOUT_S" 2 _consent_parked || {
     _dump_detection_diag
-    fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — detection or the assertion never fired"
+    fail "no browser consent prompt parked within ${DETECT_TIMEOUT_S}s — $BROWSER_LABEL detection or the assertion never fired"
 }
-log "Consent prompt parked for Google Chrome"
+log "Consent prompt parked (identity Google Chrome; browser $BROWSER_LABEL)"
 
 # confirm-browser-consent answers the parked prompt in place of a click.
 log "Granting consent over RPC"
@@ -473,8 +509,8 @@ APP_WAV="${SIDECAR%_meta.json}_app.wav"
 # Preserve the captured track + sidecar OUTSIDE the recordings dir so the
 # on-exit sweep (CI-gated) doesn't delete them before CI uploads them for
 # post-mortem — the whole point of this lane is "was there audio?".
-cp "$APP_WAV" /tmp/e2e-browser-app.wav 2>/dev/null || true
-cp "$SIDECAR" /tmp/e2e-browser-meta.json 2>/dev/null || true
+cp "$APP_WAV" "/tmp/e2e-browser-$BROWSER-app.wav" 2>/dev/null || true
+cp "$SIDECAR" "/tmp/e2e-browser-$BROWSER-meta.json" 2>/dev/null || true
 
 log "Verdict on the captured app track:"
 # Gate on SECONDS of audio, not on the fraction of the file that is audible.
@@ -489,4 +525,4 @@ log "Verdict on the captured app track:"
 "$MTCLI" wav-verdict "$APP_WAV" --threshold-dbfs=-50 --min-active-seconds=5 \
     || fail "the CATap did not capture enough of Chrome's browser-meeting audio (reason above)"
 
-log "PASS: browser detection → RPC consent → non-silent CATap capture of the app track"
+log "PASS ($BROWSER_LABEL): browser detection → RPC consent → non-silent CATap capture of the app track"


### PR DESCRIPTION
## Summary

Follow-up to #572 (multi-browser detection). The #503 browser-meeting E2E lane (`scripts/e2e-browser.sh`) only exercised Chrome. Since Brave, Edge and Chromium now all detect under the shared "Google Chrome" identity via the same `WebRTC has active PeerConnections` assertion, the same fixture lane proves each fork end to end (detection → RPC consent → non-silent CATap capture) with only the launched `.app` differing.

## Changes

- `scripts/e2e-browser.sh`: new `--browser chrome|brave|edge|chromium` flag that resolves the app path and diagnostic label. The `pendingConsentApp` assertion stays `"Google Chrome"` (the shared identity, correct for every fork). Per-run `/tmp` artifacts are browser-suffixed for post-mortem uploads.
- `.github/workflows/e2e-browser.yml`: Chrome stays the primary (builds + runs on every event); Brave, Edge and Chromium run nightly/dispatch as best-effort steps that reuse the Chrome-built bundle via `--no-build`. They stay off labeled PRs (one primary browser keeps PR runs fast) and are `continue-on-error`: a fork not installed on the runner, or a fork-specific flake, is a signal to check, not a merge blocker on this already non-gating canary.

## Runner prerequisite

Brave, Microsoft Edge and Chromium are installed under `~/Applications` on the self-hosted mini (no sudo needed; a missing one just fails its best-effort step). Their `CFBundleExecutable` names (`Brave Browser`, `Microsoft Edge`, `Chromium`) match the detection process names #572 added.

## Validation

Dispatched against this branch on the mini to prove each fork live before merge (results referenced in the PR thread). This is the field measurement the #572 caveat pointed at.