### PR TITLE
fix(app): negotiate max_completion_tokens when max_tokens is rejected

### DIFF
--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -13,16 +13,25 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     /// bytes. Catches a fully-stalled connection, but does NOT bound total time —
     /// a slow-but-trickling stream resets it on every byte. See `maxTotalSeconds`.
     let timeoutSeconds: TimeInterval
-    /// Hard wall-clock cap for the whole generation. `timeoutSeconds` alone lets
+    /// Wall-clock cap for a single request attempt. `timeoutSeconds` alone lets
     /// a struggling LLM that trickles tokens run for hours (each byte resets the
     /// idle timer); this deadline ends it regardless. Generous by default so a
-    /// legitimately long protocol isn't cut off.
+    /// legitimately long protocol isn't cut off. Note the deadline is applied per
+    /// attempt, so the `max_completion_tokens` fallback in `generate()` can span
+    /// up to twice it — only reachable via an endpoint that trickles a 400 body.
     let maxTotalSeconds: TimeInterval
     /// Output-token cap sent as `max_tokens`, or `max_completion_tokens` when the
     /// endpoint rejects the former. Bounds a runaway/verbose
     /// generation (the 131k-context case that ground for ~2h) by length rather
     /// than time. Generous — a meeting protocol is well under this — and a hit
     /// is surfaced as `protocolTruncated`, never silently presented as complete.
+    ///
+    /// The two names are not interchangeable: `max_completion_tokens` bounds
+    /// visible output tokens *plus* reasoning tokens, and reasoning tokens never
+    /// arrive as content deltas. A long transcript can therefore end the stream on
+    /// `finish_reason: length` with little or no content, surfaced here as
+    /// `protocolTruncated`. The old name never had to account for that, since the
+    /// models that accept it emit no reasoning tokens.
     let maxOutputTokens: Int
     let session: URLSession
 

--- a/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/OpenAIProtocolGenerator.swift
@@ -18,7 +18,8 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
     /// idle timer); this deadline ends it regardless. Generous by default so a
     /// legitimately long protocol isn't cut off.
     let maxTotalSeconds: TimeInterval
-    /// Output-token cap sent as `max_tokens`. Bounds a runaway/verbose
+    /// Output-token cap sent as `max_tokens`, or `max_completion_tokens` when the
+    /// endpoint rejects the former. Bounds a runaway/verbose
     /// generation (the 131k-context case that ground for ~2h) by length rather
     /// than time. Generous — a meeting protocol is well under this — and a hit
     /// is surfaced as `protocolTruncated`, never silently presented as complete.
@@ -53,11 +54,42 @@ struct OpenAIProtocolGenerator: ProtocolGenerating {
             ["role": "user", "content": transcript],
         ]
 
+        do {
+            return try await send(messages: messages, tokenLimit: .maxTokens)
+        } catch let ProtocolError.httpError(status, body)
+            where status == 400 && Self.rejectsMaxTokens(body) {
+            logger.info("Endpoint rejected 'max_tokens'; retrying with 'max_completion_tokens'")
+            return try await send(messages: messages, tokenLimit: .maxCompletionTokens)
+        }
+    }
+
+    /// Name of the output-token cap parameter in the request body.
+    ///
+    /// OpenAI renamed `max_tokens` to `max_completion_tokens`; current models
+    /// (GPT-5 family and newer) reject the old name with HTTP 400, while local
+    /// servers such as LM Studio and Ollama only understand the old one. So the
+    /// old name is sent first and the new one used only on an explicit refusal.
+    enum TokenLimitParameter: String {
+        case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+    }
+
+    /// True when a 400 body is the API specifically refusing `max_tokens` and
+    /// naming `max_completion_tokens` as the replacement. Both names must appear
+    /// so unrelated 400s (bad model, bad key, malformed request) don't retry.
+    static func rejectsMaxTokens(_ errorBody: String) -> Bool {
+        errorBody.contains(TokenLimitParameter.maxCompletionTokens.rawValue)
+            && errorBody.contains(TokenLimitParameter.maxTokens.rawValue)
+    }
+
+    private func send(
+        messages: [[String: Any]], tokenLimit: TokenLimitParameter,
+    ) async throws -> String {
         let body: [String: Any] = [
             "model": model,
             "messages": messages,
             "stream": true,
-            "max_tokens": maxOutputTokens,
+            tokenLimit.rawValue: maxOutputTokens,
         ]
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -336,6 +336,79 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
         _ = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
     }
 
+    // MARK: - max_tokens / max_completion_tokens negotiation
+
+    /// Verbatim 400 body returned by the OpenAI Chat Completions API (and Azure
+    /// Foundry) for GPT-5-family models when `max_tokens` is sent.
+    private static let unsupportedMaxTokensBody = """
+    {"error":{"message":"Unsupported parameter: 'max_tokens' is not supported \
+    with this model. Use 'max_completion_tokens' instead.",\
+    "type":"invalid_request_error","param":"max_tokens",\
+    "code":"unsupported_parameter"}}
+    """
+
+    func testRejectsMaxTokensMatchesUnsupportedParameterBody() {
+        XCTAssertTrue(OpenAIProtocolGenerator.rejectsMaxTokens(Self.unsupportedMaxTokensBody))
+    }
+
+    func testRejectsMaxTokensIgnoresUnrelatedErrors() {
+        XCTAssertFalse(
+            OpenAIProtocolGenerator.rejectsMaxTokens(
+                #"{"error":{"message":"Incorrect API key provided","code":"invalid_api_key"}}"#,
+            ),
+        )
+        XCTAssertFalse(
+            OpenAIProtocolGenerator.rejectsMaxTokens(
+                #"{"error":{"message":"The model does not exist","param":"model"}}"#,
+            ),
+        )
+        XCTAssertFalse(OpenAIProtocolGenerator.rejectsMaxTokens(""))
+    }
+
+    func testGenerateRetriesWithMaxCompletionTokensWhenRejected() async throws {
+        final class Recorder: @unchecked Sendable { var keys: [String] = [] }
+        let recorder = Recorder()
+
+        MockURLProtocol.handler = { request in
+            if self.requestBody(request)["max_tokens"] != nil {
+                recorder.keys.append("max_tokens")
+                return self.mockResponse(
+                    request, status: 400, body: Data(Self.unsupportedMaxTokensBody.utf8),
+                )
+            }
+            recorder.keys.append("max_completion_tokens")
+            return self.mockResponse(request, body: Data(Self.okSSE.utf8))
+        }
+
+        let gen = makeGenerator(session: makeMockSession())
+        let result = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
+
+        XCTAssertEqual(result, "OK")
+        XCTAssertEqual(recorder.keys, ["max_tokens", "max_completion_tokens"])
+    }
+
+    func testGenerateDoesNotRetryOnUnrelated400() async throws {
+        final class Recorder: @unchecked Sendable { var count = 0 }
+        let recorder = Recorder()
+
+        MockURLProtocol.handler = { request in
+            recorder.count += 1
+            return self.mockResponse(
+                request, status: 400,
+                body: Data(#"{"error":{"message":"Incorrect API key provided"}}"#.utf8),
+            )
+        }
+
+        let gen = makeGenerator(session: makeMockSession())
+        do {
+            _ = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
+            XCTFail("expected the 400 to propagate")
+        } catch let ProtocolError.httpError(status, _) {
+            XCTAssertEqual(status, 400)
+        }
+        XCTAssertEqual(recorder.count, 1, "an unrelated 400 must not trigger a retry")
+    }
+
     func testGenerateDiarizedDoesNotThrow() async throws {
         MockURLProtocol.handler = { request in
             self.mockResponse(request, body: Data(Self.okSSE.utf8))

--- a/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/OpenAIProtocolGeneratorTests.swift
@@ -363,6 +363,13 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
             ),
         )
         XCTAssertFalse(OpenAIProtocolGenerator.rejectsMaxTokens(""))
+        // Only one of the two names present: a value error, not the rename.
+        XCTAssertFalse(OpenAIProtocolGenerator.rejectsMaxTokens(
+            #"{"error":{"message":"max_tokens is too large: 16000","param":"max_tokens"}}"#,
+        ))
+        XCTAssertFalse(OpenAIProtocolGenerator.rejectsMaxTokens(
+            #"{"error":{"message":"Use max_completion_tokens for this model"}}"#,
+        ))
     }
 
     func testGenerateRetriesWithMaxCompletionTokensWhenRejected() async throws {
@@ -376,6 +383,9 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
                     request, status: 400, body: Data(Self.unsupportedMaxTokensBody.utf8),
                 )
             }
+            let retryBody = self.requestBody(request)
+            XCTAssertEqual(retryBody["max_completion_tokens"] as? Int, 16000)
+            XCTAssertNil(retryBody["max_tokens"], "the retry must replace the cap, not add to it")
             recorder.keys.append("max_completion_tokens")
             return self.mockResponse(request, body: Data(Self.okSSE.utf8))
         }
@@ -407,6 +417,27 @@ final class OpenAIProtocolGeneratorTests: XCTestCase { // swiftlint:disable:this
             XCTAssertEqual(status, 400)
         }
         XCTAssertEqual(recorder.count, 1, "an unrelated 400 must not trigger a retry")
+    }
+
+    func testGenerateDoesNotRetryOnNon400NamingBothParameters() async throws {
+        final class Recorder: @unchecked Sendable { var count = 0 }
+        let recorder = Recorder()
+
+        MockURLProtocol.handler = { request in
+            recorder.count += 1
+            return self.mockResponse(
+                request, status: 502, body: Data(Self.unsupportedMaxTokensBody.utf8),
+            )
+        }
+
+        let gen = makeGenerator(session: makeMockSession())
+        do {
+            _ = try await gen.generate(transcript: "Test", title: "Test", diarized: false)
+            XCTFail("expected the 502 to propagate")
+        } catch let ProtocolError.httpError(status, _) {
+            XCTAssertEqual(status, 502)
+        }
+        XCTAssertEqual(recorder.count, 1, "only an explicit 400 refusal may retry")
     }
 
     func testGenerateDiarizedDoesNotThrow() async throws {


### PR DESCRIPTION
Fixes #582.

## Problem

`OpenAIProtocolGenerator` sends the output cap as `max_tokens`. The OpenAI Chat
Completions API renamed that to `max_completion_tokens`, and GPT-5-family models now
reject the old name with HTTP 400 instead of accepting it as an alias. Every protocol
generation fails, so users get `.txt` transcripts but never an `.md` protocol.

It cannot simply be renamed: LM Studio and Ollama accept only `max_tokens`.

## Approach

Send `max_tokens` as today. Only when the endpoint answers **400 with a body naming
both parameters** does it retry once with `max_completion_tokens`. Requiring both names
to appear keeps unrelated 400s (bad key, unknown model, malformed request) from
triggering a pointless second request.

No new setting, no model-name sniffing, and existing local-server users are unaffected —
they never see the retry path.

The retry costs one extra round-trip on the first generation against a strict endpoint;
the 400 comes back immediately. Caching the negotiated parameter per endpoint would
avoid even that, but it needs somewhere to persist the preference, so I left it out —
happy to add it if you'd prefer.

## Testing

- 141 tests green in `OpenAIProtocolGeneratorTests` + `ProtocolGeneratorTests`
- Four new tests: the real Azure 400 body matches; unrelated 400s don't; a rejection
  produces exactly `["max_tokens", "max_completion_tokens"]` in order; an unrelated 400
  produces exactly one attempt
- **Verified end-to-end** against Azure AI Foundry with a `gpt-5.4` deployment, on both
  a live auto-detected meeting and a batch import (⌘P). Protocols generate correctly
  where every attempt previously failed with the 400.
- Also re-checked against `grok-4.3`, which accepts `max_tokens`, to confirm the
  non-retry path still works unchanged.

Note: `swift test` for the full suite hangs locally on
`AppSettingsTests.testOpenAIAPIKeyViaKeychainHelper` (blocks on a macOS Keychain
prompt), so I ran the affected suites rather than the whole thing. Unrelated to this
change, but flagging it.
