### PR TITLE
Make the recording lifecycle testable and cover the in-progress marker

### DIFF
--- a/app/MeetingTranscriber/Sources/AudioCapturing.swift
+++ b/app/MeetingTranscriber/Sources/AudioCapturing.swift
@@ -1,0 +1,96 @@
+import AudioTapLib
+import Foundation
+
+/// The part of `AudioCaptureSession` one recording drives.
+///
+/// Lives here rather than in AudioTapLib because it is the *consumer's* view of
+/// that class, not part of what the capture library offers: the library's own
+/// tests drive `AppAudioCapture` and `MicCaptureHandler` directly and need no
+/// seam over the session.
+///
+/// Separately, it is deliberately *not* `@available`-gated even though its only
+/// production conformer is. The OS floor belongs to the hardware, so it is
+/// stated once, in `LiveCaptureSession.make`, where the compiler enforces it.
+/// Gating the role instead would put an `@available` type back into
+/// `DualSourceRecorder`'s stored properties — exactly what the type-erased
+/// `AnyObject` storage there used to be working around — and would also let a
+/// caller on 14.0 declare an `any AudioCapturing` it could never obtain.
+protocol AudioCapturing: AnyObject {
+    func start() throws
+    func stop() -> AudioCaptureResult
+    var appLevelDBFS: Double { get }
+    var micLevelDBFS: Double { get }
+    var appCaptureGaveUp: Bool { get }
+    var micCaptureGaveUp: Bool { get }
+}
+
+@available(macOS 14.2, *)
+extension AudioCaptureSession: AudioCapturing {}
+
+/// Everything `DualSourceRecorder.start()` decides before any hardware is
+/// touched: which process tree to tap, where each track is written, which
+/// microphone to open.
+///
+/// Passed to the capture-session factory rather than assembled inside it, so a
+/// test can build a session that touches nothing and still see the decisions
+/// under test — above all which tracks a `RecordingSource` opens at all, which
+/// is the difference between a microphone-only recording and one with a tap.
+/// Field order mirrors `AudioCaptureSession.init` so the two lists can be
+/// diffed by eye when a capture option is added.
+struct CaptureSessionRequest {
+    /// The process tree to tap, empty when no tap is opened.
+    let pids: [pid_t]
+    /// Where the raw app track is written, or nil to open no process tap at
+    /// all. Nil is the microphone-only shape, not a tap that captured nothing.
+    let appOutputURL: URL?
+    let sampleRate: Int
+    let channels: Int
+    /// Where the mic track is written, or nil when the microphone is not
+    /// recorded ("No Microphone").
+    let micOutputURL: URL?
+    let micDeviceUID: String?
+    let debugLogging: Bool
+    let appLiveSink: LiveAudioSink?
+    let micLiveSink: LiveAudioSink?
+}
+
+/// Builds the capture session a recording runs on. Injected into
+/// `DualSourceRecorder` so `start()` and `stop()` — which carry the in-progress
+/// marker crash recovery keys on — can be driven without audio hardware.
+typealias CaptureSessionFactory = @MainActor (CaptureSessionRequest) throws -> any AudioCapturing
+
+/// The production capture session: real taps on real hardware.
+enum LiveCaptureSession {
+    @MainActor
+    static func make(_ request: CaptureSessionRequest) throws -> any AudioCapturing {
+        // The one place the 14.2 floor is stated, and the compiler requires it
+        // here: `AudioCaptureSession` is gated and this function is not. Every
+        // caller reaches a real session through here, so no copy of this check
+        // is needed anywhere else — and a copy elsewhere would be unenforced.
+        guard #available(macOS 14.2, *) else { throw RecorderError.unsupportedOS }
+
+        // Mic device-change e2e (issue #379): inject a one-shot tap fault so the
+        // app self-triggers a mid-recording restart with an invalid format and
+        // the lane can verify the installTap NSException recovery. Compiled ONLY
+        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION); the fault is
+        // physically absent from every shipped binary.
+        #if E2E_FAULT_INJECTION
+            let micDebugFault: DebugTapFault? = DebugTapFault(triggerRestartAfter: 2)
+        #else
+            let micDebugFault: DebugTapFault? = nil
+        #endif
+
+        return AudioCaptureSession(
+            pids: request.pids,
+            appOutputURL: request.appOutputURL,
+            sampleRate: request.sampleRate,
+            channels: request.channels,
+            micOutputURL: request.micOutputURL,
+            micDeviceUID: request.micDeviceUID,
+            debugLogging: request.debugLogging,
+            appLiveSink: request.appLiveSink,
+            micLiveSink: request.micLiveSink,
+            micDebugFault: micDebugFault,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -37,36 +37,29 @@ struct CaptureFormat {
 @MainActor
 @Observable
 class DualSourceRecorder: RecordingProvider {
-    @available(macOS 14.2, *)
-    private var captureSession: AudioCaptureSession? {
-        get { _captureSession as? AudioCaptureSession }
-        set { _captureSession = newValue }
-    }
-
-    // Type-erased storage to avoid @available on stored properties
-    private var _captureSession: AnyObject?
+    /// The session capturing right now, nil between recordings. Stored as the
+    /// `AudioCapturing` role rather than the concrete `AudioCaptureSession`,
+    /// which is what removes the `@available` gate from this property — the
+    /// reason the storage used to be a type-erased `AnyObject` plus a cast.
+    private var captureSession: (any AudioCapturing)?
     private(set) var isRecording = false
     private(set) var recordingStartDate: Date = .distantPast
     private var startTimestamp: String?
 
     var appLevelDBFS: Double {
-        guard #available(macOS 14.2, *) else { return -120 }
-        return captureSession?.appLevelDBFS ?? -120
+        captureSession?.appLevelDBFS ?? -120
     }
 
     var micLevelDBFS: Double {
-        guard #available(macOS 14.2, *) else { return -120 }
-        return captureSession?.micLevelDBFS ?? -120
+        captureSession?.micLevelDBFS ?? -120
     }
 
     var appCaptureGaveUp: Bool {
-        guard #available(macOS 14.2, *) else { return false }
-        return captureSession?.appCaptureGaveUp ?? false
+        captureSession?.appCaptureGaveUp ?? false
     }
 
     var micCaptureGaveUp: Bool {
-        guard #available(macOS 14.2, *) else { return false }
-        return captureSession?.micCaptureGaveUp ?? false
+        captureSession?.micCaptureGaveUp ?? false
     }
 
     /// Requested app-audio capture format (what the CATap aggregate device is
@@ -81,9 +74,35 @@ class DualSourceRecorder: RecordingProvider {
     private let targetRate = AudioConstants.targetSampleRate
     private let appChannels = DualSourceRecorder.defaultAppChannels
 
-    /// Recordings directory.
-    static var recordingsDir: URL {
-        AppPaths.recordingsDir
+    /// The staging directory every other consumer reads independently: the
+    /// janitor, crash recovery, the orphan scan and `AudioPersistencePolicy`
+    /// all resolve `AppPaths.recordingsDir` for themselves. Named rather than
+    /// inlined as a default argument so a test can pin the two together.
+    static let defaultRecordingsDir = AppPaths.recordingsDir
+
+    /// Where this recorder stages its tracks.
+    ///
+    /// Injectable so a test can drive a whole recording without writing into
+    /// the production staging directory. **Only a test may inject one:** the
+    /// consumers above are not part of this seam, so a production recorder
+    /// staging anywhere else would write markers and tracks that no recovery,
+    /// no janitor and no orphan scan ever looks at, and whose finished mix
+    /// `AudioPersistencePolicy` would misread as a user-picked import.
+    private let recordingsDir: URL
+
+    /// Builds the capture session each recording runs on. Same injection
+    /// `WatchingController` already makes one level up with `makeRecorder`.
+    private let makeCaptureSession: CaptureSessionFactory
+
+    /// `makeCaptureSession`'s default wraps the factory in a closure rather
+    /// than naming it: a bare reference to a static declared in another file
+    /// compiles here and then fails to link.
+    init(
+        recordingsDir: URL = DualSourceRecorder.defaultRecordingsDir,
+        makeCaptureSession: @escaping CaptureSessionFactory = { try LiveCaptureSession.make($0) },
+    ) {
+        self.recordingsDir = recordingsDir
+        self.makeCaptureSession = makeCaptureSession
     }
 
     /// Remove leftover raw app temp files (current or legacy suffix) a previous
@@ -358,12 +377,19 @@ class DualSourceRecorder: RecordingProvider {
         debugLogging: Bool = false,
     ) throws {
         guard !isRecording else { return }
+        // The compiler no longer needs this — the 14.2 floor is enforced inside
+        // the factory, the only path to a real session. It is here so that the
+        // rejection is the FIRST thing that happens: below this line the start
+        // creates a directory, writes a marker and walks the target's process
+        // tree, so without it a 14.1 user gets whichever of those fails first
+        // (a filesystem error, say) instead of the one message naming their OS,
+        // and pays a full process enumeration per detected meeting for a
+        // session that can never open.
         guard #available(macOS 14.2, *) else {
             throw RecorderError.unsupportedOS
         }
 
-        let recDir = Self.recordingsDir
-        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
 
         let ts = Self.timestamp()
         startTimestamp = ts
@@ -371,17 +397,17 @@ class DualSourceRecorder: RecordingProvider {
         // Written before capture opens and removed in `stop()`, so a surviving
         // one means this process died mid-recording. The app temp says the same
         // for a recording that taps an app; this covers the ones that do not.
-        try? Data().write(to: Self.inProgressMarker(stem: ts, in: recDir))
+        try? Data().write(to: Self.inProgressMarker(stem: ts, in: recordingsDir))
 
         // ── AudioTapLib capture session ──
         // A source with no target opens no tap at all, so it gets neither a
         // temp file nor a PID list; the session then has the mic as its only
         // channel and treats a mic failure as terminal.
         let appTempURL: URL? = source.capturesAppAudio
-            ? recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.appRaw)")
+            ? recordingsDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.appRaw)")
             : nil
         let micURL: URL? = source.capturesMicrophone
-            ? recDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mic)")
+            ? recordingsDir.appendingPathComponent("\(ts)\(RecordingFileSuffix.mic)")
             : nil
 
         // Electron/WebView2 apps (Teams 2.x, Slack, Discord) render call
@@ -391,37 +417,26 @@ class DualSourceRecorder: RecordingProvider {
         // root PID alone if the bundle URL is unavailable.
         let effectivePids = source.appPID.map { Self.resolveTapPIDs(rootPID: $0) } ?? []
 
-        // Mic device-change e2e (issue #379): inject a one-shot tap fault so the
-        // app self-triggers a mid-recording restart with an invalid format and
-        // the lane can verify the installTap NSException recovery. Compiled ONLY
-        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION); the fault is
-        // physically absent from every shipped binary.
-        #if E2E_FAULT_INJECTION
-            let micDebugFault: DebugTapFault? = DebugTapFault(triggerRestartAfter: 2)
-        #else
-            let micDebugFault: DebugTapFault? = nil
-        #endif
-
-        let session = AudioCaptureSession(
-            pids: effectivePids,
-            appOutputURL: appTempURL,
-            sampleRate: recordRate,
-            channels: appChannels,
-            micOutputURL: micURL,
-            micDeviceUID: (micDeviceUID?.isEmpty ?? true) ? nil : micDeviceUID,
-            debugLogging: debugLogging,
-            appLiveSink: appLiveSink,
-            micLiveSink: micLiveSink,
-            micDebugFault: micDebugFault,
-        )
+        let session: any AudioCapturing
         do {
+            session = try makeCaptureSession(CaptureSessionRequest(
+                pids: effectivePids,
+                appOutputURL: appTempURL,
+                sampleRate: recordRate,
+                channels: appChannels,
+                micOutputURL: micURL,
+                micDeviceUID: (micDeviceUID?.isEmpty ?? true) ? nil : micDeviceUID,
+                debugLogging: debugLogging,
+                appLiveSink: appLiveSink,
+                micLiveSink: micLiveSink,
+            ))
             try session.start()
         } catch {
             // Nothing else would ever remove it: `stop()` is unreachable with
             // `isRecording` still false, and the cleanup pass below keys on
             // tracks this start never created. The marker means "interrupted
             // mid-recording", and a start that never opened is not that.
-            try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: recDir))
+            try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: recordingsDir))
             startTimestamp = nil
             throw error
         }
@@ -439,9 +454,6 @@ class DualSourceRecorder: RecordingProvider {
     func stop() throws -> RecordingResult {
         guard isRecording else {
             throw RecorderError.notRecording
-        }
-        guard #available(macOS 14.2, *) else {
-            throw RecorderError.unsupportedOS
         }
 
         isRecording = false
@@ -462,7 +474,7 @@ class DualSourceRecorder: RecordingProvider {
         // fallback wrote raw native-rate audio.
         let recording = try Self.buildRecording(
             from: captureResult,
-            recordingsDir: Self.recordingsDir,
+            recordingsDir: recordingsDir,
             timestamp: ts,
             recordingStartDate: recordingStartDate,
             format: CaptureFormat(requestedChannels: 1, requestedRate: targetRate, targetRate: targetRate),
@@ -475,7 +487,7 @@ class DualSourceRecorder: RecordingProvider {
         // re-mix from the surviving tracks, which is what the app-audio path
         // has always got from its temp. The mix itself is what stops a
         // completed recording from being recovered twice.
-        try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: Self.recordingsDir))
+        try? FileManager.default.removeItem(at: Self.inProgressMarker(stem: ts, in: recordingsDir))
         return recording
     }
 

--- a/app/MeetingTranscriber/Tests/AppPathsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPathsTests.swift
@@ -26,6 +26,15 @@ final class AppPathsTests: XCTestCase {
         XCTAssertTrue(AppPaths.recordingsDir.path.hasPrefix(AppPaths.dataDir.path))
     }
 
+    /// The full staging path, not just its parent. It is the default
+    /// `DualSourceRecorder` stages into and the directory crash recovery and
+    /// the orphan scan walk, so moving it silently would strand recordings.
+    func testRecordingsDirIsTheAppSupportStagingPath() {
+        XCTAssertTrue(
+            AppPaths.recordingsDir.path.contains("Library/Application Support/MeetingTranscriber/recordings"),
+        )
+    }
+
     func testProtocolsDirIsUnderDataDir() {
         XCTAssertTrue(AppPaths.protocolsDir.path.hasPrefix(AppPaths.dataDir.path))
     }

--- a/app/MeetingTranscriber/Tests/AppStateTests.swift
+++ b/app/MeetingTranscriber/Tests/AppStateTests.swift
@@ -738,41 +738,6 @@ final class AppStateTests: XCTestCase { // swiftlint:disable:this type_body_leng
         XCTAssertTrue(notifier.calls.isEmpty)
     }
 
-    // MARK: - startManualRecording (async, environment-sensitive)
-
-    // DualSourceRecorder.start() requires real audio hardware — will throw in CI.
-    // AppState catches the error and fires notify("Error", ...) / sets watchLoop = nil.
-    // Both paths fire exactly one notification, so we assert on that.
-
-    func testStartManualRecordingSendsNotification() async {
-        let (state, notifier) = makeState()
-        state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
-        addTeardownBlock { state.watching.watchLoop?.stop() }
-
-        state.watching.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
-        // Success → "Manual Recording" / hardware unavailable → "Error"
-        await waitFor(!notifier.calls.isEmpty)
-
-        XCTAssertTrue(
-            notifier.calls.contains { $0.title == "Manual Recording" || $0.title == "Error" },
-            "Expected a notification but got none. calls: \(notifier.calls)",
-        )
-    }
-
-    func testStartManualRecordingStopsExistingAutoWatchLoop() async {
-        let (state, _) = makeState()
-        state.permissions.handle(HealthCheckResult(screenRecording: .healthy, microphone: .healthy))
-        let (existingLoop, _) = makeTestWatchLoop()
-        existingLoop.start()
-        state.watching.watchLoop = existingLoop
-        XCTAssertTrue(existingLoop.isActive)
-
-        state.watching.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
-        await waitFor(!existingLoop.isActive)
-
-        XCTAssertFalse(existingLoop.isActive, "Existing auto-watch loop should be stopped")
-    }
-
     // MARK: - Engine Switching
 
     func testActiveTranscriptionEngineDefaultsToWhisperKit() {

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderCrashRecoveryTests.swift
@@ -388,6 +388,45 @@ final class DualSourceRecorderCrashRecoveryTests: XCTestCase {
         )
     }
 
+    /// An empty track must never become a mix. Recovery reaches this stem
+    /// before the janitor does, so a `buildRecording` that read zero samples as
+    /// audio would write a silent `_mix.wav` — and the orphan scan enqueues
+    /// every untracked mix, so a start that captured nothing would come back as
+    /// a meeting to transcribe.
+    func testAStemWhoseTrackNeverGotAudioProducesNoMix() throws {
+        let dir = try makeTempDirectory(prefix: "crash_empty_track_mix")
+        let stem = "20260311_250000"
+        let marker = DualSourceRecorder.inProgressMarker(stem: stem, in: dir)
+        try Data().write(to: marker)
+        let micWav = dir.appendingPathComponent(stem + RecordingFileSuffix.mic)
+        try AudioMixer.saveWAV(samples: [], sampleRate: 16000, url: micWav)
+        try backdate([marker, micWav])
+
+        let count = DualSourceRecorder.recoverCrashedRecordings(in: dir)
+
+        XCTAssertEqual(count, 0, "there was nothing to recover")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent(stem + RecordingFileSuffix.mix).path),
+            "a silent mix would be picked up by the orphan scan and transcribed as a meeting",
+        )
+    }
+
+    /// A marker whose tracks are both gone: a start that threw before either
+    /// file was created, or a stem someone cleaned up by hand. Recovery has
+    /// nothing to rebuild from and must say so, because its caller counts a
+    /// return as a rescued recording and hands the mix path on.
+    func testRecoveringAStemWithNoTracksAtAllThrows() throws {
+        let dir = try makeTempDirectory(prefix: "crash_no_tracks")
+
+        XCTAssertThrowsError(
+            try DualSourceRecorder.recoverCrashedRecording(stem: "20260311_260000", in: dir),
+        ) { error in
+            guard case RecorderError.noAudioData = error else {
+                return XCTFail("expected noAudioData, got \(error)")
+            }
+        }
+    }
+
     /// Zero the `data` size the way a writer killed mid-stream does.
     private func leaveHeaderUnfinalized(at url: URL) throws {
         var data = try Data(contentsOf: url)

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderLifecycleTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderLifecycleTests.swift
@@ -1,0 +1,208 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// The in-progress marker's whole life: written before capture opens, dropped
+/// again when the start never opened, and dropped only once a durable mix
+/// exists. Crash recovery reads that marker as "this process died mid-
+/// recording", so every one of these transitions decides whether a real
+/// recording is rescued, lost, or resurrected as a duplicate.
+///
+/// Reachable at all because the recorder takes its staging directory and its
+/// capture session as arguments. Without both, driving `start()` would open the
+/// real hardware and write into the production staging directory that crash
+/// recovery and the orphan scan walk.
+@MainActor
+final class DualSourceRecorderLifecycleTests: XCTestCase {
+    // MARK: - Doubles
+
+    /// A capture session that touches nothing: it throws what the test staged,
+    /// records what the recorder asked for, and reports back the file the test
+    /// wrote.
+    private final class FakeCaptureSession: AudioCapturing {
+        var startError: (any Error)?
+        /// The mic track `stop()` reports, set by a test after `start()` has
+        /// picked the URL and the test has written fixture audio there.
+        var micTrack: URL?
+        var appLevelDBFS: Double = -120
+        var micLevelDBFS: Double = -120
+        var appCaptureGaveUp = false
+        var micCaptureGaveUp = false
+        /// What the recorder asked the factory for, so a test can assert on the
+        /// choices and write to the URLs it picked.
+        var lastRequest: CaptureSessionRequest?
+
+        func start() throws {
+            if let startError { throw startError }
+        }
+
+        func stop() -> AudioCaptureResult {
+            AudioCaptureResult(
+                appAudioFileURL: nil, micAudioFileURL: micTrack,
+                actualSampleRate: 16000, actualChannels: 1, micDelay: 0,
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRecorder(dir: URL) -> (DualSourceRecorder, FakeCaptureSession) {
+        let session = FakeCaptureSession()
+        let recorder = DualSourceRecorder(recordingsDir: dir) { request in
+            session.lastRequest = request
+            return session
+        }
+        return (recorder, session)
+    }
+
+    /// Stems of the markers in `dir`, read through the same suffix rule the
+    /// janitor and crash recovery use rather than a second copy of it.
+    private func markerStems(in dir: URL) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .compactMap { RecordingFileSuffix.stripInProgress(from: $0) }
+    }
+
+    /// Start a microphone-only recording and hand back the mic track's URL, so
+    /// the test can stage what the session will report at `stop()`.
+    private func startMicOnly(
+        recorder: DualSourceRecorder,
+        session: FakeCaptureSession,
+    ) throws -> URL {
+        try recorder.start(source: .micOnly)
+        return try XCTUnwrap(session.lastRequest?.micOutputURL)
+    }
+
+    // MARK: - start
+
+    func testStartMarksTheRecordingUnderTheSameStemAsItsTracks() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_start")
+        let (recorder, session) = makeRecorder(dir: dir)
+
+        let micURL = try startMicOnly(recorder: recorder, session: session)
+
+        XCTAssertTrue(recorder.isRecording)
+        let track = try XCTUnwrap(RecordingFileSuffix.stripSuffix(from: micURL.lastPathComponent))
+        XCTAssertEqual(
+            try markerStems(in: dir), [track.stem],
+            "recovery pairs marker and tracks by stem, so a marker under any other name rescues nothing",
+        )
+    }
+
+    /// The microphone-only shape (issue #633): no process tap is opened at all,
+    /// which is not the same as a tap that captured nothing — the session
+    /// treats a mic failure as terminal only when the mic is the whole
+    /// recording.
+    func testAMicrophoneOnlyRecordingOpensNoProcessTap() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_mic_only")
+        let (recorder, session) = makeRecorder(dir: dir)
+
+        try recorder.start(source: .micOnly)
+
+        let request = try XCTUnwrap(session.lastRequest)
+        XCTAssertNil(request.appOutputURL, "a tap would capture a meeting that is happening in the room")
+        XCTAssertNotNil(request.micOutputURL)
+        XCTAssertTrue(request.pids.isEmpty)
+    }
+
+    /// The mirror image: "No Microphone" opens the tap and no mic track.
+    func testAnAppOnlyRecordingOpensNoMicrophone() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_app_only")
+        let (recorder, session) = makeRecorder(dir: dir)
+
+        // A PID no process holds: the tap-PID resolution then has no bundle to
+        // enumerate and falls back to the root alone, with nothing to depend on
+        // in whatever else is running on the machine.
+        try recorder.start(source: .appOnly(pid: 999_999))
+
+        let request = try XCTUnwrap(session.lastRequest)
+        XCTAssertNotNil(request.appOutputURL)
+        XCTAssertNil(request.micOutputURL)
+        XCTAssertEqual(request.pids, [999_999])
+    }
+
+    /// A start that threw before capture opened is not an interrupted
+    /// recording, and nothing else would ever clear its marker: `stop()` is
+    /// unreachable with `isRecording` still false, and the janitor keys on
+    /// tracks this start never created.
+    func testAStartThatNeverOpenedLeavesNoMarkerBehind() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_start_failed")
+        let (recorder, session) = makeRecorder(dir: dir)
+        session.startError = RecorderError.noAudioData
+
+        XCTAssertThrowsError(try recorder.start(source: .micOnly))
+
+        XCTAssertFalse(recorder.isRecording)
+        XCTAssertEqual(try markerStems(in: dir), [], "a start that never opened is not a crash")
+    }
+
+    // MARK: - stop
+
+    func testStopDropsTheMarkerOnceTheMixExists() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_stop")
+        let (recorder, session) = makeRecorder(dir: dir)
+        let micURL = try startMicOnly(recorder: recorder, session: session)
+        try AudioMixer.saveWAV(samples: [Float](repeating: 0.2, count: 16000), sampleRate: 16000, url: micURL)
+        session.micTrack = micURL
+
+        let recording = try recorder.stop()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recording.mixPath.path))
+        XCTAssertFalse(recorder.isRecording)
+        XCTAssertEqual(
+            try markerStems(in: dir), [],
+            "a marker left beside a finished recording turns into a false crash on the next launch",
+        )
+    }
+
+    /// A stop whose mix write fails has finished nothing. Keeping the marker is
+    /// what lets the next launch re-mix from the surviving tracks — the same
+    /// second chance the app-audio path has always had from its raw temp.
+    func testAStopWhoseMixFailsKeepsTheMarkerForTheNextLaunch() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_stop_failed")
+        let (recorder, session) = makeRecorder(dir: dir)
+        let micURL = try startMicOnly(recorder: recorder, session: session)
+        // Past the size guard, but not decodable audio: the mix fails after the
+        // tracks have been read and before anything durable is written.
+        try Data(repeating: 0xFF, count: 128).write(to: micURL)
+        session.micTrack = micURL
+
+        XCTAssertThrowsError(try recorder.stop())
+
+        XCTAssertEqual(
+            try markerStems(in: dir).count, 1,
+            "dropping the marker here would strand a mic-only recording for good",
+        )
+    }
+
+    // MARK: - Channel reporting
+
+    /// The levels and the give-up flags the menu bar reads come from the live
+    /// session. A level cannot say a channel was abandoned: one that fell
+    /// silent may come back, one that gave up will not.
+    func testTheRecorderReportsTheLiveSessionsChannelState() throws {
+        let dir = try makeTempDirectory(prefix: "lifecycle_levels")
+        let (recorder, session) = makeRecorder(dir: dir)
+        // Each channel gets a different value from its sibling, so a forwarder
+        // wired to the wrong one — or hardcoded to the no-session default —
+        // fails rather than coinciding with the right answer.
+        session.appLevelDBFS = -12
+        session.micLevelDBFS = -30
+        session.appCaptureGaveUp = true
+        session.micCaptureGaveUp = false
+
+        // Between recordings there is no session to ask, and silence plus "has
+        // not given up" is the only safe answer: a spurious give-up would tell
+        // the user a capture died that never ran.
+        XCTAssertEqual(recorder.appLevelDBFS, -120, accuracy: 0.001)
+        XCTAssertEqual(recorder.micLevelDBFS, -120, accuracy: 0.001)
+        XCTAssertFalse(recorder.appCaptureGaveUp)
+        XCTAssertFalse(recorder.micCaptureGaveUp)
+
+        try recorder.start(source: .micOnly)
+
+        XCTAssertEqual(recorder.appLevelDBFS, -12, accuracy: 0.001)
+        XCTAssertEqual(recorder.micLevelDBFS, -30, accuracy: 0.001)
+        XCTAssertTrue(recorder.appCaptureGaveUp)
+        XCTAssertFalse(recorder.micCaptureGaveUp)
+    }
+}

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderTests.swift
@@ -59,9 +59,13 @@ final class DualSourceRecorderTests: XCTestCase {
 
     // MARK: - Recordings Directory
 
-    func testRecordingsDirPath() {
-        let dir = DualSourceRecorder.recordingsDir
-        XCTAssertTrue(dir.path.contains("Library/Application Support/MeetingTranscriber/recordings"))
+    /// The staging directory is injectable, but the default is load-bearing:
+    /// the janitor, crash recovery, the orphan scan and the persistence policy
+    /// each resolve `AppPaths.recordingsDir` for themselves, so a recorder
+    /// defaulting anywhere else would stage where none of them ever looks and
+    /// every crashed recording would be lost with the suite still green.
+    func testTheDefaultStagingDirectoryIsTheOneRecoveryScans() {
+        XCTAssertEqual(DualSourceRecorder.defaultRecordingsDir, AppPaths.recordingsDir)
     }
 
     // MARK: - Stop Without Start

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -333,6 +333,21 @@ class MockRecorder: RecordingProvider {
     }
 }
 
+/// A recorder whose `start` fails the way a busy or absent input device does.
+/// Injected through the `makeRecorder:` seam so the non-permission failure arm
+/// is reachable without hardware. Shared so the files that need it don't reach
+/// across into each other.
+@MainActor
+final class ThrowingRecorder: RecordingProvider {
+    func start(source _: RecordingSource, micDeviceUID _: String?, debugLogging _: Bool) throws {
+        throw RecorderError.noAudioData
+    }
+
+    func stop() throws -> RecordingResult {
+        throw RecorderError.notRecording
+    }
+}
+
 /// A `MeetingDetecting` stub that never detects a meeting and reports any given
 /// meeting as inactive — so a `WatchLoop.handleMeeting(...)` ends immediately.
 /// Shared so per-test files don't each redeclare it.

--- a/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
+++ b/app/MeetingTranscriber/Tests/WatchLoopE2ETests.swift
@@ -15,7 +15,7 @@ final class WatchLoopE2ETests: XCTestCase { // swiftlint:disable:this balanced_x
 
         // Ensure recordingsDir exists (handleMeeting writes intermediate 16kHz files there)
         try FileManager.default.createDirectory(
-            at: DualSourceRecorder.recordingsDir,
+            at: AppPaths.recordingsDir,
             withIntermediateDirectories: true,
         )
     }

--- a/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerManualRecordingTests.swift
@@ -56,6 +56,72 @@ final class WatchingControllerManualRecordingTests: XCTestCase {
         XCTAssertTrue(controller.isManualRecording)
     }
 
+    // MARK: - What the user is told
+
+    /// A start reports itself. These two live here rather than at the
+    /// `AppState` level, where they used to accept either outcome because the
+    /// production recorder decided it by whether the machine had a usable input
+    /// device: this is the level that owns the recorder seam, so each outcome
+    /// can be asked for and asserted on its own.
+    func testAStartedRecordingIsReportedToTheUser() async {
+        let notifier = RecordingNotifier()
+        let controller = makeWatchingController(
+            logDir: tmpDir, notifier: notifier, permissionHealth: .allHealthy,
+        )
+        addTeardownBlock { await controller.stopManualRecording() }
+
+        controller.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        // Wait for the report, not for `isManualRecording`: the loop sets that
+        // inside the start, one statement before the notification, so waiting
+        // on it can win the race and read an empty list.
+        await waitFor(!notifier.calls.isEmpty, timeout: .seconds(2))
+
+        XCTAssertEqual(notifier.calls.first?.title, "Manual Recording")
+        XCTAssertTrue(controller.isManualRecording)
+    }
+
+    /// The other outcome, and the one that matters more: capture that cannot
+    /// open has to be reported. A silent failure is indistinguishable from a
+    /// recording in progress, so the user finds out when the protocol never
+    /// arrives.
+    func testACaptureThatCannotOpenIsReportedToTheUser() async {
+        let notifier = RecordingNotifier()
+        let controller = makeWatchingController(
+            // Explicit label and all arguments on one line: `make` takes several
+            // function-type parameters, so binding by position is the trap the
+            // RPC integration tests warn about — and splitting the last argument
+            // onto its own line is what lets the formatter turn it back into the
+            // trailing closure this comment exists to prevent.
+            // swiftlint:disable:next trailing_closure
+            logDir: tmpDir, notifier: notifier, permissionHealth: .allHealthy, makeRecorder: { ThrowingRecorder() },
+        )
+        addTeardownBlock { await controller.stopManualRecording() }
+
+        controller.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        await waitFor(!notifier.calls.isEmpty, timeout: .seconds(2))
+
+        XCTAssertEqual(notifier.calls.first?.title, "Error")
+        XCTAssertFalse(controller.isManualRecording, "a start that failed is not a recording")
+    }
+
+    /// A manual start takes over from meeting watching. The auto loop has to be
+    /// stopped, not merely dropped: the controller's reference is what stops
+    /// it, so overwriting it would leave a detector polling forever with no
+    /// owner.
+    func testAManualStartStopsTheAutoWatchLoopItTakesOverFrom() async {
+        let controller = makeWatchingController(logDir: tmpDir, permissionHealth: .allHealthy)
+        let (existingLoop, _) = makeTestWatchLoop()
+        existingLoop.start()
+        controller.watchLoop = existingLoop
+        addTeardownBlock { await controller.stopManualRecording() }
+        XCTAssertTrue(existingLoop.isActive, "precondition")
+
+        controller.startManualRecording(pid: 1234, appName: "Chrome", title: "Standup")
+        await waitFor(!existingLoop.isActive, timeout: .seconds(2))
+
+        XCTAssertFalse(existingLoop.isActive, "the loop being taken over from must be stopped")
+    }
+
     /// The app-picker half of the #624 ownership rule, which the two guards in
     /// `beginManualRecording` do not cover: an auto-detected meeting sets no
     /// `manualRecordingInfo`, so `isManualRecording` reads false and a picker

--- a/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
+++ b/app/MeetingTranscriber/Tests/WatchingControllerRecordControlTests.swift
@@ -358,17 +358,3 @@ actor OutcomeBox {
         value
     }
 }
-
-/// A recorder whose `start` fails the way a busy or absent input device does.
-/// Injected through the `makeRecorder:` seam so the non-permission failure arm
-/// is reachable without hardware.
-@MainActor
-final class ThrowingRecorder: RecordingProvider {
-    func start(source _: RecordingSource, micDeviceUID _: String?, debugLogging _: Bool) throws {
-        throw RecorderError.noAudioData
-    }
-
-    func stop() throws -> RecordingResult {
-        throw RecorderError.notRecording
-    }
-}


### PR DESCRIPTION
## What

`DualSourceRecorder.start()` and `stop()` carry the in-progress marker that crash recovery keys on, and neither could be driven from a test: the staging directory was a static reading `AppPaths`, and the capture session was constructed inline from the concrete `AudioCaptureSession`. Driving either meant opening real audio hardware and writing into the production staging directory that crash recovery and the orphan scan walk. The marker lifecycle was therefore covered only by its end states, never by the transitions themselves.

Both dependencies now arrive through `init`, the same injection `WatchingController` already makes one level up with `makeRecorder`.

## Why it is worth the seam

- The whole marker lifecycle is now pinned: written under the same stem as the tracks (recovery pairs the two by name), removed again when the start never opened, removed on a stop only once the mix exists, and deliberately **kept** when the mix fails so the next launch can re-mix from the surviving tracks. That last one is a microphone-only recording's only second chance and had nothing pinning it.
- Which tracks each `RecordingSource` opens is now asserted. "No tap at all" versus "a tap that captured nothing" is what decides whether a microphone failure is terminal.
- Two crash-recovery dead ends that were reachable and untested: an empty track must not become a mix (the orphan scan enqueues every untracked mix, so a start that captured nothing would come back as a meeting to transcribe), and recovering a stem with no tracks must throw rather than hand back a path to a file that does not exist.

## Incidental

- The session is stored as the new `AudioCapturing` role rather than the concrete class, which drops the type-erased `AnyObject` storage and the four `#available` guards the level accessors needed to read through it. Those accessors are polled for the whole duration of every recording, so a dynamic cast is gone from the one hot path here.
- The 14.2 floor now lives in the factory, where the compiler enforces it. `start()` keeps a copy only so an unsupported OS is rejected before the directory, the marker and the target's process tree are touched.
- Three tests drove the production recorder through `AppState` and accepted either outcome, "Manual Recording" or "Error", because that recorder decides which by whether the machine has a usable input device. They passed whichever way it went. They move to `WatchingController`, the level that owns the recorder seam and already isolates its own defaults domain, and each outcome is now asked for deliberately.

  Measured effect: a full test run no longer leaves a raw capture temp in the production staging directory. The failing start created the file before it threw, and nothing on that path deletes it again, so every run left one behind next to real recordings.

## Known limits, stated in the code

- Injecting the staging directory is **half a seam**: the janitor, crash recovery, the orphan scan and `AudioPersistencePolicy` each resolve `AppPaths.recordingsDir` for themselves, so only a test may pass a different one. The default is named rather than inlined so a test pins it against the path those consumers read.
- A microphone start that fails *after* its output file is opened leaves an empty 4 KB track that nothing reaps once the marker is removed. No audio is lost; deleting audio files on a failure path is the worse failure mode this design avoids.

## Verification

- Full suite green (the one failure, `SpeakerMatcherRealRecordingBacktest`, is environmental and fails identically on `main` without a Downloads grant).
- `swiftlint analyze --strict` over a full compiler log: 425 files, 0 violations.
- Release-mode and App Store parity builds both pass.
- Every new assertion is mutation-proven: eight separate mutations (marker not written, marker kept after a failed start, marker never dropped on stop, marker dropped before the mix exists, a mic-only source opening a tap, a level accessor that stops forwarding, and the default staging directory moved) are each caught by the intended test.