### PR TITLE
fix(app): observe output-folder changes in settings

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings+OutputDirectory.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+OutputDirectory.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Everything derived from `customOutputDirBookmark`. The bookmark itself has to
+/// stay a stored property on the class so `@Observable` can track it; the rest
+/// lives here to keep `AppSettings.swift` under its `file_length` budget.
+extension AppSettings {
+    /// Resolved URL from the security-scoped bookmark, or nil when none is set
+    /// or the bookmark no longer resolves. Read-only: security-scoped *access*
+    /// is the caller's job — every call site does its own paired
+    /// `startAccessingSecurityScopedResource()` / `stopAccessing…`.
+    ///
+    /// A stale bookmark still resolves, so this deliberately does not repair it.
+    /// `body` reads this through `effectiveOutputDir`, and repairing here would
+    /// write to observed state from inside a view update. `repairStaleCustomOutputDirBookmark()`
+    /// does that once at launch instead.
+    var customOutputDir: URL? {
+        var isStale = false
+        return resolveCustomOutputDir(isStale: &isStale)
+    }
+
+    /// The effective output directory: custom choice or ~/Downloads/MeetingTranscriber/.
+    var effectiveOutputDir: URL {
+        customOutputDir ?? AppPaths.downloadsProtocolsDir
+    }
+
+    /// Store a user-selected directory as a security-scoped bookmark.
+    func setCustomOutputDir(_ url: URL) {
+        guard let data = makeBookmark(for: url) else { return }
+        customOutputDirBookmark = data
+    }
+
+    /// Clear the custom output directory, reverting to the default.
+    func clearCustomOutputDir() {
+        customOutputDirBookmark = nil
+    }
+
+    /// Re-create the bookmark when macOS reports it stale (the folder moved or
+    /// was renamed). Call once at launch, off the view-update path — see the note
+    /// on `customOutputDir`. No-op when no bookmark is set or it still resolves.
+    func repairStaleCustomOutputDirBookmark() {
+        var isStale = false
+        guard let url = resolveCustomOutputDir(isStale: &isStale), isStale,
+              let refreshed = makeBookmark(for: url)
+        else { return }
+        customOutputDirBookmark = refreshed
+    }
+
+    // MARK: - Helpers
+
+    private func resolveCustomOutputDir(isStale: inout Bool) -> URL? {
+        guard let data = customOutputDirBookmark else { return nil }
+        return try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale,
+        )
+    }
+
+    private func makeBookmark(for url: URL) -> Data? {
+        try? url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -409,53 +409,10 @@ final class AppSettings {
 
     // MARK: - Output Directory
 
-    /// Security-scoped bookmark for a user-chosen output directory.
+    /// Security-scoped output-dir bookmark. Stored so `@Observable` can track it.
+    /// Everything derived from it lives in `AppSettings+OutputDirectory.swift`.
     var customOutputDirBookmark: Data? {
-        get { defaults.data(forKey: "customOutputDirBookmark") }
-        set { defaults.set(newValue, forKey: "customOutputDirBookmark") }
-    }
-
-    /// Resolved URL from the security-scoped bookmark. Calls `startAccessingSecurityScopedResource()`.
-    var customOutputDir: URL? {
-        guard let data = customOutputDirBookmark else { return nil }
-        var isStale = false
-        guard let url = try? URL(
-            resolvingBookmarkData: data,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale,
-        ) else { return nil }
-        if isStale {
-            // Re-create bookmark from resolved URL
-            if let newData = try? url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil,
-            ) {
-                customOutputDirBookmark = newData
-            }
-        }
-        return url
-    }
-
-    /// Store a user-selected directory as a security-scoped bookmark.
-    func setCustomOutputDir(_ url: URL) {
-        guard let data = try? url.bookmarkData(
-            options: .withSecurityScope,
-            includingResourceValuesForKeys: nil,
-            relativeTo: nil,
-        ) else { return }
-        customOutputDirBookmark = data
-    }
-
-    /// Clear the custom output directory, reverting to the default.
-    func clearCustomOutputDir() {
-        customOutputDirBookmark = nil
-    }
-
-    /// The effective output directory: custom choice or ~/Downloads/MeetingTranscriber/.
-    var effectiveOutputDir: URL {
-        customOutputDir ?? AppPaths.downloadsProtocolsDir
+        didSet { defaults.set(customOutputDirBookmark, forKey: "customOutputDirBookmark") }
     }
 
     // MARK: - Diagnostics
@@ -547,6 +504,7 @@ final class AppSettings {
         openAIEndpoint = defaults.object(forKey: "openAIEndpoint") as? String
             ?? Self.defaultOpenAIEndpoint
         openAIModel = defaults.object(forKey: "openAIModel") as? String ?? "llama3.1"
+        customOutputDirBookmark = defaults.data(forKey: "customOutputDirBookmark")
 
         // Migrate legacy "audioDebugLogging" key (renamed to "verboseDiagnostics" 2026-05-04).
         // New key wins if both are set; legacy value seeds the new key on first launch.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -195,7 +195,12 @@ final class AppState {
         // This is the only production construction of `AppSettings` — tests
         // inject their own, so none of them touch the real domains.
         LegacyDefaultsMigration.run(into: .standard)
-        return AppSettings()
+        let settings = AppSettings()
+        // Once, here, rather than from `customOutputDir` — that getter is read
+        // during view updates, and repairing there would write observed state
+        // mid-`body`.
+        settings.repairStaleCustomOutputDirBookmark()
+        return settings
     }
 
     private static func makeUpdateChecker() -> UpdateChecker {

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -152,6 +152,102 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(defaults.double(forKey: "pollInterval"), 1.0)
     }
 
+    // MARK: - Output Directory (issue #626)
+
+    /// The Settings UI derives the folder it shows from `effectiveOutputDir`.
+    /// While `customOutputDirBookmark` was a computed passthrough to
+    /// `UserDefaults`, `@Observable` had no stored property to track, so
+    /// choosing a new folder never invalidated the view and the label kept
+    /// showing the previous path until the app was relaunched.
+    func testCustomOutputDirBookmarkNotifiesObservers() throws {
+        let dir = try makeTempDirectory(prefix: "AppSettingsOutputDir")
+        let changed = expectation(description: "effectiveOutputDir observers notified")
+        withObservationTracking {
+            _ = settings.effectiveOutputDir
+        } onChange: {
+            changed.fulfill()
+        }
+
+        settings.setCustomOutputDir(dir)
+
+        wait(for: [changed], timeout: 1.0)
+        // The notification is only half of it: assert the derived value the UI
+        // actually renders followed too. A plain `dir.bookmarkData()` would not
+        // resolve under `.withSecurityScope`, leaving this on the default path
+        // and the test green either way — hence the real API.
+        XCTAssertEqual(
+            settings.effectiveOutputDir.resolvingSymlinksInPath().path,
+            dir.resolvingSymlinksInPath().path,
+        )
+    }
+
+    /// The counterpart: reading the derived value must not write to the observed
+    /// bookmark. `body` reads `effectiveOutputDir`, so a mutation on this path
+    /// would invalidate the view during its own update.
+    func testReadingEffectiveOutputDirDoesNotMutateTheBookmark() throws {
+        let dir = try makeTempDirectory(prefix: "AppSettingsOutputDir")
+        settings.setCustomOutputDir(dir)
+        let bookmark = try XCTUnwrap(settings.customOutputDirBookmark)
+
+        withObservationTracking {
+            _ = settings.effectiveOutputDir
+        } onChange: {
+            XCTFail("reading effectiveOutputDir must not mutate observed state")
+        }
+        _ = settings.effectiveOutputDir
+
+        XCTAssertEqual(settings.customOutputDirBookmark, bookmark)
+    }
+
+    /// Repair is a no-op while the bookmark still resolves. The stale branch
+    /// itself needs a folder moved out from under a live bookmark, which isn't
+    /// reproducible in-process — it stays covered by the launch call site only.
+    func testRepairLeavesAResolvableBookmarkAlone() throws {
+        let dir = try makeTempDirectory(prefix: "AppSettingsOutputDir")
+        settings.setCustomOutputDir(dir)
+        let bookmark = try XCTUnwrap(settings.customOutputDirBookmark)
+
+        settings.repairStaleCustomOutputDirBookmark()
+
+        XCTAssertEqual(settings.customOutputDirBookmark, bookmark)
+    }
+
+    func testClearCustomOutputDirNotifiesObservers() throws {
+        let dir = try makeTempDirectory(prefix: "AppSettingsOutputDir")
+        settings.setCustomOutputDir(dir)
+
+        let changed = expectation(description: "reset notifies observers")
+        withObservationTracking {
+            _ = settings.effectiveOutputDir
+        } onChange: {
+            changed.fulfill()
+        }
+
+        settings.clearCustomOutputDir()
+
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertEqual(settings.effectiveOutputDir, AppPaths.downloadsProtocolsDir)
+    }
+
+    /// Guards the other half of the move to a stored property: the bookmark
+    /// must still round-trip through `UserDefaults` across launches.
+    func testCustomOutputDirBookmarkPersistsAcrossInstances() throws {
+        let dir = try makeTempDirectory(prefix: "AppSettingsOutputDir")
+        settings.setCustomOutputDir(dir)
+        let bookmark = try XCTUnwrap(settings.customOutputDirBookmark)
+        XCTAssertEqual(defaults.data(forKey: "customOutputDirBookmark"), bookmark)
+
+        let reloaded = AppSettings(defaults: defaults, apiKeyAccount: apiKeyAccount)
+        XCTAssertEqual(reloaded.customOutputDirBookmark, bookmark)
+        XCTAssertEqual(
+            reloaded.effectiveOutputDir.resolvingSymlinksInPath().path,
+            dir.resolvingSymlinksInPath().path,
+        )
+
+        reloaded.clearCustomOutputDir()
+        XCTAssertNil(defaults.data(forKey: "customOutputDirBookmark"))
+    }
+
     // MARK: - watchApps
 
     func testWatchAppsAllEnabled() {


### PR DESCRIPTION
Fixes #626.

## What

Choosing a new output folder in Settings persisted correctly, but the label kept showing the previous path until the app was relaunched.

## Why

`AppSettings` is `@Observable`, and every other setting in it is a stored property that writes through in `didSet`:

```swift
var openAIModel: String {
    didSet { defaults.set(openAIModel, forKey: "openAIModel") }
}
```

`customOutputDirBookmark` was the one exception — a computed passthrough straight to `UserDefaults`:

```swift
var customOutputDirBookmark: Data? {
    get { defaults.data(forKey: "customOutputDirBookmark") }
    set { defaults.set(newValue, forKey: "customOutputDirBookmark") }
}
```

With no stored property behind it, `@Observable` has nothing to register access or mutation against, so `OutputSettingsView` — whose label derives from `settings.effectiveOutputDir` → `customOutputDir` → `customOutputDirBookmark` — was never invalidated. A relaunch re-evaluates `body` from scratch and picks up the new value, which matches the reported behaviour exactly.

Only the display was affected: I confirmed on my own install that the pipeline wrote recordings and protocols to the newly picked directory while Settings still showed the old one.

## How

- Back the bookmark with a stored property persisted via `didSet`, seeded from `defaults` in `init` — the pattern the rest of the file already uses.
- Guard the stale-bookmark repair inside `customOutputDir` with a conditional reassignment. That write happens in a *getter*; harmless while it only touched `UserDefaults`, but now that the property is observed, an unconditional write would invalidate a view during its own `body` evaluation. Same reasoning as the existing note on `asymmetricSilenceWarningSeconds`.

## Tests

Three added to `AppSettingsTests`:

- `testCustomOutputDirBookmarkNotifiesObservers` — `withObservationTracking` over `effectiveOutputDir` must fire when the bookmark changes.
- `testClearCustomOutputDirNotifiesObservers` — same for the Reset button path.
- `testCustomOutputDirBookmarkPersistsAcrossInstances` — guards the other half of the move: the bookmark must still round-trip through `UserDefaults` across launches, and clearing must remove the key.

The observation tests use a plain (non-security-scoped) bookmark: creating a scoped one needs an entitlement the test binary doesn't carry, and the behaviour under test is independent of the bookmark flavour. This mirrors what `RPCSettingsStateTests` already does.

Verified the tests actually gate the fix — with the `AppSettings` change stashed, both observation tests fail while the persistence test stays green.

## Verification

- `swift test --filter AppSettingsTests` → 56/56 pass.
- Full `swift test`: 17 failures, but the same 17 occur on an unmodified `main` in this environment (`SettingsViewTests`, `GeneralSettings*`, `MouseInjectionTests`, `…WithoutAnApplication`, etc. — UI tests that need an app host). Diff of failing-test names between `main` and this branch is empty.
- I could not run `./scripts/lint.sh` — no SwiftLint/SwiftFormat locally. Longest added line is 91 chars (limit 160) and the trailing-comma style is preserved, but a CI lint pass is the real check.
