### PR TITLE
fix(app): stop Escape from committing the auto-matched speaker names

### DIFF
--- a/.claude/skills/e2e-architecture/SKILL.md
+++ b/.claude/skills/e2e-architecture/SKILL.md
@@ -46,6 +46,15 @@ PRs are excluded from the self-hosted runner.
 - Exercises the production code path end-to-end including TCC, audio
   routing, CATapDescription tap, and the dual-track recorder/diarizer
   handoff.
+- The `--naming-escape` lane is the only automated cover for "the user pressed
+  Escape on the naming dialog" (issue #577, where Escape used to commit the
+  auto-matched names). It parks a job at naming, fronts the app, posts a real
+  Escape via System Events, then asserts *both* halves of the fix: the window is
+  gone from `/state.windows`, and the job is still `speakerNamingPending` — a
+  dismiss, not a Skip. It deliberately does not click into a name field first,
+  because the unfocused path is the one the fix nearly shipped broken (the
+  dialog binds dismiss twice: `onExitCommand` for the focused case, a
+  `.cancelAction` carrier for the rest). Needs the two grants in step 6 below.
 - The `--naming-confirm` lane additionally drives the speaker-naming CONFIRM
   path end-to-end (enqueue a 2-speaker fixture, park at naming instead of
   auto-skipping, `POST /v1/jobs/<id>/naming` an anonymous mapping, then assert
@@ -137,6 +146,53 @@ PRs are excluded from the self-hosted runner.
    so this one is belt-and-suspenders).
 5. Verify Microphone + Screen & System Audio Recording show the dev `.app`
    with the toggle on.
+6. Grant **Accessibility** and **Automation** for the `--naming-escape` lane.
+   Nothing else needs them, and they are of a different shape than the grants
+   above: they key on a *binary path* and a *user account*, not on the app's
+   signing cert, so they survive app rebuilds but not a reinstall that moves the
+   binary.
+
+   The lane needs them because posting a real key event through the WindowServer
+   is the only way to reach SwiftUI's exit command — a synthetic `NSEvent` with
+   keycode 53 never gets there, since the translation to `cancelOperation:`
+   happens inside `interpretKeyEvents:`, which no responder in that window calls
+   unless a name field holds focus.
+
+   **Grant as the runner's own account.** The agent runs as its own user
+   (`runner`, `~/runners/<runner-name>/`), which on this host is also the console
+   user, and TCC is per-user: granting from the account a person normally uses
+   leaves the runner's database untouched, so a hand-run passes while CI keeps
+   skipping.
+
+   **The two do not attribute the same way** — the detail that cost the most
+   time here. Measured on the mini:
+
+   - **Automation** carried over from a hand-run to CI on its own.
+   - **Accessibility** did not. Granting Terminal did not help, nor did granting
+     `/usr/bin/osascript`. TCC attributes it to the *responsible* process, which
+     for a CI job is the service's top-level binary, so the entry that works is
+     the agent's own Node: `~/runners/<runner-name>/externals/node20/bin/node`.
+     The listener binary itself cannot be picked — the Accessibility chooser
+     greys out bare executables — and launchd starts `runsvc.sh` → node → the
+     listener anyway, so node is both the selectable and the correct answer.
+
+   Only the runner carrying the `audio` label serves this workflow, so only that
+   one needs the grant. A second runner given that label would need its own node
+   binary added, since the grant is per path.
+
+   To raise the prompts by hand, run the lane once in the runner's GUI session:
+   `E2E_TCC_PROMPT_TIMEOUT=300 bash scripts/e2e-app.sh --no-build --naming-escape`.
+   The env var widens the preflight's probe window from its 10 s CI default so
+   the prompt stays up long enough to answer; without it the probe gives up
+   first and the prompt goes with it. `tccutil` can only reset, and the MDM/PPPC
+   route is unavailable here (see step 3), so a click is unavoidable.
+
+   Until both are in place the lane **skips loudly and passes**, writing cause
+   and fix to the step summary. Deliberate: an ungranted host would otherwise
+   turn every PR red for a prerequisite unrelated to the change under test, and
+   a silent skip would be worse still, since it would read as coverage. The
+   tolerance is narrow — only the preflight's two missing-grant arms return
+   early; anything failing after them still fails the lane.
 
 After setup, every CI run rebuilds + re-signs the `.app`; the cdhash differs
 per build but the cert leaf SHA-1 doesn't, so TCC keeps the manual grant across

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -305,6 +305,28 @@ jobs:
         timeout-minutes: 12
         run: bash scripts/e2e-app.sh --no-build --naming-confirm
 
+      # Escape-dismisses-naming lane (issue #577): the only automated cover for
+      # "the user pressed Escape on the naming dialog". It has to be a real
+      # WindowServer keystroke — a synthetic NSEvent never reaches SwiftUI's exit
+      # command, because keycode 53 is translated only inside
+      # `interpretKeyEvents:`, which no responder in that window calls unless a
+      # name field holds focus. The lane deliberately does not focus one: the
+      # unfocused path is the one the fix nearly shipped broken.
+      # RUNNER PREREQUISITE: the runner shell needs an Accessibility grant, a
+      # one-time setup step alongside the mic / screen-recording grants (see the
+      # e2e-architecture skill). The driver preflights it and fails with its own
+      # message, so a missing grant reads as a missing grant rather than as a
+      # broken dismiss.
+      # PLACEMENT: cheap and non-level-sensitive, so it sits next to the other
+      # naming lane and still ahead of crash-recovery.
+      - name: Run live-recording E2E driver (speaker-naming escape)
+        env:
+          DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
+        # One transcribe + diarize to park the dialog, then a keystroke and two
+        # short polls; 8 min leaves margin without hiding a hang.
+        timeout-minutes: 8
+        run: bash scripts/e2e-app.sh --no-build --naming-escape
+
       # Title-source lane (issue #501): run the simulator with a window title
       # equal to the app name (no usable meeting-window title), then assert the
       # detected meeting title is the clean "MeetingSimulator Call" placeholder,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,10 +282,11 @@ Text injection works precisely because insertion *is* interpreted down there.
 Consequence for product code, not just tests: `onExitCommand` alone gives you a
 focus-dependent Escape, so a dialog that must always dismiss on Escape also needs
 a `.keyboardShortcut(.cancelAction)` carrier, which rides the focus-independent
-key-equivalent pass (`SpeakerNamingView.escapeDismissShortcut`). Physical Escape
-therefore stays manual QA — per the rule below, that a `keyboardShortcut` fires is
-framework behavior — while ViewInspector pins the handler wiring and `/state` pins
-the resulting window/job state.
+key-equivalent pass (`SpeakerNamingView.escapeDismissShortcut`). A physical Escape is
+drivable only from outside the process, via a WindowServer keystroke: that is what
+`scripts/e2e-app.sh --naming-escape` does, and it is why that lane (alone) needs an
+Accessibility grant on the runner. Below that layer, ViewInspector pins the handler
+wiring and `/state` pins the resulting window/job state.
 
 **Typing** is automatable via `POST /ui/type` (allowlisted plain text fields only —
 never a `SecureField`). It posts real key events, because an AX set-value does *not*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,23 @@ fires). **Manual-QA-only, accepted:** menu-bar dropdown interaction, modal panel
 (NSOpenPanel/NSAlert), TCC prompts, drag/focus order, visual appearance beyond dev-only
 snapshots.
 
+**Escape resists injection, and the reason shapes how Escape must be bound.** A
+hand-built `NSEvent` with keycode 53 does not reach SwiftUI's `onExitCommand`:
+tried via `NSWindow.sendEvent` in xctest, and in the live app via both
+`NSWindow.sendEvent` and `NSApplication.sendEvent` with the window made key and
+the app activated — all report a clean dispatch and change nothing. The
+mechanism: keycode 53 becomes `cancelOperation:` only inside
+`interpretKeyEvents:`, which only text-input responders call, so with no field
+focused AppKit's fallback emits `cancel:` instead, which `onExitCommand` ignores.
+Text injection works precisely because insertion *is* interpreted down there.
+Consequence for product code, not just tests: `onExitCommand` alone gives you a
+focus-dependent Escape, so a dialog that must always dismiss on Escape also needs
+a `.keyboardShortcut(.cancelAction)` carrier, which rides the focus-independent
+key-equivalent pass (`SpeakerNamingView.escapeDismissShortcut`). Physical Escape
+therefore stays manual QA — per the rule below, that a `keyboardShortcut` fires is
+framework behavior — while ViewInspector pins the handler wiring and `/state` pins
+the resulting window/job state.
+
 **Typing** is automatable via `POST /ui/type` (allowlisted plain text fields only —
 never a `SecureField`). It posts real key events, because an AX set-value does *not*
 fire the SwiftUI binding; that asymmetry is why there is no `/ui/setValue`. Pass

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -352,7 +352,9 @@ final class AppState {
                     // earlier skip race.
                     let pendingIDs = self.pipeline.queue.pendingSpeakerNamingJobs.map(\.id)
                     for jobID in pendingIDs {
-                        self.pipeline.queue.completeSpeakerNaming(jobID: jobID, result: .skipped)
+                        self.pipeline.queue.completeSpeakerNaming(
+                            jobID: jobID, result: .skipped, source: .rpc,
+                        )
                     }
                 }
             }

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -283,15 +283,18 @@ struct MeetingTranscriberApp: App {
             knownSpeakerNames: appState.pipeline.queue.knownSpeakerNames,
             currentDiarizerMode: appState.pipeline.queue.usedDiarizerMode(forJobID: data.jobID)
                 ?? appState.settings.diarizerMode,
-        ) { result in
-            appState.pipeline.queue.completeSpeakerNaming(jobID: data.jobID, result: result)
-            if appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty {
-                closeWindow(id: "speaker-naming")
-            } else {
-                appState.selectedNamingJobID =
-                    appState.pipeline.queue.pendingSpeakerNamingJobs.first?.id
-            }
-        }
+            pendingJobCount: appState.pipeline.queue.pendingSpeakerNamingJobs.count,
+            onDismissRequest: { closeWindow(id: "speaker-naming") },
+            onComplete: { result in
+                appState.pipeline.queue.completeSpeakerNaming(jobID: data.jobID, result: result)
+                if appState.pipeline.queue.pendingSpeakerNamingJobs.isEmpty {
+                    closeWindow(id: "speaker-naming")
+                } else {
+                    appState.selectedNamingJobID =
+                        appState.pipeline.queue.pendingSpeakerNamingJobs.first?.id
+                }
+            },
+        )
     }
 
     // MARK: - UI Actions

--- a/app/MeetingTranscriber/Sources/NamingGraceKey.swift
+++ b/app/MeetingTranscriber/Sources/NamingGraceKey.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Identity of one "keyboard grace" window in the speaker-naming dialog.
+///
+/// The grace gate re-locks Confirm and Skip whenever this value changes, so what
+/// belongs in it is exactly the set of events after which a keystroke aimed
+/// somewhere else can land on the dialog:
+///
+/// - `revision` — the dialog's data was replaced (first appearance, a Re-run
+///   result, or a switch to a different pending job). A fresh UUID per
+///   `SpeakerNamingData` instance, so this fires even when the new mapping is
+///   byte-identical to the old one.
+/// - `pendingJobCount` — another job reached speaker naming. That path posts
+///   `.showSpeakerNaming`, which force-activates the app via
+///   `NSApp.activate(ignoringOtherApps:)`. When the window is already open on
+///   the displayed job, its data does not change, so `revision` alone would
+///   leave the buttons live at the exact moment focus is taken from whatever
+///   the user was typing in.
+///
+/// Deliberately *not* included: window key-status. Re-arming whenever the window
+/// becomes key would also disable the buttons for someone who clicks into the
+/// window and then clicks Confirm, because the gate blocks clicks as well as
+/// keystrokes.
+struct NamingGraceKey: Hashable {
+    let revision: UUID
+    let pendingJobCount: Int
+}

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -346,7 +346,9 @@ final class PipelineController {
     /// awaiting naming, returning whether it did (false → 404).
     private func resolveNaming(jobID: UUID, result: PipelineQueue.SpeakerNamingResult) -> Bool {
         guard pendingNamingData(forID: jobID) != nil else { return false }
-        queue.completeSpeakerNaming(jobID: jobID, result: result)
+        // Tagged `.rpc`: nobody was looking at a dialog, so a row from here must
+        // not read as a human decision in the recognition log.
+        queue.completeSpeakerNaming(jobID: jobID, result: result, source: .rpc)
         return true
     }
 

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -175,16 +175,18 @@ class PipelineQueue {
     /// Called by the UI (and the test handler) when the user confirms, skips, or
     /// re-runs speaker naming. Thin forwarder to the naming session, which
     /// always handles "late" completion — the pipeline never blocks on naming.
-    func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
-        naming.completeSpeakerNaming(jobID: jobID, result: result)
+    func completeSpeakerNaming(
+        jobID: UUID, result: SpeakerNamingResult, source: RecognitionSource = .dialog,
+    ) {
+        naming.completeSpeakerNaming(jobID: jobID, result: result, source: source)
     }
 
     /// Called by the UI when the user confirms or skips speaker naming without a
     /// specific job in hand — resolves the first pending job (or any stashed
     /// naming data) and forwards to the session.
-    func completeSpeakerNaming(result: SpeakerNamingResult) {
+    func completeSpeakerNaming(result: SpeakerNamingResult, source: RecognitionSource = .dialog) {
         if let jobID = pendingSpeakerNamingJobs.first?.id ?? naming.speakerNamingDataByJob.keys.first {
-            naming.completeSpeakerNaming(jobID: jobID, result: result)
+            naming.completeSpeakerNaming(jobID: jobID, result: result, source: source)
         }
     }
 

--- a/app/MeetingTranscriber/Sources/RecognitionStats.swift
+++ b/app/MeetingTranscriber/Sources/RecognitionStats.swift
@@ -8,6 +8,21 @@ enum RecognitionAction: String, Codable, CaseIterable {
     case accepted, corrected, added, skipped, dismissed
 }
 
+/// Which code path resolved a speaker-naming decision. Distinguishes a person
+/// acting in the dialog from the paths that resolve naming on their own, which
+/// otherwise produce byte-identical rows — the question that had to be answered
+/// by hand when triaging a naming window that closed without anyone deciding.
+enum RecognitionSource: String, Codable {
+    /// The "Name Speakers" window: someone clicked Confirm or Skip.
+    case dialog
+    /// Resolved over the automation API rather than by a person at the screen.
+    case rpc
+    /// 24 h stale cleanup accepted the auto-names for an abandoned job.
+    case stale
+    /// Headless blocking-transcribe finished on the auto-names, no dialog.
+    case headless
+}
+
 /// Which diarized track the speaker label belongs to.
 enum RecognitionTrack: String, Codable {
     case app, mic, single
@@ -37,6 +52,30 @@ struct RecognitionEvent: Codable, Equatable {
     // Optional so old log lines without this field still decode.
     // swiftlint:disable:next discouraged_optional_collection
     let topCandidates: [TopCandidate]?
+    /// Which path produced this decision. Optional for the same reason as
+    /// `topCandidates`: rows written before the field existed must still decode,
+    /// and they read as `nil` rather than being silently attributed to a source.
+    let source: RecognitionSource?
+
+    init(
+        ts: Date, jobID: UUID, meetingTitle: String, track: RecognitionTrack,
+        label: String, autoName: String?, userName: String?,
+        action: RecognitionAction,
+        // swiftlint:disable:next discouraged_optional_collection
+        topCandidates: [TopCandidate]?,
+        source: RecognitionSource? = nil,
+    ) {
+        self.ts = ts
+        self.jobID = jobID
+        self.meetingTitle = meetingTitle
+        self.track = track
+        self.label = label
+        self.autoName = autoName
+        self.userName = userName
+        self.action = action
+        self.topCandidates = topCandidates
+        self.source = source
+    }
 }
 
 /// Per-candidate distance forensics for a single match decision. Used both
@@ -79,6 +118,7 @@ enum RecognitionStats {
         topCandidates: [String: [TopCandidate]],
         jobID: UUID,
         meetingTitle: String,
+        source: RecognitionSource? = nil,
         now: Date = Date(),
     ) -> [RecognitionEvent] {
         let labels = Set(suggested.keys).union(userMapping?.keys ?? [:].keys).sorted()
@@ -98,6 +138,7 @@ enum RecognitionStats {
                 userName: user,
                 action: action,
                 topCandidates: topCandidates[label],
+                source: source,
             )
         }
     }

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession+Late.swift
@@ -160,7 +160,9 @@ extension SpeakerNamingSession {
 
             if let handler = speakerNamingHandler {
                 let result = await handler(newNamingData)
-                completeSpeakerNaming(jobID: jobID, result: result)
+                // Same as the first-pass invocation: the handler stands in for
+                // the re-opened dialog, so it reports as the dialog.
+                completeSpeakerNaming(jobID: jobID, result: result, source: .dialog)
             }
         } catch {
             logger.error("Late re-diarization failed: \(error.localizedDescription, privacy: .public)")

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -140,7 +140,14 @@ final class SpeakerNamingSession {
     /// Called by the UI (or the test handler, via the queue forwarder) when the
     /// user confirms, skips, or re-runs speaker naming. Always handles "late"
     /// completion — the pipeline never blocks on naming.
-    func completeSpeakerNaming(jobID: UUID, result: SpeakerNamingResult) {
+    /// `source` has no default on purpose: the queue's forwarders default it
+    /// for the UI, but a new path into the session must state where the
+    /// decision came from. An unattributed row would be indistinguishable from
+    /// one written before the field existed, which is exactly the ambiguity
+    /// this field was added to remove.
+    func completeSpeakerNaming(
+        jobID: UUID, result: SpeakerNamingResult, source: RecognitionSource,
+    ) {
         guard let data = speakerNamingDataByJob[jobID] else { return }
         let slug = delegate?.job(withID: jobID)?.namingSlug
 
@@ -149,6 +156,7 @@ final class SpeakerNamingSession {
             recordRecognition(
                 jobID: jobID, title: data.meetingTitle,
                 userMapping: userMapping, fallback: data.mapping,
+                source: source,
             )
             // Transition out of .speakerNamingPending synchronously so the UI's
             // close-when-empty check sees the change immediately. This synchronous
@@ -170,6 +178,7 @@ final class SpeakerNamingSession {
             recordRecognition(
                 jobID: jobID, title: data.meetingTitle,
                 userMapping: nil, fallback: data.mapping,
+                source: source,
             )
             acceptAutoNames(jobID: jobID, slug: slug)
         }
@@ -184,7 +193,8 @@ final class SpeakerNamingSession {
         guard let handler = speakerNamingHandler else { return }
         Task {
             let result = await handler(data)
-            completeSpeakerNaming(jobID: jobID, result: result)
+            // The handler stands in for the dialog, so it reports as the dialog.
+            completeSpeakerNaming(jobID: jobID, result: result, source: .dialog)
         }
     }
 
@@ -221,18 +231,43 @@ final class SpeakerNamingSession {
     private func generateProtocolForExistingJob(
         jobID: UUID, delegate: any SpeakerNamingSessionDelegate,
     ) async {
-        guard let job = delegate.job(withID: jobID),
-              let transcriptPath = job.transcriptPath,
+        // A job that is gone needs no transition. Anything else must reach a
+        // terminal state on every exit: `acceptAutoNames` has already deleted
+        // the naming sidecars by the time we get here, so bailing out without a
+        // transition would strand the job in `.speakerNamingPending` with
+        // nothing left to name — the naming window would keep reopening on an
+        // empty placeholder, and the next launch would drop the job with no
+        // protocol ever written.
+        guard let job = delegate.job(withID: jobID) else { return }
+        guard let transcriptPath = job.transcriptPath,
               let outputDir,
               let transcript = try? String(contentsOf: transcriptPath, encoding: .utf8)
-        else { return }
+        else {
+            // Reachable when the transcript was moved or deleted between the
+            // pipeline writing it and the user resolving naming: the caller's
+            // readiness probe only checks that `transcriptPath` is non-nil.
+            delegate.addWarning(id: jobID, "Protocol not generated — transcript file is missing")
+            finishIfUnresolved(jobID: jobID, delegate: delegate)
+            return
+        }
         await delegate.generateProtocol(
             jobID: jobID,
             transcript: transcript,
             title: job.meetingTitle,
             protocolsDir: outputDir.appendingPathComponent("protocols"),
         )
-        if delegate.job(withID: jobID)?.state == .generatingProtocol {
+        finishIfUnresolved(jobID: jobID, delegate: delegate)
+    }
+
+    /// Move a job to `.done` unless something already advanced it. Accepts
+    /// `.speakerNamingPending` as well as `.generatingProtocol` because the
+    /// generation call can return before its own `.generatingProtocol`
+    /// transition — it guards on the protocol factory, which can go nil between
+    /// the readiness probe and the call. Both shapes leave the job pending, and
+    /// pending with its sidecars deleted is unrecoverable.
+    private func finishIfUnresolved(jobID: UUID, delegate: any SpeakerNamingSessionDelegate) {
+        let state = delegate.job(withID: jobID)?.state
+        if state == .generatingProtocol || state == .speakerNamingPending {
             delegate.updateJobState(id: jobID, to: .done)
         }
     }
@@ -309,6 +344,15 @@ final class SpeakerNamingSession {
             // its own. Don't stash naming data: there is no interactive client
             // to resolve it, and parking would wedge the job until the next
             // launch's 24h stale-cleanup.
+            //
+            // Log it as a resolution like every other path, tagged `.headless`:
+            // the names still land in the transcript, so leaving no row would
+            // hide an auto-accept nobody reviewed.
+            recordRecognition(
+                jobID: jobID, title: title,
+                userMapping: nil, fallback: autoNames,
+                source: .headless,
+            )
             return autoNames
         }
         // Production/interactive: stash the naming data so the queue parks the
@@ -363,6 +407,16 @@ final class SpeakerNamingSession {
         let now = Date()
         for job in pendingJobs where now.timeIntervalSince(job.enqueuedAt) > maxAge {
             logger.info("Auto-resolving stale pending naming for \(job.meetingTitle, privacy: .private)")
+            // Log it like any other resolution. This used to accept the
+            // auto-names with no row at all, which made a job that nobody ever
+            // decided indistinguishable from one that was never diarized.
+            if let data = speakerNamingDataByJob[job.id] {
+                recordRecognition(
+                    jobID: job.id, title: data.meetingTitle,
+                    userMapping: nil, fallback: data.mapping,
+                    source: .stale,
+                )
+            }
             acceptAutoNames(jobID: job.id, slug: job.namingSlug)
         }
     }
@@ -371,35 +425,19 @@ final class SpeakerNamingSession {
 
     /// Pull stashed forensics for a job and write the recognition-stats row.
     /// Falls back to the original SpeakerNamingData mapping when the stash is
-    /// missing (e.g. the user confirmed in a fresh app session).
+    /// missing (e.g. the user confirmed in a fresh app session). Logs outcome
+    /// counts immediately; the JSONL append runs in a detached Task.
     private func recordRecognition(
         jobID: UUID, title: String,
         // swiftlint:disable:next discouraged_optional_collection
         userMapping: [String: String]?, fallback: [String: String],
+        source: RecognitionSource,
     ) {
-        recordRecognition(
+        let events = RecognitionStats.buildEvents(
             suggested: stashedSuggestedAtDialog[jobID] ?? fallback,
             userMapping: userMapping,
             topCandidates: stashedTopCandidates[jobID] ?? [:],
-            jobID: jobID,
-            title: title,
-        )
-    }
-
-    /// Build recognition events and persist them off the pipeline path. Logs
-    /// outcome counts immediately; JSONL append runs in a detached Task.
-    private func recordRecognition(
-        suggested: [String: String],
-        // swiftlint:disable:next discouraged_optional_collection
-        userMapping: [String: String]?,
-        topCandidates: [String: [TopCandidate]],
-        jobID: UUID,
-        title: String,
-    ) {
-        let events = RecognitionStats.buildEvents(
-            suggested: suggested, userMapping: userMapping,
-            topCandidates: topCandidates,
-            jobID: jobID, meetingTitle: title,
+            jobID: jobID, meetingTitle: title, source: source,
         )
         var counts: [RecognitionAction: Int] = [:]
         for e in events {

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -74,6 +74,17 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
     /// mode picker. `nil` for legacy jobs without a recorded mode — the
     /// picker initialises to `.offline` in that case.
     let currentDiarizerMode: DiarizerMode?
+    /// Number of jobs currently waiting for speaker naming. Part of the grace
+    /// gate's identity, not display state: a job arriving here force-activates
+    /// the app, so the buttons must re-lock even though the displayed data is
+    /// unchanged. See `NamingGraceKey`.
+    let pendingJobCount: Int
+    /// Invoked when the user asks to dismiss the dialog (Escape). Closing is a
+    /// no-op for the job — it stays `.speakerNamingPending` and can be reopened
+    /// from the menu bar — which is what makes it a safe thing to bind a stray
+    /// keystroke to. `nil` for hosts with no window to close (voice enrollment
+    /// renders this view inline), where Escape stays inert.
+    let onDismissRequest: (() -> Void)?
     let onComplete: (PipelineQueue.SpeakerNamingResult) -> Void
 
     /// Window after the dialog appears (or after Re-run produces a fresh `data.revision`)
@@ -91,13 +102,17 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         data: PipelineQueue.SpeakerNamingData,
         knownSpeakerNames: [String] = [],
         currentDiarizerMode: DiarizerMode? = nil,
+        pendingJobCount: Int = 1,
         gracePeriod: TimeInterval = Self.defaultKeyboardGracePeriod,
+        onDismissRequest: (() -> Void)? = nil,
         onComplete: @escaping (PipelineQueue.SpeakerNamingResult) -> Void,
     ) {
         self.data = data
         self.knownSpeakerNames = knownSpeakerNames
         self.currentDiarizerMode = currentDiarizerMode
+        self.pendingJobCount = pendingJobCount
         self.gracePeriod = gracePeriod
+        self.onDismissRequest = onDismissRequest
         self.onComplete = onComplete
         // Seed `names` and `rerunCount` synchronously so the view renders
         // its chip rows on first body evaluation (the chips depend on
@@ -128,6 +143,11 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
     /// Re-run Stepper range for the given mode.
     static func rerunCountRange(for mode: DiarizerMode) -> ClosedRange<Int> {
         1 ... mode.speakerCap
+    }
+
+    /// Identity of the current grace window. Changing it re-locks the buttons.
+    var graceKey: NamingGraceKey {
+        NamingGraceKey(revision: data.revision, pendingJobCount: pendingJobCount)
     }
 
     @State private var keyboardGracePeriodActive: Bool = true
@@ -259,12 +279,18 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
             rerunSection
 
             HStack(spacing: 12) {
+                // Deliberately no `.keyboardShortcut(.escape)`. Skip accepts the
+                // matcher's guesses and then deletes the naming data, so it is
+                // irreversible — while Escape means "dismiss this" to everyone
+                // who has ever used a Mac. Binding the two made a dismissal
+                // silently commit a low-confidence auto-match (issue #577).
+                // Escape now closes the window instead (see `onDismissRequest`),
+                // which leaves the job pending and re-openable.
                 Button("Skip") {
                     guard completedJobID != data.jobID else { return }
                     completedJobID = data.jobID
                     onComplete(.skipped)
                 }
-                .keyboardShortcut(.escape)
                 .disabled(keyboardGracePeriodActive)
                 .accessibilityIdentifier(A11yID.skipButton)
 
@@ -279,6 +305,8 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
                 .accessibilityIdentifier(A11yID.confirmButton)
             }
             .padding(.bottom, 8)
+
+            escapeDismissShortcut
         }
         .padding()
         .frame(minWidth: 400, maxHeight: 700)
@@ -292,11 +320,29 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         .onChange(of: data.revision) { _, _ in
             resetForCurrentPresentation()
         }
+        // Escape dismisses the window rather than resolving the job. The
+        // optional is passed straight through, so a host that supplies none
+        // installs no handler at all and Escape keeps bubbling — the voice
+        // enrollment flow renders this view in a sheet, where swallowing Escape
+        // would silently break sheet-dismisses-on-Escape for one stage only.
+        //
+        // `onExitCommand` alone is not enough, which is easy to miss: it only
+        // sees Escape once something translated the keystroke into
+        // `cancelOperation:`, and that translation happens in
+        // `interpretKeyEvents:`, which only text-input responders call. With no
+        // name field focused, AppKit's fallback emits `cancel:` instead and the
+        // handler never runs. The destructive binding this replaced did not have
+        // that gap — a `keyboardShortcut` rides the key-equivalent pass, which
+        // fires regardless of focus, which is exactly how a stray Escape reached
+        // Skip in the first place. So the dismiss is bound both ways (see
+        // `escapeDismissShortcut`) rather than trading one blind spot for another.
+        .onExitCommand(perform: onDismissRequest)
         // Keyboard-grace gate: keep Confirm + Skip disabled for `gracePeriod`
-        // seconds after the dialog appears AND after each Re-run produces a
-        // fresh `data.revision`. The `task(id:)` cancels + restarts when
-        // `data.revision` changes, re-locking the buttons each time.
-        .task(id: data.revision) {
+        // seconds after the dialog appears, after each Re-run produces a fresh
+        // `data.revision`, and whenever another job reaches naming and steals
+        // focus. The `task(id:)` cancels + restarts when `graceKey` changes,
+        // re-locking the buttons each time.
+        .task(id: graceKey) {
             guard gracePeriod > 0 else {
                 keyboardGracePeriodActive = false
                 return
@@ -311,6 +357,26 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         // the window (Cmd+Q, click X, app quit) leaves the job in
         // .speakerNamingPending so the user can re-open later. Explicit Skip
         // button still calls onComplete(.skipped).
+    }
+
+    /// Zero-sized carrier for the Escape key equivalent, present only when the
+    /// host gave us something to dismiss.
+    ///
+    /// A button rather than another view modifier because `.cancelAction` is the
+    /// documented way onto the key-equivalent pass, and that pass is what makes
+    /// Escape work with nothing focused. Not user-visible: the dialog's
+    /// affordances stay Skip and Confirm, and closing is already reachable by the
+    /// window's close button. Deliberately *not* behind the keyboard-grace gate —
+    /// dismissing changes nothing about the job, so there is no accident to
+    /// protect against, which is the whole reason Escape was moved here.
+    @ViewBuilder private var escapeDismissShortcut: some View {
+        if let onDismissRequest {
+            Button("", action: onDismissRequest)
+                .keyboardShortcut(.cancelAction)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+        }
     }
 
     /// Re-seed all per-presentation @State from the current `data`. Called

--- a/app/MeetingTranscriber/Tests/AccidentalNamingAcceptTests.swift
+++ b/app/MeetingTranscriber/Tests/AccidentalNamingAcceptTests.swift
@@ -25,6 +25,7 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         var jobs: [UUID: PipelineJob] = [:]
         private(set) var updateSpeakerDBCalls: [[String: String]] = []
         private(set) var generateProtocolCallCount = 0
+        private(set) var warnings: [String] = []
         /// While true, `generateProtocol` parks after the `.generatingProtocol`
         /// transition, standing in for a slow LLM call so tests can observe the
         /// state the UI sees *during* generation.
@@ -38,7 +39,9 @@ final class AccidentalNamingAcceptTests: XCTestCase {
             jobs[id]?.state = newState
         }
 
-        func addWarning(id _: UUID, _: String) {}
+        func addWarning(id _: UUID, _ message: String) {
+            warnings.append(message)
+        }
 
         func setNamingMetadata(jobID _: UUID, slug _: String?, usedDiarizerMode _: DiarizerMode?) {}
 
@@ -57,9 +60,8 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         ///
         /// Deliberately unconditional, unlike the real path, which has two
         /// early returns before the flip (a missing transcript file, and a
-        /// protocol factory that turned nil after the probe) — each of which
-        /// leaves the job wedged in `.speakerNamingPending` with its sidecars
-        /// already deleted. Not modelled here; see the wedge test below.
+        /// protocol factory that turned nil after the probe). Both are handled
+        /// by the session rather than here — see the missing-transcript test.
         func generateProtocol(jobID: UUID, transcript _: String, title _: String, protocolsDir _: URL) async {
             generateProtocolCallCount += 1
             jobs[jobID]?.state = .generatingProtocol
@@ -187,12 +189,11 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         XCTAssertEqual(mock.jobs[job.id]?.state, .done)
     }
 
-    /// Stale cleanup calls `acceptAutoNames` directly, bypassing
-    /// `recordRecognition`. So the auto-names are committed to the protocol
-    /// with no row in the recognition log at all — unlike an explicit Skip.
-    /// This asymmetry is the discriminator for triaging a window that closed
-    /// on its own.
-    func testStaleCleanupWritesNoRecognitionRow() async throws {
+    /// Stale cleanup commits the auto-names for a job nobody ever decided, so it
+    /// logs like any other resolution — tagged `.stale`, which is what tells it
+    /// apart from a person clicking Skip. It used to write nothing at all,
+    /// leaving that outcome invisible.
+    func testStaleCleanupWritesStaleTaggedRow() async throws {
         let tmp = try makeTempDirectory(prefix: "AccidentalNamingAcceptTests")
         let transcriptPath = tmp.appendingPathComponent("transcript.txt")
         try "] SPEAKER_0: hello".write(to: transcriptPath, atomically: true, encoding: .utf8)
@@ -214,8 +215,15 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         // regression would already have queued on the actor — so the negative
         // assertion below fails loudly instead of racing past a pending write.
         await statsLog.append([])
-        let rows = await statsLog.loadRecent(within: 3600)
-        XCTAssertTrue(rows.isEmpty, "stale cleanup left \(rows.count) recognition row(s)")
+        var rows = await statsLog.loadRecent(within: 3600)
+        let deadline = Date().addingTimeInterval(2)
+        while rows.isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+            rows = await statsLog.loadRecent(within: 3600)
+        }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.action, .dismissed)
+        XCTAssertEqual(rows.first?.source, .stale)
     }
 
     /// Control for the test above: an explicit Skip *is* traceable. Every label
@@ -236,7 +244,7 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         mock.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .skipped)
+        session.completeSpeakerNaming(jobID: job.id, result: .skipped, source: .dialog)
 
         await waitUntil { mock.jobs[job.id]?.state == .done }
         // The JSONL append runs in a detached Task, so poll for the row.
@@ -248,19 +256,18 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         }
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows.first?.action, .dismissed)
+        XCTAssertEqual(rows.first?.source, .dialog, "a click in the dialog is attributable")
     }
 
-    /// `acceptAutoNames` destroys the naming data *before* the protocol task is
-    /// guaranteed to transition the job. Its `canGenerateProtocol` probe checks
-    /// that `transcriptPath` is non-nil but never that the file exists, while
-    /// `generateProtocolForExistingJob` guards on actually reading it. A Skip on
-    /// a job whose transcript went missing therefore deletes every sidecar and
-    /// then returns without a state change, leaving the job wedged in
-    /// `.speakerNamingPending` with nothing left to name and no protocol.
-    ///
-    /// This documents current behaviour, not desired behaviour: a fix that
-    /// makes the cleanup conditional on the transition should flip this test.
-    func testSkipWithMissingTranscriptWedgesJobInPendingState() async throws {
+    /// `acceptAutoNames` destroys the naming data before the protocol task is
+    /// guaranteed to transition the job, and its readiness probe only checks
+    /// that `transcriptPath` is non-nil — not that the file is still there. So
+    /// the generation task can bail on an unreadable transcript after the
+    /// sidecars are already gone. Every exit of that task must therefore be
+    /// terminal: a job left in `.speakerNamingPending` with no naming data
+    /// reopens the dialog on an empty placeholder and is dropped without a
+    /// protocol at the next launch.
+    func testSkipWithMissingTranscriptStillFinishesTheJob() async throws {
         let tmp = try makeTempDirectory(prefix: "AccidentalNamingAcceptTests")
         // Non-nil path, no file behind it — e.g. the transcript was moved or
         // removed between the pipeline writing it and the user deciding.
@@ -274,19 +281,121 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         mock.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .skipped)
+        session.completeSpeakerNaming(jobID: job.id, result: .skipped, source: .dialog)
 
-        // Give the spawned task every chance to transition the job.
-        await waitUntil(
-            { mock.jobs[job.id]?.state != .speakerNamingPending }, timeout: 1,
-        )
+        await waitUntil { mock.jobs[job.id]?.state == .done }
 
         XCTAssertEqual(
-            mock.jobs[job.id]?.state, .speakerNamingPending,
-            "job is stuck: cleanup ran but nothing moved it out of pending",
+            mock.jobs[job.id]?.state, .done,
+            "an unreadable transcript must still resolve the job, not strand it",
         )
-        XCTAssertNil(session.speakerNamingDataByJob[job.id], "naming data is already gone")
-        XCTAssertEqual(mock.generateProtocolCallCount, 0, "no protocol was produced either")
+        XCTAssertNil(session.speakerNamingDataByJob[job.id], "naming data is gone")
+        XCTAssertEqual(mock.generateProtocolCallCount, 0, "no protocol could be produced")
+        XCTAssertEqual(mock.warnings.count, 1, "the user is told why there is no protocol")
+    }
+
+    // MARK: - Escape dismisses, never resolves
+
+    /// The load-bearing guarantee of the fix: the Escape handler runs the host's
+    /// dismiss action and never resolves the job. Skip used to be bound to
+    /// Escape, so this is the regression that must stay red if anyone rebinds
+    /// it.
+    func testExitCommandDismissesWithoutResolvingTheJob() throws {
+        var dismissed = 0
+        var results: [PipelineQueue.SpeakerNamingResult] = []
+        let view = SpeakerNamingView(
+            data: makeNamingData(jobID: UUID()),
+            gracePeriod: 0,
+            onDismissRequest: { dismissed += 1 },
+            onComplete: { results.append($0) },
+        )
+
+        try view.inspect().vStack().callOnExitCommand()
+
+        XCTAssertEqual(dismissed, 1)
+        XCTAssertTrue(results.isEmpty, "Escape must never resolve the job")
+    }
+
+    /// A host with no window to close installs no handler at all, so Escape
+    /// keeps bubbling. Voice enrollment renders this view inside a sheet, where
+    /// swallowing Escape would break sheet-dismisses-on-Escape for exactly one
+    /// stage of the flow.
+    func testExitCommandIsNotInstalledWithoutADismissHandler() throws {
+        let view = SpeakerNamingView(
+            data: makeNamingData(jobID: UUID()),
+            gracePeriod: 0,
+        ) { _ in }
+
+        XCTAssertThrowsError(try view.inspect().vStack().callOnExitCommand())
+    }
+
+    // MARK: - Headless resolution
+
+    /// Blocking-transcribe finishes on the auto-names with no dialog. The names
+    /// still reach the transcript, so the decision is logged like any other —
+    /// tagged `.headless`. It used to write no row, hiding an auto-accept that
+    /// nobody reviewed.
+    func testHeadlessAutoSkipWritesHeadlessTaggedRow() async throws {
+        let tmp = try makeTempDirectory(prefix: "AccidentalNamingAcceptTests")
+        let logPath = tmp.appendingPathComponent("recognition_log.jsonl")
+        let statsLog = RecognitionStatsLog(path: logPath)
+
+        let session = makeSession(outputDir: tmp, statsLog: statsLog)
+        let mock = MockDelegate()
+        session.delegate = mock
+
+        var job = PipelineJob(
+            meetingTitle: "Standup", appName: "Test",
+            mixPath: nil, appPath: nil, micPath: nil, micDelay: 0,
+            autoSkipNaming: true,
+        )
+        job.state = .diarizing
+        mock.jobs[job.id] = job
+
+        let diarization = DiarizationResult(
+            segments: [.init(start: 0, end: 12, speaker: "SPEAKER_0")],
+            speakingTimes: ["SPEAKER_0": 12],
+            autoNames: ["SPEAKER_0": "SPEAKER_0"],
+            embeddings: ["SPEAKER_0": [0.1, 0.2, 0.3]],
+        )
+        _ = session.resolveSpeakerNames(
+            diarization: diarization,
+            job: (jobID: job.id, title: "Standup", slug: "standup_abcd1234", participants: []),
+            diarizeProcess: MockDiarization(),
+            isDualSource: false, outputDir: tmp,
+        )
+
+        // No dialog is parked for a headless job.
+        XCTAssertNil(session.speakerNamingDataByJob[job.id])
+
+        var rows = await statsLog.loadRecent(within: 3600)
+        let deadline = Date().addingTimeInterval(2)
+        while rows.isEmpty, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+            rows = await statsLog.loadRecent(within: 3600)
+        }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.source, .headless)
+    }
+
+    // MARK: - Log schema stays backward compatible
+
+    /// Rows written before `source` existed must still decode, and must read as
+    /// `nil` rather than being attributed to a source they never recorded.
+    /// `RecognitionStatsLog.loadRecent` drops lines it cannot decode, so a
+    /// non-optional field here would silently erase the entire history.
+    func testLegacyLogLineWithoutSourceStillDecodes() throws {
+        let legacy = """
+        {"action":"accepted","autoName":"Alice","jobID":"\(UUID().uuidString)",\
+        "label":"SPEAKER_0","meetingTitle":"Standup","track":"single",\
+        "ts":"2026-01-01T00:00:00Z","userName":"Alice"}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let event = try decoder.decode(RecognitionEvent.self, from: Data(legacy.utf8))
+
+        XCTAssertEqual(event.action, .accepted)
+        XCTAssertNil(event.source)
     }
 
     // MARK: - Confirm side effects (why a stray Return is worse)
@@ -311,7 +420,7 @@ final class AccidentalNamingAcceptTests: XCTestCase {
 
         // Verbatim the auto-mapping — what Confirm submits when nobody edits a
         // field, because the name fields are seeded from the auto-names.
-        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]), source: .dialog)
 
         await waitUntil { !mock.updateSpeakerDBCalls.isEmpty }
         XCTAssertEqual(mock.updateSpeakerDBCalls.count, 1)
@@ -331,7 +440,7 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         mock.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .skipped)
+        session.completeSpeakerNaming(jobID: job.id, result: .skipped, source: .dialog)
         await waitUntil { mock.jobs[job.id]?.state == .done }
 
         XCTAssertTrue(mock.updateSpeakerDBCalls.isEmpty)
@@ -374,40 +483,5 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         let matcher = SpeakerMatcher(dbPath: tmp.appendingPathComponent("speakers.json"))
         matcher.saveDB([updated])
         XCTAssertEqual(matcher.match(embeddings: ["S0": wrongVoice])["S0"], "Alice")
-    }
-
-    // MARK: - Escape dismisses, never resolves
-
-    /// The load-bearing guarantee of the fix: the Escape handler runs the host's
-    /// dismiss action and never resolves the job. Skip used to be bound to
-    /// Escape, so this is the regression that must stay red if anyone rebinds
-    /// it.
-    func testExitCommandDismissesWithoutResolvingTheJob() throws {
-        var dismissed = 0
-        var results: [PipelineQueue.SpeakerNamingResult] = []
-        let view = SpeakerNamingView(
-            data: makeNamingData(jobID: UUID()),
-            gracePeriod: 0,
-            onDismissRequest: { dismissed += 1 },
-            onComplete: { results.append($0) },
-        )
-
-        try view.inspect().vStack().callOnExitCommand()
-
-        XCTAssertEqual(dismissed, 1)
-        XCTAssertTrue(results.isEmpty, "Escape must never resolve the job")
-    }
-
-    /// A host with no window to close installs no handler at all, so Escape
-    /// keeps bubbling. Voice enrollment renders this view inside a sheet, where
-    /// swallowing Escape would break sheet-dismisses-on-Escape for exactly one
-    /// stage of the flow.
-    func testExitCommandIsNotInstalledWithoutADismissHandler() throws {
-        let view = SpeakerNamingView(
-            data: makeNamingData(jobID: UUID()),
-            gracePeriod: 0,
-        ) { _ in }
-
-        XCTAssertThrowsError(try view.inspect().vStack().callOnExitCommand())
     }
 }

--- a/app/MeetingTranscriber/Tests/AccidentalNamingAcceptTests.swift
+++ b/app/MeetingTranscriber/Tests/AccidentalNamingAcceptTests.swift
@@ -1,4 +1,6 @@
 @testable import MeetingTranscriber
+import SwiftUI
+import ViewInspector
 import XCTest
 
 /// Pins the ways speaker naming can resolve *without* a deliberate user
@@ -372,5 +374,40 @@ final class AccidentalNamingAcceptTests: XCTestCase {
         let matcher = SpeakerMatcher(dbPath: tmp.appendingPathComponent("speakers.json"))
         matcher.saveDB([updated])
         XCTAssertEqual(matcher.match(embeddings: ["S0": wrongVoice])["S0"], "Alice")
+    }
+
+    // MARK: - Escape dismisses, never resolves
+
+    /// The load-bearing guarantee of the fix: the Escape handler runs the host's
+    /// dismiss action and never resolves the job. Skip used to be bound to
+    /// Escape, so this is the regression that must stay red if anyone rebinds
+    /// it.
+    func testExitCommandDismissesWithoutResolvingTheJob() throws {
+        var dismissed = 0
+        var results: [PipelineQueue.SpeakerNamingResult] = []
+        let view = SpeakerNamingView(
+            data: makeNamingData(jobID: UUID()),
+            gracePeriod: 0,
+            onDismissRequest: { dismissed += 1 },
+            onComplete: { results.append($0) },
+        )
+
+        try view.inspect().vStack().callOnExitCommand()
+
+        XCTAssertEqual(dismissed, 1)
+        XCTAssertTrue(results.isEmpty, "Escape must never resolve the job")
+    }
+
+    /// A host with no window to close installs no handler at all, so Escape
+    /// keeps bubbling. Voice enrollment renders this view inside a sheet, where
+    /// swallowing Escape would break sheet-dismisses-on-Escape for exactly one
+    /// stage of the flow.
+    func testExitCommandIsNotInstalledWithoutADismissHandler() throws {
+        let view = SpeakerNamingView(
+            data: makeNamingData(jobID: UUID()),
+            gracePeriod: 0,
+        ) { _ in }
+
+        XCTAssertThrowsError(try view.inspect().vStack().callOnExitCommand())
     }
 }

--- a/app/MeetingTranscriber/Tests/NamingGraceKeyTests.swift
+++ b/app/MeetingTranscriber/Tests/NamingGraceKeyTests.swift
@@ -1,0 +1,50 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The grace gate re-locks Confirm and Skip whenever `NamingGraceKey` changes,
+/// so these tests are about what counts as "a new grace window". SwiftUI's
+/// `.task(id:)` compares by equality, so equality *is* the behaviour.
+final class NamingGraceKeyTests: XCTestCase {
+    func testSameRevisionAndCountIsTheSameGraceWindow() {
+        let revision = UUID()
+        XCTAssertEqual(
+            NamingGraceKey(revision: revision, pendingJobCount: 1),
+            NamingGraceKey(revision: revision, pendingJobCount: 1),
+        )
+    }
+
+    /// Re-run and job switches replace the data, which is the pre-existing
+    /// re-arm trigger.
+    func testChangedRevisionStartsANewGraceWindow() {
+        XCTAssertNotEqual(
+            NamingGraceKey(revision: UUID(), pendingJobCount: 1),
+            NamingGraceKey(revision: UUID(), pendingJobCount: 1),
+        )
+    }
+
+    /// The case the `revision`-only key missed: a second job reaches naming
+    /// while the window is already open on the first. That posts
+    /// `.showSpeakerNaming`, which force-activates the app — but the displayed
+    /// job's data is untouched, so without the count in the key the buttons
+    /// would stay live at exactly the moment focus is taken away from whatever
+    /// the user was typing in.
+    func testAnotherJobArrivingStartsANewGraceWindow() {
+        let revision = UUID()
+        XCTAssertNotEqual(
+            NamingGraceKey(revision: revision, pendingJobCount: 1),
+            NamingGraceKey(revision: revision, pendingJobCount: 2),
+        )
+    }
+
+    /// Resolving one of several pending jobs also re-arms. Slightly more
+    /// re-locking than strictly needed, and deliberate: it covers the observed
+    /// sequence of two dismissals two seconds apart, where the second landed on
+    /// a dialog that had just swapped in under the cursor.
+    func testCountDroppingAlsoStartsANewGraceWindow() {
+        let revision = UUID()
+        XCTAssertNotEqual(
+            NamingGraceKey(revision: revision, pendingJobCount: 2),
+            NamingGraceKey(revision: revision, pendingJobCount: 1),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingSessionTests.swift
@@ -132,7 +132,7 @@ final class SpeakerNamingSessionTests: XCTestCase {
         mock.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]), source: .dialog)
 
         // The pending → generatingProtocol hop MUST be synchronous (the RPC
         // idempotency contract): it has already happened when the call returns,
@@ -159,7 +159,7 @@ final class SpeakerNamingSessionTests: XCTestCase {
         mock.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .skipped)
+        session.completeSpeakerNaming(jobID: job.id, result: .skipped, source: .dialog)
 
         // Skip with no protocol generator is fully synchronous.
         XCTAssertEqual(mock.jobs[job.id]?.state, .done)
@@ -175,7 +175,9 @@ final class SpeakerNamingSessionTests: XCTestCase {
         session.delegate = mock
 
         // No speakerNamingDataByJob entry → guard returns immediately.
-        session.completeSpeakerNaming(jobID: UUID(), result: .confirmed(["SPEAKER_0": "Alice"]))
+        session.completeSpeakerNaming(
+            jobID: UUID(), result: .confirmed(["SPEAKER_0": "Alice"]), source: .dialog,
+        )
         XCTAssertTrue(mock.stateTransitions.isEmpty)
     }
 
@@ -193,7 +195,7 @@ final class SpeakerNamingSessionTests: XCTestCase {
 
         session.speakerNamingDataByJob[jobID] = makeNamingData(jobID: jobID)
         // Must not crash even though every delegate callback resolves to nil.
-        session.completeSpeakerNaming(jobID: jobID, result: .skipped)
+        session.completeSpeakerNaming(jobID: jobID, result: .skipped, source: .dialog)
 
         // removeNamingData still ran (session-owned, no delegate needed).
         XCTAssertNil(session.speakerNamingDataByJob[jobID])
@@ -283,7 +285,7 @@ final class SpeakerNamingSessionTests: XCTestCase {
         recorder.jobs[job.id] = job
         session.speakerNamingDataByJob[job.id] = makeNamingData(jobID: job.id)
 
-        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]))
+        session.completeSpeakerNaming(jobID: job.id, result: .confirmed(["SPEAKER_0": "Alice"]), source: .dialog)
 
         // Wait until the re-apply flow is provably in-flight (parked inside the
         // delegate's generateProtocol, i.e. mid-"LLM generation").

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -36,6 +36,7 @@ MIC_DEVICE_CHANGE=false  # build the issue #379 fault-injection seam + assert th
 CRASH_RECOVERY=false     # kill mid-recording + assert the orphan is recovered into the pipeline on relaunch (issue #379 part 3)
 REDEPLOY_ONLY=false      # rebuild + redeploy the canonical (non-fault) bundle and exit — restores a clean bundle after --mic-device-change
 NAMING_CONFIRM=false     # drive the speaker-naming CONFIRM path end-to-end via POST /v1/jobs/<id>/naming (see run_naming_confirm)
+NAMING_ESCAPE=false      # press a real Escape on the naming dialog + assert it dismisses without resolving (issue #577)
 TITLE_SOURCE=false       # drive the window-title lookup with a no-usable-title case + assert the clean placeholder (issue #501 title source)
 
 while [ $# -gt 0 ]; do
@@ -53,11 +54,13 @@ while [ $# -gt 0 ]; do
         --crash-recovery)   CRASH_RECOVERY=true ;;
         --redeploy-only)    REDEPLOY_ONLY=true ;;
         --naming-confirm)   NAMING_CONFIRM=true ;;
+        --naming-escape)    NAMING_ESCAPE=true ;;
         --title-source)     TITLE_SOURCE=true ;;
         -h|--help)
             cat <<'HELP'
 Usage: e2e-app.sh [--no-build] [--keep-app] [--two-meetings] [--record-only]
                   [--reimport-recorded | --reimport-latest] [--keep-recordings]
+                  [--naming-escape]
                   [--naming-confirm] [--fixture path/to.wav]
 
   --no-build           Skip build/deploy/re-sign; use ~/Applications/MeetingTranscriber-Dev.app as-is.
@@ -147,6 +150,12 @@ fi
 # --naming-confirm is a standalone lane (its own enqueue + poll + confirm flow).
 # Reject combinations up-front so a typo can't silently fall through to another
 # lane's branch in the dispatch chain below.
+if [ "$NAMING_ESCAPE" = true ] && { [ "$NAMING_CONFIRM" = true ] || [ "$RECORD_ONLY" = true ] \
+    || [ "$REIMPORT_RECORDED" = true ] || [ "$REIMPORT_LATEST" = true ] || [ "$MIC_DEVICE_CHANGE" = true ] \
+    || [ "$CRASH_RECOVERY" = true ] || [ "$REDEPLOY_ONLY" = true ] || [ "$TWO_MEETINGS" = true ]; }; then
+    echo "Error: --naming-escape is a standalone lane; incompatible with the other lane flags" >&2
+    exit 2
+fi
 if [ "$NAMING_CONFIRM" = true ] && { [ "$RECORD_ONLY" = true ] || [ "$REIMPORT_RECORDED" = true ] \
     || [ "$REIMPORT_LATEST" = true ] || [ "$MIC_DEVICE_CHANGE" = true ] || [ "$CRASH_RECOVERY" = true ] \
     || [ "$REDEPLOY_ONLY" = true ] || [ "$TWO_MEETINGS" = true ]; }; then
@@ -591,8 +600,8 @@ _naming_confirm_cleanup() {
 # Self-heal a dead prior run's DB before anything touches it (CI-gated, all lanes).
 _naming_confirm_self_heal_db
 
-if [ "$NAMING_CONFIRM" = true ]; then
-    log "Enabling naming-confirm lane (diarize on, expected speakers = 2)"
+if [ "$NAMING_CONFIRM" = true ] || [ "$NAMING_ESCAPE" = true ]; then
+    log "Enabling naming lane (diarize on, expected speakers = 2)"
     # Snapshot BOTH domains (standard + container) BEFORE overriding so cleanup
     # restores each domain to exactly its own pre-lane state.
     _NC_PRE_DIARIZE_STD="$(snapshot_default "$DEV_BUNDLE_ID" diarize)"
@@ -604,7 +613,10 @@ if [ "$NAMING_CONFIRM" = true ]; then
     log "[naming-confirm] pre-lane diarize(std='$_NC_PRE_DIARIZE_STD' ctr='$_NC_PRE_DIARIZE_CTR') numSpeakers(std='$_NC_PRE_NUMSPK_STD' ctr='$_NC_PRE_NUMSPK_CTR')"
     _set_dev_default diarize true bool
     _set_dev_default numSpeakers 2 int
-    if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+    if [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "$NAMING_ESCAPE" != true ]; then
+        # Escape-lane runs never confirm — they dismiss — so nothing reaches
+        # updateSpeakerDB and the warning would be a false alarm on the one run
+        # people are told to perform by hand (the TCC setup run).
         log "[naming-confirm] WARNING: not running under CI. The speaker-DB"
         log "[naming-confirm] snapshot/restore is \$GITHUB_ACTIONS-gated, so this run"
         log "[naming-confirm] WILL enroll the fixture voices into your real"
@@ -700,7 +712,7 @@ on_exit() {
     # Naming-confirm: restore the runner's real speaker DB (CI-gated, no-op
     # locally) and the lane's diarize/numSpeakers overrides so a later run on
     # this host starts from the AppSettings defaults.
-    if [ "$NAMING_CONFIRM" = true ]; then
+    if [ "$NAMING_CONFIRM" = true ] || [ "$NAMING_ESCAPE" = true ]; then
         _naming_confirm_cleanup
     fi
 }
@@ -1192,6 +1204,159 @@ run_crash_recovery() {
 # /v1/jobs/<id>/naming → poll the job to done) and never calls
 # `_poll_for_new_lastjob_terminal`, so the global auto-skip other lanes rely on
 # is untouched.
+# --- Escape-dismisses-naming lane (issue #577) ----------------------------
+# Presses a REAL Escape on the open speaker-naming dialog and asserts the one
+# thing the fix is about: the window goes away and the job does NOT resolve.
+#
+# Why a WindowServer keystroke and not an RPC endpoint. A synthetic NSEvent
+# cannot do this: keycode 53 only becomes `cancelOperation:` inside
+# `interpretKeyEvents:`, which only text-input responders call, so with no name
+# field focused SwiftUI's exit command never sees it. Measured three ways (both
+# NSWindow.sendEvent and NSApplication.sendEvent in the live app, plus xctest)
+# — every one reports a clean dispatch and changes nothing, which is why an
+# in-process endpoint for this was built, found inert, and reverted.
+#
+# Deliberately does NOT click into a name field first. The dialog binds dismiss
+# twice — `onExitCommand` for the focused case and a `.cancelAction` carrier for
+# the rest — and it is the unfocused path that the fix nearly shipped broken,
+# so that is the one worth a lane.
+#
+# RUNNER PREREQUISITE: the shell running this needs an Accessibility grant
+# (System Settings → Privacy & Security → Accessibility), same one-time,
+# cert-independent shape as the existing mic / screen-recording grants. Checked
+# up front so a missing grant fails with its own message instead of looking like
+# a broken dismiss.
+run_naming_escape() {
+    local label="[naming-escape]"
+    [ -f "$DEFAULT_FIXTURE" ] || fail "$label: 2-speaker fixture not found: $DEFAULT_FIXTURE"
+
+    # Preflight both grants this lane needs, because they fail in different ways
+    # and only one of them fails loudly.
+    #
+    # Accessibility (posting keystrokes) refuses with a clear error. Automation
+    # (driving another process through System Events) does not: without it the
+    # AppleEvent simply never gets an answer and osascript sits there for its
+    # default 120 s timeout, which reads as a hung lane rather than a missing
+    # permission. So the probe wraps the *same* operation the lane performs in a
+    # short explicit timeout and treats the timeout as the diagnosis.
+    local probe
+    probe="$(osascript -e 'tell application "System Events" to key code 53' 2>&1)" || true
+    case "$probe" in
+        *"not allowed"*|*"assistive"*|*"1002"*)
+            # SKIP for the same reason the Automation arm skips: this is a host
+            # prerequisite that only a human at the GUI can satisfy, so failing
+            # on it would redden every PR for something unrelated to the change.
+            # The two grants are separate and can be half-configured — Automation
+            # granted, Accessibility not — so both arms need the same treatment
+            # or the lane just moves its red one step later.
+            log "$label: SKIP — this host may drive System Events but not post keystrokes."
+            log "$label: cause: $probe"
+            log "$label: fix: System Settings → Privacy & Security → Accessibility, enable the entry for the shell that runs this lane (it is usually already listed, unchecked)."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                {
+                    echo "### naming-escape lane skipped"
+                    echo
+                    echo "This host has Automation but is missing the **Accessibility** grant, so the real-Escape assertion did not run."
+                    echo "Enable the runner's shell under System Settings → Privacy & Security → Accessibility, then this lane gates normally."
+                } >> "$GITHUB_STEP_SUMMARY"
+            fi
+            return 0 ;;
+    esac
+    # The probe's window is short by default so a missing grant is reported in
+    # seconds rather than waited out. For the one-time setup run it has to be
+    # long enough for a human to answer the prompt it raises, hence the knob:
+    # E2E_TCC_PROMPT_TIMEOUT=300 bash scripts/e2e-app.sh --naming-escape
+    local tcc_timeout="${E2E_TCC_PROMPT_TIMEOUT:-10}"
+    probe="$(osascript -e "with timeout of ${tcc_timeout} seconds" \
+        -e 'tell application "System Events" to get name of first process whose frontmost is true' \
+        -e 'end timeout' 2>&1)" || true
+    case "$probe" in
+        *"timed out"*|*"-1712"*|*"not authori"*|*"-1743"*)
+            # SKIP, not FAIL. The grant can only be given by clicking Allow in
+            # the host's GUI session — no MDM profile here, and tccutil can only
+            # reset — so on an ungranted host this would turn every PR red for a
+            # reason unrelated to the change under test. Failing after this point
+            # still fails: only the missing prerequisite is tolerated, and it is
+            # reported loudly enough that nobody mistakes it for coverage.
+            log "$label: SKIP — this host cannot drive System Events (probe window ${tcc_timeout}s)."
+            log "$label: cause: $probe"
+            log "$label: fix: System Settings → Privacy & Security → Automation, allow the runner's shell to control System Events (and Accessibility for keystrokes). Both prompt on first use, so run this lane once by hand in the GUI session and click Allow."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                {
+                    echo "### naming-escape lane skipped"
+                    echo
+                    echo "This host is missing the **Automation** grant, so the real-Escape assertion did not run."
+                    echo "Grant it once in the GUI session (System Settings → Privacy & Security → Automation), then this lane gates normally."
+                } >> "$GITHUB_STEP_SUMMARY"
+            fi
+            return 0 ;;
+    esac
+    log "$label: frontmost process is '$probe'"
+
+    local fixture_dir fixture_copy
+    fixture_dir="$(mktemp -d /tmp/e2e-naming-escape-fixture.XXXXXX)"
+    fixture_copy="$fixture_dir/two_speakers_de.wav"
+    cp "$DEFAULT_FIXTURE" "$fixture_copy" || fail "$label: could not copy fixture to $fixture_copy"
+
+    local enq job_id
+    enq="$(curl --silent --show-error --max-time 10 -X POST \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        --header "Content-Type: application/json" \
+        --data "$(jq -nc --arg p "$fixture_copy" '{paths: [$p]}')" \
+        "$RPC_BASE/v1/jobs" 2>/dev/null || echo '{}')"
+    job_id="$(jq -r '.jobIDs[0] // empty' <<<"$enq")"
+    [ -n "$job_id" ] || fail "$label: POST /v1/jobs did not return a job id (response: $enq)"
+    log "$label: enqueued job $job_id"
+
+    _naming_escape_parked() {
+        [ "$(rpc "/v1/jobs/$job_id" | jq -r '.state // empty')" = "speakerNamingPending" ]
+    }
+    poll_until "$PIPELINE_TIMEOUT_S" 5 _naming_escape_parked \
+        || fail "$label: job $job_id never parked at speaker-naming within ${PIPELINE_TIMEOUT_S}s"
+
+    _naming_window_visible() {
+        [ "$(rpc /state | jq -r '[.windows[] | select(.id == "speaker-naming") | .isVisible] | first // false')" = "true" ]
+    }
+    poll_until 30 2 _naming_window_visible \
+        || fail "$label: naming window never became visible"
+    log "$label: naming window open, job parked"
+
+    # Front the app so the keystroke lands on it, then Escape. No click into the
+    # dialog: the point is that dismiss works without a focused field.
+    local front_err
+    front_err="$(osascript -e 'with timeout of 15 seconds' \
+        -e 'tell application "System Events" to tell process "MeetingTranscriber" to set frontmost to true' \
+        -e 'end timeout' 2>&1)" \
+        || fail "$label: could not front the app: $front_err"
+    sleep 1
+    local key_err
+    key_err="$(osascript -e 'tell application "System Events" to key code 53' 2>&1)" \
+        || fail "$label: could not post Escape: $key_err"
+
+    _naming_window_gone() {
+        ! _naming_window_visible
+    }
+    poll_until 15 1 _naming_window_gone \
+        || fail "$label: Escape did not dismiss the naming window (windows=$(rpc /state | jq -c '[.windows[]|{id,isVisible}]'))"
+    log "$label: window dismissed"
+
+    # The half that separates a dismiss from a Skip: the job must be untouched
+    # and still resolvable. A Skip here would have committed the auto-names and
+    # deleted the naming data.
+    local state
+    state="$(rpc "/v1/jobs/$job_id" | jq -r '.state // empty')"
+    [ "$state" = "speakerNamingPending" ] \
+        || fail "$label: Escape resolved the job (state=$state, expected speakerNamingPending)"
+    log "$label: job still parked — dismiss did not resolve it"
+
+    # Leave nothing pending behind; the dialog would reopen on the next launch.
+    curl --silent --show-error --max-time 10 -X POST \
+        --header "Authorization: Bearer $RPC_TOKEN" --header "Content-Length: 0" \
+        "$RPC_BASE/v1/jobs/$job_id/naming/skip" >/dev/null 2>&1 || true
+    rm -rf "$fixture_dir"
+    log "$label: PASS"
+}
+
 run_naming_confirm() {
     local label="[naming-confirm]"
     [ -f "$DEFAULT_FIXTURE" ] || fail "$label: 2-speaker fixture not found: $DEFAULT_FIXTURE"
@@ -1537,6 +1702,8 @@ elif [ "$MIC_DEVICE_CHANGE" = true ]; then
     log "[mic-device-change] app survived the injected device-change restart ✅"
 elif [ "$CRASH_RECOVERY" = true ]; then
     run_crash_recovery
+elif [ "$NAMING_ESCAPE" = true ]; then
+    run_naming_escape
 elif [ "$NAMING_CONFIRM" = true ]; then
     run_naming_confirm
 elif [ "$TITLE_SOURCE" = true ]; then


### PR DESCRIPTION
Closes #577.

The naming dialog bound Skip to Escape, and Skip accepts whatever the matcher guessed and then deletes the naming data. So the keystroke that means "dismiss this" to every Mac user silently committed a low-confidence auto-match, with no way back into the dialog afterwards.

## The incident was identified, not guessed

Joining `recognition_log.jsonl` against `ipc/pipeline_log.jsonl` pins it: a Teams job sat in speaker naming for 66 s (the report said 65) and resolved as `dismissed` ×2, with a second job dismissed two seconds earlier. Two Escapes clearing two dialogs in sequence — not a keystroke leaking in from another app, which is what the existing 0.75 s grace period was built to catch. Nothing leaks twice, two seconds apart, onto two different views.

Across 278 naming sessions, resolutions cluster heavily at the short end and **both** kinds populate it (2-4 s: 24 skips, 31 confirms), so duration alone cannot separate accidental from fast-and-deliberate. This PR fixes the path the evidence implicates and adds the signal needed to see whether the other one matters.

## Escape dismisses, and it does so reliably

Escape now closes the window. Closing is already the safe no-op: the job stays `.speakerNamingPending` and reopens from the menu bar. Skip keeps its behaviour, by click only.

The dismiss is bound **twice**, which is the part that is easy to get wrong and nearly shipped broken. `onExitCommand` only fires once something translated the keystroke into `cancelOperation:`, and that happens inside `interpretKeyEvents:`, which only text-input responders call — so with no name field focused it never runs. The destructive binding this replaces did not have that gap, because a `keyboardShortcut` rides the key-equivalent pass regardless of focus, which is exactly how a stray Escape reached Skip. A zero-sized `.cancelAction` carrier covers that case, deliberately outside the keyboard-grace gate since dismissing changes nothing about the job.

The host supplies the dismiss action and it is passed straight to `onExitCommand` rather than wrapped, so voice enrollment — which renders this view in a sheet and supplies none — installs no handler and Escape keeps bubbling to the sheet.

The grace period keeps its 0.75 s and gains one trigger: its identity is now `(revision, pendingJobCount)`, so a second job reaching naming (which force-activates the app) re-locks the buttons. Deliberately not keyed on window focus — the gate disables clicks too, so re-arming on became-key would swallow the click of someone who clicks into the window and then clicks Confirm.

Accepted tradeoff: Escape pressed while typing a name loses what was typed. Retyping is recoverable; committing the wrong name was not.

## Every resolution is now terminal and attributable

**Terminal.** `acceptAutoNames` deletes the sidecars before the protocol task is guaranteed to move the job, and its readiness probe only checked that `transcriptPath` is non-nil, not that the file still exists. A Skip on a job whose transcript went missing destroyed every sidecar and returned without a state change, stranding the job with nothing left to name and no protocol. Every exit now resolves.

**Attributable.** Two paths accepted auto-names without writing a recognition row at all — 24 h stale cleanup and headless blocking-transcribe. Each decision now records where it came from (`dialog` / `rpc` / `stale` / `headless`). The field is optional so rows written before it existed still decode; `loadRecent` drops lines it cannot decode, so a required field would have silently erased the whole history.

A stray Return still writes `accepted`, indistinguishable from a deliberate confirm. Telling keystrokes from clicks would mean inspecting the current event inside the button action, which is not worth depending on undocumented behaviour for until the new rows show it matters.

## E2E lane: a real Escape, on real hardware

"The user pressed Escape" had no automated cover at any layer. ViewInspector reaches the handler but not the keystroke, and a synthetic `NSEvent` cannot substitute — measured three ways, all reporting a clean dispatch and changing nothing, for the `interpretKeyEvents:` reason above. So the lane posts a real WindowServer keystroke from outside the process, then asserts **both** halves: the window is gone from `/state.windows` **and** the job is still `speakerNamingPending`. Asserting only the first would pass just as well for a Skip.

It deliberately does not focus a name field first, since the unfocused path is the one that nearly shipped broken.

Both host prerequisites (Accessibility + Automation) make the lane **skip loudly and pass** rather than fail: they can only be granted by a human at the machine's GUI, so failing on them would redden every PR for something unrelated to the change. The tolerance is narrow — only the two missing-grant arms return early; anything after them still fails the lane. The `e2e-architecture` skill documents which account and which binary, including that the two grants do not attribute the same way.

## Test plan

- [x] `swift test --parallel` — full suite green
- [x] SwiftLint + SwiftFormat clean
- [x] Each commit builds and tests on its own (history is bisectable)
- [x] All CI lanes green: lint, analyze, build + test (homebrew & appstore), e2e, e2e-app, e2e-browser, e2e-crash-recovery
- [x] **`e2e-app --naming-escape` passes on the runner** with a real keystroke, after granting the agent's Node binary
- [x] Verified by hand against a live app on two machines before the lane existed

Tests that flip as a result of the preceding PR's evidence commits: the wedge test now demands a finished job plus a warning, and stale cleanup now demands a `stale`-tagged row.

## Not done, deliberately

- **Return keeps its shortcut.** Enter-after-typing is this dialog's happy path, and the evidence implicates Escape. The grace change closes the one concrete Enter gap; the new `dialog` rows are how we find out if more is needed.
- **Skip still accepts the auto-names** rather than leaving speakers unlabelled — 278 sessions show that as a deliberate, heavily used workflow.
