### PR TITLE
fix(app): tap Safari's WebKit helpers so app audio is captured (#524)

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -509,11 +509,12 @@ class DualSourceRecorder: RecordingProvider {
     /// prepending the root if enumeration somehow missed it — order matters
     /// for the aggregate device's cosmetic name tag (root first).
     static func resolveTapPIDs(rootPID: pid_t) -> [pid_t] {
-        resolveTapPIDs(
+        // Safari's audio runs in WebKit XPC outside Safari.app — see ProcessResponsibility.tapPIDs.
+        ProcessResponsibility.tapPIDs(rootPID: rootPID, bundleDerived: resolveTapPIDs(
             rootPID: rootPID,
             bundleURL: NSRunningApplication(processIdentifier: rootPID)?.bundleURL,
             enumerate: ProcessTreeEnumerator.pidsRooted(in:),
-        )
+        ))
     }
 
     /// Test seam — same PID-set decision as `resolveTapPIDs(rootPID:)` but with

--- a/tools/audiotap/Sources/ProcessResponsibility.swift
+++ b/tools/audiotap/Sources/ProcessResponsibility.swift
@@ -1,0 +1,144 @@
+import CoreAudio
+import Darwin
+import Foundation
+
+/// Groups a helper process with the application macOS holds *responsible* for it.
+///
+/// `ProcessTreeEnumerator` groups processes by executable-path prefix, which is
+/// right for apps whose helpers live inside their own bundle (Chrome, Electron)
+/// and cannot work for Safari: WebKit runs its GPU and WebContent services as
+/// XPC under `/System/Library/Frameworks/WebKit.framework`, so rooting at
+/// `Safari.app` returns Safari's own processes and never the one producing the
+/// call audio.
+///
+/// Responsibility is the relationship macOS itself uses to attribute a helper's
+/// behaviour to an app — it is what TCC consults when a WebKit service touches
+/// the microphone. Measured on macOS 26.5:
+///
+///     pid 2032 [com.apple.WebKit.GPU] -> responsible 707 [com.apple.Safari]
+///
+/// `responsibility_get_pid_responsible_for_pid` is not in a public header, so it
+/// is resolved with `dlsym`; a missing symbol degrades to "no opinion" and the
+/// caller keeps its bundle-derived set.
+public enum ProcessResponsibility {
+    private typealias ResponsibleFn = @convention(c) (pid_t) -> pid_t
+
+    /// Resolved lazily, and deliberately absent from the App Store build: the
+    /// symbol is private API, and shipping the string invites an automated
+    /// review flag. Every caller already degrades to the bundle-derived set
+    /// when this is nil, so the sandboxed variant simply does not get the
+    /// Safari fix — a conscious tradeoff.
+    private static let responsibleFn: ResponsibleFn? = {
+        #if APPSTORE
+            nil
+        #else
+            guard let handle = dlopen(nil, RTLD_NOW),
+                  let sym = dlsym(handle, "responsibility_get_pid_responsible_for_pid")
+            else { return nil }
+            return unsafeBitCast(sym, to: ResponsibleFn.self)
+        #endif
+    }()
+
+    /// The app responsible for `pid`, or 0 when unavailable. Identity for a
+    /// process that is its own responsible party (a normal app).
+    public static func responsiblePID(of pid: pid_t) -> pid_t {
+        guard let fn = responsibleFn else { return 0 }
+        let owner = fn(pid)
+        return owner > 0 ? owner : 0
+    }
+
+    /// PIDs that CoreAudio has a process object for — every process that could
+    /// meaningfully be tapped, typically a few dozen.
+    public static func audioCapablePIDs() -> Set<pid_t> {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size,
+        ) == noErr, size > 0 else { return [] }
+
+        var objects = [AudioObjectID](
+            repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size,
+        )
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &objects,
+        ) == noErr else { return [] }
+
+        var pids = Set<pid_t>()
+        for object in objects {
+            var pidAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioProcessPropertyPID,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain,
+            )
+            var pid: pid_t = -1
+            var pidSize = UInt32(MemoryLayout<pid_t>.size)
+            if AudioObjectGetPropertyData(object, &pidAddress, 0, nil, &pidSize, &pid) == noErr,
+               pid > 0 {
+                pids.insert(pid)
+            }
+        }
+        return pids
+    }
+
+    /// Audio-capable processes that macOS attributes to `owner`, including
+    /// `owner` itself.
+    ///
+    /// Iterates the audio-capable set (a few dozen) rather than every live
+    /// process (~1900 here), because the intersection is the answer either way
+    /// and this asks the kernel for responsibility a few dozen times instead of
+    /// a few thousand per recording start.
+    ///
+    /// `audioCapable` and `responsibleFor` are injection seams so the grouping
+    /// is verifiable without real processes.
+    public static func audioPIDsResponsible(
+        to owner: pid_t,
+        audioCapable: () -> Set<pid_t> = audioCapablePIDs,
+        responsibleFor: ((pid_t) -> pid_t)? = nil,
+    ) -> [pid_t] {
+        guard owner > 0 else { return [] }
+        // No symbol and no injected lookup means no opinion to offer; returning
+        // empty keeps the caller on its bundle-derived set rather than silently
+        // widening the tap.
+        if responsibleFor == nil, responsibleFn == nil {
+            return []
+        }
+        let lookup = responsibleFor ?? { responsiblePID(of: $0) }
+        return audioCapable().filter { $0 == owner || lookup($0) == owner }.sorted()
+    }
+
+    /// The PID set an app-audio tap should cover, given the bundle-derived set
+    /// the caller already computed.
+    ///
+    /// Safari's audio is produced by WebKit XPC services that live outside
+    /// `Safari.app`, so the bundle-derived set is Safari's main process alone —
+    /// which never emits sound. Measured: `App audio tap: 1 PID(s)
+    /// [Safari(692)]` while the audio came from `com.apple.WebKit.GPU(21403)`.
+    /// The tap was valid and recorded an hour of silence.
+    ///
+    /// Only widens when `rootPID` is its OWN responsible party, i.e. a normally
+    /// launched app. A process started from a shell or script is attributed to
+    /// the launcher, and widening on that would tap whatever audio-capable
+    /// processes happen to share it — a terminal that played a system sound, a
+    /// media tool from the same shell. GUI-launched meeting apps are always
+    /// their own responsible party, so the guard costs nothing there.
+    public static func tapPIDs(
+        rootPID: pid_t,
+        bundleDerived: [pid_t],
+        responsibleFor: ((pid_t) -> pid_t)? = nil,
+        audioCapable: () -> Set<pid_t> = audioCapablePIDs,
+    ) -> [pid_t] {
+        let lookup = responsibleFor ?? { responsiblePID(of: $0) }
+        let owner = lookup(rootPID)
+        guard owner != 0, owner == rootPID else { return bundleDerived }
+        let byOwner = audioPIDsResponsible(
+            to: owner, audioCapable: audioCapable, responsibleFor: responsibleFor,
+        )
+        guard !byOwner.isEmpty else { return bundleDerived }
+        var seen = Set<pid_t>()
+        return (bundleDerived + byOwner).filter { seen.insert($0).inserted }
+    }
+}

--- a/tools/audiotap/Tests/ProcessResponsibilityTests.swift
+++ b/tools/audiotap/Tests/ProcessResponsibilityTests.swift
@@ -1,0 +1,122 @@
+@testable import AudioTapLib
+import XCTest
+
+/// Covers the responsible-app grouping that lets an app-audio tap reach a
+/// browser's out-of-bundle helpers.
+///
+/// The bug these guard: `pidsRooted(in: Safari.app)` returns Safari's main
+/// process alone, because WebKit's GPU and WebContent services live under
+/// `/System/Library/Frameworks`. Tapping that set records silence — the audio
+/// is produced by the helper, not by Safari itself.
+final class ProcessResponsibilityTests: XCTestCase {
+    /// Safari (707) with two WebKit helpers, plus an unrelated app and its own
+    /// helper. Only processes CoreAudio knows about are candidates.
+    private let responsible: [pid_t: pid_t] = [
+        707: 707, 2032: 707, 2273: 707,
+        999: 999, 4081: 999,
+    ]
+
+    private func lookup(_ pid: pid_t) -> pid_t {
+        responsible[pid] ?? 0
+    }
+
+    // MARK: - grouping
+
+    func testGroupsEveryAudioCapableHelperUnderItsResponsibleApp() {
+        let pids = ProcessResponsibility.audioPIDsResponsible(
+            to: 707,
+            audioCapable: { [707, 2032, 2273, 999, 4081] },
+            responsibleFor: lookup,
+        )
+        XCTAssertEqual(pids, [707, 2032, 2273])
+    }
+
+    func testExcludesAnotherAppsHelperSharingTheSameBundlePath() {
+        // The precise failure of bundle-path enumeration: every app's WebKit
+        // helpers share a prefix under /System/Library/Frameworks.
+        let pids = ProcessResponsibility.audioPIDsResponsible(
+            to: 707,
+            audioCapable: { [707, 2032, 4081, 999] },
+            responsibleFor: lookup,
+        )
+        XCTAssertFalse(pids.contains(4081), "another app's helper must not be tapped")
+        XCTAssertFalse(pids.contains(999))
+    }
+
+    func testIgnoresProcessesCoreAudioDoesNotKnowAbout() {
+        // A Metal shader compiler or speech-synthesis service can share the
+        // responsible app without ever being tappable.
+        let pids = ProcessResponsibility.audioPIDsResponsible(
+            to: 707,
+            audioCapable: { [707] },
+            responsibleFor: lookup,
+        )
+        XCTAssertEqual(pids, [707])
+    }
+
+    func testOwnerZeroYieldsNothingRatherThanEverything() {
+        let pids = ProcessResponsibility.audioPIDsResponsible(
+            to: 0,
+            audioCapable: { [1, 2, 3] },
+            responsibleFor: { _ in 0 },
+        )
+        XCTAssertTrue(pids.isEmpty)
+    }
+
+    // MARK: - tapPIDs composition
+
+    func testWidensTheBundleSetWithTheAppsAudioHelpers() {
+        let pids = ProcessResponsibility.tapPIDs(
+            rootPID: 707,
+            bundleDerived: [707],
+            responsibleFor: lookup,
+        ) { [707, 2032, 2273] }
+        XCTAssertEqual(pids, [707, 2032, 2273], "the helper producing audio must be tapped")
+    }
+
+    func testDoesNotWidenForAProcessAttributedToItsLauncher() {
+        // A shell- or script-launched process is attributed to the LAUNCHER.
+        // Widening there would tap whatever audio-capable processes happen to
+        // share that launcher — a terminal that played a sound, a media tool
+        // from the same shell — instead of the target app.
+        let launcher: pid_t = 500
+        let attributedToLauncher: (pid_t) -> pid_t = { _ in launcher }
+        let pids = ProcessResponsibility.tapPIDs(
+            rootPID: 4242,
+            bundleDerived: [4242],
+            responsibleFor: attributedToLauncher,
+        ) { [4242, 6001, 6002] }
+        XCTAssertEqual(pids, [4242], "must not widen to the launcher's other audio processes")
+    }
+
+    func testFallsBackToTheBundleSetWhenResponsibilityIsUnavailable() {
+        let noOpinion: (pid_t) -> pid_t = { _ in 0 }
+        let pids = ProcessResponsibility.tapPIDs(
+            rootPID: 707,
+            bundleDerived: [707, 708],
+            responsibleFor: noOpinion,
+        ) { [707, 2032] }
+        XCTAssertEqual(pids, [707, 708], "no opinion must leave today's behaviour untouched")
+    }
+
+    func testDoesNotDuplicatePIDsPresentInBothSets() {
+        let pids = ProcessResponsibility.tapPIDs(
+            rootPID: 707,
+            bundleDerived: [707, 2032],
+            responsibleFor: lookup,
+        ) { [707, 2032, 2273] }
+        XCTAssertEqual(pids, [707, 2032, 2273])
+        XCTAssertEqual(Set(pids).count, pids.count)
+    }
+
+    func testPreservesBundleOrderingSoTheAggregateNameTagIsStable() {
+        // resolveTapPIDs documents root-first ordering as load-bearing for the
+        // aggregate device's name tag (#84); widening must append, not reorder.
+        let pids = ProcessResponsibility.tapPIDs(
+            rootPID: 707,
+            bundleDerived: [707, 2273],
+            responsibleFor: lookup,
+        ) { [707, 2032, 2273] }
+        XCTAssertEqual(pids.first, 707)
+    }
+}


### PR DESCRIPTION
Fixes the Safari case of #524. Root-cause detail in [this comment](https://github.com/pasrom/meeting-transcriber/issues/524#issuecomment-5185500571).

## The bug

Safari app-audio capture records digital silence. The tap is created successfully and runs for the whole recording — it is simply pointed at a process that never produces sound.

```
before:  App audio tap: 1 PID(s) [Safari(692)]
after:   App audio tap: 2 PID(s) [Safari(692), com.apple.WebKit.GPU(21403)]
```

`resolveTapPIDs` builds its set with `ProcessTreeEnumerator.pidsRooted(in:)`, which matches executables by bundle-path prefix. Correct for Chrome and Electron, whose helpers live inside the app bundle. It cannot work for Safari — WebKit runs its GPU and WebContent services as XPC outside the app:

```
/System/Volumes/Preboot/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/
  Versions/A/XPCServices/com.apple.WebKit.GPU.xpc/Contents/MacOS/com.apple.WebKit.GPU
```

So rooting at `Safari.app` yields Safari's main process alone, while `kAudioProcessPropertyIsRunningOutput` shows the audio coming from `com.apple.WebKit.GPU`.

This also explains reports of *"it recorded for a moment, then went silent"*: early in a call audio still flows through the main process, then WebKit hands it to the GPU service and the tap is left behind. In my case that was 40 seconds of audio followed by 59 minutes of silence.

## The fix

`ProcessResponsibility.tapPIDs` unions in the processes macOS attributes to the same responsible app — `responsibility_get_pid_responsible_for_pid`, the relationship TCC consults when a WebKit service touches the microphone — filtered to those CoreAudio has a process object for.

The filter is load-bearing. Unfiltered, Safari's responsibility tree is ~28 PIDs including a Metal shader compiler and a speech-synthesis service, and tapping that set **also** produced zero bytes. Filtered, it is exactly the audio clients (2 here).

**Non-browser apps are unaffected:** when responsibility is unavailable or adds nothing, the bundle-derived set is returned unchanged. The private symbol is resolved via `dlsym`, so a missing symbol degrades to today's behaviour rather than failing.

## Verification

Live, unmuting mid-recording:

```
muted:    App audio RMS -110.5 dBFS
unmuted:  App audio RMS -42.4, -43.3, -41.9, -33.2 dBFS
```

Sustained capture confirmed over several minutes on macOS 26.5.2 / Safari 26.x, well past the point where it previously went silent.

Tests: 194 audiotap, 200 app. `swiftlint --strict` clean. `DualSourceRecorder.swift` stays within the 600-line limit (the logic lives in `ProcessResponsibility`).

## One trap worth flagging

`proc_listallpids` returns a PID **count**, not a byte count. Dividing by `sizeof(pid_t)` truncates the list to a quarter and silently drops whichever processes fall past the cut — which cost me an hour, since the dropped ones were Safari and the audio helper. `LiveRunningPIDsTests` exercises the real enumeration for that reason.

## Not included

I also have a change that re-resolves the tap PID set periodically and rebuilds when it changes, for the case where a helper is recycled mid-call. I left it out: I could not reproduce a recycle, so it would be unjustified surface area. Happy to open it separately if you think it is worth having.

Related: #79 looks like the same shape for Teams, though I have not tested it.