### PR TITLE
feat(app): gate mic-track echo before transcription (opt-in)

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -182,6 +182,16 @@ final class AppSettings {
         didSet { defaults.set(micDeviceUID, forKey: "micDeviceUID") }
     }
 
+    /// Gate the mic track with `AudioMixer.suppressEcho` before transcription
+    /// and diarization (dual-source recordings only). Without a headset the mic
+    /// re-captures the loudspeaker playback of the remote side; `mix()` already
+    /// gates that echo, but transcription reads the raw per-track files, not
+    /// the mix. Config-only, no UI (issue #422):
+    /// `defaults write app.meetingtranscriber dualTrackMicEchoSuppressionEnabled -bool true`
+    var dualTrackMicEchoSuppressionEnabled: Bool {
+        didSet { defaults.set(dualTrackMicEchoSuppressionEnabled, forKey: "dualTrackMicEchoSuppressionEnabled") }
+    }
+
     /// Master switch for the per-channel signal indicator. When on, AppState runs a
     /// ~10 Hz level poller while recording and flips the menu-bar red when one
     /// channel goes silent while the other carries audio. Default: on.
@@ -501,6 +511,7 @@ final class AppSettings {
         noMic = defaults.object(forKey: "noMic") as? Bool ?? false
         recordOnly = defaults.object(forKey: "recordOnly") as? Bool ?? false
         micDeviceUID = defaults.object(forKey: "micDeviceUID") as? String ?? ""
+        dualTrackMicEchoSuppressionEnabled = defaults.object(forKey: "dualTrackMicEchoSuppressionEnabled") as? Bool ?? false
         micName = defaults.object(forKey: "micName") as? String ?? "Me"
         perChannelIndicatorEnabled = defaults.object(forKey: "perChannelIndicatorEnabled") as? Bool ?? true
         liveTranscriptionEnabled = defaults.object(forKey: "liveTranscriptionEnabled") as? Bool ?? false

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -167,6 +167,28 @@ enum AudioMixer {
         }
     }
 
+    /// File-level wrapper for `suppressEcho`: gates the mic track at `micURL`
+    /// against the app track at `appURL` and rewrites `micURL` in place.
+    /// No-op when either track is empty — a silent/dead channel must not turn
+    /// a valid mic file into a zero-frame WAV.
+    static func suppressEchoInFile(
+        appURL: URL,
+        micURL: URL,
+        sampleRate: Int,
+        micDelay: TimeInterval = 0,
+    ) throws {
+        let appSamples = try loadAudioFileAsFloat32(url: appURL)
+        var micSamples = try loadAudioFileAsFloat32(url: micURL)
+        guard !appSamples.isEmpty, !micSamples.isEmpty else { return }
+        suppressEcho(
+            appSamples: appSamples,
+            micSamples: &micSamples,
+            sampleRate: sampleRate,
+            micDelay: clampMicDelay(micDelay),
+        )
+        try saveWAV(samples: micSamples, sampleRate: sampleRate, url: micURL)
+    }
+
     // MARK: - Resampling
 
     /// Resample audio using AVAudioConverter (proper anti-aliasing filter).

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -110,6 +110,7 @@ final class PipelineController {
             diarizeEnabled: settings.diarize,
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
+            micEchoSuppressionEnabled: settings.dualTrackMicEchoSuppressionEnabled,
             speakerMatcherFactory: { SpeakerMatcher() },
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -238,6 +238,18 @@ extension PipelineQueue {
             try await appResample
             try await micResample
 
+            // Gate mic_16k here so transcription, mic diarization, and the
+            // persisted `_mic_16k.wav` (late re-diarization) all see the
+            // cleaned track — rationale on `dualTrackMicEchoSuppressionEnabled`.
+            if micEchoSuppressionEnabled {
+                try AudioMixer.suppressEchoInFile(
+                    appURL: app16k,
+                    micURL: mic16k,
+                    sampleRate: AudioConstants.targetSampleRate,
+                    micDelay: ctx.micDelay,
+                )
+            }
+
             // Transcribe each track separately
             let appSegments = try await engine.transcribeSegments(audioPath: app16k)
             let micSegments = try await engine.transcribeSegments(audioPath: mic16k)

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -57,6 +57,7 @@ class PipelineQueue {
     let diarizeEnabled: Bool
     let numSpeakers: Int
     let micLabel: String
+    let micEchoSuppressionEnabled: Bool
     let speakerMatcherFactory: () -> SpeakerMatcher
     let vadConfig: VADConfig?
     /// nil disables JSONL logging. AppState injects a real instance for production;
@@ -227,6 +228,7 @@ class PipelineQueue {
         self.diarizeEnabled = false
         self.numSpeakers = 0
         self.micLabel = "Me"
+        self.micEchoSuppressionEnabled = false
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
@@ -301,6 +303,7 @@ class PipelineQueue {
         diarizeEnabled: Bool = false,
         numSpeakers: Int = 0,
         micLabel: String = "Me",
+        micEchoSuppressionEnabled: Bool = false,
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
@@ -330,6 +333,7 @@ class PipelineQueue {
         // of micLabel for both the tagging and the re-split, so sanitizing here
         // keeps them consistent.)
         self.micLabel = micLabel == DiarizationProcess.remoteSpeakerLabel ? "Me" : micLabel
+        self.micEchoSuppressionEnabled = micEchoSuppressionEnabled
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -307,6 +307,17 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "includePreReleases"))
     }
 
+    // MARK: - Dual-track mic echo suppression
+
+    func test_dualTrackMicEchoSuppressionEnabled_defaultsToFalse() {
+        XCTAssertFalse(settings.dualTrackMicEchoSuppressionEnabled)
+    }
+
+    func test_dualTrackMicEchoSuppressionEnabled_persistsToUserDefaults() {
+        settings.dualTrackMicEchoSuppressionEnabled = true
+        XCTAssertTrue(defaults.bool(forKey: "dualTrackMicEchoSuppressionEnabled"))
+    }
+
     // MARK: - Record Only
 
     func test_recordOnly_defaultsToFalse() {

--- a/app/MeetingTranscriber/Tests/AudioMixerEchoSuppressionFileTests.swift
+++ b/app/MeetingTranscriber/Tests/AudioMixerEchoSuppressionFileTests.swift
@@ -1,0 +1,103 @@
+import AVFoundation
+@testable import MeetingTranscriber
+import XCTest
+
+/// File-level echo-suppression tests (`AudioMixer.suppressEchoInFile`) — the
+/// wrapper that gates the mic 16 kHz track in place before transcription and
+/// diarization when `dualTrackMicEchoSuppressionEnabled` is on (issue #422).
+final class AudioMixerEchoSuppressionFileTests: XCTestCase {
+    private func tempWAV(_ samples: [Float], sampleRate: Int = 16000) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mixer-test-\(UUID().uuidString).wav")
+        try AudioMixer.saveWAV(samples: samples, sampleRate: sampleRate, url: url)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testSuppressEchoInFileGatesMicAndPersists() throws {
+        let sampleRate = 16000
+        let windowSize = sampleRate / 50 // 320, same 20ms windows as suppressEcho
+        let windowCount = 40
+
+        // App energy in window 20 → gate spans windows 18...30 (2 before, 10 after).
+        var appSamples = [Float](repeating: 0, count: windowCount * windowSize)
+        for j in (20 * windowSize) ..< (21 * windowSize) {
+            appSamples[j] = 1.0
+        }
+        // Mic carries 0.5 everywhere plus louder "double-talk" speech in window 20 —
+        // the gate is a hard zero, so genuine simultaneous mic speech is dropped
+        // too. That trade-off is the documented behavior, mirrored from mix().
+        var micSamples = [Float](repeating: 0.5, count: windowCount * windowSize)
+        for j in (20 * windowSize) ..< (21 * windowSize) {
+            micSamples[j] = 0.9
+        }
+
+        let appURL = try tempWAV(appSamples, sampleRate: sampleRate)
+        let micURL = try tempWAV(micSamples, sampleRate: sampleRate)
+
+        try AudioMixer.suppressEchoInFile(
+            appURL: appURL, micURL: micURL, sampleRate: sampleRate,
+        )
+
+        // Reload from disk — the rewrite must be persisted, not in-memory only.
+        let reloaded = try AudioMixer.loadAudioFileAsFloat32(url: micURL)
+        XCTAssertEqual(reloaded.count, micSamples.count)
+        func micWindow(_ w: Int) -> Float {
+            reloaded[w * windowSize]
+        }
+        XCTAssertEqual(micWindow(17), 0.5, accuracy: 0.01, "below the gate stays untouched")
+        XCTAssertEqual(micWindow(18), 0.0, "first gated window")
+        XCTAssertEqual(micWindow(20), 0.0, "double-talk window is gated too (documented trade-off)")
+        XCTAssertEqual(micWindow(30), 0.0, "last gated window")
+        XCTAssertEqual(micWindow(31), 0.5, accuracy: 0.01, "above the gate stays untouched")
+    }
+
+    func testSuppressEchoInFileEmptyAppTrackIsNoOp() throws {
+        // A dead/silent app channel yields a zero-frame WAV; gating against it
+        // must leave the mic file untouched instead of rewriting it.
+        let sampleRate = 16000
+        let appURL = try tempWAV([], sampleRate: sampleRate)
+        let micSamples = [Float](repeating: 0.5, count: sampleRate)
+        let micURL = try tempWAV(micSamples, sampleRate: sampleRate)
+
+        try AudioMixer.suppressEchoInFile(
+            appURL: appURL, micURL: micURL, sampleRate: sampleRate,
+        )
+
+        let reloaded = try AudioMixer.loadAudioFileAsFloat32(url: micURL)
+        XCTAssertEqual(reloaded.count, micSamples.count)
+        XCTAssertEqual(reloaded[0], 0.5, accuracy: 0.01, "mic content survives an empty app track")
+    }
+
+    func testSuppressEchoInFileClampsExcessiveMicDelay() throws {
+        // 35s of audio; app energy at window 10 (gate app windows 8...20).
+        // micDelay = -100s is beyond maxMicDelay (30s). Unclamped it would map the
+        // gate to mic windows ~5008..., outside the file — nothing gated. Clamped
+        // to -30s (delayWindows = -1500) the gate lands on mic windows 1508...1520,
+        // so a zeroed window 1508 proves the file path clamps like mix() does.
+        let sampleRate = 16000
+        let windowSize = sampleRate / 50
+        let windowCount = 1750
+
+        var appSamples = [Float](repeating: 0, count: windowCount * windowSize)
+        for j in (10 * windowSize) ..< (11 * windowSize) {
+            appSamples[j] = 1.0
+        }
+        let micSamples = [Float](repeating: 0.5, count: windowCount * windowSize)
+
+        let appURL = try tempWAV(appSamples, sampleRate: sampleRate)
+        let micURL = try tempWAV(micSamples, sampleRate: sampleRate)
+
+        try AudioMixer.suppressEchoInFile(
+            appURL: appURL, micURL: micURL, sampleRate: sampleRate, micDelay: -100,
+        )
+
+        let reloaded = try AudioMixer.loadAudioFileAsFloat32(url: micURL)
+        func micWindow(_ w: Int) -> Float {
+            reloaded[w * windowSize]
+        }
+        XCTAssertEqual(micWindow(1500), 0.5, accuracy: 0.01, "below the clamped gate stays untouched")
+        XCTAssertEqual(micWindow(1508), 0.0, "clamped delay lands the gate inside the file")
+        XCTAssertEqual(micWindow(1521), 0.5, accuracy: 0.01, "above the clamped gate stays untouched")
+    }
+}


### PR DESCRIPTION
Without a headset, the microphone re-captures the remote side's loudspeaker playback. `AudioMixer.suppressEcho` already gates exactly that kind of mic energy — but it only runs inside `mix()`, and on a dual-source recording the mix is not what gets transcribed; the raw per-track files are. So the gate never reaches the path that matters, and the echo arrives as duplicated speech attributed to the mic speaker, with its embeddings polluting speaker matching.

Refs #422, #581.

## Measurement

17-minute two-party Teams call, built-in mic and speakers, no headset. Method: over the raw `_app.wav` / `_mic.wav` pair, take 1-second blocks where the app track is loud and the mic track is quieter than it — i.e. only the remote side is speaking — then cross-correlate app→mic per block with the lag constrained to 0–120 ms. 310 blocks qualified.

| | |
|---|---|
| Remote voice in `_app.wav` | −19.7 dBFS (median) |
| Same voice in `_mic.wav` | −22.8 dBFS (median) |
| Attenuation | **3.2 dB** |
| Cross-correlation | median 0.44, top decile 0.69, peak 0.92 |
| Lag | ~3 ms |

The 3 dB is the part worth stressing: the remote side arrives in the microphone at nearly the same level as in the app tap. That is not a faint bleed — it is a second, near-full copy of the far end, and both copies get transcribed.

## What this does

New config-only setting `dualTrackMicEchoSuppressionEnabled` (default off, no UI):

```
defaults write app.meetingtranscriber dualTrackMicEchoSuppressionEnabled -bool true
```

When on, the existing gate runs over `mic_16k.wav` right after resampling, so transcription, mic diarization, and the persisted `_mic_16k.wav` used for late re-diarization all read the cleaned track. `AudioMixer.suppressEchoInFile` is a file-level wrapper around the existing sample-level `suppressEcho`; the delay handling matches `mix()`.

## Trade-off

This is an energy gate, not an echo-similarity detector — unchanged from what `mix()` already does. It zeroes each 20 ms mic window whose corresponding app window is above threshold, plus a margin, so genuine double-talk on the mic side is gated out along with the echo. That is why it is opt-in rather than on by default.

## Commits

1. the gate itself, plus tests covering the clamp and empty-track cases
2. a doc fix — the setting's example named the pre-rename bundle identifier, which would have written the key into a domain nothing reads
3. the `defaultsToFalse` / `persistsToUserDefaults` pair the other settings have

I have been running this on my own recordings for two and a half weeks.
