### PR TITLE
Fix the stated Xcode requirement, and stop the icon snapshots failing on every Xcode update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,14 @@
 
 ## Prerequisites
 
-- macOS 14.2+
-- Xcode 16+ (Swift toolchain)
+- macOS 14.2+ to run the app (the audio tap needs it)
+- Xcode 26+ to build it. Every package manifest declares `swift-tools-version: 6.2`, which arrived with Swift 6.2 in Xcode 26; an older Xcode fails on the manifest before it compiles anything.
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (for protocol generation)
+
+If you run `./scripts/lint.sh`, you also need SwiftLint and SwiftFormat 0.62.0 or
+newer; the format config disables rules older versions do not recognise and will
+reject outright. CI pins exact versions, listed in `scripts/tool-versions.sh`, and
+`lint.sh` warns when your local ones differ.
 
 ## Setup
 

--- a/app/MeetingTranscriber/Tests/MenuBarIconSnapshotTests.swift
+++ b/app/MeetingTranscriber/Tests/MenuBarIconSnapshotTests.swift
@@ -8,6 +8,20 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         ProcessInfo.processInfo.environment["CI"] != nil
     }
 
+    /// Byte-exact image comparison tests the rasteriser as much as the icon. An
+    /// Xcode update re-renders every badge identically to the eye and fails all
+    /// 29 references at once, which is exactly what happened between May and
+    /// August and cost half an hour to prove harmless. A perceptual tolerance
+    /// absorbs that.
+    ///
+    /// It is not blind: the smallest genuine difference in this suite is one
+    /// animation frame against its neighbour, and those still fail against each
+    /// other at these values. Anything a person would call a changed badge fails
+    /// by a wide margin.
+    private static let icon = Snapshotting<NSImage, NSImage>.image(
+        precision: 0.99, perceptualPrecision: 0.98,
+    )
+
     override func invokeTest() {
         withSnapshotTesting(record: .missing) {
             super.invokeTest()
@@ -19,7 +33,7 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         let staticBadges: [BadgeKind] = [.inactive, .userAction, .done, .error, .updateAvailable]
         for badge in staticBadges {
             let image = MenuBarIcon.image(badge: badge)
-            assertSnapshot(of: image, as: .image, named: "\(badge)")
+            assertSnapshot(of: image, as: Self.icon, named: "\(badge)")
         }
     }
 
@@ -27,7 +41,7 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         try XCTSkipIf(isCI, "Snapshot tests are machine-dependent")
         for frame in 0 ..< MenuBarIcon.frameCount {
             let image = MenuBarIcon.image(badge: .recording, animationFrame: frame)
-            assertSnapshot(of: image, as: .image, named: "frame\(frame)")
+            assertSnapshot(of: image, as: Self.icon, named: "frame\(frame)")
         }
     }
 
@@ -35,7 +49,7 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         try XCTSkipIf(isCI, "Snapshot tests are machine-dependent")
         for frame in 0 ..< MenuBarIcon.frameCount {
             let image = MenuBarIcon.image(badge: .transcribing, animationFrame: frame)
-            assertSnapshot(of: image, as: .image, named: "frame\(frame)")
+            assertSnapshot(of: image, as: Self.icon, named: "frame\(frame)")
         }
     }
 
@@ -43,7 +57,7 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         try XCTSkipIf(isCI, "Snapshot tests are machine-dependent")
         for frame in 0 ..< MenuBarIcon.frameCount {
             let image = MenuBarIcon.image(badge: .diarizing, animationFrame: frame)
-            assertSnapshot(of: image, as: .image, named: "frame\(frame)")
+            assertSnapshot(of: image, as: Self.icon, named: "frame\(frame)")
         }
     }
 
@@ -51,7 +65,7 @@ final class MenuBarIconSnapshotTests: XCTestCase {
         try XCTSkipIf(isCI, "Snapshot tests are machine-dependent")
         for frame in 0 ..< MenuBarIcon.frameCount {
             let image = MenuBarIcon.image(badge: .processing, animationFrame: frame)
-            assertSnapshot(of: image, as: .image, named: "frame\(frame)")
+            assertSnapshot(of: image, as: Self.icon, named: "frame\(frame)")
         }
     }
 


### PR DESCRIPTION
Two small things that were quietly wrong, unrelated except that both only bite someone working locally.

## CONTRIBUTING asked for an Xcode that cannot build this

The prerequisites named Xcode 16. Every package manifest declares `swift-tools-version: 6.2`, which arrived with Swift 6.2 in Xcode 26, so Xcode 16 fails on the manifest before compiling a line. The line has been wrong since the app package moved to 6.2 and is now wrong four times over, since the three side packages followed.

The lint tooling is named too, because SwiftFormat below 0.62.0 rejects the config outright over rule names it does not know. That is a confusing first run for anyone who takes the file at its word.

## The icon snapshots failed on an Xcode update, and would again

All 29 references mismatched, so a local `swift test` was red in files nobody had touched. These tests skip on CI by design, so nothing upstream ever noticed.

The cause is the renderer, not the icon. The images are indistinguishable to the eye, keep their 36x36 size, and every new rendering is uniformly about 15 percent smaller as a file, which is what a changed anti-aliasing pass looks like rather than a changed drawing. The reference set was recorded on 2 May; Xcode on that machine moved to 26.6 on 28 June.

Worth ruling out first, because `MenuBarIcon.swift` did change six times in between, twice in ways that touch rendering. Neither explains it: those paths draw only with the record-only overlay or the asymmetric-silence tint active, both off in these cases, and a feature change would move some badges rather than all of them by the same proportion, static ones included.

The documented remedy is to re-record the references, and that was the first thing tried. It works and it is also the weaker answer: it rewrites 29 binaries and resets the clock until the next toolchain update repeats the whole exercise. Comparing rendered images byte for byte tests the rasteriser as much as the icon. So this PR changes the comparison instead, and leaves every reference untouched.

## The tolerance was measured in both directions

A tolerance nobody tests against a real change is just a switched-off test, so:

- **It absorbs the drift it exists for.** The references as they stand in the repo, the ones that failed 29 times byte-exact against the current renderer, pass at these values.
- **It still catches a real change.** Replacing one animation frame's reference with its neighbour, the smallest genuine difference anywhere in this suite, produces exactly one failure. A changed badge fails by a far wider margin.

## Verification

`swift test --filter MenuBarIconSnapshotTests` goes from 29 failures to 6 tests, 0 failures, against the unmodified references. The wider suite was not re-run: the only changed files are one test file and a markdown file, and CI skips these tests anyway.
