### PR TITLE
chore: add GitHub Sponsors funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: pasrom


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the Sponsor button shows up on the repository page and in the sidebar.

The file is only a pointer. The Sponsors listing it points at now exists and has six published tiers, three monthly and three one-time, so the button leads somewhere real rather than to an empty page. That ordering was the reason this was not added earlier.

No code touched, no behaviour change.