### PR TITLE
fix(build): keep the dev bundle's entitlements when a script re-signs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,17 @@ jobs:
         run: bash scripts/lint.sh --format-only
       - name: SwiftLint
         run: swiftlint lint --strict --reporter github-actions-logging
+      # Globbed, not enumerated: the list used to name two of the four files and
+      # nobody noticed, and a script test nobody runs is indistinguishable from
+      # no test at all. The naming pattern is therefore the contract — a
+      # scripts/tests/test_*.sh must be self-contained and finish in about a
+      # second. The step runs under `bash -e`, so the first failure stops it.
       - name: Script regression tests
         run: |
-          bash scripts/tests/test_build_release_signing.sh
-          bash scripts/tests/test_build_perf_report.sh
+          for t in scripts/tests/test_*.sh; do
+            echo "==> $t"
+            bash "$t"
+          done
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -352,15 +352,10 @@ else
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed — check DEVELOPER_ID + E2E_SIGNING_KEYCHAIN env vars"
     else
-        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
-        DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
-        if [ ! -f "$DEV_KEYCHAIN" ] || [ ! -f "$DEV_CERT_PATH" ]; then
-            fail "no Developer ID and dev keychain missing ($DEV_KEYCHAIN / $DEV_CERT_PATH) — set DEVELOPER_ID env or run scripts/setup-self-hosted-runner.sh first"
-        fi
-        DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
-            | sed 's/^.*=//' | tr -d ':')"
+        DEV_CERT_HASH="$(dev_signing_identity)"
+        [ -n "$DEV_CERT_HASH" ] \
+            || fail "no Developer ID and no '$DEV_CERT_NAME' identity in $DEV_KEYCHAIN — set DEVELOPER_ID env or run scripts/setup-self-hosted-runner.sh first"
         log "Re-signing $DEV_BUNDLE_DEPLOY with self-signed dev cert ($DEV_CERT_HASH)"
-        security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
     fi

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -335,7 +335,10 @@ else
     # without re-signing TCC would see a different cert SHA on every
     # rebuild and lose the grant. CI path uses the imported Developer ID;
     # local-dev path falls back to the self-signed cert from
-    # setup-self-hosted-runner.sh.
+    # setup-self-hosted-runner.sh. resign_deployed_bundle carries the dev
+    # entitlements through that re-sign, and skips it entirely when the build
+    # already used this certificate — a bare codesign would silently strip both
+    # the microphone and the time-sensitive entitlement (issue #609).
     if [ -n "${DEVELOPER_ID:-}" ]; then
         log "Re-signing $DEV_BUNDLE_DEPLOY with Developer ID '$DEVELOPER_ID'"
         # Re-assert the signing keychain right before codesign — a parallel
@@ -346,9 +349,7 @@ else
         if [ -n "${E2E_SIGNING_KEYCHAIN:-}" ]; then
             "$SCRIPT_DIR/keychain-prepend.sh" "$E2E_SIGNING_KEYCHAIN"
         fi
-        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
-        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
-        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed — check DEVELOPER_ID + E2E_SIGNING_KEYCHAIN env vars"
     else
         DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
@@ -360,9 +361,7 @@ else
             | sed 's/^.*=//' | tr -d ':')"
         log "Re-signing $DEV_BUNDLE_DEPLOY with self-signed dev cert ($DEV_CERT_HASH)"
         security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
-        codesign --force --sign "$DEV_CERT_HASH" \
-            --keychain "$DEV_KEYCHAIN" \
-            "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed — try re-running scripts/setup-self-hosted-runner.sh"
     fi
 fi

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -202,9 +202,7 @@ else
         if [ -n "${E2E_SIGNING_KEYCHAIN:-}" ]; then
             "$SCRIPT_DIR/keychain-prepend.sh" "$E2E_SIGNING_KEYCHAIN"
         fi
-        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
-        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
-        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed"
     else
         DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
@@ -215,8 +213,7 @@ else
             | sed 's/^.*=//' | tr -d ':')"
         log "Re-signing with self-signed dev cert ($DEV_CERT_HASH)"
         security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
-        codesign --force --sign "$DEV_CERT_HASH" \
-            --keychain "$DEV_KEYCHAIN" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed"
     fi
 fi

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -205,14 +205,10 @@ else
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed"
     else
-        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
-        DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
-        [ -f "$DEV_KEYCHAIN" ] && [ -f "$DEV_CERT_PATH" ] \
-            || fail "no Developer ID and dev keychain missing — run scripts/setup-self-hosted-runner.sh first"
-        DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
-            | sed 's/^.*=//' | tr -d ':')"
+        DEV_CERT_HASH="$(dev_signing_identity)"
+        [ -n "$DEV_CERT_HASH" ] \
+            || fail "no Developer ID and no '$DEV_CERT_NAME' identity in $DEV_KEYCHAIN — run scripts/setup-self-hosted-runner.sh first"
         log "Re-signing with self-signed dev cert ($DEV_CERT_HASH)"
-        security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed"
     fi

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -142,14 +142,10 @@ else
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed"
     else
-        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
-        DEV_CERT_PATH="/tmp/meetingtranscriber-setup/dev-cert.crt"
-        [ -f "$DEV_KEYCHAIN" ] && [ -f "$DEV_CERT_PATH" ] \
-            || fail "no Developer ID and dev keychain missing — run scripts/setup-self-hosted-runner.sh first"
-        DEV_CERT_HASH="$(openssl x509 -in "$DEV_CERT_PATH" -noout -fingerprint -sha1 \
-            | sed 's/^.*=//' | tr -d ':')"
+        DEV_CERT_HASH="$(dev_signing_identity)"
+        [ -n "$DEV_CERT_HASH" ] \
+            || fail "no Developer ID and no '$DEV_CERT_NAME' identity in $DEV_KEYCHAIN — run scripts/setup-self-hosted-runner.sh first"
         log "Re-signing with self-signed dev cert ($DEV_CERT_HASH)"
-        security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed"
     fi

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -139,9 +139,7 @@ else
         if [ -n "${E2E_SIGNING_KEYCHAIN:-}" ]; then
             "$SCRIPT_DIR/keychain-prepend.sh" "$E2E_SIGNING_KEYCHAIN"
         fi
-        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
-        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
-        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || fail "codesign with Developer ID failed"
     else
         DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
@@ -152,8 +150,7 @@ else
             | sed 's/^.*=//' | tr -d ':')"
         log "Re-signing with self-signed dev cert ($DEV_CERT_HASH)"
         security unlock-keychain -p "" "$DEV_KEYCHAIN" || true
-        codesign --force --sign "$DEV_CERT_HASH" \
-            --keychain "$DEV_KEYCHAIN" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
             || fail "codesign with dev cert failed"
     fi
 fi

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -136,18 +136,10 @@ if [ "$NO_BUILD" = false ]; then
         resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || die "Developer ID re-sign failed"
     else
-        # Local-dev path: self-signed cert from setup-self-hosted-runner.sh.
-        # Resolve the SHA-1 directly from the keychain (the .pem written
-        # to /tmp/ by the setup script is volatile — gone on every reboot
-        # on the self-hosted Mini). Unlock with empty password (matches
-        # the keychain creation in setup-self-hosted-runner.sh), then
-        # sign with the hash.
-        DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
-        DEV_CERT_NAME="MeetingTranscriberDevSelfHosted"
+        # Local-dev path: self-signed cert from setup-self-hosted-runner.sh,
+        # resolved from the keychain by dev_signing_identity.
         if [ -f "$DEV_KEYCHAIN" ]; then
-            security unlock-keychain -p "" "$DEV_KEYCHAIN" 2>/dev/null || true
-            DEV_CERT_HASH="$(security find-identity -v -p codesigning "$DEV_KEYCHAIN" \
-                | awk -v name="$DEV_CERT_NAME" '$0 ~ name { print $2; exit }')"
+            DEV_CERT_HASH="$(dev_signing_identity)"
             if [ -n "$DEV_CERT_HASH" ]; then
                 echo "▸ Re-signing with self-signed dev cert (SHA1=${DEV_CERT_HASH})..."
                 # codesign honours `--keychain` for the signing identity but

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -133,9 +133,7 @@ if [ "$NO_BUILD" = false ]; then
     fi
     if [ -n "${DEVELOPER_ID:-}" ]; then
         echo "▸ Re-signing with Developer ID '$DEVELOPER_ID'…"
-        SIGN_ARGS=(--force --sign "$DEVELOPER_ID")
-        [ -n "${E2E_SIGNING_KEYCHAIN:-}" ] && SIGN_ARGS+=(--keychain "$E2E_SIGNING_KEYCHAIN")
-        codesign "${SIGN_ARGS[@]}" "$DEV_BUNDLE_DEPLOY" >/dev/null \
+        resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEVELOPER_ID" "${E2E_SIGNING_KEYCHAIN:-}" \
             || die "Developer ID re-sign failed"
     else
         # Local-dev path: self-signed cert from setup-self-hosted-runner.sh.
@@ -156,8 +154,7 @@ if [ "$NO_BUILD" = false ]; then
                 # still consults the user-domain search list for trust-chain
                 # resolution. Prepending the dev keychain matches scripts/e2e-app.sh.
                 "$ROOT/scripts/keychain-prepend.sh" "$DEV_KEYCHAIN" 2>/dev/null || true
-                codesign --force --sign "$DEV_CERT_HASH" --keychain "$DEV_KEYCHAIN" \
-                    "$DEV_BUNDLE_DEPLOY" >/dev/null \
+                resign_deployed_bundle "$DEV_BUNDLE_DEPLOY" "$DEV_CERT_HASH" "$DEV_KEYCHAIN" \
                     || die "dev-cert re-sign failed"
             else
                 echo "  Run scripts/setup-self-hosted-runner.sh to (re-)create it" >&2

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -9,10 +9,13 @@
 #
 # This file has no shebang and no `set -e` — it inherits the caller's.
 # Sourcing it also gives the caller $RELEASE_BUNDLE_ID / $DEV_BUNDLE_ID, so no
-# driver has to restate an identifier that only Info.plist should own.
+# driver has to restate an identifier that only Info.plist should own, plus
+# resign_deployed_bundle, which every driver that deploys a bundle needs.
 
 # shellcheck source=bundle-ids.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bundle-ids.sh"
+# shellcheck source=signing.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/signing.sh"
 
 # Graceful AppleScript quit → SIGTERM → SIGKILL ladder. Returns 0 when
 # the process is gone, 1 if it survived even SIGKILL (unusual; means

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -220,6 +220,35 @@ identity_sha1() {
     return 0
 }
 
+# The self-hosted runner's own signing identity, installed by
+# scripts/setup-self-hosted-runner.sh. Overridable so a test can point at a
+# fixture keychain.
+DEV_KEYCHAIN="${DEV_KEYCHAIN:-$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db}"
+DEV_CERT_NAME="${DEV_CERT_NAME:-MeetingTranscriberDevSelfHosted}"
+
+# dev_signing_identity → SHA-1 of that certificate, empty when it is not there.
+#
+# Resolved from the KEYCHAIN, which is where the setup script installs it and
+# where codesign reads it from when signing. The lanes used to hash the export
+# copy the setup script also leaves in /tmp/meetingtranscriber-setup — and macOS
+# discards /tmp across a reboot, after which a lane aborted with "run
+# scripts/setup-self-hosted-runner.sh first" although the keychain and the
+# identity were both intact. Nothing depends on that copy any more; it is an
+# artifact to look at.
+#
+# The unlock belongs here rather than at the call sites: the empty password is a
+# property of how the setup script creates THIS keychain, and codesign needs the
+# private key a moment later.
+# The lookup itself is identity_sha1's, so there is one definition of how a name
+# becomes a hash — including its refusal to guess between two certificates whose
+# names both contain the string, which here means an identity left behind under a
+# renamed variant.
+dev_signing_identity() {
+    [ -f "$DEV_KEYCHAIN" ] || return 0
+    security unlock-keychain -p "" "$DEV_KEYCHAIN" 2>/dev/null || true
+    identity_sha1 "$DEV_CERT_NAME" "$DEV_KEYCHAIN"
+}
+
 # resign_deployed_bundle <app-bundle> <identity> [keychain]
 #
 # Re-sign a bundle that was built and deployed elsewhere, with a stable identity

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -32,6 +32,11 @@ PROFILE_DIR="${PROFILE_DIR:-$_SIGNING_LIB_ROOT/signing}"
 
 TIME_SENSITIVE_KEY="com.apple.developer.usernotifications.time-sensitive"
 
+# The dev bundle every e2e lane deploys is the Homebrew variant, so
+# resign_deployed_bundle resolves its base entitlements here rather than having
+# four lanes each spell the same path — one more place for them to drift apart.
+DEV_ENTITLEMENTS="${DEV_ENTITLEMENTS:-$_SIGNING_LIB_ROOT/app/MeetingTranscriber/Entitlements/Homebrew.entitlements}"
+
 # profile_for <bundle-id> → path, or empty when none is available.
 #
 # "No profile" is a normal outcome, not a failure, so this must return 0 either
@@ -149,4 +154,153 @@ verify_signing() {
 # the check and of the key itself, instead of re-spelling both.
 bundle_has_time_sensitive() {
     codesign -d --entitlements :- "$1" 2>/dev/null | grep -q "$TIME_SENSITIVE_KEY"
+}
+
+# bundle_signing_cert_sha1 <app-bundle>
+#
+# SHA-1 of the leaf certificate the bundle is signed with, empty when it is
+# unsigned or ad-hoc signed. The hash and not the certificate's name, because
+# the hash is what TCC keys a grant on and two certificates share a name across
+# a renewal — a name comparison would call those two the same certificate.
+bundle_signing_cert_sha1() {
+    local bundle="$1" dir hash=""
+    # Absolute, because the subshell below changes directory: a relative path
+    # would resolve against the temp dir, yield no certificate, and read as
+    # "unsigned" — which sends the caller down the destructive branch.
+    case "$bundle" in /*) ;; *) bundle="$PWD/$bundle" ;; esac
+    dir="$(mktemp -d)"
+    # --extract-certificates writes codesign0, codesign1, … into the CURRENT
+    # directory, hence the subshell cd. codesign0 is the leaf.
+    ( cd "$dir" && codesign -d --extract-certificates "$bundle" >/dev/null 2>&1 ) || true
+    if [ -f "$dir/codesign0" ]; then
+        # `|| true`: an unsigned or odd bundle is a normal answer (empty), not a
+        # failure. Under the callers' `pipefail` a non-zero pipeline here would
+        # become the function's status and abort their `hash="$(…)"` assignment
+        # with no output at all — the same trap documented at profile_for.
+        hash="$(openssl x509 -inform DER -in "$dir/codesign0" -noout -fingerprint -sha1 2>/dev/null \
+            | sed 's/^.*=//' | tr -d ':' | tr '[:lower:]' '[:upper:]' || true)"
+    fi
+    rm -rf "$dir"
+    printf '%s' "$hash"
+}
+
+# identity_sha1 <identity> [keychain]
+#
+# The same hash for an identity held as either a 40-hex SHA-1 (what the lanes
+# compute from the runner's self-signed certificate) or a name (what the
+# DEVELOPER_ID secret carries). Empty when a name resolves to nothing, or to more
+# than one certificate.
+#
+# The name is matched as a SUBSTRING, because that is how codesign resolves
+# `--sign <name>`: per its man page it takes the certificate whose subject common
+# name *contains* the string. Anchoring on the fully quoted name that
+# `find-identity` prints would reject identities codesign accepts — and since an
+# unresolved identity can never match the bundle, the caller would then always
+# take the destructive branch.
+identity_sha1() {
+    local identity="$1" keychain="${2:-}"
+    if [[ $identity =~ ^[0-9A-Fa-f]{40}$ ]]; then
+        printf '%s' "$identity" | tr '[:lower:]' '[:upper:]'
+        return 0
+    fi
+    local args=(-v -p codesigning) matches count
+    [ -n "$keychain" ] && args+=("$keychain")
+    # `|| true` because a keychain that cannot be read is a normal answer (empty),
+    # not a failure — without it, `pipefail` would make this the function's status
+    # and abort the caller's `want="$(…)"` assignment with no output at all, the
+    # trap documented at profile_for.
+    matches="$(security find-identity "${args[@]}" 2>/dev/null \
+        | awk -v name="$identity" 'index($0, name) { print toupper($2) }' \
+        | sort -u || true)"
+    count="$(printf '%s' "$matches" | grep -c . || true)"
+    # Ambiguous is not a match. Guessing between two certificates that both
+    # contain the name could skip a re-sign the bundle needed; re-signing when it
+    # was unnecessary only costs a signature.
+    [ "$count" = 1 ] && printf '%s' "$matches"
+    return 0
+}
+
+# resign_deployed_bundle <app-bundle> <identity> [keychain]
+#
+# Re-sign a bundle that was built and deployed elsewhere, with a stable identity
+# so TCC keeps its grants across rebuilds, WITHOUT discarding what the build
+# signed into it (issue #609). Two measured facts make that more than a codesign
+# call:
+#
+#   - `codesign --force --sign X "$bundle"` with no `--entitlements` writes a
+#     signature carrying NO entitlements at all. That is how the e2e lanes used
+#     to drop the microphone entitlement and — where a profile had authorised it
+#     — the time-sensitive one, one step after the build verified it survived.
+#   - The key cannot simply be re-requested here, because a profile authorises
+#     specific CERTIFICATES and macOS refuses to launch a bundle whose restricted
+#     entitlement no embedded profile covers (see this file's header).
+#
+# So a bundle whose VALID signature is already by the requested certificate is
+# left alone — re-signing it could only subtract — and otherwise the bundle is
+# re-signed with the base entitlements, dropping a profile the new signature
+# cannot honour. That last part matters: a profile left embedded next to a missing
+# key is what makes e2e-browser.sh's pairing check fail while pointing at
+# prepare_signing, which did its job correctly.
+#
+# Validity is part of the question, not a detail: test_rpc.sh copies a fresh
+# binary into an already-signed bundle, so the certificate still matches while the
+# signature no longer does. Keeping that signature would launch a bundle macOS
+# refuses to run.
+#
+# The keychain is a parameter rather than pass-through codesign flags, so no
+# caller has to expand a possibly-empty array under `set -u`.
+resign_deployed_bundle() {
+    local bundle="$1" identity="$2" keychain="${3:-}"
+
+    local want have=""
+    want="$(identity_sha1 "$identity" "$keychain")"
+    # Only worth asking the bundle when the identity resolved: one that did not
+    # can never claim a match.
+    if [ -n "$want" ]; then
+        have="$(bundle_signing_cert_sha1 "$bundle")"
+    fi
+
+    if [ "$want" = "$have" ] && [ -n "$have" ] && codesign --verify "$bundle" 2>/dev/null; then
+        echo "  Already signed by the requested certificate — keeping that signature;"
+        echo "  re-signing would only drop the entitlements it carries."
+    else
+        # Checked before the bundle is touched, so a bad path cannot leave a
+        # half-changed bundle behind. Without it the path surfaces as codesign's
+        # "cannot read entitlement data", which reads like a malformed plist.
+        [ -f "$DEV_ENTITLEMENTS" ] \
+            || { echo "  ERROR: entitlements not found: $DEV_ENTITLEMENTS" >&2; return 1; }
+
+        # The profile is SET ASIDE rather than deleted, and put back if signing
+        # fails. It is sealed in _CodeSignature/CodeResources, so a bundle missing
+        # it fails `codesign --verify` even though nothing else changed: deleting
+        # first would turn a failed re-sign — a locked keychain, an identity the
+        # parallel runner's search-list churn hid — into an unlaunchable bundle at
+        # the shared, TCC-granted deploy path. The bare re-sign this replaced was
+        # at least all-or-nothing.
+        local profile="$bundle/Contents/embedded.provisionprofile" stash=""
+        if [ -f "$profile" ]; then
+            stash="$(mktemp -d)/embedded.provisionprofile"
+            mv "$profile" "$stash" \
+                || { echo "  ERROR: could not set the embedded profile aside" >&2; return 1; }
+            echo "  Setting the embedded provisioning profile aside: '$identity' is not"
+            echo "  the certificate it authorises, so $TIME_SENSITIVE_KEY cannot come along."
+            echo "  (Point DEVELOPER_ID at the profile's certificate to keep the built signature.)"
+            echo "  WARNING: with no profile embedded, e2e-browser.sh can only SKIP its"
+            echo "  check that the consent prompt breaks through Focus (issue #543)."
+        fi
+
+        local args=(--force --sign "$identity" --entitlements "$DEV_ENTITLEMENTS")
+        [ -n "$keychain" ] && args+=(--keychain "$keychain")
+        if ! codesign "${args[@]}" "$bundle" >/dev/null; then
+            [ -n "$stash" ] && mv "$stash" "$profile"
+            return 1
+        fi
+
+        # verify_signing speaks only about the profile pairing, and on this path
+        # there is no profile left to pair with — so check the thing this function
+        # exists for. A signature with no entitlements at all is issue #609 itself.
+        codesign -d --entitlements :- "$bundle" 2>/dev/null | grep -q '<key>' \
+            || { echo "  ERROR: the new signature carries no entitlements (issue #609)" >&2; return 1; }
+    fi
+    verify_signing "$bundle"
 }

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -70,10 +70,16 @@ SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}
 # time-sensitive consent prompt (issue #543).
 # shellcheck source=lib/signing.sh
 source "$SCRIPT_DIR/lib/signing.sh"
-prepare_signing "$APP_BUNDLE" "$SPM_DIR/Entitlements/Homebrew.entitlements" "$DEV_BUNDLE_ID" "$SIGN_HASH"
+# $DEV_ENTITLEMENTS is that same path, named once in the library so this build
+# and any later re-sign of the deployed bundle cannot drift apart (issue #609).
+prepare_signing "$APP_BUNDLE" "$DEV_ENTITLEMENTS" "$DEV_BUNDLE_ID" "$SIGN_HASH"
 if [ -n "$SIGNING_IDENTITY" ]; then
-    codesign --force --sign "$SIGNING_IDENTITY" --entitlements "$SIGNING_ENTITLEMENTS" "$APP_BUNDLE" 2>/dev/null && \
-        echo "  Signed with: $SIGNING_IDENTITY (+ entitlements)"
+    # Failure is fatal and its stderr is kept. This used to be `2>/dev/null && echo`,
+    # which hid both: a bad entitlements path left the bundle completely UNSIGNED
+    # with no diagnostic, and every lane that rsyncs it then loses its TCC grants.
+    codesign --force --sign "$SIGNING_IDENTITY" --entitlements "$SIGNING_ENTITLEMENTS" "$APP_BUNDLE" \
+        || { echo "codesign failed for $APP_BUNDLE (identity $SIGNING_IDENTITY, entitlements $SIGNING_ENTITLEMENTS)" >&2; exit 1; }
+    echo "  Signed with: $SIGNING_IDENTITY (+ entitlements)"
 fi
 verify_signing "$APP_BUNDLE"
 

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -195,11 +195,14 @@ security unlock-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN" \
 
 # Sign explicitly with our cert — run_app.sh's signing step uses
 # `find-identity -v` and so won't pick up our untrusted cert. Doing it
-# here keeps run_app.sh untouched for other callers.
+# here keeps run_app.sh untouched for other callers. Through the shared
+# helper, so this bootstrap keeps the bundle's entitlements the way the e2e
+# lanes now do; signing it bare used to leave the very bundle a human grants
+# TCC to without any (issue #609).
 log "Signing with $CERT_NAME"
-codesign --force --sign "$CERT_HASH" \
-    --keychain "$DEV_KEYCHAIN" \
-    "$APP_BUNDLE_PATH" >/dev/null \
+# shellcheck source=lib/signing.sh
+source "$SCRIPT_DIR/lib/signing.sh"
+resign_deployed_bundle "$APP_BUNDLE_PATH" "$CERT_HASH" "$DEV_KEYCHAIN" \
     || fail "codesign failed"
 
 log "Signed: $(codesign -dv "$APP_BUNDLE_PATH" 2>&1 | grep -E 'Identifier|Authority' | head -2 | tr '\n' ' ')"

--- a/scripts/setup-self-hosted-runner.sh
+++ b/scripts/setup-self-hosted-runner.sh
@@ -31,13 +31,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-CERT_NAME="MeetingTranscriberDevSelfHosted"
+# The certificate name and keychain path come from the library, which is also
+# where the e2e lanes look the identity up: spelling either of them twice means a
+# rename here makes every lane abort with "run scripts/setup-self-hosted-runner.sh
+# first" right after this script succeeded.
+# shellcheck source=lib/signing.sh
+source "$SCRIPT_DIR/lib/signing.sh"
+CERT_NAME="$DEV_CERT_NAME"
 CERT_ORG="meetingtranscriber-self-hosted"
 # Dedicated keychain with empty password keeps everything non-interactive:
 # - `-A` ACL imports don't need TouchID
 # - `set-key-partition-list -k ""` succeeds without prompts
 # Login keychain has neither property over SSH, hence the separation.
-DEV_KEYCHAIN="$HOME/Library/Keychains/meetingtranscriber-dev.keychain-db"
 DEV_KEYCHAIN_PASS=""
 APP_BUNDLE_PATH="$HOME/Applications/MeetingTranscriber-Dev.app"
 # /tmp because world-readable; the cert file may also be useful for a
@@ -55,8 +60,13 @@ fail() { printf '[setup] FAIL: %s\n' "$*" >&2; exit 1; }
 # cert from it without nuking other identities the operator may have added),
 # neither (full create). /tmp is volatile so the cert-only-missing case
 # is common after a reboot.
+# `-v` matches how dev_signing_identity queries it. Without the flag this check
+# also counts an identity the codesigning policy REJECTS (the invalid-key-usage
+# state described below), so the script would report "already there, skipping"
+# while every lane reports the identity missing and advises running this script —
+# advice that could then never help.
 if [ -f "$DEV_KEYCHAIN" ] \
-    && security find-identity -p codesigning "$DEV_KEYCHAIN" 2>/dev/null \
+    && security find-identity -v -p codesigning "$DEV_KEYCHAIN" 2>/dev/null \
         | grep -q "$CERT_NAME"; then
     if [ ! -f "$CERT_PATH" ]; then
         log "Re-exporting cert from dev keychain → $CERT_PATH"
@@ -200,8 +210,6 @@ security unlock-keychain -p "$DEV_KEYCHAIN_PASS" "$DEV_KEYCHAIN" \
 # lanes now do; signing it bare used to leave the very bundle a human grants
 # TCC to without any (issue #609).
 log "Signing with $CERT_NAME"
-# shellcheck source=lib/signing.sh
-source "$SCRIPT_DIR/lib/signing.sh"
 resign_deployed_bundle "$APP_BUNDLE_PATH" "$CERT_HASH" "$DEV_KEYCHAIN" \
     || fail "codesign failed"
 

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -41,7 +41,12 @@ ok "mt-cli built"
 # --- Assemble + sign bundle. ---
 cp "$SPM_DIR/.build/release/MeetingTranscriber" "$APP_BINARY"
 SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}')
-codesign --force --sign "$SIGN_HASH" "$APP_BUNDLE" 2>/dev/null
+# Through the shared helper: signing bare would strip the entitlements the
+# bundle was built with, and this lane launches the bundle it signs (issue #609).
+# shellcheck source=lib/signing.sh
+source "$REPO_ROOT/scripts/lib/signing.sh"
+resign_deployed_bundle "$APP_BUNDLE" "$SIGN_HASH" \
+    || fail "codesign failed for $APP_BUNDLE (identity $SIGN_HASH)"
 ok "signed"
 
 # --- Launch with env var. ---

--- a/scripts/tests/test_signing_resign.sh
+++ b/scripts/tests/test_signing_resign.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# Regression test for the deployed-bundle re-sign in scripts/lib/signing.sh.
+#
+# Bug history (issue #609):
+#   Every e2e lane deploys the dev bundle to a stable path and re-signs it with a
+#   stable identity, so TCC keeps its grants across rebuilds. That re-sign was a
+#   bare `codesign --force --sign X "$bundle"`, and a signature written that way
+#   carries NO entitlements at all — which is why the build's own "Verified
+#   com.apple.developer.usernotifications.time-sensitive survived signing" line
+#   was printed one step before the key was thrown away again. The microphone
+#   entitlement went with it.
+#
+#   It also left the bundle INCOHERENT: the embedded provisioning profile
+#   survived (rsync copies it in) while the entitlement it authorises did not,
+#   which is the exact pairing scripts/e2e-browser.sh asserts — so the lane
+#   failed pointing at prepare_signing, which had done its job correctly.
+#
+# Real codesign wherever the assertion is about a real signature (ad-hoc signing
+# needs no certificate, so this runs on a contributor's machine too); a
+# PATH-stubbed codesign only for the case that needs a bundle signed by a
+# certificate nobody can be assumed to hold.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+MIC_KEY="com.apple.security.device.audio-input"
+# Spelled out rather than sourced from signing.sh on purpose: this pins the key
+# macOS actually wants, so a typo in the library's constant fails here.
+TS_KEY="com.apple.developer.usernotifications.time-sensitive"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$2"; then
+        printf 'PASS\n'
+    else
+        printf 'FAIL\n'
+        FAILED=1
+    fi
+}
+
+# Builds a signable throwaway .app plus a base entitlements file in $1, and
+# echoes the bundle path. codesign needs an Info.plist naming a real executable,
+# nothing more.
+_make_bundle() {
+    local workdir="$1" bundle="$1/Some.app"
+    mkdir -p "$bundle/Contents/MacOS"
+    cp /bin/echo "$bundle/Contents/MacOS/Some"
+    cat > "$bundle/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>CFBundleExecutable</key><string>Some</string>
+    <key>CFBundleIdentifier</key><string>com.example.resign-test</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+PLIST
+    cat > "$workdir/base.entitlements" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>$MIC_KEY</key><true/></dict></plist>
+PLIST
+    printf '%s' "$bundle"
+}
+
+# A codesign stand-in for the cases that need a bundle signed by a certificate
+# nobody can be assumed to hold. It reports $STUB_LEAF_DER as the bundle's leaf,
+# reports $STUB_ENTITLEMENT as its entitlements, fails `--verify` when
+# $STUB_VERIFY is `fail`, and records every invocation so "did not rewrite the
+# signature" becomes an assertion rather than an inference.
+_write_codesign_stub() {
+    local workdir="$1"
+    mkdir -p "$workdir/bin"
+    cat > "$workdir/bin/codesign" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CODESIGN_CALLS"
+case "$*" in
+    *--verify*)                 [ "${STUB_VERIFY:-ok}" = fail ] && exit 1 ;;
+    *--extract-certificates*)   cp "$STUB_LEAF_DER" ./codesign0 ;;
+    *"--entitlements :-"*)
+        printf '<plist version="1.0"><dict><key>%s</key><true/></dict></plist>' \
+            "$STUB_ENTITLEMENT" ;;
+esac
+exit 0
+STUB
+    chmod +x "$workdir/bin/codesign"
+}
+
+# A real certificate whose SHA-1 the library will compute from the stub's DER.
+# It never signs anything; it only has to be extractable and hashable.
+# Returns non-zero when the fixture could not be built, because an empty hash
+# silently reroutes the cases that use it: they would take the re-sign branch and
+# report PASS while the branch they exist to pin never ran, and the sibling case
+# would fail accusing working production code.
+_make_leaf_cert() {
+    local workdir="$1" hash
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -keyout "$workdir/key.pem" -outform DER -out "$workdir/leaf.der" \
+        -days 1 -subj "/CN=Resign Test" 2>/dev/null || return 1
+    hash="$(openssl x509 -inform DER -in "$workdir/leaf.der" -noout -fingerprint -sha1 2>/dev/null \
+        | sed 's/^.*=//' | tr -d ':')"
+    [ -n "$hash" ] || return 1
+    printf '%s' "$hash"
+}
+
+# Runs the function under test the way a lane does: `set -euo pipefail`, library
+# sourced, entitlements pointed at the fixture. Echoes nothing, returns its status.
+#
+# A separate bash PROCESS, not a subshell: run_test calls each test from an `if`
+# condition, and bash suppresses errexit for the whole dynamic extent of a tested
+# command — nested subshells included. A subshell here would quietly run without
+# `set -e` no matter how it was set, so a test could never observe an abort.
+_resign() {
+    local workdir="$1"
+    shift
+    DEV_ENTITLEMENTS="$workdir/base.entitlements" \
+    SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
+        bash -c 'set -euo pipefail
+                 # shellcheck source=../lib/signing.sh
+                 source "$SIGNING_LIB"
+                 resign_deployed_bundle "$@"' bash "$@" >/dev/null 2>&1
+}
+
+# Each test has one exit point, so the temp dir is removed exactly once and the
+# assertions can still look at the bundle: a RETURN trap would outlive the
+# function that set it and fire again inside run_test.
+#
+# Named for what it can actually falsify: the re-sign branch WRITES the base
+# entitlements where the old bare codesign wrote none. It cannot show that
+# anything was "kept" — the keys come from $DEV_ENTITLEMENTS, not from the
+# bundle's prior signature. Keeping is the skip branch's job, and the case below
+# pins that by asserting the signature was not rewritten at all.
+test_resign_keeps_the_entitlements() {
+    local workdir bundle status entitlements rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+
+    # Stand in for what a lane finds on disk: a deployed copy of a build that
+    # was signed with the base entitlements.
+    codesign --force --sign - --entitlements "$workdir/base.entitlements" "$bundle" 2>/dev/null
+
+    _resign "$workdir" "$bundle" "-"
+    status=$?
+    entitlements="$(codesign -d --entitlements :- "$bundle" 2>/dev/null)"
+
+    if [ "$status" -ne 0 ]; then
+        echo "  resign_deployed_bundle exited $status" >&2
+        rc=1
+    fi
+    case "$entitlements" in
+        *"$MIC_KEY"*) ;;
+        *)
+            echo "  the re-signed bundle lost $MIC_KEY (dump: ${entitlements:-<empty>})" >&2
+            rc=1
+            ;;
+    esac
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+test_resign_keeps_a_signature_by_the_same_certificate() {
+    local workdir bundle status hash rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    # A profile is embedded, as it would be after rsync from a provisioned build.
+    printf 'stand-in for a provisioning profile' \
+        > "$bundle/Contents/embedded.provisionprofile"
+
+    hash="$(_make_leaf_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_codesign_stub "$workdir"
+
+    (
+        export CODESIGN_CALLS="$workdir/calls.log" \
+               STUB_LEAF_DER="$workdir/leaf.der" \
+               STUB_ENTITLEMENT="$TS_KEY" \
+               PATH="$workdir/bin:$PATH"
+        _resign "$workdir" "$bundle" "$hash"
+    )
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+        echo "  resign_deployed_bundle exited $status" >&2
+        rc=1
+    fi
+    if grep -q -- '--force' "$workdir/calls.log" 2>/dev/null; then
+        echo "  re-signed a bundle already signed by that certificate — a rewrite" >&2
+        echo "  can only drop the entitlements the embedded profile authorises" >&2
+        rc=1
+    fi
+    if [ ! -f "$bundle/Contents/embedded.provisionprofile" ]; then
+        echo "  removed the provisioning profile although the signature was kept" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# scripts/test_rpc.sh copies a fresh binary into an already-signed bundle, so the
+# certificate still matches while the signature no longer does. Keeping it would
+# launch a bundle macOS refuses to run, so validity is part of the skip question.
+test_resign_replaces_a_stale_signature_by_the_same_certificate() {
+    local workdir bundle status hash rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    hash="$(_make_leaf_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_codesign_stub "$workdir"
+
+    (
+        export CODESIGN_CALLS="$workdir/calls.log" \
+               STUB_LEAF_DER="$workdir/leaf.der" \
+               STUB_ENTITLEMENT="$TS_KEY" \
+               STUB_VERIFY=fail \
+               PATH="$workdir/bin:$PATH"
+        _resign "$workdir" "$bundle" "$hash"
+    )
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+        echo "  resign_deployed_bundle exited $status" >&2
+        rc=1
+    fi
+    if ! grep -q -- '--force' "$workdir/calls.log" 2>/dev/null; then
+        echo "  kept a signature that no longer verifies, only because the" >&2
+        echo "  certificate matched — the bundle would not launch" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# An identity given as a name that the keychain cannot resolve must be a normal
+# empty answer. `security` failing under the callers' `pipefail` used to become
+# the function's status and abort their assignment with no output at all — the
+# trap this library already documents at profile_for.
+test_resign_survives_an_unreadable_keychain() {
+    local workdir bundle status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+
+    # codesign is stubbed as well, so the only thing that could stop the
+    # function short of signing is the failing lookup itself. Without
+    # STUB_LEAF_DER the stub reports no certificate, which is the honest state
+    # for a bundle whose identity could not be resolved.
+    _write_codesign_stub "$workdir"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$workdir/bin/security"
+    chmod +x "$workdir/bin/security"
+
+    (
+        export CODESIGN_CALLS="$workdir/calls.log" \
+               STUB_LEAF_DER="$workdir/absent.der" \
+               STUB_ENTITLEMENT="$MIC_KEY" \
+               PATH="$workdir/bin:$PATH"
+        _resign "$workdir" "$bundle" "Developer ID Application: Nobody (T0)" \
+            "$workdir/absent.keychain-db"
+    )
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+        echo "  exited $status instead of re-signing with the identity as given" >&2
+        rc=1
+    fi
+    if ! grep -q -- '--force' "$workdir/calls.log" 2>/dev/null; then
+        echo "  never reached codesign: the failing keychain lookup became the" >&2
+        echo "  function's status and aborted the caller's assignment silently" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# A failed re-sign must leave the bundle exactly as it arrived. The profile is
+# sealed in _CodeSignature/CodeResources, so removing it before signing turns a
+# codesign failure — a locked keychain, an identity the runner's search-list churn
+# hid — into an unlaunchable bundle at the shared, TCC-granted deploy path.
+test_failed_resign_leaves_the_bundle_intact() {
+    local workdir bundle status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    printf 'stand-in for a provisioning profile' \
+        > "$bundle/Contents/embedded.provisionprofile"
+    codesign --force --sign - --entitlements "$workdir/base.entitlements" "$bundle" 2>/dev/null
+
+    # Real codesign, real failure: no certificate carries this name.
+    _resign "$workdir" "$bundle" "NoSuchIdentity-$$"
+    status=$?
+
+    if [ "$status" -eq 0 ]; then
+        echo "  reported success although codesign could not sign" >&2
+        rc=1
+    fi
+    if [ ! -f "$bundle/Contents/embedded.provisionprofile" ]; then
+        echo "  the profile is gone after a failed re-sign" >&2
+        rc=1
+    fi
+    if ! codesign --verify "$bundle" 2>/dev/null; then
+        echo "  the bundle no longer verifies after a failed re-sign: the signature" >&2
+        echo "  it arrived with seals the profile, so removing it breaks the seal" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+test_resign_drops_a_profile_it_cannot_honour() {
+    local workdir bundle status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    codesign --force --sign - --entitlements "$workdir/base.entitlements" "$bundle" 2>/dev/null
+    printf 'stand-in for a provisioning profile' \
+        > "$bundle/Contents/embedded.provisionprofile"
+
+    _resign "$workdir" "$bundle" "-"
+    status=$?
+
+    if [ "$status" -ne 0 ]; then
+        echo "  resign_deployed_bundle exited $status" >&2
+        rc=1
+    fi
+    if [ -f "$bundle/Contents/embedded.provisionprofile" ]; then
+        echo "  kept a profile whose entitlement the new signature does not carry —" >&2
+        echo "  that pairing is what e2e-browser.sh fails on, blaming prepare_signing" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# The defect was never in the library, it was in copies of a codesign call. Only
+# the two scripts that sign a bundle they just built may name a certificate;
+# anything re-signing a bundle someone else built goes through the helper, which
+# is the part that keeps the entitlements.
+test_only_the_build_scripts_name_a_certificate() {
+    local offenders
+    # Matches a codesign invocation rather than the bare flag, and skips comment
+    # lines, so documenting the rule cannot fail the required lint job.
+    # scripts/lib is included because the pattern is just as wrong there — with
+    # signing.sh excluded, as the one place the call belongs.
+    offenders="$(grep -nE '^[^#]*codesign[^|]*--sign' \
+        "$REPO_ROOT"/scripts/*.sh "$REPO_ROOT"/scripts/lib/*.sh 2>/dev/null \
+        | grep -vE '/(build_release|run_app|signing)\.sh:' || true)"
+    if [ -n "$offenders" ]; then
+        echo "  these scripts sign a bundle directly instead of via" >&2
+        echo "  resign_deployed_bundle, which is how the entitlements got" >&2
+        echo "  dropped (issue #609):" >&2
+        printf '  %s\n' "$offenders" >&2
+        return 1
+    fi
+}
+
+echo "Testing the deployed-bundle re-sign in scripts/lib/signing.sh"
+echo
+run_test "a re-sign writes the base entitlements instead of none" \
+    test_resign_keeps_the_entitlements
+run_test "a signature by the requested certificate is left alone" \
+    test_resign_keeps_a_signature_by_the_same_certificate
+run_test "a stale signature by that certificate is replaced anyway" \
+    test_resign_replaces_a_stale_signature_by_the_same_certificate
+run_test "an identity the keychain cannot resolve does not abort the caller" \
+    test_resign_survives_an_unreadable_keychain
+run_test "a failed re-sign leaves the bundle exactly as it arrived" \
+    test_failed_resign_leaves_the_bundle_intact
+run_test "a profile the new signature cannot honour is removed" \
+    test_resign_drops_a_profile_it_cannot_honour
+run_test "only the build scripts name a signing certificate" \
+    test_only_the_build_scripts_name_a_certificate
+echo
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "Some tests FAILED."
+fi
+exit "$FAILED"

--- a/scripts/tests/test_signing_resign.sh
+++ b/scripts/tests/test_signing_resign.sh
@@ -333,6 +333,76 @@ test_resign_drops_a_profile_it_cannot_honour() {
     return "$rc"
 }
 
+# The runner's identity comes from the keychain, which persists, and not from the
+# export copy the setup script leaves in /tmp, which macOS discards on reboot.
+test_dev_identity_comes_from_the_keychain() {
+    local workdir out rc=0
+    workdir="$(mktemp -d)"
+    mkdir -p "$workdir/bin"
+    : > "$workdir/dev.keychain-db"
+    # A find-identity transcript, so the assertion is about parsing the keychain's
+    # answer rather than about this machine happening to hold that certificate.
+    #
+    # The transcript DEPENDS on the keychain argument: asked about our keychain it
+    # answers with the dev certificate, asked about anything else (or about no
+    # keychain at all, i.e. the ambient search list) it answers with a different
+    # one. Without that, a lookup that dropped the keychain argument and read the
+    # user's search list — the "identity came from the wrong source" bug this
+    # function exists to prevent — would satisfy the assertion just as well.
+    cat > "$workdir/bin/security" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+    find-identity)
+        if [ "\${!#}" = "$workdir/dev.keychain-db" ]; then
+            printf '  1) AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555 "Apple Development: someone"\n'
+            printf '  2) 1234567890ABCDEF1234567890ABCDEF12345678 "MeetingTranscriberDevSelfHosted"\n'
+            printf '     2 valid identities found\n'
+        else
+            printf '  1) 9999888877776666555544443333222211110000 "MeetingTranscriberDevSelfHosted"\n'
+            printf '     1 valid identities found\n'
+        fi ;;
+esac
+exit 0
+STUB
+    chmod +x "$workdir/bin/security"
+
+    out="$(PATH="$workdir/bin:$PATH" \
+        DEV_KEYCHAIN="$workdir/dev.keychain-db" \
+        SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
+        bash -c 'set -euo pipefail; source "$SIGNING_LIB"; dev_signing_identity' 2>/dev/null)"
+
+    if [ "$out" != "1234567890ABCDEF1234567890ABCDEF12345678" ]; then
+        echo "  expected the dev certificate's SHA-1 from the keychain, got: ${out:-<empty>}" >&2
+        rc=1
+    fi
+
+    # An absent keychain is a normal answer, not a failure: the lanes decide what
+    # to do about it, and one of them only warns.
+    out="$(PATH="$workdir/bin:$PATH" \
+        DEV_KEYCHAIN="$workdir/absent.keychain-db" \
+        SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
+        bash -c 'set -euo pipefail; source "$SIGNING_LIB"; dev_signing_identity' 2>/dev/null)"
+    if [ -n "$out" ]; then
+        echo "  expected nothing for an absent keychain, got: $out" >&2
+        rc=1
+    fi
+
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+test_no_lane_depends_on_the_volatile_cert_copy() {
+    local offenders
+    offenders="$(grep -ln 'meetingtranscriber-setup' "$REPO_ROOT"/scripts/e2e-*.sh 2>/dev/null)"
+    if [ -n "$offenders" ]; then
+        echo "  these lanes read the setup script's /tmp export copy, which macOS" >&2
+        echo "  discards on reboot — after which the lane aborts although the" >&2
+        echo "  keychain and the identity are intact:" >&2
+        printf '  %s\n' "$offenders" >&2
+        return 1
+    fi
+}
+
 # The defect was never in the library, it was in copies of a codesign call. Only
 # the two scripts that sign a bundle they just built may name a certificate;
 # anything re-signing a bundle someone else built goes through the helper, which
@@ -369,6 +439,10 @@ run_test "a failed re-sign leaves the bundle exactly as it arrived" \
     test_failed_resign_leaves_the_bundle_intact
 run_test "a profile the new signature cannot honour is removed" \
     test_resign_drops_a_profile_it_cannot_honour
+run_test "the runner's identity is resolved from the keychain" \
+    test_dev_identity_comes_from_the_keychain
+run_test "no lane depends on the volatile /tmp certificate copy" \
+    test_no_lane_depends_on_the_volatile_cert_copy
 run_test "only the build scripts name a signing certificate" \
     test_only_the_build_scripts_name_a_certificate
 echo


### PR DESCRIPTION
Closes #609.

## What was wrong

Every e2e lane deploys the dev bundle to `~/Applications/MeetingTranscriber-Dev.app` and re-signs it with a stable identity, so TCC keeps its grants across rebuilds. That re-sign was a bare `codesign --force --sign X "$bundle"` — and a signature written that way carries **no entitlements at all**.

Measured on the real provisioned dev bundle:

| | time-sensitive | microphone | profile | signature |
|---|---|---|---|---|
| as built | yes | yes | embedded | Developer ID |
| old re-sign | **NO** | **NO** | embedded | Developer ID |

So the build printed "Verified com.apple.developer.usernotifications.time-sensitive survived signing" one step before the key was thrown away again, and the microphone entitlement went with it. The dev app on the runner could never break the consent prompt through a Focus mode.

The state left behind also **misattributed the failure**: the embedded profile survived (rsync copies it in) while the entitlement it authorises did not, and that pairing is exactly what `scripts/e2e-browser.sh` asserts. So once a profile exists the browser lane fails pointing at `prepare_signing`, which had done its job correctly and said so. That is why this stayed invisible — with no profile in `signing/` nothing is embedded, the entitlement is never requested, and the lane skips its own check.

## The fix

The key cannot simply be re-requested at the re-sign: a provisioning profile authorises specific *certificates*, and macOS refuses to launch a bundle whose restricted entitlement no embedded profile covers ("Launchd job spawn failed", measured previously and documented in `scripts/lib/signing.sh`). Passing the derived entitlements blindly would ship a bundle that does not start.

So `resign_deployed_bundle` decides:

- **The bundle already carries a valid signature by the certificate the caller would use** → leave it alone. Re-signing there can only subtract: same certificate, same TCC identity, and the entitlements the build derived stay intact. This answers the question the issue closes with — the re-sign is redundant precisely when the profile-aware path picked the certificate itself.
- **Anything else** → re-sign with the base entitlements (so the microphone entitlement stops being collateral damage), setting aside a profile the new signature cannot honour so the bundle is coherently unprovisioned rather than looking provisioned while missing the key.

Details that carry weight rather than being incidental:

**A failed re-sign leaves the bundle exactly as it arrived.** The profile is sealed in `_CodeSignature/CodeResources`, so removing it before signing would turn a codesign failure — a locked keychain, an identity the parallel runner's search-list churn hid — into an unlaunchable bundle at the shared, TCC-granted path. It is moved aside and moved back on failure.

**Validity is part of the skip question.** `scripts/test_rpc.sh` copies a fresh binary into an already-signed bundle, so the certificate still matches while the signature no longer does (measured: a replaced binary makes `codesign --verify` fail). Keeping that signature would launch a bundle macOS refuses to run.

**Certificates are compared by leaf SHA-1, not by name.** The hash is what TCC keys a grant on, and two certificates share a name across a renewal — a name comparison would call those two the same certificate, skip a re-sign that was needed, and leave the grant tied to the other one, silently.

**A named identity is matched as a substring, as codesign matches it.** Per its man page codesign takes the certificate whose subject common name *contains* the string, so anchoring on the fully quoted name would reject identities codesign accepts — and an unresolvable identity can never match the bundle, which would make the destructive branch unconditional. Ambiguity is not a match: two certificates containing the name resolve to nothing, because re-signing unnecessarily only costs a signature while wrongly skipping costs the grant.

**The re-sign verifies what it wrote.** `verify_signing` speaks only about the profile pairing, and on that path there is no profile left to pair with, so the helper additionally rejects a signature carrying no entitlements at all — issue #609 itself.

Six scripts carried the same bare re-sign: the four e2e lanes, `setup-self-hosted-runner.sh` (which signs the very bundle a human grants TCC to, so the whole runner's grants rest on it) and `test_rpc.sh`. All six now call the library, and `run_app.sh`'s own signing step no longer swallows codesign's status and stderr — that hid the case where a bad entitlements path leaves the bundle completely unsigned with no diagnostic.

Nothing changes on CI as it stands: with no profile present, the re-signed bundle simply keeps its microphone entitlement — and on the runner the build already uses the certificate the lane wanted, so the re-sign is skipped rather than performed-and-destructive.

## Second fix: the runner's identity survives a reboot

`setup-self-hosted-runner.sh` installs the self-signed certificate into the dev keychain and also drops an export copy under `/tmp/meetingtranscriber-setup`. Three lanes hashed that copy and guarded on its existence — but macOS discards `/tmp` across a reboot, so after every restart those lanes aborted with "run scripts/setup-self-hosted-runner.sh first" while the keychain and the identity were perfectly intact.

`dev_signing_identity` now resolves it from the keychain, which is the source codesign itself reads from and which persists. One lane already did that, which is the evidence that four copies of this resolution were three too many: the fix existed in one of them and could not reach the others. The certificate name and keychain path are named once in the library and used by the bootstrap too, and the bootstrap's own presence check now uses `find-identity -v` like the resolver — otherwise a certificate the codesigning policy rejects makes setup say "already there, skipping" while every lane says it is missing, with no way out.

Each lane keeps its own reaction to a missing identity: three fail, and the silent-recording lane still only warns, because it can run without capture.

## Tests

`scripts/tests/test_signing_resign.sh`, nine cases, each verified red without its fix:

- a re-sign writes the base entitlements where the old bare call wrote none (the original regression)
- a valid signature by the requested certificate is left alone, and its profile with it (a stubbed codesign records invocations, so "did not rewrite" is an assertion, not an inference)
- a **stale** signature by that same certificate is replaced anyway
- an identity the keychain cannot resolve does not abort the caller: the lookup's failure used to become the function's status and kill the lane at the assignment with no output at all, the trap this library already documents one function above
- **a failed re-sign leaves the bundle exactly as it arrived** — real codesign, real failure, asserting the profile is still there and the signature still verifies
- a profile the new signature cannot honour is set aside
- the runner's identity is resolved from the keychain, with a stub that answers differently per keychain so a lookup reading the ambient search list instead would fail
- no lane depends on the volatile `/tmp` certificate copy
- only the scripts that sign a bundle they just built name a certificate at all — the defect was never in the library, it was in copies of a codesign call, so this pins the shape rather than the mechanism

The tests drive the function in a separate bash **process** rather than a subshell. Bash suppresses `errexit` for the whole dynamic extent of a command whose status is being tested, nested subshells included — and the harness calls every test from an `if`. In a subshell they would have run without `set -e` however explicitly it was set, so the abort case could not have been observed at all.

The CI step that runs these had itself skipped two of the four existing script tests; the first commit globs the directory so the same omission cannot recur.

## Verified live

Both self-hosted lanes are green on this branch, and the browser lane takes the new path:

```
[e2e-app] Re-signing …/MeetingTranscriber-Dev.app with Developer ID '***'
  Already signed by the requested certificate — keeping that signature;
  re-signing would only drop the entitlements it carries.
```

That the TCC grant survived is not an inference: Chrome, Brave, Edge, Chromium and the real Jitsi leg all captured real audio (`"isSilent":false`, overall RMS ≈ -16.8 dBFS), which needs the audio-capture grant that keys on the signing certificate. The production-app lane runs a full live recording through the same signing path.

Beyond the suite, the helper was measured against the real provisioned dev bundle across all four arms — identity given as a full name, as a partial name, a certificate the profile does not cover, and a signing failure — and against a real keychain for the identity resolution.