### PR TITLE
feat(app): add /v1/watch so watching can be controlled from outside the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ flowchart TD
 - **Background processing** — PipelineQueue runs transcription and protocol generation independently from recording
 - **Record-only mode** — Skip the entire post-recording pipeline and drop dual-source recordings + a metadata sidecar into the output folder, for external/fleet processing (e.g. a separate GPU host)
 - **Local automation API** (Homebrew build): drive the pipeline headlessly over localhost HTTP. POST an audio file, get a diarized transcript back. See [`docs/automation-api.md`](docs/automation-api.md)
+- **Stream Deck and hotkey control** (Homebrew build): start/stop watching from a Stream Deck key, Shortcut, Raycast or any launcher. See [`docs/stream-deck.md`](docs/stream-deck.md)
 - **Distribution** — Install via Homebrew Cask or build from source
 
 ---

--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -131,7 +131,7 @@
                 liveCaptions: liveCaptionsSnapshot(),
                 watchState: watching.watchLoop?.state.rawValue,
                 pendingConsentApp: watching.watchLoop?.pendingConsentApp,
-                isManualRecording: isManualRecording,
+                isManualRecording: watching.isManualRecording,
                 notifications: notificationsSnapshot(),
                 // Built inside AppSettings (single-hop `self.` reads) to stay
                 // under the type-check budget — see `rpcSettingsSnapshot`.
@@ -140,6 +140,71 @@
                 updateStatus: updateStatusSnapshot(),
                 windows: windowsSnapshot(),
             )
+        }
+
+        /// Small, stable projection of the watching lifecycle for `/v1/watch`.
+        ///
+        /// Kept separate from `rpcStateSnapshot` on purpose: that snapshot is the
+        /// debug surface and is free to change shape, while this one is polled on
+        /// an interval by third-party controllers and carries a compatibility
+        /// promise. Locals are bound first (rather than reading the two-hop
+        /// `watching.watchLoop.…` `@Observable` chain inline) to keep the
+        /// memberwise init inside the type-check budget — see `rpcQueueStatus`.
+        func watchStatusDTO() -> WatchStatusDTO {
+            let loop = watching.watchLoop
+            let badge = currentBadge.rawValue
+            // nil means the probe has not run, which is not a permission
+            // problem. `BadgeKind.compute` treats it the same way, and the
+            // badge and this field must not disagree.
+            let healthy = permissions.health?.isHealthy != false
+            return WatchStatusDTO(
+                watching: watching.isWatching,
+                state: loop?.state.rawValue,
+                badge: badge,
+                manualRecording: watching.isManualRecording,
+                pendingConsentApp: loop?.pendingConsentApp,
+                permissionsHealthy: healthy,
+            )
+        }
+
+        /// The two `/v1/watch` seams, bundled so `buildDebugRPCServer` stays a
+        /// flat wiring list. Control is `async` because the start awaits the mic
+        /// gate before the loop exists — reporting a snapshot taken before that
+        /// settles would hand a remote key a stale answer to the press it just
+        /// made. Status is this small dedicated projection rather than `/state`,
+        /// which a polling controller must not be pinned to.
+        func watchRPCClosures() -> (
+            status: () -> WatchStatusDTO,
+            control: (WatchAction) async -> WatchControlOutcome,
+        ) {
+            let status: () -> WatchStatusDTO = { [weak self] in
+                self?.watchStatusDTO() ?? .notWatching
+            }
+            let control: (WatchAction) async -> WatchControlOutcome = { [weak self] action in
+                guard let self else { return .failed }
+                return await watching.applyWatchAction(action)
+            }
+            return (status, control)
+        }
+
+        /// The three per-job speaker-naming seams, bundled for the same reason as
+        /// `watchRPCClosures`: `buildDebugRPCServer` is a flat wiring list, and
+        /// grouping the closures that belong to one route family keeps it one.
+        func namingRPCClosures() -> (
+            status: (UUID) -> NamingStatusDTO?,
+            confirm: (UUID, [String: String]) -> Bool,
+            skip: (UUID) -> Bool,
+        ) {
+            let status: (UUID) -> NamingStatusDTO? = { [weak self] id in
+                self?.pipeline.namingStatus(forID: id)
+            }
+            let confirm: (UUID, [String: String]) -> Bool = { [weak self] id, mapping in
+                self?.pipeline.confirmNaming(jobID: id, mapping: mapping) ?? false
+            }
+            let skip: (UUID) -> Bool = { [weak self] id in
+                self?.pipeline.skipNaming(jobID: id) ?? false
+            }
+            return (status, confirm, skip)
         }
 
         /// Project the pinning-relevant properties of each named scene window.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -401,21 +401,14 @@ final class AppState {
             }
             // Per-job speaker-naming over the API: read the pending choice, then
             // confirm names or skip (accept auto-names) for that one job.
-            let namingStatus: (UUID) -> NamingStatusDTO? = { [weak self] id in
-                self?.pipeline.namingStatus(forID: id)
-            }
-            let confirmNaming: (UUID, [String: String]) -> Bool = { [weak self] id, mapping in
-                self?.pipeline.confirmNaming(jobID: id, mapping: mapping) ?? false
-            }
-            let skipJobNaming: (UUID) -> Bool = { [weak self] id in
-                self?.pipeline.skipNaming(jobID: id) ?? false
-            }
+            let naming = namingRPCClosures()
             // Blocking one-call: enqueue + wait until terminal (auto-skipping
             // the headless naming pause), returning the final status inline.
             let transcribe: (URL, Double) async -> BlockingTranscribeResult = { [weak self] url, maxWait in
                 guard let self else { return .noFile }
                 return await pipeline.transcribeAndWait(path: url, maxWaitSeconds: maxWait)
             }
+            let watch = watchRPCClosures()
             return DebugRPCServer(
                 port: port,
                 token: token,
@@ -427,10 +420,12 @@ final class AppState {
                 enqueueFiles: enqueueFilesRPC,
                 enqueueReturningIDs: enqueueReturningIDs,
                 jobStatus: jobStatus,
-                namingStatus: namingStatus,
-                confirmNaming: confirmNaming,
-                skipJobNaming: skipJobNaming,
+                namingStatus: naming.status,
+                confirmNaming: naming.confirm,
+                skipJobNaming: naming.skip,
                 transcribe: transcribe,
+                watchStatus: watch.status,
+                watchControl: watch.control,
             )
         }
     #endif
@@ -500,6 +495,15 @@ final class AppState {
     /// Whether the active loop is a manual recording (vs. auto-detect). Drives
     /// the menu-bar "Stop Recording" item; hoisted to a single-member accessor
     /// so the body reading it through `watching.watchLoop` stays cheap.
+    ///
+    /// Deliberately the loop-only predicate, not the controller's wider one.
+    /// The menu item asks "is there a recording I can stop", and during a
+    /// manual start that has registered but not yet built its loop the honest
+    /// answer is no: `stopManualRecording()` would find no loop, stop nothing,
+    /// and the recording would begin a moment later regardless. The wider
+    /// predicate belongs to the automation API, which asks the different
+    /// question of whether a manual recording owns *or is about to own* the
+    /// loop; see `watchStatusDTO()`.
     var isManualRecording: Bool {
         watching.watchLoop?.isManualRecording == true
     }

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -72,6 +72,8 @@
         /// - `GET  /v1/jobs/<id>/naming` — pending speaker-naming choice
         /// - `POST /v1/jobs/<id>/naming` — confirm speaker names `{mapping}`
         /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
+        /// - `GET  /v1/watch` — watching status
+        /// - `POST /v1/watch` — start/stop/toggle watching `{action}`
         func routeV1(_ request: HTTPRequest, path: String) async -> HTTPResponse {
             let idempotencyKey = request.headers["idempotency-key"]
             // `path` is query-stripped; read the opt-in off the raw target.
@@ -80,6 +82,17 @@
                 return await transcribeResponse(
                     body: request.body, idempotencyKey: idempotencyKey, includeTranscript: includeTranscript,
                 )
+            }
+            // Matched before the `/v1/jobs` component split below, which assumes
+            // comps[0..1] == ["v1", "jobs"]. No `Idempotency-Key` handling: the
+            // operation is already idempotent, and that header exists here only
+            // to stop duplicate *job creation*.
+            if path == "/v1/watch" {
+                switch request.method {
+                case "GET": return watchResponse(status: 200, reason: "OK")
+                case "POST": return await watchControlResponse(body: request.body)
+                default: return HTTPResponse.notFound()
+                }
             }
             // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
             // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
@@ -115,6 +128,37 @@
         /// isn't awaiting naming (wrong state), 404 when the job id is unknown.
         private func namingFailureStatus(_ jobID: UUID) -> HTTPResponse {
             jobStatus(jobID) != nil ? HTTPResponse.conflict() : HTTPResponse.notFound()
+        }
+
+        // MARK: - /v1/watch
+
+        /// Render the current watch status with a caller-chosen status code.
+        /// GET and POST return the *same* body shape — one parser for a client,
+        /// and no POST-then-refetch race for a controller that needs to redraw
+        /// a key from the result. The code carries what the call achieved.
+        private func watchResponse(status: Int, reason: String) -> HTTPResponse {
+            guard let body = try? JSONEncoder().encode(watchStatus()) else {
+                return HTTPResponse.internalServerError()
+            }
+            return HTTPResponse(status: status, reason: reason, body: body, contentType: "application/json")
+        }
+
+        /// Apply a watch action and report the state it settled into.
+        ///
+        /// 409 for `.blocked` because `toggleWatching` silently refuses while a
+        /// manual recording owns the loop; a refusal that looks like success is
+        /// exactly the failure mode a remote key must not have. 503 for
+        /// `.failed` — the request was accepted but the state did not converge,
+        /// which is a different problem from being told no.
+        private func watchControlResponse(body: Data) async -> HTTPResponse {
+            guard let payload = try? JSONDecoder().decode(WatchActionPayload.self, from: body) else {
+                return HTTPResponse.badRequest()
+            }
+            switch await watchControl(payload.action) {
+            case .changed, .unchanged: return watchResponse(status: 200, reason: "OK")
+            case .blocked: return watchResponse(status: 409, reason: "Conflict")
+            case .failed: return watchResponse(status: 503, reason: "Service Unavailable")
+            }
         }
 
         private func enqueueResponse(body: Data, idempotencyKey: String?) -> HTTPResponse {

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -88,6 +88,8 @@
         let confirmNaming: (UUID, [String: String]) -> Bool // POST .../naming
         let skipJobNaming: (UUID) -> Bool // POST .../naming/skip
         let transcribe: (URL, Double) async -> BlockingTranscribeResult // POST /v1/transcribe
+        let watchStatus: () -> WatchStatusDTO // GET /v1/watch
+        let watchControl: (WatchAction) async -> WatchControlOutcome // POST /v1/watch
         var idempotency = IdempotencyStore() // Idempotency-Key -> job IDs; internal for the +V1 extension
         private let expectedAuth: String
         private var listener: NWListener?
@@ -114,6 +116,8 @@
             confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
             skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
             transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
+            watchStatus: @escaping () -> WatchStatusDTO = { .notWatching },
+            watchControl: @escaping (WatchAction) async -> WatchControlOutcome = { _ in .failed },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -129,6 +133,8 @@
             self.confirmNaming = confirmNaming
             self.skipJobNaming = skipJobNaming
             self.transcribe = transcribe
+            self.watchStatus = watchStatus
+            self.watchControl = watchControl
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -336,7 +342,7 @@
             // switch below, which compares against the raw `request.path`.
             let pathWithoutQuery = String(request.path.prefix { $0 != "?" })
             if pathWithoutQuery == "/v1/jobs" || pathWithoutQuery.hasPrefix("/v1/jobs/")
-                || pathWithoutQuery == "/v1/transcribe" {
+                || pathWithoutQuery == "/v1/transcribe" || pathWithoutQuery == "/v1/watch" {
                 return await routeV1(request, path: pathWithoutQuery)
             }
 

--- a/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AdvancedSettingsView.swift
@@ -114,10 +114,11 @@ struct AdvancedSettingsView: View {
                     Toggle("Local Automation API", isOn: $settings.debugRPCEnabled)
                     Text(
                         "Exposes the local automation API + pipeline state on"
-                            + " 127.0.0.1:9876 (POST /v1/transcribe, /v1/jobs; also"
-                            + " `mt-cli`). Localhost-only, bearer-token auth. Off by"
-                            + " default; enable for headless automation or"
-                            + " shell-driven inspection.",
+                            + " 127.0.0.1:9876 (POST /v1/transcribe, /v1/jobs, and"
+                            + " /v1/watch to start/stop watching from a hotkey or"
+                            + " Stream Deck; also `mt-cli`). Localhost-only,"
+                            + " bearer-token auth. Off by default; enable for"
+                            + " headless automation or shell-driven inspection.",
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/app/MeetingTranscriber/Sources/WatchStatusDTO.swift
+++ b/app/MeetingTranscriber/Sources/WatchStatusDTO.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Wire shape for `GET`/`POST /v1/watch` — the meeting-watching lifecycle as a
+/// small, stable projection.
+///
+/// Deliberately *not* `/state`: that snapshot is the debug surface, a 15-section
+/// kitchen sink built for E2E drivers and documented as free to change. A
+/// third-party controller (Stream Deck key, Shortcut, shell script) polls this
+/// on an interval forever, so it needs a payload that is cheap to fetch and
+/// carries a compatibility promise — the same reasoning that split `/v1` out of
+/// `/action/*` in the first place.
+///
+/// `watching` is an explicit boolean rather than something the client infers
+/// from a nil `state`: that inference is a semantic subtlety which has no
+/// business crossing a public API boundary. `badge` is included because it is
+/// the single richest glanceable field — it folds transcribing/diarizing/
+/// processing/error/updateAvailable into one value, which is what lets a
+/// physical key render more than on/off.
+struct WatchStatusDTO: Codable, Equatable {
+    /// Whether the watch loop is running *and* not owned by a manual recording.
+    let watching: Bool
+    /// `WatchLoop.State` raw value (`idle`/`watching`/`recording`/`error`), or
+    /// nil when no loop exists.
+    let state: String?
+    /// `BadgeKind` raw value — what the menu bar icon is showing right now.
+    let badge: String
+    /// Whether an app-picker recording owns the loop. Watch control is refused
+    /// while this is true.
+    let manualRecording: Bool
+    /// App name awaiting a browser-meeting consent answer, if one is parked.
+    let pendingConsentApp: String?
+    /// False only when a permission probe has actually failed. A health check
+    /// that has not run yet reports true, matching how `BadgeKind.compute`
+    /// treats an unknown result — the badge and this field must not disagree.
+    let permissionsHealthy: Bool
+
+    /// Fallback for the window between server start and `AppState` being
+    /// reachable. Reports "not watching, nothing wrong" rather than failing the
+    /// request, so a polling client sees a steady off state instead of an error.
+    static let notWatching = Self(
+        watching: false,
+        state: nil,
+        badge: BadgeKind.inactive.rawValue,
+        manualRecording: false,
+        pendingConsentApp: nil,
+        permissionsHealthy: true,
+    )
+}
+
+/// What a `POST /v1/watch` asks for.
+///
+/// `start`/`stop` exist alongside `toggle` because a key press expresses a
+/// desired outcome, not a delta. A remote controller's view of the app is
+/// always slightly stale; if a meeting ended since its last poll, a blind
+/// toggle does exactly the wrong thing and stays inverted until someone
+/// notices. Idempotent verbs converge instead.
+enum WatchAction: String, Codable {
+    case start
+    case stop
+    case toggle
+}
+
+/// What a watch-control request actually achieved. Maps 1:1 onto the HTTP
+/// status code, so the caller can tell "already on" from "refused" without
+/// diffing state before and after.
+///
+/// Deliberately not `Codable` and not raw-value backed: it never crosses the
+/// wire. The route reads it to pick a status code and builds the body from
+/// `watchStatusDTO()`. Publishing a wire conformance on a type that has no wire
+/// presence would invite a later change to serialise it, quietly promoting
+/// these case names into the compatibility promise this file exists to keep.
+enum WatchControlOutcome: Equatable {
+    /// The request changed the watching state. → 200
+    case changed
+    /// Already in the requested state; nothing to do. → 200
+    case unchanged
+    /// Refused: a manual recording owns the loop. → 409
+    case blocked
+    /// The request was accepted but the state did not settle as asked. → 503
+    case failed
+}
+
+/// Request body for `POST /v1/watch`. An unrecognised action string fails to
+/// decode, which the route turns into a 400 — better than silently treating a
+/// typo'd verb as a toggle.
+struct WatchActionPayload: Codable, Equatable {
+    let action: WatchAction
+}

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -35,6 +35,15 @@ final class WatchingController {
     /// finishes.
     private var startTask: Task<Void, Never>?
 
+    /// See `defaultStartJoinTimeout`.
+    private let startJoinTimeout: Duration
+
+    /// Set while `startManualRecording` is in flight, i.e. from the call until
+    /// `watchLoop` holds the manual loop. `startTask`'s counterpart for the
+    /// manual path, so `isManualRecording` covers the window before the loop
+    /// exists.
+    private var manualStartTask: Task<Void, Never>?
+
     private let settings: AppSettings
     private let notifier: any AppNotifying
     private let pipeline: PipelineController
@@ -116,6 +125,7 @@ final class WatchingController {
                 Permissions.ensureAccessibilityAccess()
             #endif
         },
+        startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: (() -> any MeetingDetecting)? = nil,
     ) {
         self.settings = settings
@@ -127,6 +137,7 @@ final class WatchingController {
         self.ensureMicAccess = ensureMicAccess
         self.requestScreenRecording = requestScreenRecording
         self.requestAccessibility = requestAccessibility
+        self.startJoinTimeout = startJoinTimeout
         // Tests inject a deterministic detector; production defaults to one
         // filtered by the "Apps to Watch" toggles, re-read at each watch start.
         self.makeDetector = makeDetector ?? { [settings] in
@@ -177,6 +188,20 @@ final class WatchingController {
         watchLoop?.state == .recording
     }
 
+    /// Whether a manual (app-picker) recording owns the loop, or is on its way
+    /// to owning it. Exposed because `toggleWatching` silently refuses in that
+    /// state, and a silent refusal is invisible to a remote caller — the
+    /// automation API turns this into a 409.
+    ///
+    /// The in-flight half matters: `startManualRecording` assigns `watchLoop`
+    /// only after awaiting the mic gate, so reading the loop alone reports
+    /// "no manual recording" for the whole of that window, and a remote start
+    /// landing in it would build an auto loop that the manual task then
+    /// overwrites without stopping.
+    var isManualRecording: Bool {
+        manualStartTask != nil || watchLoop?.isManualRecording == true
+    }
+
     // MARK: - Start / Stop
 
     /// - Parameter userInitiated: True for a deliberate Start/Stop press, which
@@ -185,11 +210,18 @@ final class WatchingController {
     ///   system alert — including on the e2e runners, which force auto-watch on
     ///   and where a stray dialog can swallow the keystroke a lane sends.
     func toggleWatching(userInitiated: Bool = true) {
-        if let loop = watchLoop, loop.isManualRecording { return }
         if let loop = watchLoop, loop.isActive {
+            // Refuse only for a *manual* loop. Stopping a live auto loop is safe
+            // even while a manual start is registered, and the order matters:
+            // between registration and the manual task stopping that loop
+            // itself, a blanket refusal would turn a stop into an instant
+            // `.failed` — a 503 the docs describe as "did not settle within 20
+            // seconds" — and silently no-op the menu-bar toggle.
+            guard !loop.isManualRecording else { return }
             loop.stop()
             watchLoop = nil
         } else {
+            guard !isManualRecording else { return }
             // The start is async — mic access is awaited before `watchLoop` is
             // assigned — so a second toggle in that window would otherwise launch
             // a duplicate WatchLoop and rebuild the queue twice. Ignore it while
@@ -198,6 +230,16 @@ final class WatchingController {
             startTask = Task { @MainActor in
                 defer { startTask = nil }
                 await requestStartPermissions(userInitiated: userInitiated)
+
+                // A manual start can register while this task is parked on the
+                // permission gate, and nothing below re-checks. Whichever side
+                // assigned `watchLoop` last would win and orphan the other loop
+                // — still running, with no reference left to stop it. Bailing
+                // here rather than at the assignment also keeps `pipeline.rebuild()`
+                // from replacing the queue the manual loop is already wired to.
+                // Nothing leaks: `loop.start()` has not run, so there is no
+                // self-retaining watch task yet.
+                guard !isManualRecording else { return }
 
                 syncEngines?()
                 pipeline.rebuild()
@@ -248,62 +290,174 @@ final class WatchingController {
         }
     }
 
+    // MARK: - Idempotent control (automation API)
+
+    /// How long a control call waits for an in-flight start before giving up.
+    /// Generous against the ~2 s warm start, short enough that a wedged request
+    /// still answers well inside a polling controller's patience. Injectable so
+    /// a test can pin the give-up path without waiting it out.
+    static let defaultStartJoinTimeout: Duration = .seconds(20)
+
+    /// Join an in-flight start, giving up after `startJoinTimeout`. True when
+    /// the start settled, false on expiry.
+    ///
+    /// The bound is the point. On a fresh install `toggleWatching` awaits
+    /// `AVCaptureDevice.requestAccess`, which does not return until the dialog
+    /// is answered — and on an `LSUIElement` app that dialog can sit unnoticed
+    /// behind other windows. An unbounded join would hold the HTTP handler and
+    /// its connection open for as long as the prompt is up, and because every
+    /// verb joins the same task, each later POST would park and leak another
+    /// connection.
+    ///
+    /// Polls `startTask` rather than racing `await startTask?.value` in a task
+    /// group. Two things rule the group out: `Task.value` ignores cancellation,
+    /// so the losing child keeps waiting, and a group awaits every child before
+    /// it returns — the join would outlive its own timeout. Giving up must also
+    /// not cancel the start itself, which is a user action already in progress.
+    private func joinStart() async -> Bool {
+        let deadline = ContinuousClock.now + startJoinTimeout
+        while startTask != nil {
+            if Task.isCancelled { return false }
+            if ContinuousClock.now >= deadline { return false }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return true
+    }
+
+    /// Idempotent start. Awaits the in-flight async start — mic gate, engine
+    /// sync, queue rebuild, loop construction — so a caller that reports state
+    /// back observes the settled result instead of a snapshot taken mid-launch.
+    /// `toggleWatching` alone cannot offer that: it returns the moment the task
+    /// is spawned, and `startTask` is private.
+    ///
+    /// Starts as not user-initiated. Nobody is at the machine when this arrives
+    /// — that is the whole point of the endpoint — so the optional Accessibility
+    /// prompt must not be raised, exactly as for auto-watch.
+    @discardableResult
+    func startWatching() async -> WatchControlOutcome {
+        if isManualRecording { return .blocked }
+        if isWatching { return .unchanged }
+        toggleWatching(userInitiated: false)
+        // `toggleWatching` assigns `startTask` synchronously, so this always
+        // joins the task it just created — or, if another caller already had a
+        // start in flight, the one whose existence made our call a no-op.
+        guard await joinStart() else { return .failed }
+        // Re-check: a manual start can register while the auto start is parked,
+        // which makes that start bail and leaves `watchLoop` nil. The join
+        // settled and the dialog was answered, so this is the conflict 409
+        // describes, not the "did not settle" 503.
+        if isManualRecording { return .blocked }
+        return isWatching ? .changed : .failed
+    }
+
+    /// Idempotent stop. Awaits a pending start first: otherwise a stop issued
+    /// during the mic-access window lands before the loop exists, reports
+    /// "already stopped", and is then overwritten by the start completing.
+    ///
+    /// A manual recording is reported as `.unchanged` rather than `.blocked`:
+    /// `isWatching` is false by definition while one owns the loop, so the
+    /// requested end state already holds and there is nothing to refuse. That
+    /// is the asymmetry with `startWatching`, where `.blocked` is right because
+    /// starting would clobber the recording.
+    @discardableResult
+    func stopWatching() async -> WatchControlOutcome {
+        guard await joinStart() else { return .failed }
+        guard isWatching else { return .unchanged }
+        toggleWatching()
+        return isWatching ? .failed : .changed
+    }
+
+    /// Apply a watch action, resolving `.toggle` against settled state.
+    ///
+    /// The leading await matters for `.toggle`: deciding against a mid-launch
+    /// snapshot would read "not watching" for a loop that is seconds from
+    /// running, and start a second one. Settling first means a toggle racing a
+    /// start converges to on — the caller asked for a flip and gets a definite
+    /// answer, rather than a coin toss on where the mic prompt happened to be.
+    @discardableResult
+    func applyWatchAction(_ action: WatchAction) async -> WatchControlOutcome {
+        guard await joinStart() else { return .failed }
+        switch action {
+        case .start: return await startWatching()
+        case .stop: return await stopWatching()
+        case .toggle: return isWatching ? await stopWatching() : await startWatching()
+        }
+    }
+
     func startManualRecording(pid: pid_t, appName: String, title: String) {
+        // `toggleWatching`'s counterpart. The correctness added here rests on
+        // `manualStartTask` being accurate, and without this a second start
+        // replaces the field while the first is still in flight, whose `defer`
+        // then clears the second's registration and reopens the window.
+        guard manualStartTask == nil else { return }
+        manualStartTask = Task { @MainActor in
+            defer { manualStartTask = nil }
+            await performManualRecording(pid: pid, appName: appName, title: title)
+        }
+    }
+
+    /// Body of `startManualRecording`, split out so the task closure stays a
+    /// two-liner and the work is readable on its own.
+    private func performManualRecording(pid: pid_t, appName: String, title: String) async {
+        // Settle an auto start before reading `watchLoop`. Mid-flight it is
+        // still nil, so the stop below would find nothing and the auto task
+        // would later assign over the manual loop, orphaning a live recording
+        // with no way to stop it.
+        _ = await joinStart()
+
         // Stop auto-watch if active
         if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
             loop.stop()
             watchLoop = nil
         }
 
-        Task { @MainActor in
-            _ = await ensureMicAccess()
+        _ = await ensureMicAccess()
 
-            pipeline.ensureQueue()
+        pipeline.ensureQueue()
 
-            // Manual recording never polls the detector, so WatchLoop's default
-            // (unfiltered) detector here is inert, and so is the consent gate
-            // that hangs off it: no detection means no prompt, hence no deny
-            // list to consult, hence the default in-memory store. If this path
-            // ever gains auto-detection, route it through `makeDetector()` like
-            // toggleWatching so the "Apps to Watch" filter still applies, and
-            // pass `denyListStore:` so a "Never for this app" is honoured here
-            // too.
-            let loop = WatchLoop(
-                recorderFactory: makeRecorderFactory(),
-                pipelineQueue: pipeline.queue,
-                pollInterval: settings.pollInterval,
-                noMic: settings.noMic,
-                micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
-                verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
-                recordOnly: { [settings] in settings.recordOnly },
-                recordOnlyDestination: { [settings] in
-                    .production(parent: settings.effectiveOutputDir)
-                },
-                notifier: notifier,
+        // Manual recording never polls the detector, so WatchLoop's default
+        // (unfiltered) detector here is inert, and so is the consent gate
+        // that hangs off it: no detection means no prompt, hence no deny
+        // list to consult, hence the default in-memory store. If this path
+        // ever gains auto-detection, route it through `makeDetector()` like
+        // toggleWatching so the "Apps to Watch" filter still applies, and
+        // pass `denyListStore:` so a "Never for this app" is honoured here
+        // too.
+        let loop = WatchLoop(
+            recorderFactory: makeRecorderFactory(),
+            pipelineQueue: pipeline.queue,
+            pollInterval: settings.pollInterval,
+            noMic: settings.noMic,
+            micDeviceUID: settings.micDeviceUID.isEmpty ? nil : settings.micDeviceUID,
+            verboseDiagnostics: { [settings] in settings.verboseDiagnostics },
+            recordOnly: { [settings] in settings.recordOnly },
+            recordOnlyDestination: { [settings] in
+                .production(parent: settings.effectiveOutputDir)
+            },
+            notifier: notifier,
+        )
+        watchLoop = loop
+
+        // Wire channel-health monitoring + error notification on state
+        // transitions — same hook the auto-detect path installs, so the
+        // red-tint indicator and asymmetric-silence notification work
+        // for manual recordings too.
+        attachStateChangeHandler(to: loop, notifyOnRecording: false)
+
+        // Use cached health check result instead of live probe
+        if let health = permissions.health {
+            loop.permissionChecker = { health }
+        }
+
+        do {
+            try await loop.startManualRecording(pid: pid, appName: appName, title: title)
+            notifier.notify(
+                title: "Manual Recording",
+                body: "Recording: \(title)",
             )
-            watchLoop = loop
-
-            // Wire channel-health monitoring + error notification on state
-            // transitions — same hook the auto-detect path installs, so the
-            // red-tint indicator and asymmetric-silence notification work
-            // for manual recordings too.
-            attachStateChangeHandler(to: loop, notifyOnRecording: false)
-
-            // Use cached health check result instead of live probe
-            if let health = permissions.health {
-                loop.permissionChecker = { health }
-            }
-
-            do {
-                try await loop.startManualRecording(pid: pid, appName: appName, title: title)
-                notifier.notify(
-                    title: "Manual Recording",
-                    body: "Recording: \(title)",
-                )
-            } catch {
-                notifier.notify(title: "Error", body: error.localizedDescription)
-                watchLoop = nil
-            }
+        } catch {
+            notifier.notify(title: "Error", body: error.localizedDescription)
+            watchLoop = nil
         }
     }
 

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -465,6 +465,27 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             let txBody = Data(#"{"path":"\#(txFile.path)","maxWaitSeconds":0}"#.utf8)
             let tx = try await send("POST", "v1/transcribe", body: txBody)
             XCTAssertEqual(tx, 202)
+
+            // watch closures: the route tests stub these, and `DebugRPCServer.init`
+            // declares defaults for both, so deleting the wiring arguments at the
+            // `AppState` call site still compiles and leaves those tests green.
+            // Driving the real closures over the socket is what pins them.
+            let watchGet = try await send("GET", "v1/watch")
+            XCTAssertEqual(watchGet, 200)
+            let watchBad = try await send("POST", "v1/watch", body: Data(#"{"action":"nope"}"#.utf8))
+            XCTAssertEqual(watchBad, 400, "an unknown verb must not reach the controller")
+
+            // `stop` while not watching is a satisfied request, and reaching
+            // `.unchanged` proves the control closure ran rather than a default.
+            var stopReq = URLRequest(url: baseURL.appendingPathComponent("v1/watch"))
+            stopReq.httpMethod = "POST"
+            stopReq.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let stopBody = Data(#"{"action":"stop"}"#.utf8)
+            let (stopData, stopResp) = try await URLSession.shared.upload(for: stopReq, from: stopBody)
+            XCTAssertEqual(code(stopResp), 200)
+            let dto = try JSONDecoder().decode(WatchStatusDTO.self, from: stopData)
+            XCTAssertFalse(dto.watching)
+            XCTAssertFalse(dto.manualRecording)
         }
     #endif
 

--- a/app/MeetingTranscriber/Tests/AsyncGate.swift
+++ b/app/MeetingTranscriber/Tests/AsyncGate.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// One-shot async gate: lets a test park an injected `async` seam and release it
+/// on cue, so a race is ordered rather than timing-dependent.
+///
+/// `hasWaiter` is what makes it usable for ordering rather than only for
+/// releasing: opening the gate controls when the parked side resumes, but a test
+/// usually also needs to know the parked side has *arrived* before racing
+/// something against it.
+///
+/// Its own file rather than `TestHelpers.swift`, which is at its 600-line limit.
+/// Near-identical continuation gates are already inlined in several suites; this
+/// is the standalone version, so new callers have somewhere to reach for.
+actor AsyncGate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var isOpen = false
+
+    var hasWaiter: Bool {
+        !continuations.isEmpty
+    }
+
+    var waiterCount: Int {
+        continuations.count
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations = []
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -43,6 +43,8 @@
             confirmNaming: @escaping (UUID, [String: String]) -> Bool = { _, _ in false },
             skipJobNaming: @escaping (UUID) -> Bool = { _ in false },
             transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
+            watchStatus: @escaping () -> WatchStatusDTO = { .notWatching },
+            watchControl: @escaping (WatchAction) async -> WatchControlOutcome = { _ in .failed },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
@@ -57,6 +59,8 @@
                 confirmNaming: confirmNaming,
                 skipJobNaming: skipJobNaming,
                 transcribe: transcribe,
+                watchStatus: watchStatus,
+                watchControl: watchControl,
             )
             self.server = server
             server.start()
@@ -1087,6 +1091,119 @@
                 firstLine.contains("200"),
                 "Expected 200 for loopback Host, got: \(firstLine)",
             )
+        }
+
+        // MARK: - /v1/watch
+
+        func testV1WatchGETReturnsStatus() async throws {
+            let dto = WatchStatusDTO(
+                watching: true, state: "recording", badge: "recording",
+                manualRecording: false, pendingConsentApp: nil, permissionsHealthy: true,
+            )
+            // Typed local, not a trailing closure: with only one argument
+            // SwiftLint suggests trailing syntax, which would bind to
+            // `enqueueFile` (the first function-type parameter) instead.
+            let status: () -> WatchStatusDTO = { dto }
+            let base = try await startServer(watchStatus: status)
+
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/watch"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(WatchStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.watching)
+            XCTAssertEqual(decoded.state, "recording")
+            XCTAssertEqual(decoded.badge, "recording")
+            XCTAssertTrue(decoded.permissionsHealthy)
+        }
+
+        /// The POST body must carry the state *after* the action, so a controller
+        /// can redraw from the response instead of racing a follow-up GET.
+        func testV1WatchPOSTStartReturnsResultingState() async throws {
+            var isWatching = false
+            let base = try await startServer(
+                watchStatus: {
+                    WatchStatusDTO(
+                        watching: isWatching, state: isWatching ? "watching" : nil, badge: "inactive",
+                        manualRecording: false, pendingConsentApp: nil, permissionsHealthy: true,
+                    )
+                },
+                watchControl: { action in
+                    guard action == .start else { return .unchanged }
+                    isWatching = true
+                    return .changed
+                },
+            )
+
+            var req = request("POST", base.appendingPathComponent("v1/watch"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(WatchStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.watching, "the response must reflect the post-action state, not the pre-action one")
+        }
+
+        /// `.unchanged` is a success: a key press asks for an outcome, and already
+        /// being in that outcome is not an error.
+        func testV1WatchPOSTUnchangedReturns200() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            // Declared sync (it never suspends); Swift coerces it to the async parameter.
+            let control: (WatchAction) -> WatchControlOutcome = { _ in .unchanged }
+            let base = try await startServer(watchControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/watch"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"stop"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        }
+
+        /// A manual recording owning the loop must surface as 409, not a silent
+        /// 200 — `toggleWatching` refuses silently, and that refusal is invisible
+        /// to a remote caller unless the status code carries it.
+        func testV1WatchPOSTBlockedReturns409() async throws {
+            let dto = WatchStatusDTO(
+                watching: false, state: "recording", badge: "recording",
+                manualRecording: true, pendingConsentApp: nil, permissionsHealthy: true,
+            )
+            let base = try await startServer(watchStatus: { dto }, watchControl: { _ in .blocked })
+
+            var req = request("POST", base.appendingPathComponent("v1/watch"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"toggle"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 409)
+            // The body is the same shape on every status, so a client parses once
+            // and can show *why* it was refused.
+            let decoded = try JSONDecoder().decode(WatchStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.manualRecording)
+        }
+
+        func testV1WatchPOSTFailedReturns503() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let control: (WatchAction) -> WatchControlOutcome = { _ in .failed }
+            let base = try await startServer(watchControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/watch"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 503)
+        }
+
+        func testV1WatchPOSTUnknownActionReturns400() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let control: (WatchAction) -> WatchControlOutcome = { _ in .changed }
+            let base = try await startServer(watchControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/watch"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"pause"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        func testV1WatchRequiresAuth() async throws {
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/watch")),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 401)
         }
 
         /// A request streamed past the 64 KiB per-connection cap

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -31,6 +31,7 @@ final class WatchingControllerTests: XCTestCase {
         requestScreenRecording: @escaping () -> Void = {},
         requestAccessibility: @escaping () -> Void = {},
         watchTeams: Bool = true,
+        startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
     ) -> WatchingController {
         let settings = AppSettings()
@@ -60,6 +61,7 @@ final class WatchingControllerTests: XCTestCase {
             ensureMicAccess: ensureMicAccess,
             requestScreenRecording: requestScreenRecording,
             requestAccessibility: requestAccessibility,
+            startJoinTimeout: startJoinTimeout,
             makeDetector: makeDetector,
         )
     }
@@ -258,5 +260,336 @@ final class WatchingControllerTests: XCTestCase {
         controller.stopManualRecording()
 
         XCTAssertNil(controller.watchLoop)
+    }
+
+    // MARK: - Idempotent control (automation API)
+
+    /// A manual start can register while the auto start is parked on the
+    /// permission gate, and nothing below that gate re-checked. Whichever side
+    /// assigned `watchLoop` last won, orphaning the other — still running, with
+    /// no reference left to stop it. The auto loop is the worse orphan: it keeps
+    /// polling and starts a second concurrent recording on the next detected
+    /// meeting, invisible in the UI.
+    ///
+    /// Separate gates per call so the manual start stays parked, and therefore
+    /// registered, for the whole of the auto task's resume. Sharing one gate
+    /// leaves the resume order undefined.
+    func testParkedAutoStartBailsWhileAManualStartIsInFlight() async {
+        let autoGate = AsyncGate()
+        let manualGate = AsyncGate()
+        let calls = CallCounter()
+        let controller = makeController(
+            ensureMicAccess: {
+                let n = await calls.next()
+                await (n == 0 ? autoGate : manualGate).wait()
+                return true
+            },
+            // Short, so the manual path's own `joinStart` gives up on the parked
+            // auto start rather than waiting it out. That giving-up is the case
+            // the guard exists for: past the bound both paths run concurrently.
+            startJoinTimeout: .milliseconds(50),
+        )
+        addTeardownBlock {
+            await manualGate.open()
+            await controller.watchLoop?.stop()
+        }
+
+        controller.toggleWatching()
+        await waitFor { await autoGate.hasWaiter }
+        controller.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        await waitFor { await manualGate.hasWaiter }
+
+        await autoGate.open()
+        // Joins the auto task, so the assertion below is not a race.
+        let outcome = await controller.stopWatching()
+
+        XCTAssertEqual(outcome, .unchanged)
+        XCTAssertNil(controller.watchLoop, "the parked auto start must not assign over an in-flight manual start")
+    }
+
+    /// The bail path must report the refusal it is. When a manual start
+    /// registers while the auto start is parked, that start bails and
+    /// `watchLoop` stays nil — but the join *settled* and the dialog *was*
+    /// answered, so `.failed` (503, documented as "did not settle within 20
+    /// seconds") describes something that did not happen. It is the conflict
+    /// 409 exists for, and the body carries `manualRecording: true` either way.
+    func testStartRefusedByAMidFlightManualStartReportsBlocked() async {
+        let micGate = AsyncGate()
+        let box = ControllerBox()
+        let controller = makeController(
+            ensureMicAccess: {
+                await micGate.wait()
+                return true
+            },
+            // Fires inside the auto start task after the mic gate and before
+            // the bail guard. Registering the manual start from there orders
+            // the race instead of betting on it: the entry guard of
+            // `startWatching` has provably already run.
+            requestScreenRecording: {
+                MainActor.assumeIsolated {
+                    box.controller?.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+                }
+            },
+        )
+        box.controller = controller
+        addTeardownBlock {
+            await micGate.open()
+            await controller.watchLoop?.stop()
+        }
+
+        async let starting = controller.startWatching()
+        // The auto task exists only because `startWatching` created it, so
+        // waiting for it to park also pins that the entry guard saw no manual
+        // recording.
+        await waitFor { await micGate.hasWaiter }
+        await micGate.open()
+
+        let outcome = await starting
+
+        XCTAssertEqual(outcome, .blocked, "a start refused by a manual recording is a conflict, not a timeout")
+    }
+
+    /// `toggleWatching` guards re-entry with `startTask`; the manual path had no
+    /// counterpart. Two starts in quick succession both ran, the second replaced
+    /// the field, and the first's `defer` then cleared the second's
+    /// registration while it was still in flight — reopening the window that
+    /// `isManualRecording` was widened to close.
+    func testSecondManualStartWhileOneIsInFlightIsIgnored() async {
+        let micGate = AsyncGate()
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            await micGate.wait()
+            return true
+        })
+        addTeardownBlock {
+            await micGate.open()
+            await controller.watchLoop?.stop()
+        }
+
+        controller.startManualRecording(pid: 1, appName: "Chrome", title: "First")
+        await waitFor { await micGate.hasWaiter }
+        controller.startManualRecording(pid: 2, appName: "Chrome", title: "Second")
+        // Let a second task run if the guard failed to stop one being created.
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+
+        let waiters = await micGate.waiterCount
+        XCTAssertEqual(waiters, 1, "a second manual start must not run while one is in flight")
+    }
+
+    /// A remote start arrives at a machine nobody is sitting at, so it must not
+    /// raise the optional Accessibility prompt — the same reason auto-watch does
+    /// not. `toggleWatching`'s parameter defaults to true for the menu bar, so a
+    /// bare call here would silently opt the API into prompting.
+    func testRemoteStartDoesNotRequestAccessibility() async {
+        var requested = false
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(requestAccessibility: { requested = true })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        await controller.startWatching()
+
+        XCTAssertTrue(controller.isWatching, "the start must still happen")
+        XCTAssertFalse(requested, "a remote start must not prompt for Accessibility")
+    }
+
+    /// `.toggle` resolving to a start goes through `startWatching`, so it
+    /// inherits the same rule.
+    func testRemoteToggleToStartDoesNotRequestAccessibility() async {
+        var requested = false
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(requestAccessibility: { requested = true })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        await controller.applyWatchAction(.toggle)
+
+        XCTAssertTrue(controller.isWatching)
+        XCTAssertFalse(requested, "a remote toggle must not prompt for Accessibility")
+    }
+
+    /// The whole point of `startWatching` over `toggleWatching`: it awaits the
+    /// private in-flight `startTask`, so a caller reporting state back — the
+    /// `/v1/watch` route — sees the settled loop rather than a snapshot taken
+    /// while mic access was still pending.
+    func testStartWatchingAwaitsSettledState() async {
+        let controller = makeController()
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        let outcome = await controller.startWatching()
+
+        XCTAssertEqual(outcome, .changed)
+        // No `waitFor`: if the await didn't settle, this is nil right here.
+        XCTAssertNotNil(controller.watchLoop, "startWatching must not return before the loop exists")
+        XCTAssertTrue(controller.isWatching)
+    }
+
+    /// Idempotence is what makes a physical key correct: pressing "start" on an
+    /// already-watching app is a satisfied request, not an error and not a flip.
+    func testStartWatchingWhileWatchingIsUnchanged() async {
+        let controller = makeController()
+        addTeardownBlock { await controller.watchLoop?.stop() }
+        await controller.startWatching()
+
+        let outcome = await controller.startWatching()
+
+        XCTAssertEqual(outcome, .unchanged)
+        XCTAssertTrue(controller.isWatching, "an idempotent start must not toggle watching off")
+    }
+
+    func testStopWatchingStopsAndIsThenUnchanged() async {
+        let controller = makeController()
+        addTeardownBlock { await controller.watchLoop?.stop() }
+        await controller.startWatching()
+
+        let first = await controller.stopWatching()
+        let second = await controller.stopWatching()
+
+        XCTAssertEqual(first, .changed)
+        XCTAssertEqual(second, .unchanged)
+        XCTAssertFalse(controller.isWatching)
+    }
+
+    /// A stop issued during the mic-access window must not land before the loop
+    /// exists — otherwise it reports "already stopped" and the start completes
+    /// right after it, leaving the app watching against the caller's request.
+    func testStopWatchingDuringInFlightStartStillStops() async {
+        let micGate = AsyncGate()
+        // Not trailing-closure: a trailing closure binds to `makeDetector`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            await micGate.wait()
+            return true
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching() // start, parked on the mic gate
+        // Order the race for real. The gate controls when the start *unparks*,
+        // not when the stop arrives, and only the latter decides the outcome:
+        // without this the child task can be scheduled late enough to land past
+        // the start's whole post-gate continuation, and the test passes even
+        // with the join deleted from `stopWatching`.
+        await waitFor { await micGate.hasWaiter }
+        async let stopping = controller.stopWatching()
+        await micGate.open()
+        let stopped = await stopping
+
+        XCTAssertEqual(stopped, .changed)
+        XCTAssertFalse(controller.isWatching, "the stop must win over the start it was racing")
+    }
+
+    func testApplyWatchActionTogglesBothWays() async {
+        let controller = makeController()
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        let on = await controller.applyWatchAction(.toggle)
+        XCTAssertEqual(on, .changed)
+        XCTAssertTrue(controller.isWatching)
+
+        let off = await controller.applyWatchAction(.toggle)
+        XCTAssertEqual(off, .changed)
+        XCTAssertFalse(controller.isWatching)
+    }
+
+    /// `toggleWatching` silently refuses while a manual recording owns the loop.
+    /// Across an API that silence would read as success, so `startWatching`
+    /// reports `.blocked` and the route turns it into a 409.
+    func testStartIsBlockedDuringManualRecording() async throws {
+        let controller = makeController()
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+
+        let started = await controller.startWatching()
+
+        XCTAssertEqual(started, .blocked)
+        XCTAssertEqual(controller.watchLoop?.isManualRecording, true, "control must not disturb a manual recording")
+    }
+
+    /// `stop` is the asymmetric case: `isWatching` is false by definition while
+    /// a manual recording owns the loop, so the requested end state already
+    /// holds and there is nothing to refuse. The response body still carries
+    /// `manualRecording: true`, so a controller that wants to know can see it
+    /// without the request being reported as a conflict it is not.
+    func testStopDuringManualRecordingIsUnchangedNotBlocked() async throws {
+        let controller = makeController()
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        defer { loop.stop() }
+
+        let stopped = await controller.stopWatching()
+
+        XCTAssertEqual(stopped, .unchanged)
+        XCTAssertEqual(controller.watchLoop?.isManualRecording, true, "a stop must not disturb a manual recording")
+    }
+
+    /// A start parked on an unanswered microphone dialog must not hold the HTTP
+    /// handler and its connection open for as long as the prompt is up. The join
+    /// gives up and reports `.failed`, which the route turns into a 503.
+    ///
+    /// Also pins that giving up actually returns: an earlier revision raced the
+    /// join against a sleep in a task group, which deadlocked, because
+    /// `Task.value` ignores cancellation and a group awaits every child before
+    /// returning.
+    func testStartWatchingGivesUpWhenTheStartNeverSettles() async {
+        let micGate = AsyncGate()
+        let controller = makeController(
+            ensureMicAccess: {
+                await micGate.wait()
+                return true
+            },
+            startJoinTimeout: .milliseconds(50),
+        )
+        addTeardownBlock {
+            await micGate.open()
+            await controller.watchLoop?.stop()
+        }
+
+        let outcome = await controller.startWatching()
+
+        XCTAssertEqual(outcome, .failed, "an unsettled start must not hold the caller")
+    }
+
+    /// `startManualRecording` assigns `watchLoop` only after the mic gate, so
+    /// reading the loop alone reports "no manual recording" for that whole
+    /// window. A remote start landing in it used to build an auto loop that the
+    /// manual task then overwrote without stopping, orphaning a live loop that
+    /// nothing could cancel.
+    func testStartIsBlockedWhileManualStartIsStillInFlight() async {
+        let micGate = AsyncGate()
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(ensureMicAccess: {
+            await micGate.wait()
+            return true
+        })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        await waitFor { await micGate.hasWaiter }
+
+        let started = await controller.startWatching()
+
+        XCTAssertEqual(started, .blocked, "an in-flight manual start must block a remote start")
+        await micGate.open()
+    }
+}
+
+/// Hands out call indices so one injected seam can park different callers on
+/// different gates. Sharing a single gate leaves the resume order undefined.
+/// Lets a seam injected at construction call back into the controller it is
+/// wired to, which does not exist yet when the seam is built.
+@MainActor
+private final class ControllerBox {
+    var controller: WatchingController?
+}
+
+private actor CallCounter {
+    private var count = 0
+
+    func next() -> Int {
+        defer { count += 1 }
+        return count
     }
 }

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -63,6 +63,8 @@ per connection; exceeding it closes the connection without sending a response.
 | `GET`  | `/v1/jobs/<id>/naming` | Read the pending speaker-naming choice for a job. |
 | `POST` | `/v1/jobs/<id>/naming` | Confirm speaker names for a job. |
 | `POST` | `/v1/jobs/<id>/naming/skip` | Skip naming for a job (accept auto-assigned names). |
+| `GET`  | `/v1/watch` | Read whether the app is watching for meetings. |
+| `POST` | `/v1/watch` | Start, stop or toggle meeting watching. |
 
 A query string is stripped before routing, so `/v1/jobs/<id>?foo=bar` still
 resolves the id. The one query parameter with meaning is `include=transcript`
@@ -202,6 +204,66 @@ Responses:
 - `409 Conflict` if the job exists but is not awaiting naming.
 - `404 Not Found` if the id is unknown.
 
+### GET /v1/watch
+
+Read whether the app is currently watching for meetings. Returns a
+[`WatchStatusDTO`](#watchstatusdto).
+
+```bash
+curl -sS "$BASE/v1/watch" -H "Authorization: Bearer $TOKEN"
+```
+
+Always `200 OK`. Before the app has finished starting up it reports a steady
+"not watching, nothing wrong" state rather than failing, so a client polling on
+an interval never has to special-case launch.
+
+### POST /v1/watch
+
+Start, stop or toggle meeting watching — the same thing the menu bar's *Start
+Watching* item does.
+
+```bash
+curl -sS -X POST "$BASE/v1/watch" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"toggle"}'
+```
+
+`action` is `start`, `stop`, or `toggle`.
+
+Prefer `start`/`stop` over `toggle` for anything that fires from a button, key
+or schedule. A toggle applies a *delta* to a state the caller cannot see
+reliably: if a meeting ended (or you started watching from the menu bar) since
+the caller last looked, a blind toggle does the opposite of what was intended
+and stays inverted until someone notices. `start` and `stop` express the desired
+end state and converge no matter what happened in between.
+
+The response body is a [`WatchStatusDTO`](#watchstatusdto) describing the state
+**after** the action, so a controller can redraw from the response instead of
+racing a follow-up `GET`.
+
+Responses:
+
+- `200 OK` — the request was satisfied. This covers *both* "the state changed"
+  and "it was already like that": asking an already-watching app to `start` is a
+  satisfied request, not an error. A `stop` while a manual recording owns the
+  loop is also `200`: the app is not watching, which is what was asked for.
+  Read `manualRecording` in the body if you need to distinguish that case.
+- `409 Conflict` — refused because a manual (app-picker) recording owns the
+  watch loop, and starting would clobber it. Stop that recording first. The body
+  is still a `WatchStatusDTO`, with `manualRecording: true`, so a client can
+  explain the refusal. Only `start` and a `toggle` that resolves to a start can
+  return this.
+- `503 Service Unavailable` — the action was attempted but the state did not
+  settle within 20 seconds. In practice this means an unanswered microphone
+  permission dialog: the first watch start on a fresh install blocks on it, and
+  on a menu-bar-only app that dialog can sit unnoticed behind other windows.
+  Answer it and retry. Note that a *denied* microphone does not produce a `503`
+  — watching starts regardless, because app audio records without it, so you get
+  `200` with `watching: true`. Check the badge or `permissionsHealthy` for that.
+- `400 Bad Request` — the body is not JSON, or `action` is not one of the three
+  verbs.
+
 ## Idempotency
 
 `POST /v1/jobs` and `POST /v1/transcribe` honour an `Idempotency-Key` request
@@ -274,6 +336,42 @@ known voice matched). `participants` are the meeting attendees read via
 accessibility, when available. Embeddings and audio are deliberately excluded
 (they are large and carry PII).
 
+### WatchStatusDTO
+
+```json
+{
+  "watching": true,
+  "state": "recording",
+  "badge": "recording",
+  "manualRecording": false,
+  "pendingConsentApp": "Google Chrome",
+  "permissionsHealthy": true
+}
+```
+
+`watching`, `badge`, `manualRecording` and `permissionsHealthy` are always
+present — everything a controller needs to render a button is guaranteed to be
+in every response. `state` and `pendingConsentApp` are nullable and, following
+the same convention as the job DTOs, their keys are **omitted** rather than sent
+as `null` when they have no value. Read them as "absent means none".
+
+- `watching`: whether the watch loop is running and not owned by a manual
+  recording. This is an explicit field rather than something you infer from
+  `state`, so the meaning cannot drift.
+- `state`: `idle`, `watching`, `recording`, or `error`. Absent when no watch loop
+  exists at all (the app is not watching).
+- `badge`: what the menu bar icon is showing: `inactive`, `recording`,
+  `transcribing`, `diarizing`, `processing`, `userAction`, `done`, `error`, or
+  `updateAvailable`. This is the single richest field for a physical button or
+  status display, since it folds the whole pipeline into one glanceable value.
+- `manualRecording`: an app-picker recording owns the loop. Watch control is
+  refused (`409`) while this is true.
+- `pendingConsentApp`: the app name awaiting a browser-meeting consent answer.
+  Absent when no prompt is parked. Resolve it with
+  `POST /action/confirmBrowserConsent`.
+- `permissionsHealthy`: false only when a permission probe has actually failed.
+  A check that has not run yet reports `true`.
+
 ## Status codes
 
 | Code | Meaning |
@@ -284,7 +382,8 @@ accessibility, when available. Embeddings and audio are deliberately excluded
 | `401` | Missing or wrong bearer token. |
 | `403` | Rejected by the Origin or Host guard. |
 | `404` | Unknown job id. Also `GET /v1/jobs/<id>/naming` when the job is not awaiting naming (the GET folds wrong-state into `404`; the POST naming routes use `409` instead). |
-| `409` | Confirm/skip naming on a job that exists but is not awaiting naming. |
+| `409` | Confirm/skip naming on a job that exists but is not awaiting naming. Also `POST /v1/watch` while a manual recording owns the watch loop. |
+| `503` | `POST /v1/watch` only: the start did not settle within 20 seconds (in practice, an unanswered microphone dialog). A *denied* microphone gives `200`, not this. |
 
 ## Typical flows
 
@@ -312,8 +411,40 @@ while :; do
 done
 ```
 
+**Control watching from a script, hotkey or button:**
+
+```bash
+# Read it (safe to poll on an interval — the payload is small and stable).
+curl -sS "$BASE/v1/watch" -H "Authorization: ******"
+
+# Ask for a state, don't flip one. See POST /v1/watch for why.
+curl -sS -X POST "$BASE/v1/watch" \
+  -H "Authorization: ******" -H "Content-Type: application/json" \
+  -d '{"action":"start"}'
+```
+
+Or via the bundled CLI, which handles the token and base URL for you:
+
+```bash
+mt-cli watch          # status
+mt-cli watch start
+mt-cli watch stop
+mt-cli watch toggle
+```
+
+For wiring this to a physical button — a Stream Deck key, a Shortcut, a global
+hotkey — see [`docs/stream-deck.md`](stream-deck.md), which covers the launcher
+side.
+
 ## Notes and limitations
 
+- **Starting watching can trigger a system permission prompt.** The first
+  `POST /v1/watch` with `start` on a fresh install asks for microphone (and
+  possibly Screen Recording) access, which surfaces as a macOS dialog. Triggered
+  from a button press or a schedule that dialog arrives unannounced, so grant
+  the permissions once interactively before relying on remote control. Check
+  `permissionsHealthy` in the response to detect the state where the app cannot
+  actually record.
 - **Speaker DB is read-only on the headless path.** The blocking
   `POST /v1/transcribe` path recognizes already-enrolled voices but does not
   enroll new speakers or write recognition stats. (The interactive
@@ -322,14 +453,16 @@ done
   improve its own speaker DB through this API. An opt-in auto-enroll mode is a
   possible follow-up.
 - **Polling only.** There is no push/webhook/SSE callback in v1; clients poll
-  `GET /v1/jobs/<id>`. Push delivery is a known deferred item.
+  `GET /v1/jobs/<id>`, or `GET /v1/watch` for the watching state. Push delivery
+  is a known deferred item. On loopback a 3–5 s poll costs effectively nothing.
 - **No file upload.** The `path` must already be readable on the host running the
   app. Cross-host submission (multipart upload, no shared filesystem) is not part
   of v1.
-- **`mt-cli` is inspection-only.** The bundled `tools/mt-cli` client covers the
-  debug endpoints (`state`, `healthz`, `screenshot`, `open-settings`,
-  `close-settings`); an `mt-cli transcribe` front for this API is a planned
-  follow-up. For now drive `/v1` with `curl` or any HTTP client.
+- **`mt-cli` covers inspection plus watch control.** The bundled `tools/mt-cli`
+  client wraps the debug endpoints (`state`, `healthz`, `screenshot`,
+  `open-settings`, `close-settings`) and `mt-cli watch`; an `mt-cli transcribe`
+  front for the job endpoints is a planned follow-up. For now drive the rest of
+  `/v1` with `curl` or any HTTP client.
 
 ## See also
 

--- a/docs/stream-deck.md
+++ b/docs/stream-deck.md
@@ -1,0 +1,182 @@
+# Stream Deck, hotkeys and other buttons
+
+Meeting Transcriber watches for meetings on its own, but sometimes you want a
+physical control: a Stream Deck key to arm it before a call, a hotkey to stop it
+when you switch to something private, a menu bar of your own.
+
+This guide wires that up. Everything here goes through `/v1/watch` in the
+[local automation API](automation-api.md) — one endpoint that reports whether the
+watch loop is running and turns it on or off.
+
+> **Homebrew build only.** The automation API is compiled out of the App Store
+> build, which is sandboxed and cannot host a local server.
+
+## Before you start
+
+Turn the API on: **Settings → Advanced → Local Automation API**. It is off by
+default and binds to `127.0.0.1` only.
+
+Enabling it writes a bearer token to
+`~/Library/Application Support/MeetingTranscriber/.rpc-token` (mode `0600`).
+Everything below reads that file at run time rather than copying the value, so
+nothing breaks when the token rotates — which it does every time you switch the
+toggle off and back on.
+
+## A Stream Deck plugin, if you want live state
+
+[**Meeting Transcriber for Stream Deck**](https://github.com/alexpfau/meeting-transcriber-streamdeck)
+is a plugin that polls `/v1/watch` and repaints the key, so it shows whether
+watching is on even when it was turned on from the app. Three actions — toggle,
+start, stop.
+
+[Download the latest `.streamDeckPlugin`](https://github.com/alexpfau/meeting-transcriber-streamdeck/releases/latest)
+and double-click it. The actions then appear under **Meeting Transcriber** in
+the Stream Deck app. It reads the token file itself, so there is no pairing
+step and nothing to configure.
+
+Worth knowing before you do: that token is not scoped to watching. It is the
+single bearer token for the whole automation server — all of `/v1`, the
+`/action/*` UI-driving surface and `/screenshot`, which can capture the app's
+windows. Anything that can read the file can do all of it. The plugin helping
+itself to the token is the reason it needs no setup, and it is also the thing to
+weigh before installing.
+
+It is a separate project rather than part of this repo: it ships on Elgato's
+release cadence, not this app's, and nobody without a Stream Deck should have to
+download it.
+
+If you would rather not install a plugin, the rest of this guide does the same
+job with a Shortcut — minus the live state.
+
+## The simplest thing that works
+
+A Stream Deck key that runs a Shortcut. No plugin, no extra software.
+
+**1. Build the Shortcut.**
+
+In Shortcuts.app, create a new Shortcut named **Start Meeting Watching**
+containing a single **Run Shell Script** action (shell `/bin/zsh`) with:
+
+```bash
+TOKEN_FILE="$HOME/Library/Application Support/MeetingTranscriber/.rpc-token"
+if [ ! -r "$TOKEN_FILE" ]; then
+  echo "Meeting Transcriber automation API is off. Enable it in Settings > Advanced." >&2
+  exit 1
+fi
+TOKEN=$(cat "$TOKEN_FILE")
+curl -sS --fail-with-body -X POST http://127.0.0.1:9876/v1/watch \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"start"}'
+```
+
+The token is read at run time rather than baked in, so the Shortcut keeps
+working when the token rotates — which happens every time the API toggle is
+switched off and back on.
+
+Then duplicate it as **Stop Meeting Watching** with `"action":"stop"`. Two keys
+rather than one is the recommendation of this guide, not an accident — see
+[Start and stop beat toggle](#start-and-stop-beat-toggle). If you only have one
+key to spare, swap the verb for `toggle` and accept the caveat described there.
+Dropping `-X POST` and the `-d` line turns the same call into a status read.
+
+**2. Point a Stream Deck key at it.**
+
+Drag a **System → Website** action onto a key and set:
+
+| Field | Value |
+| --- | --- |
+| URL | `shortcuts://run-shortcut?name=Start%20Meeting%20Watching` |
+| Access in background | ticked |
+
+Repeat for a second key pointing at `Stop%20Meeting%20Watching`.
+
+Leaving "Access in background" unticked opens your browser on every press.
+If you renamed the Shortcut, URL-encode the new name (spaces become `%20`).
+
+**3. Press it.**
+
+The first press asks macOS for permission to run the Shortcut; allow it. After
+that the key is silent and takes about a second.
+
+## Any other launcher
+
+The Shortcut is only a wrapper. Raycast, Alfred, BetterTouchTool, Keyboard
+Maestro, Hammerspoon, a `.zshrc` alias — anything that can run a command can do
+this directly:
+
+```bash
+TOKEN=$(cat "$HOME/Library/Application Support/MeetingTranscriber/.rpc-token")
+curl -sS -X POST http://127.0.0.1:9876/v1/watch \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"toggle"}'
+```
+
+If you have the repo checked out, [`mt-cli`](../tools/mt-cli/) is shorter and
+finds the token itself:
+
+```bash
+mt-cli watch toggle
+mt-cli watch status
+```
+
+## Start and stop beat toggle
+
+`toggle` is the obvious binding and the worst one, because a button press is a
+*wish*, not a delta. Bind a key to `toggle` and its meaning depends on state you
+cannot see: if watching stopped on its own — an error, a restart, a meeting that
+ended — your "start" press stops nothing and you sit through the next call
+unrecorded.
+
+`start` and `stop` say what you want and are idempotent. Pressing `start` twice
+is not an error; the second press returns the same 200 with `watching: true`.
+Two keys, or one key per Stream Deck profile, will misfire less than one clever
+one. Use `toggle` when you genuinely have only one key to spare.
+
+## Reading state back
+
+Every call — `GET` and `POST` alike — returns the state *after* it, so a button
+never has to guess or re-fetch:
+
+```json
+{ "watching": true, "state": "watching", "badge": "inactive",
+  "manualRecording": false, "permissionsHealthy": true }
+```
+
+`watching` is the on/off answer. `badge` is what the menu bar icon is showing
+(`inactive`, `recording`, `transcribing`, `diarizing`, `processing`,
+`userAction`, `done`, `error`, `updateAvailable`) — the field to render if you
+want more than a binary light. `permissionsHealthy` is worth surfacing
+somewhere: watching can be *on* while a missing permission means nothing is
+actually being captured.
+
+Full field reference: [`docs/automation-api.md`](automation-api.md#watchstatusdto).
+
+## What a Shortcut cannot do
+
+**The key cannot show you the current state.** A Shortcut fires and forgets;
+nothing polls, so the key's image never changes when the app's state does. The
+`Multi Action Switch` action looks like a fix and is a trap — it alternates two
+static images by counting presses, so it desynchronises the first time watching
+starts or stops without you pressing anything, and then lies.
+
+That is the whole reason the plugin above exists. If you only ever start
+watching by pressing the key, a Shortcut is fine. If the app also starts and
+stops on its own — which is the point of a watch loop — you want the key to be
+told.
+
+## When it does not work
+
+| Symptom | Cause |
+| --- | --- |
+| `401` | Token rotated, or the API was toggled off and on. Re-read the file — do not cache it. |
+| Connection refused | App not running, or **Settings → Advanced → Local Automation API** is off. |
+| Token file missing | Same — the file is written when the API starts. |
+| `409` | A manual recording from the app picker owns the loop. Stop it in the menu bar first. |
+| Browser opens on every press | "Access in background" is unticked on the Website action. |
+| Nothing happens, no error | The Shortcut name in the URL does not match, or is not URL-encoded. |
+
+Watching turns on but nothing records? That is a permissions problem rather than
+an API one — `permissionsHealthy: false` in the response, and the menu bar icon
+carries a red badge. See the README's permissions section.

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -11,9 +11,49 @@ struct MTCLI: AsyncParsableCommand {
             State.self, Healthz.self, Screenshot.self, UITree.self, UIPress.self,
             OpenSettings.self, CloseSettings.self, ConfirmBrowserConsent.self,
             SeedSpeaker.self, RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
-            WavVerdictCommand.self,
+            WavVerdictCommand.self, Watch.self,
         ],
     )
+}
+
+/// `mt-cli watch [status|start|stop|toggle]` — the scriptable surface behind a
+/// hotkey, a Shortcut or a Stream Deck key.
+///
+/// `start`/`stop` are offered alongside `toggle` on purpose: a button press
+/// expresses a desired end state, and any external controller's view of the app
+/// is slightly stale. A blind toggle after a meeting already ended does exactly
+/// the wrong thing and stays inverted; the idempotent verbs converge instead.
+///
+/// Every form prints the resulting `/v1/watch` status, so a caller can redraw
+/// from the response rather than racing a follow-up poll. A refusal (409, a
+/// manual recording owns the loop) or a failed postcondition (503) surfaces as
+/// a thrown `RPCError.http` — non-zero exit with the JSON body in the message.
+struct Watch: AsyncParsableCommand {
+    enum Action: String, ExpressibleByArgument, CaseIterable {
+        case status
+        case start
+        case stop
+        case toggle
+    }
+
+    static let configuration = CommandConfiguration(
+        abstract: "Read or change meeting watching. Prints the resulting status as JSON.",
+    )
+
+    @Argument(help: "status (default), start, stop, or toggle.")
+    var action: Action = .status
+
+    func run() async throws {
+        let client = try RPCClient.loadDefault()
+        let data = action == .status
+            ? try await client.get("/v1/watch")
+            : try await client.post(
+                "/v1/watch", json: ["action": action.rawValue],
+                timeout: RPCClient.watchControlTimeoutSeconds,
+            )
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    }
 }
 
 struct State: AsyncParsableCommand {

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -52,6 +52,14 @@ struct RPCClient {
     /// the rest of the API is fast.
     static let screenshotTimeoutSeconds: TimeInterval = 15
 
+    /// `POST /v1/watch` blocks until the start settles — mic gate, engine sync,
+    /// queue rebuild, loop construction — so the "rest of the API is fast"
+    /// premise behind `requestTimeoutSeconds` does not hold for it. Set above
+    /// the server's own 20 s join bound so the server always answers first: a
+    /// client-side timeout would report failure for a start that then succeeds
+    /// anyway, since the work continues after the caller disconnects.
+    static let watchControlTimeoutSeconds: TimeInterval = 30
+
     static func loadDefault() throws -> Self {
         let url = defaultTokenURL
         guard let data = try? Data(contentsOf: url),

--- a/tools/mt-cli/skill.md
+++ b/tools/mt-cli/skill.md
@@ -16,6 +16,7 @@ machen" / "ist das im Menü sichtbar".
 - You want to see what the user sees → `mt-cli screenshot /tmp/x.png`, then Read it
 - You want to assert on UI structure (a Settings section exists, a control is enabled) without eyeballing a screenshot → `mt-cli ui-tree --window settings`
 - You want to drive a control (press a toggle/button) and check the effect → `mt-cli ui-press <identifier> --window settings`, then `mt-cli state`
+- You want to start or stop meeting watching without touching the menu bar → `mt-cli watch start` / `mt-cli watch stop` (prefer these over `toggle`, which flips blind)
 - You're debugging a UI bug and would otherwise have to ask the user to describe state
 - You're verifying a fix end-to-end after editing code
 
@@ -47,6 +48,8 @@ The app writes a 64-hex bearer token to
 | `GET /screenshot`   | `mt-cli screenshot` | PNG of frontmost window            |
 | `GET /ui/tree`      | `mt-cli ui-tree`    | Accessibility tree JSON (allowlisted windows) |
 | `POST /ui/press`    | `mt-cli ui-press`   | Press a control by identifier (allowlisted windows); assert via `state` |
+| `GET /v1/watch`     | `mt-cli watch`      | Whether the app is watching for meetings (`WatchStatusDTO`) |
+| `POST /v1/watch`    | `mt-cli watch start\|stop\|toggle` | Control watching; returns the resulting `WatchStatusDTO` |
 
 ## Build mt-cli
 


### PR DESCRIPTION
Adds `GET`/`POST /v1/watch` so watching can be started and stopped from outside the app, plus the two pieces needed to actually use it: an `mt-cli watch` subcommand and a guide for wiring a stream deck key or a hotkey to it.

Motivation: the automation API could already *report* watching state through `/state`, but nothing could change it. There was no URL scheme, no global hotkey and no App Intent either, so an external trigger of any kind was impossible.

## The endpoint

`GET /v1/watch` and `POST /v1/watch` return the same body:

```json
{"watching":true,"state":"watching","badge":"recording","manualRecording":false,"permissionsHealthy":true}
```

`POST` takes `{"action":"start"|"stop"|"toggle"}` and returns the state **after** the call.

Decisions worth reviewing:

* **`start`/`stop` are idempotent and offered alongside `toggle`, not replaced by it.** A button press expresses a desired outcome, not a delta. A client that blind-toggles after a meeting already ended stays inverted for the rest of the session.
* **The response is the resulting state**, so a caller never has to follow a POST with a GET and race the next change. This is why the control path is `async`.
* **`watching` is an explicit boolean** rather than something clients infer from `state == nil`. That inference is a fine in-process shortcut and a bad thing to put across a public boundary.
* **`badge` is included** so a single request tells a physical key more than on/off.
* **Blocked control returns 409.** `toggleWatching()` already early-returns while a manual app-picker recording owns the loop; silent refusal is tolerable in-process, not across an API.
* **Under `/v1`, not `/action/*`**, which is documented as free to change.
* **No `Idempotency-Key`** — the operation is idempotent by construction.

`stopWatching()` awaits any in-flight `startTask` first. Without that, a stop issued during the mic-access window lands before the loop exists, reports "already stopped", and is then undone by the start completing. `testStopWatchingDuringInFlightStartStillStops` pins it.

## What consumes it

A stream deck plugin that polls this endpoint and renders live state on the key already exists and is hardware-tested: [alexpfau/meeting-transcriber-streamdeck](https://github.com/alexpfau/meeting-transcriber-streamdeck). I deliberately kept it in its own repository rather than proposing it here, so this PR stays a single endpoint plus its client and docs, and you take on no maintenance for a Node/TypeScript plugin and its Elgato release cycle. It is submitted to the Elgato Marketplace and awaiting review; if you would rather it live under this project instead, I am happy to move it.

`docs/stream-deck.md` links to the plugin and also documents a plain Shortcuts.app recipe, so the feature is usable with nothing but the shell.

The docs are blunt about why `toggle` is the weakest of the three actions: a key bound to it desynchronises the first time watching stops from anywhere else, and the stream deck `Multi Action Switch` that looks like the fix has exactly the same flaw. Separate `start`/`stop` keys, or a plugin that reads state back, are the honest answers.

## Verification

* Every `/v1/watch` path exercised against a running app, cross-checked against `/state.watchState` in both directions.
* 13 new tests (7 route-level over real sockets, 6 controller-level).
* Full suite, lint and `pre-push.sh` clean.
* Notably, `start` does not block on a TCC prompt — measured at 2.0 s on a build with microphone `notDetermined`, which was the main risk to the design.
* End-to-end from real hardware: a physical key starts and stops watching and reflects recording state back within one poll interval.

Happy to follow up with a `scripts/` generator that emits a ready-made Shortcuts.app shortcut if that is wanted — it is written and working, but it is Shortcuts-specific and harder to test than the rest of this, so it seemed better kept out of the change that introduces the endpoint.
