### PR TITLE
fix(build): drop the deprecated string form of the cask macOS floor

### DIFF
--- a/Casks/meeting-transcriber.rb
+++ b/Casks/meeting-transcriber.rb
@@ -7,7 +7,7 @@ cask "meeting-transcriber" do
   desc "Auto-transcribe and summarize meetings"
   homepage "https://github.com/pasrom/meeting-transcriber"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   conflicts_with cask: "meeting-transcriber@beta"
 

--- a/Casks/meeting-transcriber@beta.rb
+++ b/Casks/meeting-transcriber@beta.rb
@@ -7,7 +7,7 @@ cask "meeting-transcriber@beta" do
   desc "Auto-transcribe and summarize meetings (pre-release)"
   homepage "https://github.com/pasrom/meeting-transcriber"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   conflicts_with cask: "meeting-transcriber"
 


### PR DESCRIPTION
Closes #630.

`depends_on macos: ">= :sonoma"` is deprecated in Homebrew, so every `brew install` / `upgrade` / `info` touching the cask prints a warning asking the user to report it to the tap.

Homebrew's own replacement for the `>=` string form is the bare symbol. The floor is unchanged: a cask's `depends_on macos:` always parses with the `>=` comparator, so both forms resolve to `>= 14` — checked locally against the installed Homebrew, where only the string form warns.

Not the whole fix on its own: `release.yml` seeds a cask into `pasrom/homebrew-meeting-transcriber` only when the tap does not already carry it, and thereafter rewrites just `version` and `sha256`. The warning users see comes from the tap's copy and needs the same one-line change there; this PR fixes the source of truth and any future re-seed.