### PR TITLE
fix(app): isolate AppSettings tests from the production Keychain account

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings+Computed.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+Computed.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Values derived from the stored `AppSettings` toggles. Split out of
+/// `AppSettings.swift` purely to keep that file under the `file_length` limit;
+/// there is no behavioural difference from declaring these inline.
+extension AppSettings {
+    /// The meeting apps the user opted to watch. Drives auto-detection: the
+    /// `WatchingController` default detector keeps only the assertion patterns
+    /// whose app is listed here (`PowerAssertionDetector.patterns(watching:)`),
+    /// read at each watch start. Freshness: FROZEN per watch session.
+    var watchApps: [String] {
+        var apps: [String] = []
+        if watchTeams { apps.append("Microsoft Teams") }
+        if watchZoom { apps.append("Zoom") }
+        if watchWebex { apps.append("Webex") }
+        if watchBrowserMeetings { apps.append(AppMeetingPattern.chromeBrowser.appName) }
+        if watchWeChat { apps.append(AppMeetingPattern.wechat.appName) }
+        if watchTencentMeeting { apps.append(AppMeetingPattern.tencentMeeting.appName) }
+        if watchFaceTime { apps.append(AppMeetingPattern.faceTime.appName) }
+        if watchWhatsApp { apps.append(AppMeetingPattern.whatsApp.appName) }
+        return apps
+    }
+}

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -98,6 +98,14 @@ final class AppSettings {
     /// processes don't race on the shared on-disk plist.
     @ObservationIgnored private let defaults: UserDefaults
 
+    /// Keychain account backing `openAIAPIKey`. Production callers pass
+    /// nothing → the real account. Tests inject a unique account so they never
+    /// touch the key the user configured in the app: the Keychain is scoped
+    /// per user, not per process, and the production item belongs to the app's
+    /// code signature, so a test binary reading it raises an authorization
+    /// prompt that blocks the run.
+    @ObservationIgnored private let apiKeyAccount: String
+
     // MARK: - Apps to Watch
 
     var watchTeams: Bool {
@@ -380,12 +388,12 @@ final class AppSettings {
     }
 
     var openAIAPIKey: String {
-        get { KeychainHelper.read(key: "openAIAPIKey") ?? "" }
+        get { KeychainHelper.read(key: apiKeyAccount) ?? "" }
         set {
             if newValue.isEmpty {
-                KeychainHelper.delete(key: "openAIAPIKey")
+                KeychainHelper.delete(key: apiKeyAccount)
             } else {
-                KeychainHelper.save(key: "openAIAPIKey", value: newValue)
+                KeychainHelper.save(key: apiKeyAccount, value: newValue)
             }
         }
     }
@@ -471,30 +479,12 @@ final class AppSettings {
         didSet { defaults.set(includePreReleases, forKey: "includePreReleases") }
     }
 
-    // MARK: - Computed
-
-    /// The meeting apps the user opted to watch. Drives auto-detection: the
-    /// `WatchingController` default detector keeps only the assertion patterns
-    /// whose app is listed here (`PowerAssertionDetector.patterns(watching:)`),
-    /// read at each watch start. Freshness: FROZEN per watch session.
-    var watchApps: [String] {
-        var apps: [String] = []
-        if watchTeams { apps.append("Microsoft Teams") }
-        if watchZoom { apps.append("Zoom") }
-        if watchWebex { apps.append("Webex") }
-        if watchBrowserMeetings { apps.append(AppMeetingPattern.chromeBrowser.appName) }
-        if watchWeChat { apps.append(AppMeetingPattern.wechat.appName) }
-        if watchTencentMeeting { apps.append(AppMeetingPattern.tencentMeeting.appName) }
-        if watchFaceTime { apps.append(AppMeetingPattern.faceTime.appName) }
-        if watchWhatsApp { apps.append(AppMeetingPattern.whatsApp.appName) }
-        return apps
-    }
-
     // MARK: - Init
 
     // swiftlint:disable:next function_body_length
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = .standard, apiKeyAccount: String = "openAIAPIKey") {
         self.defaults = defaults
+        self.apiKeyAccount = apiKeyAccount
 
         watchTeams = defaults.object(forKey: "watchTeams") as? Bool ?? true
         watchZoom = defaults.object(forKey: "watchZoom") as? Bool ?? true

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -9,27 +9,31 @@ final class AppSettingsTests: XCTestCase {
     private var defaults: UserDefaults!
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var testSuiteName: String!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var apiKeyAccount: String!
 
     /// Each test gets its own volatile `UserDefaults(suiteName:)` so
     /// `swift test --parallel` doesn't race on the shared on-disk plist.
     /// AppSettings receives the suite via constructor injection.
     ///
-    /// Keychain state is per-user (not per-process), so we deliberately do
-    /// NOT touch any production keychain accounts here — `swift test
-    /// --parallel` spawns a fresh `xctest` process per test method, and an
-    /// unconditional delete in setUp would race with the write performed
-    /// by `testOpenAIAPIKeyViaKeychainHelper` running in a sibling process.
-    /// The one test that needs a clean keychain slot manages the slot
-    /// itself.
+    /// The Keychain account backing `openAIAPIKey` is injected the same way,
+    /// for a stronger reason. Keychain state is per-user, not per-process, and
+    /// the production account holds the API key the user actually configured
+    /// in the app — so driving it from a test would overwrite and then delete
+    /// a real credential. It is also owned by the app's code signature, so the
+    /// test binary touching it raises a Keychain authorization prompt that
+    /// blocks `swift test` indefinitely. A unique account per test avoids both,
+    /// and removes the sibling-process race under `--parallel`.
     override func setUp() {
         super.setUp()
         testSuiteName = "AppSettingsTests-\(getpid())-\(UUID().uuidString)"
+        apiKeyAccount = "AppSettingsTests-openAIAPIKey-\(getpid())-\(UUID().uuidString)"
         guard let suite = UserDefaults(suiteName: testSuiteName) else {
             XCTFail("Could not create test UserDefaults suite")
             return
         }
         defaults = suite
-        settings = AppSettings(defaults: defaults)
+        settings = AppSettings(defaults: defaults, apiKeyAccount: apiKeyAccount)
     }
 
     override func tearDown() {
@@ -37,6 +41,8 @@ final class AppSettingsTests: XCTestCase {
         defaults.removePersistentDomain(forName: testSuiteName)
         defaults = nil
         testSuiteName = nil
+        KeychainHelper.delete(key: apiKeyAccount)
+        apiKeyAccount = nil
         super.tearDown()
     }
 
@@ -252,20 +258,19 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testOpenAIAPIKeyViaKeychainHelper() {
-        // Reset the keychain slot before + after so a crashed prior run
-        // can't seed `"sk-test-key"` and a failure here doesn't leak it
-        // to the next invocation.
-        KeychainHelper.delete(key: "openAIAPIKey")
-        defer { KeychainHelper.delete(key: "openAIAPIKey") }
-
+        // The account is unique to this test and removed in tearDown, so there
+        // is no shared slot to reset up front. Asserting through
+        // `apiKeyAccount` also proves AppSettings honours the injection: were
+        // it to fall back to the hardcoded production account, every read here
+        // would come back nil.
         XCTAssertEqual(settings.openAIAPIKey, "")
 
         settings.openAIAPIKey = "sk-test-key"
-        XCTAssertEqual(KeychainHelper.read(key: "openAIAPIKey"), "sk-test-key")
+        XCTAssertEqual(KeychainHelper.read(key: apiKeyAccount), "sk-test-key")
         XCTAssertEqual(settings.openAIAPIKey, "sk-test-key")
 
         settings.openAIAPIKey = ""
-        XCTAssertNil(KeychainHelper.read(key: "openAIAPIKey"))
+        XCTAssertNil(KeychainHelper.read(key: apiKeyAccount))
         XCTAssertEqual(settings.openAIAPIKey, "")
     }
 

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -166,10 +166,12 @@
         // MARK: - Secrets never reach the wire
 
         /// The ONLY secret `AppSettings` holds is the OpenAI API key, stored in
-        /// the process-global macOS Keychain. We deliberately do NOT write that
-        /// Keychain account here: it has no per-suite isolation and a second
-        /// writer would race `AppSettingsTests.testOpenAIAPIKeyViaKeychainHelper`
-        /// under `swift test --parallel` (a hazard that file already documents).
+        /// the user-scoped macOS Keychain. We deliberately do NOT write that
+        /// Keychain account here: it holds the key the user configured in the
+        /// app, so a test writing it would clobber a real credential and, since
+        /// the item is owned by the app's code signature, block on an
+        /// authorization prompt (`AppSettingsTests` injects a per-test account
+        /// to avoid exactly that).
         /// Instead we pin the projection can never carry a secret — no
         /// secret-bearing field name or marker anywhere in the encoded JSON —
         /// while proving the guard isn't vacuous: the non-secret OpenAI fields


### PR DESCRIPTION
Closes #584 — the Keychain half you left open after #585.

## The defect

`AppSettingsTests.testOpenAIAPIKeyViaKeychainHelper` drove the **production** Keychain slot directly: service `com.meetingtranscriber`, account `openAIAPIKey` — precisely what `AppSettings.openAIAPIKey` reads and writes.

Two consequences on any machine that also runs the app:

1. **The reported hang.** The item is owned by the app's code signature, so the test binary touching it raises an authorization prompt. `swift test` blocks on it indefinitely and the suite never finishes.
2. **Credential loss, if that prompt is granted.** The test opens with an unconditional `KeychainHelper.delete(key: "openAIAPIKey")` and defers another. That is the API key the user configured in Settings — running the suite deletes it. I had not expected this second one going in; it is the same root cause, but it makes the fix worth more than a hang alone would.

Grepping the rest of the suite: `HF_TOKEN_TEST` and the `KEYCHAIN_TEST_<UUID>` in `KeychainHelperTests` are already test-owned accounts, and `AppSettings+RPC.swift` excludes the key by construction, so `RPCSettingsStateTests` never reaches the Keychain. This was the only offender.

## The fix

`AppSettings` gains an injectable Keychain account defaulting to the production one — the same shape as the `defaults:` injection already on the initializer, and as the `promptURL:` seam from #585. No production call site changes. The fixture mints a unique account per test and removes it in `tearDown`.

Asserting through the injected account is what keeps the test honest rather than merely quiet: if `AppSettings` ignored the parameter, every read would come back nil.

I also refreshed the `RPCSettingsStateTests` comment that justified not writing the Keychain by citing the now-removed `--parallel` race against this test. The stronger reason — it is a real user credential behind a signature-gated prompt — still stands, so the comment says that instead of going stale.

## file_length

`AppSettings.swift` sat at **599** of its 600-line budget, so the two added lines failed `swiftlint --strict`. Rather than suppress the rule, the existing `Computed` section (`watchApps`) moves verbatim into `AppSettings+Computed.swift`, following the `AppSettings+RPC.swift` precedent. Pure move, no behaviour change; the main file is now 589 with headroom. Happy to reshape this if you would have made room elsewhere.

## Acceptance check

Rather than reverting the fix — which would have pointed the test back at my own real API key — I mutated the initializer to use a *different* unique account, i.e. "AppSettings does not honour the injection". The test fails on exactly the intended assertion:

```
AppSettingsTests.swift:269: error: XCTAssertEqual failed:
  ("nil") is not equal to ("Optional("sk-test-key")")
```

Restored afterwards, and confirmed no mutant residue in the diff.

## Verified locally

- `swiftlint lint --strict` → 0 violations
- SwiftFormat **0.61.1** (the CI pin, via `scripts/lint.sh --format-only`) → 0/410 files
- `AppSettingsTests`, `KeychainHelperTests`, `RPCSettingsStateTests`, `PowerAssertionDetectorPatternsTests` → 86 tests, 0 failures. No Keychain prompt appeared.

**Left to CI:** `analyze`, the full test matrix, the App Store variant and `audiotap-coverage`. I skipped the `xcodebuild` and full-suite runs deliberately this time — the full suite stalls on model downloads on my machine, and I did not want to claim a green I had not actually seen. The change has no `#if APPSTORE` interaction.
