### PR TITLE
fix(app): refuse a second manual recording instead of abandoning the first

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPickerStartState.swift
+++ b/app/MeetingTranscriber/Sources/AppPickerStartState.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Whether the app picker can start a recording, and if not, why.
+///
+/// A value rather than two booleans in the view because the two blockers are not
+/// interchangeable. A missing selection is visible on screen and needs no words;
+/// a recording already running is invisible from the picker and is the reason a
+/// press would otherwise appear to do nothing. So the recording case outranks the
+/// selection case: picking an app would not help, and saying "pick an app" there
+/// would send the user the wrong way.
+enum AppPickerStartState: Equatable {
+    /// Nothing in the way.
+    case ready
+    /// No app picked yet.
+    case noSelection
+    /// A manual recording owns the watch loop, or is on its way to owning it.
+    /// Starting a second one used to abandon the first: its audio was never
+    /// enqueued while its recorder kept capturing, retained by its own monitor
+    /// task (issue #624).
+    case manualRecordingActive
+
+    /// - Parameter startWouldBeRefused: `WatchingController.isManualRecording`,
+    ///   the *wide* predicate. The picker asks whether a start would be refused,
+    ///   and it is refused in both halves: while a manual start is still in
+    ///   flight, and once its loop exists. The loop-only predicate is the menu
+    ///   bar's different question, "is there a recording I can stop".
+    ///
+    ///   Both halves are reachable, because the menu gates *opening* this
+    ///   window, not its persistence. It closes only on its own Start or Cancel,
+    ///   so a picker opened during an in-flight start is still there once the
+    ///   loop exists, and re-renders through both states. Getting this wrong in
+    ///   either direction is silent: the loop-only predicate leaves a lingering
+    ///   picker offering Start during a live recording, where the press is
+    ///   refused and the window closes as if it had worked.
+    static func resolve(hasSelection: Bool, startWouldBeRefused: Bool) -> Self {
+        if startWouldBeRefused { return .manualRecordingActive }
+        return hasSelection ? .ready : .noSelection
+    }
+
+    var allowsStart: Bool {
+        self == .ready
+    }
+
+    /// What to tell the user, or nil when the state speaks for itself.
+    var explanation: String? {
+        switch self {
+        case .ready, .noSelection:
+            nil
+
+        case .manualRecordingActive:
+            "Another recording is already starting or under way. The menu bar shows it once it is running."
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/AppPickerView.swift
+++ b/app/MeetingTranscriber/Sources/AppPickerView.swift
@@ -38,6 +38,11 @@ struct SystemRunningAppsProvider: RunningAppsProvider {
 @MainActor
 struct AppPickerView: View {
     let appsProvider: any RunningAppsProvider
+    /// Whether a manual start would be refused right now. Pass the controller's
+    /// wide predicate, not `AppState.isManualRecording`; see
+    /// `AppPickerStartState.resolve`. Deliberately has no default: a default
+    /// would let the wiring at the call site be deleted with every test green.
+    let startWouldBeRefused: Bool
     let onStartRecording: (pid_t, String, String) -> Void
     let onCancel: () -> Void
 
@@ -46,13 +51,21 @@ struct AppPickerView: View {
     @State private var meetingTitle: String = ""
 
     init(
-        appsProvider: any RunningAppsProvider = SystemRunningAppsProvider(),
+        appsProvider: any RunningAppsProvider,
+        startWouldBeRefused: Bool,
         onStartRecording: @escaping (pid_t, String, String) -> Void,
         onCancel: @escaping () -> Void,
     ) {
         self.appsProvider = appsProvider
+        self.startWouldBeRefused = startWouldBeRefused
         self.onStartRecording = onStartRecording
         self.onCancel = onCancel
+    }
+
+    /// Bound in one place rather than inline in `body`, which keeps the button's
+    /// two modifiers cheap to type-check.
+    private var startState: AppPickerStartState {
+        .resolve(hasSelection: selectedApp != nil, startWouldBeRefused: startWouldBeRefused)
     }
 
     var body: some View {
@@ -103,6 +116,12 @@ struct AppPickerView: View {
                 TextField("Meeting title (optional)", text: $meetingTitle)
                     .textFieldStyle(.roundedBorder)
 
+                if let explanation = startState.explanation {
+                    Text(explanation)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
                 HStack {
                     Button("Cancel") {
                         onCancel()
@@ -117,7 +136,7 @@ struct AppPickerView: View {
                         onStartRecording(app.id, app.name, title)
                     }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(selectedApp == nil)
+                    .disabled(!startState.allowsStart)
                 }
             }
             .padding()

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -230,6 +230,13 @@ struct MeetingTranscriberApp: App {
 
         Window("Record App", id: "record-app") {
             AppPickerView(
+                appsProvider: SystemRunningAppsProvider(),
+                // The controller's wide predicate, not `appState.isManualRecording`.
+                // That one is loop-only for the menu bar's Stop item and reads
+                // false for the whole in-flight window. This window outlives the
+                // menu item that opened it — it closes only on its own Start or
+                // Cancel — so it has to stay truthful across both halves.
+                startWouldBeRefused: appState.watching.isManualRecording,
                 onStartRecording: { pid, appName, title in
                     appState.watching.startManualRecording(pid: pid, appName: appName, title: title)
                     closeWindow(id: "record-app")

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -390,6 +390,13 @@ final class WatchingController {
         // replaces the field while the first is still in flight, whose `defer`
         // then clears the second's registration and reopens the window.
         guard manualStartTask == nil else { return }
+        // Refuse while one is already recording. Without this the assignment
+        // below replaces `watchLoop` without stopping the live loop, so its
+        // recording is never enqueued while its recorder keeps capturing,
+        // retained by its own monitor task and reachable by nothing (#624).
+        // The picker disables Start for the same reason, but it cannot be the
+        // enforcement: a recording can begin between opening it and pressing.
+        guard watchLoop?.isManualRecording != true else { return }
         manualStartTask = Task { @MainActor in
             defer { manualStartTask = nil }
             await performManualRecording(pid: pid, appName: appName, title: title)

--- a/app/MeetingTranscriber/Tests/AppPickerStartStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPickerStartStateTests.swift
@@ -1,0 +1,54 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The picker's start decision, exercised as a value so the view test can stay a
+/// single wiring assertion.
+final class AppPickerStartStateTests: XCTestCase {
+    func testReadyOnlyWithASelectionAndNoRecording() {
+        XCTAssertEqual(
+            AppPickerStartState.resolve(hasSelection: true, startWouldBeRefused: false),
+            .ready,
+        )
+    }
+
+    func testNoSelectionBlocks() {
+        XCTAssertEqual(
+            AppPickerStartState.resolve(hasSelection: false, startWouldBeRefused: false),
+            .noSelection,
+        )
+    }
+
+    /// True for both halves of the controller's predicate: a start still in
+    /// flight and a loop already recording. Both are reachable, because the menu
+    /// gates opening this window, not its persistence.
+    func testARefusedStartBlocks() {
+        XCTAssertEqual(
+            AppPickerStartState.resolve(hasSelection: true, startWouldBeRefused: true),
+            .manualRecordingActive,
+        )
+    }
+
+    /// Precedence, not an accident: with both blockers present, telling the user
+    /// to pick an app would send them the wrong way, since picking one changes
+    /// nothing while a recording owns the loop.
+    func testARefusedStartOutranksAMissingSelection() {
+        XCTAssertEqual(
+            AppPickerStartState.resolve(hasSelection: false, startWouldBeRefused: true),
+            .manualRecordingActive,
+        )
+    }
+
+    func testOnlyReadyAllowsStart() {
+        XCTAssertTrue(AppPickerStartState.ready.allowsStart)
+        XCTAssertFalse(AppPickerStartState.noSelection.allowsStart)
+        XCTAssertFalse(AppPickerStartState.manualRecordingActive.allowsStart)
+    }
+
+    /// A missing selection is visible on screen; a recording running behind the
+    /// picker is not, so that is the only case that gets words.
+    func testOnlyTheRecordingCaseExplainsItself() {
+        XCTAssertNil(AppPickerStartState.ready.explanation)
+        XCTAssertNil(AppPickerStartState.noSelection.explanation)
+        XCTAssertNotNil(AppPickerStartState.manualRecordingActive.explanation)
+    }
+}

--- a/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPickerViewTests.swift
@@ -22,6 +22,7 @@ final class AppPickerViewTests: XCTestCase {
     func testStartButtonExists() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -32,6 +33,7 @@ final class AppPickerViewTests: XCTestCase {
     func testStartButtonDisabledWithoutSelection() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -40,9 +42,32 @@ final class AppPickerViewTests: XCTestCase {
         XCTAssertTrue(button.isDisabled())
     }
 
+    /// Wiring only: the decision itself is covered in `AppPickerStartStateTests`.
+    ///
+    /// Asserts the explanation rather than `isDisabled()` on purpose. Nothing is
+    /// selected here, so the button is disabled either way and that assertion
+    /// would pass even with the state unwired: measured, it does. The text is the
+    /// one signal that only appears when `startWouldBeRefused` actually
+    /// reaches the view. `allowsStart` is covered as a value one layer down, and
+    /// the loss itself is prevented by the guard in `WatchingController`, not
+    /// here, so an unpinned `.disabled` costs a bad press and not a recording.
+    func testStartButtonExplainsARefusedStart() throws {
+        let sut = AppPickerView(
+            appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: true,
+            onStartRecording: { _, _, _ in },
+            onCancel: {},
+        )
+        let body = try sut.inspect()
+        XCTAssertNoThrow(
+            try body.find(text: "Another recording is already starting or under way. The menu bar shows it once it is running."),
+        )
+    }
+
     func testCancelButtonExists() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -54,6 +79,7 @@ final class AppPickerViewTests: XCTestCase {
         var called = false
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: { called = true },
         )
@@ -67,6 +93,7 @@ final class AppPickerViewTests: XCTestCase {
     func testHeaderShown() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -79,6 +106,7 @@ final class AppPickerViewTests: XCTestCase {
     func testMeetingTitlePlaceholderExists() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -92,6 +120,7 @@ final class AppPickerViewTests: XCTestCase {
     func testRefreshButtonExists() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: testApps),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )
@@ -106,6 +135,7 @@ final class AppPickerViewTests: XCTestCase {
     func testEmptyAppListStillShowsButtons() throws {
         let sut = AppPickerView(
             appsProvider: MockAppsProvider(apps: []),
+            startWouldBeRefused: false,
             onStartRecording: { _, _, _ in },
             onCancel: {},
         )

--- a/app/MeetingTranscriber/Tests/CallCounter.swift
+++ b/app/MeetingTranscriber/Tests/CallCounter.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Counts calls to an injected seam, so a test can order two paths that share
+/// one closure by giving each call a distinct index.
+actor CallCounter {
+    private var count = 0
+
+    func next() -> Int {
+        defer { count += 1 }
+        return count
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
@@ -1,0 +1,53 @@
+import Foundation
+@testable import MeetingTranscriber
+
+/// Builds a `WatchingController` wired to real (but inert) sibling controllers
+/// and the supplied seams. The pipeline gets a queue on an isolated `logDir` so
+/// `rebuild()` touches no production path, and the default detector never
+/// matches a window so no recording starts.
+///
+/// Its own file because `WatchingControllerTests` sits at the 600-line cap, and
+/// because a second suite now needs the same wiring.
+@MainActor
+enum WatchingControllerFactory {
+    static func make(
+        logDir: URL,
+        ensureMicAccess: @escaping () async -> Bool = { true },
+        requestScreenRecording: @escaping () -> Void = {},
+        requestAccessibility: @escaping () -> Void = {},
+        watchTeams: Bool = true,
+        startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
+        makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
+    ) -> WatchingController {
+        let settings = AppSettings()
+        settings.watchTeams = watchTeams
+        let notifier = RecordingNotifier()
+        let pipeline = PipelineController(settings: settings, notifier: notifier)
+        pipeline.queue = PipelineQueue(logDir: logDir)
+        let channelHealth = ChannelHealthController(
+            notifier: notifier,
+            debounceSeconds: { 0 },
+            indicatorEnabled: { false },
+        )
+        let permissions = PermissionsController(notifier: notifier)
+        let liveTranscription = LiveTranscriptionCoordinator(
+            captions: LiveCaptionsState(),
+            liveEnabled: { false },
+            engineSupportsLive: { false },
+            verboseDiagnostics: { false },
+        )
+        return WatchingController(
+            settings: settings,
+            notifier: notifier,
+            pipeline: pipeline,
+            channelHealth: channelHealth,
+            permissions: permissions,
+            liveTranscription: liveTranscription,
+            ensureMicAccess: ensureMicAccess,
+            requestScreenRecording: requestScreenRecording,
+            requestAccessibility: requestAccessibility,
+            startJoinTimeout: startJoinTimeout,
+            makeDetector: makeDetector,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
@@ -1,0 +1,71 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Manual-recording ownership rules for `WatchingController`, in their own file
+/// because `WatchingControllerTests` sits at the 600-line cap.
+@MainActor
+final class WatchingControllerManualRecordingTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "WatchingControllerManualRecordingTests")
+    }
+
+    override func tearDown() async throws {
+        if let tmpDir { try? FileManager.default.removeItem(at: tmpDir) }
+        try await super.tearDown()
+    }
+
+    /// Issue #624: a second manual start while one is already recording used to
+    /// overwrite `watchLoop` without stopping the live loop, so its audio was
+    /// never enqueued while its recorder kept capturing, retained by its own
+    /// monitor task and unreachable. The refusal is what prevents the loss; the
+    /// picker is only what explains it.
+    func testSecondManualStartIsRefusedWhileOneIsRecording() async throws {
+        let micGate = AsyncGate()
+        // swiftlint:disable:next trailing_closure
+        let controller = WatchingControllerFactory.make(logDir: tmpDir, ensureMicAccess: {
+            await micGate.wait()
+            return true
+        })
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        addTeardownBlock {
+            await micGate.open()
+            await loop.stop()
+        }
+
+        controller.startManualRecording(pid: 1234, appName: "Safari", title: "Second")
+
+        // Proving a negative needs a window: a start that was *not* refused
+        // reaches the injected mic gate within a few main-actor hops and parks
+        // there.
+        await waitFor({ await micGate.hasWaiter }, timeout: .milliseconds(300))
+        let reachedTheMicGate = await micGate.hasWaiter
+
+        XCTAssertFalse(reachedTheMicGate, "a second manual start must not run while one is recording")
+        XCTAssertIdentical(controller.watchLoop, loop, "the live recording's loop must still be the owner")
+
+        // Control case, in the same test and on the same machine: without it,
+        // "never reached the gate" is also what a merely slow main actor looks
+        // like, and the assertion above would hold against a broken guard. The
+        // loop stops itself the way `monitorManualRecording` does when the pid
+        // exits, which clears `manualRecordingInfo` but leaves the controller's
+        // reference in place, so this also pins that the refusal keys on
+        // `isManualRecording` and not on `watchLoop != nil`.
+        loop.stopManualRecording()
+        XCTAssertFalse(loop.isManualRecording, "precondition for the control case")
+
+        controller.startManualRecording(pid: 1234, appName: "Safari", title: "Third")
+        await waitFor { await micGate.hasWaiter }
+
+        let allowedAfterTheRecordingEnded = await micGate.hasWaiter
+        XCTAssertTrue(
+            allowedAfterTheRecordingEnded,
+            "a start must be allowed once the recording ended, even though the controller still holds that loop",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -34,33 +34,12 @@ final class WatchingControllerTests: XCTestCase {
         startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
     ) -> WatchingController {
-        let settings = AppSettings()
-        settings.watchTeams = watchTeams
-        let notifier = RecordingNotifier()
-        let pipeline = PipelineController(settings: settings, notifier: notifier)
-        pipeline.queue = PipelineQueue(logDir: tmpDir)
-        let channelHealth = ChannelHealthController(
-            notifier: notifier,
-            debounceSeconds: { 0 },
-            indicatorEnabled: { false },
-        )
-        let permissions = PermissionsController(notifier: notifier)
-        let liveTranscription = LiveTranscriptionCoordinator(
-            captions: LiveCaptionsState(),
-            liveEnabled: { false },
-            engineSupportsLive: { false },
-            verboseDiagnostics: { false },
-        )
-        return WatchingController(
-            settings: settings,
-            notifier: notifier,
-            pipeline: pipeline,
-            channelHealth: channelHealth,
-            permissions: permissions,
-            liveTranscription: liveTranscription,
+        WatchingControllerFactory.make(
+            logDir: tmpDir,
             ensureMicAccess: ensureMicAccess,
             requestScreenRecording: requestScreenRecording,
             requestAccessibility: requestAccessibility,
+            watchTeams: watchTeams,
             startJoinTimeout: startJoinTimeout,
             makeDetector: makeDetector,
         )
@@ -583,13 +562,4 @@ final class WatchingControllerTests: XCTestCase {
 @MainActor
 private final class ControllerBox {
     var controller: WatchingController?
-}
-
-private actor CallCounter {
-    private var count = 0
-
-    func next() -> Int {
-        defer { count += 1 }
-        return count
-    }
 }


### PR DESCRIPTION
Fixes #624.

Starting a second manual recording abandoned the first: its audio was never enqueued, no protocol was produced, and its recorder kept capturing in the background with nothing able to stop it.

## What was wrong

`performManualRecording` deliberately stops only an *auto* loop before taking ownership, so a live manual loop failed the `!loop.isManualRecording` check and survived, and the assignment below then overwrote the controller's reference to it. `stopManualRecording()` never ran on it, so its recording never reached the pipeline.

It did not get collected either. The loop is retained by its own monitor task, whose `guard let self` upgrades the weak capture for the lifetime of `monitorManualRecording`, so it and its `DualSourceRecorder` stayed alive and kept capturing until the watched pid exited or the four-hour cap. Nothing outside could reach it to cancel, because the controller had just dropped its only reference.

## What changed

**The refusal is in the controller**, not only in the UI. That is the path that actually prevents the loss, and it is the only one that covers a recording starting between opening the picker and pressing Start.

**The picker says why.** Without that the refusal is silent: Start is offered, the press does nothing, and the window closes as if it had worked.

The picker is passed the controller's **wide** predicate, not `AppState.isManualRecording`. It asks whether a start would be refused, and it is refused in both halves: while a manual start is still in flight, and once its loop exists. `AppState.isManualRecording` stays loop-only because the menu bar's Stop item asks a different question, whether a recording exists that can be stopped.

That distinction is load-bearing, and I had it backwards in the first version of this branch. It is worth spelling out, because it also corrects the reachability claim in #624:

- Once a manual loop exists, the menu replaces **Record App…** with **Stop Recording** (`MenuBarView.swift:107`), so no *new* picker can be opened in that state.
- During the in-flight window the menu does still offer Record App, because no loop exists yet and `currentStatus` is nil (`AppState.swift:530`).

The menu gates opening the window, not its persistence. The picker closes only on its own Start or Cancel, so one opened during an in-flight start is still on screen once that start's loop exists, and re-renders through both states because `WatchingController` is `@Observable` and the scene reads it. Both halves of the predicate are therefore live, which is why the wide one is required.

That also settles what happens without this half: a lingering picker would offer Start during a live recording, the press would be refused by the guard, and the window would close as if it had worked. That is the complaint in #624 reproduced in the UI layer with the audio loss removed.

Hence `startWouldBeRefused` is named for the question rather than for a state: both predicates are `Bool`, the compiler cannot tell them apart, and the call site is the one link no test covers. It has no default, and `appsProvider` loses the one it had, because a default would let that wiring be deleted with every test still green.

## Verification

The controller guard is proven against two mutations, because one was not enough. Deleting the guard reddens `testSecondManualStartIsRefusedWhileOneIsRecording` at its negative assertion. Replacing it with the tempting `guard watchLoop == nil` reddens a *different* assertion in the same test, and that mutation is the one worth catching: the monitor stops a recording whose pid exited by calling the loop's own stop, which clears `manualRecordingInfo` but leaves the controller holding that loop, so keying on the reference instead of on `isManualRecording` would refuse every later manual recording, permanently.

The test also carries a control case, for the reason a negative assertion always needs one: "the second start never reached the gate" is equally what a merely slow main actor looks like. So it lets the loop stop itself and starts again, same machine, same run, and requires that one to reach the gate. Without it the negative would hold against a broken guard under load.

Two honest limitations, both also in the code comments:

- The view test asserts the explanation text rather than `isDisabled()`. Nothing is selected there, so the button is disabled either way and that assertion passes even with the state unwired. I measured that before trusting it. The text is the one signal that only appears when the flag actually reaches the view, and `allowsStart` is covered as a value one layer down.
- Nothing covers which predicate the call site passes. That is the gap that produced the mistake above, and it is not cheaply testable: it needs an `AppState` whose manual start can be parked, which is the construction seam this repo has so far declined to add. The parameter name is the mitigation, not a substitute for a test.

Gates: `swift test --parallel` green across 2620 tests, `./scripts/lint.sh` clean at 0 violations in 446 files, `./scripts/pre-push.sh` release parity passed. The app was built, re-signed with the Developer ID and launched from this branch to confirm it starts with permissions healthy.

Not covered by any automated layer, and left as manual QA per the repo's own rule: that Start actually stays disabled with an app selected. The picker window is deliberately off both the `/screenshot` and `/ui/tree` allowlists because it lists the user's running apps, and there is no action that opens it, so driving it would mean widening that surface plus adding a way to press a dynamic list row.

Attempting it by hand is also awkward for a reason worth recording: the in-flight window is sub-second once the microphone is granted, and the way to lengthen it is an unanswered permission prompt, which then owns the focus, so `bringWindowToFront` cannot raise the picker above it. The window does open, just behind the alert, and shows the explanation once the alert goes away. Delayed, not absent.

## Note on the first commit

`WatchingControllerTests.swift` sat at 595 of its 600-line cap, so it refused any new case. The controller factory and `CallCounter` are not specific to that suite and a second suite now needs them, so both move to their own files behind a thin delegator. Pure move, no behaviour change, and the suite drops to 566 lines so the next author is not back at the cap immediately. Same remedy the recent `AsyncGate` extraction used.
