### PR TITLE
test(app): pin the ownership refusal for the app-picker path

### DIFF
--- a/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerFactory.swift
@@ -23,8 +23,13 @@ enum WatchingControllerFactory {
     ///   `AppPaths.recordingsDir` — the production staging directory that orphan
     ///   recovery scans. Real `.micOnly` capture is the live lane's job, not a
     ///   unit test's; see the `e2e-architecture` skill.
+    /// - Parameter notifier: pass one to assert on the refusals this controller
+    ///   reports. A silent refusal is the failure mode several of its guards
+    ///   exist to avoid, so "was the user told" is part of the behaviour, not a
+    ///   detail. Defaults to a fresh spy when a test does not care.
     static func make(
         logDir: URL,
+        notifier: RecordingNotifier = RecordingNotifier(),
         ensureMicAccess: @escaping () async -> Bool = { true },
         requestScreenRecording: @escaping () -> Void = {},
         requestAccessibility: @escaping () -> Void = {},
@@ -44,7 +49,6 @@ enum WatchingControllerFactory {
         let settings = AppSettings(defaults: UserDefaults(suiteName: suite) ?? .standard)
         settings.watchTeams = watchTeams
         settings.noMic = noMic
-        let notifier = RecordingNotifier()
         let pipeline = PipelineController(settings: settings, notifier: notifier)
         pipeline.queue = PipelineQueue(logDir: logDir)
         let channelHealth = ChannelHealthController(

--- a/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
@@ -24,7 +24,7 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
     /// method, and without the guard it would record the one thing that setting
     /// exists to keep off tape.
     func testMicrophoneRecordingIsRefusedWhenTheUserTurnedTheMicrophoneOff() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, noMic: true)
+        let controller = makeWatchingController(logDir: tmpDir, noMic: true)
 
         controller.startMicrophoneRecording()
 
@@ -43,7 +43,7 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
         // anything would pass just as well.
         // Seeded health: without it the loop runs a live TCC probe whose answer
         // depends on the runner, and this test asserts a start *succeeds*.
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir, noMic: false, permissionHealth: .allHealthy,
         )
         addTeardownBlock { await controller.stopManualRecording() }
@@ -69,7 +69,7 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
     /// is told nothing.
     func testAnAppPickerStartIsRefusedWhileAnAutoDetectedMeetingIsRecording() async {
         let notifier = RecordingNotifier()
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir, notifier: notifier, permissionHealth: .allHealthy,
         )
         let (loop, _) = makeTestWatchLoop(detector: FixedMeetingDetector())
@@ -77,10 +77,13 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
         loop.start()
         addTeardownBlock { await loop.stop() }
         await waitFor(loop.state == .recording, timeout: .seconds(2))
-        XCTAssertFalse(
-            loop.isManualRecording,
-            "precondition: an auto meeting is what makes the ownership guards insufficient",
-        )
+        // The wait is the precondition, so assert it: if it ever expires the
+        // loop is merely `.watching`, the start is then correctly NOT refused,
+        // and the assertions below would report a timeout as a production
+        // regression. `isManualRecording` is deliberately not the check here —
+        // an auto meeting never sets `manualRecordingInfo`, so it reads false in
+        // every state and could not fail.
+        XCTAssertEqual(loop.state, .recording, "precondition: the meeting must be recording by now")
 
         controller.startManualRecording(pid: 1234, appName: "Safari", title: "Second")
         await waitFor(!controller.isManualRecording, timeout: .seconds(2))
@@ -93,6 +96,29 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
         )
     }
 
+    /// The refusal's *result*, which the picker path above cannot observe: it
+    /// goes through `startManualRecording`, which discards the task.
+    ///
+    /// `.blockedByActiveRecording` is produced in one place and consumed in one,
+    /// where `/v1/record` maps it to the documented 409. Nothing pinned that
+    /// mapping's input: changing the returned case to `.failed` left all tests
+    /// green while the endpoint answered 503 in exactly the race this guard
+    /// covers, telling a client to retry a conflict the docs say to stop on.
+    func testATakeoverRefusalReportsItselfAsBlockedRatherThanFailed() async {
+        let controller = makeWatchingController(logDir: tmpDir, permissionHealth: .allHealthy)
+        let (loop, _) = makeTestWatchLoop(detector: FixedMeetingDetector())
+        controller.watchLoop = loop
+        loop.start()
+        addTeardownBlock { await loop.stop() }
+        await waitFor(loop.state == .recording, timeout: .seconds(2))
+        XCTAssertEqual(loop.state, .recording, "precondition: the meeting must be recording by now")
+
+        let start = controller.beginManualRecording(.app(pid: 1234, appName: "Safari", title: "Second"))
+
+        let outcome = await start?.value
+        XCTAssertEqual(outcome, .blockedByActiveRecording, "a live recording is a conflict, not a failure")
+    }
+
     /// Issue #624: a second manual start while one is already recording used to
     /// overwrite `watchLoop` without stopping the live loop, so its audio was
     /// never enqueued while its recorder kept capturing, retained by its own
@@ -101,7 +127,7 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
     func testSecondManualStartIsRefusedWhileOneIsRecording() async throws {
         let micGate = AsyncGate()
         // swiftlint:disable:next trailing_closure
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, ensureMicAccess: {
+        let controller = makeWatchingController(logDir: tmpDir, ensureMicAccess: {
             await micGate.wait()
             return true
         })

--- a/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
@@ -56,6 +56,43 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
         XCTAssertTrue(controller.isManualRecording)
     }
 
+    /// The app-picker half of the #624 ownership rule, which the two guards in
+    /// `beginManualRecording` do not cover: an auto-detected meeting sets no
+    /// `manualRecordingInfo`, so `isManualRecording` reads false and a picker
+    /// start sails past both of them into the takeover that stops the loop.
+    ///
+    /// Reachable in practice because the picker window outlives the state it was
+    /// opened in: open it while idle, a meeting starts, press Start. The refusal
+    /// that prevents it lives where the takeover happens, so this pins the
+    /// behaviour for the picker path the way the record endpoint pins it for its
+    /// own. Losing it means a live meeting is truncated into a job and the user
+    /// is told nothing.
+    func testAnAppPickerStartIsRefusedWhileAnAutoDetectedMeetingIsRecording() async {
+        let notifier = RecordingNotifier()
+        let controller = WatchingControllerFactory.make(
+            logDir: tmpDir, notifier: notifier, permissionHealth: .allHealthy,
+        )
+        let (loop, _) = makeTestWatchLoop(detector: FixedMeetingDetector())
+        controller.watchLoop = loop
+        loop.start()
+        addTeardownBlock { await loop.stop() }
+        await waitFor(loop.state == .recording, timeout: .seconds(2))
+        XCTAssertFalse(
+            loop.isManualRecording,
+            "precondition: an auto meeting is what makes the ownership guards insufficient",
+        )
+
+        controller.startManualRecording(pid: 1234, appName: "Safari", title: "Second")
+        await waitFor(!controller.isManualRecording, timeout: .seconds(2))
+
+        XCTAssertIdentical(controller.watchLoop, loop, "the meeting's loop must still be the owner")
+        XCTAssertEqual(loop.state, .recording, "the meeting must still be recording")
+        XCTAssertTrue(
+            notifier.calls.contains { $0.title == "Recording Refused" },
+            "a refusal the user cannot see is the failure this guard exists to avoid; got \(notifier.calls)",
+        )
+    }
+
     /// Issue #624: a second manual start while one is already recording used to
     /// overwrite `watchLoop` without stopping the live loop, so its audio was
     /// never enqueued while its recorder kept capturing, retained by its own

--- a/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
@@ -29,7 +29,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     // MARK: - Start
 
     func testStartRecordsTheMicrophoneAndReportsTheChange() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, permissionHealth: .allHealthy)
+        let controller = makeWatchingController(logDir: tmpDir, permissionHealth: .allHealthy)
         addTeardownBlock { await controller.stopManualRecording() }
 
         let outcome = await controller.applyRecordAction(.start)
@@ -43,7 +43,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// must not build a second loop over the live one, which is the loss #624
     /// was about.
     func testSecondStartIsUnchangedAndKeepsTheRecordingItFound() async throws {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
         let loop = try await microphoneRecording(on: controller)
 
         let outcome = await controller.applyRecordAction(.start)
@@ -57,7 +57,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// setting by starting anyway would record nothing, and retrying changes
     /// nothing until the user turns it off.
     func testStartIsRefusedWhileTheMicrophoneIsSwitchedOff() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, noMic: true)
+        let controller = makeWatchingController(logDir: tmpDir, noMic: true)
 
         let outcome = await controller.applyRecordAction(.start)
 
@@ -69,7 +69,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// second permission check here, so the refusal names the source the loop
     /// was actually about to record.
     func testStartIsRefusedWhenTheMicrophonePermissionIsDenied() async {
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir,
             permissionHealth: HealthCheckResult(screenRecording: .healthy, microphone: .denied),
         )
@@ -85,7 +85,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// Recording only ever gated the process tap, and a microphone recording
     /// opens none (#633).
     func testStartProceedsWhileScreenRecordingIsDenied() async {
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir,
             permissionHealth: HealthCheckResult(screenRecording: .denied, microphone: .healthy),
         )
@@ -100,7 +100,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// 409, and the assertion that carries it is the second one: a refusal that
     /// still clobbered the running recording would be the bug, not the code.
     func testStartIsBlockedWhileAnAppRecordingOwnsTheLoop() async throws {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
         let loop = try await appRecording(on: controller)
 
         let outcome = await controller.applyRecordAction(.start)
@@ -116,7 +116,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// and a start would sail past them and clobber a meeting in progress. Only
     /// the availability check above stands between a remote key press and that.
     func testStartIsBlockedWhileAnAutoDetectedMeetingIsBeingRecorded() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
         let (loop, _) = makeTestWatchLoop(detector: FixedMeetingDetector())
         controller.watchLoop = loop
         loop.start()
@@ -140,7 +140,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
         // Explicit label, not a trailing closure: `make` takes several
         // function-type parameters and binding by position is exactly the trap
         // the RPC integration tests warn about.
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             // swiftlint:disable:next trailing_closure
             logDir: tmpDir, permissionHealth: .allHealthy, makeRecorder: { ThrowingRecorder() },
         )
@@ -155,7 +155,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// active auto loop before it knows whether it can record, so without the
     /// re-arm a 412 answers "nothing changed" while detection is off for good.
     func testARefusedStartPutsMeetingWatchingBack() async {
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir,
             permissionHealth: HealthCheckResult(screenRecording: .healthy, microphone: .denied),
         )
@@ -175,7 +175,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// prompt the docs name as the cause of a 503.
     func testAStartWaitsForAnInFlightOneWithinASingleBound() async {
         let gate = AsyncGate()
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir,
             ensureMicAccess: {
                 await gate.wait()
@@ -221,7 +221,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// whole run: without the bound the call never returns at all.
     func testTheStartThisCallLaunchesIsBoundedToo() async {
         let gate = AsyncGate()
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             logDir: tmpDir,
             ensureMicAccess: {
                 await gate.wait()
@@ -255,7 +255,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     // MARK: - Stop
 
     func testStopEndsAMicrophoneRecording() async throws {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
         _ = try await microphoneRecording(on: controller)
 
         let outcome = await controller.applyRecordAction(.stop)
@@ -265,7 +265,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     }
 
     func testStopWithNothingRecordingIsUnchanged() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
 
         let outcome = await controller.applyRecordAction(.stop)
 
@@ -277,7 +277,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// Reported as `.unchanged` rather than `.blocked` because no microphone
     /// recording is running, so the asked-for end state already holds.
     func testStopLeavesAnAppRecordingAlone() async throws {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir)
+        let controller = makeWatchingController(logDir: tmpDir)
         let loop = try await appRecording(on: controller)
 
         let outcome = await controller.applyRecordAction(.stop)
@@ -293,7 +293,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     /// path is exactly that shape, which is also why the factory's default
     /// carries one.
     func testAStopThatLosesTheRecordingIsNotReportedAsSuccess() async {
-        let controller = WatchingControllerFactory.make(
+        let controller = makeWatchingController(
             // swiftlint:disable:next trailing_closure
             logDir: tmpDir, permissionHealth: .allHealthy, makeRecorder: { MockRecorder() },
         )
@@ -309,7 +309,7 @@ final class WatchingControllerRecordControlTests: XCTestCase {
     // MARK: - Toggle
 
     func testToggleStartsThenStops() async {
-        let controller = WatchingControllerFactory.make(logDir: tmpDir, permissionHealth: .allHealthy)
+        let controller = makeWatchingController(logDir: tmpDir, permissionHealth: .allHealthy)
         addTeardownBlock { await controller.stopManualRecording() }
 
         let started = await controller.applyRecordAction(.toggle)

--- a/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerTests.swift
@@ -34,7 +34,7 @@ final class WatchingControllerTests: XCTestCase {
         startJoinTimeout: Duration = WatchingController.defaultStartJoinTimeout,
         makeDetector: @escaping () -> any MeetingDetecting = { makeSilentDetector() },
     ) -> WatchingController {
-        WatchingControllerFactory.make(
+        makeWatchingController(
             logDir: tmpDir,
             ensureMicAccess: ensureMicAccess,
             requestScreenRecording: requestScreenRecording,

--- a/app/MeetingTranscriber/Tests/XCTestCase+WatchingController.swift
+++ b/app/MeetingTranscriber/Tests/XCTestCase+WatchingController.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import MeetingTranscriber
+import XCTest
 
 /// Builds a `WatchingController` wired to real (but inert) sibling controllers
 /// and the supplied seams. The pipeline gets a queue on an isolated `logDir` so
@@ -8,8 +9,53 @@ import Foundation
 ///
 /// Its own file because `WatchingControllerTests` sits at the 600-line cap, and
 /// because a second suite now needs the same wiring.
+///
+/// An `XCTestCase` extension rather than a free-standing enum so it can reach
+/// the test-case lifecycle; the defaults suite it needs is handled below.
 @MainActor
-enum WatchingControllerFactory {
+extension XCTestCase {
+    /// Whether this process already swept. The sweep scans a directory with
+    /// hundreds of entries, and doing that per call cost 16 s across the suite
+    /// against 2.8 s; once per process is enough, since nothing creates these
+    /// files but the factory itself.
+    nonisolated(unsafe) private static var didSweepFactoryDefaults = false
+
+    /// Remove the preference files of test processes that are gone.
+    ///
+    /// Exact prefix, and only when the owning pid no longer exists, so a run in
+    /// flight keeps its own file — including a `--parallel` sibling, which is
+    /// its own process. The pid is the first component after the prefix, which
+    /// also matches the older `<pid>-<uuid>` names an earlier per-call version
+    /// of this factory left behind.
+    /// Whether no process holds this pid.
+    ///
+    /// `kill(pid, 0) != 0` alone means "not signalable", which is not the same
+    /// thing: a live process owned by another user answers `EPERM`, and reading
+    /// that as dead would have this delete a file out from under a running one.
+    /// Proven reachable by planting a file named after pid 1. Harmless in the
+    /// scenarios this factory can actually produce, and still wrong, so the
+    /// predicate says what it means.
+    private static func processIsGone(_ pid: pid_t) -> Bool {
+        kill(pid, 0) != 0 && errno == ESRCH
+    }
+
+    static func sweepDeadFactoryDefaults() {
+        guard !didSweepFactoryDefaults else { return }
+        didSweepFactoryDefaults = true
+        let prefix = "WatchingControllerFactory-"
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Preferences")
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        for name in names where name.hasPrefix(prefix) && name.hasSuffix(".plist") {
+            let stem = name.dropFirst(prefix.count).dropLast(".plist".count)
+            guard let owner = pid_t(stem.split(separator: "-").first ?? ""), owner > 0,
+                  Self.processIsGone(owner)
+            else { continue }
+            UserDefaults().removePersistentDomain(forName: String(name.dropLast(".plist".count)))
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
+        }
+    }
+
     /// - Parameter permissionHealth: seeds the health the controller hands to
     ///   each loop it builds. Pass one whenever a test asserts that a start
     ///   *succeeds*: nil leaves it unprobed, and the loop then runs a live TCC
@@ -27,7 +73,7 @@ enum WatchingControllerFactory {
     ///   reports. A silent refusal is the failure mode several of its guards
     ///   exist to avoid, so "was the user told" is part of the behaviour, not a
     ///   detail. Defaults to a fresh spy when a test does not care.
-    static func make(
+    func makeWatchingController(
         logDir: URL,
         notifier: RecordingNotifier = RecordingNotifier(),
         ensureMicAccess: @escaping () async -> Bool = { true },
@@ -45,7 +91,28 @@ enum WatchingControllerFactory {
         // `performManualRecording` reads `recordOnly` and the output directory
         // back out of that same domain — a value left behind by another test
         // would send these down the record-only path and into a user folder.
-        let suite = "WatchingControllerFactory-\(getpid())-\(UUID().uuidString)"
+        // One suite per test PROCESS, not per call, and a sweep of the ones
+        // dead processes left behind.
+        //
+        // Isolation is not optional here: this factory writes `noMic` and
+        // `watchTeams`, and `performManualRecording` reads `recordOnly` and the
+        // output directory back out of the same domain, so a value stranded in
+        // `.standard` could send a test into a real user folder. But a suite
+        // cannot be un-created: the preferences daemon owns the file's
+        // lifecycle and flushes its cached copy back after any removal the test
+        // performs. Measured across three attempts (remove domain, then also
+        // delete the file, then the full deregistration dance): 39 files
+        // survived each time. So the file is treated as reusable and the
+        // leftovers are swept by owner instead.
+        let suite = "WatchingControllerFactory-\(getpid())"
+        Self.sweepDeadFactoryDefaults()
+        // Start from a clean domain so one test never reads what another wrote.
+        // Note for a future caller: this resets the whole process-wide suite, so
+        // two controllers built inside ONE test method would have the second
+        // call wipe the first's persisted values. Their in-memory `AppSettings`
+        // survive, since it snapshots at init, but do not build two and expect
+        // both to persist.
+        UserDefaults().removePersistentDomain(forName: suite)
         let settings = AppSettings(defaults: UserDefaults(suiteName: suite) ?? .standard)
         settings.watchTeams = watchTeams
         settings.noMic = noMic


### PR DESCRIPTION
Closes the last follow-up from the #635 review: the ownership refusal was covered for the automation API and not for the app picker, which is the path where a user can walk into it by hand.

No production change.

## The gap

`beginManualRecording` guards on `manualStartTask == nil` and `watchLoop?.isManualRecording != true`. An auto-detected meeting sets no `manualRecordingInfo`, so `isManualRecording` reads **false** and a picker start passes both guards into the takeover that stops the loop.

Reachable without doing anything unusual: the picker window outlives the state it was opened in. Open it while idle, a meeting starts, press Start.

The refusal that prevents it already exists — #635 moved the check to where the takeover happens, so it is source-agnostic and covers the picker too. What was missing is a test saying so.

## What the tests pin

Removing the guard fails the first one with the damage spelled out:

```
XCTAssertEqual failed: ("idle") is not equal to ("recording")
    - the meeting must still be recording
XCTAssertTrue failed - a refusal the user cannot see is the failure this guard
    exists to avoid; got [(title: "Manual Recording", body: "Recording: Second", ...)]
```

The meeting's loop falls to `idle`, its recording is truncated into a job, and the only thing the user is told is that the *new* recording started. That is why the notification is asserted alongside the state.

The second test pins the refusal's **result**. `.blockedByActiveRecording` is produced in one place and consumed in one, where `/v1/record` maps it to the documented `409`. Changing it to `.failed` left all 46 tests green while the endpoint answered `503` in exactly the race the guard covers, telling a client to retry a conflict the docs say to stop on. Two reviews confirmed the discrimination: neutralising the guard fails both tests, changing only the returned case fails only the second.

## Second commit: a leak this PR surfaced

Review counted **371** stray `WatchingControllerFactory-*.plist` files in `~/Library/Preferences`, one per factory call, from the per-test defaults suite in use since #635. That isolation is worth keeping (the factory writes `noMic`/`watchTeams`, and `performManualRecording` reads `recordOnly` and the output directory out of the same domain), so the file is the part that had to change.

A suite cannot be un-created. Three approaches were measured, each still leaving 39 files per 47-test run: removing the domain, additionally deleting the file, and the full deregistration dance. The preferences daemon owns the lifecycle and flushes its cached copy back afterwards. So the file is treated as reusable: one suite per test *process*, reset at each use, plus a sweep of files whose owning process is gone — which also clears the existing backlog.

**510 files before a run, 2 after.**

A second-model review then planted a file named after pid 1 and watched the sweep delete it: `kill(pid, 0) != 0` means "not signalable", and a live process owned by another user answers EPERM. Harmless for files this factory creates, since they are its own and same-user processes are always signalable, but a predicate that deletes from a home directory should not be right by accident. It now requires ESRCH, verified with the same probe.

## Note for review

`makeWatchingController` takes a `notifier`, defaulting to the same internally-created spy as before, so a test can assert what the user was told. All 22 call sites were renamed mechanically; behaviour is unchanged.
