### PR TITLE
fix(app): clean up naming data when a job is dismissed

### DIFF
--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -396,6 +396,14 @@ class PipelineQueue {
     func removeJob(id: UUID) {
         if let index = jobs.firstIndex(where: { $0.id == id }) {
             processedLedger.markProcessed(mixPath: jobs[index].mixPath)
+            // Unconditional, because removing a job has to remove what belongs
+            // to it. A job dismissed while still awaiting speaker naming used to
+            // strand its sidecars for good: only cancelling cleaned them up, and
+            // Cancel is not offered in that state. Nothing sweeps the output
+            // folder for them and the job is gone from the snapshot that would
+            // have named them. Resolved jobs have nothing left here, so this
+            // costs them a no-op.
+            naming.removeNamingData(jobID: id, slug: jobs[index].namingSlug)
             jobs.remove(at: index)
         }
         stageStartByJob.removeValue(forKey: id)

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -664,6 +664,41 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(freshQueue.jobs.first?.state, .waiting)
     }
 
+    // MARK: - Dismissing a job awaiting speaker naming
+
+    /// Dismiss is offered for a job still awaiting speaker naming, and it routes
+    /// to `removeJob`, which knew nothing about naming data. Only cancelling
+    /// cleaned it up, and Cancel is not offered in that state, so the sidecars
+    /// were left behind for good: nothing sweeps the output folder for them, and
+    /// the job is gone from the snapshot that would have named them. Each 16 kHz
+    /// sidecar is mono 16-bit at 16 kHz, so a dismissed hour of a two-track
+    /// meeting stranded roughly a third of a gigabyte.
+    func testDismissingAJobAwaitingNamingCleansUpItsSidecars() async throws {
+        let (queue, _, jobID) = try await makeSingleSourceJobAtNamingPending(
+            title: "Dismissed Before Naming",
+            transcriptSegments: [TimestampedSegment(start: 0, end: 5, text: "Never named")],
+        )
+        let slug = try XCTUnwrap(queue.jobs.first { $0.id == jobID }?.namingSlug)
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        let leftovers = ["_naming.json", "_16k.wav", "_app_16k.wav", "_mic_16k.wav", "_segments.json"]
+            .map { recordingsDir.appendingPathComponent("\(slug)\($0)") }
+
+        // Premise: naming really did park with data on disk, or the test proves
+        // nothing about cleaning it up.
+        XCTAssertTrue(
+            leftovers.contains { FileManager.default.fileExists(atPath: $0.path) },
+            "no naming data was written, so there is nothing to strand",
+        )
+
+        queue.removeJob(id: jobID)
+
+        let stranded = leftovers.filter { FileManager.default.fileExists(atPath: $0.path) }
+        XCTAssertTrue(
+            stranded.isEmpty,
+            "dismissing left these behind for good: \(stranded.map(\.lastPathComponent))",
+        )
+    }
+
     // MARK: - Cancelling a job
 
     /// Cancelling is the most explicit "stop this" the app offers, yet the


### PR DESCRIPTION
Dismissing a job that is still waiting for speaker naming leaves its sidecar files in the output folder permanently.

## What happens

The menu offers **Dismiss** for a job in the speaker-naming state, and it routes to `removeJob`, which has no knowledge of naming data. Only `cancelJob` cleans that up, and **Cancel is not offered in that state**. Nothing else ever collects the files: no code sweeps the output recordings folder for orphaned sidecars, and the dismissed job is gone from the snapshot that would have identified them.

## What it costs

Every 16 kHz sidecar is mono 16-bit at 16 kHz, so 32 kB/s, which is 115 MB per hour per track. A dismissed hour of a two-track meeting strands about 346 MB across `_16k.wav`, `_app_16k.wav` and `_mic_16k.wav`, plus the two small JSON files. Those WAVs are byte-identical copies of the originals persisted in the same folder, so the folder ends up holding the same audio twice, and the user has no way to tell which half is dead.

This is in v0.6.0.

## The fix

One call in `removeJob`. It is unconditional rather than guarded on the pending state, because removing a job has to remove what belongs to it, and a job that already resolved its naming has nothing left for this to find. That also covers the neighbouring case of a job forced to done because its naming JSON was missing while the audio sidecars survived.

Checked before deciding it was safe to delete on dismissal: an open dialog no-ops afterwards, the automation API answers cleanly once the job is gone, and no recording is lost, since the original audio was moved to the output folder before naming parked and re-importing it remains the documented way back.

**Deliberately unchanged:** dismissing still means transcript without a protocol, because generation is deferred while naming is pending. That is what the button should do rather than triggering a model call on the way out. Writing it down because it is easy to mistake for an omission.

**Rejected:** routing Dismiss to `cancelJob`. That entry point also serves finished and errored rows, which `cancelJob` deliberately ignores, so the reroute would have broken dismissing those.

## Evidence

The test drives a real job to the naming state through the pipeline, dismisses it, and asserts nothing is left. It pins its own premise first, that naming data was actually written, so it cannot pass by testing nothing. Watched fail before the fix, naming the three stranded files in the failure message.

Gates run locally: full test suite, SwiftFormat against the pinned version, SwiftLint, `swiftlint analyze --strict` with zero violations, and the release-mode parity build.