### PR TITLE
fix(app): stop refusing manual recording over an optional permission

### DIFF
--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -55,6 +55,47 @@ enum PermissionProblem: Equatable {
         }
         return "\(key)=\(isBroken ? "broken" : "denied")"
     }
+
+    /// Whether this problem has to stop a recording from starting, as opposed to
+    /// only degrading a side feature. `noMic` recordings capture app audio only
+    /// and open no mic file at all (`DualSourceRecorder.start`), so the grant they
+    /// never ask for cannot block them.
+    ///
+    /// Accessibility never blocks: its only consumer is `ParticipantReader` (Teams
+    /// participant names, read in `handleMeeting`), which a recording does not need.
+    /// Settings labels it optional too, via `PermissionRow(optional: true)`, but that
+    /// row is not independent corroboration: its wording promises a mute detection
+    /// that does not exist, since mute handling is sample-level in `AudioMixer` and
+    /// level-based in `ChannelHealthController`, neither of which touches
+    /// Accessibility. Nothing links the row to this switch either, so flipping one
+    /// leaves them disagreeing with no compile error and no failing test.
+    ///
+    /// Screen Recording keeps blocking even though it is only *one* of two
+    /// sufficient grants for the app-audio tap, the other being the
+    /// `NSAudioCaptureUsageDescription` "Audio Recording" grant. That one has no
+    /// preflight API and is not modelled here, so a denied Screen Recording cannot
+    /// be told apart from a tap that will silently capture nothing. Someone who
+    /// clicked "Record App..." is sitting in front of the machine and can act on a
+    /// refusal, so the interactive path errs towards refusing, trading an over-block
+    /// (Audio Recording granted, Screen Recording denied) for never handing back a
+    /// silent file. The auto-detected path does not weigh this differently, it does
+    /// not weigh it at all: `handleMeeting` starts the recorder with no permission
+    /// check of any kind.
+    ///
+    /// The switch is exhaustive on purpose, but it guards less than it looks like.
+    /// Once a permission has `PermissionProblem` cases, every classification over
+    /// them has to be decided rather than defaulted. It does not force that first
+    /// step: `problems` below is hand-written, so a status field added to
+    /// `HealthCheckResult` compiles with no case at all and is then silently
+    /// unreported and non-blocking. Adding a permission means editing `problems`
+    /// too, and nothing but this sentence says so.
+    func blocksRecording(noMic: Bool) -> Bool {
+        switch self {
+        case .screenRecordingDenied, .screenRecordingBroken: true
+        case .microphoneDenied, .microphoneBroken: !noMic
+        case .accessibilityDenied, .accessibilityBroken: false
+        }
+    }
 }
 
 struct HealthCheckResult: Equatable {
@@ -94,6 +135,30 @@ struct HealthCheckResult: Equatable {
 
     var isHealthy: Bool {
         problems.isEmpty
+    }
+
+    /// The subset of `problems` that has to stop a recording from starting.
+    ///
+    /// A different question from `isHealthy`, which stays the aggregate "every
+    /// permission is fine" behind the menu bar badge, the permission notification
+    /// and `/state`. Sharing the `problems` list keeps their *input* identical, not
+    /// their verdict: a denied optional permission is reported by one and ignored
+    /// by the other, which is the whole point and also means the badge still calls
+    /// it an error while a recording proceeds.
+    func recordingBlockers(noMic: Bool) -> [PermissionProblem] {
+        problems.filter { $0.blocksRecording(noMic: noMic) }
+    }
+
+    /// Why a recording must be refused, or nil when nothing blocks it. Names only
+    /// the blocking problems, so a refusal never points at a permission that was
+    /// irrelevant to it.
+    ///
+    /// One call rather than a separate predicate and message, so a caller cannot
+    /// ask the two with different arguments and refuse with an empty reason.
+    func recordingRefusalReason(noMic: Bool) -> String? {
+        let blockers = recordingBlockers(noMic: noMic)
+        guard !blockers.isEmpty else { return nil }
+        return blockers.map(\.description).joined(separator: "\n")
     }
 
     var notificationBody: String {

--- a/app/MeetingTranscriber/Sources/WatchLoop.swift
+++ b/app/MeetingTranscriber/Sources/WatchLoop.swift
@@ -224,9 +224,10 @@ class WatchLoop {
             return
         }
 
+        // Gate on what this path needs, not on overall health (see `blocksRecording`).
         let health = await permissionChecker()
-        if !health.isHealthy {
-            throw RecorderError.permissionDenied(health.notificationBody)
+        if let refusal = health.recordingRefusalReason(noMic: noMic) {
+            throw RecorderError.permissionDenied(refusal)
         }
 
         // Stop auto-watch if active

--- a/app/MeetingTranscriber/Tests/RecordingBlockerTests.swift
+++ b/app/MeetingTranscriber/Tests/RecordingBlockerTests.swift
@@ -1,0 +1,88 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Which permission problems have to stop a recording from starting, as opposed
+/// to only degrading a side feature. Deliberately a different question from the
+/// aggregate `isHealthy` in `PermissionHealthCheckTests`: these two must be able
+/// to disagree, and several of the assertions below exist to pin exactly that.
+final class RecordingBlockerTests: XCTestCase {
+    func testAccessibilityProblemsDoNotBlockRecording() {
+        for status in [PermissionStatus.denied, .broken] {
+            let result = PermissionHealthCheck.overallHealth(
+                screenRecording: .healthy,
+                microphone: .healthy,
+                accessibility: status,
+            )
+            // The menu bar badge and the permission notification still report a
+            // problem, the recording gate does not. Anything that collapses the
+            // two notions back together breaks here.
+            XCTAssertFalse(result.isHealthy, "accessibility \(status) is still a reported problem")
+            XCTAssertTrue(result.recordingBlockers(noMic: false).isEmpty)
+            XCTAssertNil(result.recordingRefusalReason(noMic: false))
+        }
+    }
+
+    func testMicrophoneProblemsBlockRecording() {
+        for (status, problem) in [
+            (PermissionStatus.denied, PermissionProblem.microphoneDenied),
+            (.broken, .microphoneBroken),
+        ] {
+            let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: status)
+            XCTAssertEqual(result.recordingBlockers(noMic: false), [problem])
+            XCTAssertNotNil(result.recordingRefusalReason(noMic: false))
+        }
+    }
+
+    func testScreenRecordingProblemsBlockRecording() {
+        for (status, problem) in [
+            (PermissionStatus.denied, PermissionProblem.screenRecordingDenied),
+            (.broken, .screenRecordingBroken),
+        ] {
+            let result = PermissionHealthCheck.overallHealth(screenRecording: status, microphone: .healthy)
+            XCTAssertEqual(result.recordingBlockers(noMic: false), [problem])
+            XCTAssertNotNil(result.recordingRefusalReason(noMic: false))
+        }
+    }
+
+    func testMicrophoneProblemDoesNotBlockAMicLessRecording() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .denied)
+        XCTAssertNotNil(result.recordingRefusalReason(noMic: false))
+        // A no-mic recording captures app audio only, so it never asks for the grant.
+        XCTAssertNil(result.recordingRefusalReason(noMic: true))
+    }
+
+    func testScreenRecordingProblemStillBlocksAMicLessRecording() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .denied, microphone: .healthy)
+        XCTAssertNotNil(result.recordingRefusalReason(noMic: true))
+    }
+
+    func testRefusalReasonNamesOnlyBlockingProblems() throws {
+        let result = PermissionHealthCheck.overallHealth(
+            screenRecording: .healthy,
+            microphone: .denied,
+            accessibility: .denied,
+        )
+        let body = try XCTUnwrap(result.recordingRefusalReason(noMic: false))
+        XCTAssertTrue(body.contains("Microphone"))
+        XCTAssertFalse(body.contains("Accessibility"))
+        // The aggregate body is untouched and still names both.
+        XCTAssertTrue(result.notificationBody.contains("Microphone"))
+        XCTAssertTrue(result.notificationBody.contains("Accessibility"))
+    }
+
+    func testRefusalReasonNamesEveryBlockingProblem() throws {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .denied, microphone: .denied)
+        XCTAssertEqual(result.recordingBlockers(noMic: false).count, 2)
+        // Without this, naming only the first blocker passes every other test, and a
+        // user who fixes the one permission the message named is refused a second
+        // time over one that was equally blocking and equally known the first time.
+        let reason = try XCTUnwrap(result.recordingRefusalReason(noMic: false))
+        XCTAssertTrue(reason.contains("Screen Recording"))
+        XCTAssertTrue(reason.contains("Microphone"))
+    }
+
+    func testHealthyBlocksNothing() {
+        let result = PermissionHealthCheck.overallHealth(screenRecording: .healthy, microphone: .healthy)
+        XCTAssertNil(result.recordingRefusalReason(noMic: false))
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchLoopTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopTests.swift
@@ -294,6 +294,56 @@ final class WatchLoopTests: XCTestCase {
         }
     }
 
+    func testManualRecordingStartsWhenOnlyAccessibilityDenied() async throws {
+        let (loop, recorder) = makeTestWatchLoop()
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .healthy, accessibility: .denied)
+        }
+
+        // Accessibility feeds participant reading and mute detection, neither of
+        // which this path uses, and Settings presents it as optional. Refusing
+        // over it left the app recording an auto-detected meeting while turning
+        // down the one the user asked for by hand.
+        try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
+
+        XCTAssertTrue(recorder.startCalled)
+        XCTAssertTrue(loop.isManualRecording)
+    }
+
+    func testManualRecordingRefusalNamesOnlyBlockingPermissions() async {
+        let (loop, _) = makeTestWatchLoop()
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .broken, accessibility: .denied)
+        }
+
+        do {
+            try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
+            XCTFail("Expected permissionDenied error")
+        } catch let error as RecorderError {
+            guard case let .permissionDenied(reason) = error else {
+                XCTFail("Expected permissionDenied, got \(error)")
+                return
+            }
+            XCTAssertTrue(reason.contains("Microphone"))
+            // Naming a permission that had nothing to do with the refusal sends
+            // the user to the wrong pane in System Settings.
+            XCTAssertFalse(reason.contains("Accessibility"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testMicLessManualRecordingStartsWithoutMicrophonePermission() async throws {
+        let (loop, recorder) = makeTestWatchLoop(noMic: true)
+        loop.permissionChecker = {
+            HealthCheckResult(screenRecording: .healthy, microphone: .denied)
+        }
+
+        try await loop.startManualRecording(pid: 123, appName: "Test", title: "Test")
+
+        XCTAssertTrue(recorder.startCalled)
+    }
+
     // MARK: - RecordOnlyDestination
 
     func test_production_destinationSplitsScopeAndWriteDir() {


### PR DESCRIPTION
Fixes #616.

"Record App..." refused to start whenever *any* permission was reported as a problem, including the one the app itself labels optional. With Accessibility denied and everything else healthy, a manually picked recording was turned down with "Accessibility permission denied", while the auto-detected path recorded the same meeting without that grant. Settings calls the permission "Optional", so the app contradicted itself in three places at once.

## What changed

`HealthCheckResult` answered one question, "is every permission fine". Callers with a different question had to reuse it. This adds the second question next to it: which problems have to stop a recording from starting.

`isHealthy` is untouched and keeps its aggregate meaning for the menu bar badge, the permission notification and `/state`. Sharing the `problems` list keeps their input identical, not their verdict, which is the point.

Which problems block:

| Permission | Blocks a recording | Why |
|---|---|---|
| Microphone | yes, unless the recording is mic-less | the recording asks for it |
| Screen Recording | yes | see below |
| Accessibility | no | its only consumer is participant reading, which the recording does not need |

`blocksRecording` takes `noMic` because whether a permission blocks genuinely depends on configuration: a recording that captures app audio only opens no mic file at all, so that grant cannot block it. That was the same defect as the reported one with a different permission, so it is fixed in the same pass rather than left to be reported later.

Screen Recording keeps blocking even though it is only one of two sufficient grants for the app-audio tap. The other one, the "Audio Recording" grant, has no preflight API and is not modelled in the health check, so a denied Screen Recording cannot be told apart from a tap that will silently capture nothing. Handing back a silent file is the worse outcome for someone sitting there waiting for a recording, so the interactive path errs towards refusing. The known cost is an over-block for anyone who granted Audio Recording and denied Screen Recording.

A refusal now names only the permissions that actually caused it, so it no longer sends the user to an unrelated pane in System Settings. It is a single call returning the reason or nil, rather than a separate predicate and message, so a caller cannot ask the two with different arguments and refuse with an empty reason.

## Testing

Eight pure tests on the new classification, three on the gate. The regression test for the report starts a manual recording with Accessibility as the only denied permission and asserts it records. All three gate tests were confirmed red against the old gate first, each failing with the exact error the shipped code produces, and the multi-blocker message test was confirmed by mutation: truncating the reason to its first entry fails that test and only that test.

Confirmed on a running build, before and after, in one sitting. Two dev builds from the same tree differing only by these two commits, same bundle identifier, same signing identity, same TCC state throughout (`accessibility=denied, screenRecording=healthy, microphone=healthy`, verified over the local state endpoint before each run). Same click both times, "Record App..." on the same target:

| Build | Result |
|---|---|
| without the fix | notification "Error / Permission problem: Accessibility permission denied", nothing recorded |
| with the fix | notification "Manual Recording: Brave Browser", recording runs |

That run also confirmed by measurement what was previously only derived from the code: while the recording was running, the app posted "Permission Problem: Accessibility permission denied" and the menu bar badge read as an error. The badge point below is therefore observed, not inferred.

Full suite green, SwiftFormat and SwiftLint --strict clean, release-mode parity build clean.

## Deliberately not in this change

The auto-detected path still has no permission gate at all. Fail-open is arguably right there, since nobody is present to act on a refusal and a partial capture beats losing the meeting, but it is currently an omission rather than a decision, and settling it deserves its own change. The classification comment says plainly that there is no check there, rather than implying a symmetric choice.

The menu bar badge still reports a denied optional permission as an error, so a user who declines only Accessibility now gets working manual recording alongside a red warning about it. Folding optional permissions out of `isHealthy` outright would be the wrong correction, since the features that do degrade would then have no indicator at all; the shape that fits is a severity distinction rendered as warning versus error, which the Settings permission rows already draw. That is a feature rather than part of this fix.

The gate reads a cached health snapshot rather than probing live, so granting a permission may not unblock the path within the same interaction. After this change the reported case can no longer be affected by that staleness, and the remaining exposure is unmeasured.

The optional-ness of Accessibility is now stated in two places, here and as `PermissionRow(optional: true)` in Settings, with nothing linking them. Unifying them is a real rewire, since the Settings pane reads TCC directly rather than consuming `PermissionProblem`. The comment says so rather than presenting the two as agreement.

`WatchLoop.swift` is now exactly at the 600-line limit, so the next line added there forces a split.
