### PR TITLE
fix(app): recover microphone-only recordings after a crash

### DIFF
--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -100,6 +100,7 @@ class DualSourceRecorder: RecordingProvider {
     nonisolated static func cleanupTempFiles(
         recordingsDir: URL = AppPaths.recordingsDir,
         minAge: TimeInterval = 30,
+        reapMarkersWrittenBefore: Date? = nil,
     ) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
@@ -107,6 +108,7 @@ class DualSourceRecorder: RecordingProvider {
             includingPropertiesForKeys: nil,
         ) else { return }
         let cutoff = Date().addingTimeInterval(-minAge)
+        let markerCutoff = reapMarkersWrittenBefore ?? launchedAt
 
         for file in entries where RecordingFileSuffix.stripAppRaw(from: file.lastPathComponent) != nil {
             if let mtime = (try? fm.attributesOfItem(atPath: file.path)[.modificationDate]) as? Date,
@@ -115,6 +117,85 @@ class DualSourceRecorder: RecordingProvider {
             logger.info("Removed orphaned temp file: \(file.lastPathComponent)")
         }
 
+        // Markers whose recording can never be rescued. A start that threw
+        // before capture opened leaves one with no tracks at all; a track that
+        // never received a buffer is a bare header. Either way recovery fails
+        // on that stem at every launch and every watch-start, warning each
+        // time, and nothing else deletes a marker — so without this pass they
+        // are permanent.
+        //
+        // The guard is "written before this process existed", NOT the `minAge`
+        // window pass 1 uses, because the two files age differently: a raw temp
+        // is touched on every buffer, so a live one is always fresh, while a
+        // marker is written once at start and never again. Its age is the
+        // recording's length, so any window at all eventually expires under a
+        // recording that is still running — and a mic wedged mid-capture (the
+        // issue #588 shape) delivers no buffers, leaving a bare-header track
+        // that reads as nothing worth keeping. Reaping there would strand the
+        // recording for good: once the marker is gone a later crash leaves a
+        // lone `_mic.wav`, which is invisible to crash recovery AND to the
+        // orphan scan, which only takes paired groups. This pass also runs on
+        // every watch-start, behind a re-mix that can take minutes, so "the
+        // recording only just began" is not a bound that holds.
+        for file in entries {
+            guard let stem = RecordingFileSuffix.stripInProgress(from: file.lastPathComponent),
+                  let written = (try? fm.attributesOfItem(atPath: file.path)[.modificationDate]) as? Date,
+                  written < markerCutoff,
+                  !isStillRescuable(stem: stem, in: recordingsDir) else { continue }
+            try? fm.removeItem(at: file)
+            logger.info("Removed marker for a recording that captured nothing: \(file.lastPathComponent)")
+        }
+    }
+
+    /// When this process started, as the kernel records it. Anchors the marker
+    /// reaping above: a marker this process wrote is necessarily younger, so
+    /// its own live recording can never be reaped, however long it runs. A
+    /// lazily-initialised `Date()` would not do — nothing guarantees it is
+    /// touched before the first `start()`. Unreadable resolves to the distant
+    /// past, which reaps nothing at all: leaving a stale marker costs a warning
+    /// per launch, reaping a live one costs the recording.
+    nonisolated private static let launchedAt: Date = {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        guard sysctl(&mib, 4, &info, &size, nil, 0) == 0 else { return .distantPast }
+        let started = info.kp_proc.p_starttime
+        return Date(timeIntervalSince1970: Double(started.tv_sec) + Double(started.tv_usec) / 1_000_000)
+    }()
+
+    /// Size of a track that never received a buffer. Measured, not assumed:
+    /// `AVAudioFile` pads its header with a JUNK chunk to a 4 KB boundary, so
+    /// a mic file this app opened and closed empty is exactly this large, not
+    /// the canonical 44 bytes a hand-built WAV header would be. Anything
+    /// carrying audio is larger; the blind spot is a foreign 44-byte-header
+    /// file holding under 4 KB of PCM, a tenth of a second nobody would want
+    /// rescued.
+    nonisolated private static let emptyTrackBytes = 4096
+
+    /// Whether a later recovery pass could still rescue this stem: no mix yet,
+    /// and either a raw app temp or a mic track with PCM past its header. A
+    /// stem that already has a mix is finished whatever its marker says, and
+    /// leaving that marker would turn into a false crash the moment the
+    /// finished job moves the mix into the output folder.
+    ///
+    /// Size is the test, not readability: an unfinalized header reads as zero
+    /// frames while its PCM is intact, so probing readability here would reap
+    /// the marker of a recording that is entirely rescuable. The cost of the
+    /// cruder test is that a large unreadable track keeps its marker and warns
+    /// once per launch, which is the direction to err in.
+    ///
+    /// The rejected empty track is left on disk. It is not user-visible (this
+    /// is the app's staging directory), so it is 4 KB of litter rather than
+    /// something to explain, and deleting audio files here is a far worse
+    /// failure mode than keeping them.
+    nonisolated private static func isStillRescuable(stem: String, in dir: URL) -> Bool {
+        let fm = FileManager.default
+        let mix = dir.appendingPathComponent(stem + RecordingFileSuffix.mix)
+        guard !fm.fileExists(atPath: mix.path) else { return false }
+        if crashedTemp(stem: stem, in: dir) != nil { return true }
+        let mic = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        let size = (try? fm.attributesOfItem(atPath: mic.path)[.size] as? Int) ?? 0
+        return size > emptyTrackBytes
     }
 
     // MARK: - Crash recovery (#379 durability, part 3)
@@ -333,7 +414,17 @@ class DualSourceRecorder: RecordingProvider {
             micLiveSink: micLiveSink,
             micDebugFault: micDebugFault,
         )
-        try session.start()
+        do {
+            try session.start()
+        } catch {
+            // Nothing else would ever remove it: `stop()` is unreachable with
+            // `isRecording` still false, and the cleanup pass below keys on
+            // tracks this start never created. The marker means "interrupted
+            // mid-recording", and a start that never opened is not that.
+            try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: recDir))
+            startTimestamp = nil
+            throw error
+        }
         captureSession = session
 
         isRecording = true

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -114,6 +114,7 @@ class DualSourceRecorder: RecordingProvider {
             try? fm.removeItem(at: file)
             logger.info("Removed orphaned temp file: \(file.lastPathComponent)")
         }
+
     }
 
     // MARK: - Crash recovery (#379 durability, part 3)
@@ -131,11 +132,32 @@ class DualSourceRecorder: RecordingProvider {
         var seen = Set<String>()
         var stems: [String] = []
         for name in filenames {
-            guard let stem = RecordingFileSuffix.stripAppRaw(from: name) else { continue }
+            // Either signal identifies a crash, and a dual-source one leaves
+            // both, so the `seen` set keeps such a stem from being reported
+            // twice. Nothing else counts: see `RecordingFileSuffix.inProgress`
+            // for why a lone mic track must never be read as an interruption.
+            guard let stem = RecordingFileSuffix.stripAppRaw(from: name)
+                ?? RecordingFileSuffix.stripInProgress(from: name) else { continue }
             guard !mixStems.contains(stem), seen.insert(stem).inserted else { continue }
             stems.append(stem)
         }
         return stems
+    }
+
+    /// When this stem's audio was last written, across whichever tracks exist,
+    /// or nil when it has none (nothing to recover, and nothing to wait for).
+    nonisolated private static func lastTrackWrite(stem: String, in dir: URL) -> Date? {
+        let fm = FileManager.default
+        let candidates = RecordingFileSuffix.appRawAny.map { stem + $0 } + [stem + RecordingFileSuffix.mic]
+        return candidates
+            .map { dir.appendingPathComponent($0) }
+            .compactMap { (try? fm.attributesOfItem(atPath: $0.path)[.modificationDate]) as? Date }
+            .max()
+    }
+
+    /// Path of the in-progress marker for one recording.
+    nonisolated static func inProgressMarker(stem: String, in dir: URL) -> URL {
+        dir.appendingPathComponent(stem + RecordingFileSuffix.inProgress)
     }
 
     /// Locate a crashed stem's surviving temp, current format first. Returns
@@ -164,17 +186,20 @@ class DualSourceRecorder: RecordingProvider {
     /// would otherwise be lost.
     @discardableResult
     nonisolated static func recoverCrashedRecording(stem: String, in recDir: URL) throws -> URL {
-        guard let temp = crashedTemp(stem: stem, in: recDir) else {
-            throw RecorderError.noAudioData
-        }
+        let temp = crashedTemp(stem: stem, in: recDir)
         let micWav = recDir.appendingPathComponent(stem + RecordingFileSuffix.mic)
         let hasMic = FileManager.default.fileExists(atPath: micWav.path)
+        // No app temp is the microphone-only shape, which is recoverable from
+        // the mic track alone. With neither there is nothing to rescue.
+        guard temp != nil || hasMic else {
+            throw RecorderError.noAudioData
+        }
         if hasMic { _ = try? WavHeaderRepair.repairIfNeeded(at: micWav) }
 
-        let rate = temp.isLegacy ? defaultRecordRate : AudioConstants.targetSampleRate
-        let channels = temp.isLegacy ? defaultAppChannels : 1
+        let rate = temp?.isLegacy == true ? defaultRecordRate : AudioConstants.targetSampleRate
+        let channels = temp?.isLegacy == true ? defaultAppChannels : 1
         let result = AudioCaptureResult(
-            appAudioFileURL: temp.url,
+            appAudioFileURL: temp?.url,
             micAudioFileURL: hasMic ? micWav : nil,
             actualSampleRate: rate,
             actualChannels: channels,
@@ -215,11 +240,18 @@ class DualSourceRecorder: RecordingProvider {
         let cutoff = Date().addingTimeInterval(-minAge)
         var recovered = 0
         for stem in crashedRecordingStems(in: names) {
-            guard let temp = crashedTemp(stem: stem, in: dir) else { continue }
-            if let mtime = (try? fm.attributesOfItem(atPath: temp.url.path)[.modificationDate]) as? Date,
-               mtime > cutoff { continue }
+            // Freshness is read off the TRACKS, not the marker: the marker is
+            // written once at start, so an hour into a live recording it looks
+            // ancient while the tracks are still growing. Re-mixing under a
+            // running writer is what this guard exists to prevent.
+            if lastTrackWrite(stem: stem, in: dir).map({ $0 > cutoff }) ?? true { continue }
             do {
                 let mix = try recoverCrashedRecording(stem: stem, in: dir)
+                // The mix alone would already stop `crashedRecordingStems` from
+                // re-reporting this stem; the marker goes too so a recovery
+                // whose mix is later moved into the output folder cannot look
+                // like a fresh crash.
+                try? fm.removeItem(at: inProgressMarker(stem: stem, in: dir))
                 logger.info("Recovered crashed recording: \(mix.lastPathComponent)")
                 recovered += 1
             } catch {
@@ -254,6 +286,11 @@ class DualSourceRecorder: RecordingProvider {
 
         let ts = Self.timestamp()
         startTimestamp = ts
+
+        // Written before capture opens and removed in `stop()`, so a surviving
+        // one means this process died mid-recording. The app temp says the same
+        // for a recording that taps an app; this covers the ones that do not.
+        try? Data().write(to: Self.inProgressMarker(stem: ts, in: recDir))
 
         // ── AudioTapLib capture session ──
         // A source with no target opens no tap at all, so it gets neither a
@@ -332,13 +369,23 @@ class DualSourceRecorder: RecordingProvider {
         // not the device-facing recordRate/appChannels — is the expected file
         // format; a buildRecording mismatch warning then means the resampler
         // fallback wrote raw native-rate audio.
-        return try Self.buildRecording(
+        let recording = try Self.buildRecording(
             from: captureResult,
             recordingsDir: Self.recordingsDir,
             timestamp: ts,
             recordingStartDate: recordingStartDate,
             format: CaptureFormat(requestedChannels: 1, requestedRate: targetRate, targetRate: targetRate),
         )
+
+        // Dropped only once the mix exists, exactly where `buildRecording`
+        // drops the raw app temp. A stop whose mix write fails has not
+        // finished anything, and the failure (a full disk, say) usually
+        // survives to the next launch: keeping the marker lets that launch
+        // re-mix from the surviving tracks, which is what the app-audio path
+        // has always got from its temp. The mix itself is what stops a
+        // completed recording from being recovered twice.
+        try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: Self.recordingsDir))
+        return recording
     }
 
     /// Resolve the PID set to tap for a meeting-matched root PID.

--- a/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
+++ b/app/MeetingTranscriber/Sources/RecordingFileSuffix.swift
@@ -6,6 +6,21 @@ enum RecordingFileSuffix {
     static let app = "_app.wav"
     static let mic = "_mic.wav"
 
+    /// Written when a recording starts and removed when it stops, so a
+    /// surviving one means the process died mid-recording.
+    ///
+    /// The raw app temp below carries the same meaning for a recording that
+    /// taps an app, but only for those: a microphone-only recording (issue
+    /// #633) opens no tap and writes no temp, so a crash left nothing to find
+    /// and the audio was lost. This marker is source-independent.
+    ///
+    /// It must stay the ONLY new crash signal. "A mic track with no mix" looks
+    /// like an interrupted recording and is in fact the normal end state of
+    /// every processed one, since `AudioPersistencePolicy` moves the mix into
+    /// the output folder and leaves the mic track in staging. Inferring a crash
+    /// from that once re-processed 40 recordings on a live archive.
+    static let inProgress = "_recording.marker"
+
     /// Raw float32 app-audio temp file written live during capture (16 kHz
     /// mono, in-IOProc resampled) and consumed by `buildRecording` at `stop()`.
     /// A leftover one means the writer was killed mid-recording (crash) — see
@@ -24,6 +39,11 @@ enum RecordingFileSuffix {
     /// Both raw-temp suffixes, current format first — the probe order used by
     /// crash recovery and temp cleanup.
     static let appRawAny: [String] = [appRaw, legacyAppRaw]
+
+    /// Strip the in-progress marker suffix, or nil when `filename` is not one.
+    static func stripInProgress(from filename: String) -> String? {
+        filename.hasSuffix(inProgress) ? String(filename.dropLast(inProgress.count)) : nil
+    }
 
     static let all: [String] = [mix, app, mic]
 

--- a/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
+++ b/app/MeetingTranscriber/Sources/WavHeaderRepair.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "WavHeaderRepair")
 
 /// Repairs an unfinalized WAV — one whose `RIFF`/`data` chunk sizes were left
 /// at placeholder values because the writer was killed before it closed the
@@ -52,10 +55,35 @@ enum WavHeaderRepair {
         // would make a filesize-derived size wrong, corrupting a valid file).
         guard declaredDataSize == 0 else { return false }
 
+        // Captured before the rewrite and restored after it: repairing a
+        // header is not capturing audio, but an in-place write stamps the file
+        // as modified now. The crash-recovery chain reads mtime to answer "is a
+        // writer still alive?", and this runs immediately before it, so a
+        // bumped mtime makes a crashed recording look live — deferring its
+        // rescue while `cleanupTempFiles`, which judges the raw app temp by its
+        // own age, deletes the very track that rescue needed. The file keeps
+        // the age its audio actually has.
+        let capturedAt = (try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
+
         try handle.seek(toOffset: UInt64(dataOffset + 4))
         try handle.write(contentsOf: leBytes(UInt32(actualDataSize)))
         try handle.seek(toOffset: 4)
         try handle.write(contentsOf: leBytes(UInt32(correctRiffSize)))
+        try handle.close()
+        if let capturedAt {
+            do {
+                try FileManager.default.setAttributes(
+                    [.modificationDate: capturedAt], ofItemAtPath: url.path,
+                )
+            } catch {
+                // Worth a line: a silent failure here puts the file back in the
+                // state this restore exists to prevent, and the consequence
+                // (a crashed recording read as live, its app track deleted)
+                // surfaces nowhere near the cause.
+                logger.warning("Could not restore the modification date after a header repair")
+            }
+        }
         return true
     }
 

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
@@ -22,6 +22,57 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         XCTAssertEqual(stems, ["20260311_100000"])
     }
 
+    /// A microphone-only recording leaves no raw app temp, so nothing marked it
+    /// as crashed and its audio was lost. An in-progress marker written at start
+    /// and removed at stop is the signal, because it is the one thing only a
+    /// crash leaves behind.
+    func testCrashedRecordingStemsDetectsAMicOnlyRecordingByItsMarker() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_recording.marker", // crashed mic-only: marker, no mix
+            "20260311_100000_mic.wav",
+            "notes.txt",
+        ])
+        XCTAssertEqual(stems, ["20260311_100000"])
+    }
+
+    /// THE regression guard. "A mic track with no mix" is the normal end state
+    /// of every successfully processed recording: `AudioPersistencePolicy` moves
+    /// the mix into the output folder and leaves the mic track in staging.
+    /// Treating that as a crash signature once re-processed 40 real recordings
+    /// on a live archive. Only the marker may ever mean crash.
+    func testAFinishedRecordingIsNeverMistakenForACrash() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            // Exactly what a processed mic-only recording leaves behind.
+            "20260311_120000_mic.wav",
+            // And a processed dual-source one, whose mix also moved away.
+            "20260311_130000_mic.wav",
+            "20260311_130000_app.wav",
+        ])
+        XCTAssertTrue(stems.isEmpty, "no marker means no crash, however incomplete the leftovers look")
+    }
+
+    /// A marker whose recording did finish (mix still alongside) is not a crash
+    /// either: the mix is proof `stop()` ran, whatever happened to the marker.
+    func testAMarkerNextToAMixIsNotACrash() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_recording.marker",
+            "20260311_100000_mix.wav",
+            "20260311_100000_mic.wav",
+        ])
+        XCTAssertTrue(stems.isEmpty)
+    }
+
+    /// The marker and the raw app temp describe the same crash, so a dual-source
+    /// crash that leaves both must surface once, not twice.
+    func testAStemIsReportedOnceWhenBothSignalsSurvive() {
+        let stems = DualSourceRecorder.crashedRecordingStems(in: [
+            "20260311_100000_recording.marker",
+            "20260311_100000_app16k_raw.tmp",
+            "20260311_100000_mic.wav",
+        ])
+        XCTAssertEqual(stems, ["20260311_100000"])
+    }
+
     /// A crashed recording (surviving raw app `.tmp` + mic WAV, no mix) is
     /// re-mixed into a readable `_mix.wav` and the raw temp is consumed.
     func testRecoverCrashedRecordingsRemixesOrphanedRawAppAndMic() throws {
@@ -33,11 +84,13 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         try writeRawFloat32([Float](repeating: 0.3, count: 16000 * 2), to: appTmp)
         let micWav = dir.appendingPathComponent(stem + "_mic.wav")
         try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
-        // A crashed recording's temp predates the relaunch — backdate it past
-        // the in-progress guard.
-        try FileManager.default.setAttributes(
-            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
-        )
+        // A crash freezes EVERY track at the moment it happened, so backdate
+        // both. Backdating only the temp described a state production never
+        // produces (app track two minutes cold, mic track written just now, no
+        // process alive) and hid the case the guard is really for: a mic
+        // channel that gave up while the app track kept growing (issue #588) is
+        // a live recording, and re-mixing under its writer would corrupt it.
+        try backdate([appTmp, micWav])
 
         let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
 
@@ -76,9 +129,7 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         try writeRawFloat32([Float](repeating: 0.3, count: 48000 * 2), to: appTmp)
         let micWav = dir.appendingPathComponent(stem + "_mic.wav")
         try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
-        try FileManager.default.setAttributes(
-            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: appTmp.path,
-        )
+        try backdate([appTmp, micWav])
 
         let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
 
@@ -107,5 +158,117 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
             FileManager.default.fileExists(atPath: dir.appendingPathComponent(stem + "_mix.wav").path),
             "no mix should be produced for an in-progress temp",
         )
+    }
+
+    /// The point of the marker: a microphone-only recording that died leaves
+    /// only its mic track, and before this it was lost because nothing said a
+    /// crash had happened.
+    func testACrashedMicrophoneOnlyRecordingIsRecoveredFromItsMarker() throws {
+        let dir = try makeTempDirectory(prefix: "crash_mic_only")
+        let stem = "20260311_170000"
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        try backdate([micWav])
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 1, "a microphone-only crash must be recoverable")
+        let mix = dir.appendingPathComponent(stem + "_mix.wav")
+        XCTAssertGreaterThan(
+            try AudioMixer.loadAudioFileAsFloat32(url: mix).count, 0,
+            "the recovered mix must carry the microphone audio",
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: marker.path),
+            "the marker is consumed, so a later run cannot recover the same recording twice",
+        )
+    }
+
+    /// Once a stem has been dealt with, nothing may still look crashed. The
+    /// recorder's own removal in `stop()` is not drivable here (it needs a live
+    /// capture session), and deliberately does not have to be: `stop()` writes
+    /// the mix before dropping the marker, and a stem with a mix is excluded
+    /// from recovery whatever became of its marker.
+    func testNothingLooksCrashedOnceRecoveryHasDealtWithIt() throws {
+        let dir = try makeTempDirectory(prefix: "crash_marker_cleared")
+        let stem = "20260311_180000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try backdate([micWav])
+
+        _ = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertTrue(
+            DualSourceRecorder.crashedRecordingStems(
+                in: (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? [],
+            ).isEmpty,
+            "nothing may still look crashed once it has been dealt with",
+        )
+    }
+
+    /// The launch sequence in the order `PipelineController` actually runs it.
+    /// Header repair rewrites the crashed mic track in place, which touches its
+    /// mtime; if freshness then reads that as "a writer is still alive",
+    /// recovery defers while `cleanupTempFiles` — which judges the temp by its
+    /// own age — deletes the app track on the same launch. The remote half of
+    /// the meeting would be gone before the next launch could rescue it.
+    func testTheLaunchSequenceRecoversARecordingWhoseMicHeaderItJustRepaired() throws {
+        let dir = try makeTempDirectory(prefix: "crash_launch_order")
+        let stem = "20260311_190000"
+        let appTmp = dir.appendingPathComponent(stem + "_app16k_raw.tmp")
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000 * 2), to: appTmp)
+        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try leaveHeaderUnfinalized(at: micWav) // what a killed writer leaves behind
+        try backdate([appTmp, micWav])
+
+        _ = WavHeaderRepair.repairUnfinalized(in: dir)
+        let recovered = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir)
+
+        XCTAssertEqual(recovered, 1, "repairing a header must not read as freshly captured audio")
+        XCTAssertGreaterThan(
+            try AudioMixer.loadAudioFileAsFloat32(url: dir.appendingPathComponent(stem + "_mix.wav")).count, 0,
+            "the recovered mix must carry both tracks",
+        )
+    }
+
+    /// Freshness spans every track, not just the app temp. A mic channel that
+    /// gave up while the app track keeps growing (issue #588) is a live
+    /// recording, and re-mixing under its writer would corrupt it.
+    func testARecordingWhoseMicDiedButWhoseAppTrackGrowsIsNotRecovered() throws {
+        let dir = try makeTempDirectory(prefix: "crash_mic_died")
+        let stem = "20260311_240000"
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try backdate([micWav]) // the dead channel, cold
+        let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000), to: appTmp) // still being written
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 0, "one live track is enough to mean the recording is still running")
+    }
+
+    /// Zero the `data` size the way a writer killed mid-stream does.
+    private func leaveHeaderUnfinalized(at url: URL) throws {
+        var data = try Data(contentsOf: url)
+        let marker = try XCTUnwrap(data.range(of: Data("data".utf8)), "no data chunk")
+        data.replaceSubrange(marker.upperBound ..< marker.upperBound + 4, with: [0, 0, 0, 0])
+        data.replaceSubrange(4 ..< 8, with: [4, 0, 0, 0])
+        try data.write(to: url)
+    }
+
+    /// Age every file past the in-progress guard, the way a crash does.
+    private func backdate(_ urls: [URL]) throws {
+        for url in urls {
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: url.path,
+            )
+        }
     }
 }

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
@@ -186,28 +186,179 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         )
     }
 
-    /// Once a stem has been dealt with, nothing may still look crashed. The
-    /// recorder's own removal in `stop()` is not drivable here (it needs a live
-    /// capture session), and deliberately does not have to be: `stop()` writes
-    /// the mix before dropping the marker, and a stem with a mix is excluded
-    /// from recovery whatever became of its marker.
-    func testNothingLooksCrashedOnceRecoveryHasDealtWithIt() throws {
-        let dir = try makeTempDirectory(prefix: "crash_marker_cleared")
-        let stem = "20260311_180000"
+    /// A start that threw before capture opened leaves a marker and no tracks.
+    /// Nothing else removes one: `stop()` never ran, and recovery fails on
+    /// `noAudioData` every launch and every watch-start, warning each time.
+    func testAMarkerFromAStartThatCapturedNothingIsCleanedUp() throws {
+        let dir = try makeTempDirectory(prefix: "marker_no_tracks")
+        let stem = "20260311_200000"
         let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
         try Data().write(to: marker)
-        let micWav = dir.appendingPathComponent(stem + "_mic.wav")
-        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
-        try backdate([micWav])
+        try backdate([marker])
 
-        _ = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path), "a marker with no audio is a dead end")
+    }
+
+    /// Same dead end one step later: the mic file exists but never received a
+    /// buffer, so it is a bare header and there is still nothing to rescue.
+    func testAMarkerBesideATrackThatNeverGotAudioIsCleanedUp() throws {
+        let dir = try makeTempDirectory(prefix: "marker_empty_track")
+        let stem = "20260311_210000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [], sampleRate: 16000, url: micWav)
+        try backdate([marker, micWav])
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path), "an empty track rescues nothing")
+    }
+
+    /// The control case. A janitor that deleted every old marker would pass the
+    /// two tests above and quietly throw away the recordings this whole
+    /// mechanism exists to rescue, since it runs on the same launch, right
+    /// after recovery.
+    func testCleanupKeepsAMarkerWhoseTrackStillHoldsAudio() throws {
+        let dir = try makeTempDirectory(prefix: "marker_with_audio")
+        let stem = "20260311_220000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try backdate([marker, micWav])
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
 
         XCTAssertTrue(
-            DualSourceRecorder.crashedRecordingStems(
-                in: (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? [],
-            ).isEmpty,
-            "nothing may still look crashed once it has been dealt with",
+            FileManager.default.fileExists(atPath: marker.path),
+            "the marker of a rescuable recording must survive the cleanup pass",
         )
+    }
+
+    /// A recording that started moments ago has a marker and no tracks yet,
+    /// which is the same shape on disk as a failed start. Only age tells them
+    /// apart, and the queue rebuild that runs this pass fires on watch-start,
+    /// immediately before the loop may begin recording.
+    func testCleanupKeepsAFreshMarker() throws {
+        let dir = try makeTempDirectory(prefix: "marker_fresh")
+        let marker = DualSourceRecorder.inProgressMarker(stem: "20260311_230000", in: dir)
+        try Data().write(to: marker)
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path), "a recording may have just started")
+    }
+
+    /// THE guard for this pass. A marker is written once at start and never
+    /// touched, so its age is simply how long the recording has been running:
+    /// no age window survives a long one. A mic wedged mid-capture (issue #588)
+    /// delivers no buffers either, so its track stays at bare-header size and
+    /// reads as worthless. Reaping there strands the recording for good, since
+    /// a later crash then leaves a lone mic track that neither crash recovery
+    /// nor the orphan scan will look at. Only "written before this process
+    /// existed" can tell a foreign leftover from our own running capture.
+    func testCleanupKeepsAnOldMarkerWrittenByTheRunningProcess() throws {
+        let dir = try makeTempDirectory(prefix: "marker_ours")
+        let stem = "20260311_250000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [], sampleRate: 16000, url: micWav) // wedged: nothing flushed
+        try backdate([marker, micWav]) // and running long enough to look ancient
+
+        DualSourceRecorder.cleanupTempFiles(
+            recordingsDir: dir, reapMarkersWrittenBefore: Date(timeIntervalSinceNow: -300),
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: marker.path),
+            "a marker younger than the process that would reap it is a live recording, not a leftover",
+        )
+    }
+
+    /// The threshold pinned from the side that loses data. Between an empty
+    /// track and a full second of audio there is room to raise it without any
+    /// test noticing, and every byte of that room is somebody's recording.
+    func testCleanupKeepsAMarkerWhoseTrackHoldsASingleFrame() throws {
+        let dir = try makeTempDirectory(prefix: "marker_one_frame")
+        let stem = "20260311_260000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [0.2], sampleRate: 16000, url: micWav)
+        try backdate([marker, micWav])
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: marker.path),
+            "one frame is still audio, and the marker is what gets it rescued",
+        )
+    }
+
+    /// The app-audio half of the same predicate, and the case that makes it
+    /// load-bearing. The pass deletes stale raw temps before it looks at
+    /// markers, so a temp still present here is one being written right now:
+    /// a live recording belonging to another instance of the app, whose marker
+    /// predates ours. Reaping it would strip a running capture of its only
+    /// crash signal.
+    func testCleanupKeepsAMarkerBesideALiveRawAppTemp() throws {
+        let dir = try makeTempDirectory(prefix: "marker_raw_temp")
+        let stem = "20260311_270000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        try backdate([marker])
+        let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000), to: appTmp) // fresh: still being written
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: marker.path),
+            "a temp that survived the pass above is a live writer, not a leftover",
+        )
+    }
+
+    /// A marker beside a finished mix is stale, not a crash. Left alone it
+    /// would become a false crash the moment the finished job moves the mix
+    /// into the output folder, leaving marker plus mic track behind.
+    func testAMarkerBesideAFinishedMixIsReaped() throws {
+        let dir = try makeTempDirectory(prefix: "marker_finished")
+        let stem = "20260311_280000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        let mix = dir.appendingPathComponent(stem + RecordingFileSuffix.mix)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: mix)
+        try backdate([marker, micWav, mix])
+
+        DualSourceRecorder.cleanupTempFiles(recordingsDir: dir, reapMarkersWrittenBefore: Date())
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: marker.path),
+            "a recording with a mix is finished, whatever its marker says",
+        )
+    }
+
+    /// Freshness spans every track, not just the app temp. A mic channel that
+    /// gave up while the app track keeps growing (issue #588) is a live
+    /// recording, and re-mixing under its writer would corrupt it.
+    func testARecordingWhoseMicDiedButWhoseAppTrackGrowsIsNotRecovered() throws {
+        let dir = try makeTempDirectory(prefix: "crash_mic_died")
+        let stem = "20260311_240000"
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
+        try backdate([micWav]) // the dead channel, cold
+        let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
+        try writeRawFloat32([Float](repeating: 0.3, count: 16000), to: appTmp) // still being written
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 0, "one live track is enough to mean the recording is still running")
     }
 
     /// The launch sequence in the order `PipelineController` actually runs it.
@@ -235,23 +386,6 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
             try AudioMixer.loadAudioFileAsFloat32(url: dir.appendingPathComponent(stem + "_mix.wav")).count, 0,
             "the recovered mix must carry both tracks",
         )
-    }
-
-    /// Freshness spans every track, not just the app temp. A mic channel that
-    /// gave up while the app track keeps growing (issue #588) is a live
-    /// recording, and re-mixing under its writer would corrupt it.
-    func testARecordingWhoseMicDiedButWhoseAppTrackGrowsIsNotRecovered() throws {
-        let dir = try makeTempDirectory(prefix: "crash_mic_died")
-        let stem = "20260311_240000"
-        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
-        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micWav)
-        try backdate([micWav]) // the dead channel, cold
-        let appTmp = dir.appendingPathComponent(stem + RecordingFileSuffix.appRaw)
-        try writeRawFloat32([Float](repeating: 0.3, count: 16000), to: appTmp) // still being written
-
-        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
-
-        XCTAssertEqual(count, 0, "one live track is enough to mean the recording is still running")
     }
 
     /// Zero the `data` size the way a writer killed mid-stream does.

--- a/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
+++ b/app/MeetingTranscriber/Tests/WavHeaderRepairTests.swift
@@ -129,6 +129,31 @@ final class WavHeaderRepairTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: validURL), validBefore, "a finalized WAV must be left unchanged")
     }
 
+    /// The repair must not age the file forward. Everything downstream reads
+    /// mtime to decide whether a writer is still alive, and this runs first at
+    /// launch: a file stamped "modified now" reads as a live recording, which
+    /// defers the crash rescue that was about to happen while the cleanup pass
+    /// deletes the raw app track it needed. A header rewrite is metadata, not
+    /// newly captured audio, and must not claim to be.
+    func testRepairPreservesTheFilesModificationDate() throws {
+        let (url, _) = try writeFinalizedWav(seconds: 0.4)
+        defer { try? FileManager.default.removeItem(at: url) }
+        try corruptHeader(at: url)
+        let crashedAt = Date(timeIntervalSinceNow: -120)
+        try FileManager.default.setAttributes([.modificationDate: crashedAt], ofItemAtPath: url.path)
+
+        XCTAssertTrue(try WavHeaderRepair.repairIfNeeded(at: url), "the fixture should need repairing")
+
+        let after = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date,
+        )
+        XCTAssertEqual(
+            after.timeIntervalSince1970, crashedAt.timeIntervalSince1970, accuracy: 1,
+            "the repaired file must keep the age its audio actually has",
+        )
+        XCTAssertGreaterThan(readableFrames(url), 0, "and it must still have been repaired")
+    }
+
     func testRepairUnfinalizedSkipsRecentlyModifiedWavs() throws {
         // A WAV still being written by a live recording legitimately has a zero
         // data size. The launch scan must not "repair" it: stamping a partial


### PR DESCRIPTION
## Problem

Crash recovery keyed on the leftover raw app temp file. In the normal flow `buildRecording` deletes it once the mix exists, so a surviving one means `stop()` never ran. A microphone-only recording opens no tap and writes no such temp, so nothing marked it as interrupted and its audio was simply lost.

## Approach

An empty marker file, written at start and dropped once the mix exists. It is the one thing on disk that only a crash leaves behind. Either signal identifies a crash, and a dual-source recording leaves both, so a stem is reported once.

**Rejected: reading "a mic track with no mix" as the crash signature.** That is the normal end state of every recording the pipeline finishes, since a completed job moves the mix into the output folder and leaves the mic track in staging. It would re-process an entire archive on the next launch. A regression test pins it, and it is the test that matters most here.

## The three parts

**Header repair no longer ages a track forward.** `repairIfNeeded` rewrote two size fields in place, and an in-place write stamps the file as modified now. That is wrong on its face and load-bearing in context: the launch sequence runs it immediately before crash recovery, which reads mtime to decide whether a writer is still alive. Without it the sequence destroys audio, because the repaired mic track reads as live, recovery defers, and the cleanup pass deletes the raw app temp on the same launch by its own age.

**Recovery.** `stop()` drops the marker only after `buildRecording` returns, mirroring the raw app temp, which is deleted at that same point. A stop whose mix write fails has finished nothing, and the failure usually survives to the next launch, so keeping the marker lets that launch re-mix from the surviving tracks. Freshness now spans every track rather than the app temp alone: a mic channel that gives up while the app track keeps growing is a live recording, and re-mixing under its writer would corrupt it.

**Reaping.** A marker nothing can consume is permanent, and recovery then fails on that stem at every launch and every watch-start. The failed start removes its own marker, and the cleanup pass reaps any marker whose stem holds nothing a later recovery could use.

Reaping is guarded on "written before this process existed" rather than an age window, because the two files age differently. A raw temp is touched on every buffer, so a live one is always fresh; a marker is written once, so its age is just how long the recording has been running and any window expires under a recording still in progress. A wedged mic delivers no buffers either, leaving a bare-header track that reads as worthless. Reaping there would strand the recording for good, since once the marker is gone a later crash leaves a lone mic track that neither crash recovery nor the orphan scan will look at.

## Notes for review

The empty-track threshold is measured, not the canonical 44-byte WAV header: `AVAudioFile` pads its header with a JUNK chunk to 4 KB, so a track opened and closed empty is exactly that size, and one flushed buffer already exceeds it. Size is deliberately the test rather than readability, because an unfinalized header reads as zero frames while its PCM is intact. The empty file itself is left in place; deleting audio there is a far worse failure mode than keeping 4 KB of litter.

Not covered by tests: the marker removal on a failed `session.start()`. Nothing in the suite drives `DualSourceRecorder.start()`, since the staging directory is a non-injectable static. The reaping pass covers the same end state, so a regression there costs a stray marker rather than a recording.

## Verification

19 crash-recovery tests plus the header-repair unit test. Every guard was mutation-tested: reverting to an age window, dropping the finished-mix check, drifting the empty-track threshold upward, and dropping the app-temp branch are each caught by exactly one test, and reinstating the rejected "mic without mix" signature is caught too. Full suite green, lint and `swiftlint analyze --strict` clean, release-mode parity including the App Store variant.