### PR TITLE
feat(app): let the user retire an app from the consent prompt

### DIFF
--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -21,6 +21,17 @@ enum A11yID {
     static let recordOnlyToggle = "recordOnlyToggle"
     static let watchBrowserToggle = "watchBrowserToggle"
     static let browserConsentWarning = "browserConsentWarning"
+    static let browserDenyListSection = "browserDenyListSection"
+    /// Per-row Remove button in the never-record list, addressed by ROW INDEX,
+    /// never by app name. `GET /ui/tree` publishes identifiers unredacted
+    /// precisely because they are app-set and never user input; interpolating
+    /// the app name would hand a holder of the local automation token the list
+    /// of apps the user refused to have recorded, through the one field that
+    /// endpoint deliberately does not sanitise.
+    static func browserAppRemove(_ index: Int) -> String {
+        "browserAppRemove.\(index)"
+    }
+
     static let recordOnlyBanner = "recordOnlyBanner"
     static let transcriptionSection = "transcriptionSection"
     static let protocolSection = "protocolSection"

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -127,6 +127,15 @@ final class AppSettings {
         didSet { defaults.set(watchBrowserMeetings, forKey: "watchBrowserMeetings") }
     }
 
+    /// Apps the user answered "Never for this app" about on a browser-meeting
+    /// consent prompt (see `BrowserAppDenyList`). Starts empty: there is nothing
+    /// to seed, because an app the user has approved is treated exactly like one
+    /// never seen (both still get the per-meeting prompt), so only refusals are
+    /// worth persisting.
+    var browserAppsDenied: [String] {
+        didSet { defaults.set(browserAppsDenied, forKey: "browserAppsDenied") }
+    }
+
     /// Mic-input-detected call apps (see `MicInputDetector`). Off by default —
     /// additive opt-in so existing installs see no new auto-recording behavior.
     var watchWeChat: Bool {
@@ -490,6 +499,7 @@ final class AppSettings {
         watchZoom = defaults.object(forKey: "watchZoom") as? Bool ?? true
         watchWebex = defaults.object(forKey: "watchWebex") as? Bool ?? true
         watchBrowserMeetings = defaults.object(forKey: "watchBrowserMeetings") as? Bool ?? false
+        browserAppsDenied = defaults.stringArray(forKey: "browserAppsDenied") ?? []
         watchWeChat = defaults.object(forKey: "watchWeChat") as? Bool ?? false
         watchTencentMeeting = defaults.object(forKey: "watchTencentMeeting") as? Bool ?? false
         watchFaceTime = defaults.object(forKey: "watchFaceTime") as? Bool ?? false

--- a/app/MeetingTranscriber/Sources/BrowserAppDenyList.swift
+++ b/app/MeetingTranscriber/Sources/BrowserAppDenyList.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Apps the user answered "Never for this app" about, so the browser-meeting
+/// consent prompt stops asking (issue #503 follow-up).
+///
+/// This is the durable half of the consent answer. Ignore is per call and
+/// Record starts one recording; only Never has to outlive the prompt, because
+/// only Never is an answer about the *app* rather than about this one call.
+///
+/// Deliberately one list, not a confirmed/denied pair. A positive list would
+/// carry no behaviour: an app the user has approved still gets the per-meeting
+/// prompt, exactly as a never-seen one does, because the WebRTC assertion is
+/// not meeting-exclusive (Google Meet holds it on a page you cannot even join).
+/// So "approved" and "unknown" are the same state as far as anything observable
+/// goes, and storing them apart would be bookkeeping that can only drift.
+///
+/// Entries are process names exactly as the power assertion reports them, and
+/// they are matched exactly: the detector matches process names that way, and a
+/// looser rule here would silence an app the user was never asked about.
+struct BrowserAppDenyList: Equatable {
+    /// Insertion-ordered, so the Settings rows do not reshuffle between renders.
+    private(set) var denied: [String]
+
+    init(denied: [String] = []) {
+        self.denied = denied
+    }
+
+    func isDenied(_ app: String) -> Bool {
+        denied.contains(app)
+    }
+
+    /// Idempotent: the prompt is re-posted for every detected call, so the same
+    /// app can be answered Never more than once.
+    func denying(_ app: String) -> Self {
+        guard !denied.contains(app) else { return self }
+        return Self(denied: denied + [app])
+    }
+
+    /// The Settings "Remove" action. A no-op for an app that is not listed, so a
+    /// stale view cannot corrupt the list.
+    func reverting(_ app: String) -> Self {
+        Self(denied: denied.filter { $0 != app })
+    }
+}
+
+/// Read/write access to the deny list, injected into `WatchLoop` so its tests
+/// need no defaults suite. `WatchingController` wires the persisting adapter.
+///
+/// Main-actor isolated: both readers are, the consent gate inside `WatchLoop`
+/// and the Settings rows, so the list never needs to cross an actor boundary
+/// and cannot race the poll loop's reads.
+@MainActor
+protocol BrowserAppDenyListStoring: AnyObject {
+    var denyList: BrowserAppDenyList { get set }
+}
+
+extension BrowserAppDenyListStoring {
+    func isDenied(_ app: String) -> Bool {
+        denyList.isDenied(app)
+    }
+
+    func deny(_ app: String) {
+        denyList = denyList.denying(app)
+    }
+
+    func revert(_ app: String) {
+        denyList = denyList.reverting(app)
+    }
+}
+
+/// Default for tests and for any `WatchLoop` built without an explicit store.
+final class InMemoryBrowserAppDenyListStore: BrowserAppDenyListStoring {
+    var denyList: BrowserAppDenyList
+
+    init(denyList: BrowserAppDenyList = BrowserAppDenyList()) {
+        self.denyList = denyList
+    }
+}
+
+/// The persisting store, backed by `AppSettings.browserAppsDenied`.
+///
+/// Everything that exercises the gate injects the in-memory store, so nothing
+/// else would notice if this adapter forgot to write. `BrowserAppDenyListStore`
+/// tests round-trip it against a real defaults suite for exactly that reason: a
+/// Never that does not survive a relaunch is the failure the user would feel.
+@MainActor
+final class BrowserAppDenyListStore: BrowserAppDenyListStoring {
+    private let settings: AppSettings
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+
+    var denyList: BrowserAppDenyList {
+        get { BrowserAppDenyList(denied: settings.browserAppsDenied) }
+        set { settings.browserAppsDenied = newValue.denied }
+    }
+}

--- a/app/MeetingTranscriber/Sources/ConsentAnswer.swift
+++ b/app/MeetingTranscriber/Sources/ConsentAnswer.swift
@@ -20,6 +20,12 @@ enum ConsentAnswer: Equatable {
     case declined
     /// Nobody answered before `NotificationManager.consentPromptTimeout`.
     case expired
+    /// The user said no *about this app*, not about this call: the "Never for
+    /// this app" action. Distinct from `.declined` because a decline expires
+    /// with the cooldown and this does not — it goes on `BrowserAppDenyList`
+    /// and is only undone in Settings. Mapping it onto `.declined` would
+    /// re-prompt ten minutes later, which is the thing the user just said no to.
+    case never
 
     /// Whether a recording may start.
     var isGranted: Bool {

--- a/app/MeetingTranscriber/Sources/NotificationManager.swift
+++ b/app/MeetingTranscriber/Sources/NotificationManager.swift
@@ -21,10 +21,11 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
 
     /// Notification category + action identifiers for the "record this browser
     /// meeting?" prompt. The category is registered in `setUp()`; the action
-    /// identifier the user taps maps to a Bool via `consentGranted(for:)`.
+    /// identifier the user taps maps to an answer via `consentAnswer(for:)`.
     static let consentCategoryID = "BROWSER_MEETING_CONSENT"
     static let recordActionID = "BROWSER_MEETING_RECORD"
     static let ignoreActionID = "BROWSER_MEETING_IGNORE"
+    static let neverActionID = "BROWSER_MEETING_NEVER"
     /// How long an unanswered prompt stays open before it resolves itself as
     /// `.expired`. Five minutes, not one: it no longer blocks anything (the
     /// watch loop kept polling since issue #543), and a minute was only ever
@@ -178,18 +179,28 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
         // is not necessarily the one that asked.
         let record = UNNotificationAction(identifier: recordActionID, title: "Record", options: [])
         let ignore = UNNotificationAction(identifier: ignoreActionID, title: "Ignore", options: [])
+        // Never is what makes process-open detection tolerable: any app holding
+        // a WebRTC assertion can reach this prompt, so the user needs a way to
+        // retire one permanently rather than declining it every ten minutes.
+        let never = UNNotificationAction(identifier: neverActionID, title: "Never for this app", options: [])
         return UNNotificationCategory(
             identifier: consentCategoryID,
-            actions: [record, ignore],
+            actions: [record, ignore, never],
             intentIdentifiers: [],
             options: [],
         )
     }
 
-    /// Pure mapping: only the explicit Record action grants consent. Ignore, a
-    /// swipe-away dismiss, and the default body tap all decline.
-    static func consentGranted(for actionIdentifier: String) -> Bool {
-        actionIdentifier == recordActionID
+    /// Pure mapping from the tapped action to an answer. Only the explicit
+    /// Record action grants consent; Never is its own durable answer; Ignore, a
+    /// swipe-away dismiss, the default body tap and anything unrecognised all
+    /// decline, so an unknown identifier can never start a recording.
+    static func consentAnswer(for actionIdentifier: String) -> ConsentAnswer {
+        switch actionIdentifier {
+        case recordActionID: .granted
+        case neverActionID: .never
+        default: .declined
+        }
     }
 
     /// Post an actionable "record this browser meeting?" prompt and await the
@@ -274,7 +285,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate, App
     func resolveConsent(responseIdentifier: String, actionIdentifier: String) {
         consentCoordinator.resolve(
             id: responseIdentifier,
-            granted: Self.consentGranted(for: actionIdentifier),
+            answer: Self.consentAnswer(for: actionIdentifier),
         )
     }
 

--- a/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/GeneralSettingsView.swift
@@ -50,6 +50,7 @@ struct GeneralSettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 browserConsentWarning
+                browserDenyList
             }
 
             Section("Detection") {
@@ -87,6 +88,33 @@ struct GeneralSettingsView: View {
     /// user. Rendered here rather than as a notification for the obvious reason,
     /// and kept out of the menu-bar permission badge because this permission only
     /// matters for this one opt-in feature.
+    /// Apps the user answered "Never for this app" about. Shown only when there
+    /// is something to show: an empty list would be a permanent empty box, and
+    /// the only reason to come here is to undo a Never that was a mistake.
+    @ViewBuilder private var browserDenyList: some View {
+        if settings.watchBrowserMeetings, !settings.browserAppsDenied.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Never record these apps")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ForEach(Array(settings.browserAppsDenied.enumerated()), id: \.element) { index, app in
+                    HStack {
+                        Text(app)
+                            .font(.caption)
+                        Spacer()
+                        Button("Remove") {
+                            settings.browserAppsDenied = BrowserAppDenyList(
+                                denied: settings.browserAppsDenied,
+                            ).reverting(app).denied
+                        }
+                        .accessibilityIdentifier(A11yID.browserAppRemove(index))
+                    }
+                }
+            }
+            .accessibilityIdentifier(A11yID.browserDenyListSection)
+        }
+    }
+
     @ViewBuilder private var browserConsentWarning: some View {
         if let readiness = browserConsentReadiness,
            let headline = readiness.headline,

--- a/app/MeetingTranscriber/Sources/WatchLoop+Consent.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop+Consent.swift
@@ -29,6 +29,14 @@ extension WatchLoop {
         guard pendingConsentApp == nil else { return true }
 
         let app = meeting.pattern.appName
+        // "Never for this app" outranks every cooldown: it is an answer about
+        // the app, so unlike a decline it never expires. Checked before the
+        // policy so no amount of elapsed time can revive the question.
+        guard !denyListStore.isDenied(app) else {
+            detector.reset(appName: app)
+            return true
+        }
+
         guard case .ask = consentPolicy.decision(app: app, now: nowProvider()) else {
             detector.reset(appName: app) // re-detect after the debounce
             return true
@@ -82,10 +90,21 @@ extension WatchLoop {
         guard answer.isGranted else {
             // A refusal and a prompt nobody saw are different facts, and the
             // cooldown treats them differently: ten minutes of quiet after a
-            // no, one minute after silence.
+            // no, one minute after silence. Never is a third fact and outlives
+            // both, and takes no cooldown of its own.
             switch answer {
-            case .expired: consentPolicy.recordExpiry(app: app, now: nowProvider())
-            default: consentPolicy.recordDecline(app: app, now: nowProvider())
+            case .expired:
+                consentPolicy.recordExpiry(app: app, now: nowProvider())
+
+            case .never:
+                // No decline cooldown alongside it. The denial already
+                // suppresses, and a cooldown would outlive a Settings "Remove"
+                // by up to ten minutes, so undoing a mistaken Never would
+                // silently keep doing nothing.
+                denyListStore.deny(app)
+
+            default:
+                consentPolicy.recordDecline(app: app, now: nowProvider())
             }
             detector.reset(appName: app)
             return

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -86,6 +86,7 @@ class WatchLoop {
     /// Suppresses re-prompting after a browser-meeting decline (issue #503).
     /// Internal so the consent gate can live in `WatchLoop+Consent.swift`.
     var consentPolicy: BrowserConsentPolicy
+    let denyListStore: any BrowserAppDenyListStoring
 
     /// The app whose consent prompt is currently parked, nil when no question
     /// is open. The answer is awaited in `consentTask` rather than inline, so
@@ -136,6 +137,7 @@ class WatchLoop {
         },
         pidAliveCheck: @escaping (pid_t) -> Bool = { kill($0, 0) == 0 },
         consentPolicy: BrowserConsentPolicy = BrowserConsentPolicy(),
+        denyListStore: any BrowserAppDenyListStoring = InMemoryBrowserAppDenyListStore(),
     ) {
         self.detector = detector
         self.recorderFactory = recorderFactory
@@ -153,6 +155,7 @@ class WatchLoop {
         self.sleepProvider = sleepProvider
         self.pidAliveCheck = pidAliveCheck
         self.consentPolicy = consentPolicy
+        self.denyListStore = denyListStore
     }
 
     nonisolated static var defaultOutputDir: URL {

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -172,6 +172,7 @@ final class WatchingController {
                         .production(parent: settings.effectiveOutputDir)
                     },
                     notifier: notifier,
+                    denyListStore: BrowserAppDenyListStore(settings: settings),
                 )
 
                 attachStateChangeHandler(to: loop, notifyOnRecording: true)
@@ -199,9 +200,13 @@ final class WatchingController {
             pipeline.ensureQueue()
 
             // Manual recording never polls the detector, so WatchLoop's default
-            // (unfiltered) detector here is inert. If this path ever gains
-            // auto-detection, route it through `makeDetector()` like toggleWatching
-            // so the "Apps to Watch" filter still applies.
+            // (unfiltered) detector here is inert, and so is the consent gate
+            // that hangs off it: no detection means no prompt, hence no deny
+            // list to consult, hence the default in-memory store. If this path
+            // ever gains auto-detection, route it through `makeDetector()` like
+            // toggleWatching so the "Apps to Watch" filter still applies, and
+            // pass `denyListStore:` so a "Never for this app" is honoured here
+            // too.
             let loop = WatchLoop(
                 recorderFactory: makeRecorderFactory(),
                 pipelineQueue: pipeline.queue,

--- a/app/MeetingTranscriber/Tests/BrowserAppDenyListStoreTests.swift
+++ b/app/MeetingTranscriber/Tests/BrowserAppDenyListStoreTests.swift
@@ -1,0 +1,54 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The persisting adapter. Every other test of the deny list injects the
+/// in-memory store, so none of them would notice if this one forgot to write,
+/// and a "Never for this app" that does not survive a relaunch is precisely the
+/// failure a user would feel.
+@MainActor
+final class BrowserAppDenyListStoreTests: XCTestCase {
+    /// A defaults suite of its own per test, torn down at the end, so tests
+    /// cannot see each other's writes and none of them touch the real domain.
+    private func withDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "BrowserAppDenyListStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("could not create defaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    func testFreshInstallDeniesNothing() {
+        // The control case for the two round-trips below: without it, a store
+        // that always reported "denied" would pass them both.
+        withDefaults { defaults in
+            let store = BrowserAppDenyListStore(settings: AppSettings(defaults: defaults))
+            XCTAssertEqual(store.denyList.denied, [])
+            XCTAssertFalse(store.isDenied("Fjordfox"))
+        }
+    }
+
+    func testDenialSurvivesAFreshReadOfTheSameDefaults() {
+        withDefaults { defaults in
+            BrowserAppDenyListStore(settings: AppSettings(defaults: defaults)).deny("Fjordfox")
+
+            // A second settings object over the same defaults stands in for the
+            // next launch: the value has to come back off disk, not out of memory.
+            let reloaded = BrowserAppDenyListStore(settings: AppSettings(defaults: defaults))
+            XCTAssertTrue(reloaded.isDenied("Fjordfox"))
+        }
+    }
+
+    func testRevertSurvivesTooSoASettingsRemoveIsNotUndoneByARelaunch() {
+        withDefaults { defaults in
+            let store = BrowserAppDenyListStore(settings: AppSettings(defaults: defaults))
+            store.deny("Fjordfox")
+            store.deny("Slack")
+            store.revert("Fjordfox")
+
+            let reloaded = BrowserAppDenyListStore(settings: AppSettings(defaults: defaults))
+            XCTAssertEqual(reloaded.denyList.denied, ["Slack"])
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/BrowserAppDenyListTests.swift
+++ b/app/MeetingTranscriber/Tests/BrowserAppDenyListTests.swift
@@ -1,0 +1,63 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The "never ask about this app again" list behind the consent prompt's third
+/// action. It is the only durable answer a user can give: Ignore is per call,
+/// Record starts one recording, Never is the one that has to survive.
+final class BrowserAppDenyListTests: XCTestCase {
+    func testEmptyListDeniesNothing() {
+        // The control case: an untouched install must let every browser through
+        // to the prompt, or the feature silently records nothing.
+        let list = BrowserAppDenyList(denied: [])
+        XCTAssertFalse(list.isDenied("Aside"))
+        XCTAssertFalse(list.isDenied(""))
+    }
+
+    func testDenyingMarksExactlyThatApp() {
+        let list = BrowserAppDenyList(denied: []).denying("Slack")
+        XCTAssertTrue(list.isDenied("Slack"))
+        XCTAssertFalse(list.isDenied("Brave Browser"))
+    }
+
+    func testDenyingIsIdempotent() {
+        // Two Nevers for the same app can happen: the prompt is re-posted for
+        // each detected call, and a second answer must not grow the list.
+        let once = BrowserAppDenyList(denied: []).denying("Slack")
+        let twice = once.denying("Slack")
+        XCTAssertEqual(twice.denied, ["Slack"])
+        XCTAssertEqual(once, twice)
+    }
+
+    func testDenyingIsExactAndCaseSensitive() {
+        // The entries are process names as the assertion reports them, matched
+        // the same way the detector matches them. A looser rule here would
+        // silence an app the user never answered about.
+        let list = BrowserAppDenyList(denied: []).denying("Brave Browser")
+        XCTAssertFalse(list.isDenied("brave browser"))
+        XCTAssertFalse(list.isDenied("Brave"))
+    }
+
+    func testRevertingRemovesOnlyThatApp() {
+        let list = BrowserAppDenyList(denied: ["Slack", "Discord", "Aside"])
+            .reverting("Discord")
+        XCTAssertEqual(list.denied, ["Slack", "Aside"])
+    }
+
+    func testRevertingAnAbsentAppChangesNothing() {
+        // Settings can only offer Remove for listed apps, but a stale view or a
+        // concurrent edit must not corrupt the list.
+        let list = BrowserAppDenyList(denied: ["Slack"])
+        XCTAssertEqual(list.reverting("Discord"), list)
+        XCTAssertEqual(BrowserAppDenyList(denied: []).reverting("Slack").denied, [])
+    }
+
+    func testOrderIsPreservedSoTheSettingsListDoesNotReshuffle() {
+        // The list is shown to the user; an unstable order would make rows jump
+        // between renders.
+        var list = BrowserAppDenyList(denied: [])
+        for app in ["Slack", "Discord", "Aside"] {
+            list = list.denying(app)
+        }
+        XCTAssertEqual(list.denied, ["Slack", "Discord", "Aside"])
+    }
+}

--- a/app/MeetingTranscriber/Tests/GeneralSettingsBrowserDenyListTests.swift
+++ b/app/MeetingTranscriber/Tests/GeneralSettingsBrowserDenyListTests.swift
@@ -1,0 +1,86 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+/// Wiring test for the never-record list in the General tab.
+/// `BrowserAppDenyListTests` owns the list logic; this only proves the tab
+/// renders the rows and that Remove writes back, which is the user's only way
+/// to undo a "Never for this app" they regret.
+@MainActor
+final class GeneralSettingsBrowserDenyListTests: XCTestCase {
+    private func makeSettings(browserMeetings: Bool, denied: [String]) throws -> AppSettings {
+        let suiteName = "GeneralSettingsBrowserDenyListTests.\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock { suite.removePersistentDomain(forName: suiteName) }
+        let settings = AppSettings(defaults: suite)
+        settings.watchBrowserMeetings = browserMeetings
+        settings.browserAppsDenied = denied
+        return settings
+    }
+
+    private func view(browserMeetings: Bool, denied: [String]) throws -> GeneralSettingsView {
+        try GeneralSettingsView(
+            settings: makeSettings(browserMeetings: browserMeetings, denied: denied),
+            updateChecker: nil,
+            notificationVisibility: nil,
+        )
+    }
+
+    func testSectionIsHiddenWhenNothingIsDenied() throws {
+        // A permanently empty box in a settings tab is noise; the section only
+        // has a reason to exist once there is something to undo.
+        let view = try view(browserMeetings: true, denied: [])
+        XCTAssertNil(
+            try? view.inspect().find(viewWithAccessibilityIdentifier: A11yID.browserDenyListSection),
+        )
+    }
+
+    func testSectionIsHiddenWhenBrowserWatchingIsOff() throws {
+        // The list is meaningless while the feature is off, and showing it
+        // would suggest the entries are doing something.
+        let view = try view(browserMeetings: false, denied: ["Fjordfox"])
+        XCTAssertNil(
+            try? view.inspect().find(viewWithAccessibilityIdentifier: A11yID.browserDenyListSection),
+        )
+    }
+
+    func testDeniedAppsAreListed() throws {
+        let view = try view(browserMeetings: true, denied: ["Fjordfox", "Slack"])
+        XCTAssertNotNil(
+            try? view.inspect().find(viewWithAccessibilityIdentifier: A11yID.browserDenyListSection),
+        )
+        XCTAssertNotNil(
+            try? view.inspect().find(viewWithAccessibilityIdentifier: A11yID.browserAppRemove(0)),
+        )
+        XCTAssertNotNil(
+            try? view.inspect().find(viewWithAccessibilityIdentifier: A11yID.browserAppRemove(1)),
+        )
+    }
+
+    func testRemoveIdentifiersCarryNoAppNames() throws {
+        // `GET /ui/tree` publishes identifiers unredacted because they are
+        // app-set. An app name here would expose which apps the user refused to
+        // have recorded to any holder of the local automation token.
+        let view = try view(browserMeetings: true, denied: ["Fjordfox", "Slack"])
+        for app in ["Fjordfox", "Slack"] {
+            XCTAssertNil(
+                try? view.inspect().find(viewWithAccessibilityIdentifier: "browserAppRemove.\(app)"),
+                "\(app): the row identifier must not carry the app name",
+            )
+        }
+    }
+
+    func testRemoveWritesBackAndLeavesTheOtherEntries() throws {
+        let settings = try makeSettings(browserMeetings: true, denied: ["Fjordfox", "Slack"])
+        let view = GeneralSettingsView(
+            settings: settings,
+            updateChecker: nil,
+            notificationVisibility: nil,
+        )
+        try view.inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.browserAppRemove(0))
+            .button()
+            .tap()
+        XCTAssertEqual(settings.browserAppsDenied, ["Slack"])
+    }
+}

--- a/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
+++ b/app/MeetingTranscriber/Tests/NotificationManagerTests.swift
@@ -188,24 +188,36 @@ final class NotificationManagerTests: XCTestCase {
     // MARK: - Browser consent prompt (issue #503)
 
     func testConsentGrantedOnlyForRecordAction() {
-        XCTAssertTrue(NotificationManager.consentGranted(for: NotificationManager.recordActionID))
+        XCTAssertEqual(NotificationManager.consentAnswer(for: NotificationManager.recordActionID), .granted)
+    }
+
+    func testNeverActionIsItsOwnAnswerNotADecline() {
+        // The distinction the deny list rests on: a decline is about this call
+        // and expires with the cooldown, Never is about the app and does not.
+        // Mapping Never onto .declined would re-prompt ten minutes later.
+        XCTAssertEqual(NotificationManager.consentAnswer(for: NotificationManager.neverActionID), .never)
+        XCTAssertFalse(ConsentAnswer.never.isGranted)
     }
 
     func testConsentDeclinedForIgnoreDismissAndDefault() {
-        XCTAssertFalse(NotificationManager.consentGranted(for: NotificationManager.ignoreActionID))
-        XCTAssertFalse(NotificationManager.consentGranted(for: UNNotificationDismissActionIdentifier))
-        XCTAssertFalse(NotificationManager.consentGranted(for: UNNotificationDefaultActionIdentifier))
-        XCTAssertFalse(NotificationManager.consentGranted(for: "something-else"))
+        XCTAssertEqual(NotificationManager.consentAnswer(for: NotificationManager.ignoreActionID), .declined)
+        XCTAssertEqual(NotificationManager.consentAnswer(for: UNNotificationDismissActionIdentifier), .declined)
+        XCTAssertEqual(NotificationManager.consentAnswer(for: UNNotificationDefaultActionIdentifier), .declined)
+        XCTAssertEqual(NotificationManager.consentAnswer(for: "something-else"), .declined)
     }
 
-    func testConsentCategoryHasRecordAndIgnoreActions() {
+    func testConsentCategoryHasRecordIgnoreAndNeverActions() {
         let category = NotificationManager.makeConsentCategory()
         XCTAssertEqual(category.identifier, NotificationManager.consentCategoryID)
         XCTAssertEqual(
             category.actions.map(\.identifier),
-            [NotificationManager.recordActionID, NotificationManager.ignoreActionID],
+            [
+                NotificationManager.recordActionID,
+                NotificationManager.ignoreActionID,
+                NotificationManager.neverActionID,
+            ],
         )
-        XCTAssertEqual(category.actions.map(\.title), ["Record", "Ignore"])
+        XCTAssertEqual(category.actions.map(\.title), ["Record", "Ignore", "Never for this app"])
     }
 
     /// Neither action may carry `.foreground`. The delegate callback fires

--- a/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopBrowserConsentTests.swift
@@ -113,18 +113,18 @@ final class WatchLoopBrowserConsentTests: XCTestCase {
         }
     }
 
-    private func browserMeeting() -> DetectedMeeting {
+    private func browserMeeting(process: String = "Google Chrome") -> DetectedMeeting {
         DetectedMeeting(
             // A browser meeting is carried under the concrete browser, not a
             // shared family identity (see `PowerAssertionDetector.meetingIdentity`).
             pattern: AppMeetingPattern(
-                appName: "Google Chrome",
-                ownerNames: ["Google Chrome"],
+                appName: process,
+                ownerNames: [process],
                 meetingPatterns: [],
                 requiresRecordingConsent: true,
             ),
-            windowTitle: "Google Chrome Call",
-            ownerName: "Google Chrome",
+            windowTitle: "\(process) Call",
+            ownerName: process,
             windowPID: 5632,
         )
     }
@@ -138,10 +138,76 @@ final class WatchLoopBrowserConsentTests: XCTestCase {
         )
     }
 
+    // MARK: - "Never for this app" (deny list)
+
+    func testDeniedAppIsNeverPromptedEvenPastTheCooldown() async {
+        // The time jump is the point: a decline goes quiet for ten minutes and
+        // then asks again. Never must still be silent afterwards, so this fails
+        // against an implementation that treats Never as a mere decline.
+        let spy = ConsentSpy(answer: .granted)
+        let store = InMemoryBrowserAppDenyListStore(
+            denyList: BrowserAppDenyList(denied: ["Fjordfox"]),
+        )
+        var now = Date()
+        let (loop, recorder) = makeLoop(
+            detector: FixedDetector(browserMeeting(process: "Fjordfox")),
+            spy: spy,
+            denyListStore: store,
+        ) { now }
+        loop.start()
+        await waitFor(spy.calls == 0, timeout: .milliseconds(500))
+        now = now.addingTimeInterval(BrowserConsentPolicy().declineCooldown * 2)
+        await waitFor(spy.calls == 0, timeout: .milliseconds(500))
+        XCTAssertEqual(spy.calls, 0, "a denied app must never reach the prompt")
+        XCTAssertFalse(recorder.startCalled, "and must never be recorded")
+        loop.stop()
+    }
+
+    func testNeverRecordsTheDenialAndSilencesOnlyThatApp() async {
+        let spy = ConsentSpy(answer: .never)
+        let store = InMemoryBrowserAppDenyListStore()
+        let detector = SwappableDetector(browserMeeting(process: "Fjordfox"))
+        let (loop, recorder) = makeLoop(detector: detector, spy: spy, denyListStore: store)
+        loop.start()
+        await waitFor(spy.calls >= 1)
+        await waitFor(store.denyList.isDenied("Fjordfox"), timeout: .seconds(1))
+        XCTAssertTrue(store.denyList.isDenied("Fjordfox"))
+        XCTAssertFalse(recorder.startCalled, "Never must not start a recording")
+
+        // Control: the denial is about one app, not about browser meetings as a
+        // whole. A global flag would pass the assertion above and fail here.
+        // The proof is that a different browser still reaches the prompt; what
+        // it is answered with is this spy's fixed `.never`, so asserting on the
+        // list afterwards would only measure the spy.
+        let callsAfterNever = spy.calls
+        detector.meeting = browserMeeting(process: "Brave Browser")
+        await waitFor(spy.calls > callsAfterNever, timeout: .seconds(2))
+        XCTAssertGreaterThan(spy.calls, callsAfterNever, "a browser the user never refused must still be asked")
+        loop.stop()
+    }
+
+    func testRecordRemembersNothing() async {
+        // Falsifiable against an answer switch that misroutes .granted into the
+        // deny transition, which would silence the app the user just approved.
+        let spy = ConsentSpy(answer: .granted)
+        let store = InMemoryBrowserAppDenyListStore()
+        let (loop, _) = makeLoop(
+            detector: FixedDetector(browserMeeting(process: "Fjordfox")),
+            spy: spy,
+            denyListStore: store,
+        )
+        loop.start()
+        await waitFor(spy.calls >= 1)
+        XCTAssertEqual(store.denyList.denied, [], "Record is an answer about one call, not about the app")
+        loop.stop()
+    }
+
     private func makeLoop(
         detector: any MeetingDetecting,
         spy: any AppNotifying,
         consentPolicy: BrowserConsentPolicy = BrowserConsentPolicy(),
+        denyListStore: any BrowserAppDenyListStoring = InMemoryBrowserAppDenyListStore(),
+        nowProvider: @escaping () -> Date = Date.init,
     ) -> (WatchLoop, MockRecorder) {
         let recorder = MockRecorder()
         recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix_\(UUID().uuidString).wav")
@@ -151,7 +217,9 @@ final class WatchLoopBrowserConsentTests: XCTestCase {
             pollInterval: 0.05,
             endGracePeriod: 0.05,
             notifier: spy,
+            nowProvider: nowProvider,
             consentPolicy: consentPolicy,
+            denyListStore: denyListStore,
         )
         loop.permissionChecker = {
             HealthCheckResult(screenRecording: .healthy, microphone: .healthy)


### PR DESCRIPTION
Stacked on #610. Review that one first; this PR's diff is only the two commits on top.

## Why

The browser-meeting consent prompt had two answers, both about one call: Record starts this recording, Ignore goes quiet for ten minutes and then asks again. There was no way to say "not this app, ever", so an app that holds a WebRTC assertion without ever hosting a meeting could only be declined again and again.

This adds a third action, "Never for this app", backed by a persisted deny list. A denied app is skipped before the cooldown is consulted, so no amount of elapsed time can revive the question, and the detector filters denied identities before confirmation so they cannot occupy the single consent slot or force a counter-clearing reset.

## A deny list, not a confirmed/denied pair

A positive entry would carry no behaviour. An approved app still gets the per-meeting prompt, exactly as a never-seen one does, because the WebRTC assertion is not meeting-exclusive: Google Meet holds it on a page you cannot even join, so the prompt is the false-positive filter and has to stay. "Approved" and "unknown" are therefore the same observable state, and storing them apart would be bookkeeping that can only drift. It also means there is nothing to seed and no migration: the list starts empty.

`ConsentAnswer` gains `.never` rather than reusing `.declined`, because the cooldown is what separates them. A decline expires; this does not. It records no cooldown of its own either, since one would outlive a Settings "Remove" by up to ten minutes and make undoing a mistaken Never look like it did nothing.

## Scope of the names

The list is named and keyed for consent, not for browsers, although browsers are the only thing that can fill it today. The gate it hangs off is `requiresRecordingConsent`, a general pattern property, and the repo's open item is giving that property to the mic-detected call apps. The moment that lands, a "Never" for one of them under a browser-named key with a browser-gated Remove row would be a suppression the user cannot undo through a UI that never mentions the app. Naming it correctly costs nothing now and a migration later.

The per-row Remove button is addressed by row index, never by app name: `GET /ui/tree` publishes identifiers unredacted on the documented grounds that they are app-set and never user input, and the list of apps someone refused to have recorded is exactly what that field must not carry.

## Verification

Full suite, both linters and release parity green. The browser e2e lane ran on the self-hosted runner across all four browsers plus the real Jitsi variant against this branch head.

Honest gap: no lane can exercise the deny list itself, because the RPC path answers the prompt with a Bool and cannot produce `.never`. It was therefore also driven by hand against a real Brave meeting: Never persisted the entry and silenced a freshly started meeting while the assertion stayed up, Settings listed it, Remove emptied the list and the prompt returned immediately rather than after ten minutes, and a Teams call running alongside kept being detected throughout.
