### PR TITLE
test(app): stop buildSystemPrompt tests reading the real user prompt

### DIFF
--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -94,8 +94,13 @@ enum ProtocolGenerator {
     /// Build the localized system prompt: `loadPrompt` + `applyLanguage`
     /// + optional `diarizationNote`. Excludes the transcript itself —
     /// callers append or attach it as they see fit.
-    static func buildSystemPrompt(diarized: Bool, language: String) -> String {
-        var prompt = applyLanguage(loadPrompt(), language: language)
+    ///
+    /// `promptURL` is forwarded to `loadPrompt` and exists for the same reason:
+    /// without it tests fall through to the shared `AppPaths.customPromptFile`,
+    /// so their result depends on whether the developer has customised their own
+    /// prompt through the app.
+    static func buildSystemPrompt(diarized: Bool, language: String, promptURL: URL = AppPaths.customPromptFile) -> String {
+        var prompt = applyLanguage(loadPrompt(from: promptURL), language: language)
         if diarized { prompt += diarizationNote }
         return prompt
     }

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -211,15 +211,23 @@ final class ProtocolGeneratorTests: XCTestCase {
 
     // MARK: - System Prompt Construction
 
-    func testBuildSystemPromptSubstitutesLanguage() {
-        let prompt = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "Polish")
-        XCTAssertTrue(prompt.contains("Polish"))
-        XCTAssertFalse(prompt.contains("{LANGUAGE}"))
+    func testBuildSystemPromptSubstitutesLanguage() throws {
+        let url = makeTempFile(suffix: ".md")
+        try "Protocol language: {LANGUAGE}.".write(to: url, atomically: true, encoding: .utf8)
+
+        let prompt = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "Polish", promptURL: url)
+
+        // Equality also pins that the injected URL is honoured: reading the shared
+        // user file or the built-in default would not produce this exact string.
+        XCTAssertEqual(prompt, "Protocol language: Polish.")
     }
 
     func testBuildSystemPromptAppendsDiarizationNoteWhenDiarized() {
-        let plain = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "German")
-        let diarized = ProtocolGenerator.buildSystemPrompt(diarized: true, language: "German")
+        // Never created, so both calls fall back to the built-in default rather
+        // than to whatever the developer has in their own prompt file.
+        let url = makeTempFile(suffix: ".md")
+        let plain = ProtocolGenerator.buildSystemPrompt(diarized: false, language: "German", promptURL: url)
+        let diarized = ProtocolGenerator.buildSystemPrompt(diarized: true, language: "German", promptURL: url)
         XCTAssertGreaterThan(diarized.count, plain.count)
         XCTAssertTrue(diarized.contains(ProtocolGenerator.diarizationNote))
         XCTAssertFalse(plain.contains(ProtocolGenerator.diarizationNote))


### PR DESCRIPTION
Closes the `buildSystemPrompt` half of #584, as requested on #583.

## The gap

`buildSystemPrompt` called `loadPrompt()` with its default argument, so it resolved to `AppPaths.customPromptFile` even under test. The three tests that call it read `~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`, so their result depends on whether the developer has customised their own prompt through the app.

`loadPrompt` already took an injectable `url` for exactly this reason, and its doc comment says so. The gap was only that `buildSystemPrompt` had no matching parameter to forward. This adds one with the same default, so both production callers (`OpenAIProtocolGenerator`, `ClaudeCLIProtocolGenerator`) are unchanged.

## Both tests, not just the failing one

Only `testBuildSystemPromptSubstitutesLanguage` was red, because only it asserts on content. `testBuildSystemPromptAppendsDiarizationNoteWhenDiarized` compares a diarized against a non-diarized prompt, so it holds whatever the text happens to be — it was reading your file too, and passing by construction rather than by isolation. Since your note was that the test passes on your machine only because your customised prompt still happens to contain the placeholder, leaving the second one reading real state seemed like the same bug waiting for a different edit. Both now point at test-owned fixtures.

The two use different fixtures on purpose: the language test writes a known prompt, the diarization test names a path it never creates so both calls fall back to the built-in default.

## Why equality rather than containment

The language test now writes `Protocol language: {LANGUAGE}.` and asserts the result equals `Protocol language: Polish.`. Equality is what pins the fix. `contains("Polish")` would still pass against any prompt that happened to mention the language, so it would not notice the forwarding being dropped again — which makes it the assertion that turns this from a passing test into a regression test.

## Verification

Run with the real customised prompt file in place, since that is the condition that reproduces the failure — my copy is 4537 bytes and contains no `{LANGUAGE}`.

- Reverting the `from: promptURL` forwarding turns `testBuildSystemPromptSubstitutesLanguage` red, and the diff in the failure output is your prompt file leaking in, which is the defect itself.
- With the fix: both tests green, and the `ProtocolGenerator`, `OpenAIProtocolGenerator` and `ClaudeCLIProtocolGenerator` suites green.
- SwiftFormat 0.61.1 pinned from the workflow: 0 of 409 files need formatting. `swiftlint --strict`: 0 violations.

## Scope

The keychain hang in `AppSettingsTests.testOpenAIAPIKeyViaKeychainHelper` is untouched, so #584 stays open for it. That one is a shared-scope problem rather than a missing parameter, so it wants its own change — happy to take it if you want it, though the fix there is less obvious than this one.