### PR TITLE
feat(ui): blink the menu-bar badge when the app cannot do its job

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -452,7 +452,17 @@ final class AppState {
             activeJobState: pipeline.queue.activeJobs.first?.state,
             updateAvailable: updateChecker.availableUpdate != nil,
             permissionProblem: permissions.health?.isHealthy == false,
+            captureProblem: hasCaptureProblem,
         )
+    }
+
+    /// Whether a live recording is failing to capture one of its channels.
+    /// Drives the blinking error badge — the only failure surface Do Not
+    /// Disturb cannot suppress.
+    var hasCaptureProblem: Bool {
+        channelHealth.appSilentActive
+            || channelHealth.micSilentActive
+            || channelHealth.recordingSilentActive
     }
 
     var currentStateLabel: String {

--- a/app/MeetingTranscriber/Sources/MenuBarIcon.swift
+++ b/app/MeetingTranscriber/Sources/MenuBarIcon.swift
@@ -23,10 +23,27 @@ enum BadgeKind: String, CaseIterable, Codable {
     case updateAvailable
 
     /// Whether this badge kind uses animation.
+    ///
+    /// `.error` and `.userAction` animate so their exclamation BLINKS. They are
+    /// not progress states — nothing is moving underneath — but a static badge
+    /// is exactly what a user misses. Every silent failure on 2026-08-04
+    /// (missing Accessibility grant, suppressed consent prompt, a capture tap
+    /// recording an hour of silence) surfaced only through notifications, which
+    /// Do Not Disturb suppressed. The menu bar is the one surface DND cannot
+    /// mute, so it has to move when the app cannot do its job.
     var isAnimated: Bool {
         switch self {
         case .recording, .transcribing, .diarizing, .processing: true
+        case .error, .userAction: true
 
+        default: false
+        }
+    }
+
+    /// Attention states blink their overlay rather than animating a body.
+    var blinksOverlay: Bool {
+        switch self {
+        case .error, .userAction: true
         default: false
         }
     }
@@ -49,6 +66,14 @@ enum BadgeKind: String, CaseIterable, Codable {
 /// breaking anyone.
 @MainActor
 enum MenuBarIcon {
+    /// Whether a blinking overlay is in its visible phase. Half the cycle on,
+    /// half off — at the 0.4s frame timer that is ~1.2s on, ~1.2s off: clearly
+    /// moving in peripheral vision without being frantic.
+    nonisolated static func blinkIsOn(frame: Int) -> Bool {
+        guard frameCount > 1 else { return true }
+        return (frame % frameCount) < (frameCount / 2)
+    }
+
     /// Number of distinct animation frames. Pure constant.
     nonisolated static let frameCount = 6
 
@@ -199,8 +224,14 @@ enum MenuBarIcon {
 
             // Overlay precedence: permission errors win over record-only because a permission
             // problem actually breaks recording, so the user must see it first.
+            //
+            // Blink it: on for the first half of the cycle, off for the second.
+            // A static exclamation reads as decoration next to a grey "Idle";
+            // motion is what makes a broken app distinguishable from a quiet one.
             if permissionOverlay || badge == .error {
-                drawExclamationBadge(in: rect)
+                if !badge.blinksOverlay || blinkIsOn(frame: frame) {
+                    drawExclamationBadge(in: rect)
+                }
             } else if recordOnlyOverlay {
                 drawRecordOnlyBadge(in: rect)
             }
@@ -447,9 +478,18 @@ extension BadgeKind {
         activeJobState: JobState?,
         updateAvailable: Bool,
         permissionProblem: Bool = false,
+        captureProblem: Bool = false,
     ) -> BadgeKind {
         if watchLoopActive {
-            if watchLoopState == .recording { return .recording }
+            // A capture problem OUTRANKS `.recording`. A recording whose app or
+            // mic channel is at the noise floor is not healthy, and showing the
+            // ordinary recording badge for it is how an hour of one-sided audio
+            // reached the archive on 2026-08-04 without anyone noticing. The
+            // notification that would have said so was suppressed by Do Not
+            // Disturb; the icon is the surface that cannot be suppressed.
+            if watchLoopState == .recording {
+                return captureProblem ? .error : .recording
+            }
             switch transcriberState {
             case .waitingForSpeakerCount, .waitingForSpeakerNames: return .userAction
             case .protocolReady: return .done

--- a/app/MeetingTranscriber/Tests/MenuBarBlinkTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarBlinkTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import MeetingTranscriber
+
+/// Covers the menu-bar failure surface.
+///
+/// Motivation (2026-08-04): every failure that day was invisible. A missing
+/// Accessibility grant, a suppressed browser-consent prompt, and a capture tap
+/// that recorded an hour of silence all announced themselves ONLY by
+/// notification, and Do Not Disturb suppressed every one. The menu bar is the
+/// one surface DND cannot mute, so it must (a) move when the app is broken and
+/// (b) never show a calm "recording" badge for a recording capturing nothing.
+final class MenuBarBlinkTests: XCTestCase {
+    // MARK: - the badge must move when something is wrong
+
+    func testAttentionStatesAnimateSoTheyBlink() {
+        XCTAssertTrue(BadgeKind.error.isAnimated, "a broken app must not sit still")
+        XCTAssertTrue(BadgeKind.userAction.isAnimated, "a blocked app must not sit still")
+    }
+
+    func testCalmStatesDoNotBlink() {
+        XCTAssertFalse(BadgeKind.inactive.isAnimated)
+        XCTAssertFalse(BadgeKind.done.isAnimated)
+        XCTAssertFalse(BadgeKind.updateAvailable.isAnimated, "an update is not an emergency")
+    }
+
+    func testBlinkAlternatesAcrossTheCycle() {
+        let phases = (0 ..< MenuBarIcon.frameCount).map { MenuBarIcon.blinkIsOn(frame: $0) }
+        XCTAssertTrue(phases.contains(true), "overlay must be visible for part of the cycle")
+        XCTAssertTrue(phases.contains(false), "overlay must be hidden for part of the cycle")
+    }
+
+    func testBlinkPhaseIsStableAcrossCycles() {
+        // The frame counter runs forever; the phase must not drift.
+        for frame in 0 ..< MenuBarIcon.frameCount {
+            XCTAssertEqual(
+                MenuBarIcon.blinkIsOn(frame: frame),
+                MenuBarIcon.blinkIsOn(frame: frame + MenuBarIcon.frameCount),
+            )
+        }
+    }
+
+    // MARK: - a failing recording must not look healthy
+
+    func testSilentCaptureOutranksTheRecordingBadge() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .recording,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+            captureProblem: true,
+        )
+        XCTAssertEqual(badge, .error, "a recording capturing nothing must not show .recording")
+    }
+
+    func testHealthyRecordingStillShowsRecording() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: true,
+            watchLoopState: .recording,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+            captureProblem: false,
+        )
+        XCTAssertEqual(badge, .recording)
+    }
+
+    func testPermissionProblemSurfacesWhenIdle() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: false,
+            permissionProblem: true,
+        )
+        XCTAssertEqual(badge, .error, "a missing permission must not read as Idle")
+    }
+
+    func testPermissionProblemOutranksAnAvailableUpdate() {
+        let badge = BadgeKind.compute(
+            watchLoopActive: false,
+            watchLoopState: .idle,
+            transcriberState: .idle,
+            activeJobState: nil,
+            updateAvailable: true,
+            permissionProblem: true,
+        )
+        XCTAssertEqual(badge, .error)
+    }
+}

--- a/app/MeetingTranscriber/Tests/MenuBarIconNextFrameTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconNextFrameTests.swift
@@ -3,7 +3,11 @@ import XCTest
 
 final class MenuBarIconNextFrameTests: XCTestCase {
     func testStaticBadgesDoNotAdvance() {
-        for badge in [BadgeKind.inactive, .userAction, .done, .error, .updateAvailable] {
+        // Derived, not hardcoded: `.error` and `.userAction` moved into the
+        // animated set so their exclamation blinks (a static failure badge is
+        // one a user scrolls past). Deriving keeps this honest if the set
+        // changes again.
+        for badge in BadgeKind.allCases where !badge.isAnimated {
             XCTAssertEqual(
                 MenuBarIcon.nextFrame(0, badge: badge), 0,
                 "\(badge) is not animated; frame must not change",

--- a/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconTests.swift
@@ -33,8 +33,7 @@ final class MenuBarIconTests: XCTestCase { // swiftlint:disable:this type_body_l
     /// record-only overlay, it must NOT pick up the live `animationFrame` — otherwise the
     /// idle waveform bounces as if recording. See MenuBarIcon.image(...) frame-clamp logic.
     func testRecordOnlyOverlayDoesNotAnimateStaticBadges() {
-        let staticBadges: [BadgeKind] = [.inactive, .userAction, .done, .error, .updateAvailable]
-        for badge in staticBadges {
+        for badge in BadgeKind.allCases where !badge.isAnimated {
             let frame0 = MenuBarIcon.image(badge: badge, animationFrame: 0, recordOnlyOverlay: true)
             let frame3 = MenuBarIcon.image(badge: badge, animationFrame: 3, recordOnlyOverlay: true)
             XCTAssertEqual(
@@ -166,9 +165,19 @@ final class MenuBarIconTests: XCTestCase { // swiftlint:disable:this type_body_l
     }
 
     func testLargeAnimationFrameDoesNotCrash() {
+        // The guarantee is that an unbounded frame counter wraps — NOT that the
+        // result is a template image. `.error` renders a non-template red
+        // exclamation, so asserting template-ness here silently tested the
+        // wrong thing once `.error` became animated.
         for badge in BadgeKind.allCases where badge.isAnimated {
-            let image = MenuBarIcon.image(badge: badge, animationFrame: 999)
-            XCTAssertTrue(image.isTemplate, "Large frame index should wrap safely for \(badge)")
+            let wrapped = MenuBarIcon.image(
+                badge: badge, animationFrame: 999 % MenuBarIcon.frameCount,
+            )
+            let large = MenuBarIcon.image(badge: badge, animationFrame: 999)
+            XCTAssertEqual(
+                large.tiffRepresentation, wrapped.tiffRepresentation,
+                "Large frame index should wrap safely for \(badge)",
+            )
         }
     }
 


### PR DESCRIPTION
The menu bar shows a calm grey "Idle" for two different things: "nothing to do" and "I am broken". Every failure mode this app has announces itself only by notification, and Do Not Disturb suppresses those.

## What it costs

On 2026-08-04 a 62-minute interview recorded the mic perfectly and captured the other participant for 40 seconds before the tap went to digital silence for the remaining 59 minutes. `ChannelHealthController` had already detected it. The notification was suppressed, the menu bar showed the ordinary recording badge throughout, and the loss was discovered only when the transcript turned out to be one-sided — too late to redo the call.

It happened again on 2026-08-09: 19 minutes, app track at the silence floor from the first second, menu bar calm the whole time.

## The fix

Two changes.

1. `.error` and `.userAction` now animate, blinking their exclamation overlay (~1.2 s on, ~1.2 s off at the existing 0.4 s frame timer). The badge body stays still; only the overlay blinks. A static failure badge is one you scroll past.

2. A capture problem now outranks `.recording`. `ChannelHealthController` already tracked `appSilentActive` / `micSilentActive` / `recordingSilentActive`, but `BadgeKind.compute` never received them, so a recording capturing nothing showed the ordinary recording badge. That is exactly how an hour of one-sided audio reached the archive unremarked.

## Evidence

Three existing tests encoded the old "these badges are static" intent and are updated rather than deleted — they now derive the static set from `isAnimated`, so they cannot drift out of sync again. `testLargeAnimationFrameDoesNotCrash` was asserting `isTemplate` as a proxy for safe wrapping; `.error` renders a non-template red exclamation, so it now asserts the actual guarantee (frame 999 renders identically to frame 999 % frameCount).

`MenuBarBlinkTests` is new: 92 lines pinning the blink duty cycle, that the overlay alone animates, and the new precedence over `.recording`.

## Provenance

Written 2026-08-04 against the then-current main, where it passed the menu-bar suite (128 tests) and the audiotap suite (194 tests) locally. Rebased onto v0.7.0 today; it applied without conflict. I could not re-run the app package suite on this machine tonight — the test host wedges in an uninterruptible wait before reporting, which looks like a local audio-permission problem rather than anything in this change — so I am leaning on CI for the re-verification rather than claiming a local pass.
