### PR TITLE
feat(app): add /v1/record to start and stop a microphone recording over the automation API

### DIFF
--- a/app/MeetingTranscriber/Sources/AppState+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppState+RPC.swift
@@ -187,6 +187,55 @@
             return (status, control)
         }
 
+        /// Small, stable projection of the microphone-recording lifecycle for
+        /// `/v1/record`, the sibling of `watchStatusDTO()` and kept separate from
+        /// `rpcStateSnapshot` for the same reason.
+        func recordStatusDTO() -> RecordStatusDTO {
+            let loop = watching.watchLoop
+            // Asked through `recordingBlockers`, the same function the gate
+            // inside `WatchLoop` consults, so this cannot come to a different
+            // verdict than the refusal a POST would produce. nil means the probe
+            // has not run, which is not a permission problem — `BadgeKind.compute`
+            // and `WatchStatusDTO.permissionsHealthy` read an unknown result the
+            // same way.
+            let micHealthy = permissions.health?.recordingBlockers(for: .micOnly).isEmpty ?? true
+            return RecordStatusDTO(
+                recording: watching.isRecordingMicrophoneOnly,
+                startPending: watching.isManualStartPending,
+                state: loop?.state.rawValue,
+                badge: currentBadge.rawValue,
+                otherRecordingActive: watching.isRecordingOtherThanMicrophone,
+                noMic: settings.noMic,
+                microphoneHealthy: micHealthy,
+            )
+        }
+
+        /// The two `/v1/record` seams, bundled like `watchRPCClosures` so
+        /// `buildDebugRPCServer` stays a flat wiring list. Control is `async`
+        /// because the start awaits the mic gate, the queue and the loop before
+        /// there is anything true to report.
+        func recordRPCClosures() -> (
+            status: () -> RecordStatusDTO,
+            control: (RecordAction) async -> RecordControlOutcome,
+        ) {
+            let status: () -> RecordStatusDTO = { [weak self] in
+                self?.recordStatusDTO() ?? .notRecording
+            }
+            let control: (RecordAction) async -> RecordControlOutcome = { [weak self] action in
+                guard let self else { return .failed }
+                // Seed the health cache before answering. The status projection
+                // reads that cache while the gate inside the start path falls
+                // back to a *live* probe when it is empty, so on an unprobed
+                // launch `GET` would report a healthy microphone and the `POST`
+                // right after it would refuse with a 412 whose body says nothing
+                // is wrong. One probe closes that, and after it both sides read
+                // the same value.
+                if permissions.health == nil { await permissions.check() }
+                return await watching.applyRecordAction(action)
+            }
+            return (status, control)
+        }
+
         /// The three per-job speaker-naming seams, bundled for the same reason as
         /// `watchRPCClosures`: `buildDebugRPCServer` is a flat wiring list, and
         /// grouping the closures that belong to one route family keeps it one.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -414,6 +414,7 @@ final class AppState {
                 return await pipeline.transcribeAndWait(path: url, maxWaitSeconds: maxWait)
             }
             let watch = watchRPCClosures()
+            let record = recordRPCClosures()
             return DebugRPCServer(
                 port: port,
                 token: token,
@@ -431,6 +432,8 @@ final class AppState {
                 transcribe: transcribe,
                 watchStatus: watch.status,
                 watchControl: watch.control,
+                recordStatus: record.status,
+                recordControl: record.control,
             )
         }
     #endif

--- a/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer+V1.swift
@@ -74,6 +74,8 @@
         /// - `POST /v1/jobs/<id>/naming/skip` — skip naming for one job
         /// - `GET  /v1/watch` — watching status
         /// - `POST /v1/watch` — start/stop/toggle watching `{action}`
+        /// - `GET  /v1/record` — microphone-recording status
+        /// - `POST /v1/record` — start/stop/toggle a microphone recording `{action}`
         func routeV1(_ request: HTTPRequest, path: String) async -> HTTPResponse {
             let idempotencyKey = request.headers["idempotency-key"]
             // `path` is query-stripped; read the opt-in off the raw target.
@@ -87,13 +89,7 @@
             // comps[0..1] == ["v1", "jobs"]. No `Idempotency-Key` handling: the
             // operation is already idempotent, and that header exists here only
             // to stop duplicate *job creation*.
-            if path == "/v1/watch" {
-                switch request.method {
-                case "GET": return watchResponse(status: 200, reason: "OK")
-                case "POST": return await watchControlResponse(body: request.body)
-                default: return HTTPResponse.notFound()
-                }
-            }
+            if let response = await controlResourceResponse(request, path: path) { return response }
             // The caller (DebugRPCServer.route) already gated on the `/v1/jobs`
             // prefix, so comps[0..1] are always ["v1", "jobs"]; the count checks
             // below just keep indexing safe.
@@ -124,6 +120,51 @@
             return HTTPResponse.notFound()
         }
 
+        /// The paths `controlResourceResponse` claims. `DebugRPCServer.route`
+        /// reads the same set to decide what to hand to `routeV1`, so a third
+        /// resource is added in one place: splitting the two lists is how a new
+        /// resource ends up answering 404 with its handler sitting right there.
+        static let controlResourcePaths: Set<String> = ["/v1/watch", "/v1/record"]
+
+        /// The two lifecycle resources — watching and microphone recording —
+        /// which share a shape: GET reads the status, POST applies an action and
+        /// answers with the state it settled into. Nil when `path` is neither, so
+        /// the caller falls through to the `/v1/jobs` routing below.
+        ///
+        /// Matched here, before that routing splits the path into components and
+        /// assumes it starts `["v1", "jobs"]`. Neither takes an
+        /// `Idempotency-Key`: both are already idempotent, and that header exists
+        /// on this API only to stop duplicate *job creation*.
+        private func controlResourceResponse(
+            _ request: HTTPRequest, path: String,
+        ) async -> HTTPResponse? {
+            guard Self.controlResourcePaths.contains(path) else { return nil }
+            switch (path, request.method) {
+            case ("/v1/watch", "GET"): return jsonResponse(watchStatus())
+            case ("/v1/watch", "POST"): return await watchControlResponse(body: request.body)
+            case ("/v1/record", "GET"): return jsonResponse(recordStatus())
+            case ("/v1/record", "POST"): return await recordControlResponse(body: request.body)
+            default: return HTTPResponse.notFound()
+            }
+        }
+
+        /// JSON-encode a status payload with a caller-chosen code. Both control
+        /// resources answer GET and POST with the *same* body shape, so a client
+        /// parses one thing, and the code carries what the call achieved.
+        ///
+        /// Not snapshotted atomically with that outcome: the body is built after
+        /// the action's `await` resumes, so a stop landing in between is
+        /// reflected. Still better than making the client refetch, which races
+        /// the same way and costs a round trip.
+        private func jsonResponse(
+            _ payload: some Encodable, status: Int = 200, reason: String = "OK",
+        ) -> HTTPResponse {
+            guard let body = try? JSONEncoder().encode(payload) else {
+                return HTTPResponse.internalServerError()
+            }
+            return HTTPResponse(status: status, reason: reason, body: body, contentType: "application/json")
+        }
+
         /// Failure status for confirm/skip naming: 409 when the job exists but
         /// isn't awaiting naming (wrong state), 404 when the job id is unknown.
         private func namingFailureStatus(_ jobID: UUID) -> HTTPResponse {
@@ -131,17 +172,6 @@
         }
 
         // MARK: - /v1/watch
-
-        /// Render the current watch status with a caller-chosen status code.
-        /// GET and POST return the *same* body shape — one parser for a client,
-        /// and no POST-then-refetch race for a controller that needs to redraw
-        /// a key from the result. The code carries what the call achieved.
-        private func watchResponse(status: Int, reason: String) -> HTTPResponse {
-            guard let body = try? JSONEncoder().encode(watchStatus()) else {
-                return HTTPResponse.internalServerError()
-            }
-            return HTTPResponse(status: status, reason: reason, body: body, contentType: "application/json")
-        }
 
         /// Apply a watch action and report the state it settled into.
         ///
@@ -155,9 +185,35 @@
                 return HTTPResponse.badRequest()
             }
             switch await watchControl(payload.action) {
-            case .changed, .unchanged: return watchResponse(status: 200, reason: "OK")
-            case .blocked: return watchResponse(status: 409, reason: "Conflict")
-            case .failed: return watchResponse(status: 503, reason: "Service Unavailable")
+            case .changed, .unchanged: return jsonResponse(watchStatus())
+            case .blocked: return jsonResponse(watchStatus(), status: 409, reason: "Conflict")
+            case .failed: return jsonResponse(watchStatus(), status: 503, reason: "Service Unavailable")
+            }
+        }
+
+        // MARK: - /v1/record
+
+        /// Apply a record action and report the state it settled into.
+        ///
+        /// The extra code over `/v1/watch` is 412. A `start` that cannot capture
+        /// anything — "No Microphone" is set, or the microphone permission is
+        /// denied or broken — is not a transient failure to retry (503) and not
+        /// somebody else holding the loop (409). It stays refused until a switch
+        /// is flipped, and the body says which one: `noMic` and
+        /// `microphoneHealthy` tell the two apart.
+        ///
+        /// The contrast with `/v1/watch` is deliberate: a denied microphone
+        /// answers `200` there, because app audio still records without it. Here
+        /// nothing would, so 200 would be a lie.
+        private func recordControlResponse(body: Data) async -> HTTPResponse {
+            guard let payload = try? JSONDecoder().decode(RecordActionPayload.self, from: body) else {
+                return HTTPResponse.badRequest()
+            }
+            switch await recordControl(payload.action) {
+            case .changed, .unchanged: return jsonResponse(recordStatus())
+            case .blocked: return jsonResponse(recordStatus(), status: 409, reason: "Conflict")
+            case .refused: return jsonResponse(recordStatus(), status: 412, reason: "Precondition Failed")
+            case .failed: return jsonResponse(recordStatus(), status: 503, reason: "Service Unavailable")
             }
         }
 

--- a/app/MeetingTranscriber/Sources/DebugRPCServer.swift
+++ b/app/MeetingTranscriber/Sources/DebugRPCServer.swift
@@ -90,6 +90,8 @@
         let transcribe: (URL, Double) async -> BlockingTranscribeResult // POST /v1/transcribe
         let watchStatus: () -> WatchStatusDTO // GET /v1/watch
         let watchControl: (WatchAction) async -> WatchControlOutcome // POST /v1/watch
+        let recordStatus: () -> RecordStatusDTO // GET /v1/record
+        let recordControl: (RecordAction) async -> RecordControlOutcome // POST /v1/record
         var idempotency = IdempotencyStore() // Idempotency-Key -> job IDs; internal for the +V1 extension
         private let expectedAuth: String
         private var listener: NWListener?
@@ -118,6 +120,8 @@
             transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
             watchStatus: @escaping () -> WatchStatusDTO = { .notWatching },
             watchControl: @escaping (WatchAction) async -> WatchControlOutcome = { _ in .failed },
+            recordStatus: @escaping () -> RecordStatusDTO = { .notRecording },
+            recordControl: @escaping (RecordAction) async -> RecordControlOutcome = { _ in .failed },
         ) {
             self.port = NWEndpoint.Port(rawValue: port) ?? NWEndpoint.Port.any
             self.expectedAuth = "Bearer \(token)"
@@ -135,6 +139,8 @@
             self.transcribe = transcribe
             self.watchStatus = watchStatus
             self.watchControl = watchControl
+            self.recordStatus = recordStatus
+            self.recordControl = recordControl
         }
 
         /// Generate a 32-byte hex token, persist atomically with mode 0600, return it.
@@ -342,7 +348,8 @@
             // switch below, which compares against the raw `request.path`.
             let pathWithoutQuery = String(request.path.prefix { $0 != "?" })
             if pathWithoutQuery == "/v1/jobs" || pathWithoutQuery.hasPrefix("/v1/jobs/")
-                || pathWithoutQuery == "/v1/transcribe" || pathWithoutQuery == "/v1/watch" {
+                || pathWithoutQuery == "/v1/transcribe"
+                || Self.controlResourcePaths.contains(pathWithoutQuery) {
                 return await routeV1(request, path: pathWithoutQuery)
             }
 

--- a/app/MeetingTranscriber/Sources/ManualRecordingRequest.swift
+++ b/app/MeetingTranscriber/Sources/ManualRecordingRequest.swift
@@ -11,3 +11,30 @@ enum ManualRecordingRequest {
     case app(pid: pid_t, appName: String, title: String)
     case microphone
 }
+
+/// How a manual-recording start ended.
+///
+/// The menu ignores it — a click is fire-and-forget and learns the outcome from
+/// the notification the start path already posts. The automation API cannot:
+/// it has to answer the caller with a status code, and "the microphone is
+/// denied" and "the recorder failed" are a different answer to the same POST.
+/// Retrying the first changes nothing until someone opens System Settings,
+/// which is exactly the line between 412 and 503.
+enum ManualRecordingStartResult: Equatable {
+    case started
+
+    /// A recording was already in progress when the start reached the point of
+    /// taking the loop over. Decided there rather than only at the caller's
+    /// guard, because that guard runs before the task is scheduled and the watch
+    /// loop can enter a meeting in between.
+    case blockedByActiveRecording
+
+    /// A permission this recording needs is denied or broken, so nothing was
+    /// captured. Raised by `WatchLoop` from the same gate the auto-detect path
+    /// uses, rather than re-derived here, so the refusal names the permission
+    /// that actually blocks *this* source.
+    case permissionRefused
+
+    /// The recorder itself would not start.
+    case failed
+}

--- a/app/MeetingTranscriber/Sources/RecordStatusDTO.swift
+++ b/app/MeetingTranscriber/Sources/RecordStatusDTO.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Wire shape for `GET`/`POST /v1/record` — the microphone-recording lifecycle
+/// as a small, stable projection, built alongside `WatchStatusDTO` and for the
+/// same audience: a Stream Deck key, a Shortcut, a shell script.
+///
+/// A resource of its own rather than a verb on `/v1/watch`, because the two
+/// answer different questions and refuse for different reasons. Watching arms
+/// the detector and records nothing by itself, so it starts on a machine whose
+/// microphone is switched off or denied; this one records the room right now,
+/// where either of those means capturing nothing at all.
+///
+/// The fields are facts, not advice. A client decides what to draw from them:
+/// `recording` for the key itself, and `otherRecordingActive` / `noMic` /
+/// `microphoneHealthy` to explain a refusal it just received — or to grey the
+/// key out before pressing.
+struct RecordStatusDTO: Codable, Equatable {
+    /// Whether a microphone-only recording is in progress.
+    ///
+    /// Deliberately narrower than "something is recording": an app-picker
+    /// recording and an auto-detected meeting are not this endpoint's recording,
+    /// and reporting them here would invite a client to `stop` one it never
+    /// started. `otherRecordingActive` carries those.
+    let recording: Bool
+    /// Whether a start has been accepted but is not recording yet.
+    ///
+    /// A start can sit for a while: it waits on the microphone permission gate,
+    /// and on a first run that means an OS dialog nobody has answered. Without
+    /// this field the whole window reads as plain idle, so a key that renders
+    /// "press to start" from `recording` keeps offering a press that will only
+    /// queue behind the one already waiting. `WatchStatusDTO.manualRecording`
+    /// covers the same window on the other resource.
+    let startPending: Bool
+    /// `WatchLoop.State` raw value (`idle`/`watching`/`recording`/`error`), or
+    /// nil when no loop exists.
+    let state: String?
+    /// `BadgeKind` raw value — what the menu bar icon is showing right now.
+    let badge: String
+    /// Whether some other capture owns the watch loop: an auto-detected meeting
+    /// or an app-picker recording. A start is refused with 409 while this is
+    /// true, because it would clobber a recording already in progress.
+    let otherRecordingActive: Bool
+    /// Whether the user set "No Microphone (app audio only)". A start is refused
+    /// with 412 while it is: honouring the setting here would record nothing,
+    /// and overriding it would put on tape the one thing the setting exists to
+    /// keep off it.
+    let noMic: Bool
+    /// False only when a microphone probe has actually failed — denied, or
+    /// allowed-but-not-working. A check that has not run yet reports true, the
+    /// same way `WatchStatusDTO.permissionsHealthy` treats an unknown result.
+    ///
+    /// Scoped to the one permission a microphone recording needs, not the
+    /// aggregate: a denied Screen Recording grant is irrelevant here (nothing
+    /// taps a process), and reporting it would describe this endpoint as broken
+    /// on exactly the machines where it is the capture path that still works.
+    let microphoneHealthy: Bool
+
+    /// Fallback for the window between server start and `AppState` being
+    /// reachable. Reports "not recording, nothing in the way" rather than
+    /// failing the request, so a client polling on an interval never has to
+    /// special-case launch.
+    static let notRecording = Self(
+        recording: false,
+        startPending: false,
+        state: nil,
+        badge: BadgeKind.inactive.rawValue,
+        otherRecordingActive: false,
+        noMic: false,
+        microphoneHealthy: true,
+    )
+}
+
+/// What a `POST /v1/record` asks for. `start`/`stop` sit alongside `toggle` for
+/// the reason spelled out on `WatchAction`.
+///
+/// A separate enum from that one, rather than a shared verb set, so a verb added
+/// to one resource does not silently appear on the other's payload.
+enum RecordAction: String, Codable {
+    case start
+    case stop
+    case toggle
+}
+
+/// What a record-control request actually achieved. Maps 1:1 onto the HTTP
+/// status code, so a caller can tell "already recording" from "refused" without
+/// diffing state before and after.
+///
+/// Deliberately not `Codable`, for the same reason as `WatchControlOutcome`: it
+/// never crosses the wire. The route reads it to pick a status code and builds
+/// the body from `recordStatusDTO()`.
+///
+/// One case more than `WatchControlOutcome`, and that case is why this endpoint
+/// exists as its own resource: a microphone recording has preconditions that
+/// watching does not, and both of them mean nothing would be captured.
+enum RecordControlOutcome: Equatable {
+    /// The request changed the recording state. → 200
+    case changed
+    /// Already in the requested state; nothing to do. → 200
+    case unchanged
+    /// Refused: another recording owns the loop and starting would clobber it. → 409
+    case blocked
+    /// Refused on a precondition the caller has to fix first — "No Microphone"
+    /// is set, or the microphone permission is denied or broken. → 412
+    ///
+    /// Distinct from `.failed` because retrying changes nothing: the answer is
+    /// stable until someone flips a switch, in Settings or in System Settings.
+    case refused
+    /// The request was accepted but the state did not settle as asked. → 503
+    case failed
+}
+
+/// Request body for `POST /v1/record`. An unrecognised action string fails to
+/// decode, which the route turns into a 400 — better than silently treating a
+/// typo'd verb as a toggle.
+struct RecordActionPayload: Codable, Equatable {
+    let action: RecordAction
+}

--- a/app/MeetingTranscriber/Sources/WatchingController+Detectors.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController+Detectors.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Which detection strategies auto-watch runs, and how the "Apps to Watch"
+/// toggles filter them. Line-cap split out of `WatchingController`; both are
+/// static and take their settings as a parameter, so nothing here touches the
+/// controller's own state.
+@MainActor
+extension WatchingController {
+    /// The auto-detect detector, filtered by the user's "Apps to Watch" toggles
+    /// (`settings.watchApps`). Extracted so the toggle → detection wiring is
+    /// unit-testable without spinning up a watch loop.
+    static func defaultDetector(settings: AppSettings) -> any MeetingDetecting {
+        CompositeMeetingDetector(defaultDetectors(settings: settings))
+    }
+
+    /// The strategies `defaultDetector` composes, in priority order. Split out
+    /// so the toggle wiring stays assertable: a test can configure one
+    /// strategy's injectable providers without reaching into the composite.
+    static func defaultDetectors(settings: AppSettings) -> [any MeetingDetecting] {
+        let assertions = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: settings.watchApps),
+        )
+        // Read through the settings each poll rather than captured once, so a
+        // Settings "Remove" takes effect without restarting the watch loop.
+        assertions.isIdentityDenied = { [settings] app in
+            settings.consentDeniedApps.contains(app)
+        }
+        return [
+            assertions,
+            MicInputDetector(patterns: MicInputDetector.patterns(watching: settings.watchApps)),
+        ]
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchingController+RecordControl.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController+RecordControl.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// The `/v1/record` control surface: microphone recording as an idempotent
+/// resource a remote caller can drive, alongside the watch control in
+/// `WatchingController` proper.
+///
+/// Its own file because that one sits at the line cap; the handful of members it
+/// reaches into (`settings`, `watchLoop`, `manualStartTask`, `joinStarts`,
+/// `joinManualStart`, `beginManualRecording`, `stopManualRecording`,
+/// `startWatching`) are internal rather than private for exactly that.
+///
+/// The whole surface is about one recording shape, `RecordingSource.micOnly`.
+/// Everything else the loop can be doing — an app-picker recording, an
+/// auto-detected meeting — is somebody else's recording here: a start refuses
+/// rather than clobbering it, and a stop leaves it alone rather than ending a
+/// meeting the caller never asked about.
+@MainActor
+extension WatchingController {
+    /// Whether a microphone-only recording is in progress.
+    ///
+    /// Derived from `activeRecordingSource`, the loop's own answer to "what is
+    /// being captured", rather than from a flag this file would have to keep in
+    /// step. It reads nil until the loop is actually recording, which is why
+    /// every caller below settles the in-flight starts first.
+    var isRecordingMicrophoneOnly: Bool {
+        watchLoop?.activeRecordingSource == .micOnly
+    }
+
+    /// Whether something other than a microphone recording owns the loop.
+    ///
+    /// Both halves of that matter. It is what makes a start a 409 instead of a
+    /// clobbered recording (#624), and it is what keeps a microphone recording
+    /// that is *already running* out of the way of a request to start one — that
+    /// is not a conflict, it is the requested end state.
+    var isRecordingOtherThanMicrophone: Bool {
+        guard let source = watchLoop?.activeRecordingSource else { return false }
+        return source != .micOnly
+    }
+
+    /// Whether a manual start is registered but has not produced a recording
+    /// yet. Deliberately not "some manual recording exists": an app recording
+    /// that is already running is reported by `isRecordingOtherThanMicrophone`,
+    /// and calling that pending would tell a key to wait for something that is
+    /// never going to become its recording.
+    var isManualStartPending: Bool {
+        manualStartTask != nil
+    }
+
+    /// Apply a record action, resolving `.toggle` against settled state.
+    ///
+    /// The join leads, for the reason `applyWatchAction` gives: deciding against
+    /// a mid-launch snapshot would read "nothing is recording" for a recording
+    /// that is seconds from running, and start a second one.
+    @discardableResult
+    func applyRecordAction(_ action: RecordAction) async -> RecordControlOutcome {
+        guard await joinStarts() else { return .failed }
+        switch action {
+        case .start: return await applyRecordStart()
+
+        case .stop: return applyRecordStop()
+
+        case .toggle:
+            return isRecordingMicrophoneOnly ? applyRecordStop() : await applyRecordStart()
+        }
+    }
+
+    /// Idempotent start. Awaits the start it launched — mic gate, queue, loop
+    /// construction, the permission gate inside `WatchLoop` — so the caller
+    /// reports the settled result rather than a snapshot taken mid-launch, and
+    /// so a refusal reaches it as a refusal instead of as a silent no-op.
+    private func applyRecordStart() async -> RecordControlOutcome {
+        if isRecordingMicrophoneOnly { return .unchanged }
+        if isRecordingOtherThanMicrophone { return .blocked }
+        if settings.noMic { return .refused }
+        // Read before the start, because the start is what takes the loop away.
+        let wasWatching = isWatching
+        // nil means an ownership guard refused between the check above and here.
+        guard let start = beginManualRecording(.microphone) else { return .blocked }
+        // Bound the start we just launched, not only the ones we found running.
+        // Without this the endpoint has no deadline at all in the one case the
+        // docs name for its 503: an unanswered microphone prompt.
+        guard await joinManualStart() else { return .failed }
+        switch await start.value {
+        // Trust the result rather than re-reading the state: a stop that landed
+        // between the task finishing and this line would turn a recording that
+        // started, and was then deliberately ended, into "did not settle".
+        case .started: return .changed
+        case .blockedByActiveRecording: return .blocked
+        case .permissionRefused: await rearmWatching(wasWatching); return .refused
+        case .failed: await rearmWatching(wasWatching); return .failed
+        }
+    }
+
+    /// Put meeting watching back after a start that captured nothing.
+    ///
+    /// A manual start stops an active auto loop before it knows whether it can
+    /// record, so a refusal leaves detection off. That is survivable in the menu
+    /// bar, where the icon shows it. Over the API it is not: the answer says
+    /// "nothing changed, fix a setting and retry" while the machine has quietly
+    /// stopped watching for meetings, and nothing re-arms it until relaunch.
+    private func rearmWatching(_ wasWatching: Bool) async {
+        guard wasWatching, !isWatching else { return }
+        await startWatching()
+    }
+
+    /// Idempotent stop, and only of a microphone recording.
+    ///
+    /// Anything else running reports `.unchanged` rather than `.blocked`: no
+    /// microphone recording is in progress, so the requested end state already
+    /// holds and there is nothing to refuse. Same asymmetry `stopWatching`
+    /// documents, and the same reason — a stop that reached across and ended
+    /// somebody else's meeting would be far worse than a 200 that did nothing.
+    private func applyRecordStop() -> RecordControlOutcome {
+        guard isRecordingMicrophoneOnly else { return .unchanged }
+        let loop = watchLoop
+        let errorBeforeStop = loop?.lastError
+        stopManualRecording()
+        if isRecordingMicrophoneOnly { return .failed }
+        // A stop whose recorder threw is not a success, however idle the loop
+        // looks afterwards: `WatchLoop.stopManualRecording` skips the enqueue on
+        // a throw, so there is no job, no transcript and no protocol, and this
+        // controller has already dropped the loop that knows why. Answering 200
+        // there tells the caller their recording is safe when it is gone.
+        if let errorAfterStop = loop?.lastError, errorAfterStop != errorBeforeStop {
+            return .failed
+        }
+        return .changed
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchingController+WatchControl.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController+WatchControl.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// The `/v1/watch` control surface: meeting watching as an idempotent resource a
+/// remote caller can drive.
+///
+/// Split out alongside its `+RecordControl` sibling, so the two automation-API
+/// surfaces sit next to each other rather than inside the lifecycle class both
+/// of them drive. `joinStart` is internal rather than private for that split.
+@MainActor
+extension WatchingController {
+    /// Idempotent start. Awaits the in-flight async start — mic gate, engine
+    /// sync, queue rebuild, loop construction — so a caller that reports state
+    /// back observes the settled result instead of a snapshot taken mid-launch.
+    /// `toggleWatching` alone cannot offer that: it returns the moment the task
+    /// is spawned, and `startTask` is private.
+    ///
+    /// Starts as not user-initiated. Nobody is at the machine when this arrives
+    /// — that is the whole point of the endpoint — so the optional Accessibility
+    /// prompt must not be raised, exactly as for auto-watch.
+    @discardableResult
+    func startWatching() async -> WatchControlOutcome {
+        if isManualRecording { return .blocked }
+        if isWatching { return .unchanged }
+        toggleWatching(userInitiated: false)
+        // `toggleWatching` assigns `startTask` synchronously, so this always
+        // joins the task it just created — or, if another caller already had a
+        // start in flight, the one whose existence made our call a no-op.
+        guard await joinStart() else { return .failed }
+        // Re-check: a manual start can register while the auto start is parked,
+        // which makes that start bail and leaves `watchLoop` nil. The join
+        // settled and the dialog was answered, so this is the conflict 409
+        // describes, not the "did not settle" 503.
+        if isManualRecording { return .blocked }
+        return isWatching ? .changed : .failed
+    }
+
+    /// Idempotent stop. Awaits a pending start first: otherwise a stop issued
+    /// during the mic-access window lands before the loop exists, reports
+    /// "already stopped", and is then overwritten by the start completing.
+    ///
+    /// A manual recording is reported as `.unchanged` rather than `.blocked`:
+    /// `isWatching` is false by definition while one owns the loop, so the
+    /// requested end state already holds and there is nothing to refuse. That
+    /// is the asymmetry with `startWatching`, where `.blocked` is right because
+    /// starting would clobber the recording.
+    @discardableResult
+    func stopWatching() async -> WatchControlOutcome {
+        guard await joinStart() else { return .failed }
+        guard isWatching else { return .unchanged }
+        toggleWatching()
+        return isWatching ? .failed : .changed
+    }
+
+    /// Apply a watch action, resolving `.toggle` against settled state.
+    ///
+    /// The leading await matters for `.toggle`: deciding against a mid-launch
+    /// snapshot would read "not watching" for a loop that is seconds from
+    /// running, and start a second one. Settling first means a toggle racing a
+    /// start converges to on — the caller asked for a flip and gets a definite
+    /// answer, rather than a coin toss on where the mic prompt happened to be.
+    @discardableResult
+    func applyWatchAction(_ action: WatchAction) async -> WatchControlOutcome {
+        guard await joinStart() else { return .failed }
+        switch action {
+        case .start: return await startWatching()
+        case .stop: return await stopWatching()
+        case .toggle: return isWatching ? await stopWatching() : await startWatching()
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/WatchingController.swift
+++ b/app/MeetingTranscriber/Sources/WatchingController.swift
@@ -42,9 +42,9 @@ final class WatchingController {
     /// `watchLoop` holds the manual loop. `startTask`'s counterpart for the
     /// manual path, so `isManualRecording` covers the window before the loop
     /// exists.
-    private var manualStartTask: Task<Void, Never>?
+    var manualStartTask: Task<ManualRecordingStartResult, Never>?
 
-    private let settings: AppSettings
+    let settings: AppSettings
     private let notifier: any AppNotifying
     private let pipeline: PipelineController
     private let channelHealth: ChannelHealthController
@@ -105,6 +105,16 @@ final class WatchingController {
     /// `PowerAssertionDetector`.
     private let makeDetector: () -> any MeetingDetecting
 
+    /// Recorder factory, the `makeDetector` seam's counterpart for capture.
+    ///
+    /// Injectable so a test can assert that a start succeeded, or make one fail
+    /// on demand, without opening the machine's real input device.
+    /// `DualSourceRecorder` writes into `AppPaths.recordingsDir`, the production
+    /// staging directory that orphan recovery scans, which is not somewhere a
+    /// unit test may leave files. (It does start on the hosted CI runners, so
+    /// this is about where the bytes land, not about whether capture works.)
+    private let makeRecorder: @MainActor () -> any RecordingProvider
+
     /// Engine-sync hook, wired by `activate`. Bridges to
     /// `EngineController.syncEngineSettings()`; nil until `activate` runs, in
     /// which case the up-front sync is skipped (EngineController's own reactive
@@ -127,6 +137,7 @@ final class WatchingController {
         },
         startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: (() -> any MeetingDetecting)? = nil,
+        makeRecorder: @escaping @MainActor () -> any RecordingProvider = { DualSourceRecorder() },
     ) {
         self.settings = settings
         self.notifier = notifier
@@ -138,36 +149,12 @@ final class WatchingController {
         self.requestScreenRecording = requestScreenRecording
         self.requestAccessibility = requestAccessibility
         self.startJoinTimeout = startJoinTimeout
+        self.makeRecorder = makeRecorder
         // Tests inject a deterministic detector; production defaults to one
         // filtered by the "Apps to Watch" toggles, re-read at each watch start.
         self.makeDetector = makeDetector ?? { [settings] in
             Self.defaultDetector(settings: settings)
         }
-    }
-
-    /// The auto-detect detector, filtered by the user's "Apps to Watch" toggles
-    /// (`settings.watchApps`). Extracted so the toggle → detection wiring is
-    /// unit-testable without spinning up a watch loop.
-    static func defaultDetector(settings: AppSettings) -> any MeetingDetecting {
-        CompositeMeetingDetector(defaultDetectors(settings: settings))
-    }
-
-    /// The strategies `defaultDetector` composes, in priority order. Split out
-    /// so the toggle wiring stays assertable: a test can configure one
-    /// strategy's injectable providers without reaching into the composite.
-    static func defaultDetectors(settings: AppSettings) -> [any MeetingDetecting] {
-        let assertions = PowerAssertionDetector(
-            patterns: PowerAssertionDetector.patterns(watching: settings.watchApps),
-        )
-        // Read through the settings each poll rather than captured once, so a
-        // Settings "Remove" takes effect without restarting the watch loop.
-        assertions.isIdentityDenied = { [settings] app in
-            settings.consentDeniedApps.contains(app)
-        }
-        return [
-            assertions,
-            MicInputDetector(patterns: MicInputDetector.patterns(watching: settings.watchApps)),
-        ]
     }
 
     /// Wire the engine-sync hook. Called once from `AppState.init` after its
@@ -290,7 +277,18 @@ final class WatchingController {
         }
     }
 
-    // MARK: - Idempotent control (automation API)
+    /// Whether a manual start may take over the loop it found, given what that
+    /// loop is doing. False while it is recording: taking it over stops it, and
+    /// a recording in progress is not something a later start may end.
+    ///
+    /// A pure function over the phase rather than an inline comparison, because
+    /// the guard it backs only fires in a race that no test can schedule
+    /// reliably — this is the layer that can be pinned.
+    static func mayTakeOverLoop(in state: WatchLoop.State) -> Bool {
+        state != .recording
+    }
+
+    // MARK: - Settling in-flight starts (shared by both control surfaces)
 
     /// How long a control call waits for an in-flight start before giving up.
     /// Generous against the ~2 s warm start, short enough that a wedged request
@@ -314,9 +312,48 @@ final class WatchingController {
     /// so the losing child keeps waiting, and a group awaits every child before
     /// it returns — the join would outlive its own timeout. Giving up must also
     /// not cancel the start itself, which is a user action already in progress.
-    private func joinStart() async -> Bool {
+    ///
+    func joinStart() async -> Bool {
+        await join { self.startTask != nil }
+    }
+
+    /// Bounded wait for the manual start alone, for a caller that just launched
+    /// one and has to answer for how it went.
+    ///
+    /// The task parks on the microphone TCC prompt, which on a menu-bar app can
+    /// sit unanswered behind other windows for as long as nobody looks. Awaiting
+    /// its value directly would hold an HTTP handler and its connection open for
+    /// exactly that long — the leak `joinStart` above exists to prevent. The task
+    /// clears `manualStartTask` in its own `defer`, so polling that is polling
+    /// its completion, and giving up here does not cancel a start the user may
+    /// still be about to answer.
+    func joinManualStart() async -> Bool {
+        await join { self.manualStartTask != nil }
+    }
+
+    /// Settle *both* in-flight starts, auto and manual, under one deadline.
+    ///
+    /// `/v1/record` waits for a quiet moment before deciding what a request
+    /// means: reading the loop mid-launch reports "nothing is recording", and
+    /// the start that follows would then be a second one.
+    ///
+    /// One predicate rather than two joins in sequence, for two reasons. The
+    /// bound stays the 20 seconds the API documents instead of doubling to 40,
+    /// which would put it above the client's own timeout and report a start that
+    /// then succeeds as a failure. And it is the stricter question: waiting for
+    /// one and then the other can watch the auto start finish, spend the second
+    /// wait on the manual one, and return true while a fresh auto start is
+    /// already in flight again.
+    func joinStarts() async -> Bool {
+        await join { self.startTask != nil || self.manualStartTask != nil }
+    }
+
+    /// Bounded wait for an in-flight start, shared by both joins. True when it
+    /// settled, false on expiry or cancellation. See `joinStart` for why the
+    /// bound and the polling shape are what they are.
+    private func join(while inFlight: () -> Bool) async -> Bool {
         let deadline = ContinuousClock.now + startJoinTimeout
-        while startTask != nil {
+        while inFlight() {
             if Task.isCancelled { return false }
             if ContinuousClock.now >= deadline { return false }
             try? await Task.sleep(for: .milliseconds(50))
@@ -324,65 +361,7 @@ final class WatchingController {
         return true
     }
 
-    /// Idempotent start. Awaits the in-flight async start — mic gate, engine
-    /// sync, queue rebuild, loop construction — so a caller that reports state
-    /// back observes the settled result instead of a snapshot taken mid-launch.
-    /// `toggleWatching` alone cannot offer that: it returns the moment the task
-    /// is spawned, and `startTask` is private.
-    ///
-    /// Starts as not user-initiated. Nobody is at the machine when this arrives
-    /// — that is the whole point of the endpoint — so the optional Accessibility
-    /// prompt must not be raised, exactly as for auto-watch.
-    @discardableResult
-    func startWatching() async -> WatchControlOutcome {
-        if isManualRecording { return .blocked }
-        if isWatching { return .unchanged }
-        toggleWatching(userInitiated: false)
-        // `toggleWatching` assigns `startTask` synchronously, so this always
-        // joins the task it just created — or, if another caller already had a
-        // start in flight, the one whose existence made our call a no-op.
-        guard await joinStart() else { return .failed }
-        // Re-check: a manual start can register while the auto start is parked,
-        // which makes that start bail and leaves `watchLoop` nil. The join
-        // settled and the dialog was answered, so this is the conflict 409
-        // describes, not the "did not settle" 503.
-        if isManualRecording { return .blocked }
-        return isWatching ? .changed : .failed
-    }
-
-    /// Idempotent stop. Awaits a pending start first: otherwise a stop issued
-    /// during the mic-access window lands before the loop exists, reports
-    /// "already stopped", and is then overwritten by the start completing.
-    ///
-    /// A manual recording is reported as `.unchanged` rather than `.blocked`:
-    /// `isWatching` is false by definition while one owns the loop, so the
-    /// requested end state already holds and there is nothing to refuse. That
-    /// is the asymmetry with `startWatching`, where `.blocked` is right because
-    /// starting would clobber the recording.
-    @discardableResult
-    func stopWatching() async -> WatchControlOutcome {
-        guard await joinStart() else { return .failed }
-        guard isWatching else { return .unchanged }
-        toggleWatching()
-        return isWatching ? .failed : .changed
-    }
-
-    /// Apply a watch action, resolving `.toggle` against settled state.
-    ///
-    /// The leading await matters for `.toggle`: deciding against a mid-launch
-    /// snapshot would read "not watching" for a loop that is seconds from
-    /// running, and start a second one. Settling first means a toggle racing a
-    /// start converges to on — the caller asked for a flip and gets a definite
-    /// answer, rather than a coin toss on where the mic prompt happened to be.
-    @discardableResult
-    func applyWatchAction(_ action: WatchAction) async -> WatchControlOutcome {
-        guard await joinStart() else { return .failed }
-        switch action {
-        case .start: return await startWatching()
-        case .stop: return await stopWatching()
-        case .toggle: return isWatching ? await stopWatching() : await startWatching()
-        }
-    }
+    // MARK: - Manual recording
 
     func startManualRecording(pid: pid_t, appName: String, title: String) {
         beginManualRecording(.app(pid: pid, appName: appName, title: title))
@@ -407,28 +386,41 @@ final class WatchingController {
         beginManualRecording(.microphone)
     }
 
-    private func beginManualRecording(_ request: ManualRecordingRequest) {
+    /// Start a manual recording, or refuse. Returns the start's task so a caller
+    /// that has to answer for the outcome can await it; nil means one of the two
+    /// ownership guards below refused before anything began.
+    @discardableResult
+    func beginManualRecording(
+        _ request: ManualRecordingRequest,
+    ) -> Task<ManualRecordingStartResult, Never>? {
         // `toggleWatching`'s counterpart. The correctness added here rests on
         // `manualStartTask` being accurate, and without this a second start
         // replaces the field while the first is still in flight, whose `defer`
         // then clears the second's registration and reopens the window.
-        guard manualStartTask == nil else { return }
+        guard manualStartTask == nil else { return nil }
         // Refuse while one is already recording. Without this the assignment
         // below replaces `watchLoop` without stopping the live loop, so its
         // recording is never enqueued while its recorder keeps capturing,
         // retained by its own monitor task and reachable by nothing (#624).
         // The picker disables Start for the same reason, but it cannot be the
         // enforcement: a recording can begin between opening it and pressing.
-        guard watchLoop?.isManualRecording != true else { return }
-        manualStartTask = Task { @MainActor in
+        guard watchLoop?.isManualRecording != true else { return nil }
+        let task = Task { @MainActor in
             defer { manualStartTask = nil }
-            await performManualRecording(request)
+            return await performManualRecording(request)
         }
+        // Assigned after construction, not inline: the body is `@MainActor` and
+        // so is this, so it cannot run before we return, and the field is set
+        // for the whole window either way.
+        manualStartTask = task
+        return task
     }
 
     /// Body of `beginManualRecording`, split out so the task closure stays a
     /// two-liner and the work is readable on its own.
-    private func performManualRecording(_ request: ManualRecordingRequest) async {
+    private func performManualRecording(
+        _ request: ManualRecordingRequest,
+    ) async -> ManualRecordingStartResult {
         // Settle an auto start before reading `watchLoop`. Mid-flight it is
         // still nil, so the stop below would find nothing and the auto task
         // would later assign over the manual loop, orphaning a live recording
@@ -437,6 +429,19 @@ final class WatchingController {
 
         // Stop auto-watch if active
         if let loop = watchLoop, loop.isActive, !loop.isManualRecording {
+            // Re-checked here, and not only wherever the caller checked it: that
+            // check ran before this task was scheduled, and the poll loop can
+            // have entered a meeting in the meantime. Stopping the loop then
+            // truncates a recording in progress, which is the loss #624 was
+            // about, reachable from the app picker (its window outlives the
+            // state it was opened in) and from the automation API alike.
+            guard Self.mayTakeOverLoop(in: loop.state) else {
+                notifier.notify(
+                    title: "Recording Refused",
+                    body: "A meeting is already being recorded",
+                )
+                return .blockedByActiveRecording
+            }
             loop.stop()
             watchLoop = nil
         }
@@ -495,9 +500,18 @@ final class WatchingController {
                 title: "Manual Recording",
                 body: "Recording: \(loop.manualRecordingInfo?.title ?? "")",
             )
+            return .started
         } catch {
             notifier.notify(title: "Error", body: error.localizedDescription)
             watchLoop = nil
+            // The permission arm is told apart by the error the gate raises, not
+            // by re-asking the health check here: only the loop knows which
+            // source it was about to record, and the whole point of that gate is
+            // that the answer differs per source.
+            guard let recorderError = error as? RecorderError,
+                  case .permissionDenied = recorderError
+            else { return .failed }
+            return .permissionRefused
         }
     }
 
@@ -514,9 +528,14 @@ final class WatchingController {
     /// the `LiveTranscriptionController`. `async` so the coordinator can await the
     /// prior recording's stop-time flush before reusing a kept EOU session.
     private func makeRecorderFactory() -> @MainActor () async -> any RecordingProvider {
-        { [weak self] in
-            let recorder = DualSourceRecorder()
-            await self?.liveTranscription.attachSinks(to: recorder)
+        { [weak self, makeRecorder] in
+            let recorder = makeRecorder()
+            // Live captions tap the concrete recorder's buffer sinks, so this is
+            // the production recorder or nothing. An injected double has no
+            // sinks and needs none: captions are off in every test that uses one.
+            if let dualSource = recorder as? DualSourceRecorder {
+                await self?.liveTranscription.attachSinks(to: dualSource)
+            }
             return recorder
         }
     }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -401,22 +401,34 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             XCTAssertNil(server.boundPort)
         }
 
+        /// Boots the `AppState`-wired server on an OS-assigned port and returns
+        /// its base URL. Shared by the two socket tests below, which are separate
+        /// only because one function cannot hold both under the length cap.
+        /// `DebugRPCServerIntegrationTests.startServer` cannot stand in: it
+        /// builds a bare `DebugRPCServer`, and driving the `AppState`-built one
+        /// is the whole point here.
+        private func startWiredServer(
+            _ state: AppState, token: String,
+        ) async throws -> (server: DebugRPCServer, baseURL: URL) {
+            let server = state.buildDebugRPCServer(port: 0, token: token)
+            server.start()
+            addTeardownBlock { await server.stop() }
+            for _ in 0 ..< 50 {
+                if let p = server.boundPort, let url = URL(string: "http://127.0.0.1:\(p)") {
+                    return (server, url)
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            throw XCTestError(.timeoutWhileWaiting)
+        }
+
         /// End-to-end over a real socket: every /v1 closure buildDebugRPCServer
         /// wires (enqueueReturningIDs, jobStatus, namingStatus, confirmNaming,
         /// skipJobNaming) is exercised through the actual AppState → pipeline path.
         func testBuildDebugRPCServerServesV1OverSocket() async throws {
             let (state, _) = makeState()
             let token = "appstate-rpc-e2e-token"
-            let server = state.buildDebugRPCServer(port: 0, token: token)
-            server.start()
-            defer { server.stop() }
-
-            var base: URL?
-            for _ in 0 ..< 50 {
-                if let p = server.boundPort { base = URL(string: "http://127.0.0.1:\(p)"); break }
-                try await Task.sleep(for: .milliseconds(20))
-            }
-            let baseURL = try XCTUnwrap(base)
+            let baseURL = try await startWiredServer(state, token: token).baseURL
 
             func send(_ method: String, _ path: String, body: Data? = nil) async throws -> Int {
                 var req = URLRequest(url: baseURL.appendingPathComponent(path))
@@ -486,6 +498,37 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
             let dto = try JSONDecoder().decode(WatchStatusDTO.self, from: stopData)
             XCTAssertFalse(dto.watching)
             XCTAssertFalse(dto.manualRecording)
+        }
+
+        /// The `/v1/record` half of the same job, in its own test because the one
+        /// above is at the function-length cap.
+        ///
+        /// One assertion, deliberately. `DebugRPCServer.init` defaults the record
+        /// closures, so deleting the wiring arguments at the `AppState` call site
+        /// would still compile and leave every route test green — and a `stop`
+        /// with nothing recording is the one call that tells the two apart, since
+        /// the real closure answers 200 (`unchanged`) where the default answers
+        /// `.failed`, which the route renders as 503. A `GET` would pass against
+        /// the default too, and the 400 is decided by `JSONDecoder` before any
+        /// closure is reached.
+        func testBuildDebugRPCServerServesV1RecordOverSocket() async throws {
+            let (state, _) = makeState()
+            // A verdict the default `.notRecording` projection cannot produce,
+            // so the body distinguishes the wired status closure from it just as
+            // the 200 distinguishes the wired control closure from `.failed`.
+            state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .denied))
+            let token = "appstate-rpc-record-token"
+            let baseURL = try await startWiredServer(state, token: token).baseURL
+
+            var req = URLRequest(url: baseURL.appendingPathComponent("v1/record"))
+            req.httpMethod = "POST"
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let body = Data(#"{"action":"stop"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: body)
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let dto = try JSONDecoder().decode(RecordStatusDTO.self, from: data)
+            XCTAssertFalse(dto.microphoneHealthy, "the wired status closure, not the init default")
         }
     #endif
 

--- a/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/DebugRPCServerIntegrationTests.swift
@@ -45,6 +45,8 @@
             transcribe: @escaping (URL, Double) async -> BlockingTranscribeResult = { _, _ in .noFile },
             watchStatus: @escaping () -> WatchStatusDTO = { .notWatching },
             watchControl: @escaping (WatchAction) async -> WatchControlOutcome = { _ in .failed },
+            recordStatus: @escaping () -> RecordStatusDTO = { .notRecording },
+            recordControl: @escaping (RecordAction) async -> RecordControlOutcome = { _ in .failed },
         ) async throws -> URL {
             let server = DebugRPCServer(
                 port: 0,
@@ -61,6 +63,8 @@
                 transcribe: transcribe,
                 watchStatus: watchStatus,
                 watchControl: watchControl,
+                recordStatus: recordStatus,
+                recordControl: recordControl,
             )
             self.server = server
             server.start()
@@ -1196,6 +1200,143 @@
             req.httpBody = Data(#"{"action":"pause"}"#.utf8)
             let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        // MARK: - /v1/record
+
+        func testV1RecordGETReturnsStatus() async throws {
+            let dto = RecordStatusDTO(
+                recording: true, startPending: false, state: "recording", badge: "recording",
+                otherRecordingActive: false, noMic: false, microphoneHealthy: true,
+            )
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let status: () -> RecordStatusDTO = { dto }
+            let base = try await startServer(recordStatus: status)
+
+            let (data, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/record"), headers: authHeader),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(RecordStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.recording)
+            XCTAssertEqual(decoded.state, "recording")
+            XCTAssertEqual(decoded.badge, "recording")
+            XCTAssertTrue(decoded.microphoneHealthy)
+        }
+
+        /// Same contract as `/v1/watch`: the body carries the state *after* the
+        /// action, so a controller redraws from the response instead of racing a
+        /// follow-up GET.
+        func testV1RecordPOSTStartReturnsResultingState() async throws {
+            var isRecording = false
+            let base = try await startServer(
+                recordStatus: {
+                    RecordStatusDTO(
+                        recording: isRecording, startPending: false, state: isRecording ? "recording" : nil,
+                        badge: "inactive", otherRecordingActive: false,
+                        noMic: false, microphoneHealthy: true,
+                    )
+                },
+                recordControl: { action in
+                    guard action == .start else { return .unchanged }
+                    isRecording = true
+                    return .changed
+                },
+            )
+
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            let decoded = try JSONDecoder().decode(RecordStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.recording, "the response must reflect the post-action state, not the pre-action one")
+        }
+
+        func testV1RecordPOSTUnchangedReturns200() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let control: (RecordAction) -> RecordControlOutcome = { _ in .unchanged }
+            let base = try await startServer(recordControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"stop"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        }
+
+        func testV1RecordPOSTBlockedReturns409() async throws {
+            let dto = RecordStatusDTO(
+                recording: false, startPending: false, state: "recording", badge: "recording",
+                otherRecordingActive: true, noMic: false, microphoneHealthy: true,
+            )
+            let base = try await startServer(recordStatus: { dto }, recordControl: { _ in .blocked })
+
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 409)
+            let decoded = try JSONDecoder().decode(RecordStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.otherRecordingActive, "the body has to say what is holding the loop")
+        }
+
+        /// The code that distinguishes this resource from `/v1/watch`, where the
+        /// same machine state answers 200 because app audio still records. Here
+        /// nothing would, and no amount of retrying changes that — so it must be
+        /// neither a 200 nor a 503, and the body has to say which switch is off.
+        func testV1RecordPOSTRefusedReturns412() async throws {
+            let dto = RecordStatusDTO(
+                recording: false, startPending: false, state: nil, badge: "inactive",
+                otherRecordingActive: false, noMic: true, microphoneHealthy: false,
+            )
+            let base = try await startServer(recordStatus: { dto }, recordControl: { _ in .refused })
+
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (data, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 412)
+            let decoded = try JSONDecoder().decode(RecordStatusDTO.self, from: data)
+            XCTAssertTrue(decoded.noMic)
+            XCTAssertFalse(decoded.microphoneHealthy)
+        }
+
+        func testV1RecordPOSTFailedReturns503() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let control: (RecordAction) -> RecordControlOutcome = { _ in .failed }
+            let base = try await startServer(recordControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"start"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 503)
+        }
+
+        func testV1RecordPOSTUnknownActionReturns400() async throws {
+            // Typed local, not a trailing closure — see testV1WatchGETReturnsStatus.
+            let control: (RecordAction) -> RecordControlOutcome = { _ in .changed }
+            let base = try await startServer(recordControl: control)
+            var req = request("POST", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpBody = Data(#"{"action":"pause"}"#.utf8)
+            let (_, response) = try await URLSession.shared.upload(for: req, from: XCTUnwrap(req.httpBody))
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        /// The method arm of the control-resource table. Without it a `DELETE`
+        /// could be answered with a 200 status body, i.e. a verb the API never
+        /// defined would look implemented.
+        func testV1RecordRejectsAnUndefinedMethod() async throws {
+            let base = try await startServer()
+            var req = request("DELETE", base.appendingPathComponent("v1/record"), headers: authHeader)
+            req.httpMethod = "DELETE"
+            let (_, response) = try await URLSession.shared.data(for: req)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+        }
+
+        func testV1RecordRequiresAuth() async throws {
+            let base = try await startServer()
+            let (_, response) = try await URLSession.shared.data(
+                for: request("GET", base.appendingPathComponent("v1/record")),
+            )
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 401)
         }
 
         func testV1WatchRequiresAuth() async throws {

--- a/app/MeetingTranscriber/Tests/FixedMeetingDetector.swift
+++ b/app/MeetingTranscriber/Tests/FixedMeetingDetector.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import MeetingTranscriber
+
+/// A meeting for tests that need one but do not care what it is.
+func makeTestMeeting(pid: pid_t = 4242) -> DetectedMeeting {
+    DetectedMeeting(
+        pattern: AppMeetingPattern(
+            appName: "Test App",
+            ownerNames: ["TestApp"],
+            meetingPatterns: [#"^Meeting:.*"#],
+            idlePatterns: [#"^Test App$"#],
+        ),
+        windowTitle: "Meeting: Sprint",
+        ownerName: "TestApp",
+        windowPID: pid,
+    )
+}
+
+/// Reports one meeting forever, so a started `WatchLoop` enters `handleMeeting`
+/// and stays there. `makeSilentDetector`'s opposite, and the counterpart to
+/// `ImmediatelyInactiveDetector` below. Immutable, which keeps it Sendable-safe.
+final class FixedMeetingDetector: MeetingDetecting {
+    private let meeting: DetectedMeeting
+
+    init(_ meeting: DetectedMeeting = makeTestMeeting()) {
+        self.meeting = meeting
+    }
+
+    func checkOnce() -> DetectedMeeting? {
+        meeting
+    }
+
+    func isMeetingActive(_: DetectedMeeting) -> Bool {
+        true
+    }
+
+    func reset(appName _: String?) {}
+}
+
+extension HealthCheckResult {
+    /// Every permission granted and working. The seed for tests that assert a
+    /// recording starts, so nothing they measure depends on the runner's TCC
+    /// state — `makeTestWatchLoop` installs the same verdict for the same reason.
+    static let allHealthy = Self(screenRecording: .healthy, microphone: .healthy)
+}

--- a/app/MeetingTranscriber/Tests/RPCRecordStatusTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCRecordStatusTests.swift
@@ -1,0 +1,115 @@
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// The `/v1/record` status projection: which recording it calls its own,
+    /// which it calls somebody else's, and the two switches a client needs in
+    /// order to explain a 412 it just received.
+    @MainActor
+    final class RPCRecordStatusTests: XCTestCase {
+        func testAMicrophoneRecordingIsThisEndpointsRecording() async throws {
+            let state = makeRPCTestState()
+            XCTAssertFalse(state.recordStatusDTO().recording, "precondition: nothing is recording")
+
+            let (loop, _) = makeTestWatchLoop()
+            state.watching.watchLoop = loop
+            try await loop.startMicrophoneRecording()
+            defer { loop.stop() }
+
+            let dto = state.recordStatusDTO()
+            XCTAssertTrue(dto.recording)
+            XCTAssertFalse(dto.otherRecordingActive)
+            XCTAssertEqual(dto.state, "recording")
+        }
+
+        /// The narrowing that keeps a client from stopping a meeting it never
+        /// started: an app recording is reported, but not as this endpoint's.
+        func testAnAppRecordingIsReportedAsSomebodyElses() async throws {
+            let state = makeRPCTestState()
+            let (loop, _) = makeTestWatchLoop()
+            state.watching.watchLoop = loop
+            try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+            defer { loop.stop() }
+
+            let dto = state.recordStatusDTO()
+            XCTAssertFalse(dto.recording, "an app recording is not a microphone recording")
+            XCTAssertTrue(dto.otherRecordingActive, "but a client has to be told something holds the loop")
+        }
+
+        /// `badge` is the field a physical key renders, and the only one no test
+        /// read off a real projection: hardcoding it to `inactive` left the suite
+        /// green while the key froze on the wrong glyph mid-recording.
+        func testBadgeFollowsTheLiveBadge() async throws {
+            let state = makeRPCTestState()
+            let (loop, _) = makeTestWatchLoop()
+            state.watching.watchLoop = loop
+            try await loop.startMicrophoneRecording()
+            defer { loop.stop() }
+
+            XCTAssertEqual(state.recordStatusDTO().badge, state.currentBadge.rawValue)
+            XCTAssertEqual(state.recordStatusDTO().badge, "recording")
+        }
+
+        /// The wire shape itself, which every other test misses by encoding and
+        /// decoding the same type: a renamed key round-trips perfectly and breaks
+        /// every documented client. Also pins the omit-don't-null convention the
+        /// docs promise for `state`.
+        func testTheWireShapeMatchesWhatTheDocsPromise() throws {
+            let dto = RecordStatusDTO.notRecording
+
+            let object = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: JSONEncoder().encode(dto)) as? [String: Any],
+            )
+
+            XCTAssertEqual(
+                Set(object.keys),
+                ["recording", "startPending", "badge", "otherRecordingActive", "noMic", "microphoneHealthy"],
+                "these key names are the published contract",
+            )
+            XCTAssertNil(object["state"], "a nil value is omitted, not sent as null")
+        }
+
+        /// The window a polling key would otherwise read as plain idle. Narrow
+        /// on purpose: a *running* app recording is not a pending microphone
+        /// start, and reporting it as one would have a key wait for something
+        /// that is never going to become its recording.
+        func testOnlyAnInFlightStartCountsAsPending() async throws {
+            let state = makeRPCTestState()
+            XCTAssertFalse(state.recordStatusDTO().startPending, "nothing in flight")
+
+            let (loop, _) = makeTestWatchLoop()
+            state.watching.watchLoop = loop
+            try await loop.startManualRecording(pid: 42, appName: "Chrome", title: "Standup")
+            defer { loop.stop() }
+
+            let dto = state.recordStatusDTO()
+            XCTAssertFalse(dto.startPending, "a running app recording is not a pending start")
+            XCTAssertTrue(dto.otherRecordingActive, "it is reported here instead")
+        }
+
+        func testTheNoMicrophoneSettingIsReported() {
+            let state = makeRPCTestState()
+            XCTAssertFalse(state.recordStatusDTO().noMic)
+
+            state.settings.noMic = true
+
+            XCTAssertTrue(state.recordStatusDTO().noMic, "a client needs this to explain the refusal it just got")
+        }
+
+        /// Scoped to the microphone, and asked through the same
+        /// `recordingBlockers` the gate uses. A denied Screen Recording grant
+        /// blocks no microphone recording, so reporting it here would describe
+        /// the endpoint as broken on exactly the machines where it is the
+        /// capture path that still works.
+        func testOnlyAMicrophoneProblemMakesTheStatusUnhealthy() {
+            let state = makeRPCTestState()
+            XCTAssertTrue(state.recordStatusDTO().microphoneHealthy, "an unprobed check is not a problem")
+
+            state.permissions.handle(HealthCheckResult(screenRecording: .denied, microphone: .healthy))
+            XCTAssertTrue(state.recordStatusDTO().microphoneHealthy)
+
+            state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .broken))
+            XCTAssertFalse(state.recordStatusDTO().microphoneHealthy, "allowed-but-not-working is a problem too")
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -200,8 +200,20 @@ func makeSilentDetector() -> MeetingDetector {
 /// Creates a WatchLoop backed by a MockRecorder and a silent detector.
 /// Assign the returned loop to `appState.watching.watchLoop` in tests that need
 /// an active loop without calling toggleWatching() (which requires Permissions).
+/// A `MockRecorder` that can complete a stop. Without `mixPath` its `stop()`
+/// throws `noAudioData`, which is the *lost recording* path, not the happy one —
+/// a test that means to exercise a clean stop and forgets this pins the wrong
+/// behaviour as correct.
+@MainActor
+func makeMockRecorder() -> MockRecorder {
+    let recorder = MockRecorder()
+    recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+    return recorder
+}
+
 @MainActor
 func makeTestWatchLoop(
+    detector: any MeetingDetecting = makeSilentDetector(),
     pipelineQueue: PipelineQueue? = nil,
     recordOnly: @escaping () -> Bool = { false },
     recordOnlyOutputDir: @escaping () -> URL = { AppPaths.recordingsDir },
@@ -209,10 +221,9 @@ func makeTestWatchLoop(
     noMic: Bool = false,
     micDeviceUID: String? = nil,
 ) -> (WatchLoop, MockRecorder) {
-    let recorder = MockRecorder()
-    recorder.mixPath = URL(fileURLWithPath: "/tmp/test_mix.wav")
+    let recorder = makeMockRecorder()
     let loop = WatchLoop(
-        detector: makeSilentDetector(),
+        detector: detector,
         recorderFactory: { recorder },
         pipelineQueue: pipelineQueue,
         pollInterval: 0.05,
@@ -223,9 +234,7 @@ func makeTestWatchLoop(
         recordOnlyDestination: { .unscoped(recordOnlyOutputDir()) },
         notifier: notifier,
     )
-    loop.permissionChecker = {
-        HealthCheckResult(screenRecording: .healthy, microphone: .healthy)
-    }
+    loop.permissionChecker = { .allHealthy }
     return (loop, recorder)
 }
 

--- a/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
@@ -10,6 +10,19 @@ import Foundation
 /// because a second suite now needs the same wiring.
 @MainActor
 enum WatchingControllerFactory {
+    /// - Parameter permissionHealth: seeds the health the controller hands to
+    ///   each loop it builds. Pass one whenever a test asserts that a start
+    ///   *succeeds*: nil leaves it unprobed, and the loop then runs a live TCC
+    ///   check whose microphone arm opens the real input device. Under
+    ///   `swift test --parallel` that is several forked processes probing the
+    ///   HAL at once, and it intermittently comes back denied, which the start
+    ///   then correctly refuses.
+    /// - Parameter makeRecorder: defaults to a `MockRecorder` carrying a mix
+    ///   path, so a stop through it takes the success path. Nothing built here
+    ///   touches real audio hardware, because `DualSourceRecorder` writes into
+    ///   `AppPaths.recordingsDir` — the production staging directory that orphan
+    ///   recovery scans. Real `.micOnly` capture is the live lane's job, not a
+    ///   unit test's; see the `e2e-architecture` skill.
     static func make(
         logDir: URL,
         ensureMicAccess: @escaping () async -> Bool = { true },
@@ -17,10 +30,18 @@ enum WatchingControllerFactory {
         requestAccessibility: @escaping () -> Void = {},
         watchTeams: Bool = true,
         noMic: Bool = false,
+        permissionHealth: HealthCheckResult? = nil,
         startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
+        makeRecorder: @escaping @MainActor () -> any RecordingProvider = { makeMockRecorder() },
     ) -> WatchingController {
-        let settings = AppSettings()
+        // Own defaults suite, like `makeRPCTestState`: `AppSettings()` on
+        // `.standard` writes into the test host's real preferences, and
+        // `performManualRecording` reads `recordOnly` and the output directory
+        // back out of that same domain — a value left behind by another test
+        // would send these down the record-only path and into a user folder.
+        let suite = "WatchingControllerFactory-\(getpid())-\(UUID().uuidString)"
+        let settings = AppSettings(defaults: UserDefaults(suiteName: suite) ?? .standard)
         settings.watchTeams = watchTeams
         settings.noMic = noMic
         let notifier = RecordingNotifier()
@@ -32,6 +53,7 @@ enum WatchingControllerFactory {
             indicatorEnabled: { false },
         )
         let permissions = PermissionsController(notifier: notifier)
+        if let permissionHealth { permissions.handle(permissionHealth) }
         let liveTranscription = LiveTranscriptionCoordinator(
             captions: LiveCaptionsState(),
             liveEnabled: { false },
@@ -50,6 +72,7 @@ enum WatchingControllerFactory {
             requestAccessibility: requestAccessibility,
             startJoinTimeout: startJoinTimeout,
             makeDetector: makeDetector,
+            makeRecorder: makeRecorder,
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
@@ -41,7 +41,11 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
     func testMicrophoneRecordingStartsWhenTheMicrophoneIsAllowed() async {
         // Control for the refusal above: without it a method that never starts
         // anything would pass just as well.
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, noMic: false)
+        // Seeded health: without it the loop runs a live TCC probe whose answer
+        // depends on the runner, and this test asserts a start *succeeds*.
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir, noMic: false, permissionHealth: .allHealthy,
+        )
         addTeardownBlock { await controller.stopManualRecording() }
 
         controller.startMicrophoneRecording()

--- a/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
@@ -1,0 +1,374 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The controller half of `/v1/record`: idempotent microphone start/stop, and
+/// the two refusals that make it a resource of its own rather than a verb on
+/// `/v1/watch`.
+///
+/// Nothing here touches real audio hardware. Cases that only need a recording to
+/// exist inject a `makeTestWatchLoop` loop; cases that assert a start actually
+/// happens go through the controller's own start path, which the factory wires
+/// to a `MockRecorder` — `DualSourceRecorder` writes into the production staging
+/// directory, which is not somewhere a unit test may leave files. Real
+/// microphone capture is covered by the live lane, not from here.
+@MainActor
+final class WatchingControllerRecordControlTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tmpDir = try makeTempDirectory(prefix: "WatchingControllerRecordControlTests")
+    }
+
+    override func tearDown() async throws {
+        if let tmpDir { try? FileManager.default.removeItem(at: tmpDir) }
+        try await super.tearDown()
+    }
+
+    // MARK: - Start
+
+    func testStartRecordsTheMicrophoneAndReportsTheChange() async {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir, permissionHealth: .allHealthy)
+        addTeardownBlock { await controller.stopManualRecording() }
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .changed)
+        XCTAssertTrue(controller.isRecordingMicrophoneOnly)
+    }
+
+    /// Already recording is a satisfied request, not an error — the same rule
+    /// `/v1/watch` follows. The second half is the one that matters: the repeat
+    /// must not build a second loop over the live one, which is the loss #624
+    /// was about.
+    func testSecondStartIsUnchangedAndKeepsTheRecordingItFound() async throws {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let loop = try await microphoneRecording(on: controller)
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .unchanged)
+        XCTAssertIdentical(controller.watchLoop, loop, "the live recording must keep the loop")
+        XCTAssertTrue(controller.isRecordingMicrophoneOnly)
+    }
+
+    /// One of the two refusals the endpoint reports as 412. Honouring the
+    /// setting by starting anyway would record nothing, and retrying changes
+    /// nothing until the user turns it off.
+    func testStartIsRefusedWhileTheMicrophoneIsSwitchedOff() async {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir, noMic: true)
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .refused)
+        XCTAssertNil(controller.watchLoop, "nothing may be recorded while the microphone is switched off")
+    }
+
+    /// The other one. It comes back through the start itself rather than from a
+    /// second permission check here, so the refusal names the source the loop
+    /// was actually about to record.
+    func testStartIsRefusedWhenTheMicrophonePermissionIsDenied() async {
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir,
+            permissionHealth: HealthCheckResult(screenRecording: .healthy, microphone: .denied),
+        )
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .refused, "a denied microphone must not read as a transient failure")
+        XCTAssertFalse(controller.isRecordingMicrophoneOnly)
+    }
+
+    /// Control case for the refusal above: without it, a start that refuses on
+    /// *any* permission problem would pass that test just as well. Screen
+    /// Recording only ever gated the process tap, and a microphone recording
+    /// opens none (#633).
+    func testStartProceedsWhileScreenRecordingIsDenied() async {
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir,
+            permissionHealth: HealthCheckResult(screenRecording: .denied, microphone: .healthy),
+        )
+        addTeardownBlock { await controller.stopManualRecording() }
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .changed, "Screen Recording gates a tap this recording never opens")
+        XCTAssertTrue(controller.isRecordingMicrophoneOnly)
+    }
+
+    /// 409, and the assertion that carries it is the second one: a refusal that
+    /// still clobbered the running recording would be the bug, not the code.
+    func testStartIsBlockedWhileAnAppRecordingOwnsTheLoop() async throws {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let loop = try await appRecording(on: controller)
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .blocked)
+        XCTAssertIdentical(controller.watchLoop, loop, "the live recording must keep the loop")
+        XCTAssertTrue(loop.isManualRecording)
+    }
+
+    /// The refusal that carries the most weight, and the one the ownership
+    /// guards inside `beginManualRecording` do *not* provide: an auto-detected
+    /// meeting sets no `manualRecordingInfo`, so `isManualRecording` reads false
+    /// and a start would sail past them and clobber a meeting in progress. Only
+    /// the availability check above stands between a remote key press and that.
+    func testStartIsBlockedWhileAnAutoDetectedMeetingIsBeingRecorded() async {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let (loop, _) = makeTestWatchLoop(detector: FixedMeetingDetector())
+        controller.watchLoop = loop
+        loop.start()
+        addTeardownBlock { await loop.stop() }
+        await waitFor(loop.state == .recording, timeout: .seconds(2))
+        XCTAssertFalse(loop.isManualRecording, "precondition: this is what makes the guards below insufficient")
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .blocked)
+        XCTAssertIdentical(controller.watchLoop, loop, "the meeting's loop must still be the owner")
+        XCTAssertEqual(loop.state, .recording, "the meeting must still be recording")
+    }
+
+    /// The distinction the endpoint exists to make, in the direction nothing
+    /// covered: a recorder that will not start is 503 "try again", NOT the 412
+    /// that tells a client to stop retrying until it changes a setting.
+    /// Collapsing the error classification to `.permissionRefused` used to leave
+    /// the whole suite green.
+    func testARecorderFailureIsNotReportedAsARefusal() async {
+        // Explicit label, not a trailing closure: `make` takes several
+        // function-type parameters and binding by position is exactly the trap
+        // the RPC integration tests warn about.
+        let controller = WatchingControllerFactory.make(
+            // swiftlint:disable:next trailing_closure
+            logDir: tmpDir, permissionHealth: .allHealthy, makeRecorder: { ThrowingRecorder() },
+        )
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .failed, "a device that will not open is transient, not a precondition")
+        XCTAssertFalse(controller.isRecordingMicrophoneOnly)
+    }
+
+    /// A refused start must not leave the machine blind. The start stops an
+    /// active auto loop before it knows whether it can record, so without the
+    /// re-arm a 412 answers "nothing changed" while detection is off for good.
+    func testARefusedStartPutsMeetingWatchingBack() async {
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir,
+            permissionHealth: HealthCheckResult(screenRecording: .healthy, microphone: .denied),
+        )
+        addTeardownBlock { await controller.stopManualRecording() }
+        await controller.startWatching()
+        XCTAssertTrue(controller.isWatching, "precondition")
+
+        let outcome = await controller.applyRecordAction(.start)
+
+        XCTAssertEqual(outcome, .refused)
+        XCTAssertTrue(controller.isWatching, "a refusal must not switch meeting detection off")
+    }
+
+    /// The bound the docs promise, and the half of the predicate that would
+    /// otherwise never be exercised: a start already in flight has to be waited
+    /// for, once, and the wait has to give up rather than hang on the microphone
+    /// prompt the docs name as the cause of a 503.
+    func testAStartWaitsForAnInFlightOneWithinASingleBound() async {
+        let gate = AsyncGate()
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir,
+            ensureMicAccess: {
+                await gate.wait()
+                return true
+            },
+            startJoinTimeout: .milliseconds(80),
+        )
+        addTeardownBlock {
+            await gate.open()
+            await controller.stopManualRecording()
+        }
+        controller.startMicrophoneRecording()
+        await waitFor { await gate.hasWaiter }
+
+        let began = ContinuousClock.now
+        let outcome = await controller.applyRecordAction(.start)
+        let elapsed = ContinuousClock.now - began
+
+        XCTAssertEqual(outcome, .failed, "a start that never settles is a 503, not a hang")
+        XCTAssertLessThan(elapsed, .milliseconds(400), "one bound, not two, and not unbounded")
+    }
+
+    /// The guard behind the race above, at the only layer that can be pinned:
+    /// the interleaving itself (a meeting starting between the caller's check
+    /// and the takeover) is not something a test can schedule reliably.
+    func testALoopThatIsRecordingMayNotBeTakenOver() {
+        XCTAssertFalse(WatchingController.mayTakeOverLoop(in: .recording))
+        for state in [WatchLoop.State.idle, .watching, .error] {
+            XCTAssertTrue(
+                WatchingController.mayTakeOverLoop(in: state),
+                "only a recording is untouchable; \(state) may be taken over",
+            )
+        }
+    }
+
+    /// D1, directly: the start this call launches must be bounded too. The
+    /// earlier case bounds a start it *found*; remove the wait on the one it
+    /// creates and only this one goes red — the endpoint would then hang for as
+    /// long as the microphone prompt sits unanswered.
+    ///
+    /// Driven from a child task with its own deadline rather than awaited
+    /// inline, so a regression fails in under a second instead of wedging the
+    /// whole run: without the bound the call never returns at all.
+    func testTheStartThisCallLaunchesIsBoundedToo() async {
+        let gate = AsyncGate()
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir,
+            ensureMicAccess: {
+                await gate.wait()
+                return true
+            },
+            permissionHealth: .allHealthy,
+            startJoinTimeout: .milliseconds(80),
+        )
+        addTeardownBlock {
+            await gate.open()
+            await controller.stopManualRecording()
+        }
+
+        let settled = OutcomeBox()
+        let call = Task { @MainActor in
+            await settled.store(controller.applyRecordAction(.start))
+        }
+        var outcome: RecordControlOutcome?
+        for _ in 0 ..< 80 where outcome == nil {
+            outcome = await settled.read()
+            if outcome == nil { try? await Task.sleep(for: .milliseconds(10)) }
+        }
+        call.cancel()
+
+        XCTAssertEqual(
+            outcome, .failed,
+            "an unanswered permission prompt must answer 503, not hold the request open",
+        )
+    }
+
+    // MARK: - Stop
+
+    func testStopEndsAMicrophoneRecording() async throws {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        _ = try await microphoneRecording(on: controller)
+
+        let outcome = await controller.applyRecordAction(.stop)
+
+        XCTAssertEqual(outcome, .changed)
+        XCTAssertFalse(controller.isRecordingMicrophoneOnly)
+    }
+
+    func testStopWithNothingRecordingIsUnchanged() async {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+
+        let outcome = await controller.applyRecordAction(.stop)
+
+        XCTAssertEqual(outcome, .unchanged)
+    }
+
+    /// The refusal that would hurt most if it were missing: a stop aimed at the
+    /// microphone reaching across and ending a meeting the caller never started.
+    /// Reported as `.unchanged` rather than `.blocked` because no microphone
+    /// recording is running, so the asked-for end state already holds.
+    func testStopLeavesAnAppRecordingAlone() async throws {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let loop = try await appRecording(on: controller)
+
+        let outcome = await controller.applyRecordAction(.stop)
+
+        XCTAssertEqual(outcome, .unchanged)
+        XCTAssertTrue(loop.isManualRecording, "an app recording must survive a microphone stop")
+        XCTAssertIdentical(controller.watchLoop, loop)
+    }
+
+    /// A stop whose recorder throws loses the recording: `WatchLoop` skips the
+    /// enqueue, so there is no job and no transcript. Answering 200 there tells
+    /// the caller their meeting is safe when it is gone. The mock without a mix
+    /// path is exactly that shape, which is also why the factory's default
+    /// carries one.
+    func testAStopThatLosesTheRecordingIsNotReportedAsSuccess() async {
+        let controller = WatchingControllerFactory.make(
+            // swiftlint:disable:next trailing_closure
+            logDir: tmpDir, permissionHealth: .allHealthy, makeRecorder: { MockRecorder() },
+        )
+        addTeardownBlock { await controller.stopManualRecording() }
+        let started = await controller.applyRecordAction(.start)
+        XCTAssertEqual(started, .changed, "precondition")
+
+        let outcome = await controller.applyRecordAction(.stop)
+
+        XCTAssertEqual(outcome, .failed, "no job was enqueued, so this was not a successful stop")
+    }
+
+    // MARK: - Toggle
+
+    func testToggleStartsThenStops() async {
+        let controller = WatchingControllerFactory.make(logDir: tmpDir, permissionHealth: .allHealthy)
+        addTeardownBlock { await controller.stopManualRecording() }
+
+        let started = await controller.applyRecordAction(.toggle)
+        XCTAssertEqual(started, .changed)
+        XCTAssertTrue(controller.isRecordingMicrophoneOnly)
+
+        let stopped = await controller.applyRecordAction(.toggle)
+        XCTAssertEqual(stopped, .changed)
+        XCTAssertFalse(controller.isRecordingMicrophoneOnly)
+    }
+
+    // MARK: - Helpers
+
+    /// A live microphone recording on a mock-recorder loop the controller owns.
+    /// Injected rather than started for real, so what these tests measure is the
+    /// ownership rule and not the machine's audio hardware.
+    private func microphoneRecording(on controller: WatchingController) async throws -> WatchLoop {
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startMicrophoneRecording()
+        addTeardownBlock { await loop.stop() }
+        return loop
+    }
+
+    /// The same, for an app-picker recording — the thing a microphone start must
+    /// refuse and a microphone stop must leave alone.
+    private func appRecording(on controller: WatchingController) async throws -> WatchLoop {
+        let (loop, _) = makeTestWatchLoop()
+        controller.watchLoop = loop
+        try await loop.startManualRecording(pid: 99, appName: "Chrome", title: "Meeting")
+        addTeardownBlock { await loop.stop() }
+        return loop
+    }
+}
+
+/// Collects an outcome produced by a child task, so a test can put a deadline
+/// on a call that is supposed to be bounded and fail fast when it is not.
+actor OutcomeBox {
+    private var value: RecordControlOutcome?
+
+    func store(_ outcome: RecordControlOutcome) {
+        value = outcome
+    }
+
+    func read() -> RecordControlOutcome? {
+        value
+    }
+}
+
+/// A recorder whose `start` fails the way a busy or absent input device does.
+/// Injected through the `makeRecorder:` seam so the non-permission failure arm
+/// is reachable without hardware.
+@MainActor
+final class ThrowingRecorder: RecordingProvider {
+    func start(source _: RecordingSource, micDeviceUID _: String?, debugLogging _: Bool) throws {
+        throw RecorderError.noAudioData
+    }
+
+    func stop() throws -> RecordingResult {
+        throw RecorderError.notRecording
+    }
+}

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -65,6 +65,8 @@ per connection; exceeding it closes the connection without sending a response.
 | `POST` | `/v1/jobs/<id>/naming/skip` | Skip naming for a job (accept auto-assigned names). |
 | `GET`  | `/v1/watch` | Read whether the app is watching for meetings. |
 | `POST` | `/v1/watch` | Start, stop or toggle meeting watching. |
+| `GET`  | `/v1/record` | Read whether a microphone-only recording is running. |
+| `POST` | `/v1/record` | Start, stop or toggle a microphone-only recording. |
 
 A query string is stripped before routing, so `/v1/jobs/<id>?foo=bar` still
 resolves the id. The one query parameter with meaning is `include=transcript`
@@ -264,6 +266,80 @@ Responses:
 - `400 Bad Request` — the body is not JSON, or `action` is not one of the three
   verbs.
 
+### GET /v1/record
+
+Read whether a microphone-only recording is running. Returns a
+[`RecordStatusDTO`](#recordstatusdto).
+
+```bash
+curl -sS "$BASE/v1/record" -H "Authorization: Bearer $TOKEN"
+```
+
+Always `200 OK`, on the same terms as `GET /v1/watch`: before the app has
+finished starting up it reports a steady "not recording, nothing in the way"
+state rather than failing.
+
+### POST /v1/record
+
+Record the system microphone with no app audio, for a meeting happening in the
+room rather than in an app. The same thing the menu bar's *Record Microphone*
+item does.
+
+```bash
+curl -sS -X POST "$BASE/v1/record" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"start"}'
+```
+
+`action` is `start`, `stop`, or `toggle`. Prefer `start`/`stop` for anything
+that fires from a button, key or schedule, for the reason spelled out under
+`POST /v1/watch`.
+
+The response body is a [`RecordStatusDTO`](#recordstatusdto) describing the state
+**after** the action.
+
+Responses:
+
+- `200 OK` — the request was satisfied, covering both "the state changed" and
+  "it was already like that". A `stop` while something *else* is being recorded
+  is also `200`: no microphone recording is running, which is what was asked
+  for, and that other recording is deliberately left alone. This endpoint only
+  ever stops the recording it could have started.
+- `409 Conflict` — refused because another recording owns the watch loop: an
+  auto-detected meeting, or an app-picker recording. Starting would clobber it.
+  Stop that recording first, or use `POST /v1/watch` if it is a detected
+  meeting. `otherRecordingActive` is normally `true` in the body; it can read
+  `false` when the conflict is a start that registered moments earlier and has
+  not reached `recording` yet, in which case `startPending` is the one that is
+  set. Only `start` and a `toggle` that resolves to a start can return this.
+- `412 Precondition Failed` — refused because nothing would be captured. Either
+  "No Microphone (app audio only)" is set in Settings, or the microphone
+  permission is denied or broken. Read `noMic` and `microphoneHealthy` in the
+  body to tell the two apart. **Retrying does not help**: unlike `503` this
+  answer is stable until someone changes a setting, so a retry loop should stop
+  on it.
+- `400 Bad Request` — the body is undecodable or `action` is not one of the
+  three verbs. Unlike the codes above this one carries an **empty** body, not a
+  `RecordStatusDTO`, because nothing was applied and there is no resulting state
+  to report.
+- `503 Service Unavailable` — the start was attempted and did not produce a
+  recording. Two causes: it did not settle within 20 seconds (in practice an
+  unanswered microphone permission dialog), or the recorder itself refused to
+  start, which a device that is absent or held by another process looks like. A
+  `stop` answers `503` when the recording could not be handed to the pipeline,
+  i.e. the audio is gone; the job you would poll for does not exist.
+
+Retrying is right for `503` and pointless for `412`. That is the whole reason
+they are separate codes.
+
+**Why a denied microphone is `412` here and `200` on `/v1/watch`.** Watching
+starts fine without the microphone, because app audio still records, so a `200`
+with `watching: true` is the truth there. A microphone-only recording has no
+second channel to fall back on, so the same machine state means nothing at all
+would be captured, and reporting success would be a lie a client could not
+detect until it went looking for the file.
+
 ## Idempotency
 
 `POST /v1/jobs` and `POST /v1/transcribe` honour an `Idempotency-Key` request
@@ -406,6 +482,46 @@ as `null` when they have no value. Read them as "absent means none".
 - `permissionsHealthy`: false only when a permission probe has actually failed.
   A check that has not run yet reports `true`.
 
+### RecordStatusDTO
+
+```json
+{
+  "recording": true,
+  "startPending": false,
+  "state": "recording",
+  "badge": "recording",
+  "otherRecordingActive": false,
+  "noMic": false,
+  "microphoneHealthy": true
+}
+```
+
+`recording`, `startPending`, `badge`, `otherRecordingActive`, `noMic` and
+`microphoneHealthy` are always present. `state` is nullable and its key is **omitted** rather than sent
+as `null`, following the same convention as the other DTOs.
+
+- `recording`: whether a **microphone-only** recording is in progress.
+  Deliberately narrower than "something is recording": an app-picker recording
+  and an auto-detected meeting are reported by `otherRecordingActive` instead,
+  so a client is never invited to `stop` a recording it did not start.
+- `startPending`: a start has been accepted but is not recording yet. It waits
+  on the microphone permission gate, which on a first run means an OS dialog
+  somebody has to answer, so this window is not always short. Without this field
+  a poller would read it as plain idle and press again.
+- `state`: `idle`, `watching`, `recording`, or `error`. Absent when no watch loop
+  exists at all.
+- `badge`: what the menu bar icon is showing. Same values as in
+  [`WatchStatusDTO`](#watchstatusdto).
+- `otherRecordingActive`: some other capture owns the watch loop. A `start` is
+  refused with `409` while this is true.
+- `noMic`: the "No Microphone (app audio only)" setting is on. A `start` is
+  refused with `412` while this is true.
+- `microphoneHealthy`: false only when a microphone probe has actually failed
+  (denied, or allowed but not working). A check that has not run yet reports
+  `true`. Scoped to the one permission this endpoint needs: a denied Screen
+  Recording grant does not appear here, because a microphone recording opens no
+  process tap for it to gate.
+
 ## Status codes
 
 | Code | Meaning |
@@ -416,8 +532,9 @@ as `null` when they have no value. Read them as "absent means none".
 | `401` | Missing or wrong bearer token. |
 | `403` | Rejected by the Origin or Host guard. |
 | `404` | Unknown job id. Also `GET /v1/jobs/<id>/naming` when the job is not awaiting naming (the GET folds wrong-state into `404`; the POST naming routes use `409` instead). |
-| `409` | Confirm/skip naming on a job that exists but is not awaiting naming. Also `POST /v1/watch` while a manual recording owns the watch loop. |
-| `503` | `POST /v1/watch` only: the start did not settle within 20 seconds (in practice, an unanswered microphone dialog). A *denied* microphone gives `200`, not this. |
+| `409` | Confirm/skip naming on a job that exists but is not awaiting naming. Also `POST /v1/watch` while a manual recording owns the watch loop, and `POST /v1/record` while any other recording owns it. |
+| `412` | `POST /v1/record` only: nothing would be captured ("No Microphone" is set, or the mic permission is denied/broken). Stable until a setting changes, so do not retry. |
+| `503` | `POST /v1/watch` and `POST /v1/record`: the action was attempted and did not take. On `/v1/watch` that means the state did not settle within 20 seconds; on `/v1/record` also a recorder that would not start, or a stop whose audio could not be handed to the pipeline. Retryable, unlike `412`. On `/v1/watch` a *denied* microphone gives `200`, not this; on `/v1/record` it gives `412`. |
 
 ## Typical flows
 
@@ -466,6 +583,19 @@ mt-cli watch stop
 mt-cli watch toggle
 ```
 
+**Record an in-person meeting:**
+
+```bash
+mt-cli record start
+# ... the meeting happens in the room ...
+mt-cli record stop
+```
+
+The recording then goes through the normal pipeline and shows up as a job, so
+`GET /v1/jobs/<id>` and the naming endpoints apply to it exactly as they do to
+an imported file. Stop on a `412`: it means nothing is being captured, and the
+answer will not change on a retry.
+
 For wiring this to a physical button — a Stream Deck key, a Shortcut, a global
 hotkey — see [`docs/stream-deck.md`](stream-deck.md), which covers the launcher
 side.
@@ -492,11 +622,31 @@ side.
 - **No file upload.** The `path` must already be readable on the host running the
   app. Cross-host submission (multipart upload, no shared filesystem) is not part
   of v1.
-- **`mt-cli` covers inspection plus watch control.** The bundled `tools/mt-cli`
-  client wraps the debug endpoints (`state`, `healthz`, `screenshot`,
-  `open-settings`, `close-settings`) and `mt-cli watch`; an `mt-cli transcribe`
-  front for the job endpoints is a planned follow-up. For now drive the rest of
-  `/v1` with `curl` or any HTTP client.
+- **A microphone recording has no end signal of its own.** An app recording ends
+  when the app quits and a detected meeting ends when the meeting does, but a
+  room has no process to watch, so `POST /v1/record` with `stop` is the only way
+  it ends short of the duration cap. A caller that starts one owns stopping it.
+- **A refused start puts watching back, a successful one does not.** Taking the
+  loop for a recording stops meeting detection; when the start is then refused
+  (`412`) or fails (`503`), detection is restored, so a refusal really does
+  leave the machine as it found it. A start that succeeds does not, which is the
+  next bullet.
+- **Recording the microphone turns meeting watching off, and stopping does not
+  turn it back on.** A recording takes over the watch loop, so after a
+  `start`/`stop` pair the app is idle even on a machine set to watch
+  automatically. Same for the app-picker recording in the menu bar; it is just
+  easier to miss over the API, where nobody is looking at the menu bar icon.
+  Follow a `stop` with `POST /v1/watch {"action":"start"}` if the app should keep
+  watching.
+- **A crash during a microphone recording loses the track.** Recovery on the
+  next launch keys on artefacts an app-audio tap leaves behind, and a
+  microphone-only recording leaves none. Known limitation, not a regression.
+- **`mt-cli` covers inspection plus watch and record control.** The bundled
+  `tools/mt-cli` client wraps the debug endpoints (`state`, `healthz`,
+  `screenshot`, `open-settings`, `close-settings`) plus `mt-cli watch` and
+  `mt-cli record`; an `mt-cli transcribe` front for the job endpoints is a
+  planned follow-up. For now drive the rest of `/v1` with `curl` or any HTTP
+  client.
 
 ## See also
 

--- a/docs/stream-deck.md
+++ b/docs/stream-deck.md
@@ -121,6 +121,32 @@ mt-cli watch toggle
 mt-cli watch status
 ```
 
+## A key for meetings in the room
+
+Everything above wires a key to *watching*, which arms the detector and waits
+for an app to hold a call. A meeting around a table has no app to detect, so it
+has its own resource, `/v1/record`, which records the system microphone and no
+app audio. Same recipe, one path changed:
+
+```bash
+TOKEN=$(cat "$HOME/Library/Application Support/MeetingTranscriber/.rpc-token")
+curl -sS --fail-with-body -X POST http://127.0.0.1:9876/v1/record \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"start"}'
+```
+
+Or `mt-cli record start` / `mt-cli record stop`.
+
+Two things differ from a watch key, and both matter for a button:
+
+- **Nothing stops it but you.** A detected meeting ends when the call does; a
+  room does not, so the recording runs until a `stop` (or the duration cap).
+  This is the one place where having a second key really is worth it.
+- **`412` means it is not recording and never started.** Either "No Microphone
+  (app audio only)" is on in Settings, or the microphone permission is denied.
+  Unlike the other error codes this one does not clear by pressing again.
+
 ## Start and stop beat toggle
 
 `toggle` is the obvious binding and the worst one, because a button press is a
@@ -173,7 +199,8 @@ told.
 | `401` | Token rotated, or the API was toggled off and on. Re-read the file — do not cache it. |
 | Connection refused | App not running, or **Settings → Advanced → Local Automation API** is off. |
 | Token file missing | Same — the file is written when the API starts. |
-| `409` | A manual recording from the app picker owns the loop. Stop it in the menu bar first. |
+| `409` | A recording already owns the loop: from the app picker, or a detected meeting. Stop it first. |
+| `412` | `/v1/record` only. "No Microphone" is set, or the mic permission is denied. Pressing again will not help. |
 | Browser opens on every press | "Access in background" is unticked on the Website action. |
 | Nothing happens, no error | The Shortcut name in the URL does not match, or is not URL-encoded. |
 

--- a/tools/mt-cli/Sources/MTCLI.swift
+++ b/tools/mt-cli/Sources/MTCLI.swift
@@ -11,48 +11,91 @@ struct MTCLI: AsyncParsableCommand {
             State.self, Healthz.self, Screenshot.self, UITree.self, UIPress.self,
             OpenSettings.self, CloseSettings.self, ConfirmBrowserConsent.self,
             SeedSpeaker.self, RenameSpeaker.self, DeleteSpeaker.self, MergeSpeakers.self,
-            WavVerdictCommand.self, Watch.self,
+            WavVerdictCommand.self, Watch.self, Record.self,
         ],
     )
 }
 
-/// `mt-cli watch [status|start|stop|toggle]` — the scriptable surface behind a
-/// hotkey, a Shortcut or a Stream Deck key.
+/// The verb set both `/v1` lifecycle resources accept.
 ///
 /// `start`/`stop` are offered alongside `toggle` on purpose: a button press
 /// expresses a desired end state, and any external controller's view of the app
 /// is slightly stale. A blind toggle after a meeting already ended does exactly
 /// the wrong thing and stays inverted; the idempotent verbs converge instead.
 ///
-/// Every form prints the resulting `/v1/watch` status, so a caller can redraw
-/// from the response rather than racing a follow-up poll. A refusal (409, a
-/// manual recording owns the loop) or a failed postcondition (503) surfaces as
-/// a thrown `RPCError.http` — non-zero exit with the JSON body in the message.
-struct Watch: AsyncParsableCommand {
-    enum Action: String, ExpressibleByArgument, CaseIterable {
-        case status
-        case start
-        case stop
-        case toggle
+/// Shared by the two subcommands below. Not the wire contract — the server's
+/// `WatchAction` and `RecordAction` are, and those stay separate so a verb added
+/// to one resource does not silently appear on the other.
+enum ControlAction: String, ExpressibleByArgument, CaseIterable {
+    case status
+    case start
+    case stop
+    case toggle
+}
+
+/// Read or change one `/v1` lifecycle resource, printing the resulting status.
+///
+/// Always prints the state *after* the call, so a caller can redraw from the
+/// response rather than racing a follow-up poll. A refusal surfaces as a thrown
+/// `RPCError.http` — non-zero exit with the JSON body in the message.
+private func runControl(resource: String, action: ControlAction) async throws {
+    let client = try RPCClient.loadDefault()
+    let data = action == .status
+        ? try await client.get(resource)
+        : try await client.post(
+            resource, json: ["action": action.rawValue],
+            timeout: RPCClient.controlTimeoutSeconds,
+        )
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+/// `mt-cli record [status|start|stop|toggle]` — the microphone counterpart to
+/// `mt-cli watch`, for a meeting happening in the room rather than in an app
+/// (issue #633).
+///
+/// What differs from watching is the refusals, and both are worth knowing before
+/// scripting against it. `409` means something else is being recorded and
+/// starting would clobber it. `412` means nothing would be captured: either "No
+/// Microphone (app audio only)" is set, or the microphone permission is denied
+/// or broken. A 412 will not clear on its own, so a retry loop should stop on
+/// it; the printed body says which of the two it was.
+struct Record: AsyncParsableCommand {
+    /// The resource this command drives. Named rather than inlined at the call
+    /// site so a test can pin it: `Record` and `Watch` differ in this one
+    /// string, and getting it wrong starts the wrong thing without a compile
+    /// error.
+    static let resource = "/v1/record"
+
+    static let configuration = CommandConfiguration(
+        abstract: "Read or change microphone recording. Prints the resulting status as JSON.",
+    )
+
+    @Argument(help: "status (default), start, stop, or toggle.")
+    var action: ControlAction = .status
+
+    func run() async throws {
+        try await runControl(resource: Self.resource, action: action)
     }
+}
+
+/// `mt-cli watch [status|start|stop|toggle]` — the scriptable surface behind a
+/// hotkey, a Shortcut or a Stream Deck key.
+///
+/// A refusal here is `409`: a manual recording owns the loop.
+struct Watch: AsyncParsableCommand {
+    /// See `Record.resource`.
+    static let resource = "/v1/watch"
 
     static let configuration = CommandConfiguration(
         abstract: "Read or change meeting watching. Prints the resulting status as JSON.",
     )
 
     @Argument(help: "status (default), start, stop, or toggle.")
-    var action: Action = .status
+    var action: ControlAction = .status
 
     func run() async throws {
-        let client = try RPCClient.loadDefault()
-        let data = action == .status
-            ? try await client.get("/v1/watch")
-            : try await client.post(
-                "/v1/watch", json: ["action": action.rawValue],
-                timeout: RPCClient.watchControlTimeoutSeconds,
-            )
-        FileHandle.standardOutput.write(data)
-        FileHandle.standardOutput.write(Data("\n".utf8))
+        try await runControl(resource: Self.resource, action: action)
     }
 }
 

--- a/tools/mt-cli/Sources/RPCClient.swift
+++ b/tools/mt-cli/Sources/RPCClient.swift
@@ -52,13 +52,14 @@ struct RPCClient {
     /// the rest of the API is fast.
     static let screenshotTimeoutSeconds: TimeInterval = 15
 
-    /// `POST /v1/watch` blocks until the start settles — mic gate, engine sync,
-    /// queue rebuild, loop construction — so the "rest of the API is fast"
-    /// premise behind `requestTimeoutSeconds` does not hold for it. Set above
-    /// the server's own 20 s join bound so the server always answers first: a
-    /// client-side timeout would report failure for a start that then succeeds
-    /// anyway, since the work continues after the caller disconnects.
-    static let watchControlTimeoutSeconds: TimeInterval = 30
+    /// `POST /v1/watch` and `POST /v1/record` both block until the start
+    /// settles — mic gate, engine sync, queue rebuild, loop construction — so
+    /// the "rest of the API is fast" premise behind `requestTimeoutSeconds`
+    /// does not hold for either. Set above the server's own 20 s join bound so
+    /// the server always answers first: a client-side timeout would report
+    /// failure for a start that then succeeds anyway, since the work continues
+    /// after the caller disconnects.
+    static let controlTimeoutSeconds: TimeInterval = 30
 
     static func loadDefault() throws -> Self {
         let url = defaultTokenURL

--- a/tools/mt-cli/Tests/ControlCommandTests.swift
+++ b/tools/mt-cli/Tests/ControlCommandTests.swift
@@ -1,0 +1,36 @@
+@testable import mt_cli
+import XCTest
+
+/// The two `/v1` lifecycle subcommands. They share `runControl`, so the thing
+/// worth pinning is which resource each one names: the copy-paste that sends
+/// `mt-cli record` at `/v1/watch` compiles, runs, and starts the wrong thing.
+final class ControlCommandTests: XCTestCase {
+    func testEachCommandNamesItsOwnResource() {
+        XCTAssertEqual(Record.resource, "/v1/record")
+        XCTAssertEqual(Watch.resource, "/v1/watch")
+    }
+
+    func testBothDefaultToReadingRatherThanChanging() throws {
+        XCTAssertEqual(try Record.parse([]).action, .status)
+        XCTAssertEqual(try Watch.parse([]).action, .status)
+    }
+
+    func testEveryVerbParses() throws {
+        for verb in ControlAction.allCases {
+            XCTAssertEqual(try Record.parse([verb.rawValue]).action, verb)
+        }
+    }
+
+    func testAnUnknownVerbIsRejectedRatherThanTreatedAsAToggle() {
+        XCTAssertThrowsError(try Record.parse(["pause"]))
+    }
+
+    /// The control routes block until the start settles, so this bound has to
+    /// sit ABOVE the server's own 20 s join. Below it the client gives up first
+    /// and reports a failure for a start that then succeeds — the exact thing
+    /// the constant exists to prevent, and a one-character edit away.
+    func testControlTimeoutOutlivesTheServersJoinBound() {
+        XCTAssertGreaterThan(RPCClient.controlTimeoutSeconds, 20)
+        XCTAssertGreaterThan(RPCClient.controlTimeoutSeconds, RPCClient.requestTimeoutSeconds)
+    }
+}

--- a/tools/mt-cli/skill.md
+++ b/tools/mt-cli/skill.md
@@ -17,6 +17,7 @@ machen" / "ist das im Menü sichtbar".
 - You want to assert on UI structure (a Settings section exists, a control is enabled) without eyeballing a screenshot → `mt-cli ui-tree --window settings`
 - You want to drive a control (press a toggle/button) and check the effect → `mt-cli ui-press <identifier> --window settings`, then `mt-cli state`
 - You want to start or stop meeting watching without touching the menu bar → `mt-cli watch start` / `mt-cli watch stop` (prefer these over `toggle`, which flips blind)
+- You want to record the microphone for an in-person meeting → `mt-cli record start` / `mt-cli record stop`. A `412` means nothing would be recorded ("No Microphone" is set, or the mic permission is denied), and it will not clear by retrying; a `409` means something else is being recorded and the request refused rather than clobber it
 - You're debugging a UI bug and would otherwise have to ask the user to describe state
 - You're verifying a fix end-to-end after editing code
 
@@ -50,6 +51,8 @@ The app writes a 64-hex bearer token to
 | `POST /ui/press`    | `mt-cli ui-press`   | Press a control by identifier (allowlisted windows); assert via `state` |
 | `GET /v1/watch`     | `mt-cli watch`      | Whether the app is watching for meetings (`WatchStatusDTO`) |
 | `POST /v1/watch`    | `mt-cli watch start\|stop\|toggle` | Control watching; returns the resulting `WatchStatusDTO` |
+| `GET /v1/record`    | `mt-cli record`     | Whether a microphone-only recording is running (`RecordStatusDTO`) |
+| `POST /v1/record`   | `mt-cli record start\|stop\|toggle` | Control microphone recording; returns the resulting `RecordStatusDTO` |
 
 ## Build mt-cli
 


### PR DESCRIPTION
Adds `/v1/record`, the automation counterpart to the menu bar's *Record Microphone* item that landed with #633. A remote caller can start and stop a recording of the room, and read whether one is running.

Closes the gap that made #633 awkward to accept: the menu bar is manual-QA-only by project rule, so there was no way to drive the feature from a script, and no way to assert the result other than looking at the disk afterwards.

## The endpoint

`GET /v1/record` reads the status. `POST /v1/record` takes `{"action": "start"|"stop"|"toggle"}` and answers with the state after the action, same body shape on every status code, like `/v1/watch`.

| Situation | Code |
|---|---|
| Started, or already recording | `200` |
| Stopped, or nothing of ours was running | `200` |
| Undecodable body, or a verb that is not one of the three | `400`, empty body |
| Another recording owns the loop | `409` |
| "No Microphone" is set, or the mic permission is denied or broken | `412` |
| The start did not settle in time, the recorder would not start, or a stop could not hand its audio to the pipeline | `503` |

**Why 412 and not 200.** On `/v1/watch` a denied microphone deliberately answers `200` with `watching: true`, because app audio still records without it. Here nothing would be captured at all, so `200` would be a lie the caller could not detect until it went looking for a file. `412` also says what `503` does not: retrying will not help, the answer is stable until someone flips a switch. The body carries `noMic` and `microphoneHealthy` so a client can say which switch. In one sentence: **retry a `503`, never a `412`.**

## Three rules worth reading twice

**A start while a detected meeting is being recorded is refused.** An auto-detected meeting sets no `manualRecordingInfo`, so the ownership guards inside `beginManualRecording` read it as "nothing is recording", and a start would sail past them and take the loop. That is the loss #624 was about, now reachable over the network. The check is repeated where the takeover actually happens, not only where the request decides, because the poll loop can enter a meeting in between. That second check also closes the same hole for the app picker, whose window outlives the state it was opened in.

**A stop only ever stops a microphone recording.** Anything else running answers `200` and is left alone: no microphone recording is in progress, so the asked-for end state already holds, and a stop that reached across and ended somebody else's meeting would be far worse than a `200` that did nothing. A stop whose recorder throws is not a success either, however idle the loop looks afterwards, because the audio never reached the pipeline and there is no job to poll for.

**Every wait is bounded.** The start parks on the microphone permission prompt, which on a menu-bar app can sit unanswered behind other windows, so an unbounded await would hold the HTTP handler and its connection open for exactly that long.

## Verified on the running app

Driven against a live dev build at this branch head, not only in tests:

```
GET  /v1/record   200  recording:false  startPending:false  state:"watching"
POST start        200  recording:true   badge:"recording"   state:"recording"
POST start        200  unchanged, same recording kept
POST /v1/watch    409  refused while the microphone recording owns the loop
POST {"pause"}    400  0-byte body
DELETE            404
POST stop         200  recording:false
POST stop         200  unchanged
GET  /v1/watch         watching:false   <- a recording takes the loop; see Known limits
```

It produced `20260818_083613_mic.wav` plus its mix, and **no `_app.wav`**, which is the claim the feature rests on.

## Also here

- `mt-cli record [status|start|stop|toggle]`, sharing one verb set and one body with `mt-cli watch`; the resource string each names is what the tests pin, since getting it wrong starts the wrong thing without a compile error.
- `docs/automation-api.md`: the routes, the DTO, the status-code table, and the 412 reasoning in full, since a reader who finds `/v1/watch` and `/v1/record` side by side would otherwise read the difference as an inconsistency.
- `docs/stream-deck.md`: a section for a key that records the room, including the two ways it differs from a watch key.

## What review found, since the history no longer shows it

The commits are folded, so this is the only place the defects are recorded. All were mine, none were caught by the test suite, and two rounds of review found eight:

1. **The endpoint had no deadline at all.** The bound covered the starts a request *finds*, never the one it launches, so the documented `503` could not fire in the one case the docs name for it and the handler held its connection open instead.
2. **A stop that lost the recording answered `200`.** When the recorder throws, the loop skips the enqueue and goes idle; reading that as success told the caller their meeting was safe when there was no job, no transcript and no protocol.
3. **A refused start switched meeting detection off.** Taking the loop happens before the start knows whether it can record, so a `412` said "nothing changed" while the machine had quietly stopped watching. It now puts watching back.
4. **The ownership check sat on the wrong side of the suspension**, so a meeting starting in that window was truncated.
5. **The status contradicted the refusal it had just sent.** The projection read the cached permission health while the gate falls back to a live probe, so `GET` could report a healthy microphone and the `POST` right after it refuse with a `412` whose body said nothing was wrong.
6. **No field for "a start is in flight"**, so a polling key read the whole start window as idle and pressed again. That is `startPending`, which the sibling resource has had all along.
7. An earlier pass had already caught a **doubled wait bound** (40 s against a documented 20 and a client that gives up at 30) and a **menu-bar refusal that lost its explanation** when its gate was routed through a shared decision type whose checks run in a different order.

Four documentation promises the code did not keep were corrected with them: the missing `400`, the too-narrow `503`, `otherRecordingActive` promised as always true on a `409`, and the re-arm above.

## Known limits

- A microphone recording has no end signal of its own, so a caller that starts one owns stopping it.
- A **successful** recording takes the watch loop and stopping does not hand it back, so a start/stop pair leaves the app not watching even where auto-watch is on. A refused or failed start does put it back.
- A crash during a recording still loses the track, because recovery keys on artefacts only an app-audio tap leaves behind.

All three are in the API docs.

## Notes for review

`RecordStatusDTO` is a separate wire contract from `WatchStatusDTO` rather than a shared one: the fields a client needs differ, and the two carry independent compatibility promises. The CLI's verb enum *is* shared, since it is not the contract.

Three files are split out of `WatchingController`, which was at the line cap. The last of them moves the watch-control surface as well, so the two automation-API surfaces sit side by side rather than one of them inside the lifecycle class both drive. A handful of members are internal rather than private for that split.

The recorder is now injectable, next to the detector seam that already existed. Unit tests no longer open the real input device, which also means **no unit test covers real `.micOnly` capture** any more; that belongs to the live lane, and the `--mic-only` lane is still outstanding because nothing has yet measured whether the runner's default input carries signal.
