### PR TITLE
Put the side packages under the app's warning gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,10 @@ jobs:
           # failure, leaving swiftlint analyze to pass against an empty log.
           set -o pipefail
           cd app/MeetingTranscriber
-          xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' build-for-testing 2>&1 | tee /tmp/xcodebuild.log
+          # SWIFT_SUPPRESS_WARNINGS=NO: without it xcodebuild fails outright on
+          # AudioTapLib's warning gate. Reason at the flag in
+          # tools/audiotap/Package.swift.
+          xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' SWIFT_SUPPRESS_WARNINGS=NO build-for-testing 2>&1 | tee /tmp/xcodebuild.log
           cd "$GITHUB_WORKSPACE"
           swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging
       - name: Cancel run on failure

--- a/tools/audiotap/Package.swift
+++ b/tools/audiotap/Package.swift
@@ -1,5 +1,25 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
+
+// The same gate the app package runs under. `treatAllWarnings(as:)` is what
+// pins the manifest to tools-version 6.2; it does not exist in 6.0.
+//
+// One caveat, because the failure is not obvious from the error text: Xcode
+// passes `-suppress-warnings` to any package it builds as a dependency, and
+// that conflicts outright with the `-warnings-as-errors` below, so an
+// `xcodebuild` of the app fails on this target before compiling anything.
+// Build it with `SWIFT_SUPPRESS_WARNINGS=NO`, as CI's analyze job does.
+// `swift build` and `swift test` are unaffected, which is every other path
+// the repo uses, the release build included.
+let strictSwiftSettings: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+    // `unsafeFlags` is legal only because the app consumes this library by
+    // path; SwiftPM rejects it in a package resolved from a URL.
+    .unsafeFlags([
+        "-Xfrontend", "-warn-long-function-bodies=300",
+        "-Xfrontend", "-warn-long-expression-type-checking=300",
+    ]),
+]
 
 let package = Package(
     name: "AudioTapLib",
@@ -18,12 +38,14 @@ let package = Package(
             name: "AudioTapLib",
             dependencies: ["CExceptionCatcher"],
             path: "Sources",
-            exclude: ["CExceptionCatcher"]
+            exclude: ["CExceptionCatcher"],
+            swiftSettings: strictSwiftSettings
         ),
         .testTarget(
             name: "AudioTapLibTests",
             dependencies: ["AudioTapLib", "CExceptionCatcher"],
-            path: "Tests"
+            path: "Tests",
+            swiftSettings: strictSwiftSettings
         ),
     ]
 )

--- a/tools/audiotap/Package.swift
+++ b/tools/audiotap/Package.swift
@@ -19,6 +19,7 @@ let strictSwiftSettings: [SwiftSetting] = [
         "-Xfrontend", "-warn-long-function-bodies=300",
         "-Xfrontend", "-warn-long-expression-type-checking=300",
     ]),
+    .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(

--- a/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler+Restart.swift
@@ -77,7 +77,7 @@ extension MicCaptureHandler {
         // attempt always builds a new session rather than reusing the engine.
         let candidate = sessionFactory()
         var rate: Double?
-        var thrown: Error?
+        var thrown: (any Error)?
         do {
             rate = try startEngine(deviceUID: deviceUID, on: candidate)
         } catch {
@@ -121,7 +121,7 @@ extension MicCaptureHandler {
     /// Publish a successful attempt, or discard it if the session was sealed
     /// while it was on its way here. Main queue only.
     private func adopt(
-        _ candidate: MicEngineSessionProviding,
+        _ candidate: any MicEngineSessionProviding,
         deviceUID: String?,
         generation: Int,
         rate: Double?,

--- a/tools/audiotap/Sources/MicCaptureHandler.swift
+++ b/tools/audiotap/Sources/MicCaptureHandler.swift
@@ -31,8 +31,8 @@ public class MicCaptureHandler: @unchecked Sendable {
     /// never touches audio hardware (the CI runner has no input device) and can
     /// be made to block on demand, which is how the issue #588 wedge is
     /// exercised without a Bluetooth headset.
-    let sessionFactory: () -> MicEngineSessionProviding
-    var session: MicEngineSessionProviding
+    let sessionFactory: () -> any MicEngineSessionProviding
+    var session: any MicEngineSessionProviding
     /// `internal` (not `private`) so the cross-file `+Timeline` extension can
     /// write gap-fill silence to it.
     ///
@@ -99,7 +99,7 @@ public class MicCaptureHandler: @unchecked Sendable {
     /// use a schedule that does not spend six seconds proving a give-up.
     let decideRetry: @Sendable (Int) -> CaptureRestartRetryAction
     private var deviceChangeListener: AudioObjectPropertyListenerBlock?
-    var configChangeObserver: NSObjectProtocol?
+    var configChangeObserver: (any NSObjectProtocol)?
     var selectedDeviceUID: String?
     /// Wall-clock anchoring so a device-restart gap becomes silence in the WAV
     /// instead of an under-run (issue #379 follow-up — see `+Timeline`).
@@ -136,7 +136,7 @@ public class MicCaptureHandler: @unchecked Sendable {
         debugFault: DebugTapFault? = nil,
         removeInputTap: @escaping (AVAudioEngine) -> Void = { $0.inputNode.removeTap(onBus: 0) },
     ) {
-        let factory: () -> MicEngineSessionProviding = {
+        let factory: () -> any MicEngineSessionProviding = {
             MicEngineSession(removeInputTap: removeInputTap)
         }
         self.init(
@@ -157,7 +157,7 @@ public class MicCaptureHandler: @unchecked Sendable {
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
         debugFault: DebugTapFault? = nil,
-        sessionFactory: @escaping () -> MicEngineSessionProviding,
+        sessionFactory: @escaping () -> any MicEngineSessionProviding,
         decideRetry: @escaping @Sendable (Int) -> CaptureRestartRetryAction
             = CaptureRestartRetryPolicy.decide,
     ) {
@@ -202,7 +202,7 @@ public class MicCaptureHandler: @unchecked Sendable {
 
     // swiftlint:disable function_body_length
     @discardableResult
-    func startEngine(deviceUID: String?, on session: MicEngineSessionProviding) throws -> Double {
+    func startEngine(deviceUID: String?, on session: any MicEngineSessionProviding) throws -> Double {
         // The one call in here that can block forever (issue #588).
         let hwFormat = try session.hardwareFormat(deviceUID: deviceUID)
         logger.info("Mic hardware format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount)ch")

--- a/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
+++ b/tools/audiotap/Tests/MicCaptureHandlerWedgeTests.swift
@@ -103,7 +103,7 @@ final class MicCaptureHandlerWedgeTests: XCTestCase {
         var remaining = sessions
         // Typed locals, not trailing closures: SwiftFormat restyles a labelled
         // closure argument into a trailing one and mangles the call.
-        let factory: () -> MicEngineSessionProviding = {
+        let factory: () -> any MicEngineSessionProviding = {
             remaining.isEmpty ? WedgingSession() : remaining.removeFirst()
         }
         guard let decideRetry else {

--- a/tools/audiotap/Tests/MicChannelMapTests.swift
+++ b/tools/audiotap/Tests/MicChannelMapTests.swift
@@ -123,12 +123,9 @@ final class MicChannelMapTests: XCTestCase {
 
         let outBuf = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: 1600))
         var error: NSError?
-        var fed = false
+        let feed = FeedOnce(buffer: inBuf)
         converter.convert(to: outBuf, error: &error) { _, status in
-            if fed { status.pointee = .noDataNow; return nil }
-            fed = true
-            status.pointee = .haveData
-            return inBuf
+            feed.next(status)
         }
         if let error { throw error }
 

--- a/tools/audiotap/Tests/MicConverterFactoryTests.swift
+++ b/tools/audiotap/Tests/MicConverterFactoryTests.swift
@@ -59,12 +59,9 @@ final class MicConverterFactoryTests: XCTestCase {
             AVAudioPCMBuffer(pcmFormat: setup.converter.outputFormat, frameCapacity: 1600),
         )
         var error: NSError?
-        var fed = false
+        let feed = FeedOnce(buffer: inBuf)
         setup.converter.convert(to: outBuf, error: &error) { _, status in
-            if fed { status.pointee = .noDataNow; return nil }
-            fed = true
-            status.pointee = .haveData
-            return inBuf
+            feed.next(status)
         }
         XCTAssertNil(error)
 

--- a/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
+++ b/tools/audiotap/Tests/MicEngineSessionSeamTests.swift
@@ -31,7 +31,7 @@ final class MicEngineSessionSeamTests: XCTestCase {
         // built is a broken test either way.
         // swiftlint:disable:next force_unwrapping
         var format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 2)!
-        var hardwareFormatError: Error?
+        var hardwareFormatError: (any Error)?
 
         func hardwareFormat(deviceUID: String?) throws -> AVAudioFormat {
             calls.append(.hardwareFormat(deviceUID: deviceUID))

--- a/tools/audiotap/Tests/MicOutputFileHandoffTests.swift
+++ b/tools/audiotap/Tests/MicOutputFileHandoffTests.swift
@@ -43,7 +43,12 @@ final class MicOutputFileHandoffTests: XCTestCase {
         let fake = Fake()
         let handler = MicCaptureHandler(outputURL: url) { fake }
         try handler.start()
-        let block = try XCTUnwrap(fake.tapBlock, "start() must install the production tap block")
+        // `nonisolated(unsafe)`: a tap block is a bare function value, so the
+        // `@preconcurrency` import does not reach it and the dispatch closure
+        // below cannot capture it otherwise. Deliberately not a lock or a queue:
+        // any real ordering primitive would establish the happens-before edge
+        // this test exists to leave out.
+        nonisolated(unsafe) let block = try XCTUnwrap(fake.tapBlock, "start() must install the production tap block")
 
         let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
         let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256))

--- a/tools/meeting-simulator/Package.swift
+++ b/tools/meeting-simulator/Package.swift
@@ -1,5 +1,15 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
+
+// The same gate the app package runs under. `treatAllWarnings(as:)` is what
+// pins the manifest to tools-version 6.2; it does not exist in 6.0.
+let strictSwiftSettings: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+    .unsafeFlags([
+        "-Xfrontend", "-warn-long-function-bodies=300",
+        "-Xfrontend", "-warn-long-expression-type-checking=300",
+    ]),
+]
 
 let package = Package(
     name: "meeting-simulator",
@@ -14,6 +24,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources",
+            swiftSettings: strictSwiftSettings,
         ),
     ]
 )

--- a/tools/meeting-simulator/Package.swift
+++ b/tools/meeting-simulator/Package.swift
@@ -9,6 +9,7 @@ let strictSwiftSettings: [SwiftSetting] = [
         "-Xfrontend", "-warn-long-function-bodies=300",
         "-Xfrontend", "-warn-long-expression-type-checking=300",
     ]),
+    .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(

--- a/tools/mt-cli/Package.swift
+++ b/tools/mt-cli/Package.swift
@@ -1,5 +1,15 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
+
+// The same gate the app package runs under. `treatAllWarnings(as:)` is what
+// pins the manifest to tools-version 6.2; it does not exist in 6.0.
+let strictSwiftSettings: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+    .unsafeFlags([
+        "-Xfrontend", "-warn-long-function-bodies=300",
+        "-Xfrontend", "-warn-long-expression-type-checking=300",
+    ]),
+]
 
 let package = Package(
     name: "mt-cli",
@@ -14,11 +24,13 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources",
+            swiftSettings: strictSwiftSettings,
         ),
         .testTarget(
             name: "mt-cli-tests",
             dependencies: ["mt-cli"],
             path: "Tests",
+            swiftSettings: strictSwiftSettings,
         ),
     ],
 )

--- a/tools/mt-cli/Package.swift
+++ b/tools/mt-cli/Package.swift
@@ -9,6 +9,7 @@ let strictSwiftSettings: [SwiftSetting] = [
         "-Xfrontend", "-warn-long-function-bodies=300",
         "-Xfrontend", "-warn-long-expression-type-checking=300",
     ]),
+    .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(


### PR DESCRIPTION
The app package fails the build on any compiler warning and requires an explicit `any` for existentials. Its three sibling packages (`tools/audiotap`, `tools/mt-cli`, `tools/meeting-simulator`) never did. This closes that gap.

AudioTapLib is where it matters. It holds the capture-restart machinery, the most lock- and queue-dense code in the repo, and it was the one package whose warnings nobody had to read. Its test target had collected nine concurrency warnings, all of them `AVAudioPCMBuffer` values and tap blocks captured into `@Sendable` closures.

## What changed

- Those nine warnings fixed. The converter tests reuse `FeedOnce`, the single-shot input provider the production resamplers already feed. The handoff test marks its tap block `nonisolated(unsafe)` rather than adding synchronisation of its own, since a lock or a queue would establish the happens-before edge that test exists to leave out.
- All three manifests to tools-version 6.2 with `treatAllWarnings(as: .error)`, the same 300 ms type-check thresholds the app package uses, and `ExistentialAny`.
- Ten `any` annotations, all in AudioTapLib and all syntactic. The two CLI packages needed no code change at all.
- `SWIFT_SUPPRESS_WARNINGS=NO` in the analyze job, for the reason below.

## The one non-obvious part

Xcode passes `-suppress-warnings` to every package it builds as a *dependency*, and that is a hard conflict with `-warnings-as-errors` rather than a precedence question: the driver refuses the pair, so AudioTapLib fails before compiling a line. An `xcodebuild` of the app therefore needs `SWIFT_SUPPRESS_WARNINGS=NO`. The analyze job is the only place in the repo that builds through xcodebuild; the release build and every test lane go through `swift build` / `swift test`, which never pass the flag. The manifest carries the explanation at the flag, because the compiler error names the conflict but not the cause.

Why 6.2 and not 6.3: `treatAllWarnings(as:)` does not exist below 6.2, and 6.3 adds no manifest API we need while raising the minimum toolchain to exactly the version the oldest CI machine runs, leaving no headroom.

## Verification

Local, macOS 26 / Swift 6.3.3 unless noted:

- AudioTapLib: 250 tests green, warning-free build in both the Homebrew and the App Store variant
- mt-cli: 21 tests green; meeting-simulator builds
- App package: 2566 tests green, plus the release-mode parity build
- Pinned SwiftFormat and `swiftlint --strict`: clean across 438 files
- The full analyze path reproduced end to end: `xcodebuild build-for-testing` succeeds and `swiftlint analyze --strict` reports 0 violations across 394 files
- AudioTapLib also builds clean under the gate on Swift 6.3.1, the toolchain the self-hosted lanes run, so the older compiler will not turn the gate red there
