### PR TITLE
refactor(app): give a capture attempt ownership of the HAL objects it builds

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture+Restart.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+Restart.swift
@@ -47,8 +47,9 @@ extension AppAudioCapture {
         restartQueue.async { [weak self] in
             guard let self else { return }
             var failed = false
+            var built: AppTapSession?
             do {
-                try self.performAttempt()
+                built = try self.performAttempt()
             } catch {
                 logger.error("Failed to restart app audio capture: \(error.localizedDescription, privacy: .public)")
                 failed = true
@@ -60,29 +61,36 @@ extension AppAudioCapture {
             guard outcome != .rejectStale else {
                 logger.info("App audio: discarding a restart attempt that outlived its deadline")
                 // A stale attempt that SUCCEEDED built a live tap. It has
-                // returned, so the HAL is answering and this releases it.
-                if succeeded { self.stopCapture() }
+                // returned, so the HAL is answering, and it releases what IT
+                // built rather than reaching into fields a newer attempt may
+                // already own.
+                built?.destroy()
                 return
             }
             DispatchQueue.main.async {
-                self.finishRestart(generation: generation, succeeded: succeeded)
+                self.finishRestart(generation: generation, succeeded: succeeded, built: built)
             }
         }
     }
 
     /// Publish or discard a returned attempt, then let the coordinator decide what
     /// comes next. Main queue only, so a stop and an adoption cannot interleave.
-    private func finishRestart(generation: Int, succeeded: Bool) {
+    private func finishRestart(generation: Int, succeeded: Bool, built: AppTapSession?) {
         if succeeded {
             guard case .adopt = restartArbiter.withLock({ $0.handle(.commitReady(generation: generation)) })
             else {
                 logger.info("App audio: discarding a restart that succeeded after the session was sealed")
-                stopCapture()
+                // Same rule as the stale path above: destroy what this attempt
+                // built, not whatever happens to be installed.
+                built?.destroy()
                 return
             }
             // Only start() and this adoption may declare capture running. Leaving
             // it to startCapture would let an attempt that returns after a give-up
             // resurrect the IOProc against a file descriptor the session closed.
+            // Same as start(): a nil here is the test seam, not a successful
+            // attempt that built nothing.
+            if let built { install(built) }
             isRunning = true
         }
         let event: OutputDeviceChangeCoordinator.Event = succeeded

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -40,9 +40,11 @@ public class AppAudioCapture: @unchecked Sendable {
     /// #379 follow-up — see `writeCapturedBuffer` in `+Resampling`). `internal`
     /// for that cross-file extension; touched only on `writeQueue`.
     var timelineAnchor = TimelineAnchor(rate: Int(speechSampleRate))
-    private var aggregateID = AudioObjectID(kAudioObjectUnknown)
-    private var tapID = AudioObjectID(kAudioObjectUnknown)
-    private var procID: AudioDeviceIOProcID?
+    /// What the currently installed attempt built, or nil while nothing is
+    /// installed. Main-queue confined: only `start()`, the restart adoption and
+    /// `stopCapture` touch it, and all three run there. An attempt in flight
+    /// holds its own session locally and never reads this.
+    private var tapSession: AppTapSession?
     /// Gates the IOProc callback (read on `writeQueue`), set on the start/stop
     /// path on the main thread. It is set only by `start()` and by the restart
     /// adoption, never by `startCapture` itself, and must follow `AudioDeviceStart`,
@@ -116,7 +118,7 @@ public class AppAudioCapture: @unchecked Sendable {
 
     /// The work one attempt performs. Injectable so a test can substitute a call
     /// that blocks the way a wedged HAL call does; nil means the real thing.
-    private let attemptBody: (() throws -> Void)?
+    private let attemptBody: (() throws -> AppTapSession?)?
 
     /// Called when app-audio capture was abandoned, either because a restart
     /// attempt exceeded its deadline or because the retry budget ran out.
@@ -165,7 +167,7 @@ public class AppAudioCapture: @unchecked Sendable {
         channels: Int = 2,
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
-        attemptBody: (() throws -> Void)?,
+        attemptBody: (() throws -> AppTapSession?)?,
     ) {
         self.pids = pids
         self.outputFileDescriptor = outputFileDescriptor
@@ -178,16 +180,29 @@ public class AppAudioCapture: @unchecked Sendable {
     }
 
     /// One attempt's worth of work: bring the tap up, or whatever a test injected.
-    func performAttempt() throws {
+    func performAttempt() throws -> AppTapSession? {
         if let attemptBody {
-            try attemptBody()
-        } else {
-            try startCapture()
+            return try attemptBody()
         }
+        return try startCapture()
+    }
+
+    /// Install what an attempt built and publish its rate. The only two callers
+    /// are `start()` and the restart adoption, which is what keeps a returning
+    /// stale attempt from resurrecting capture.
+    ///
+    /// Caller guarantees nothing is installed: both callers follow a stop in the
+    /// same cycle. Taking a non-optional keeps "a successful attempt built
+    /// something" a fact the type system carries rather than a convention.
+    func install(_ session: AppTapSession) {
+        tapSession = session
+        actualSampleRate = session.resolvedSampleRate
     }
 
     public func start() throws {
-        try performAttempt()
+        // Only the test seam returns nothing: production startCapture either
+        // hands back a session or throws.
+        if let built = try performAttempt() { install(built) }
         // startCapture deliberately no longer sets this. Declaring capture
         // running belongs to start() and to the restart adoption, so an attempt
         // that returns after a give-up cannot do it.
@@ -311,7 +326,7 @@ public class AppAudioCapture: @unchecked Sendable {
     }
 
     // swiftlint:disable:next function_body_length
-    private func startCapture() throws {
+    private func startCapture() throws -> AppTapSession {
         let translated = try translatePIDs()
         let processObjectIDs = translated.map(\.audioObjectID)
 
@@ -377,13 +392,20 @@ public class AppAudioCapture: @unchecked Sendable {
                 userInfo: [NSLocalizedDescriptionKey: hint],
             )
         }
-        tapID = newTapID
-        let tapRate = Self.queryTapSampleRate(tapID: tapID)
-        logger.info("Created process tap: \(self.tapID) rate=\(tapRate, privacy: .public) Hz")
+        // From here the attempt owns what it builds. Every failure below hands
+        // back one object instead of remembering which of three ids it created.
+        //
+        // The drain captures the queue by value on purpose. A `[weak self]` drain
+        // would silently skip the barrier once self is gone, which is exactly the
+        // write-after-close bug the barrier exists to prevent, and a strong self
+        // would make the session keep its owner alive.
+        let session = AppTapSession(tapID: newTapID) { [writeQueue] in writeQueue.sync {} }
+        let tapRate = Self.queryTapSampleRate(tapID: newTapID)
+        logger.info("Created process tap: \(newTapID) rate=\(tapRate, privacy: .public) Hz")
 
         if debugLogging {
             logger.info(
-                "[debug] Tap format: rate=\(tapRate, privacy: .public) Hz, tapID=\(self.tapID, privacy: .public)",
+                "[debug] Tap format: rate=\(tapRate, privacy: .public) Hz, tapID=\(newTapID, privacy: .public)",
             )
         }
 
@@ -398,7 +420,7 @@ public class AppAudioCapture: @unchecked Sendable {
             desc as CFDictionary, &newAggregateID,
         )
         guard aggStatus == noErr else {
-            releaseTapAndAggregate()
+            session.destroy()
             throw NSError(
                 domain: "audiotap", code: Int(aggStatus),
                 userInfo: [
@@ -407,8 +429,18 @@ public class AppAudioCapture: @unchecked Sendable {
                 ],
             )
         }
-        aggregateID = newAggregateID
-        logger.info("Created aggregate device: \(self.aggregateID)")
+        // Resolving the rate here rather than after the IOProc is value ordering,
+        // not race-safety: it reads only the tap format and the device's
+        // nominal/stream-format properties, so it is valid before the device
+        // starts, and doing it now lets the session carry it. The IOProc's
+        // first-callback measured correction layers on top of the published copy.
+        session.attach(
+            aggregateID: newAggregateID,
+            resolvedSampleRate: Self.resolveActualSampleRate(
+                deviceID: newAggregateID, tapID: newTapID, requestedRate: sampleRate,
+            ),
+        )
+        logger.info("Created aggregate device: \(newAggregateID)")
 
         // Set up IOProc to read audio data and write to file descriptor
         let fd = outputFileDescriptor
@@ -417,11 +449,10 @@ public class AppAudioCapture: @unchecked Sendable {
         // installed rather than the one actually delivering these buffers, so a
         // block that outlives its own attempt would correct its rate against a
         // stranger.
-        let ownAggregateID = aggregateID
         var newProcID: AudioDeviceIOProcID?
         let ioProcStatus = AudioDeviceCreateIOProcIDWithBlock(
-            &newProcID, aggregateID, writeQueue,
-        ) { [weak self] _, inInputData, inInputTime, _, _ in
+            &newProcID, newAggregateID, writeQueue,
+        ) { [weak self, session] _, inInputData, inInputTime, _, _ in
             guard let self, self.isRunning else { return }
             let abl = inInputData.pointee
 
@@ -438,7 +469,7 @@ public class AppAudioCapture: @unchecked Sendable {
                 self.actualChannels = Int(abl.mBuffers.mNumberChannels)
 
                 // Device is running — query the measured actual rate
-                let measuredRate = Self.queryActualSampleRate(deviceID: ownAggregateID)
+                let measuredRate = Self.queryActualSampleRate(deviceID: session.aggregateID)
                 if measuredRate > 0, measuredRate != self.actualSampleRate {
                     logger.warning(
                         "Measured rate \(measuredRate) Hz differs from cached \(self.actualSampleRate) Hz — updating",
@@ -472,7 +503,7 @@ public class AppAudioCapture: @unchecked Sendable {
         }
 
         guard ioProcStatus == noErr, let validProcID = newProcID else {
-            releaseTapAndAggregate()
+            session.destroy()
             throw NSError(
                 domain: "audiotap", code: Int(ioProcStatus),
                 userInfo: [
@@ -481,30 +512,11 @@ public class AppAudioCapture: @unchecked Sendable {
                 ],
             )
         }
-        procID = validProcID
+        session.attach(procID: validProcID)
 
-        // Resolve and store the sample rate BEFORE starting the device — value
-        // ordering, not race-safety (the field's lock handles cross-thread
-        // access, see its declaration). Writing the resolved value first lets
-        // the IOProc's first-callback measured-rate correction layer on top
-        // instead of a post-start write clobbering it. Resolving is valid
-        // pre-start: `resolveActualSampleRate` reads only the tap format and the
-        // device's nominal/stream-format properties; the one started-device
-        // query (kAudioDevicePropertyActualSampleRate) lives in the IOProc.
-        actualSampleRate = Self.resolveActualSampleRate(
-            deviceID: aggregateID, tapID: tapID, requestedRate: sampleRate,
-        )
-
-        let startStatus = AudioDeviceStart(aggregateID, procID)
+        let startStatus = AudioDeviceStart(newAggregateID, validProcID)
         guard startStatus == noErr else {
-            // The IOProc was registered a few lines up and outlives the aggregate
-            // unless it is destroyed explicitly. Every other throw site in this
-            // function releases exactly what it had built; this one forgot the
-            // registration, so a device that refuses to start leaked one per
-            // attempt for the life of the process.
-            AudioDeviceDestroyIOProcID(aggregateID, validProcID)
-            procID = nil
-            releaseTapAndAggregate()
+            session.destroy()
             throw NSError(
                 domain: "audiotap", code: Int(startStatus),
                 userInfo: [
@@ -518,22 +530,10 @@ public class AppAudioCapture: @unchecked Sendable {
         // restart adoption may do that, so an attempt that returns after a
         // give-up cannot resurrect the IOProc against a file descriptor the
         // session has already closed.
-        logger.info("Audio capture started (PIDs \(self.pids), rate: \(self.actualSampleRate) Hz)")
-    }
-
-    /// Destroy the tap and the aggregate and forget both ids. Every caller that
-    /// releases them must also clear them: `stopCapture` destroys whatever the
-    /// fields point at, so a field left holding a destroyed id makes the next
-    /// stop free something this object no longer owns.
-    private func releaseTapAndAggregate() {
-        if aggregateID != kAudioObjectUnknown {
-            AudioHardwareDestroyAggregateDevice(aggregateID)
-            aggregateID = AudioObjectID(kAudioObjectUnknown)
-        }
-        if tapID != kAudioObjectUnknown {
-            AudioHardwareDestroyProcessTap(tapID)
-            tapID = AudioObjectID(kAudioObjectUnknown)
-        }
+        logger.info(
+            "Audio capture started (PIDs \(self.pids), rate: \(session.resolvedSampleRate) Hz)",
+        )
+        return session
     }
 
     func stopCapture() {
@@ -545,17 +545,11 @@ public class AppAudioCapture: @unchecked Sendable {
             )
         }
 
-        if let procID {
-            AudioDeviceStop(aggregateID, procID)
-            AudioDeviceDestroyIOProcID(aggregateID, procID)
-            self.procID = nil
-        }
-        // Drain pending IOProc blocks before the caller closes the fd —
-        // AudioDeviceStop doesn't synchronize against blocks already dispatched
-        // onto writeQueue, so without this barrier a late buffer could write
-        // to a closed/recycled fd.
-        writeQueue.sync {}
-        releaseTapAndAggregate()
+        // The session owns the release order, including the write-queue drain
+        // that keeps a late buffer from writing into a descriptor the caller is
+        // about to close.
+        tapSession?.destroy()
+        tapSession = nil
         didLogFormat = false
     }
 

--- a/tools/audiotap/Sources/AppTapSession.swift
+++ b/tools/audiotap/Sources/AppTapSession.swift
@@ -1,0 +1,121 @@
+import CoreAudio
+import Foundation
+
+/// The HAL calls a session makes when it gives its objects back, injectable so
+/// the release choreography can be asserted without audio hardware. The real
+/// implementation is the only one that ships; the seam exists because the
+/// ordering below is the part that goes wrong silently.
+@available(macOS 14.2, *)
+struct AppTapSessionHAL {
+    var stopDevice: @Sendable (AudioObjectID, AudioDeviceIOProcID) -> Void
+    var destroyIOProc: @Sendable (AudioObjectID, AudioDeviceIOProcID) -> Void
+    var destroyAggregate: @Sendable (AudioObjectID) -> Void
+    var destroyTap: @Sendable (AudioObjectID) -> Void
+
+    static let real = Self(
+        stopDevice: { AudioDeviceStop($0, $1) },
+        destroyIOProc: { AudioDeviceDestroyIOProcID($0, $1) },
+        destroyAggregate: { AudioHardwareDestroyAggregateDevice($0) },
+        destroyTap: { AudioHardwareDestroyProcessTap($0) },
+    )
+}
+
+/// The HAL objects one capture attempt builds: a process tap, the private
+/// aggregate device wrapping it, and the IOProc registration that delivers its
+/// buffers.
+///
+/// They used to live in three fields on `AppAudioCapture`, written as the attempt
+/// progressed. That made "who owns these" a question about timing rather than
+/// about a reference: an attempt that returned after the session was sealed had
+/// to be cleaned up by reaching back into fields a newer attempt might already
+/// have overwritten, and every failure path had to remember to blank what it had
+/// released. Two defects came out of exactly that shape, both of them silent.
+///
+/// Here the attempt gets an object instead. Whoever holds it destroys it, once,
+/// and a stale attempt destroys its own rather than reaching into shared state.
+/// `@unchecked Sendable` because a built session is handed from the queue that
+/// built it to the main queue for adoption. Safety comes from ownership, not from
+/// locking: exactly one thread holds a session at a time, the handoff goes through
+/// a queue hop that establishes happens-before, and the only mutable state is
+/// `procID` (attached before the handoff) and `destroyed`. Destroying from a
+/// second thread concurrently would be a data race, which is why the rule is
+/// ownership rather than a defensive flag.
+@available(macOS 14.2, *)
+final class AppTapSession: @unchecked Sendable {
+    let tapID: AudioObjectID
+    /// Filled in as the attempt gets further. A session that never got past the
+    /// tap still cleans up correctly, which is the point: every failure path
+    /// hands back one object instead of remembering which of three ids it owns.
+    private(set) var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    /// The rate this attempt resolved before starting its device. The
+    /// measured-rate correction from the first callback deliberately does NOT
+    /// live here: that value is read on the write queue for every buffer and
+    /// again after the session is gone, so it stays a published copy on the
+    /// capture object.
+    private(set) var resolvedSampleRate = 0
+    private(set) var procID: AudioDeviceIOProcID?
+
+    private let hal: AppTapSessionHAL
+    private let drain: () -> Void
+    private var destroyed = false
+
+    init(
+        tapID: AudioObjectID,
+        hal: AppTapSessionHAL = .real,
+        drain: @escaping () -> Void,
+    ) {
+        self.tapID = tapID
+        self.hal = hal
+        self.drain = drain
+    }
+
+    /// The aggregate wraps the tap, so it can only exist once the tap does. The
+    /// resolved rate arrives with it because resolving reads both ids.
+    func attach(aggregateID: AudioObjectID, resolvedSampleRate: Int) {
+        self.aggregateID = aggregateID
+        self.resolvedSampleRate = resolvedSampleRate
+    }
+
+    /// The registration is attached after the fact because creating it needs the
+    /// aggregate this session already owns, and the block it installs has to be
+    /// able to reach the session it belongs to.
+    func attach(procID: AudioDeviceIOProcID?) {
+        self.procID = procID
+    }
+
+    /// Give everything back, in the order the HAL requires, at most once.
+    ///
+    /// The drain sits between destroying the registration and destroying the
+    /// device on purpose: `AudioDeviceStop` does not synchronise against blocks
+    /// already dispatched onto the write queue, so without the barrier a late
+    /// buffer writes into a file descriptor the caller is about to close.
+    ///
+    /// Single-shot because the alternative is a caller tracking whether someone
+    /// else got there first, which is the bookkeeping this type exists to remove.
+    ///
+    /// Ids that were never created are skipped rather than handed to the HAL: an
+    /// attempt that threw while building owns only part of the set, and asking
+    /// CoreAudio to destroy `kAudioObjectUnknown` is not something this code
+    /// should rely on being harmless.
+    ///
+    /// Must not be called ON the write queue: the drain is a `sync` onto it and
+    /// would deadlock. Every caller today is either the main queue or the restart
+    /// queue, and the injected-drain tests cannot catch a violation.
+    func destroy() {
+        guard !destroyed else { return }
+        destroyed = true
+
+        if let procID {
+            hal.stopDevice(aggregateID, procID)
+            hal.destroyIOProc(aggregateID, procID)
+            self.procID = nil
+        }
+        drain()
+        if aggregateID != kAudioObjectUnknown {
+            hal.destroyAggregate(aggregateID)
+        }
+        if tapID != kAudioObjectUnknown {
+            hal.destroyTap(tapID)
+        }
+    }
+}

--- a/tools/audiotap/Tests/AppAudioCaptureSessionOwnershipTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureSessionOwnershipTests.swift
@@ -1,0 +1,135 @@
+@testable import AudioTapLib
+import CoreAudio
+import XCTest
+
+/// Who destroys the HAL objects a restart attempt built, and when.
+///
+/// None of this was assertable before the attempt had an object to own: the ids
+/// went into fields as the attempt progressed, so "the stale attempt cleaned up
+/// after itself" and "the stop cleaned up after the stale attempt" were the same
+/// observation. Now each attempt hands back a distinguishable session, and the
+/// spy records which one was released.
+@available(macOS 14.2, *)
+final class AppAudioCaptureSessionOwnershipTests: XCTestCase {
+    /// Records destroys per session, keyed by the tap id so two attempts in one
+    /// test are told apart.
+    private final class HALSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _destroyed: [AudioObjectID] = []
+
+        var destroyedTaps: [AudioObjectID] {
+            lock.lock(); defer { lock.unlock() }
+            return _destroyed
+        }
+
+        func operations() -> AppTapSessionHAL {
+            AppTapSessionHAL(
+                stopDevice: { _, _ in },
+                destroyIOProc: { _, _ in },
+                destroyAggregate: { _ in },
+                destroyTap: { [weak self] tap in
+                    self?.lock.lock(); self?._destroyed.append(tap); self?.lock.unlock()
+                },
+            )
+        }
+    }
+
+    /// A scripted attempt: hands back a session with the given tap id, and can be
+    /// made to block until released so a stop or a deadline lands mid-flight.
+    private final class Attempt: @unchecked Sendable {
+        private let gate = DispatchSemaphore(value: 0)
+        let entered = XCTestExpectation(description: "attempt is inside the HAL")
+
+        var shouldWedge = false
+        var tapIDs: [AudioObjectID] = []
+        private let spy: HALSpy
+        private let lock = NSLock()
+        private var index = 0
+
+        init(spy: HALSpy) {
+            self.spy = spy
+        }
+
+        func release() {
+            gate.signal()
+        }
+
+        func run() -> AppTapSession? {
+            lock.lock()
+            let id = index < tapIDs.count ? tapIDs[index] : AudioObjectID(99)
+            index += 1
+            lock.unlock()
+            if shouldWedge {
+                entered.fulfill()
+                gate.wait()
+            }
+            let session = AppTapSession(tapID: id, hal: spy.operations()) {}
+            session.attach(aggregateID: id &+ 100, resolvedSampleRate: 48000)
+            return session
+        }
+    }
+
+    private func makeCapture(_ attempt: Attempt) -> AppAudioCapture {
+        AppAudioCapture(pids: [1], outputFileDescriptor: FileHandle.nullDevice.fileDescriptor) {
+            attempt.run()
+        }
+    }
+
+    // MARK: -
+
+    func testARestartThatSucceedsAfterAGiveUpDestroysWhatItBuiltAndNothingElse() throws {
+        let spy = HALSpy()
+        let attempt = Attempt(spy: spy)
+        attempt.tapIDs = [1, 2] // 1 is adopted by start(), 2 is the late attempt
+        let capture = makeCapture(attempt)
+
+        let gaveUp = expectation(description: "give-up reported")
+        capture.onGiveUp = { gaveUp.fulfill() }
+
+        try capture.start()
+        attempt.shouldWedge = true
+        capture.handleOutputDeviceChanged()
+        wait(for: [gaveUp], timeout: RestartArbiter.attemptTimeout + 5)
+
+        // The restart's own stop released the installed session before the
+        // attempt launched. The wedged attempt is still holding its own.
+        XCTAssertEqual(spy.destroyedTaps, [1])
+
+        attempt.release()
+        let settled = expectation(description: "the late attempt has been handled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        // It released exactly what it built. Before the attempt owned an object,
+        // this path called stopCapture() and freed whatever the fields held.
+        XCTAssertEqual(spy.destroyedTaps, [1, 2])
+
+        capture.stop()
+        XCTAssertEqual(
+            spy.destroyedTaps, [1, 2],
+            "a stop must not free a session that was never installed, nor free one twice",
+        )
+    }
+
+    func testACleanRestartInstallsTheSessionTheAttemptReturned() throws {
+        let spy = HALSpy()
+        let attempt = Attempt(spy: spy)
+        attempt.tapIDs = [1, 2]
+        let capture = makeCapture(attempt)
+
+        try capture.start()
+        capture.handleOutputDeviceChanged()
+
+        let settled = expectation(description: "the restart completed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { settled.fulfill() }
+        wait(for: [settled], timeout: 5)
+
+        XCTAssertEqual(spy.destroyedTaps, [1], "the outgoing session is released by the restart")
+
+        capture.stop()
+        // The proof of adoption is which session the stop releases: if the
+        // restart had failed to install what it built, the stop would free
+        // nothing, and a live tap would outlive the recording.
+        XCTAssertEqual(spy.destroyedTaps, [1, 2])
+    }
+}

--- a/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureWedgeTests.swift
@@ -54,6 +54,9 @@ final class AppAudioCaptureWedgeTests: XCTestCase {
     private func makeCapture(_ attempt: Attempt) -> AppAudioCapture {
         AppAudioCapture(pids: [1], outputFileDescriptor: FileHandle.nullDevice.fileDescriptor) {
             try attempt.run()
+            // These tests are about the restart choreography, not about what an
+            // attempt builds; returning nothing keeps their dynamics unchanged.
+            return nil
         }
     }
 

--- a/tools/audiotap/Tests/AppTapSessionTests.swift
+++ b/tools/audiotap/Tests/AppTapSessionTests.swift
@@ -1,0 +1,123 @@
+@testable import AudioTapLib
+import CoreAudio
+import XCTest
+
+/// The HAL objects one capture attempt builds, as a value that owns them.
+///
+/// None of this is reachable by a test today: `startCapture` writes the ids into
+/// shared fields as it goes, and the test seam replaces the whole function, so
+/// the release choreography is verified by reading. Giving the attempt an object
+/// to own is what makes the choreography assertable without audio hardware, and
+/// these are the assertions it buys.
+@available(macOS 14.2, *)
+final class AppTapSessionTests: XCTestCase {
+    /// Records what the session asks the HAL to do, in order. Unchecked because
+    /// the HAL closures are `@Sendable`; the lock is what actually makes it safe,
+    /// and the session calls them one at a time anyway.
+    private final class HALSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [String] = []
+
+        var calls: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+
+        private func record(_ s: String) {
+            lock.lock(); _calls.append(s); lock.unlock()
+        }
+
+        func operations() -> AppTapSessionHAL {
+            AppTapSessionHAL(
+                stopDevice: { [weak self] device, _ in self?.record("stop(\(device))") },
+                destroyIOProc: { [weak self] device, _ in self?.record("destroyIOProc(\(device))") },
+                destroyAggregate: { [weak self] device in self?.record("destroyAggregate(\(device))") },
+                destroyTap: { [weak self] tap in self?.record("destroyTap(\(tap))") },
+            )
+        }
+
+        func recordDrain() {
+            record("drain")
+        }
+    }
+
+    private func makeSession(
+        spy: HALSpy, withIOProc: Bool = true,
+    ) -> AppTapSession {
+        let session = AppTapSession(tapID: 11, hal: spy.operations()) { spy.recordDrain() }
+        session.attach(aggregateID: 22, resolvedSampleRate: 48000)
+        if withIOProc {
+            // A captureless closure converts to the C function pointer the HAL
+            // hands back. It is never invoked here; the session only stores it.
+            let proc: AudioDeviceIOProcID = { _, _, _, _, _, _, _ in noErr }
+            session.attach(procID: proc)
+        }
+        return session
+    }
+
+    func testDestroyReleasesInTheOrderTheHalRequires() {
+        let spy = HALSpy()
+        let session = makeSession(spy: spy)
+
+        session.destroy()
+
+        // The drain must sit between destroying the IOProc and destroying the
+        // device: a block already dispatched onto the write queue would
+        // otherwise write to a file descriptor the caller is about to close.
+        XCTAssertEqual(
+            spy.calls,
+            ["stop(22)", "destroyIOProc(22)", "drain", "destroyAggregate(22)", "destroyTap(11)"],
+        )
+    }
+
+    func testDestroyIsSingleShot() {
+        let spy = HALSpy()
+        let session = makeSession(spy: spy)
+
+        session.destroy()
+        session.destroy()
+        session.destroy()
+
+        // Ownership, not flags, is what should make this safe: whoever holds the
+        // session destroys it once. The guard exists so a stale attempt racing an
+        // adoption cannot free ids the HAL may already have recycled.
+        XCTAssertEqual(spy.calls.count { $0.hasPrefix("destroyTap") }, 1)
+        XCTAssertEqual(spy.calls.count { $0.hasPrefix("destroyAggregate") }, 1)
+        XCTAssertEqual(spy.calls.count { $0.hasPrefix("destroyIOProc") }, 1)
+    }
+
+    func testASessionThatNeverRegisteredAnIOProcStillReleasesTheRest() {
+        let spy = HALSpy()
+        let session = makeSession(spy: spy, withIOProc: false)
+
+        session.destroy()
+
+        // This is the aggregate-creation and IOProc-creation failure paths: the
+        // attempt threw before it had a registration, and must still hand back
+        // the tap and the aggregate rather than leaking them.
+        XCTAssertEqual(spy.calls, ["drain", "destroyAggregate(22)", "destroyTap(11)"])
+    }
+
+    func testItDoesNotAskTheHalToDestroyIdsItNeverGot() {
+        let spy = HALSpy()
+        // The aggregate-creation failure path: the attempt owns a tap and nothing
+        // else. Handing kAudioObjectUnknown to CoreAudio is not something this
+        // code should rely on being harmless, so those calls are skipped.
+        // No `attach`: the aggregate never came into existence.
+        let session = AppTapSession(tapID: 11, hal: spy.operations()) { spy.recordDrain() }
+
+        session.destroy()
+
+        XCTAssertEqual(spy.calls, ["drain", "destroyTap(11)"])
+    }
+
+    func testAnUnusedSessionReportsWhatItOwns() {
+        let spy = HALSpy()
+        let session = makeSession(spy: spy, withIOProc: false)
+
+        XCTAssertEqual(session.tapID, 11)
+        XCTAssertEqual(session.aggregateID, 22)
+        XCTAssertEqual(session.resolvedSampleRate, 48000)
+        XCTAssertNil(session.procID, "a session only has a registration once one was attached")
+    }
+}


### PR DESCRIPTION
The structural change #589 asked for, which the earlier pass deliberately skipped. That pass closed the three hazards that could reach a user and said in its own description why it stopped: the refactor had no CI coverage, so it would land verified by review alone.

That reasoning turned out to be half right. The refactor has no coverage *before* it exists. Building it is what makes the choreography assertable without audio hardware, and two assertions that were impossible to write are in this PR.

## What changes

A capture attempt builds three things: a process tap, the private aggregate device wrapping it, and an IOProc registration. They lived in three fields on `AppAudioCapture`, written as the attempt progressed, which made "who owns these" a question about timing rather than about a reference. An attempt returning after its deadline had to clean up by reaching back into fields a newer attempt might already have overwritten, and every failure path had to remember to blank what it had released.

Both defects fixed immediately before this came out of that shape: a registration leaked on every failed device start, and destroyed ids left in the fields made a later stop free objects the process no longer owned.

Now `startCapture` builds an `AppTapSession` and hands it back. One optional session field replaces the three ids, main-queue confined, installed only by `start()` and the restart adoption. A stale attempt destroys what **it** built. The session fills in as the attempt gets further and skips ids it never got, so the aggregate-creation failure stops being a special case that has to remember it owns only a tap.

`install` takes a non-optional session, so "a successful attempt built something" is carried by the type instead of by convention.

## What deliberately did not move

The measured sample rate the first callback corrects, the resampler, the timeline anchor, the first-frame time and the byte counters stay on the capture object. They look per-attempt and are read per-recording: the rate and channel count are read on the write queue for every buffer and again after the session is gone, and the resampler and the anchor exist precisely to span a device swap. Moving them would have turned plain field reads into cross-queue races and broken restart continuity across a device change.

That was the plan's original mistake, caught in review before any code was written. The failure mode it would have produced is the worst kind: every recording on a device that misreports its rate silently time-warped, with no error, on exactly the Bluetooth hardware the correction exists for.

The session carries only the rate the attempt resolved before starting, and adoption publishes it in the same main-queue frame the coordinator then reads it in.

## Behaviour changes worth naming

- Resolving the rate moved ahead of the IOProc registration. It reads the tap format, and failing that the device's nominal and physical stream formats, none of which a registration creates.
- A stop with nothing installed no longer drains the write queue. Safe by construction: blocks exist only while a registration does, and every destroy drains before its owner returns.
- A failed attempt no longer publishes a rate at all, since the field changes only on install. Strictly more correct; every reader sits behind the running flag or behind adoption.
- One new hardware-only behaviour: destroy always stops the device before destroying the registration, including on the start-failure path where it never started. Apple does not document that case. The status is discarded and the path throws anyway, so the worst plausible outcome is a stray coreaudiod log line. Adding per-id bookkeeping to avoid it would reintroduce the disease this type cures.

## Verification

Two assertions that could not be written before, both verified red against deliberately broken versions: a restart that succeeds after a give-up releases exactly what it built and nothing else, and a clean restart installs the session its attempt returned. The session's own release choreography is pinned separately, including that the write-queue drain sits between destroying the registration and destroying the device, and that ids the attempt never got are skipped.

A third assertion was planned and dropped. "A stop during an in-flight attempt cannot touch that attempt's objects" survived two different mutations, because the refactor made it structural: no field exposes those objects any more, and the arbiter answers `rejectStale` for a return in a stopped session, so that path never reaches adoption at all. An unfalsifiable test is worse than none.

Gates: 248 tests in `tools/audiotap`, the full `app/MeetingTranscriber` suite, SwiftFormat and SwiftLint clean over 424 files, `swiftlint analyze --strict` clean over 346, the release-mode parity build, and a thread-sanitizer run with no reports. Both commits compile standalone.

What no test covers, stated plainly: CI never executes `startCapture`, because the seam replaces the whole function and the runner has no audio hardware. The three throw-site wirings are verified by reading and by the session's own ownership tests, not by exercising the real HAL chain. The live-recording lane exercises the success path only.

Refs #589
