### PR TITLE
fix(app): close per-attempt state hazards in the capture restart paths

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture+AggregateDescription.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+AggregateDescription.swift
@@ -1,0 +1,42 @@
+import CoreAudio
+import Foundation
+
+/// The CFDictionary that describes the private aggregate device wrapping a
+/// process tap.
+///
+/// Pure configuration data: it reads nothing off the instance and owns nothing,
+/// which is why it lives here rather than inline in `startCapture`. That
+/// function holds the object lifecycle (create, adopt, release, forget), and
+/// keeping a twenty-line literal in the middle of it buried the ordering that
+/// actually matters.
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    /// - Parameters:
+    ///   - nameTag: root PID, embedded in the device name. Purely cosmetic, it
+    ///     is what makes an orphaned aggregate identifiable in
+    ///     `system_profiler SPAudioDataType`.
+    ///   - outputUID: the device the tap follows, used as main sub-device.
+    ///   - tapUUID: the process tap to attach.
+    static func aggregateDescription(
+        nameTag: String,
+        outputUID: String,
+        tapUUID: String,
+    ) -> [String: Any] {
+        [
+            kAudioAggregateDeviceNameKey as String: "audiotap-\(nameTag)",
+            kAudioAggregateDeviceUIDKey as String: UUID().uuidString,
+            kAudioAggregateDeviceMainSubDeviceKey as String: outputUID,
+            kAudioAggregateDeviceIsPrivateKey as String: true,
+            kAudioAggregateDeviceTapAutoStartKey as String: true,
+            kAudioAggregateDeviceSubDeviceListKey as String: [
+                [kAudioSubDeviceUIDKey as String: outputUID],
+            ],
+            kAudioAggregateDeviceTapListKey as String: [
+                [
+                    kAudioSubTapUIDKey as String: tapUUID,
+                    kAudioSubTapDriftCompensationKey as String: true,
+                ],
+            ],
+        ]
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -398,7 +398,7 @@ public class AppAudioCapture: @unchecked Sendable {
             desc as CFDictionary, &newAggregateID,
         )
         guard aggStatus == noErr else {
-            AudioHardwareDestroyProcessTap(tapID)
+            releaseTapAndAggregate()
             throw NSError(
                 domain: "audiotap", code: Int(aggStatus),
                 userInfo: [
@@ -466,8 +466,7 @@ public class AppAudioCapture: @unchecked Sendable {
         }
 
         guard ioProcStatus == noErr, let validProcID = newProcID else {
-            AudioHardwareDestroyAggregateDevice(aggregateID)
-            AudioHardwareDestroyProcessTap(tapID)
+            releaseTapAndAggregate()
             throw NSError(
                 domain: "audiotap", code: Int(ioProcStatus),
                 userInfo: [
@@ -492,8 +491,14 @@ public class AppAudioCapture: @unchecked Sendable {
 
         let startStatus = AudioDeviceStart(aggregateID, procID)
         guard startStatus == noErr else {
-            AudioHardwareDestroyAggregateDevice(aggregateID)
-            AudioHardwareDestroyProcessTap(tapID)
+            // The IOProc was registered a few lines up and outlives the aggregate
+            // unless it is destroyed explicitly. Every other throw site in this
+            // function releases exactly what it had built; this one forgot the
+            // registration, so a device that refuses to start leaked one per
+            // attempt for the life of the process.
+            AudioDeviceDestroyIOProcID(aggregateID, validProcID)
+            procID = nil
+            releaseTapAndAggregate()
             throw NSError(
                 domain: "audiotap", code: Int(startStatus),
                 userInfo: [
@@ -508,6 +513,21 @@ public class AppAudioCapture: @unchecked Sendable {
         // give-up cannot resurrect the IOProc against a file descriptor the
         // session has already closed.
         logger.info("Audio capture started (PIDs \(self.pids), rate: \(self.actualSampleRate) Hz)")
+    }
+
+    /// Destroy the tap and the aggregate and forget both ids. Every caller that
+    /// releases them must also clear them: `stopCapture` destroys whatever the
+    /// fields point at, so a field left holding a destroyed id makes the next
+    /// stop free something this object no longer owns.
+    private func releaseTapAndAggregate() {
+        if aggregateID != kAudioObjectUnknown {
+            AudioHardwareDestroyAggregateDevice(aggregateID)
+            aggregateID = AudioObjectID(kAudioObjectUnknown)
+        }
+        if tapID != kAudioObjectUnknown {
+            AudioHardwareDestroyProcessTap(tapID)
+            tapID = AudioObjectID(kAudioObjectUnknown)
+        }
     }
 
     func stopCapture() {
@@ -529,14 +549,7 @@ public class AppAudioCapture: @unchecked Sendable {
         // onto writeQueue, so without this barrier a late buffer could write
         // to a closed/recycled fd.
         writeQueue.sync {}
-        if aggregateID != kAudioObjectUnknown {
-            AudioHardwareDestroyAggregateDevice(aggregateID)
-            aggregateID = AudioObjectID(kAudioObjectUnknown)
-        }
-        if tapID != kAudioObjectUnknown {
-            AudioHardwareDestroyProcessTap(tapID)
-            tapID = AudioObjectID(kAudioObjectUnknown)
-        }
+        releaseTapAndAggregate()
         didLogFormat = false
     }
 

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -387,25 +387,11 @@ public class AppAudioCapture: @unchecked Sendable {
             )
         }
 
-        // Create aggregate device with the tap. The name embeds the root PID
-        // (first entry) — purely cosmetic for `system_profiler SPAudioDataType`.
-        let nameTag = pids.first.map(String.init) ?? "0"
-        let desc: [String: Any] = [
-            kAudioAggregateDeviceNameKey as String: "audiotap-\(nameTag)",
-            kAudioAggregateDeviceUIDKey as String: UUID().uuidString,
-            kAudioAggregateDeviceMainSubDeviceKey as String: systemOutputUID,
-            kAudioAggregateDeviceIsPrivateKey as String: true,
-            kAudioAggregateDeviceTapAutoStartKey as String: true,
-            kAudioAggregateDeviceSubDeviceListKey as String: [
-                [kAudioSubDeviceUIDKey as String: systemOutputUID],
-            ],
-            kAudioAggregateDeviceTapListKey as String: [
-                [
-                    kAudioSubTapUIDKey as String: tap.uuid.uuidString,
-                    kAudioSubTapDriftCompensationKey as String: true,
-                ],
-            ],
-        ]
+        let desc = Self.aggregateDescription(
+            nameTag: pids.first.map(String.init) ?? "0",
+            outputUID: systemOutputUID,
+            tapUUID: tap.uuid.uuidString,
+        )
 
         var newAggregateID = AudioObjectID(kAudioObjectUnknown)
         let aggStatus = AudioHardwareCreateAggregateDevice(

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -412,6 +412,12 @@ public class AppAudioCapture: @unchecked Sendable {
 
         // Set up IOProc to read audio data and write to file descriptor
         let fd = outputFileDescriptor
+        // The device this block belongs to, captured by value. Reading the field
+        // from inside the callback would query whatever device the newest attempt
+        // installed rather than the one actually delivering these buffers, so a
+        // block that outlives its own attempt would correct its rate against a
+        // stranger.
+        let ownAggregateID = aggregateID
         var newProcID: AudioDeviceIOProcID?
         let ioProcStatus = AudioDeviceCreateIOProcIDWithBlock(
             &newProcID, aggregateID, writeQueue,
@@ -432,7 +438,7 @@ public class AppAudioCapture: @unchecked Sendable {
                 self.actualChannels = Int(abl.mBuffers.mNumberChannels)
 
                 // Device is running — query the measured actual rate
-                let measuredRate = Self.queryActualSampleRate(deviceID: self.aggregateID)
+                let measuredRate = Self.queryActualSampleRate(deviceID: ownAggregateID)
                 if measuredRate > 0, measuredRate != self.actualSampleRate {
                     logger.warning(
                         "Measured rate \(measuredRate) Hz differs from cached \(self.actualSampleRate) Hz — updating",

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -74,10 +74,6 @@ public class MicCaptureHandler: @unchecked Sendable {
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
     var configChangeObserver: NSObjectProtocol?
     var selectedDeviceUID: String?
-    private var fileSampleRate: Double = 0
-    private var converter: AVAudioConverter?
-    /// Pre-computed resampling ratio (fileSampleRate / tapSampleRate), avoids division in audio callback.
-    private var resampleRatio: Double = 1.0
     /// Wall-clock anchoring so a device-restart gap becomes silence in the WAV
     /// instead of an under-run (issue #379 follow-up — see `+Timeline`).
     /// `internal` for that cross-file extension; survives restarts (never reset).
@@ -197,8 +193,10 @@ public class MicCaptureHandler: @unchecked Sendable {
         // once the session was sealed by a give-up or a stop: a wedged attempt
         // that returns later must not recreate (and thereby truncate) a
         // recording that was already finalized.
+        // Always the speech rate; it was a stored property whose only value was
+        // this constant, which made it look like per-session state.
+        let fileSampleRate = speechSampleRate
         if outputFile == nil, arbiter.withLock({ $0.mayCreateOutputFile }) {
-            fileSampleRate = speechSampleRate
             let wavSettings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatLinearPCM,
                 AVSampleRateKey: fileSampleRate,
@@ -220,8 +218,14 @@ public class MicCaptureHandler: @unchecked Sendable {
             timelineAnchor = TimelineAnchor(rate: Int(fileSampleRate))
         }
 
-        converter = nil
-        resampleRatio = fileSampleRate / tapFormat.sampleRate
+        // Locals, captured by value below. Sharing them across sessions loses
+        // audio silently: a restart attempt rebuilds them for ITS format before
+        // the arbiter has agreed to adopt it, while the previous session's tap
+        // block is still installed and still delivering buffers in the old one.
+        // Those buffers then go through a converter that does not match them and
+        // are dropped without an error (issue #589).
+        let resampleRatio = fileSampleRate / tapFormat.sampleRate
+        var converter: AVAudioConverter?
         if let setup = MicConverterFactory.make(tapFormat: tapFormat, fileSampleRate: fileSampleRate) {
             converter = setup.converter
             if let channel = setup.selectedChannel {
@@ -230,7 +234,7 @@ public class MicCaptureHandler: @unchecked Sendable {
                 )
             }
             logger.info(
-                "Mic: converting \(Int(tapFormat.sampleRate))Hz/\(tapFormat.channelCount)ch → \(Int(self.fileSampleRate))Hz/1ch",
+                "Mic: converting \(Int(tapFormat.sampleRate))Hz/\(tapFormat.channelCount)ch → \(Int(fileSampleRate))Hz/1ch",
             )
         }
 
@@ -252,9 +256,9 @@ public class MicCaptureHandler: @unchecked Sendable {
             self.publishCurrentLevel()
             self.maybeReportDebugRMS()
             do {
-                if let converter = self.converter {
+                if let converter {
                     let outputFrames = resampleOutputCapacity(
-                        inputFrames: buffer.frameLength, ratio: self.resampleRatio,
+                        inputFrames: buffer.frameLength, ratio: resampleRatio,
                     )
                     guard let outputBuffer = AVAudioPCMBuffer(
                         pcmFormat: converter.outputFormat,

--- a/tools/audiotap/Tests/AggregateDescriptionTests.swift
+++ b/tools/audiotap/Tests/AggregateDescriptionTests.swift
@@ -1,0 +1,66 @@
+@testable import AudioTapLib
+import CoreAudio
+import XCTest
+
+/// The aggregate description is the one part of the HAL bring-up that is pure
+/// data, so it is also the one part that can be pinned without hardware. Each
+/// key here has a failure mode that is silent rather than loud: a device that
+/// shows up in everyone's Sound settings, or one that records nothing at all.
+@available(macOS 14.2, *)
+final class AggregateDescriptionTests: XCTestCase {
+    private func makeDescription() -> [String: Any] {
+        AppAudioCapture.aggregateDescription(
+            nameTag: "4242", outputUID: "BuiltInSpeakerDevice", tapUUID: "TAP-UUID",
+        )
+    }
+
+    func testTheDeviceIsPrivateAndAutoStarts() {
+        let desc = makeDescription()
+
+        // Not private: the tap's aggregate appears in System Settings > Sound as
+        // a selectable device for every app on the machine.
+        XCTAssertEqual(desc[kAudioAggregateDeviceIsPrivateKey as String] as? Bool, true)
+        // Not auto-starting: the tap exists and delivers nothing, which is the
+        // silent-recording failure this project keeps re-diagnosing.
+        XCTAssertEqual(desc[kAudioAggregateDeviceTapAutoStartKey as String] as? Bool, true)
+    }
+
+    func testItFollowsTheGivenOutputDevice() throws {
+        let desc = makeDescription()
+
+        XCTAssertEqual(
+            desc[kAudioAggregateDeviceMainSubDeviceKey as String] as? String, "BuiltInSpeakerDevice",
+        )
+        let subDevices = try XCTUnwrap(
+            desc[kAudioAggregateDeviceSubDeviceListKey as String] as? [[String: Any]],
+        )
+        XCTAssertEqual(subDevices.count, 1)
+        XCTAssertEqual(subDevices.first?[kAudioSubDeviceUIDKey as String] as? String, "BuiltInSpeakerDevice")
+    }
+
+    func testItCarriesTheTapWithDriftCompensation() throws {
+        let desc = makeDescription()
+
+        let taps = try XCTUnwrap(desc[kAudioAggregateDeviceTapListKey as String] as? [[String: Any]])
+        XCTAssertEqual(taps.count, 1)
+        XCTAssertEqual(taps.first?[kAudioSubTapUIDKey as String] as? String, "TAP-UUID")
+        // Without drift compensation the captured stream slowly desynchronises
+        // from the mic track, which shows up as speakers talking over each other
+        // later in a long recording rather than as an error.
+        XCTAssertEqual(taps.first?[kAudioSubTapDriftCompensationKey as String] as? Bool, true)
+    }
+
+    func testTheNameIsIdentifiableAndTheUIDIsUniquePerDevice() throws {
+        let first = makeDescription()
+        let second = makeDescription()
+
+        // The name is how an orphaned aggregate is found in
+        // `system_profiler SPAudioDataType` after a crash.
+        XCTAssertEqual(first[kAudioAggregateDeviceNameKey as String] as? String, "audiotap-4242")
+        // The UID must not repeat: two live aggregates sharing one UID collide in
+        // the HAL, and a restart builds the second while the first still exists.
+        let firstUID = try XCTUnwrap(first[kAudioAggregateDeviceUIDKey as String] as? String)
+        let secondUID = try XCTUnwrap(second[kAudioAggregateDeviceUIDKey as String] as? String)
+        XCTAssertNotEqual(firstUID, secondUID)
+    }
+}

--- a/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
+++ b/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
@@ -39,8 +39,13 @@ final class MicEngineSessionSeamTests: XCTestCase {
             return format
         }
 
-        func installTap(format: AVAudioFormat, block _: AVAudioNodeTapBlock) {
+        /// The handler's real tap block, so a test can drive audio through the
+        /// production write path after the fact.
+        var tapBlock: AVAudioNodeTapBlock?
+
+        func installTap(format: AVAudioFormat, block: @escaping AVAudioNodeTapBlock) {
             calls.append(.installTap(sampleRate: format.sampleRate))
+            tapBlock = block
             tapInstalled = true
         }
 
@@ -110,5 +115,48 @@ final class MicEngineSessionSeamTests: XCTestCase {
         XCTAssertThrowsError(try handler.start())
         XCTAssertEqual(session.calls, [.hardwareFormat(deviceUID: nil)])
         XCTAssertFalse(session.tapInstalled)
+    }
+
+    // MARK: - Converter ownership (issue #589)
+
+    func testATapBlockKeepsWritingAfterAnotherAttemptBuildsADifferentFormat() throws {
+        // A restart attempt configures the converter for ITS format before the
+        // arbiter has agreed to adopt it. While that runs, the still-installed
+        // tap block of the previous session keeps receiving buffers. If the
+        // converter is shared, those buffers are fed through a converter built
+        // for a format they do not have, and the audio is silently dropped.
+        let running = FakeSession()
+        running.format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
+        let attempt = FakeSession()
+        attempt.format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2))
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("converter-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+        var sessions = [running, attempt]
+        let handler = MicCaptureHandler(outputURL: url) { sessions.removeFirst() }
+
+        try handler.start()
+        let block = try XCTUnwrap(running.tapBlock)
+        let sizeAfterStart = try Data(contentsOf: url).count
+
+        // A second attempt configures itself for a different format.
+        _ = try handler.startEngine(deviceUID: nil, on: attempt)
+
+        // The first session's block is still installed and still delivering.
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: running.format, frameCapacity: 4096))
+        buffer.frameLength = 4096
+        let samples = try XCTUnwrap(buffer.floatChannelData?[0])
+        for frame in 0 ..< 4096 {
+            samples[frame] = Float(sin(Double(frame) * 0.05)) * 0.5
+        }
+        block(buffer, AVAudioTime(hostTime: mach_absolute_time()))
+        handler.stop()
+
+        XCTAssertGreaterThan(
+            try Data(contentsOf: url).count,
+            sizeAfterStart,
+            "audio delivered to a session's own tap block must reach the file",
+        )
     }
 }


### PR DESCRIPTION
Closes concrete hazards from the class #589 describes, and deliberately stops short of the structural change the issue asks for. That split is the point of this PR, so it is spelled out below rather than left to the reader. `Refs #589`, not `Fixes`.

A restart attempt writes its results into fields on the object it is restarting while it is still running. Adoption is what decides whether the attempt counts, but the writes happen before that decision.

## Room first

`AppAudioCapture.swift` was at its length cap, so the ownership fix below had nowhere to go. The aggregate-device description moves out into its own file: twenty lines of CFDictionary literal that read nothing off the instance and own nothing, sitting in the middle of the function that holds the object lifecycle. Pure move, no behaviour change.

Deliberately **not** done: moving `startCapture` itself out. `aggregateID`, `tapID` and `procID` are `private`, so that split would mean widening visibility to satisfy a line cap.

## The microphone converter, shared where it should have been per-attempt

`startEngine` configured the converter and the resample ratio for its own hardware format before the arbiter had agreed to adopt anything. Those were instance fields the tap block read through `self`, so a block could convert with a converter built for a format it was never installed against, and `AVAudioConverter` drops those buffers silently: no throw, no error, no log line.

Both are now locals captured by value in the block. `fileSampleRate` stops being a stored property at the same time, since its only value was ever the speech rate.

How reachable this was, stated precisely rather than dramatically: the production path seals the arbiter and tears the outgoing session down before the attempt runs, so later invocations of the old block return at the `isRecording` guard. What remained was one block execution already past that guard on the render thread, racing the attempt's unsynchronised write. A one-buffer window, and a real cross-thread data race. The fix removes the shared field instead of relying on that window staying small.

The test drives the production tap block and is red against the commit before it: a session at 48 kHz mono, a second attempt configuring for 44.1 kHz stereo, then a buffer fed into the first session's own block leaves the WAV at exactly its 4096-byte header. It reaches that state by calling `startEngine` directly, so read it as a unit test of "the block uses its own converter", not as evidence about production interleaving.

## Release and forget: two defects on the failure paths

The `AudioDeviceStart` failure destroyed the aggregate and the tap but left the IOProc registration it had created moments earlier, so a device that refuses to start leaked one registration per attempt for the life of the process.

And all three throw sites left their destroyed ids in the instance fields. `stopCapture` destroys `aggregateID` and `tapID` whenever they are not `kAudioObjectUnknown`, so a later stop frees ids this object no longer owns. Reachable, not theoretical: a device change stops capture, the attempt fails at `AudioDeviceStart`, the arbiter parks in `.backingOff`, and a stop during that backoff resolves to `.teardown` and runs `stopCapture` against the stale fields. Ignored error statuses today, a genuine use-after-destroy the moment coreaudiod recycles an id in that window.

Since "destroy it and forget it" now appears at four sites including `stopCapture`, it is one helper rather than four copies. That is the shape the fix is arguing for anyway: the fields describe what this object actually owns.

## The IOProc block measuring a stranger's device

The first-callback rate correction read the aggregate id out of the instance field inside the callback, so the block asked whichever device the newest attempt had installed rather than the one delivering the buffer it was handling. Captured by value now.

This one is hardening, not a live bug, and the difference matters for the follow-up. Three invariants currently keep the bad interleaving out of reach, all maintained in other files: the block returns at the `isRunning` guard, and `isRunning` is false throughout every attempt because a device change always begins with a stop and only `start()` and the adoption set it true; the no-stop `.restart` action only follows a failed attempt, so no old IOProc is live; and `stopCapture` drains the write queue before clearing the field. Correctness by choreography three files away is exactly what the follow-up should replace with ownership.

## Deliberately not in this PR

The structural change the issue asks for: `startCapture` building its tap, aggregate and IOProc as an attempt-local value that adoption installs and a stale attempt destroys.

Three reasons, the first being the honest one. It is a large refactor of the HAL chain with **no CI coverage at all** (the test seam replaces the entire function body, and the runner has no audio hardware), so it would land verified by review only. Its value is structural: what could actually reach a user is closed here, so the remainder converts "cannot hurt you" into "cannot happen". And large unverifiable surgery on this path unsupervised is how a regression happened in the predecessor work.

The shape it should take: an `AppTapSession` holding `tapID`, `aggregateID`, `procID`, the resolved sample rate, the write queue, and also `didLogFormat` and `actualChannels`, which are per-attempt state in shared fields today. The block's write to `actualSampleRate` needs an ownership decision as well: the session owns it, adoption publishes it. Single-shot `destroy()` mirroring today's teardown order exactly (stop, destroy IOProc, drain the write queue, destroy aggregate, destroy tap). Protocol-backed for the same reason the microphone session already is: it is the only way to test the choreography without hardware. Ownership then decides who destroys what, so each session is destroyed exactly once by construction rather than by flags. Three things become testable with fakes that are not testable today: destroy-called-exactly-once for a late successful attempt after a give-up, a stop during an in-flight attempt destroying nothing, and a clean restart adopting the identical session object.

**A trap for whoever does it:** not everything the attempt touches is attempt-local. `outputFile` and the timeline anchor on the microphone side, and the resampler, timeline anchor and byte counters on the app-audio side, are per-recording **by design**: a restart appends to the same WAV, the anchor exists to bridge restart gaps, and the resampler deliberately spans device swaps and rebuilds its converter on a rate change. Mechanically moving "whatever the attempt writes" into the session would break restart continuity.

## Verification

2514 tests in `app/MeetingTranscriber`, 237 in `tools/audiotap`, SwiftFormat and SwiftLint clean over 420 files, `swiftlint analyze --strict` clean over 346, and the release-mode parity build. Each of the four commits compiles standalone.

The converter test was verified red against the commit before it. The two app-audio fixes have no reachable test: no test on CI executes a line of `startCapture`, because the seam replaces the whole body and the runner has no audio hardware to make `AudioDeviceStart` fail against. One qualification so the claim is not stronger than the truth: the IOProc device capture *could* be tested by extracting the block into an injectable factory, which is a new seam this PR defers along with the rest; making the `AudioDeviceStart` failure testable genuinely requires the deferred refactor.

Refs #589
