### PR TITLE
fix(app): bound capture restart attempts so a stuck one cannot freeze the app

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -81,6 +81,17 @@ ignore:
   - "tools/audiotap/Sources/AppAudioCapture.swift"
   - "tools/audiotap/Sources/MicCaptureHandler.swift"
   - "tools/audiotap/Sources/AudioCaptureSession.swift"
+  # The AVAudioEngine wrapper extracted out of MicCaptureHandler.swift: reading
+  # `inputNode`, pinning the device, installing the tap, prepare/start, teardown.
+  # No test can drive its BRING-UP path: hardwareFormat / installTap / start need
+  # real input hardware, and on the CI runner reading `inputNode` raises an
+  # uncatchable NSException. Tests do construct it and do execute teardown's
+  # no-tap guard and deviceIDForUID (MicCaptureHandlerStopTests, the wedge tests),
+  # so this entry knowingly trades that sliver of visible coverage for not
+  # reporting the hardware-bound remainder as a regression. It follows code that
+  # was already ignored while it lived in MicCaptureHandler.swift. The logic that
+  # drives the session through the protocol stays counted.
+  - "tools/audiotap/Sources/MicEngineSession.swift"
   # Fault-injection test seam (#379): a 2-field config struct constructed ONLY
   # in the e2e build's composition root under #if E2E_FAULT_INJECTION, so the
   # xctest suite never executes its init. Exercised by e2e-mic-device-change.yml;

--- a/app/MeetingTranscriber/Sources/ChannelHealthController.swift
+++ b/app/MeetingTranscriber/Sources/ChannelHealthController.swift
@@ -156,9 +156,12 @@ final class ChannelHealthController {
                 appSilentActive = true
                 micSilentActive = false
             }
+            let gaveUp = channel == .mic ? recorder.micCaptureGaveUp : recorder.appCaptureGaveUp
             notifier.notify(
-                title: "Capture Channel Silent",
-                body: Self.asymmetricSilenceMessage(for: channel),
+                title: gaveUp ? "Capture Channel Lost" : "Capture Channel Silent",
+                body: gaveUp
+                    ? Self.captureGaveUpMessage(for: channel)
+                    : Self.asymmetricSilenceMessage(for: channel),
             )
 
         case .recovered:
@@ -186,6 +189,25 @@ final class ChannelHealthController {
         }
 
         return event
+    }
+
+    /// Message for a channel whose capture restart was abandoned (issue #588),
+    /// as opposed to one that merely went quiet.
+    ///
+    /// Two things make this a different message rather than a variation. The
+    /// track is gone for the rest of this recording, so advice to check the
+    /// device or the mute state would send the user chasing something that
+    /// cannot help. And when the cause was an attempt that never returned, it is
+    /// stuck inside a system call that cannot be cancelled, holding a thread and
+    /// a noticeable share of a core until the process exits, so restarting is
+    /// not a suggestion but the actual remedy. Giving up because the retry budget
+    /// ran out costs no CPU, hence the hedge.
+    nonisolated static func captureGaveUpMessage(for channel: AudioChannel) -> String {
+        let track = channel == .mic ? "Microphone" : "App-audio"
+        return "\(track) capture could not recover after an audio device change and has stopped "
+            + "for this recording. The rest of the recording continues. "
+            + "Restart Meeting Transcriber to bring the channel back, and to release the extra CPU "
+            + "a stuck restart attempt may still be holding."
     }
 
     nonisolated static func asymmetricSilenceMessage(for channel: AudioChannel) -> String {

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -33,33 +33,6 @@ struct CaptureFormat {
     let targetRate: Int
 }
 
-/// Abstraction for recording, enabling mock injection in tests.
-@MainActor
-protocol RecordingProvider {
-    func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging: Bool) throws
-    func stop() throws -> RecordingResult
-
-    /// Instantaneous app-audio level in dBFS. -120 when no capture session is
-    /// active or the tap stopped delivering buffers in the last 0.5 s.
-    /// Drives the menu-bar asymmetric-silence indicator. Default: -120
-    /// (mocks that don't simulate audio levels stay silent).
-    var appLevelDBFS: Double { get }
-
-    /// Instantaneous mic level in dBFS, with the same semantics as
-    /// `appLevelDBFS`.
-    var micLevelDBFS: Double { get }
-}
-
-extension RecordingProvider {
-    var appLevelDBFS: Double {
-        -120
-    }
-
-    var micLevelDBFS: Double {
-        -120
-    }
-}
-
 /// Orchestrates app audio capture (via AudioTapLib) + mic recording, then mixes.
 @MainActor
 @Observable
@@ -84,6 +57,16 @@ class DualSourceRecorder: RecordingProvider {
     var micLevelDBFS: Double {
         guard #available(macOS 14.2, *) else { return -120 }
         return captureSession?.micLevelDBFS ?? -120
+    }
+
+    var appCaptureGaveUp: Bool {
+        guard #available(macOS 14.2, *) else { return false }
+        return captureSession?.appCaptureGaveUp ?? false
+    }
+
+    var micCaptureGaveUp: Bool {
+        guard #available(macOS 14.2, *) else { return false }
+        return captureSession?.micCaptureGaveUp ?? false
     }
 
     /// Requested app-audio capture format (what the CATap aggregate device is

--- a/app/MeetingTranscriber/Sources/RecordingProvider.swift
+++ b/app/MeetingTranscriber/Sources/RecordingProvider.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Abstraction for recording, enabling mock injection in tests.
+@MainActor
+protocol RecordingProvider {
+    func start(appPID: pid_t, noMic: Bool, micDeviceUID: String?, debugLogging: Bool) throws
+    func stop() throws -> RecordingResult
+
+    /// Instantaneous app-audio level in dBFS. -120 when no capture session is
+    /// active or the tap stopped delivering buffers in the last 0.5 s.
+    /// Drives the menu-bar asymmetric-silence indicator. Default: -120
+    /// (mocks that don't simulate audio levels stay silent).
+    var appLevelDBFS: Double { get }
+
+    /// Instantaneous mic level in dBFS, with the same semantics as
+    /// `appLevelDBFS`.
+    var micLevelDBFS: Double { get }
+
+    /// True once a channel's capture was abandoned for good (issue #588),
+    /// whether a restart attempt never returned or the retry budget ran out.
+    /// The level alone cannot say this: a channel that fell silent may come
+    /// back, one that gave up will not.
+    /// Default false so mocks that do not simulate capture failures stay quiet.
+    var appCaptureGaveUp: Bool { get }
+    var micCaptureGaveUp: Bool { get }
+}
+
+extension RecordingProvider {
+    var appLevelDBFS: Double {
+        -120
+    }
+
+    var micLevelDBFS: Double {
+        -120
+    }
+
+    var appCaptureGaveUp: Bool { false }
+    var micCaptureGaveUp: Bool { false }
+}

--- a/app/MeetingTranscriber/Sources/RecordingProvider.swift
+++ b/app/MeetingTranscriber/Sources/RecordingProvider.swift
@@ -34,6 +34,11 @@ extension RecordingProvider {
         -120
     }
 
-    var appCaptureGaveUp: Bool { false }
-    var micCaptureGaveUp: Bool { false }
+    var appCaptureGaveUp: Bool {
+        false
+    }
+
+    var micCaptureGaveUp: Bool {
+        false
+    }
 }

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -337,8 +337,10 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
 
         XCTAssertEqual(notifier.calls.count, 1)
-        XCTAssertEqual(notifier.calls.first?.body,
-                       ChannelHealthController.captureGaveUpMessage(for: .mic))
+        XCTAssertEqual(
+            notifier.calls.first?.body,
+            ChannelHealthController.captureGaveUpMessage(for: .mic),
+        )
     }
 
     func testASilentChannelThatDidNotGiveUpKeepsTheSilenceMessage() {
@@ -349,8 +351,10 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         controller.applyTick(recorder: recorder, now: t0)
         _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
 
-        XCTAssertEqual(notifier.calls.first?.body,
-                       ChannelHealthController.asymmetricSilenceMessage(for: .mic))
+        XCTAssertEqual(
+            notifier.calls.first?.body,
+            ChannelHealthController.asymmetricSilenceMessage(for: .mic),
+        )
     }
 
     func testTheGiveUpMessageRecommendsARestart() {

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -321,4 +321,43 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         _ = controller.applyTick(recorder: recorder, now: t1.addingTimeInterval(30))
         XCTAssertTrue(controller.recordingSilentActive, "reset sibling monitor re-fires on a fresh silent window")
     }
+
+    // MARK: - Capture give-up (issue #588)
+
+    func testASilentChannelThatGaveUpGetsTheRestartMessage() {
+        // A channel that merely fell silent may come back. One whose restart
+        // attempt was abandoned will not, and the wedged attempt keeps burning
+        // CPU until the app restarts, so the user must be told something else.
+        let (controller, recorder, notifier, _) = makeController()
+        recorder.appLevelDBFS = -20
+        recorder.micLevelDBFS = -120
+        recorder.micCaptureGaveUp = true
+
+        controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
+
+        XCTAssertEqual(notifier.calls.count, 1)
+        XCTAssertEqual(notifier.calls.first?.body,
+                       ChannelHealthController.captureGaveUpMessage(for: .mic))
+    }
+
+    func testASilentChannelThatDidNotGiveUpKeepsTheSilenceMessage() {
+        let (controller, recorder, notifier, _) = makeController()
+        recorder.appLevelDBFS = -20
+        recorder.micLevelDBFS = -120
+
+        controller.applyTick(recorder: recorder, now: t0)
+        _ = controller.applyTick(recorder: recorder, now: t0.addingTimeInterval(30))
+
+        XCTAssertEqual(notifier.calls.first?.body,
+                       ChannelHealthController.asymmetricSilenceMessage(for: .mic))
+    }
+
+    func testTheGiveUpMessageRecommendsARestart() {
+        // The leaked thread only goes away with the process, so the advice has to
+        // say so; "check your mic" would send the user chasing the wrong thing.
+        let message = ChannelHealthController.captureGaveUpMessage(for: .mic)
+        XCTAssertTrue(message.lowercased().contains("restart"))
+        XCTAssertNotEqual(message, ChannelHealthController.asymmetricSilenceMessage(for: .mic))
+    }
 }

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -317,6 +317,10 @@ class MockRecorder: RecordingProvider {
     /// the protocol's default implementations.
     var micLevelDBFS: Double = -120
     var appLevelDBFS: Double = -120
+    /// Whether a channel's capture restart was abandoned (issue #588). Default
+    /// false, matching the protocol's default, so existing tests are unaffected.
+    var micCaptureGaveUp = false
+    var appCaptureGaveUp = false
 
     /// Overrides the `recordingStartDate` `stop()` reports. `nil` (default)
     /// yields `Date()` at stop time, matching a real recorder; set it to pin a

--- a/tools/audiotap/Sources/AppAudioCapture+Restart.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+Restart.swift
@@ -1,0 +1,168 @@
+import CoreAudio
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "AppAudioCapture")
+
+/// The output-device restart path, split out of `AppAudioCapture.swift` to stay
+/// under the 600-line lint cap.
+///
+/// `OutputDeviceChangeCoordinator` decides what a device change should do and how
+/// many times to try. It cannot help when an attempt never comes back, because it
+/// only runs again once one does, and `startCapture` is a chain of HAL calls
+/// through a coreaudiod that can stop answering (issue #588). Attempts therefore
+/// run off the main queue, carry a generation, and are bounded by a deadline.
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    func handleOutputDeviceChanged() {
+        guard isRunning else { return }
+        let action = deviceChangeCoordinator.handle(.deviceChanged)
+        guard action != .ignore else { return }
+
+        logger.info("App audio: default output device changed, recreating tap...")
+        if debugLogging {
+            let newName = getDefaultOutputDeviceName() ?? "?"
+            let newUID = getDefaultOutputDeviceUID() ?? "?"
+            logger.info(
+                "[debug] Output device change → name=\(newName, privacy: .public) uid=\(newUID, privacy: .public)",
+            )
+        }
+        applyAction(action)
+    }
+
+    /// Run one attempt off the main queue under a deadline, then feed the result
+    /// into the coordinator. A result that arrives after the deadline is dropped:
+    /// the tap it built, if any, is not adopted.
+    func completeRestart() {
+        // `.retryDue`, not `.deviceChanged`: every launch on this path arrives
+        // through scheduleRetry, and after a failed attempt the phase is
+        // `.backingOff`, where a device change is deliberately ignored.
+        guard case let .launchAttempt(generation) = restartArbiter.withLock({ $0.handle(.retryDue) })
+        else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + RestartArbiter.attemptTimeout) { [weak self] in
+            self?.handleRestartTimeout(generation: generation)
+        }
+
+        restartQueue.async { [weak self] in
+            guard let self else { return }
+            var failed = false
+            do {
+                try self.performAttempt()
+            } catch {
+                logger.error("Failed to restart app audio capture: \(error.localizedDescription, privacy: .public)")
+                failed = true
+            }
+            let succeeded = !failed
+            let outcome = self.restartArbiter.withLock { state in
+                state.handle(.attemptReturned(generation: generation, succeeded: succeeded))
+            }
+            guard outcome != .rejectStale else {
+                logger.info("App audio: discarding a restart attempt that outlived its deadline")
+                // A stale attempt that SUCCEEDED built a live tap. It has
+                // returned, so the HAL is answering and this releases it.
+                if succeeded { self.stopCapture() }
+                return
+            }
+            DispatchQueue.main.async {
+                self.finishRestart(generation: generation, succeeded: succeeded)
+            }
+        }
+    }
+
+    /// Publish or discard a returned attempt, then let the coordinator decide what
+    /// comes next. Main queue only, so a stop and an adoption cannot interleave.
+    private func finishRestart(generation: Int, succeeded: Bool) {
+        if succeeded {
+            guard case .adopt = restartArbiter.withLock({ $0.handle(.commitReady(generation: generation)) })
+            else {
+                logger.info("App audio: discarding a restart that succeeded after the session was sealed")
+                stopCapture()
+                return
+            }
+            // Only start() and this adoption may declare capture running. Leaving
+            // it to startCapture would let an attempt that returns after a give-up
+            // resurrect the IOProc against a file descriptor the session closed.
+            isRunning = true
+        }
+        let event: OutputDeviceChangeCoordinator.Event = succeeded
+            ? .startSucceeded(rate: actualSampleRate)
+            : .startFailed
+        applyAction(deviceChangeCoordinator.handle(event))
+    }
+
+    /// The attempt for `generation` never came back. Abandon app-audio capture
+    /// without touching the HAL resources it is stuck inside: any teardown here
+    /// would block behind the same call.
+    private func handleRestartTimeout(generation: Int) {
+        guard case .giveUp = restartArbiter.withLock({ $0.handle(.attemptTimedOut(generation: generation)) })
+        else { return }
+
+        logger.error(
+            "App audio: restart attempt did not return within \(RestartArbiter.attemptTimeout, privacy: .public)s — giving up on the app track",
+        )
+        markStoppedAfterGiveUp()
+        onGiveUp?()
+    }
+
+    private func applyAction(_ action: OutputDeviceChangeCoordinator.Action) {
+        switch action {
+        case .ignore:
+            break
+
+        case let .stopAndRetry(delay):
+            stopCapture()
+            scheduleRetry(after: delay)
+
+        case let .restart(delay):
+            scheduleRetry(after: delay)
+
+        case .complete:
+            logger.info("App audio: tap restarted (rate: \(self.actualSampleRate) Hz)")
+
+        case .giveUp:
+            // The coordinator also emits this for a rate-zero "success" while
+            // capture is genuinely running; there the arbiter is in .capturing
+            // and answers .ignore, which keeps that case at its old behaviour.
+            guard case .giveUp = restartArbiter.withLock({ $0.handle(.retryBudgetExhausted) }) else {
+                // The coordinator also reports .giveUp for a rate-zero "success"
+                // while capture is genuinely running. Keep the old breadcrumb:
+                // a tap left running at rate 0 should not vanish from the log.
+                logger.error("App audio: retry failed; giving up")
+                return
+            }
+            logger.error("App audio: retry budget exhausted; giving up on the app track")
+            onGiveUp?()
+        }
+    }
+
+    private func scheduleRetry(after delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.completeRestart()
+        }
+    }
+
+    /// Seal the state after a give-up without touching any HAL resource: the
+    /// wedged attempt may be inside a call that owns them.
+    func markStoppedAfterGiveUp() {
+        isRunning = false
+    }
+
+    func installOutputDeviceChangeListener() {
+        guard !outputListenerInstalled else { return }
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.handleOutputDeviceChanged()
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultOutputAddress,
+            DispatchQueue.main,
+            listener,
+        )
+        if status == noErr {
+            outputDeviceChangeListener = listener
+            outputListenerInstalled = true
+            logger.info("App audio: listening for default output device changes")
+        }
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -44,17 +44,18 @@ public class AppAudioCapture: @unchecked Sendable {
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var procID: AudioDeviceIOProcID?
     /// Gates the IOProc callback (read on `writeQueue`), set on the start/stop
-    /// path on the main thread. `isRunning = true` must follow `AudioDeviceStart`,
+    /// path on the main thread. It is set only by `start()` and by the restart
+    /// adoption, never by `startCapture` itself, and must follow `AudioDeviceStart`,
     /// so it can't be reordered ahead of the callback's read — hence an atomic lock.
     private let runningLock = OSAllocatedUnfairLock(initialState: false)
-    private var isRunning: Bool {
+    var isRunning: Bool {
         get { runningLock.withLock { $0 } }
         set { runningLock.withLock { $0 = newValue } }
     }
 
-    private var outputListenerInstalled = false
+    var outputListenerInstalled = false
     /// Stored listener block so we can pass the same instance to remove.
-    private var outputDeviceChangeListener: AudioObjectPropertyListenerBlock?
+    var outputDeviceChangeListener: AudioObjectPropertyListenerBlock?
     private let writeQueue = DispatchQueue(
         label: "audiotap.writer", qos: .userInteractive,
     )
@@ -73,7 +74,7 @@ public class AppAudioCapture: @unchecked Sendable {
     }
 
     /// CoreAudio property address for default output device changes.
-    private var defaultOutputAddress = AudioObjectPropertyAddress(
+    var defaultOutputAddress = AudioObjectPropertyAddress(
         mSelector: kAudioHardwarePropertyDefaultOutputDevice,
         mScope: kAudioObjectPropertyScopeGlobal,
         mElement: kAudioObjectPropertyElementMain,
@@ -98,7 +99,26 @@ public class AppAudioCapture: @unchecked Sendable {
 
     private var didLogFormat = false
     /// Pure state machine that decides when/what to dispatch on device-change events.
-    private var deviceChangeCoordinator = OutputDeviceChangeCoordinator()
+    var deviceChangeCoordinator = OutputDeviceChangeCoordinator()
+
+    /// Bounds a single restart attempt (issue #588). The coordinator above decides
+    /// *what* a device change should do and how many times; this decides how long
+    /// one attempt may take before it counts as never returning.
+    let restartArbiter = OSAllocatedUnfairLock(initialState: RestartArbiter())
+
+    /// Restart attempts run here, never on the main queue. `startCapture` is a
+    /// chain of HAL calls through the same coreaudiod that can stop answering,
+    /// and on the main queue a stuck one takes the whole app down.
+    let restartQueue = DispatchQueue(label: "com.meetingtranscriber.audiotap.app-restart",
+                                             qos: .userInitiated)
+
+    /// The work one attempt performs. Injectable so a test can substitute a call
+    /// that blocks the way a wedged HAL call does; nil means the real thing.
+    private let attemptBody: (() throws -> Void)?
+
+    /// Called when app-audio capture was abandoned, either because a restart
+    /// attempt exceeded its deadline or because the retry budget ran out.
+    public var onGiveUp: (() -> Void)?
 
     /// - Parameters:
     ///   - pids: Process IDs to capture audio from. Pass the meeting app's
@@ -114,7 +134,7 @@ public class AppAudioCapture: @unchecked Sendable {
     ///   - liveSink: Optional callback receiving a copy of each captured buffer.
     ///     Called on the audio IOProc thread — must not block. Nil = no-op,
     ///     existing batch path unchanged.
-    public init(
+    public convenience init(
         pids: [pid_t],
         outputFileDescriptor: Int32,
         sampleRate: Int = 48000,
@@ -122,17 +142,55 @@ public class AppAudioCapture: @unchecked Sendable {
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
     ) {
+        self.init(
+            pids: pids,
+            outputFileDescriptor: outputFileDescriptor,
+            sampleRate: sampleRate,
+            channels: channels,
+            debugLogging: debugLogging,
+            liveSink: liveSink,
+            attemptBody: nil,
+        )
+    }
+
+    /// Test seam. Deliberately not `public`: same-module tests substitute the
+    /// hardware work so the restart choreography can be exercised on a machine
+    /// with no audio device, and made to block so the deadline can be observed.
+    init(
+        pids: [pid_t],
+        outputFileDescriptor: Int32,
+        sampleRate: Int = 48000,
+        channels: Int = 2,
+        debugLogging: Bool = false,
+        liveSink: LiveAudioSink? = nil,
+        attemptBody: (() throws -> Void)?,
+    ) {
         self.pids = pids
         self.outputFileDescriptor = outputFileDescriptor
         self.sampleRate = sampleRate
         self.channels = channels
         self.debugLogging = debugLogging
         self.liveSink = liveSink
+        self.attemptBody = attemptBody
         resampler = StreamingMonoResampler(targetRate: Int(speechSampleRate))
     }
 
+    /// One attempt's worth of work: bring the tap up, or whatever a test injected.
+    func performAttempt() throws {
+        if let attemptBody {
+            try attemptBody()
+        } else {
+            try startCapture()
+        }
+    }
+
     public func start() throws {
-        try startCapture()
+        try performAttempt()
+        // startCapture deliberately no longer sets this. Declaring capture
+        // running belongs to start() and to the restart adoption, so an attempt
+        // that returns after a give-up cannot do it.
+        isRunning = true
+        _ = restartArbiter.withLock { $0.handle(.startSucceeded) }
         installOutputDeviceChangeListener()
     }
 
@@ -457,12 +515,14 @@ public class AppAudioCapture: @unchecked Sendable {
             )
         }
 
-        isRunning = true
-
+        // Deliberately does NOT declare capture running. Only start() and the
+        // restart adoption may do that, so an attempt that returns after a
+        // give-up cannot resurrect the IOProc against a file descriptor the
+        // session has already closed.
         logger.info("Audio capture started (PIDs \(self.pids), rate: \(self.actualSampleRate) Hz)")
     }
 
-    private func stopCapture() {
+    func stopCapture() {
         isRunning = false
 
         if debugLogging {
@@ -493,7 +553,22 @@ public class AppAudioCapture: @unchecked Sendable {
     }
 
     public func stop() {
-        stopCapture()
+        // Ask first: an attempt may be stuck inside the same coreaudiod, and every
+        // HAL call below would block behind it. Safe to skip in that case because
+        // an attempt is only ever launched after the coordinator already ran
+        // stopCapture(), so no IOProc is live while one is outstanding.
+        let decision = restartArbiter.withLock { $0.handle(.stopRequested) }
+        switch decision {
+        case .teardown:
+            stopCapture()
+
+        case .sealAndSkipEngine:
+            logger.warning("App audio: stopping while a restart attempt is outstanding — leaving its resources alone")
+            markStoppedAfterGiveUp()
+
+        default:
+            break
+        }
         if outputListenerInstalled, let listener = outputDeviceChangeListener {
             AudioObjectRemovePropertyListenerBlock(
                 AudioObjectID(kAudioObjectSystemObject),
@@ -505,84 +580,5 @@ public class AppAudioCapture: @unchecked Sendable {
             outputListenerInstalled = false
         }
         logger.info("Audio capture stopped")
-    }
-}
-
-// MARK: - Output device change handling
-
-@available(macOS 14.2, *)
-extension AppAudioCapture {
-    func installOutputDeviceChangeListener() {
-        guard !outputListenerInstalled else { return }
-        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.handleOutputDeviceChanged()
-        }
-        let status = AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &defaultOutputAddress,
-            DispatchQueue.main,
-            listener,
-        )
-        if status == noErr {
-            outputDeviceChangeListener = listener
-            outputListenerInstalled = true
-            logger.info("App audio: listening for default output device changes")
-        }
-    }
-
-    func handleOutputDeviceChanged() {
-        guard isRunning else { return }
-        let action = deviceChangeCoordinator.handle(.deviceChanged)
-        guard action != .ignore else { return }
-
-        logger.info("App audio: default output device changed, recreating tap...")
-        if debugLogging {
-            let newName = getDefaultOutputDeviceName() ?? "?"
-            let newUID = getDefaultOutputDeviceUID() ?? "?"
-            logger.info(
-                "[debug] Output device change → name=\(newName, privacy: .public) uid=\(newUID, privacy: .public)",
-            )
-        }
-        applyAction(action)
-    }
-
-    /// Try a startCapture() and feed the result into the coordinator, dispatching
-    /// any follow-up restart/retry/give-up action it asks for.
-    private func completeRestart() {
-        let event: OutputDeviceChangeCoordinator.Event
-        do {
-            try startCapture()
-            event = .startSucceeded(rate: actualSampleRate)
-        } catch {
-            logger.error("Failed to restart app audio capture: \(error.localizedDescription, privacy: .public)")
-            event = .startFailed
-        }
-        applyAction(deviceChangeCoordinator.handle(event))
-    }
-
-    private func applyAction(_ action: OutputDeviceChangeCoordinator.Action) {
-        switch action {
-        case .ignore:
-            break
-
-        case let .stopAndRetry(delay):
-            stopCapture()
-            scheduleRetry(after: delay)
-
-        case let .restart(delay):
-            scheduleRetry(after: delay)
-
-        case .complete:
-            logger.info("App audio: tap restarted (rate: \(self.actualSampleRate) Hz)")
-
-        case .giveUp:
-            logger.error("App audio: retry failed; giving up")
-        }
-    }
-
-    private func scheduleRetry(after delay: TimeInterval) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.completeRestart()
-        }
     }
 }

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -109,8 +109,10 @@ public class AppAudioCapture: @unchecked Sendable {
     /// Restart attempts run here, never on the main queue. `startCapture` is a
     /// chain of HAL calls through the same coreaudiod that can stop answering,
     /// and on the main queue a stuck one takes the whole app down.
-    let restartQueue = DispatchQueue(label: "com.meetingtranscriber.audiotap.app-restart",
-                                             qos: .userInitiated)
+    let restartQueue = DispatchQueue(
+        label: "com.meetingtranscriber.audiotap.app-restart",
+        qos: .userInitiated,
+    )
 
     /// The work one attempt performs. Injectable so a test can substitute a call
     /// that blocks the way a wedged HAL call does; nil means the real thing.

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -22,6 +22,15 @@ public class AudioCaptureSession {
 
     private var appCapture: AppAudioCapture?
     private var micCapture: MicCaptureHandler?
+
+    /// Set when a channel's capture was abandoned (issue #588), either because a
+    /// restart attempt never returned or because the retry budget ran out.
+    /// Terminal for the session, so the user needs to be told something more
+    /// useful than "this channel is quiet". In the first case a wedged attempt
+    /// also keeps a thread and a good share of a core until the process
+    /// restarts. Read from the polling path that already watches channel levels.
+    public private(set) var appCaptureGaveUp = false
+    public private(set) var micCaptureGaveUp = false
     private var appFileHandle: FileHandle?
 
     /// - Parameter pids: PIDs to capture audio from. For Electron/WebView2
@@ -84,6 +93,7 @@ public class AudioCaptureSession {
             throw error
         }
         appFileHandle = handle
+        capture.onGiveUp = { [weak self] in self?.appCaptureGaveUp = true }
         appCapture = capture
 
         // Start mic capture if requested
@@ -96,6 +106,7 @@ public class AudioCaptureSession {
             )
             do {
                 try mic.start(deviceUID: micDeviceUID)
+                mic.onGiveUp = { [weak self] in self?.micCaptureGaveUp = true }
                 micCapture = mic
             } catch {
                 logger.error("Failed to start mic capture: \(error.localizedDescription, privacy: .public). Continuing with app audio only.")

--- a/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
@@ -190,8 +190,10 @@ extension MicCaptureHandler {
                 // Re-resolve the target now rather than reusing the one captured
                 // when the backoff started: a device change during the backoff is
                 // ignored by design, so this is where a newer reality is picked up.
-                self.launchRestartAttempt(deviceUID: self.currentRestartTarget() ?? deviceUID,
-                                          generation: generation)
+                self.launchRestartAttempt(
+                    deviceUID: self.currentRestartTarget() ?? deviceUID,
+                    generation: generation,
+                )
             }
         }
     }

--- a/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
@@ -1,0 +1,204 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "MicCapture")
+
+/// The device-change restart path, split out of `MicCaptureHandler.swift` to keep
+/// it under the 600-line lint cap (same pattern as `+Timeline`).
+///
+/// Everything here exists because a restart attempt can fail to return at all
+/// (issue #588): `-[AVAudioEngine inputNode]` loops inside AVFAudio when the
+/// default-device aggregate still references a Bluetooth device that just
+/// vanished, holds the engine mutex while doing so, and cannot be cancelled.
+/// Attempts therefore run off the main queue, carry a generation, and are bounded
+/// by a deadline rather than only by a retry count.
+extension MicCaptureHandler {
+    /// A device change may launch at most one restart attempt, and the arbiter
+    /// is what enforces that: an attempt already in flight may be wedged, and
+    /// starting a second one would leak another thread into the same loop.
+    func handleDeviceChange() {
+        let isDeviceAvailable = selectedDeviceUID
+            .map { MicEngineSession.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
+        let action = MicRestartPolicy.decideRestart(
+            isRecording: isRecording,
+            // The arbiter owns "an attempt is outstanding" now, including the
+            // backoff window, so this only asks the policy about the device.
+            isRestarting: false,
+            selectedDeviceUID: selectedDeviceUID,
+            isSelectedDeviceAvailable: isDeviceAvailable,
+        )
+        guard case let .restart(deviceUID) = action else { return }
+        guard case let .launchAttempt(generation) = arbiter.withLock({ $0.handle(.deviceChanged) })
+        else { return }
+        launchRestartAttempt(deviceUID: deviceUID, generation: generation)
+    }
+
+    /// Runs one restart attempt off the main queue and arms a deadline for it.
+    ///
+    /// The deadline is the whole point: the call that brings an engine up can
+    /// loop forever inside AVFAudio and cannot be cancelled, so the only way to
+    /// find out is to stop waiting. `MicRestartRetryPolicy` still governs
+    /// attempts that come back with an error; it never sees one that hangs.
+    private func launchRestartAttempt(deviceUID: String?, generation: Int) {
+        if deviceUID == nil, let uid = selectedDeviceUID {
+            logger.warning("Mic: selected device '\(uid)' no longer available, falling back to system default")
+        }
+
+        // Everything that owns the OUTGOING session happens here, on the main
+        // queue, including its teardown. An AVAudioEngine must be released on the
+        // thread that drove it: handing it to the restart queue and stopping it
+        // there moves engine teardown off the main thread for the first time, and
+        // the retain-grace comment in MicEngineSession records what that class of
+        // mistake already cost once. The compiler says the same thing, since the
+        // session is not Sendable.
+        //
+        // The attempt therefore carries nothing but its device and its generation.
+        // It never reads `session`, so a stop running later on this same queue
+        // cannot interleave with an adoption.
+        removeConfigChangeObserver()
+        session.teardown()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + RestartArbiter.attemptTimeout) { [weak self] in
+            self?.handleAttemptTimeout(generation: generation)
+        }
+
+        restartQueue.async { [weak self] in
+            self?.runRestartAttempt(deviceUID: deviceUID, generation: generation)
+        }
+    }
+
+    /// Builds a fresh session and brings it up. Everything it produces stays
+    /// local until the arbiter agrees this attempt is still the current one, so
+    /// an attempt that returns after its deadline cannot adopt anything.
+    private func runRestartAttempt(deviceUID: String?, generation: Int) {
+        // AVAudioEngine can be in a bad state after a config change, so an
+        // attempt always builds a new session rather than reusing the engine.
+        let candidate = sessionFactory()
+        var rate: Double?
+        var thrown: Error?
+        do {
+            rate = try startEngine(deviceUID: deviceUID, on: candidate)
+        } catch {
+            thrown = error
+        }
+        let failure = thrown
+        let succeeded = failure == nil
+
+        let outcome = arbiter.withLock { state in
+            state.handle(.attemptReturned(generation: generation, succeeded: succeeded))
+        }
+
+        switch outcome {
+        case .commit:
+            // Publication happens on the main queue, where stop() also runs, so
+            // the two are totally ordered instead of racing on `session`.
+            DispatchQueue.main.async { [weak self] in
+                self?.adopt(candidate, deviceUID: deviceUID, generation: generation, rate: rate)
+            }
+
+        case .retry:
+            // A transient invalid format / installTap raise (issue #379) is
+            // recoverable: the device usually settles within a few hundred ms.
+            let reason = failure?.localizedDescription ?? "unknown error"
+            logger.error(
+                "Failed to restart mic after device change: \(reason, privacy: .public) — scheduling retry",
+            )
+            candidate.teardown()
+            DispatchQueue.main.async { [weak self] in
+                self?.scheduleRestartRetry(deviceUID: deviceUID)
+            }
+
+        default:
+            // The session was sealed while this attempt was outstanding. It owns
+            // nothing shared, so it tears its own work down and says nothing.
+            logger.info("Mic: discarding a restart attempt that outlived its deadline")
+            candidate.teardown()
+        }
+    }
+
+    /// Publish a successful attempt, or discard it if the session was sealed
+    /// while it was on its way here. Main queue only.
+    private func adopt(
+        _ candidate: MicEngineSessionProviding,
+        deviceUID: String?,
+        generation: Int,
+        rate: Double?,
+    ) {
+        guard case .adopt = arbiter.withLock({ $0.handle(.commitReady(generation: generation)) }) else {
+            logger.info("Mic: discarding a restart that succeeded after the session was sealed")
+            candidate.teardown()
+            return
+        }
+        session = candidate
+        restartRetryCount = 0
+        installConfigChangeObserver()
+        logger.info(
+            "Mic: engine restarted on \(deviceUID != nil ? "selected" : "default") device (\(Int(rate ?? 0)) Hz)",
+        )
+        if let rate, rate <= 0 {
+            logger.warning("Mic: hardware format rate is \(rate) after restart — may produce incorrect audio")
+        }
+    }
+
+    /// The attempt for `generation` never came back. Abandon the microphone
+    /// track without touching the engine it is stuck inside.
+    private func handleAttemptTimeout(generation: Int) {
+        guard case .giveUp = arbiter.withLock({ $0.handle(.attemptTimedOut(generation: generation)) })
+        else { return }
+
+        logger.error(
+            "Mic: restart attempt did not return within \(RestartArbiter.attemptTimeout, privacy: .public)s — giving up on the microphone track",
+        )
+        // Closing the file is the only cleanup that is safe here: the attempt
+        // may be inside a call that holds the engine's mutex, so any engine
+        // teardown would block this thread behind it.
+        outputFile = nil
+        onGiveUp?()
+    }
+
+    private func removeConfigChangeObserver() {
+        guard let observer = configChangeObserver else { return }
+        NotificationCenter.default.removeObserver(observer)
+        configChangeObserver = nil
+    }
+
+    /// Re-attempt a restart that came back with an error, bounded by
+    /// `maxRestartRetries`. An attempt that never came back does not reach here:
+    /// the deadline gives up instead, because each wedged attempt costs a thread
+    /// and a good fraction of a core for the rest of the process's life.
+    /// No `isRecording` guard anywhere in here: during the backoff the phase is
+    /// `.backingOff`, so capture is deliberately not "running". The arbiter is the
+    /// guard, and it answers `.ignore` for both events once the session is sealed.
+    private func scheduleRestartRetry(deviceUID: String?) {
+        switch MicRestartRetryPolicy.decide(attemptsSoFar: restartRetryCount) {
+        case .giveUp:
+            guard case .giveUp = arbiter.withLock({ $0.handle(.retryBudgetExhausted) }) else { return }
+            logger.error("Mic: giving up restart after \(MicRestartRetryPolicy.maxAttempts) failed attempts")
+            outputFile = nil
+            onGiveUp?()
+
+        case let .retry(delay):
+            restartRetryCount += 1
+            let attempt = restartRetryCount
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self else { return }
+                guard case let .launchAttempt(generation) = self.arbiter.withLock({ $0.handle(.retryDue) })
+                else { return }
+                logger.info("Mic: restart retry \(attempt)/\(MicRestartRetryPolicy.maxAttempts)")
+                // Re-resolve the target now rather than reusing the one captured
+                // when the backoff started: a device change during the backoff is
+                // ignored by design, so this is where a newer reality is picked up.
+                self.launchRestartAttempt(deviceUID: self.currentRestartTarget() ?? deviceUID,
+                                          generation: generation)
+            }
+        }
+    }
+
+    /// The device a restart should aim at right now, or nil to take the default.
+    private func currentRestartTarget() -> String? {
+        guard let uid = selectedDeviceUID else { return nil }
+        return MicEngineSession.deviceIDForUID(uid) != kAudioObjectUnknown ? uid : nil
+    }
+}

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -52,15 +52,20 @@ public class MicCaptureHandler: @unchecked Sendable {
     /// Restart attempts run here, never on the main queue: the call that brings
     /// an engine up can block forever, and on the main queue that takes the whole
     /// app down with it rather than just the microphone track.
-    let restartQueue = DispatchQueue(label: "com.meetingtranscriber.audiotap.mic-restart",
-                                             qos: .userInitiated)
+    let restartQueue = DispatchQueue(
+        label: "com.meetingtranscriber.audiotap.mic-restart",
+        qos: .userInitiated,
+    )
 
     /// Called when the microphone track was abandoned, either because a restart
     /// attempt exceeded its deadline or because the retry budget ran out. The
     /// rest of the session keeps recording.
     public var onGiveUp: (() -> Void)?
 
-    var isRecording: Bool { arbiter.withLock { $0.isCapturing } }
+    var isRecording: Bool {
+        arbiter.withLock { $0.isCapturing }
+    }
+
     // Bounded retry for transient restart failures (issue #379): a device
     // change can briefly expose an invalid format; retry with exponential
     // backoff (MicRestartRetryPolicy) rather than dropping the recording.

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -18,7 +18,12 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// IO with the render thread is impossible by lifecycle. `@unchecked Sendable`
 /// reflects that this discipline isn't expressible to the compiler.
 public class MicCaptureHandler: @unchecked Sendable {
-    private var engine = AVAudioEngine()
+    /// Builds a fresh engine session. Injectable so tests can supply one that
+    /// never touches audio hardware (the CI runner has no input device) and can
+    /// be made to block on demand, which is how the issue #588 wedge is
+    /// exercised without a Bluetooth headset.
+    private let sessionFactory: () -> MicEngineSessionProviding
+    private var session: MicEngineSessionProviding
     /// `internal` (not `private`) so the cross-file `+Timeline` extension can
     /// write gap-fill silence to it.
     var outputFile: AVAudioFile?
@@ -29,12 +34,6 @@ public class MicCaptureHandler: @unchecked Sendable {
     // build's composition root injects one (DualSourceRecorder, gated by
     // #if E2E_FAULT_INJECTION) to verify the installTap NSException recovery.
     private let debugFault: DebugTapFault?
-    /// Removes the engine's input tap in `stop()`. Injectable so a test can
-    /// assert the teardown is skipped when no tap was installed (reading
-    /// `AVAudioEngine.inputNode` throws an uncatchable NSException on an input-less host).
-    private let removeInputTap: (AVAudioEngine) -> Void
-    /// True once a tap is attached to the current engine's inputNode; gates the `inputNode` teardown in `stop()`.
-    private var tapInstalled = false
     private var isRecording = false
     private var isRestarting = false
     // Bounded retry for transient restart failures (issue #379): a device
@@ -82,40 +81,46 @@ public class MicCaptureHandler: @unchecked Sendable {
         mElement: kAudioObjectPropertyElementMain,
     )
 
-    public init(
+    public convenience init(
         outputURL: URL,
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
         debugFault: DebugTapFault? = nil,
         removeInputTap: @escaping (AVAudioEngine) -> Void = { $0.inputNode.removeTap(onBus: 0) },
     ) {
+        let factory: () -> MicEngineSessionProviding = {
+            MicEngineSession(removeInputTap: removeInputTap)
+        }
+        self.init(
+            outputURL: outputURL,
+            debugLogging: debugLogging,
+            liveSink: liveSink,
+            debugFault: debugFault,
+            sessionFactory: factory,
+        )
+    }
+
+    /// Test seam. Deliberately not `public`: `MicEngineSessionProviding` stays
+    /// internal, so the published API keeps exposing only the real engine path
+    /// while same-module tests can substitute a session that never touches audio
+    /// hardware.
+    init(
+        outputURL: URL,
+        debugLogging: Bool = false,
+        liveSink: LiveAudioSink? = nil,
+        debugFault: DebugTapFault? = nil,
+        sessionFactory: @escaping () -> MicEngineSessionProviding,
+    ) {
         self.outputURL = outputURL
         self.debugLogging = debugLogging
         self.liveSink = liveSink
         self.debugFault = debugFault
-        self.removeInputTap = removeInputTap
+        self.sessionFactory = sessionFactory
+        session = sessionFactory()
     }
 
     deinit {
         stop()
-    }
-
-    private static func deviceIDForUID(_ uid: String) -> AudioDeviceID {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyTranslateUIDToDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
-        )
-        var deviceID: AudioDeviceID = kAudioObjectUnknown
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        var cfUID: Unmanaged<CFString>? = Unmanaged.passUnretained(uid as CFString)
-        let qualifierSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
-        AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address, qualifierSize, &cfUID,
-            &size, &deviceID,
-        )
-        return deviceID
     }
 
     public func start(deviceUID: String? = nil) throws {
@@ -143,34 +148,11 @@ public class MicCaptureHandler: @unchecked Sendable {
         return tapFormat
     }
 
-    // swiftlint:disable:next function_body_length
-    private func startEngine(deviceUID: String? = nil) throws {
-        tapInstalled = false // reset per attempt; re-set once safeInstallTap attaches a tap
-        // No input device available (e.g. Mac Mini server without mic hardware) —
-        // accessing AVAudioEngine.inputNode would throw an uncatchable NSException.
-        guard AVCaptureDevice.default(for: .audio) != nil else {
-            throw MicCaptureError.noInputDevice
-        }
-
-        let inputNode = engine.inputNode
-
-        if let uid = deviceUID {
-            var deviceID = Self.deviceIDForUID(uid)
-            if deviceID != kAudioObjectUnknown {
-                let audioUnit = inputNode.audioUnit! // swiftlint:disable:this force_unwrapping
-                AudioUnitSetProperty(
-                    audioUnit,
-                    kAudioOutputUnitProperty_CurrentDevice,
-                    kAudioUnitScope_Global, 0,
-                    &deviceID, UInt32(MemoryLayout<AudioDeviceID>.size),
-                )
-                logger.info("Mic device set: \(uid) (ID \(deviceID))")
-            } else {
-                logger.warning("Unknown mic device UID '\(uid)', using default")
-            }
-        }
-
-        let hwFormat = inputNode.outputFormat(forBus: 0)
+    // swiftlint:disable function_body_length
+    @discardableResult
+    private func startEngine(deviceUID: String? = nil) throws -> Double {
+        // The one call in here that can block forever (issue #588).
+        let hwFormat = try session.hardwareFormat(deviceUID: deviceUID)
         logger.info("Mic hardware format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount)ch")
 
         let tapFormat = try validatedTapFormat(for: hwFormat)
@@ -271,22 +253,17 @@ public class MicCaptureHandler: @unchecked Sendable {
             }
         }
 
-        do {
-            try inputNode.safeInstallTap(onBus: 0, bufferSize: 4096, format: installFormat, block: tapBlock)
-        } catch {
-            logger.error("Mic: installTap failed (\(error.localizedDescription, privacy: .public)) — restart will retry")
-            throw error
-        }
-        tapInstalled = true // inputNode accessed + tap attached; stop() must remove it even if start() throws
-
-        engine.prepare()
-        try engine.start()
+        try session.installTap(format: installFormat, block: tapBlock)
+        try session.start()
         isRecording = true
         restartRetryCount = 0
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
 
         armDebugFaultIfNeeded()
+        return hwFormat.sampleRate
     }
+
+    // swiftlint:enable function_body_length
 
     private func installDeviceChangeListener() {
         guard deviceChangeListener == nil else { return }
@@ -312,7 +289,7 @@ public class MicCaptureHandler: @unchecked Sendable {
         guard configChangeObserver == nil else { return }
         configChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
-            object: engine,
+            object: session.notificationObject,
             queue: .main,
         ) { [weak self] _ in
             self?.handleEngineConfigChange()
@@ -331,7 +308,7 @@ public class MicCaptureHandler: @unchecked Sendable {
     }
 
     private func handleDeviceChange() {
-        let isDeviceAvailable = selectedDeviceUID.map { Self.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
+        let isDeviceAvailable = selectedDeviceUID.map { MicEngineSession.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
         let action = MicRestartPolicy.decideRestart(
             isRecording: isRecording,
             // Treat a pending retry as still-restarting so a device change in
@@ -358,31 +335,24 @@ public class MicCaptureHandler: @unchecked Sendable {
             logger.warning("Mic: selected device '\(uid)' no longer available, falling back to system default")
         }
 
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
-        engine.reset()
+        session.teardown()
 
         if let observer = configChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil
         }
 
-        // AVAudioEngine can be in a bad state after config change — must recreate.
-        // Hold a strong reference to the old engine for a grace period so any
-        // in-flight `AVAudioIOUnit::IOUnitPropertyListener` blocks that
-        // AVFoundation queued on a libdispatch worker fire against a live
-        // object. Without this hold, dropping the last reference here races
-        // against those blocks and crashes with EXC_BAD_ACCESS in
-        // `objc_msgSend` on the freed engine.
-        let oldEngine = engine
-        engine = AVAudioEngine()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            _ = oldEngine
-        }
+        // AVAudioEngine can be in a bad state after a config change, so the
+        // restart runs on a brand-new session rather than reusing the engine.
+        // The old one is kept alive briefly by its own teardown (see
+        // MicEngineSession.teardown) so in-flight AVFoundation listener blocks
+        // do not fire against a freed object.
+        session = sessionFactory()
 
         do {
-            try startEngine(deviceUID: deviceUID)
-            let hwRate = engine.inputNode.outputFormat(forBus: 0).sampleRate
+            // The rate comes back from startEngine: reading it again through the
+            // engine would be a second call that can wedge (issue #588).
+            let hwRate = try startEngine(deviceUID: deviceUID)
             if hwRate <= 0 {
                 logger.warning("Mic: hardware format rate is \(hwRate) after restart — may produce incorrect audio")
             }
@@ -438,25 +408,12 @@ public class MicCaptureHandler: @unchecked Sendable {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil
         }
-        // Skip the inputNode teardown when no tap was installed — the getter
-        // raises an uncatchable NSException on an input-less host (deinit path).
-        if tapInstalled {
-            removeInputTap(engine)
-        }
-        engine.stop()
-        engine.reset()
+        // Tap removal, stop/reset and the retain-grace that keeps in-flight
+        // AVFoundation listener blocks firing against a live object all live in
+        // the session now, including the "no tap was installed" guard that keeps
+        // an input-less host from raising in the deinit path.
+        session.teardown()
         outputFile = nil
-
-        // Mirror the retain-grace from executeRestart: if the caller drops
-        // MicCaptureHandler immediately after stop() returns, the engine
-        // ivar's last reference would race against any in-flight
-        // AVAudioIOUnit::IOUnitPropertyListener block AVFoundation queued
-        // on a libdispatch worker. Holding a local ref for 500 ms lets
-        // those blocks fire against a live object.
-        let retainedEngine = engine
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            _ = retainedEngine
-        }
         logger.info("Mic recording stopped")
     }
 }

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -12,18 +12,27 @@ private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", catego
 /// when still available or falling back to system default with a warning.
 ///
 /// Public API (`start`/`stop`/`currentLevelDBFS`) is called from the main actor.
-/// The `installTap` render-thread callback writes to per-buffer state guarded by
-/// `LevelPublisher` (lock-protected) and to `outputFile` which is only mutated
-/// between `engine.stop()` and `engine.start()` on the main thread, so concurrent
-/// IO with the render thread is impossible by lifecycle. `@unchecked Sendable`
-/// reflects that this discipline isn't expressible to the compiler.
+///
+/// Mutable state is split by owner. `session`, `configChangeObserver` and the
+/// retry counter are confined to the main queue: a restart attempt runs on
+/// `restartQueue`, builds a candidate session from locals, and publishes nothing
+/// until the main queue adopts it with the arbiter's approval, so a stop and an
+/// adoption are totally ordered rather than racing. `outputFile` is created in
+/// `startEngine` on whichever queue runs it (main at first start, `restartQueue`
+/// during an attempt) and only when the arbiter's `mayCreateOutputFile` allows
+/// it under the lock; it is nilled only on the main queue, by stop and by
+/// give-up. The render-thread tap block reads it through optional chaining
+/// behind an `isCapturing` check, so a buffer arriving after a seal is a dropped
+/// write rather than a write to a closed file. Per-buffer level state is guarded
+/// by `LevelPublisher`. `@unchecked Sendable` reflects that this discipline
+/// isn't expressible to the compiler.
 public class MicCaptureHandler: @unchecked Sendable {
     /// Builds a fresh engine session. Injectable so tests can supply one that
     /// never touches audio hardware (the CI runner has no input device) and can
     /// be made to block on demand, which is how the issue #588 wedge is
     /// exercised without a Bluetooth headset.
-    private let sessionFactory: () -> MicEngineSessionProviding
-    private var session: MicEngineSessionProviding
+    let sessionFactory: () -> MicEngineSessionProviding
+    var session: MicEngineSessionProviding
     /// `internal` (not `private`) so the cross-file `+Timeline` extension can
     /// write gap-fill silence to it.
     var outputFile: AVAudioFile?
@@ -34,21 +43,32 @@ public class MicCaptureHandler: @unchecked Sendable {
     // build's composition root injects one (DualSourceRecorder, gated by
     // #if E2E_FAULT_INJECTION) to verify the installTap NSException recovery.
     private let debugFault: DebugTapFault?
-    private var isRecording = false
-    private var isRestarting = false
+    /// Bounds a single restart attempt and decides what a late or superseded
+    /// attempt is allowed to do (issue #588). Lock-guarded because the watchdog
+    /// fires on main while the attempt runs on `restartQueue`, and the render
+    /// thread reads the capture state per buffer.
+    let arbiter = OSAllocatedUnfairLock(initialState: RestartArbiter())
+
+    /// Restart attempts run here, never on the main queue: the call that brings
+    /// an engine up can block forever, and on the main queue that takes the whole
+    /// app down with it rather than just the microphone track.
+    let restartQueue = DispatchQueue(label: "com.meetingtranscriber.audiotap.mic-restart",
+                                             qos: .userInitiated)
+
+    /// Called when the microphone track was abandoned, either because a restart
+    /// attempt exceeded its deadline or because the retry budget ran out. The
+    /// rest of the session keeps recording.
+    public var onGiveUp: (() -> Void)?
+
+    var isRecording: Bool { arbiter.withLock { $0.isCapturing } }
     // Bounded retry for transient restart failures (issue #379): a device
     // change can briefly expose an invalid format; retry with exponential
     // backoff (MicRestartRetryPolicy) rather than dropping the recording.
     // Reset to 0 on a successful (re)start.
-    private var restartRetryCount = 0
-    // True while a retry is pending in the backoff window. `isRestarting` is
-    // cleared synchronously when executeRestart returns, so without this a
-    // device change arriving during the 0.3 s backoff would start a second,
-    // parallel restart chain racing the pending one on `engine`.
-    private var retryScheduled = false
+    var restartRetryCount = 0
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
-    private var configChangeObserver: NSObjectProtocol?
-    private var selectedDeviceUID: String?
+    var configChangeObserver: NSObjectProtocol?
+    var selectedDeviceUID: String?
     private var fileSampleRate: Double = 0
     private var converter: AVAudioConverter?
     /// Pre-computed resampling ratio (fileSampleRate / tapSampleRate), avoids division in audio callback.
@@ -125,7 +145,8 @@ public class MicCaptureHandler: @unchecked Sendable {
 
     public func start(deviceUID: String? = nil) throws {
         selectedDeviceUID = deviceUID
-        try startEngine(deviceUID: deviceUID)
+        try startEngine(deviceUID: deviceUID, on: session)
+        _ = arbiter.withLock { $0.handle(.startSucceeded) }
         installDeviceChangeListener()
         installConfigChangeObserver()
     }
@@ -138,7 +159,7 @@ public class MicCaptureHandler: @unchecked Sendable {
     /// node bus. Matching the node's channel count and downmixing to mono in
     /// the converter (see startEngine) avoids the mismatch at the source. The
     /// 0 Hz / 0-channel guard covers the transient where the device hasn't
-    /// finished re-initialising; throwing lets executeRestart retry.
+    /// finished re-initialising; throwing lets the restart attempt retry.
     private func validatedTapFormat(for hwFormat: AVAudioFormat) throws -> AVAudioFormat {
         guard let tapFormat = TapFormatResolver.tapFormat(forHardware: hwFormat) else {
             throw MicCaptureError.invalidHardwareFormat(
@@ -150,7 +171,7 @@ public class MicCaptureHandler: @unchecked Sendable {
 
     // swiftlint:disable function_body_length
     @discardableResult
-    private func startEngine(deviceUID: String? = nil) throws -> Double {
+    func startEngine(deviceUID: String?, on session: MicEngineSessionProviding) throws -> Double {
         // The one call in here that can block forever (issue #588).
         let hwFormat = try session.hardwareFormat(deviceUID: deviceUID)
         logger.info("Mic hardware format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount)ch")
@@ -167,8 +188,11 @@ public class MicCaptureHandler: @unchecked Sendable {
 
         logger.info("Mic tap format: \(tapFormat.sampleRate) Hz, \(tapFormat.channelCount)ch")
 
-        // Always 16kHz — WhisperKit target rate
-        if outputFile == nil {
+        // Always 16kHz — WhisperKit target rate. `mayCreateOutputFile` is false
+        // once the session was sealed by a give-up or a stop: a wedged attempt
+        // that returns later must not recreate (and thereby truncate) a
+        // recording that was already finalized.
+        if outputFile == nil, arbiter.withLock({ $0.mayCreateOutputFile }) {
             fileSampleRate = speechSampleRate
             let wavSettings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatLinearPCM,
@@ -255,8 +279,6 @@ public class MicCaptureHandler: @unchecked Sendable {
 
         try session.installTap(format: installFormat, block: tapBlock)
         try session.start()
-        isRecording = true
-        restartRetryCount = 0
         logger.info("Mic recording started: \(self.outputURL.lastPathComponent)")
 
         armDebugFaultIfNeeded()
@@ -285,7 +307,7 @@ public class MicCaptureHandler: @unchecked Sendable {
     }
 
     /// Listen for AVAudioEngine configuration changes (format changes on current device).
-    private func installConfigChangeObserver() {
+    func installConfigChangeObserver() {
         guard configChangeObserver == nil else { return }
         configChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
@@ -307,94 +329,14 @@ public class MicCaptureHandler: @unchecked Sendable {
         handleDeviceChange()
     }
 
-    private func handleDeviceChange() {
-        let isDeviceAvailable = selectedDeviceUID.map { MicEngineSession.deviceIDForUID($0) != kAudioObjectUnknown } ?? false
-        let action = MicRestartPolicy.decideRestart(
-            isRecording: isRecording,
-            // Treat a pending retry as still-restarting so a device change in
-            // the backoff window doesn't spawn a competing restart chain.
-            isRestarting: isRestarting || retryScheduled,
-            selectedDeviceUID: selectedDeviceUID,
-            isSelectedDeviceAvailable: isDeviceAvailable,
-        )
-
-        switch action {
-        case let .restart(deviceUID):
-            executeRestart(deviceUID: deviceUID)
-
-        case .skip:
-            break
-        }
-    }
-
-    private func executeRestart(deviceUID: String?) {
-        isRestarting = true
-        defer { isRestarting = false }
-
-        if deviceUID == nil, let uid = selectedDeviceUID {
-            logger.warning("Mic: selected device '\(uid)' no longer available, falling back to system default")
-        }
-
-        session.teardown()
-
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
-
-        // AVAudioEngine can be in a bad state after a config change, so the
-        // restart runs on a brand-new session rather than reusing the engine.
-        // The old one is kept alive briefly by its own teardown (see
-        // MicEngineSession.teardown) so in-flight AVFoundation listener blocks
-        // do not fire against a freed object.
-        session = sessionFactory()
-
-        do {
-            // The rate comes back from startEngine: reading it again through the
-            // engine would be a second call that can wedge (issue #588).
-            let hwRate = try startEngine(deviceUID: deviceUID)
-            if hwRate <= 0 {
-                logger.warning("Mic: hardware format rate is \(hwRate) after restart — may produce incorrect audio")
-            }
-            installConfigChangeObserver()
-            logger.info("Mic: engine restarted on \(deviceUID != nil ? "selected" : "default") device (\(Int(hwRate)) Hz)")
-        } catch {
-            // A transient invalid format / installTap raise (issue #379) is
-            // recoverable: the device usually settles within a few hundred ms.
-            // Keep recording and retry with backoff instead of killing it.
-            logger.error("Failed to restart mic after device change: \(error.localizedDescription, privacy: .public) — scheduling retry")
-            scheduleRestartRetry(deviceUID: deviceUID)
-        }
-    }
-
-    /// Re-attempt a failed restart after a short backoff, bounded by
-    /// `maxRestartRetries`. Only retries while still recording; gives up (and
-    /// stops recording) once the budget is exhausted.
-    private func scheduleRestartRetry(deviceUID: String?) {
-        guard isRecording else { return }
-        switch MicRestartRetryPolicy.decide(attemptsSoFar: restartRetryCount) {
-        case .giveUp:
-            isRecording = false
-            logger.error("Mic: giving up restart after \(MicRestartRetryPolicy.maxAttempts) failed attempts")
-
-        case let .retry(delay):
-            restartRetryCount += 1
-            retryScheduled = true
-            let attempt = restartRetryCount
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                guard let self else { return }
-                self.retryScheduled = false
-                guard self.isRecording else { return }
-                logger.info("Mic: restart retry \(attempt)/\(MicRestartRetryPolicy.maxAttempts)")
-                self.executeRestart(deviceUID: deviceUID)
-            }
-        }
-    }
-
     public func stop() {
-        // Set isRecording=false first so any in-flight tap closure short-circuits
-        // before touching the soon-released AVAudioFile.
-        isRecording = false
+        // Seal first, so any in-flight tap closure short-circuits before touching
+        // the soon-released AVAudioFile. The arbiter also answers the question
+        // that decides the rest of this method: is a restart attempt currently
+        // inside the engine? If so, every engine call below would block behind
+        // the mutex that attempt holds, and stopping a recording would freeze the
+        // caller (issue #588).
+        let decision = arbiter.withLock { $0.handle(.stopRequested) }
         if let listener = deviceChangeListener {
             AudioObjectRemovePropertyListenerBlock(
                 AudioObjectID(kAudioObjectSystemObject),
@@ -412,7 +354,22 @@ public class MicCaptureHandler: @unchecked Sendable {
         // AVFoundation listener blocks firing against a live object all live in
         // the session now, including the "no tap was installed" guard that keeps
         // an input-less host from raising in the deinit path.
-        session.teardown()
+        //
+        // Skipped entirely when an attempt is stuck inside the engine: the
+        // attempt's own stale-commit path tears down what it built, and the
+        // engine it is wedged in is unreachable either way.
+        switch decision {
+        case .teardown:
+            session.teardown()
+
+        case .sealAndSkipEngine:
+            logger.warning("Mic: stopping while a restart attempt is outstanding — leaving its engine alone")
+
+        default:
+            // Already stopped. Nothing to release, and touching the engine again
+            // would be a double teardown via deinit.
+            break
+        }
         outputFile = nil
         logger.info("Mic recording stopped")
     }
@@ -539,7 +496,7 @@ private extension MicCaptureHandler {
     /// No-op in production. When a `DebugTapFault` was injected: once, after the
     /// first successful start, schedule a single self-triggered device-change
     /// restart whose tap install uses the bad format. Drives the real
-    /// handleDeviceChange → executeRestart → startEngine path so the
+    /// handleDeviceChange -> launchRestartAttempt -> startEngine path so the
     /// reproduction exercises production code, not a shortcut.
     func armDebugFaultIfNeeded() {
         guard let debugFault, !debugFaultArmed else { return }

--- a/tools/audiotap/Sources/MicEngineSession.swift
+++ b/tools/audiotap/Sources/MicEngineSession.swift
@@ -60,7 +60,9 @@ final class MicEngineSession: MicEngineSessionProviding {
 
     private(set) var tapInstalled = false
 
-    var notificationObject: AnyObject { engine }
+    var notificationObject: AnyObject {
+        engine
+    }
 
     init(removeInputTap: @escaping (AVAudioEngine) -> Void = { $0.inputNode.removeTap(onBus: 0) }) {
         self.removeInputTap = removeInputTap

--- a/tools/audiotap/Sources/MicEngineSession.swift
+++ b/tools/audiotap/Sources/MicEngineSession.swift
@@ -1,0 +1,157 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "MicEngineSession")
+
+/// Everything in the microphone path that touches `AVAudioEngine` or CoreAudio,
+/// behind a protocol so the rest of `MicCaptureHandler` can be tested without
+/// audio hardware.
+///
+/// Two reasons this seam exists, and only the second one is about tests:
+///
+/// 1. A session is exactly one engine's lifetime. A restart after a device
+///    change discards the old session and builds a new one, which is what the
+///    code already did by replacing the `AVAudioEngine` instance; naming it
+///    makes the boundary explicit.
+/// 2. The bring-up calls can block forever: `hardwareFormat`, `installTap` and
+///    `start`. `hardwareFormat` is the one that wedged in issue #588. On a fresh
+///    engine it loops inside AVFAudio when the default-device aggregate still
+///    references a Bluetooth device that just vanished, and it cannot be
+///    cancelled. Isolating those calls lets a test substitute a session that
+///    blocks on demand, and lets the handler reason about "an attempt may be
+///    stuck in here" in one place.
+///
+///    `teardown` is deliberately NOT in that class, and that assumption is
+///    load-bearing: it runs on the main queue, exactly as `stop()` always has,
+///    against an engine whose IO unit is already built, so it does not take the
+///    path that loops. If it could block forever, running it on main would
+///    reintroduce the freeze this whole design exists to prevent.
+///
+/// The CI runner has no input device at all, so no test may ever construct a
+/// real session. That is a hard constraint, not a preference: reading
+/// `AVAudioEngine.inputNode` on an input-less host raises an uncatchable
+/// NSException.
+protocol MicEngineSessionProviding: AnyObject {
+    /// The object `AVAudioEngineConfigurationChange` notifications are keyed on.
+    var notificationObject: AnyObject { get }
+
+    /// Bring the engine up far enough to report the live hardware format,
+    /// pinning `deviceUID` when one is given and still present.
+    ///
+    /// This is the call that can wedge. Everything after it is cheap.
+    func hardwareFormat(deviceUID: String?) throws -> AVAudioFormat
+
+    /// Attach the capture tap. Raises from AVFAudio are bridged to throws.
+    func installTap(format: AVAudioFormat, block: @escaping AVAudioNodeTapBlock) throws
+
+    /// `prepare()` + `start()`.
+    func start() throws
+
+    /// Remove the tap if one was installed, stop and reset the engine.
+    func teardown()
+}
+
+/// The real implementation, wrapping one `AVAudioEngine`.
+final class MicEngineSession: MicEngineSessionProviding {
+    private var engine = AVAudioEngine()
+    private let removeInputTap: (AVAudioEngine) -> Void
+
+    private(set) var tapInstalled = false
+
+    var notificationObject: AnyObject { engine }
+
+    init(removeInputTap: @escaping (AVAudioEngine) -> Void = { $0.inputNode.removeTap(onBus: 0) }) {
+        self.removeInputTap = removeInputTap
+    }
+
+    func hardwareFormat(deviceUID: String?) throws -> AVAudioFormat {
+        // No input device at all (a Mac mini without a mic, a CI runner):
+        // reading `inputNode` would raise an uncatchable NSException.
+        guard AVCaptureDevice.default(for: .audio) != nil else {
+            throw MicCaptureError.noInputDevice
+        }
+
+        let inputNode = engine.inputNode
+
+        if let uid = deviceUID {
+            var deviceID = Self.deviceIDForUID(uid)
+            if deviceID != kAudioObjectUnknown {
+                let audioUnit = inputNode.audioUnit! // swiftlint:disable:this force_unwrapping
+                AudioUnitSetProperty(
+                    audioUnit,
+                    kAudioOutputUnitProperty_CurrentDevice,
+                    kAudioUnitScope_Global, 0,
+                    &deviceID, UInt32(MemoryLayout<AudioDeviceID>.size),
+                )
+                logger.info("Mic device set: \(uid) (ID \(deviceID))")
+            } else {
+                logger.warning("Unknown mic device UID '\(uid)', using default")
+            }
+        }
+
+        return inputNode.outputFormat(forBus: 0)
+    }
+
+    func installTap(format: AVAudioFormat, block: @escaping AVAudioNodeTapBlock) throws {
+        do {
+            try engine.inputNode.safeInstallTap(onBus: 0, bufferSize: 4096, format: format, block: block)
+        } catch {
+            logger.error("Mic: installTap failed (\(error.localizedDescription, privacy: .public)) — restart will retry")
+            throw error
+        }
+        // inputNode accessed and a tap attached: teardown must remove it even if
+        // start() throws afterwards.
+        tapInstalled = true
+    }
+
+    func start() throws {
+        engine.prepare()
+        try engine.start()
+    }
+
+    func teardown() {
+        // Skip the inputNode teardown when no tap was installed — the getter
+        // raises an uncatchable NSException on an input-less host.
+        if tapInstalled {
+            removeInputTap(engine)
+            tapInstalled = false
+        }
+        engine.stop()
+        engine.reset()
+
+        // Hold a strong reference to the engine for a grace period so any
+        // in-flight `AVAudioIOUnit::IOUnitPropertyListener` blocks that
+        // AVFoundation queued on a libdispatch worker fire against a live
+        // object. Without this hold, dropping the last reference races those
+        // blocks and crashes with EXC_BAD_ACCESS in `objc_msgSend` on the freed
+        // engine.
+        let retained = engine
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            _ = retained
+        }
+    }
+
+    /// Resolve a device UID to its current `AudioDeviceID`, or
+    /// `kAudioObjectUnknown` when the device is gone. Plain CoreAudio, no engine
+    /// involved, so the restart policy can ask "is my device still there" without
+    /// going anywhere near the calls that can wedge.
+    static func deviceIDForUID(_ uid: String) -> AudioDeviceID {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslateUIDToDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var deviceID: AudioDeviceID = kAudioObjectUnknown
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var cfUID: Unmanaged<CFString>? = Unmanaged.passUnretained(uid as CFString)
+        let qualifierSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, qualifierSize, &cfUID,
+            &size, &deviceID,
+        )
+        return deviceID
+    }
+}

--- a/tools/audiotap/Sources/RestartArbiter.swift
+++ b/tools/audiotap/Sources/RestartArbiter.swift
@@ -122,7 +122,9 @@ struct RestartArbiter: Equatable {
 
     /// True only while capture is actually running: the render-thread tap block
     /// uses this to short-circuit once a restart, a give-up or a stop has begun.
-    var isCapturing: Bool { phase == .capturing }
+    var isCapturing: Bool {
+        phase == .capturing
+    }
 
     mutating func handle(_ event: Event) -> Action {
         switch (phase, event) {

--- a/tools/audiotap/Sources/RestartArbiter.swift
+++ b/tools/audiotap/Sources/RestartArbiter.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Phase machine that bounds a *single* capture-restart attempt (issue #588).
+///
+/// Why this exists: a restart attempt can enter an unbounded loop inside AVFAudio
+/// and never return. `-[AVAudioEngine inputNode]` on a fresh engine loops in
+/// `AVAudioIOUnit_OSX::_GetHWFormat` when the per-process default-device
+/// aggregate still holds dangling sub-device references to a Bluetooth device
+/// that just vanished. The call cannot be cancelled, and in the field it returned
+/// only when the device came back three hours later.
+///
+/// `MicRestartRetryPolicy` bounds how *many* attempts are made and is unaffected:
+/// a restart that fails is the transient case it was built for. This type bounds
+/// how *long* one attempt may take, and it makes the outcome safe if a wedged
+/// attempt eventually returns:
+///
+/// - every attempt carries a generation, and a result whose generation is no
+///   longer current is rejected rather than adopted,
+/// - once an attempt has timed out, output-file creation is forbidden forever,
+///   because the restart path recreates the WAV for writing when it finds no
+///   open file, which would truncate the finished recording to zero,
+/// - `stop()` learns that it must not touch the engine while an attempt is in
+///   flight, since the wedged attempt holds the engine's mutex.
+///
+/// Pure value type so the whole transition table is unit-testable without an
+/// engine, following `OutputDeviceChangeCoordinator` and `MicRestartRetryPolicy`.
+struct RestartArbiter: Equatable {
+    /// How long a single restart attempt may take before it counts as wedged.
+    ///
+    /// A healthy restart completes in roughly 300 ms (measured). The timeout only
+    /// has to separate "never returns" from "slow", so it sits far above the
+    /// healthy case: the cost of firing too early is a sacrificed microphone
+    /// track on a Bluetooth renegotiation that would have succeeded.
+    static let attemptTimeout: TimeInterval = 5.0
+
+    enum Phase: Equatable {
+        /// Nothing captured yet, or never started.
+        case idle
+        /// Capturing normally; no restart outstanding.
+        case capturing
+        /// A restart attempt was launched and has not reported back. It may be
+        /// wedged, so nothing may touch the engine and no second attempt starts.
+        case attemptInFlight(generation: Int)
+        /// An attempt came back with an error and the next one is waiting out its
+        /// backoff. A device change here is deliberately ignored: a flapping
+        /// device would otherwise skip the pacing by supplying a fresh event.
+        case backingOff
+        /// An attempt succeeded and is waiting to be adopted. The work exists but
+        /// is published to nothing yet, so a stop arriving now still wins.
+        case committing(generation: Int)
+        /// The track was abandoned, either because an attempt exceeded
+        /// `attemptTimeout` or because the retry budget ran out. Terminal: the
+        /// wedged thread and its engine are unrecoverable, and a further attempt
+        /// in the same process can wedge again because HAL client state is
+        /// process-global.
+        case gaveUp
+        /// `stop()` was honoured. Terminal.
+        case stopped
+    }
+
+    enum Event: Equatable {
+        /// Capture started (or restarted) successfully.
+        case startSucceeded
+        /// The default input device changed underneath us.
+        case deviceChanged
+        /// A launched attempt reported back. Carries its own generation so a
+        /// late report from a superseded attempt can be told apart.
+        case attemptReturned(generation: Int, succeeded: Bool)
+        /// A successful attempt reached the queue that owns publication and is
+        /// asking to be adopted.
+        case commitReady(generation: Int)
+        /// The backoff elapsed. Carries no generation because every control event
+        /// except `attemptReturned` arrives on the main queue, so at most one
+        /// retry timer exists per backoff.
+        case retryDue
+        /// The retry budget ran out on attempts that all came back with errors.
+        /// Deliberately distinct from `attemptTimedOut`, which is generation
+        /// scoped and only meaningful for an attempt that never returned.
+        case retryBudgetExhausted
+        /// The watchdog for `generation` fired.
+        case attemptTimedOut(generation: Int)
+        /// `stop()` was called.
+        case stopRequested
+    }
+
+    enum Action: Equatable {
+        case ignore
+        /// Launch a restart attempt tagged with this generation.
+        case launchAttempt(generation: Int)
+        /// The attempt's result is good; hand it to the queue that publishes.
+        case commit
+        /// Publish the attempt's result now.
+        case adopt
+        /// Discard the attempt's result and let it tear down whatever it built.
+        /// It must not touch shared state.
+        case rejectStale
+        /// The track is abandoned: either an attempt never returned, or the retry
+        /// budget ran out on attempts that did. Seal the session and notify; a
+        /// channel that owns an output file also finalizes it. Never retry.
+        case giveUp
+        /// The attempt returned an error. The existing backoff budget applies.
+        case retry
+        /// Normal `stop()`: touching the engine is safe.
+        case teardown
+        /// `stop()` while wedged or after giving up: seal the state and leave the
+        /// engine alone, or the caller wedges too.
+        case sealAndSkipEngine
+    }
+
+    private(set) var phase: Phase = .idle
+    private var generation = 0
+
+    /// False once the session is sealed. The restart path creates the output file
+    /// whenever it finds none open, so a late-returning wedged attempt would
+    /// otherwise overwrite a recording that was already finalized.
+    var mayCreateOutputFile: Bool {
+        switch phase {
+        case .idle, .capturing, .attemptInFlight, .backingOff, .committing: true
+        case .gaveUp, .stopped: false
+        }
+    }
+
+    /// True only while capture is actually running: the render-thread tap block
+    /// uses this to short-circuit once a restart, a give-up or a stop has begun.
+    var isCapturing: Bool { phase == .capturing }
+
+    mutating func handle(_ event: Event) -> Action {
+        switch (phase, event) {
+        case (.idle, .startSucceeded), (.capturing, .startSucceeded):
+            phase = .capturing
+            return .ignore
+
+        case (.capturing, .deviceChanged), (.capturing, .retryDue), (.backingOff, .retryDue):
+            generation += 1
+            phase = .attemptInFlight(generation: generation)
+            return .launchAttempt(generation: generation)
+
+        case let (.attemptInFlight(current), .attemptReturned(reported, succeeded)) where reported == current:
+            phase = succeeded ? .committing(generation: current) : .backingOff
+            return succeeded ? .commit : .retry
+
+        case let (.committing(current), .commitReady(reported)) where reported == current:
+            phase = .capturing
+            return .adopt
+
+        // Only an attempt that is still outstanding can time out. Once it has
+        // returned, the generation still matches for a moment while the commit
+        // hops queues; letting the match win there would kill a healthy restart.
+        case let (.attemptInFlight(current), .attemptTimedOut(reported)) where reported == current:
+            phase = .gaveUp
+            return .giveUp
+
+        case (.backingOff, .retryBudgetExhausted):
+            phase = .gaveUp
+            return .giveUp
+
+        case (.attemptInFlight, .stopRequested), (.gaveUp, .stopRequested):
+            phase = .stopped
+            return .sealAndSkipEngine
+
+        // Nothing holds the engine here: either no attempt is outstanding, or the
+        // one that was has already returned. Sealing instead would leave a live
+        // engine running until deinit.
+        case (.idle, .stopRequested), (.capturing, .stopRequested),
+             (.backingOff, .stopRequested), (.committing, .stopRequested):
+            phase = .stopped
+            return .teardown
+
+        // A result from an attempt that is no longer the current one. Reachable
+        // hours later: the wedged call does return if the device comes back.
+        case (_, .attemptReturned), (_, .commitReady):
+            return .rejectStale
+
+        // A watchdog whose attempt already reported back, or any control event in
+        // a sealed session.
+        case (_, .attemptTimedOut), (_, .deviceChanged), (_, .startSucceeded),
+             (_, .stopRequested), (_, .retryDue), (_, .retryBudgetExhausted):
+            return .ignore
+        }
+    }
+}

--- a/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
@@ -1,0 +1,157 @@
+@testable import AudioTapLib
+import XCTest
+
+/// The app-audio tap has the same hole the microphone path had (issue #588):
+/// `OutputDeviceChangeCoordinator` bounds how many restart attempts are made, not
+/// how long one may take, and the attempt ran on the main queue. In the incident
+/// that cost the entire remote track for three hours, because the tap teardown
+/// had already happened and its rebuild sat behind the wedged main thread while
+/// the built-in speakers were healthy the whole time.
+@available(macOS 14.2, *)
+final class AppAudioCaptureWedgeTests: XCTestCase {
+    /// Stands in for the HAL calls `startCapture` makes, with the same shape the
+    /// real wedge has: while blocked it holds a lock every other operation also
+    /// takes, so a give-up path that still tears resources down deadlocks the
+    /// test instead of passing it.
+    private final class Attempt {
+        private let halLock = NSLock()
+        private let gate = DispatchSemaphore(value: 0)
+        private let countLock = NSLock()
+        private var _starts = 0
+
+        var shouldWedge = false
+        /// When true, the attempt THROWS instead, so the coordinator's retry
+        /// budget is what runs out rather than a deadline.
+        var shouldFail = false
+        let entered = XCTestExpectation(description: "attempt entered the wedging call")
+
+        var starts: Int {
+            countLock.lock(); defer { countLock.unlock() }
+            return _starts
+        }
+
+        func release() { gate.signal() }
+
+        func run() throws {
+            countLock.lock(); _starts += 1; countLock.unlock()
+            if shouldFail { throw MicCaptureError.noInputDevice }
+            guard shouldWedge else { return }
+            halLock.lock()
+            defer { halLock.unlock() }
+            entered.fulfill()
+            gate.wait()
+        }
+
+        /// What a teardown would do: taking the same lock the wedged call holds.
+        func teardown() {
+            halLock.lock()
+            halLock.unlock()
+        }
+    }
+
+    private func makeCapture(_ attempt: Attempt) -> AppAudioCapture {
+        AppAudioCapture(pids: [1], outputFileDescriptor: FileHandle.nullDevice.fileDescriptor) {
+            try attempt.run()
+        }
+    }
+
+    func testAWedgedRestartDoesNotBlockTheMainThread() throws {
+        let attempt = Attempt()
+        let capture = makeCapture(attempt)
+        defer { attempt.release() }
+
+        try capture.start()
+        attempt.shouldWedge = true
+        capture.handleOutputDeviceChanged()
+        wait(for: [attempt.entered], timeout: 5)
+
+        let mainIsAlive = expectation(description: "main queue still services work")
+        DispatchQueue.main.async { mainIsAlive.fulfill() }
+        wait(for: [mainIsAlive], timeout: 2)
+    }
+
+    func testAWedgedRestartGivesUpWithinTheDeadline() throws {
+        let attempt = Attempt()
+        let capture = makeCapture(attempt)
+        defer { attempt.release() }
+
+        let gaveUp = expectation(description: "give-up reported")
+        capture.onGiveUp = { gaveUp.fulfill() }
+
+        try capture.start()
+        attempt.shouldWedge = true
+        capture.handleOutputDeviceChanged()
+
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+    }
+
+    func testNoFurtherAttemptRunsAfterAGiveUp() throws {
+        let attempt = Attempt()
+        let capture = makeCapture(attempt)
+        defer { attempt.release() }
+
+        let gaveUp = expectation(description: "give-up reported")
+        capture.onGiveUp = { gaveUp.fulfill() }
+
+        try capture.start()
+        attempt.shouldWedge = true
+        capture.handleOutputDeviceChanged()
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+
+        let startsAtGiveUp = attempt.starts
+        // Another device change while the old attempt is still stuck must not
+        // start a second one: each wedged attempt leaks a thread.
+        capture.handleOutputDeviceChanged()
+        let settled = expectation(description: "any retry would have run by now")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertEqual(attempt.starts, startsAtGiveUp)
+    }
+
+    func testAScheduledRetryDoesNotResurrectCaptureAfterAStop() throws {
+        // No wedge needed for this one. A device change schedules a retry, the
+        // user stops the recording before it fires, and the retry used to run
+        // anyway and bring capture back up against a file descriptor the session
+        // had already closed. Removing a headset as the meeting ends is exactly
+        // this timing.
+        let attempt = Attempt()
+        let capture = makeCapture(attempt)
+        capture.deviceChangeCoordinator = OutputDeviceChangeCoordinator(
+            initialRestartDelay: 0.05, retryDelay: 0.05,
+        )
+
+        try capture.start()
+        let startsAfterStart = attempt.starts
+
+        capture.handleOutputDeviceChanged()
+        capture.stop()
+
+        let settled = expectation(description: "the scheduled retry would have fired by now")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertEqual(attempt.starts, startsAfterStart, "a stopped session must not restart capture")
+    }
+
+    func testAnExhaustedRetryBudgetIsAGiveUpHereToo() throws {
+        // The other way the app track dies: attempts that RETURN with an error
+        // until the coordinator's budget runs out. The microphone path treats
+        // that as a full give-up, and the channel-health message the user sees
+        // depends on it, so the two channels must agree.
+        let attempt = Attempt()
+        let capture = makeCapture(attempt)
+        capture.deviceChangeCoordinator = OutputDeviceChangeCoordinator(
+            initialRestartDelay: 0.05, retryDelay: 0.05,
+        )
+
+        let gaveUp = expectation(description: "give-up reported")
+        capture.onGiveUp = { gaveUp.fulfill() }
+
+        try capture.start()
+        attempt.shouldFail = true
+        capture.handleOutputDeviceChanged()
+
+        wait(for: [gaveUp], timeout: 10)
+    }
+}

--- a/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
@@ -30,7 +30,9 @@ final class AppAudioCaptureWedgeTests: XCTestCase {
             return _starts
         }
 
-        func release() { gate.signal() }
+        func release() {
+            gate.signal()
+        }
 
         func run() throws {
             countLock.lock(); _starts += 1; countLock.unlock()

--- a/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
@@ -42,7 +42,9 @@ final class MicCaptureHandlerWedgeTests: XCTestCase {
         // swiftlint:disable:next force_unwrapping
         var format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)!
 
-        func release() { wedge.signal() }
+        func release() {
+            wedge.signal()
+        }
 
         func hardwareFormat(deviceUID _: String?) throws -> AVAudioFormat {
             record("hardwareFormat")
@@ -180,8 +182,11 @@ final class MicCaptureHandlerWedgeTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { settled.fulfill() }
         wait(for: [settled], timeout: 5)
 
-        XCTAssertEqual(try Data(contentsOf: url), afterGiveUp,
-                       "the finished recording must be byte-identical after a late return")
+        XCTAssertEqual(
+            try Data(contentsOf: url),
+            afterGiveUp,
+            "the finished recording must be byte-identical after a late return",
+        )
     }
 
     func testATimedOutAttemptSchedulesNoRetry() throws {
@@ -251,8 +256,11 @@ final class MicCaptureHandlerWedgeTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) { settled.fulfill() }
         wait(for: [settled], timeout: 5)
 
-        XCTAssertEqual(try Data(contentsOf: url), afterGiveUp,
-                       "a sealed session must not recreate and truncate the recording")
+        XCTAssertEqual(
+            try Data(contentsOf: url),
+            afterGiveUp,
+            "a sealed session must not recreate and truncate the recording",
+        )
     }
 
     // MARK: - Publication

--- a/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
@@ -1,0 +1,333 @@
+@testable import AudioTapLib
+@preconcurrency import AVFoundation
+import XCTest
+
+/// What happens when a restart attempt never returns (issue #588).
+///
+/// The fake below deliberately mirrors the real failure's shape in one respect
+/// that a naive fake would miss: the wedged AVFAudio call holds the engine's
+/// internal mutex, so every other engine operation blocks behind it. A fake that
+/// merely sleeps would let a give-up path that still calls `teardown()` pass the
+/// test while the real app freezes solid. So the blocking operation here holds a
+/// lock that every other method also takes, and the test asserts on the recorded
+/// calls rather than on timing.
+final class MicCaptureHandlerWedgeTests: XCTestCase {
+    /// A session whose `hardwareFormat` can be made to block forever while
+    /// holding the "engine mutex".
+    private final class WedgingSession: MicEngineSessionProviding {
+        /// Stands in for AVAudioEngine's internal recursive mutex.
+        private let engineMutex = NSLock()
+        private let recordLock = NSLock()
+        private var _calls: [String] = []
+        private let wedge = DispatchSemaphore(value: 0)
+
+        /// When true, `hardwareFormat` blocks until `release()` is called.
+        var shouldWedge = false
+        /// When true, `hardwareFormat` throws instead, so the attempt RETURNS with
+        /// an error and the retry budget is what runs out.
+        var shouldFail = false
+        /// Set once the wedged call has actually entered and taken the mutex.
+        let entered = XCTestExpectation(description: "attempt entered the wedging call")
+
+        var calls: [String] {
+            recordLock.lock(); defer { recordLock.unlock() }
+            return _calls
+        }
+
+        private func record(_ s: String) {
+            recordLock.lock(); _calls.append(s); recordLock.unlock()
+        }
+
+        let notificationObject: AnyObject = NSObject()
+        // swiftlint:disable:next force_unwrapping
+        var format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)!
+
+        func release() { wedge.signal() }
+
+        func hardwareFormat(deviceUID _: String?) throws -> AVAudioFormat {
+            record("hardwareFormat")
+            if shouldFail { throw MicCaptureError.noInputDevice }
+            if shouldWedge {
+                engineMutex.lock()
+                defer { engineMutex.unlock() }
+                entered.fulfill()
+                wedge.wait()
+            }
+            return format
+        }
+
+        /// The handler's real tap block, so a test can drive actual audio through
+        /// the production write path instead of leaving the WAV header-only.
+        var tapBlock: AVAudioNodeTapBlock?
+
+        func installTap(format: AVAudioFormat, block: @escaping AVAudioNodeTapBlock) {
+            engineMutex.lock(); defer { engineMutex.unlock() }
+            record("installTap(\(Int(format.sampleRate)))")
+            tapBlock = block
+        }
+
+        func start() {
+            engineMutex.lock(); defer { engineMutex.unlock() }
+            record("start")
+        }
+
+        func teardown() {
+            // Taking the same mutex is the point: if a give-up path calls this
+            // while an attempt is wedged, the test deadlocks instead of passing.
+            engineMutex.lock(); defer { engineMutex.unlock() }
+            record("teardown")
+        }
+    }
+
+    /// One buffer of non-silent audio in the session's format.
+    private func makeBuffer(_ format: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4096))
+        buffer.frameLength = 4096
+        for channel in 0 ..< Int(format.channelCount) {
+            let samples = try XCTUnwrap(buffer.floatChannelData)[channel]
+            for frame in 0 ..< 4096 {
+                samples[frame] = Float(sin(Double(frame) * 0.05)) * 0.5
+            }
+        }
+        return buffer
+    }
+
+    private func makeHandler(
+        sessions: [WedgingSession],
+    ) -> (MicCaptureHandler, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wedge-\(UUID().uuidString).wav")
+        var remaining = sessions
+        let handler = MicCaptureHandler(outputURL: url) {
+            remaining.isEmpty ? WedgingSession() : remaining.removeFirst()
+        }
+        return (handler, url)
+    }
+
+    // MARK: -
+
+    func testAWedgedAttemptDoesNotBlockTheMainThread() throws {
+        // The whole point of the fix: one stuck CoreAudio call must cost the
+        // microphone track, not the application.
+        let first = WedgingSession()
+        let wedging = WedgingSession()
+        wedging.shouldWedge = true
+        let (handler, url) = makeHandler(sessions: [first, wedging])
+        defer { try? FileManager.default.removeItem(at: url); wedging.release() }
+
+        try handler.start()
+        handler.handleDeviceChange()
+        wait(for: [wedging.entered], timeout: 5)
+
+        let mainIsAlive = expectation(description: "main queue still services work")
+        DispatchQueue.main.async { mainIsAlive.fulfill() }
+        wait(for: [mainIsAlive], timeout: 2)
+    }
+
+    func testAWedgedAttemptGivesUpWithinTheDeadline() throws {
+        let first = WedgingSession()
+        let wedging = WedgingSession()
+        wedging.shouldWedge = true
+        let (handler, url) = makeHandler(sessions: [first, wedging])
+        defer { try? FileManager.default.removeItem(at: url); wedging.release() }
+
+        let gaveUp = expectation(description: "give-up reported")
+        handler.onGiveUp = { gaveUp.fulfill() }
+
+        try handler.start()
+        handler.handleDeviceChange()
+
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+        // Give-up must never touch the wedged engine: the fake's teardown takes
+        // the mutex the wedged call holds, so a call here would hang, but assert
+        // it explicitly so the intent is visible.
+        XCTAssertFalse(wedging.calls.contains("teardown"))
+    }
+
+    func testALateReturningAttemptDoesNotTruncateTheFinishedRecording() throws {
+        // The trap this whole design exists for. The give-up closes the WAV.
+        // Hours later the wedged call returns, walks on into the code that
+        // recreates the output file for writing, and truncates a finished
+        // recording to zero bytes.
+        let first = WedgingSession()
+        let wedging = WedgingSession()
+        wedging.shouldWedge = true
+        let (handler, url) = makeHandler(sessions: [first, wedging])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let gaveUp = expectation(description: "give-up reported")
+        handler.onGiveUp = { gaveUp.fulfill() }
+
+        try handler.start()
+
+        // Record actual audio through the production tap block, so a truncation
+        // is visible in the file rather than hidden behind an empty header.
+        let block = try XCTUnwrap(first.tapBlock)
+        let buffer = try makeBuffer(first.format)
+        for _ in 0 ..< 10 {
+            block(buffer, AVAudioTime(hostTime: mach_absolute_time()))
+        }
+
+        handler.handleDeviceChange()
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+
+        let afterGiveUp = try Data(contentsOf: url)
+        XCTAssertGreaterThan(afterGiveUp.count, 10000, "the recording must contain real audio, not just a header")
+
+        // The wedged call returns and the attempt runs to completion.
+        wedging.release()
+        let settled = expectation(description: "late attempt settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertEqual(try Data(contentsOf: url), afterGiveUp,
+                       "the finished recording must be byte-identical after a late return")
+    }
+
+    func testATimedOutAttemptSchedulesNoRetry() throws {
+        // A restart that FAILS may retry; one that never returns may not, because
+        // each wedged attempt leaks a thread burning about a third of a core.
+        let first = WedgingSession()
+        let wedging = WedgingSession()
+        wedging.shouldWedge = true
+        let third = WedgingSession()
+        let (handler, url) = makeHandler(sessions: [first, wedging, third])
+        defer { try? FileManager.default.removeItem(at: url); wedging.release() }
+
+        let gaveUp = expectation(description: "give-up reported")
+        handler.onGiveUp = { gaveUp.fulfill() }
+
+        try handler.start()
+        handler.handleDeviceChange()
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+
+        let settled = expectation(description: "any retry would have run by now")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertTrue(third.calls.isEmpty, "no further attempt may be started after a give-up")
+    }
+
+    func testAnExhaustedRetryBudgetEndsTheTrackWithoutLosingIt() throws {
+        // The other way to give up: attempts that all RETURN with an error until
+        // the budget runs out. End to end, that must report a give-up and leave
+        // the recording intact.
+        //
+        // Honest limitation, established by falsification: this test does NOT
+        // pin the sealing itself. Reinstating the old broken seal leaves it
+        // green, because the backoff phase already makes `isRecording` false and
+        // the restart policy declines on that alone. What pins the seal is
+        // `testSealingAfterAReturnedFailureActuallySeals` at the arbiter layer.
+        // Both are kept: that one guards the invariant, this one guards the path.
+        let first = WedgingSession()
+        let failing = (0 ..< 8).map { _ -> WedgingSession in
+            let session = WedgingSession()
+            session.shouldFail = true
+            return session
+        }
+        let (handler, url) = makeHandler(sessions: [first] + failing)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let gaveUp = expectation(description: "give-up reported")
+        handler.onGiveUp = { gaveUp.fulfill() }
+
+        try handler.start()
+        let block = try XCTUnwrap(first.tapBlock)
+        let buffer = try makeBuffer(first.format)
+        for _ in 0 ..< 10 {
+            block(buffer, AVAudioTime(hostTime: mach_absolute_time()))
+        }
+
+        handler.handleDeviceChange()
+        // The backoff schedule sums to a few seconds across the whole budget.
+        wait(for: [gaveUp], timeout: 30)
+
+        let afterGiveUp = try Data(contentsOf: url)
+        XCTAssertGreaterThan(afterGiveUp.count, 10000, "the recording must contain real audio")
+
+        // The flapping device supplies one more event.
+        handler.handleDeviceChange()
+        let settled = expectation(description: "any relaunch would have run by now")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertEqual(try Data(contentsOf: url), afterGiveUp,
+                       "a sealed session must not recreate and truncate the recording")
+    }
+
+    // MARK: - Publication
+
+    /// Drain the main queue until `condition` holds. Adoption is dispatched to the
+    /// main queue from the restart queue, so there is no expectation the fake can
+    /// fulfil at the right moment: the observable is the handler's own state after
+    /// that block ran.
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool,
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(condition(), description, file: file, line: line)
+    }
+
+    func testASuccessfulAttemptBecomesTheLiveSession() throws {
+        // The happy half of the publication rule, which the wedge tests above can
+        // never reach: their fake never returns, so nothing is ever adopted.
+        let first = WedgingSession()
+        let candidate = WedgingSession()
+        let (handler, url) = makeHandler(sessions: [first, candidate])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try handler.start()
+        XCTAssertIdentical(handler.session as AnyObject, first, "start() must install the first session")
+
+        handler.handleDeviceChange()
+        waitUntil("the successful attempt became the live session") {
+            (handler.session as AnyObject) === candidate
+        }
+
+        XCTAssertFalse(
+            candidate.calls.contains("teardown"),
+            "an adopted session must not also be torn down — it is the live one now",
+        )
+        XCTAssertTrue(
+            first.calls.contains("teardown"),
+            "the outgoing session must be released, or every device change leaks an engine",
+        )
+    }
+
+    func testAnAttemptThatSucceedsAfterAStopIsDiscarded() throws {
+        // The rule the whole arbiter exists for, asserted on the handler rather
+        // than on the state machine: a restart that comes back after the session
+        // was sealed must publish nothing. `RestartArbiterTests` pins the decision
+        // (commitReady on a sealed session is rejectStale); this pins the reaction.
+        let first = WedgingSession()
+        let candidate = WedgingSession()
+        candidate.shouldWedge = true
+        let (handler, url) = makeHandler(sessions: [first, candidate])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try handler.start()
+        handler.handleDeviceChange()
+        wait(for: [candidate.entered], timeout: 5)
+
+        // Sealing while the attempt sits inside the engine must not block here:
+        // that is the .sealAndSkipEngine branch, which deliberately leaves the
+        // engine the attempt is stuck in alone.
+        handler.stop()
+        candidate.release()
+
+        waitUntil("the late attempt tore its own work down") {
+            candidate.calls.contains("teardown")
+        }
+        XCTAssertNotIdentical(
+            handler.session as AnyObject, candidate,
+            "a restart that finished after the stop must never become the live session",
+        )
+    }
+}

--- a/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
+++ b/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
@@ -44,7 +44,9 @@ final class MicEngineSessionSeamTests: XCTestCase {
             tapInstalled = true
         }
 
-        func start() { calls.append(.start) }
+        func start() {
+            calls.append(.start)
+        }
 
         func teardown() {
             calls.append(.teardown)

--- a/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
+++ b/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
@@ -1,0 +1,112 @@
+@testable import AudioTapLib
+@preconcurrency import AVFoundation
+import XCTest
+
+/// Pins that `MicCaptureHandler` drives its engine through `MicEngineSessionProviding`
+/// and touches no `AVAudioEngine` itself.
+///
+/// This matters beyond tidiness: every call that can wedge (issue #588) now lives
+/// behind this seam, so a test can substitute a session that never reaches audio
+/// hardware. That is not optional, it is the only way these paths are testable at
+/// all: the CI runner has no input device, and reading `AVAudioEngine.inputNode`
+/// there raises an uncatchable NSException.
+final class MicEngineSessionSeamTests: XCTestCase {
+    /// Records what the handler asked of its session, in order.
+    private final class FakeSession: MicEngineSessionProviding {
+        enum Call: Equatable {
+            case hardwareFormat(deviceUID: String?)
+            case installTap(sampleRate: Double)
+            case start
+            case teardown
+        }
+
+        private(set) var calls: [Call] = []
+        let notificationObject: AnyObject = NSObject()
+        /// Local bookkeeping, not a protocol requirement: nothing in production
+        /// asks a session whether its tap is attached.
+        private(set) var tapInstalled = false
+        // 44.1 kHz stereo, the format a built-in mic reports after a Bluetooth
+        // device goes away (measured in the incident). Force-unwrapped because a
+        // standard format at a valid rate cannot fail, and a fake that cannot be
+        // built is a broken test either way.
+        // swiftlint:disable:next force_unwrapping
+        var format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)!
+        var hardwareFormatError: Error?
+
+        func hardwareFormat(deviceUID: String?) throws -> AVAudioFormat {
+            calls.append(.hardwareFormat(deviceUID: deviceUID))
+            if let hardwareFormatError { throw hardwareFormatError }
+            return format
+        }
+
+        func installTap(format: AVAudioFormat, block _: AVAudioNodeTapBlock) {
+            calls.append(.installTap(sampleRate: format.sampleRate))
+            tapInstalled = true
+        }
+
+        func start() { calls.append(.start) }
+
+        func teardown() {
+            calls.append(.teardown)
+            tapInstalled = false
+        }
+    }
+
+    private func makeHandler(_ session: FakeSession) -> (MicCaptureHandler, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seam-\(UUID().uuidString).wav")
+        let handler = MicCaptureHandler(outputURL: url) { session }
+        return (handler, url)
+    }
+
+    func testStartDrivesTheSessionInOrder() throws {
+        let session = FakeSession()
+        let (handler, url) = makeHandler(session)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try handler.start()
+
+        XCTAssertEqual(session.calls, [
+            .hardwareFormat(deviceUID: nil),
+            .installTap(sampleRate: 44100),
+            .start,
+        ])
+        handler.stop()
+    }
+
+    func testSelectedDeviceIsPassedToTheSession() throws {
+        let session = FakeSession()
+        let (handler, url) = makeHandler(session)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try handler.start(deviceUID: "SomeDeviceUID")
+
+        XCTAssertEqual(session.calls.first, .hardwareFormat(deviceUID: "SomeDeviceUID"))
+        handler.stop()
+    }
+
+    func testStopTearsTheSessionDown() throws {
+        let session = FakeSession()
+        let (handler, url) = makeHandler(session)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try handler.start()
+        handler.stop()
+
+        XCTAssertEqual(session.calls.last, .teardown)
+    }
+
+    func testAFailingHardwareFormatIsPropagatedAndNothingElseRuns() throws {
+        // The wedge point's error path: whatever comes back from the engine must
+        // reach the caller, and the tap must not be installed on a half-built
+        // session.
+        let session = FakeSession()
+        session.hardwareFormatError = MicCaptureError.noInputDevice
+        let (handler, url) = makeHandler(session)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try handler.start())
+        XCTAssertEqual(session.calls, [.hardwareFormat(deviceUID: nil)])
+        XCTAssertFalse(session.tapInstalled)
+    }
+}

--- a/tools/audiotap/Tests/RestartArbiterTests.swift
+++ b/tools/audiotap/Tests/RestartArbiterTests.swift
@@ -1,0 +1,282 @@
+@testable import AudioTapLib
+import XCTest
+
+/// Transition table for `RestartArbiter`, the phase machine that bounds a single
+/// capture-restart attempt (issue #588).
+///
+/// The invariants these pin all come from one live incident: a restart attempt
+/// entered an unbounded loop inside AVFAudio and never returned, so every piece
+/// of state it would have written must stay unwritable afterwards, and the
+/// attempt must remain harmless if the call does eventually return (it did,
+/// three hours later).
+final class RestartArbiterTests: XCTestCase {
+    // MARK: - Launching attempts
+
+    func testDeviceChangeWhileCapturingLaunchesFirstAttempt() {
+        var arbiter = RestartArbiter()
+        XCTAssertEqual(arbiter.handle(.startSucceeded), .ignore)
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .launchAttempt(generation: 1))
+        XCTAssertEqual(arbiter.phase, .attemptInFlight(generation: 1))
+    }
+
+    func testEachDeviceChangeAdvancesTheGeneration() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .launchAttempt(generation: 1))
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: true)), .commit)
+        XCTAssertEqual(arbiter.handle(.commitReady(generation: 1)), .adopt)
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .launchAttempt(generation: 2))
+    }
+
+    func testDeviceChangeDuringAnAttemptDoesNotLaunchASecondOne() {
+        // The in-flight attempt may be wedged. Starting another one would leak a
+        // second thread into the same Apple-side loop.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .ignore)
+        XCTAssertEqual(arbiter.phase, .attemptInFlight(generation: 1))
+    }
+
+    // MARK: - Stale results
+
+    func testLateResultFromASupersededAttemptIsRejected() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptTimedOut(generation: 1))
+        // Three hours later, Apple's call finally returns.
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: true)), .rejectStale)
+        XCTAssertEqual(arbiter.phase, .gaveUp)
+    }
+
+    func testLateResultIsRejectedAfterStopToo() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.stopRequested), .sealAndSkipEngine)
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: true)), .rejectStale)
+        XCTAssertEqual(arbiter.phase, .stopped)
+    }
+
+    func testTimeoutForAStaleGenerationIsANoOp() {
+        // The watchdog for attempt 1 fires after attempt 1 already returned and
+        // attempt 2 is running. It must not kill the healthy attempt.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: true))
+        _ = arbiter.handle(.commitReady(generation: 1))
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.attemptTimedOut(generation: 1)), .ignore)
+        XCTAssertEqual(arbiter.phase, .attemptInFlight(generation: 2))
+    }
+
+    // MARK: - Give-up is terminal
+
+    func testTimeoutGivesUpAndNeverRetries() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.attemptTimedOut(generation: 1)), .giveUp)
+        XCTAssertEqual(arbiter.phase, .gaveUp)
+    }
+
+    func testGiveUpForbidsOutputFileCreationForever() {
+        // The wedged attempt, if it ever returns, walks into the code that
+        // recreates the WAV for writing. That truncates the finished recording.
+        var arbiter = RestartArbiter()
+        XCTAssertTrue(arbiter.mayCreateOutputFile)
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptTimedOut(generation: 1))
+        XCTAssertFalse(arbiter.mayCreateOutputFile)
+        // And nothing can talk it back into allowing it.
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.retryDue)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: true))
+        XCTAssertFalse(arbiter.mayCreateOutputFile)
+    }
+
+    func testDeviceChangeAfterGiveUpIsIgnored() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptTimedOut(generation: 1))
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .ignore)
+        XCTAssertEqual(arbiter.phase, .gaveUp)
+    }
+
+    // MARK: - Returned failures keep the existing retry path
+
+    func testReturnedFailureAsksForARetry() {
+        // A restart that FAILS is the transient case the retry budget exists for.
+        // Only a restart that never returns is terminal.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: false)), .retry)
+        XCTAssertEqual(arbiter.phase, .backingOff)
+    }
+
+    // MARK: - Stop
+
+    func testStopWhileAnAttemptIsInFlightForbidsEngineAccess() {
+        // stop() touches engine.inputNode and engine.stop(). The wedged attempt
+        // holds the engine mutex, so touching it would wedge the caller too.
+        // The action is the whole contract: callers branch on it, they do not
+        // ask a separate predicate.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.stopRequested), .sealAndSkipEngine)
+    }
+
+    func testStopWhileCapturingTearsDownNormally() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        XCTAssertEqual(arbiter.handle(.stopRequested), .teardown)
+        XCTAssertEqual(arbiter.phase, .stopped)
+    }
+
+    func testStopAfterGiveUpSkipsTheEngine() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptTimedOut(generation: 1))
+        XCTAssertEqual(arbiter.handle(.stopRequested), .sealAndSkipEngine)
+        XCTAssertEqual(arbiter.phase, .stopped)
+    }
+
+    func testStopIsIdempotent() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.stopRequested)
+        XCTAssertEqual(arbiter.handle(.stopRequested), .ignore)
+        XCTAssertEqual(arbiter.phase, .stopped)
+    }
+
+    // MARK: - Timeout constant
+
+    func testAttemptTimeoutIsGenerousComparedToAHealthyRestart() {
+        // A healthy restart completes in roughly 300 ms (measured in the incident
+        // log). The timeout only has to catch "never returns", so it is set far
+        // above that to avoid killing a slow but honest Bluetooth renegotiation.
+        XCTAssertGreaterThanOrEqual(RestartArbiter.attemptTimeout, 3.0)
+    }
+
+    // MARK: - Sealing after an exhausted retry budget
+
+    func testSealingAfterAReturnedFailureActuallySeals() {
+        // The retry budget can run out on attempts that DO return. That give-up
+        // has to seal the session exactly like a timeout does, or the next device
+        // change relaunches into a session whose file was already closed and
+        // recreates it, truncating everything recorded so far.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: false)), .retry)
+
+        XCTAssertEqual(arbiter.handle(.retryBudgetExhausted), .giveUp)
+        XCTAssertEqual(arbiter.phase, .gaveUp)
+        XCTAssertFalse(arbiter.mayCreateOutputFile)
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .ignore)
+    }
+
+    // MARK: - The backoff window
+
+    func testDeviceChangeDuringBackoffIsIgnored() {
+        // Restoring the pacing the old isRestarting/retryScheduled flags provided:
+        // a flapping device must not skip the backoff by supplying a fresh event.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: false))
+        XCTAssertEqual(arbiter.handle(.deviceChanged), .ignore)
+        XCTAssertEqual(arbiter.phase, .backingOff)
+    }
+
+    func testTheScheduledRetryLaunchesTheNextAttempt() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: false))
+        XCTAssertEqual(arbiter.handle(.retryDue), .launchAttempt(generation: 2))
+    }
+
+    func testAWatchdogFiringDuringBackoffDoesNotGiveUp() {
+        // A slow failing attempt can return just before its own deadline, so the
+        // watchdog fires while the backoff is already running. Killing the track
+        // there would turn a recoverable transient into a lost channel.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: false))
+        XCTAssertEqual(arbiter.handle(.attemptTimedOut(generation: 1)), .ignore)
+        XCTAssertEqual(arbiter.phase, .backingOff)
+    }
+
+    func testRetryAfterAGiveUpIsIgnored() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptTimedOut(generation: 1))
+        XCTAssertEqual(arbiter.handle(.retryDue), .ignore)
+        XCTAssertEqual(arbiter.handle(.retryBudgetExhausted), .ignore)
+    }
+
+    func testStopDuringBackoffTearsDownNormally() {
+        // Nothing is in flight, so the engine is reachable and must be released.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: false))
+        XCTAssertEqual(arbiter.handle(.stopRequested), .teardown)
+    }
+
+    // MARK: - Two-phase commit
+
+    func testSuccessIsNotCapturingUntilItIsAdopted() {
+        // The attempt returns on the restart queue but publishes nothing until the
+        // main queue adopts it, so stop and adoption are totally ordered.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        XCTAssertEqual(arbiter.handle(.attemptReturned(generation: 1, succeeded: true)), .commit)
+        XCTAssertEqual(arbiter.phase, .committing(generation: 1))
+        XCTAssertFalse(arbiter.isCapturing)
+        XCTAssertEqual(arbiter.handle(.commitReady(generation: 1)), .adopt)
+        XCTAssertEqual(arbiter.phase, .capturing)
+    }
+
+    func testAWatchdogFiringWhileCommittingDoesNotGiveUp() {
+        // The generation still matches here, but the attempt already returned.
+        // Letting the match win would kill a healthy restart.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: true))
+        XCTAssertEqual(arbiter.handle(.attemptTimedOut(generation: 1)), .ignore)
+        XCTAssertEqual(arbiter.phase, .committing(generation: 1))
+    }
+
+    func testAdoptionAfterAStopIsRejected() {
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: true))
+        XCTAssertEqual(arbiter.handle(.stopRequested), .teardown)
+        XCTAssertEqual(arbiter.handle(.commitReady(generation: 1)), .rejectStale)
+    }
+
+    func testStopWhileCommittingTearsDownRatherThanSealing() {
+        // Nothing holds the engine mutex once the attempt returned, so sealing and
+        // skipping here would leave a live tap running.
+        var arbiter = RestartArbiter()
+        _ = arbiter.handle(.startSucceeded)
+        _ = arbiter.handle(.deviceChanged)
+        _ = arbiter.handle(.attemptReturned(generation: 1, succeeded: true))
+        XCTAssertEqual(arbiter.handle(.stopRequested), .teardown)
+        XCTAssertEqual(arbiter.phase, .stopped)
+    }
+}


### PR DESCRIPTION
Fixes the freeze in #588: when a Bluetooth headset disconnects during a recording, the capture restart path could take the whole app down for hours.

## What was wrong

`-[AVAudioEngine inputNode]` on a fresh engine can enter an unbounded loop inside AVFAudio when the per-process default-device aggregate still holds dangling references to a device that just vanished. The call is not blocked, it is executing, and it cannot be cancelled. In the field it returned only when the headset came back, three hours later.

Two things turned that into an app-wide outage rather than a lost microphone track, and both are ours:

- The device-change listener and the restart ran on the **main thread**, so one stuck CoreAudio call froze the menu bar, meeting-end detection and every notification with it.
- A single restart attempt had **no deadline**. `MicRestartRetryPolicy` bounds how many attempts are made, not how long one may take, so once an attempt hung the policy never ran again.

The app-audio path had the identical hole, and in the incident it cost the remote track as well: its tap teardown had already completed and the rebuild scheduled half a second later never ran, while the built-in speakers were healthy the whole time.

## What this does

`RestartArbiter` bounds a single attempt. Attempts run on a dedicated serial queue, carry a generation, and are given a deadline. Timing out is terminal for that track rather than another retry, because each wedged attempt leaks a thread and a large share of a core for the rest of the process, and HAL client state is process-global.

Three properties make a late return harmless, which matters because the call does come back if the device returns:

- The result carries its generation and is rejected rather than adopted; the attempt tears down what it built.
- Output-file creation is refused once the session is sealed. Without that, the returning attempt finds no open file and recreates the WAV for writing, truncating a finished recording to zero.
- `stop()` consults the same state and skips engine teardown while an attempt is outstanding, so freeing the main thread does not simply move the freeze to meeting-end detection calling `stop()`.

`MicEngineSession` puts every `AVAudioEngine` touch behind a protocol so these paths are testable at all: the CI runner has no input device, and reading `inputNode` there raises an uncatchable NSException.

A give-up is now reported as **Capture Channel Lost** with a restart recommendation, instead of riding the generic asymmetric-silence warning, whose advice to check the device cannot help once the track is gone for good.

## Verification

Unit tests use a fake session whose blocking call holds a lock every other method also takes, mirroring the engine mutex. A fake that merely slept would let a give-up path that still tears the engine down pass while the real app froze solid.

Every load-bearing assertion was falsified by removing exactly the mechanism it guards. Two of those falsifications were worth the trouble:

- The truncation test initially stayed green without the guard, because no real audio had been written and both files were header-only. It now records through the production tap block and drops from 33804 to 4096 bytes against unfixed code.
- Removing the arbiter consult from the app-audio `stop()` makes a stopped session restart capture twice more.
- Whether a returned attempt is published had no coverage at all, because the wedge fake never returns and so nothing was ever adopted. Removing the adoption turns one new test red, removing the teardown of an outlived attempt turns the other red. The same pair is deliberately absent for the app-audio channel: its stale attempt is caught before the main-queue publication runs, leaving that branch reachable only through a race window the test seam cannot force, and a test written against it passed with the check removed entirely.

Gates: 236 tests in `tools/audiotap`, 2514 in `app/MeetingTranscriber`, the audiotap suite additionally under `--sanitize=thread` with no races, SwiftLint clean on both packages.

**Field test, and its limits.** A dev build survived three real headset disconnects during live recordings: the automation API kept answering, CPU stayed between 0 and 8 percent, the menu bar stayed responsive. The most useful run took the failure branch and exercised the rewritten retry path end to end:

```
Mic: installTap failed  ->  Mic: restart retry 1/5  ->  Mic: engine restarted (48000 Hz)
```

That is the same sequence the incident logged before it froze, completing in about 90 ms this time. An earlier run rebuilt the app-audio tap in 0.66 s after an output change.

None of those runs wedged, so the watchdog and the give-up notification are **field-unproven and test-proven**: they are pinned by the unit tests above, verified red against the unfixed code, not by a field observation. The wedge needs an unlucky HAL state that does not arrive on demand.

## Deliberately not in this PR

`AppAudioCapture.startCapture` still writes its tap, aggregate and IOProc identifiers into shared fields while it runs, so a late attempt is torn down after the fact rather than kept fully attempt-local. Nothing reaches the user through that, and making it structural is tracked in #589.

The unbounded loop itself is an AVFAudio defect and a Feedback report is going to Apple. Worth noting there: the immediately preceding attempt returned `kAudioHardwareBadObjectError` cleanly in 290 ms from the same device change, so the error path exists and simply is not reached.

Refs #588

