### PR TITLE
test(app): skip the headless-precondition tests when an NSApplication exists

### DIFF
--- a/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerUITypeTests.swift
@@ -315,8 +315,13 @@
         /// Fail closed: with no running application there is no window to focus or
         /// post into, so resolution yields nothing rather than a half-usable target.
         @MainActor
-        func testTargetResolutionYieldsNothingWithoutAnApplication() {
-            XCTAssertNil(NSApp, "precondition: xctest has no NSApplication")
+        func testTargetResolutionYieldsNothingWithoutAnApplication() throws {
+            // Skip rather than fail: `NSApplication.shared` is process-global and
+            // irreversible, so a sibling test that touched it invalidates this
+            // premise for every later test in the same process. CI runs
+            // `swift test --parallel`, which gives each class its own process, so
+            // the assertions below still run there.
+            try XCTSkipUnless(NSApp == nil, "another test already created the shared NSApplication")
 
             XCTAssertNil(DebugRPCServer.uiTypeTarget(forWindowIdentifier: "settings"))
             XCTAssertNil(DebugRPCServer.nsWindow(forIdentifier: "settings"))

--- a/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
+++ b/app/MeetingTranscriber/Tests/MouseInjectionTests.swift
@@ -63,8 +63,13 @@
         /// Fail closed: with no running application there is nothing to post to, so
         /// the caller is told the click did not happen instead of assuming it did.
         @MainActor
-        func testClickReportsFailureWithoutAnApplication() {
-            XCTAssertNil(NSApp, "precondition: xctest has no NSApplication")
+        func testClickReportsFailureWithoutAnApplication() throws {
+            // Skip rather than fail: `NSApplication.shared` is process-global and
+            // irreversible, so a sibling test that touched it invalidates this
+            // premise for every later test in the same process. CI runs
+            // `swift test --parallel`, which gives each class its own process, so
+            // the assertion below still runs there.
+            try XCTSkipUnless(NSApp == nil, "another test already created the shared NSApplication")
             let window = makeWindow(x: 0, y: 0, width: 100, height: 100)
 
             XCTAssertFalse(MouseInjection.click(atAXPoint: CGPoint(x: 10, y: 10), in: window))


### PR DESCRIPTION
## What

`swift test` — the command CONTRIBUTING documents — fails on a clean `main` with two tests that have nothing to do with the code under test:

```
DebugRPCServerUITypeTests.swift:319: XCTAssertNil failed: "<NSApplication: 0x…>"
  - precondition: xctest has no NSApplication
MouseInjectionTests.swift:67:       XCTAssertNil failed: "<NSApplication: 0x…>"
  - precondition: xctest has no NSApplication
```

## Why

Both tests open by asserting their own premise: that the xctest process has no `NSApplication`.

CI runs `swift test --parallel`, which gives each test class its own process, so the premise holds there. A plain `swift test` runs every class in one process, and any sibling test that reaches `NSApplication.shared` — `DebugRPCServer.swift:527` (`activate(ignoringOtherApps:)`) and `DebugRPCServer+Screenshot.swift:49` do — instantiates the shared app for everything that runs afterwards. The two tests then fail on the precondition, never reaching the behaviour they exist to cover. It's order-dependent, so which run trips it depends on scheduling.

`NSApplication.shared` is process-global and cannot be torn down, so once it exists the premise is genuinely gone — there is nothing to reset in `tearDown`.

## How

Turn the precondition assertion into `XCTSkipUnless`. Where the premise holds — CI's parallel run, and any filtered run of these classes — the assertions execute exactly as before. A single-process run now reports an honest skip instead of a false failure.

I picked the skip over hunting down the polluting test on purpose: any test touching `NSApplication.shared` is legitimate, and the pollution is irreversible, so guarding the two tests that care is the only fix that survives someone adding a third such test later.

## Verification

Full serial `swift test` on macOS 27, before vs. after: these two drop out of the failure set, nothing new appears.

Under `swift test --parallel --filter "MouseInjectionTests|DebugRPCServerUITypeTests"` both still execute (not skipped), so the coverage CI relies on is unchanged.

`./scripts/lint.sh` clean.

## Out of scope — but worth flagging

On macOS 27 a serial run still leaves 15 failures on unmodified `main`, all SwiftUI view-introspection assertions (`SettingsViewTests`, `GeneralSettings*`, `SpeakerNamingViewTests`, `VoiceEnrollmentViewTests`, `SettingsInteractionTests`) failing with `Search did not find a match` or an `XCTUnwrap` of a label that is nil. They fail under `--parallel` too, so this isn't the same isolation issue. CI is on `macos-26`, so my guess is a SwiftUI rendering/introspection change on 27 rather than a fault in the tests — I've left them alone rather than adapt your UI tests to an OS you don't target yet. Happy to open a separate issue with the full list if that's useful.

One smaller thing I noticed while chasing this: CONTRIBUTING says `swift test`, while CI runs `swift test --parallel --skip ModelPreloadTests`. Those differ in more than speed — the skip avoids the model download, and the parallelism is load-bearing for the tests above. Might be worth documenting the CI invocation as the one to run locally. I left it out of this PR to keep the change focused; say the word and I'll add it.
