### PR TITLE
fix(app): let an unrecoverable capture failure break through Focus

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -11,7 +11,13 @@ import UserNotifications
 /// Real implementation: `NotificationManager` (AppKit, used in menu bar app).
 /// Test implementation: `RecordingNotifier` (records calls, no side effects).
 protocol AppNotifying {
-    func notify(title: String, body: String)
+    /// The urgency is part of the requirement, not a defaulted convenience, so
+    /// that a conformer which ignores it has to say so. The reverse shape (a
+    /// 2-arg requirement plus a defaulted 3-arg extension) compiles just as
+    /// well and silently downgrades every time-sensitive notification a
+    /// forgetful conformer receives, which is the exact failure this urgency
+    /// exists to prevent. `notify(title:body:)` lives in the extension below.
+    func notify(title: String, body: String, urgency: NotificationUrgency)
 
     /// Ask the user whether to record a just-detected browser meeting (issue
     /// #503); true = record. `@MainActor` — the real prompt is UI. Defaults to
@@ -61,6 +67,13 @@ protocol AppNotifying {
 #endif
 
 extension AppNotifying {
+    /// Convenience for the majority of notifications, which have no deadline.
+    /// Static dispatch on purpose: it cannot be witnessed, so it can never
+    /// become a lossy override of the requirement above.
+    func notify(title: String, body: String) {
+        notify(title: title, body: body, urgency: .standard)
+    }
+
     // swiftlint:disable async_without_await
     /// Deny by default — only `NotificationManager` shows a real prompt, and
     /// "we could not ask" must never record.
@@ -547,5 +560,5 @@ final class AppState {
 
 /// No-op notifier for CLI targets and tests that don't need notifications.
 struct SilentNotifier: AppNotifying {
-    func notify(title _: String, body _: String) {}
+    func notify(title _: String, body _: String, urgency _: NotificationUrgency) {}
 }

--- a/app/MeetingTranscriber/Sources/ChannelHealthController.swift
+++ b/app/MeetingTranscriber/Sources/ChannelHealthController.swift
@@ -157,12 +157,8 @@ final class ChannelHealthController {
                 micSilentActive = false
             }
             let gaveUp = channel == .mic ? recorder.micCaptureGaveUp : recorder.appCaptureGaveUp
-            notifier.notify(
-                title: gaveUp ? "Capture Channel Lost" : "Capture Channel Silent",
-                body: gaveUp
-                    ? Self.captureGaveUpMessage(for: channel)
-                    : Self.asymmetricSilenceMessage(for: channel),
-            )
+            let alert = Self.captureAlert(channel: channel, gaveUp: gaveUp)
+            notifier.notify(title: alert.title, body: alert.body, urgency: alert.urgency)
 
         case .recovered:
             micSilentActive = false
@@ -179,6 +175,10 @@ final class ChannelHealthController {
             notifier.notify(
                 title: "Recording Appears Silent",
                 body: Self.silentRecordingMessage,
+                // Suppressible on purpose, see `captureAlert`: an auto-detected
+                // recording starts when the detector confirms rather than when
+                // anyone speaks, so a waiting room looks exactly like this.
+                urgency: .standard,
             )
 
         case .recovered:
@@ -189,6 +189,39 @@ final class ChannelHealthController {
         }
 
         return event
+    }
+
+    /// The whole notification for an asymmetric-silence episode: title, body and
+    /// whether it may break through a Focus mode. One function because all three
+    /// answer the same two questions, and three parallel branches on
+    /// `(channel, gaveUp)` would be free to drift into a "Capture Channel Lost"
+    /// title over a mere-silence body.
+    ///
+    /// On the urgency the test is not "how bad is this" but "does this have a
+    /// benign reading". Piercing Do Not Disturb is audible and interrupts a
+    /// meeting in progress, so it is only defensible where the answer is no: a
+    /// dead app-audio channel while the mic carries speech (the far side of a
+    /// call does not go digitally silent while you are talking, and this is the
+    /// case that cost a 62-minute interview 59 minutes of the other
+    /// participant), and an abandoned restart on either channel (the track
+    /// cannot come back on its own).
+    ///
+    /// A silent mic stays suppressible: that is what muting yourself looks like,
+    /// named as an intended trigger in `SettingsHelp.silentCaptureChannel`, and
+    /// what every recording looks like with "No Microphone" on. It still tints
+    /// the menu bar and still lands in Notification Center.
+    nonisolated static func captureAlert(
+        channel: AudioChannel,
+        gaveUp: Bool,
+    ) -> (title: String, body: String, urgency: NotificationUrgency) {
+        if gaveUp {
+            return ("Capture Channel Lost", captureGaveUpMessage(for: channel), .timeSensitive)
+        }
+        return (
+            "Capture Channel Silent",
+            asymmetricSilenceMessage(for: channel),
+            channel == .app ? .timeSensitive : .standard,
+        )
     }
 
     /// Message for a channel whose capture restart was abandoned (issue #588),

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -81,7 +81,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         scheduler.requestAuthorization()
     }
 
-    func notify(title: String, body: String) {
+    func notify(title: String, body: String, urgency: NotificationUrgency) {
         let deliverable = isSetUp && canDeliver()
 
         #if !APPSTORE
@@ -98,30 +98,31 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
         scheduler.add(UNNotificationRequest(
             identifier: UUID().uuidString,
-            content: Self.makeNotificationContent(title: title, body: body),
+            content: Self.makeNotificationContent(title: title, body: body, urgency: urgency),
             trigger: nil,
         ))
     }
 
     /// Pure builder for a notification's `UNMutableNotificationContent` (title,
-    /// body, sound, optional category, interruption level). Split out so the
-    /// content mapping is unit-testable without a real notification center.
+    /// body, sound, optional category, urgency). Split out so the content
+    /// mapping is unit-testable without a real notification center.
     ///
-    /// `interruptionLevel` defaults to `.active` — a banner that auto-dismisses
-    /// and is suppressed under Focus, which is right for anything the user can
-    /// read whenever they get round to it. Only the consent prompt overrides it;
-    /// see `postConsentNotification`.
+    /// `urgency` defaults to `.standard`, a banner that auto-dismisses and is
+    /// suppressed under Focus, which is right for anything the user can read
+    /// whenever they get round to it. `NotificationUrgency` is the app's whole
+    /// vocabulary here, so this is the only place a raw
+    /// `UNNotificationInterruptionLevel` is set.
     static func makeNotificationContent(
         title: String,
         body: String,
         categoryID: String? = nil,
-        interruptionLevel: UNNotificationInterruptionLevel = .active,
+        urgency: NotificationUrgency = .standard,
     ) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
-        content.interruptionLevel = interruptionLevel
+        content.interruptionLevel = urgency.interruptionLevel
         if let categoryID { content.categoryIdentifier = categoryID }
         return content
     }
@@ -271,8 +272,8 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
                 // suppressed outright by any Focus mode, so it expires unseen and
                 // browser meetings silently never record. `.timeSensitive` is the
                 // only level that breaks through Focus, and it needs the matching
-                // entitlement in Entitlements/*.entitlements to do so.
-                interruptionLevel: .timeSensitive,
+                // entitlement to do so; see `NotificationUrgency.timeSensitive`.
+                urgency: .timeSensitive,
             ),
             trigger: nil,
         ))

--- a/app/MeetingTranscriber/Sources/NotificationUrgency.swift
+++ b/app/MeetingTranscriber/Sources/NotificationUrgency.swift
@@ -1,0 +1,37 @@
+import UserNotifications
+
+/// How urgently a notification has to reach the user.
+///
+/// Two cases rather than the five `UNNotificationInterruptionLevel` offers,
+/// because only one question is being answered: may this notification break
+/// through a Focus mode. `.critical` needs its own Apple-granted entitlement
+/// and rings through a muted device, and `.passive` is quieter than anything
+/// this app posts, so neither is a policy the app has and neither is
+/// expressible here.
+enum NotificationUrgency {
+    /// A banner the user reads whenever they get round to it. Suppressed by any
+    /// Focus mode, which is right for anything without a deadline.
+    case standard
+
+    /// Breaks through Focus. Reserved for a failure the user can still act on
+    /// while it is happening.
+    ///
+    /// Honoured only when the bundle carries
+    /// `com.apple.developer.usernotifications.time-sensitive`. Do not add that
+    /// key to `Entitlements/*.entitlements`; `scripts/lib/signing.sh` documents
+    /// why and injects it from `prepare_signing` instead.
+    ///
+    /// Asking for it is unconditionally safe: without the entitlement macOS
+    /// treats the request as an ordinary banner, so an unprovisioned or
+    /// fork-built bundle degrades rather than failing. Today the notarized
+    /// Homebrew release is the build that carries it and the sandboxed App
+    /// Store one is not, which is a packaging gap this type cannot close.
+    case timeSensitive
+
+    var interruptionLevel: UNNotificationInterruptionLevel {
+        switch self {
+        case .standard: .active
+        case .timeSensitive: .timeSensitive
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -490,12 +490,14 @@ class WatchLoop {
                 update { next in
                     next.lastError = "Record-only output failed: \(error.localizedDescription)"
                 }
-                // Record-only performs no state transition, so `lastError` is
-                // never surfaced on its own. The notification is the only way
-                // the user learns their fleet pipeline lost this recording.
+                // Record-only performs no state transition, so this notification
+                // is the entire report that a recording was lost. It breaks
+                // through Focus on the same test as `captureAlert`: a failed
+                // write has no benign reading.
                 notifier.notify(
                     title: "Record-only output failed",
                     body: error.localizedDescription,
+                    urgency: .timeSensitive,
                 )
             }
             return

--- a/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/ChannelHealthIntegrationTests.swift
@@ -107,6 +107,9 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         XCTAssertFalse(controller.micSilentActive)
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertTrue(notifier.calls[0].body.lowercased().contains("app-audio"))
+        // Wiring: the policy from `captureAlert` reaches the notifier. The
+        // policy itself is table-tested above.
+        XCTAssertEqual(notifier.calls.first?.urgency, .timeSensitive)
     }
 
     // MARK: - Latch + recovery
@@ -228,6 +231,30 @@ final class ChannelHealthIntegrationTests: XCTestCase {
         XCTAssertFalse(controller.appSilentActive)
         XCTAssertEqual(notifier.calls.count, 1)
         XCTAssertEqual(notifier.calls[0].title, "Recording Appears Silent")
+        // Suppressible on purpose: a waiting room looks exactly like this.
+        XCTAssertEqual(notifier.calls.first?.urgency, .standard)
+    }
+
+    // MARK: - Focus / Do Not Disturb
+
+    /// The whole escalation policy, on the pure function. Rationale for each row
+    /// is in `ChannelHealthController.captureAlert`; what matters here is that
+    /// only the two cases without a benign reading break through, and that the
+    /// app + gaveUp combination no scenario test reaches is pinned too.
+    func testOnlyUnrecoverableCaptureFailuresBreakThroughFocus() {
+        let cases: [(channel: AudioChannel, gaveUp: Bool, expected: NotificationUrgency)] = [
+            (.app, false, .timeSensitive), // far side dead while you talk
+            (.mic, false, .standard), // looks like mute, or "No Microphone"
+            (.mic, true, .timeSensitive), // restart abandoned, track gone
+            (.app, true, .timeSensitive),
+        ]
+        for row in cases {
+            XCTAssertEqual(
+                ChannelHealthController.captureAlert(channel: row.channel, gaveUp: row.gaveUp).urgency,
+                row.expected,
+                "channel=\(row.channel) gaveUp=\(row.gaveUp)",
+            )
+        }
     }
 
     func testRecordingSilentRecoversWhenAnyChannelReturnsToSpeech() {

--- a/app/MeetingTranscriber/Tests/NotificationManagerConsentVisibilityTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerConsentVisibilityTests.swift
@@ -91,7 +91,7 @@ final class NotificationManagerConsentVisibilityTests: XCTestCase {
     /// report "not asked" rather than reach for one.
     func test_appNotifyingDefault_reportsNotDetermined() async {
         struct BareNotifier: AppNotifying {
-            func notify(title _: String, body _: String) {}
+            func notify(title _: String, body _: String, urgency _: NotificationUrgency) {}
         }
         let visibility = await BareNotifier().notificationVisibility()
         XCTAssertEqual(visibility, .unread)

--- a/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerSchedulingTests.swift
@@ -153,6 +153,27 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertEqual(fake.removedIdentifiers, [posted.identifier])
     }
 
+    // MARK: - urgency
+
+    /// The mapping that makes a capture failure survive Do Not Disturb. The
+    /// entitlement that lets macOS honour it is injected at signing time; this
+    /// pins the level the app asks for, which is the half we control.
+    func testTimeSensitiveUrgencyPostsAtThatInterruptionLevel() {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        manager.notify(title: "Capture Channel Silent", body: "x", urgency: .timeSensitive)
+        XCTAssertEqual(fake.added.first?.content.interruptionLevel, .timeSensitive)
+    }
+
+    /// The counterpart, so raising one notification cannot quietly raise all of
+    /// them: everything posted without an explicit urgency stays suppressible.
+    func testPlainNotifyStaysActive() {
+        let (manager, fake) = makeManager()
+        manager.setUp()
+        manager.notify(title: "Protocol Ready", body: "x")
+        XCTAssertEqual(fake.added.first?.content.interruptionLevel, .active)
+    }
+
     // MARK: - pure content builder
 
     func testMakeNotificationContentMapsFields() {
@@ -161,9 +182,10 @@ final class NotificationManagerSchedulingTests: XCTestCase {
         XCTAssertEqual(content.body, "B")
         XCTAssertEqual(content.categoryIdentifier, "CAT")
         XCTAssertEqual(content.sound, .default)
-        // Only the consent prompt overrides this. A transcript-ready or
-        // permission-problem notice has no deadline and must not break through
-        // the user's Focus, so the default has to stay `.active`.
+        // Overridden only by the consent prompt and the capture-failure
+        // notices. A transcript-ready or permission-problem notice has no
+        // deadline and must not break through the user's Focus, so the default
+        // has to stay `.active`.
         XCTAssertEqual(content.interruptionLevel, .active)
     }
 

--- a/app/MeetingTranscriber/Tests/RecordingNotifier.swift
+++ b/app/MeetingTranscriber/Tests/RecordingNotifier.swift
@@ -8,14 +8,14 @@
 /// the 600-line `file_length` cap: this double grows whenever `AppNotifying`
 /// does, so it is the piece under pressure.
 final class RecordingNotifier: AppNotifying {
-    private(set) var calls: [(title: String, body: String)] = []
+    private(set) var calls: [(title: String, body: String, urgency: NotificationUrgency)] = []
 
     /// What `notificationVisibility()` reports. Defaults to the protocol's
     /// own default so existing users of this double are unaffected.
     var reportedVisibility: NotificationVisibility = .unread
 
-    func notify(title: String, body: String) {
-        calls.append((title: title, body: body))
+    func notify(title: String, body: String, urgency: NotificationUrgency) {
+        calls.append((title: title, body: body, urgency: urgency))
     }
 
     // swiftlint:disable async_without_await

--- a/app/MeetingTranscriber/Tests/RecordingNotifier.swift
+++ b/app/MeetingTranscriber/Tests/RecordingNotifier.swift
@@ -1,0 +1,28 @@
+@testable import MeetingTranscriber
+
+// MARK: - AppNotifying spy
+
+/// Records all notify() calls for assertions.
+///
+/// Its own file rather than another block in `TestHelpers.swift`, which sits on
+/// the 600-line `file_length` cap: this double grows whenever `AppNotifying`
+/// does, so it is the piece under pressure.
+final class RecordingNotifier: AppNotifying {
+    private(set) var calls: [(title: String, body: String)] = []
+
+    /// What `notificationVisibility()` reports. Defaults to the protocol's
+    /// own default so existing users of this double are unaffected.
+    var reportedVisibility: NotificationVisibility = .unread
+
+    func notify(title: String, body: String) {
+        calls.append((title: title, body: body))
+    }
+
+    // swiftlint:disable async_without_await
+    @MainActor
+    func notificationVisibility() async -> NotificationVisibility {
+        reportedVisibility
+    }
+
+    // swiftlint:enable async_without_await
+}

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -270,29 +270,6 @@ final class ManagedCounter {
     }
 }
 
-// MARK: - AppNotifying spy
-
-/// Records all notify() calls for assertions.
-final class RecordingNotifier: AppNotifying {
-    private(set) var calls: [(title: String, body: String)] = []
-
-    /// What `notificationVisibility()` reports. Defaults to the protocol's
-    /// own default so existing users of this double are unaffected.
-    var reportedVisibility: NotificationVisibility = .unread
-
-    func notify(title: String, body: String) {
-        calls.append((title: title, body: body))
-    }
-
-    // swiftlint:disable async_without_await
-    @MainActor
-    func notificationVisibility() async -> NotificationVisibility {
-        reportedVisibility
-    }
-
-    // swiftlint:enable async_without_await
-}
-
 // MARK: - Shared Mock Classes
 
 /// Mock recorder that returns a pre-prepared fixture WAV as the recording result.

--- a/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
@@ -38,7 +38,7 @@ final class WatchLoopBrowserConsentTests: XCTestCase {
             self.answer = answer
         }
 
-        func notify(title _: String, body _: String) {}
+        func notify(title _: String, body _: String, urgency _: NotificationUrgency) {}
 
         // swiftlint:disable async_without_await
         @MainActor
@@ -82,7 +82,7 @@ final class WatchLoopBrowserConsentTests: XCTestCase {
             continuation != nil
         }
 
-        func notify(title _: String, body _: String) {}
+        func notify(title _: String, body _: String, urgency _: NotificationUrgency) {}
 
         @MainActor
         func askToRecord(title _: String, body _: String) async -> ConsentAnswer {

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -453,6 +453,12 @@ final class WatchLoopTests: XCTestCase {
         XCTAssertNotNil(loop.lastError, "lastError must be set so failures are observable")
         XCTAssertEqual(notifier.calls.count, 1, "user must be notified on sidecar write failure")
         XCTAssertEqual(notifier.calls.first?.title, "Record-only output failed")
+        // Record-only performs no state transition, so this notification is the
+        // entire report that a recording was lost. At the suppressible default a
+        // Focus mode drops it and the loss is silent, which is the one outcome
+        // record-only cannot afford: a fleet client's whole job is to hand the
+        // audio on.
+        XCTAssertEqual(notifier.calls.first?.urgency, .timeSensitive)
     }
 
     func test_normalMode_enqueuesAndWritesNoSidecar() async throws {


### PR DESCRIPTION
Every way this app can lose a recording is reported by notification and nothing else, and at the default `.active` interruption level a Focus mode suppresses that notification without a trace. With Do Not Disturb on, a 62-minute interview finished with 59 minutes of one-sided audio and the loss surfaced only when the transcript came back.

The bundle has carried `com.apple.developer.usernotifications.time-sensitive` since v0.6.0, but until now only the browser-consent prompt asked for that level.

## Which notifications, and why not all of them

Piercing Do Not Disturb is audible and interrupts a meeting in progress, so the test is not severity but whether the signal has a benign reading. Three of them have none:

| Notification | Level | Reason |
|---|---|---|
| App-audio channel dead while the mic carries speech | time-sensitive | The far side of a call does not go digitally silent for 90 seconds while you are talking. This is the case that lost the interview. |
| Capture restart abandoned (#588), either channel | time-sensitive | The track is gone for the rest of the recording and cannot come back on its own. |
| Record-only write failure | time-sensitive | Record-only performs no state transition, so this notification is the entire report that a recording was lost. Handing the audio on is its whole job. |
| Mic channel silent | unchanged | This is what muting yourself looks like, named as an intended trigger in the settings help, and what every recording looks like with "No Microphone" on. |
| Both channels silent | unchanged | An auto-detected recording starts when the detector confirms, not when anyone speaks, so a waiting room or an unjoined bridge is indistinguishable from a dead capture. |

The two unchanged rows still tint the menu bar and still land in Notification Center.

## Shape

`NotificationUrgency` carries two cases rather than exposing `UNNotificationInterruptionLevel` to callers, so `.critical` (a separate Apple-granted entitlement that rings through a muted device) and `.passive` are not reachable by accident. It is now the only place a raw interruption level is named outside its own file; the consent prompt was migrated onto it too.

`AppNotifying` takes the urgency as part of the requirement rather than as a defaulted convenience. The reverse shape compiles just as well and silently downgrades every time-sensitive notification a forgetful conformer receives, which is precisely the failure this change exists to fix.

The asymmetric-silence title, body and urgency now come from one `captureAlert(channel:gaveUp:)` instead of three parallel branches on the same two inputs, which could otherwise drift into a "Capture Channel Lost" title over a mere-silence body.

## Testing

The policy is table-tested on the pure function, including the app + gave-up combination no scenario reaches; two existing scenario tests gained a one-line assertion that the level actually reaches the notifier, and `NotificationManagerSchedulingTests` pins both the mapping to `.timeSensitive` and that a plain `notify` stays suppressible, so this cannot quietly become a blanket escalation.

## Known gap, not addressed here

Only the notarized Homebrew build gets the entitlement: `prepare_signing` is called from the `NOTARIZE = true` branch of `build_release.sh`, and the release workflow builds the App Store variant with `--appstore --no-notarize` while gating the profile install and the entitlement assertion on the homebrew variant. Sandboxed users therefore see no change until the capability is on the App Store App ID and that lane gets its own signing path. Requesting the level is safe regardless: without the entitlement macOS degrades it to an ordinary banner.

What is verified here is the level the app asks for. Whether the banner actually appears under an active Focus mode needs a run against a signed bundle carrying the entitlement.

## Commits

1. Move the `AppNotifying` spy into its own file (pure move; `TestHelpers.swift` sat exactly on the 600-line cap)
2. The capture-failure escalation
3. The record-only write failure, separate because it is a separate path with a separate owner; only the policy is shared