### PR TITLE
Pin the lint toolchain properly: current versions, checksums, and a path back out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,40 +53,19 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v7
-      - name: Install SwiftLint
-        run: brew install swiftlint
-      # SwiftFormat is version-pinned because `brew install` pulls whatever is
-      # current that day, which makes an unrelated PR go red on a tool release
-      # nobody chose. The two rules 0.62.0 turned on by default are switched off
-      # in .swiftformat instead, so the pin can track the current release rather
-      # than freeze at the last one that happened to agree with us. Uses the
-      # official prebuilt CLI binary from the GitHub release (single-file zip).
-      #
-      # The runner image pre-installs a newer SwiftFormat on the Homebrew path,
-      # which precedes /usr/local/bin, so `mv`-ing the pin there is shadowed.
-      # Prepend the pin dir via $GITHUB_PATH (front of PATH for later steps).
-      - name: Install SwiftFormat (pinned)
-        env:
-          SWIFTFORMAT_VERSION: "0.62.1"
+      # Both linters are pinned to an exact release *and* an exact checksum,
+      # rather than installed with `brew install`. Why: scripts/tool-versions.sh.
+      # How: scripts/ci/install-lint-tool.sh. Verification is a separate step
+      # because $GITHUB_PATH only takes effect for *later* steps, so a check in
+      # the install step would assert against the binary the pin replaces.
+      - name: Install pinned lint tools
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/swiftformat.zip" \
-            "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
-          unzip -o -j "$RUNNER_TEMP/swiftformat.zip" -d "$RUNNER_TEMP/swiftformat-bin"
-          chmod +x "$RUNNER_TEMP/swiftformat-bin/swiftformat"
-          xattr -dr com.apple.quarantine "$RUNNER_TEMP/swiftformat-bin/swiftformat" || true
-          echo "$RUNNER_TEMP/swiftformat-bin" >> "$GITHUB_PATH"
-      # Hard-fail loudly if the pin is ever shadowed by a pre-installed
-      # SwiftFormat again, instead of silently reformatting the codebase.
-      - name: Verify SwiftFormat version
-        env:
-          SWIFTFORMAT_VERSION: "0.62.1"
+          bash scripts/ci/install-lint-tool.sh swiftlint
+          bash scripts/ci/install-lint-tool.sh swiftformat
+      - name: Verify pinned lint tools
         run: |
-          got="$(swiftformat --version)"
-          echo "swiftformat resolves to: $(command -v swiftformat) ($got)"
-          if [ "$got" != "$SWIFTFORMAT_VERSION" ]; then
-            echo "::error::Expected pinned SwiftFormat $SWIFTFORMAT_VERSION but got $got (shadowed by a pre-installed binary)."
-            exit 1
-          fi
+          bash scripts/ci/install-lint-tool.sh swiftlint --verify
+          bash scripts/ci/install-lint-tool.sh swiftformat --verify
       # SwiftFormat path list lives in scripts/lint.sh; calling it keeps CI and
       # local lint runs aligned. SwiftLint stays an explicit step to use the
       # github-actions-logging reporter (annotations in the PR diff).
@@ -119,8 +98,10 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v7
-      - name: Install SwiftLint
-        run: brew install swiftlint
+      - name: Install pinned SwiftLint
+        run: bash scripts/ci/install-lint-tool.sh swiftlint
+      - name: Verify pinned SwiftLint
+        run: bash scripts/ci/install-lint-tool.sh swiftlint --verify
       - name: Build & Analyze
         run: |
           # pipefail: without it `xcodebuild ... | tee` masks an xcodebuild

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install SwiftLint
         run: brew install swiftlint
-      # SwiftFormat is version-pinned: `brew install` always pulls the latest,
-      # and 0.62.0 turned on new default rules (wrapIfStatementBodies /
-      # wrapIfExpressionBodies) that would reformat the committed codebase
-      # repo-wide. Pin to the last release whose defaults match the committed
-      # style; bump deliberately alongside a matching reformat. Uses the
+      # SwiftFormat is version-pinned because `brew install` pulls whatever is
+      # current that day, which makes an unrelated PR go red on a tool release
+      # nobody chose. The two rules 0.62.0 turned on by default are switched off
+      # in .swiftformat instead, so the pin can track the current release rather
+      # than freeze at the last one that happened to agree with us. Uses the
       # official prebuilt CLI binary from the GitHub release (single-file zip).
       #
       # The runner image pre-installs a newer SwiftFormat on the Homebrew path,
@@ -67,7 +67,7 @@ jobs:
       # Prepend the pin dir via $GITHUB_PATH (front of PATH for later steps).
       - name: Install SwiftFormat (pinned)
         env:
-          SWIFTFORMAT_VERSION: "0.61.1"
+          SWIFTFORMAT_VERSION: "0.62.1"
         run: |
           curl -fsSL -o "$RUNNER_TEMP/swiftformat.zip" \
             "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
@@ -79,7 +79,7 @@ jobs:
       # SwiftFormat again, instead of silently reformatting the codebase.
       - name: Verify SwiftFormat version
         env:
-          SWIFTFORMAT_VERSION: "0.61.1"
+          SWIFTFORMAT_VERSION: "0.62.1"
         run: |
           got="$(swiftformat --version)"
           echo "swiftformat resolves to: $(command -v swiftformat) ($got)"

--- a/.github/workflows/lint-tool-updates.yml
+++ b/.github/workflows/lint-tool-updates.yml
@@ -1,0 +1,33 @@
+name: Lint tool updates
+
+# A pin without an update path is how the formatter ended up two minors behind
+# every machine that used it. Dependabot cannot watch these versions - they sit
+# in a shell file, not a package manifest - so this asks upstream once a week
+# and opens an issue when a pin falls behind. It never fails the run: a tool
+# release is news, not a broken build.
+
+on:
+  schedule:
+    # Mondays 05:40 UTC. Off the hour because scheduled runs bunch up on it and
+    # get delayed; early enough that the issue is there before the week starts.
+    - cron: "40 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Compare the pins against the latest releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci/check-lint-tool-updates.sh

--- a/.swiftformat
+++ b/.swiftformat
@@ -22,6 +22,12 @@
 # and `private(set)`, so we let SwiftLint handle order validation and keep
 # SwiftFormat focused on whitespace / commas / wrapping.
 --disable modifierOrder
+# On by default since 0.62.0. The committed style keeps a short guard-style
+# body on the `if` line (`if fed { return nil }`), and there are 473 of them,
+# so turning these on is a repo-wide reformat in exchange for nothing.
+# Disabling them is what lets the pin track the current release.
+--disable wrapIfStatementBodies
+--disable wrapIfExpressionBodies
 
 # File scope
 --exclude FluidAudio,.build,app/MeetingTranscriber/.build,tools/audiotap/.build,tools/meeting-simulator/.build

--- a/scripts/ci/check-lint-tool-updates.sh
+++ b/scripts/ci/check-lint-tool-updates.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Compare the pinned lint tools against their latest upstream release and open
+# an issue when one falls behind.
+#
+# Why this exists: pinning removes the surprise-red, but it also removes the
+# only thing that ever moved the version. The formatter pin proved that by
+# sitting at a release nobody ran any more until it caused the exact breakage
+# it was meant to prevent. Dependabot cannot help here - it understands package
+# manifests, and these versions live in a shell file - so the nudge is this.
+#
+# Deliberately opens an issue rather than a PR: bumping is not mechanical. A new
+# release can turn on default rules, which is a judgement call about the
+# codebase, not a version string swap.
+#
+# Usage:
+#   bash scripts/ci/check-lint-tool-updates.sh
+#   bash scripts/ci/check-lint-tool-updates.sh --dry-run   # print, touch nothing
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# shellcheck source=scripts/tool-versions.sh
+source scripts/tool-versions.sh
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+# Explicit target repo: `gh` otherwise infers it from the git remote, which
+# fails the moment this runs anywhere but inside a checkout. CI always sets it.
+#
+# Expanded as `${repo_args[@]+...}` at both use sites, not plain `${repo_args[@]}`:
+# under `set -u` bash 3.2 treats an empty array as unset and aborts, and 3.2 is
+# what macOS still ships as /bin/bash. CI runs bash 5, so the naive form would
+# have worked there and broken only the documented local --dry-run.
+repo_args=()
+[[ -n "${GITHUB_REPOSITORY:-}" ]] && repo_args=(--repo "$GITHUB_REPOSITORY")
+
+check_tool() {
+    local name="$1" repo="$2" pinned="$3"
+
+    local latest
+    latest="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name')"
+    latest="${latest#v}"
+
+    if [[ "$latest" == "$pinned" ]]; then
+        echo "$name: pinned $pinned is current"
+        return 0
+    fi
+
+    echo "$name: pinned $pinned, latest $latest"
+
+    # Fixed title so the dedup key survives further releases: the issue is
+    # "this pin is behind", not "this pin is behind that specific version".
+    local title="Lint tool pin behind upstream: $name"
+    local existing
+    existing="$(gh issue list ${repo_args[@]+"${repo_args[@]}"} --state open --limit 100 --json number,title \
+        --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+    if [[ -n "$existing" ]]; then
+        echo "$name: issue #$existing is already open, leaving it alone"
+        return 0
+    fi
+
+    local body
+    body="$(cat <<EOF
+\`$name\` is pinned to **$pinned**; the latest release is **$latest**.
+
+To bump, in one commit:
+
+1. Edit \`scripts/tool-versions.sh\`: set the version and the new checksum.
+   \`\`\`
+   curl -fsSL -o /tmp/t.zip https://github.com/${repo}/releases/download/${latest}/<asset> && shasum -a 256 /tmp/t.zip
+   \`\`\`
+   The asset name for this tool is in the same file.
+2. Run \`./scripts/lint.sh\` with the new version installed locally and fix, or
+   deliberately disable, whatever the release changed. A new default rule is a
+   judgement call about this codebase, which is why this is an issue and not an
+   automatic pull request.
+3. Land the version, the checksum and any resulting changes together.
+
+Opened automatically by \`.github/workflows/lint-tool-updates.yml\`. Closing it
+without bumping is a fine answer; it will reopen when the next release lands.
+EOF
+)"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "--- would open issue: $title"
+        echo "$body"
+        return 0
+    fi
+
+    gh issue create ${repo_args[@]+"${repo_args[@]}"} --title "$title" --body "$body"
+}
+
+check_tool SwiftFormat "$SWIFTFORMAT_REPO" "$SWIFTFORMAT_VERSION"
+check_tool SwiftLint "$SWIFTLINT_REPO" "$SWIFTLINT_VERSION"

--- a/scripts/ci/install-lint-tool.sh
+++ b/scripts/ci/install-lint-tool.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Install a pinned lint tool on a GitHub Actions runner, or verify that the
+# pinned one is what PATH resolves to.
+#
+# Why pin at all: `brew install` takes whatever is current that day, so a tool
+# release with a new or stricter default rule turns an unrelated PR red, at a
+# moment nobody chose and with a diff that explains nothing.
+#
+# Why a checksum and not just a version: a release tag can be re-pointed and a
+# release asset can be replaced, so the version alone pins the URL rather than
+# the bytes. The runner executes what comes back, so the bytes are the thing to
+# pin. Versions and checksums live in scripts/tool-versions.sh.
+#
+# Usage (two steps, because $GITHUB_PATH only affects *later* steps):
+#   bash scripts/ci/install-lint-tool.sh swiftlint            # fetch + PATH
+#   bash scripts/ci/install-lint-tool.sh swiftlint --verify   # assert PATH
+#
+# .github/workflows/lint-tool-updates.yml watches for newer releases, so the
+# pin gets a nudge instead of quietly ageing.
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# shellcheck source=scripts/tool-versions.sh
+source scripts/tool-versions.sh
+
+tool="${1:-}"
+case "$tool" in
+    swiftformat)
+        version="$SWIFTFORMAT_VERSION"
+        sha256="$SWIFTFORMAT_SHA256"
+        repo="$SWIFTFORMAT_REPO"
+        asset="$SWIFTFORMAT_ASSET"
+        # `swiftformat --version` prints the bare number; `swiftlint version`
+        # does too, but the subcommand spelling differs between the two.
+        version_argv=(--version)
+        ;;
+    swiftlint)
+        version="$SWIFTLINT_VERSION"
+        sha256="$SWIFTLINT_SHA256"
+        repo="$SWIFTLINT_REPO"
+        asset="$SWIFTLINT_ASSET"
+        version_argv=(version)
+        ;;
+    *)
+        echo "usage: $0 <swiftformat|swiftlint> [--verify]" >&2
+        exit 2
+        ;;
+esac
+
+if [[ "${2:-}" == "--verify" ]]; then
+    got="$("$tool" "${version_argv[@]}")"
+    echo "$tool resolves to: $(command -v "$tool") ($got)"
+    if [[ "$got" != "$version" ]]; then
+        echo "::error::Expected pinned $tool $version but got $got (shadowed by a pre-installed binary)."
+        exit 1
+    fi
+    exit 0
+fi
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is unset - this script is meant for CI runners}"
+: "${GITHUB_PATH:?GITHUB_PATH is unset - this script is meant for CI runners}"
+
+bin_dir="$RUNNER_TEMP/$tool-bin"
+archive="$RUNNER_TEMP/$tool.zip"
+curl -fsSL -o "$archive" "https://github.com/${repo}/releases/download/${version}/${asset}"
+
+echo "$sha256  $archive" | shasum -a 256 -c - || {
+    echo "::error::Checksum mismatch for $tool $version. Expected $sha256, got $(shasum -a 256 "$archive" | cut -d' ' -f1)."
+    exit 1
+}
+
+unzip -o -j "$archive" -d "$bin_dir"
+chmod +x "$bin_dir/$tool"
+xattr -dr com.apple.quarantine "$bin_dir/$tool" || true
+
+# Prepend: the runner image ships both tools on the Homebrew path, which
+# precedes /usr/local/bin, so anything less than a PATH entry gets shadowed.
+echo "$bin_dir" >> "$GITHUB_PATH"
+echo "installed pinned $tool $version at $bin_dir"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -30,9 +30,26 @@ case "$MODE" in
     --lint-only)   RUN_FORMAT=false ;;
 esac
 
+# shellcheck source=scripts/tool-versions.sh
+source scripts/tool-versions.sh
+
+# Warn, never fail: CI runs the pinned binaries, this machine runs whatever is
+# installed, and a mismatch means a local pass and a CI pass are two different
+# claims. That is not hypothetical - the formatter pin sat two minors behind
+# the machines using it, so `--fix` here rewrote files the pinned check then
+# rejected. Warning rather than blocking on purpose: an unrelated one-line fix
+# should not be gated on a toolchain upgrade.
+warn_version_drift() {
+    local tool="$1" expected="$2" got="$3"
+    if [[ "$got" != "$expected" ]]; then
+        echo "Warning: local $tool is $got, CI pins $expected. Results can differ; 'brew upgrade $tool' to match." >&2
+    fi
+}
+
 # --- SwiftFormat (formatter) ---
 if [[ "$RUN_FORMAT" == "true" ]]; then
     if command -v swiftformat &>/dev/null; then
+        warn_version_drift swiftformat "$SWIFTFORMAT_VERSION" "$(swiftformat --version || echo unknown)"
         if [[ "$MODE" == "--fix" ]]; then
             echo "Running swiftformat..."
             swiftformat "${SWIFT_DIRS[@]}"
@@ -51,6 +68,7 @@ fi
 # `-warnings-as-errors` for full zero-warning enforcement.
 if [[ "$RUN_LINT" == "true" ]]; then
     if command -v swiftlint &>/dev/null; then
+        warn_version_drift swiftlint "$SWIFTLINT_VERSION" "$(swiftlint version || echo unknown)"
         if [[ "$MODE" == "--fix" ]]; then
             echo "Running swiftlint --fix..."
             swiftlint lint --fix --strict

--- a/scripts/tool-versions.sh
+++ b/scripts/tool-versions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Single source of truth for the pinned lint toolchain.
+#
+# Sourced by scripts/lint.sh (to warn when the local binary disagrees), by
+# scripts/ci/install-lint-tool.sh (to install exactly this), and read by
+# .github/workflows/lint-tool-updates.yml (to notice when a newer release
+# exists). Nothing else should carry a version number for these two tools.
+#
+# The checksum is the point of the pin, not the version. A release tag can be
+# re-pointed and a release asset can be replaced, so a version string alone
+# says which URL to fetch, not what came back. Regenerate both together:
+#
+#   curl -fsSL -o /tmp/t.zip <asset-url> && shasum -a 256 /tmp/t.zip
+#
+# Bumping is a deliberate act: land the new version, its checksum, and whatever
+# the new release wants changed in the same commit.
+
+SWIFTFORMAT_VERSION="0.62.1"
+SWIFTFORMAT_SHA256="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
+SWIFTFORMAT_REPO="nicklockwood/SwiftFormat"
+SWIFTFORMAT_ASSET="swiftformat.zip"
+
+SWIFTLINT_VERSION="0.65.0"
+SWIFTLINT_SHA256="d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
+SWIFTLINT_REPO="realm/SwiftLint"
+SWIFTLINT_ASSET="portable_swiftlint.zip"


### PR DESCRIPTION
Which linter binary decides whether a PR is green, and what happens to that decision over time.

## SwiftFormat was pinned to a version nobody runs

The pin sat at 0.61.1 because 0.62.0 turned `wrapIfStatementBodies` and `wrapIfExpressionBodies` on by default, and adopting them reformats 102 of 439 files for no gain. The committed style deliberately keeps short guard-style bodies on the `if` line, 473 of them.

Freezing the tool was the cheaper answer at the time, but it left dev machines drifting away from CI, and the drift bites in the worst possible way: a local `lint.sh --fix` on a current SwiftFormat rewrites those 102 files, and the pinned CI check then rejects the result, pointing at files nobody touched.

Disabling the two rules in `.swiftformat` costs nothing and lets the pin move to 0.62.1, the current release. Measured across the whole lint path: 0 of 439 files change. Config change and version bump land in one commit on purpose, because 0.61.1 does not know the rule names and exits with `Unknown rule 'wrapIfStatementBodies'`, so an older local binary now fails loudly rather than quietly reformatting.

## SwiftLint was not pinned at all

Both lint jobs ran `brew install swiftlint`, so they used whatever Homebrew shipped that morning. A release with a new or stricter default rule turns an unrelated PR red at a moment nobody chose. That is exactly what SwiftFormat was pinned against; SwiftLint never got the same treatment. The drift was already real: CI resolves to 0.65.0 while a dev machine here has 0.63.3, two minors apart.

Pinned to 0.65.0, the version CI uses right now, so no verdict changes. Measured: 0.65.0 and 0.63.3 each report 0 violations across the tree.

## Pin the bytes, not just the version

A release tag can be re-pointed and a release asset can be replaced, so a version string alone says which URL to fetch, not what came back, and the runner then executes it. Both archives now carry a SHA-256 that is checked before anything is unpacked or put on PATH.

Versions, checksums and asset names live in `scripts/tool-versions.sh`, the only place either number appears. The install logic is one script for both tools rather than inline YAML duplicated across two jobs. Verification stays a separate step because `$GITHUB_PATH` only affects later steps, so a check inside the install step would assert against the very binary the pin replaces.

## A pin needs a way back out

Pinning removes the surprise-red and, with it, the only thing that ever moved the version. The formatter pin is the proof: it sat at a release nobody ran until it caused the breakage it existed to prevent.

Dependabot cannot help. It reads package manifests, and these versions live in a shell file. So a weekly job asks upstream directly and opens an issue when a pin falls behind. An issue rather than a pull request, because a new release can switch on default rules and whether to adopt or disable them is a judgement call about this codebase; the issue carries the recipe, checksum regeneration included. It never fails the run, and the dedup key is a fixed title so a second release while the issue is open does not open a second issue.

## And the local half of the original bug

`scripts/lint.sh` still ran whatever was on PATH, which is how the drift stayed invisible. It now warns, without failing, when the local version differs from the pin. An unrelated one-line change should not be gated on a toolchain upgrade; the confusing part was never the mismatch, it was not knowing there was one.

## Verification

- Install script exercised against a simulated runner for both tools, including both failure paths: a mismatched checksum aborts before anything reaches PATH, and the verify step rejects a shadowing binary (tried against the older local SwiftLint, exit 1 with the intended message)
- Update check exercised against real upstream data in both directions: current pins report clean, a deliberately stale pin renders the issue it would file
- `./scripts/lint.sh`: 0 violations across 439 files, and the new warning fires correctly for SwiftLint and stays silent for SwiftFormat, which already matches the pin
- `actionlint` clean on both workflows; `bash -n` clean on all four scripts

## Note for anyone building locally

After this lands, a local SwiftFormat older than 0.62.0 refuses the config with an unknown-rule error. `brew upgrade swiftformat` is the fix. A SwiftLint mismatch only produces the warning.
