### PR TITLE
docs(ci): add a feature-request template and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,6 @@
+# The diagnostic-log export steps below are duplicated in feature-request.yml.
+# Issue forms have no include mechanism, so a change to the export flow in the
+# app has to be made in both files.
 name: Bug Report
 description: Report a bug in Meeting Transcriber
 title: "[Bug] "

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Blank issues are disabled so that every report arrives with the app version.
+# Most incoming requests used to be free-form, and the version is what decides
+# whether a report describes something already fixed in a newer release.
+# Discussions stays open as the low-friction route for anything that is not yet
+# a concrete bug or feature request.
+blank_issues_enabled: false
+contact_links:
+  - name: Question, setup help or an open-ended idea
+    url: https://github.com/pasrom/meeting-transcriber/discussions
+    about: Not sure it is a bug or a concrete feature request yet? Start a discussion instead.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,69 @@
+name: Feature Request
+description: Suggest a new feature or an improvement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Two things make a request much easier to act on:
+        which version you are on, and, if the idea came out of something you actually
+        ran into, what you observed.
+
+        Version matters more than it sounds: a fair number of requests turn out to be
+        already fixed in a newer release.
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: From Settings → Advanced → About. If you have not installed it yet, write "not installed".
+      placeholder: "1.2.3 (abcdef) · Homebrew"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do today, and where does the app get in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like it to do?
+      description: A rough sketch is fine. If you considered other ways to solve it, mention them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Did you observe something specific?
+      description: |
+        Fill this in only if the request came out of a concrete observation, for example
+        unusual CPU or battery load, a meeting that was not recorded, or a bad transcript.
+        Numbers, timestamps and what the menu bar icon was doing at the time help far more
+        than adjectives.
+    validations:
+      required: false
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Diagnostic log
+      description: |
+        Only useful if you answered the question above. To produce one:
+
+        1. Open Meeting Transcriber → **Settings → Advanced → Diagnostics**
+        2. Toggle **Verbose Diagnostic Logging** ON
+        3. Reproduce what you observed
+        4. Click **Export Diagnostics…** and Finder will reveal a `.log` file
+        5. Drag that `.log` file into this field
+
+        Speaker names in the log are pseudonymised (e.g. `speaker_a3f2`) and
+        transcript text is **not** included.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,3 +1,6 @@
+# The diagnostic-log export steps near the bottom of this file are duplicated
+# in bug-report.yml. Issue forms have no include mechanism, so a change to the
+# export flow in the app has to be made in both files.
 name: Feature Request
 description: Suggest a new feature or an improvement
 title: "[Feature] "


### PR DESCRIPTION
## Why

Only `bug-report.yml` existed, so feature requests arrived free-form and without an app version. Most issues from outside reporters arrive that way: of the last 36, only 7 came in through the bug form, counted by the form's `### App version` heading.

The version is not bookkeeping. It is the field that most often decides whether a report describes something a newer release already fixed. The immediate case: a request to pause watching on battery, motivated by "uses a lot of CPU going through the meeting loops", filed three days after v0.6.0 shipped. Idle watching measures between 0.12% and 0.27% average CPU across the last 40 nightly runs of the CPU lane, so the premise does not fit the watch loop. It fits two problems that were live on the previous stable and are fixed in v0.6.0: unserialized CoreML model loading, and a queue rebuild that could restart an already-transcribing job. Without knowing the version, none of that can be told apart, and the answer is guesswork.

## What

**A feature-request template.** App version is required, with an escape hatch ("not installed") so it does not block someone who has not tried the app yet. The observation and diagnostic-log fields are deliberately optional: a plain "please add X" has nothing observed behind it and a required log would deter it. They exist for the mixed case, a feature asked for because of something the reporter ran into, which is where a log turns a guess into a diagnosis.

**Blank issues off, Discussions in.** With both templates in place, a blank issue is the only remaining route that can arrive without a version. Discussions is already enabled and becomes the low-friction route via a contact link, so this narrows how reports arrive without leaving anyone who is not yet sure what they are reporting with nowhere to go. Fewer reports would be a real cost, so this adds a door rather than only closing one.

**A cross-reference between the two forms.** The diagnostic-log steps are duplicated because issue forms have no include mechanism, and the copies had already drifted on wording. A comment at each end makes a future edit to the export flow touch both.

## Note for maintainers

`blank_issues_enabled: false` governs only the web new-issue chooser. Creating a free-form issue via `gh issue create` or the API still works, so maintainer-authored RFC and planning issues are unaffected.

## Verification

All three files parse as YAML, field ids are unique, no `markdown` block carries `validations`, and both referenced labels exist in the repo. The UI paths were checked against the current source: Settings has an Advanced tab with an About section and a Diagnostics section containing a "Verbose Diagnostic Logging" toggle and an "Export Diagnostics…" button. Nothing in the repo links to `issues/new`, so turning off blank issues breaks no existing link; `CONTRIBUTING.md` points at the issues list, which is unaffected.

Worth stating plainly: GitHub only exercises an issue form once it is on the default branch, so rendering is not provable from a branch. The structural checks above are what can be verified beforehand.

The free-form count in the first paragraph replaces an earlier figure that did not reproduce. Classifying by whether a body merely mentions "App version" counts hand-written reports that include their own version table, which inflated the template side; the heading test is the one that matches what the form actually emits.