### PR TITLE
fix(app): detect Aside browser meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart TD
 
 ## Features
 
-- **Automatic meeting detection** — Recognizes Teams, Zoom, and Webex meetings via window title polling, opt-in browser meeting detection (Google Meet, Whereby, web Zoom/Teams in Chrome) gated behind a recording-consent prompt, and opt-in mic-input detection for call apps without a reliable meeting signal (WeChat, Tencent Meeting, FaceTime, WhatsApp) — per app, off by default, and unlike the browser path it starts recording without a prompt
+- **Automatic meeting detection** — Recognizes Teams, Zoom, and Webex meetings via window title polling, opt-in browser meeting detection (Google Meet, Whereby, web Zoom/Teams in Chrome, Brave, Edge, Chromium, or Aside) gated behind a recording-consent prompt, and opt-in mic-input detection for call apps without a reliable meeting signal (WeChat, Tencent Meeting, FaceTime, WhatsApp) — per app, off by default, and unlike the browser path it starts recording without a prompt
 - **Dual audio recording** — App audio ([CATapDescription](https://developer.apple.com/documentation/coreaudio/catap)) + microphone simultaneously
 - **On-device transcription** — Two engines, selectable in Settings:
   - [WhisperKit](https://github.com/argmaxinc/WhisperKit) — 99+ languages, ~1 GB model

--- a/app/MeetingTranscriber/Sources/MeetingPatterns.swift
+++ b/app/MeetingTranscriber/Sources/MeetingPatterns.swift
@@ -103,13 +103,13 @@ extension AppMeetingPattern {
     /// (issue #503). Detection is by the WebRTC power assertion (see
     /// `PowerAssertionDetector`), not window titles — a browser's window title
     /// only reflects the active tab. Every Chromium fork (Chrome, Brave, Edge,
-    /// Chromium) emits the same assertion, so all four owner names share this one
+    /// Chromium, Aside) emits the same assertion, so all five owner names share this one
     /// browser identity (one "Google Chrome" toggle). `requiresRecordingConsent`
     /// routes it through a prompt instead of auto-start; `meetingPatterns` is
     /// empty (no title-based detection in the PoC).
     static let chromeBrowser = AppMeetingPattern(
         appName: "Google Chrome",
-        ownerNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium"],
+        ownerNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium", "Aside"],
         meetingPatterns: [],
         requiresRecordingConsent: true,
     )

--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -59,7 +59,7 @@ class PowerAssertionDetector: MeetingDetecting {
         // "NoIdleSleepAssertion" named "WebRTC has active PeerConnections"
         // during any WebRTC call (Google Meet, Whereby, web Zoom/Teams/Webex).
         // The assertion lives in Chromium's content layer, so every fork
-        // (Chrome, Brave, Edge, Chromium) emits the same name — all four are
+        // (Chrome, Brave, Edge, Chromium, Aside) emits the same name — all five are
         // matched under one shared browser identity. Keyword-only, no
         // assertionTypes: a Chromium browser holds the same assertion type for
         // plain media playback (YouTube), so matching the type would fire on
@@ -67,7 +67,7 @@ class PowerAssertionDetector: MeetingDetecting {
         // only watched when the browser toggle adds "Google Chrome" to watchApps.
         AssertionPattern(
             appName: AppMeetingPattern.chromeBrowser.appName,
-            processNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium"],
+            processNames: ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium", "Aside"],
             keywords: ["webrtc", "peerconnection"],
         ),
     ]

--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -41,11 +41,14 @@ struct GeneralSettingsView: View {
                 Toggle("Tencent Meeting", isOn: $settings.watchTencentMeeting)
                 Toggle("FaceTime", isOn: $settings.watchFaceTime)
                 Toggle("WhatsApp", isOn: $settings.watchWhatsApp)
-                Toggle("Browser Web Meetings (Chrome, Brave, Edge)", isOn: $settings.watchBrowserMeetings)
+                Toggle("Browser Web Meetings", isOn: $settings.watchBrowserMeetings)
                     .accessibilityIdentifier(A11yID.watchBrowserToggle)
-                Text("Detects meetings in Chromium browsers such as Chrome, Brave, and Edge (Google Meet, Whereby, web Zoom/Teams). Asks before recording.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Detects meetings in Chromium browsers such as Chrome, Brave, Edge, and Aside "
+                        + "(Google Meet, Whereby, web Zoom/Teams). Asks before recording.",
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
                 browserConsentWarning
             }
 

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -85,16 +85,16 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
         XCTAssertNil(detector.checkOnce())
     }
 
-    // MARK: - Chromium-family browsers (Brave / Edge / Chromium) — issue #503 follow-up
+    // MARK: - Chromium-family browsers (Brave / Edge / Chromium / Aside) — issue #503 follow-up
 
     /// The browser pattern is not Chrome-specific: every Chromium fork holds the
     /// same "WebRTC has active PeerConnections" assertion (it lives in Chromium's
-    /// content layer), so Brave/Edge/Chromium calls must detect identically. They
+    /// content layer), so Brave/Edge/Chromium/Aside calls must detect identically. They
     /// share the single "Google Chrome" browser-meetings identity (one toggle),
     /// but the detected meeting is titled by the concrete browser so a Brave call
     /// is not mislabeled "Google Chrome Call".
     func testChromiumFamilyWebRTCCallsAreDetected() {
-        for process in ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium"] {
+        for process in ["Google Chrome", "Brave Browser", "Microsoft Edge", "Chromium", "Aside"] {
             let detector = PowerAssertionDetector(
                 patterns: PowerAssertionDetector.patterns(watching: ["Google Chrome"]),
                 confirmationCount: 1,
@@ -122,7 +122,7 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
     func testChromiumFamilyMediaPlaybackIsNotDetected() {
         // The WebRTC keyword gate applies to every browser process: plain media
         // playback (no WebRTC in the assertion name) must not prompt.
-        for process in ["Brave Browser", "Microsoft Edge", "Chromium"] {
+        for process in ["Brave Browser", "Microsoft Edge", "Chromium", "Aside"] {
             let detector = PowerAssertionDetector(
                 patterns: PowerAssertionDetector.patterns(watching: ["Google Chrome"]),
                 confirmationCount: 1,


### PR DESCRIPTION
## What changed

Add Aside to the Chromium-family browser detection path.

Aside is Chromium-based and exposes the same `NoIdleSleepAssertion` named `WebRTC has active PeerConnections` as Chrome, Brave, Edge, and Chromium, but its process name is `Aside`. The detector and browser owner mapping now include it, with matching tests and user-facing documentation.

## Why

Meeting Transcriber could not detect an active Google Meet session running in Aside because the power assertion detector did not recognize the `Aside` process name.

Browser detection remains opt-in and continues to require recording consent.

## Validation

- `cd app/MeetingTranscriber && swift test --parallel --filter PowerAssertionDetectorPatternsTests` — 14 tests passed.
- `cd app/MeetingTranscriber && swift test --parallel --skip MenuBarIconSnapshotTests` — all 2,523 tests passed.
- `./scripts/pre-push.sh --with-tests` — release build and test-target build passed.
- `./scripts/lint.sh --lint-only` — all 428 Swift files passed SwiftLint.
- Changed-file SwiftFormat check passed.
- `swift test --parallel` — one existing `MenuBarIconSnapshotTests/testStaticBadgeSnapshots` reference-image mismatch remains under this local Xcode/OS environment; no changed menu-bar files are involved.
- Repository-wide SwiftFormat currently reports 99 existing files requiring formatting with the installed formatter version; this PR does not reformat unrelated files.
