### PR TITLE
fix(app): request Accessibility permission at watch start

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -141,7 +141,7 @@ struct MeetingTranscriberApp: App {
             }
             .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
                 if !appState.isWatching {
-                    appState.watching.toggleWatching()
+                    appState.watching.toggleWatching(userInitiated: false)
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in

--- a/app/MeetingTranscriber/Sources/Permissions.swift
+++ b/app/MeetingTranscriber/Sources/Permissions.swift
@@ -77,28 +77,29 @@ enum Permissions {
         return false
     }
 
-    private static let accessibilityPromptLock = OSAllocatedUnfairLock(initialState: false)
-    // swiftlint:disable:next unused_declaration
-    static func ensureAccessibilityAccess() -> Bool {
-        if AXIsProcessTrusted() { return true }
-        let alreadyPrompted = accessibilityPromptLock.withLock { prompted -> Bool in
-            if prompted { return true }
-            prompted = true
-            return false
-        }
-        guard !alreadyPrompted else {
-            logger.warning("permission_denied resource=accessibility status=already_prompted")
-            return false
-        }
+    /// Ask macOS for Accessibility, every time the caller decides the moment is
+    /// right.
+    ///
+    /// Unlike its Screen Recording sibling this keeps no one-shot flag. The
+    /// alert can be dismissed without an answer, and it can stack behind the
+    /// Screen Recording one raised moments earlier; a process-wide flag burns on
+    /// that dismissal and never asks again, which is the dead end this call was
+    /// added to remove. `WatchingController` gates it on a deliberate Start
+    /// Watching with Teams watching enabled, so "every call" already means
+    /// "every time the user asks for the feature that needs it".
+    ///
+    /// Deliberately silent. `AXIsProcessTrustedWithOptions` reports the trust
+    /// state as of the call and never waits for the user, so it returns false
+    /// while the dialog is still on screen. Logging that as a denial would put a
+    /// warning nobody caused into the diagnostics bundle users attach to bug
+    /// reports. `PermissionHealthCheck` reports the real state on the next
+    /// activation.
+    static func ensureAccessibilityAccess() {
+        guard !AXIsProcessTrusted() else { return }
         // `kAXTrustedCheckOptionPrompt` is a C global imported as
         // `Unmanaged<CFString>!`, which Swift 6 treats as shared mutable
         // state. The value is set by AppKit at process load and never
         // mutates; bridge once via a nonisolated(unsafe) wrapper.
-        let options = [Self.axPromptKey: true] as CFDictionary
-        let granted = AXIsProcessTrustedWithOptions(options)
-        if !granted {
-            logger.warning("permission_denied resource=accessibility status=user_denied_prompt")
-        }
-        return granted
+        _ = AXIsProcessTrustedWithOptions([axPromptKey: true] as CFDictionary)
     }
 }

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -63,6 +63,34 @@ final class WatchingController {
     /// check reports the state.
     private let requestScreenRecording: () -> Void
 
+    /// Accessibility request, fired at watch start. Injectable so tests skip
+    /// the real TCC prompt.
+    ///
+    /// `PermissionHealthCheck` already reports a missing Accessibility grant as
+    /// a problem — red menu-bar badge plus a notification — because
+    /// `ParticipantReader` needs it to read the Teams roster via
+    /// `AXUIElementCreateApplication`. Without this call nothing ever showed the
+    /// prompt, so the app diagnosed the problem but never offered the fix and
+    /// the user had to find the Accessibility pane unaided.
+    ///
+    /// It belongs at watch start for the same reason the Screen-Recording
+    /// request does: the health check runs on every activation, so prompting
+    /// there would interrupt a user who is trying to work.
+    ///
+    /// Narrower than its two siblings on three axes, because full computer
+    /// control is the most invasive grant on macOS and this one only enriches a
+    /// recording. It fires only from a user-initiated toggle, since auto-watch
+    /// otherwise raises a system alert three seconds after every launch with no
+    /// click of any kind; only when `watchTeams` is on, since the roster read is
+    /// the grant's sole consumer and is itself Teams-gated; and the production
+    /// default is compiled out of the sandboxed build, which cannot use the API
+    /// against another process at all.
+    ///
+    /// The result is ignored, like the other two gates. Watching, capture and
+    /// transcription all work without the grant, so a refusal must not block the
+    /// start.
+    private let requestAccessibility: () -> Void
+
     /// Meeting detector factory for the auto-detect path. Injectable so tests can
     /// supply a deterministic detector instead of the IOKit-backed
     /// `PowerAssertionDetector`.
@@ -83,6 +111,11 @@ final class WatchingController {
         liveTranscription: LiveTranscriptionCoordinator,
         ensureMicAccess: @escaping () async -> Bool = { await Permissions.ensureMicrophoneAccess() },
         requestScreenRecording: @escaping () -> Void = { Permissions.ensureScreenRecordingAccess() },
+        requestAccessibility: @escaping () -> Void = {
+            #if !APPSTORE
+                Permissions.ensureAccessibilityAccess()
+            #endif
+        },
         makeDetector: (() -> any MeetingDetecting)? = nil,
     ) {
         self.settings = settings
@@ -93,6 +126,7 @@ final class WatchingController {
         self.liveTranscription = liveTranscription
         self.ensureMicAccess = ensureMicAccess
         self.requestScreenRecording = requestScreenRecording
+        self.requestAccessibility = requestAccessibility
         // Tests inject a deterministic detector; production defaults to one
         // filtered by the "Apps to Watch" toggles, re-read at each watch start.
         self.makeDetector = makeDetector ?? { [settings] in
@@ -145,7 +179,12 @@ final class WatchingController {
 
     // MARK: - Start / Stop
 
-    func toggleWatching() {
+    /// - Parameter userInitiated: True for a deliberate Start/Stop press, which
+    ///   is the one moment where asking for an optional permission is warranted.
+    ///   The auto-watch path passes false so an unattended launch raises no
+    ///   system alert — including on the e2e runners, which force auto-watch on
+    ///   and where a stray dialog can swallow the keystroke a lane sends.
+    func toggleWatching(userInitiated: Bool = true) {
         if let loop = watchLoop, loop.isManualRecording { return }
         if let loop = watchLoop, loop.isActive {
             loop.stop()
@@ -158,8 +197,7 @@ final class WatchingController {
             guard startTask == nil else { return }
             startTask = Task { @MainActor in
                 defer { startTask = nil }
-                _ = await ensureMicAccess()
-                requestScreenRecording()
+                await requestStartPermissions(userInitiated: userInitiated)
 
                 syncEngines?()
                 pipeline.rebuild()
@@ -192,6 +230,21 @@ final class WatchingController {
                 watchLoop = loop
                 loop.start()
             }
+        }
+    }
+
+    /// The permissions a watch start asks for, in the order the user meets
+    /// them. Only the mic gate is awaited, because capture cannot begin without
+    /// it; the other two register the app in their System Settings pane and are
+    /// reported by `PermissionHealthCheck` afterwards, so a refusal delays
+    /// nothing here.
+    ///
+    /// - Parameter userInitiated: see `toggleWatching`.
+    private func requestStartPermissions(userInitiated: Bool) async {
+        _ = await ensureMicAccess()
+        requestScreenRecording()
+        if userInitiated, settings.watchTeams {
+            requestAccessibility()
         }
     }
 

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -257,7 +257,11 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, _) = makeState()
         addTeardownBlock { state.watching.watchLoop?.stop() }
 
-        state.watching.toggleWatching()
+        // `AppState.init` does not expose the permission seams, so this is the
+        // one path that reaches the production defaults. Auto-watch exercises
+        // the same start without the optional Accessibility prompt, which would
+        // otherwise be a real TCC call from a unit test.
+        state.watching.toggleWatching(userInitiated: false)
         await waitFor(state.watching.watchLoop != nil)
 
         XCTAssertNotNil(state.watching.watchLoop)
@@ -267,7 +271,7 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let (state, _) = makeState()
         addTeardownBlock { state.watching.watchLoop?.stop() }
 
-        state.watching.toggleWatching()
+        state.watching.toggleWatching(userInitiated: false)
         await waitFor(state.watching.watchLoop?.isActive == true)
 
         XCTAssertEqual(state.watching.watchLoop?.isActive, true)

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -29,9 +29,12 @@ final class WatchingControllerTests: XCTestCase {
     private func makeController(
         ensureMicAccess: @escaping () async -> Bool = { true },
         requestScreenRecording: @escaping () -> Void = {},
+        requestAccessibility: @escaping () -> Void = {},
+        watchTeams: Bool = true,
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
     ) -> WatchingController {
         let settings = AppSettings()
+        settings.watchTeams = watchTeams
         let notifier = RecordingNotifier()
         let pipeline = PipelineController(settings: settings, notifier: notifier)
         pipeline.queue = PipelineQueue(logDir: tmpDir)
@@ -56,6 +59,7 @@ final class WatchingControllerTests: XCTestCase {
             liveTranscription: liveTranscription,
             ensureMicAccess: ensureMicAccess,
             requestScreenRecording: requestScreenRecording,
+            requestAccessibility: requestAccessibility,
             makeDetector: makeDetector,
         )
     }
@@ -79,6 +83,64 @@ final class WatchingControllerTests: XCTestCase {
         await waitFor(requested)
 
         XCTAssertTrue(requested, "toggleWatching must ask for Screen Recording")
+    }
+
+    // MARK: - requestAccessibility seam
+
+    /// The health check already flags a missing Accessibility grant with a red
+    /// menu-bar badge and a notification, but nothing used to ask for it, so the
+    /// app reported a problem it never offered to fix. Asking on a deliberate
+    /// Start Watching — where the participant read that needs it happens — is
+    /// what closes that gap, and pinning it here keeps the request from being
+    /// dropped again.
+    func testToggleWatchingRequestsAccessibility() async {
+        var requested = false
+        // Not trailing-closure: a trailing closure binds to the last param
+        // (`makeDetector`), not `requestAccessibility`.
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(requestAccessibility: { requested = true })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(requested)
+
+        XCTAssertTrue(requested, "toggleWatching must ask for Accessibility")
+    }
+
+    /// The roster read is the grant's only consumer and is itself Teams-gated,
+    /// so someone watching only Zoom, Webex or a browser must never be asked for
+    /// full computer control. The prompt also used to burn a process-wide
+    /// one-shot, so enabling Teams later in the same session then never asked
+    /// for the grant that had by then become necessary.
+    func testToggleWatchingSkipsAccessibilityWhenTeamsNotWatched() async {
+        var requested = false
+        let controller = makeController(
+            requestAccessibility: { requested = true },
+            watchTeams: false,
+        )
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching()
+        await waitFor(controller.watchLoop != nil)
+
+        XCTAssertFalse(requested, "watchTeams off must not ask for Accessibility")
+    }
+
+    /// Auto-watch reaches `toggleWatching` three seconds after launch with no
+    /// click of any kind, so an unconditional request raised a system alert on
+    /// every launch. It also fires mid-lane on the e2e runners, which force
+    /// auto-watch on, where a dialog can take the keystroke the naming lane
+    /// sends and fail it for a reason unrelated to the code under test.
+    func testAutoWatchStartDoesNotRequestAccessibility() async {
+        var requested = false
+        // swiftlint:disable:next trailing_closure
+        let controller = makeController(requestAccessibility: { requested = true })
+        addTeardownBlock { await controller.watchLoop?.stop() }
+
+        controller.toggleWatching(userInitiated: false)
+        await waitFor(controller.watchLoop != nil)
+
+        XCTAssertFalse(requested, "auto-watch must not ask for Accessibility")
     }
 
     // MARK: - ensureMicAccess seam


### PR DESCRIPTION
Closes #606.

## The problem

`PermissionHealthCheck` treats a missing Accessibility grant as a problem: it composites the red `!` badge onto the menu bar icon and posts a notification. But nothing ever called `Permissions.ensureAccessibilityAccess()`, so the app diagnosed the problem and never offered the fix. The only way to grant it was to find the Accessibility pane in System Settings unaided. The function was dead code — it carried a `// swiftlint:disable:next unused_declaration` suppression to keep the analyze lane quiet, which is a fair tell that it had lost its caller.

## The fix

Ask for the grant in `toggleWatching`, next to the existing microphone and Screen Recording requests. That is where the code path needing it begins: `WatchLoop.readParticipants` reaches for the Teams roster through `AXUIElementCreateApplication`, and its only call site is the auto-detect recording path that watching starts. Prompting from the health check instead would fire on every activation and interrupt someone trying to work — the same reason the Screen Recording request already lives here.

Unlike its two siblings the request is **narrowed on three axes**, because full computer control is the most invasive grant on macOS and this one only enriches a recording:

| Gate | Why |
|---|---|
| `userInitiated` | Auto-watch reaches `toggleWatching` three seconds after launch, so an unconditional request raises a system alert with no click of any kind — on every launch, and mid-lane on the e2e runners, where a dialog can take the keystroke `--naming-escape` sends |
| `settings.watchTeams` | The roster read is the grant's only consumer and is itself Teams-gated. Someone watching only Zoom, Webex or a browser must not be asked for it |
| `#if !APPSTORE` | The sandbox denies the Accessibility API against other processes, so the App Store variant would ask for a grant it can never use — and following the prompt would leave a sandboxed user permanently `.broken`, a state whose documented remedy cannot clear it |

`toggleWatching` gains `userInitiated`, defaulting to true so a deliberate press keeps asking; the auto-watch notification path passes false.

### No one-shot flag

The previous revision relied on `ensureAccessibilityAccess` being one-shot per session. That was the wrong granularity in both directions, and it is now removed rather than re-armed. The alert can be dismissed unanswered, and can stack behind the Screen Recording alert raised two lines earlier, so a process-wide flag burns on that dismissal and never asks again inside the session — precisely the dead end this PR set out to remove. With the call bounded to a deliberate Start Watching with Teams watching enabled, every call is already a moment the user asked for the feature that needs the grant.

Both `permission_denied` warnings go with it. `AXIsProcessTrustedWithOptions` reports trust as of the call and never waits for the user, so `user_denied_prompt` was logged while the dialog was still on screen and nothing had been denied; `already_prompted` logged the guard doing its job. Both were newly reachable here, both ship in the diagnostics bundle users attach to bug reports, and both would misdirect triage. The `Bool` return had no consumer once the call site discarded it, so the signature is now `Void`, matching `ensureScreenRecordingAccess`.

## On `startManualRecording`

An earlier revision of this description claimed that path "never reads participants, so it has no use for the grant". Both halves are true and neither is the reason it fails — as measured in review, it gates on overall permission health, so an outstanding Accessibility grant blocks it via `HealthCheckResult.problems` regardless of what it uses. That claim is withdrawn. The gate itself is tracked separately as #616 and is not carried here; adding a request to that path would paper over a gate that is wrong for a permission the app's own Settings calls "Optional".

## Testing

Three cases now pin the behaviour, and each was verified by mutation rather than assumed:

| Mutation | Result |
|---|---|
| Drop the `watchTeams` half of the gate | `testToggleWatchingSkipsAccessibilityWhenTeamsNotWatched` red, alone |
| Drop the `userInitiated` half | `testAutoWatchStartDoesNotRequestAccessibility` red, alone |
| Drop the gate entirely | Both red |
| Comment out `requestAccessibility()` | `testToggleWatchingRequestsAccessibility` red |

`AppStateTests.testToggleWatchingCreatesWatchLoop` and `testToggleWatchingMakesLoopActive` reach the production defaults, because `AppState.init` does not expose the permission seams. They now drive the auto-watch path, which exercises the same start without a real TCC call from a unit test — a lighter fix than widening that init, whose body type-check time is already budgeted.

Verified locally:

- SwiftFormat **0.61.1**, the version pinned at this branch point, clean (the pin has since moved to 0.62.1; re-checked below)
- `swiftlint lint --strict` — clean
- 124 tests green across `WatchingControllerTests`, `AppStateTests`, `PermissionsTests` and `PermissionHealthCheckTests`

## Not addressed here

The participant-PID question (whether `PowerAssertionDetector` hands `ParticipantReader` a helper PID with no roster panel, making the grant buy nothing today) is left as the follow-up you filed it as. It deserves a measurement against a live Teams call rather than a guess, and it does not block closing the "reported but never requested" gap.

## Landed as

Rebased onto `main` and folded into a single commit, since the two revisions are one logical change that was split only by review.

The rebase surfaced one thing neither side could see before it. `main` had meanwhile grown the watch-start closure (the loop it builds takes another argument now), so the three lines added here pushed it one line past `closure_body_length`. The `swiftlint --strict` run above was genuinely clean at the branch point and only fails against current `main`. Fixed by moving the three permission requests into `requestStartPermissions`, which gives them one name instead of suppressing the rule. The pinned SwiftFormat version drifted the same way, 0.61.1 at the branch point and 0.62.1 now.

Re-verified on the rebased commit: the full mutation table reproduces with the same per-case granularity, `./scripts/lint.sh` and `swiftlint analyze --strict` clean against the currently pinned versions, 2591 tests green, and a release build of both the Homebrew and the sandboxed variant, which is what proves the `#if !APPSTORE` default argument still compiles to a valid closure.
