### PR TITLE
fix(app): make the mic output-file handoff atomic

### DIFF
--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -35,7 +35,30 @@ public class MicCaptureHandler: @unchecked Sendable {
     var session: MicEngineSessionProviding
     /// `internal` (not `private`) so the cross-file `+Timeline` extension can
     /// write gap-fill silence to it.
-    var outputFile: AVAudioFile?
+    ///
+    /// Lock-backed because three threads touch it: it is created on whichever
+    /// queue `startEngine` runs (main at first start, the restart queue during
+    /// an attempt), nilled on the main queue by stop and by give-up, and read by
+    /// the render-thread tap block for every buffer. As a plain stored property
+    /// that is a load racing a store-and-release. The getter hands out a strong
+    /// reference and the write then happens outside the lock, so a buffer
+    /// already in flight finishes against a live object instead of one the main
+    /// queue just dropped.
+    var outputFile: AVAudioFile? {
+        get {
+            outputFileLock.lock()
+            defer { outputFileLock.unlock() }
+            return storedOutputFile
+        }
+        set {
+            outputFileLock.lock()
+            storedOutputFile = newValue
+            outputFileLock.unlock()
+        }
+    }
+
+    private let outputFileLock = NSLock()
+    private var storedOutputFile: AVAudioFile?
     private let outputURL: URL
     private let debugLogging: Bool
     private let liveSink: LiveAudioSink?

--- a/tools/audiotap/Tests/MicOutputFileHandoffTests.swift
+++ b/tools/audiotap/Tests/MicOutputFileHandoffTests.swift
@@ -1,0 +1,70 @@
+@testable import AudioTapLib
+@preconcurrency import AVFoundation
+import XCTest
+
+/// The render thread writes to `outputFile` while the main queue drops it.
+///
+/// The assertion here is thin on purpose. A load racing a store-and-release has
+/// no reliable observable behaviour: it does nothing for years, then frees a file
+/// mid-write on someone's machine. What this test does is create the unordered
+/// pair, so ThreadSanitizer has something to report. Run it under
+/// `--sanitize=thread` and it flags an unguarded property and is silent on a
+/// guarded one, which is what makes it a check rather than decoration.
+///
+/// Deliberately free of cross-thread signalling before the stop. An expectation
+/// fulfilled from the delivering thread, a `queue.sync`, or a semaphore signalled
+/// from the loop would each establish a happens-before edge between the two
+/// accesses and blind the sanitizer to exactly the pair under test. The only
+/// coordination is wall-clock sleep, which orders nothing.
+final class MicOutputFileHandoffTests: XCTestCase {
+    private final class Fake: MicEngineSessionProviding {
+        let notificationObject: AnyObject = NSObject()
+        // swiftlint:disable:next force_unwrapping
+        private let fmt = AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1)!
+        var tapBlock: AVAudioNodeTapBlock?
+
+        func hardwareFormat(deviceUID _: String?) -> AVAudioFormat {
+            fmt
+        }
+
+        func installTap(format _: AVAudioFormat, block: @escaping AVAudioNodeTapBlock) {
+            tapBlock = block
+        }
+
+        func start() {}
+        func teardown() {}
+    }
+
+    func testTheRenderThreadCanDeliverWhileTheMainQueueDropsTheFile() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("handoff-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let fake = Fake()
+        let handler = MicCaptureHandler(outputURL: url) { fake }
+        try handler.start()
+        let block = try XCTUnwrap(fake.tapBlock, "start() must install the production tap block")
+
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256))
+        buffer.frameLength = 256
+        let samples = try XCTUnwrap(buffer.floatChannelData)[0]
+        for frame in 0 ..< 256 {
+            samples[frame] = Float(sin(Double(frame) * 0.05)) * 0.5
+        }
+
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInteractive).async {
+            for _ in 0 ..< 20000 {
+                block(buffer, AVAudioTime(sampleTime: 0, atRate: 48000))
+            }
+            finished.signal()
+        }
+        // Wall clock only: let the loop get going, then stop underneath it.
+        usleep(50000)
+        handler.stop()
+        XCTAssertEqual(finished.wait(timeout: .now() + 30), .success, "the delivering loop must finish")
+
+        XCTAssertNil(handler.outputFile, "stop must leave no file behind for a later buffer to find")
+    }
+}


### PR DESCRIPTION
`MicCaptureHandler.outputFile` was a plain stored property touched by three threads: created on whichever queue `startEngine` runs, nilled on the main queue by stop and by give-up, and read by the render-thread tap block for every buffer. That is a load racing a store-and-release, so a buffer already past the capture guard could be inside `write` on a file the main queue had just dropped.

It is now lock-backed, the way the app-audio channel already treats the same class of state. The getter retains under the lock and the write happens outside it, so an in-flight buffer finishes against a live object. One uncontended lock per buffer, which is nothing next to the resample and the file write it precedes.

## The report

ThreadSanitizer flags the race against the unguarded property and is silent against this one:

```
WARNING: ThreadSanitizer: data race
  Read of size 8 by thread T1:
    #0 MicCaptureHandler.outputFile.getter
    #1 closure #2 in MicCaptureHandler.startEngine
```

## Why the first attempt saw nothing

Worth writing down, because the wrong conclusion is easy to reach and I reached it. A first version of the test fulfilled an expectation from the delivering thread before calling stop. That establishes a happens-before edge between the two accesses, so the sanitizer had nothing left to report, and I read the silence as the capture guard having closed the window.

The guard does not close it. It only orders invocations that *begin* after it flips. The last read that already passed it is unordered with the nil-store, and that is exactly the pair under test. The test now coordinates by wall-clock sleep only and joins afterwards, which orders nothing.

Acceptance holds in both directions: revert the lock and the test goes red under `--sanitize=thread`, keep it and the whole suite is clean.

## Note on the sanitizer lane

This test is only enforceable in CI once the sanitizer matrix covers `tools/audiotap`, which is a separate pull request. Until that lands, the check exists but nothing runs it automatically.

## Verification

242 tests in `tools/audiotap`, the full suite again under ThreadSanitizer with zero reports, the full `app/MeetingTranscriber` suite, SwiftFormat and SwiftLint clean over 422 files, `swiftlint analyze --strict` clean over 380, and the release-mode parity build.