### PR TITLE
fix(app): show a setting's explanation once, not on top of itself

### DIFF
--- a/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
@@ -110,7 +110,6 @@ private struct PerChannelIndicatorSection: View {
                         .monospacedDigit()
                         .frame(width: 40)
                 }
-                .help(SettingsHelp.asymmetricSilenceWarning)
             }
         }
         .accessibilityIdentifier(A11yID.channelIndicatorSection)

--- a/app/MeetingTranscriber/Sources/Settings/HelpBadge.swift
+++ b/app/MeetingTranscriber/Sources/Settings/HelpBadge.swift
@@ -4,8 +4,9 @@ import SwiftUI
 ///
 /// The bare `.help()` tooltips used elsewhere are invisible until hovered, so
 /// non-expert users never discover them (issue #505). This gives an option a
-/// visible affordance while still exposing the same text as a hover tooltip and
-/// to VoiceOver.
+/// visible affordance instead, and it is the ONE place the explanation appears:
+/// a `.help()` alongside it renders the same paragraph a second time on top of
+/// the popover, because both fire on hover.
 ///
 /// Place it as a sibling of the option's label, not inside an interactive
 /// control's label (see ``HelpfulToggle`` for why). For a plain row:
@@ -32,12 +33,15 @@ struct HelpBadge: View {
         // Show on hover (no click needed); the Button keeps click working for
         // touch / keyboard / VoiceOver, which a hover-only affordance can't reach.
         .onHover { showing = $0 }
-        // `.help` still feeds the full text to VoiceOver (AXHelp) and is the
-        // ViewInspector hook the tests match on (popover content isn't inspectable).
-        .help(text)
         .accessibilityLabel("Help")
-        // Keep the hint terse and action-describing (per HIG); the full
-        // explanation is surfaced by the popover on activation/hover.
+        // Terse and action-describing, per HIG, and deliberately NOT the whole
+        // explanation. Carrying the full text here was tried and is wrong twice
+        // over: a hint is spoken in full on every focus with no way to skim,
+        // and it is suppressible (VoiceOver Verbosity, "Speak hints"), so the
+        // explanation would be read out unasked to the people who leave hints
+        // on and be gone entirely for the people who switch them off. The
+        // popover's `Text` is an ordinary accessible element and carries the
+        // explanation for everyone.
         .accessibilityHint("Shows an explanation of this setting")
         .popover(isPresented: $showing, arrowEdge: .trailing) {
             Text(text)
@@ -58,9 +62,8 @@ struct HelpBadge: View {
 /// Nesting an interactive control in a `Toggle` label folds the button into the
 /// toggle's single accessibility element, so VoiceOver can't focus the badge
 /// separately (and on some macOS versions the toggle's label hit region can also
-/// intercept the tap). Keeping it a sibling (mirroring the existing
-/// `TuningHelpIcon` placement) keeps the badge separately focusable with its own
-/// hit target.
+/// intercept the tap). Keeping it a sibling keeps the badge separately
+/// focusable with its own hit target.
 struct HelpfulToggle: View {
     let title: String
     let help: String
@@ -78,9 +81,5 @@ struct HelpfulToggle: View {
             Toggle(title, isOn: $isOn)
                 .labelsHidden()
         }
-        // Row-wide hover tooltip preserves the pre-badge behaviour for people
-        // used to hovering the control; the badge stays the visible, clickable
-        // affordance for everyone else.
-        .help(help)
     }
 }

--- a/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SpeakersSettingsView.swift
@@ -185,8 +185,8 @@ struct SpeakersSettingsView: View {
             TuningSliderRow(knob: .minSegmentDuration, value: $settings.minSegmentDurationSeconds)
             HStack {
                 Toggle("Exclude overlap", isOn: $settings.excludeOverlap)
-                TuningHelpIcon(
-                    tooltip: "When enabled, frames with multiple active speakers are masked out during embedding extraction.",
+                HelpBadge(
+                    text: "When enabled, frames with multiple active speakers are masked out during embedding extraction.",
                 )
                 Spacer()
             }
@@ -267,7 +267,7 @@ private struct TuningSliderRow: View {
         VStack(alignment: .leading, spacing: 2) {
             HStack {
                 Text(knob.title)
-                TuningHelpIcon(tooltip: knob.help)
+                HelpBadge(text: knob.help)
                 Spacer()
                 Text("\(String(format: knob.format, value))\(knob.suffix)")
                     .monospacedDigit()
@@ -275,15 +275,5 @@ private struct TuningSliderRow: View {
             }
             Slider(value: $value, in: knob.range, step: knob.step)
         }
-    }
-}
-
-private struct TuningHelpIcon: View {
-    let tooltip: String
-
-    var body: some View {
-        Image(systemName: "questionmark.circle")
-            .foregroundStyle(.secondary)
-            .help(tooltip)
     }
 }

--- a/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
+++ b/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
@@ -49,14 +49,45 @@ final class HelpBadgeTests: XCTestCase {
         XCTAssertTrue(try iconNames(for: HelpBadge(text: "Explains the thing")).contains("info.circle"))
     }
 
-    func testBadgeIsATappableButtonCarryingTheHelpText() throws {
-        // The badge is a real Button carrying the help string. NOTE: ViewInspector
-        // 0.10.3 cannot inspect native `.popover` content, so `find(text:)` here
-        // matches the `.help()` tooltip modifier, not the popover Text. This is a
-        // declarative check; it does not exercise tap -> popover presentation.
-        let sut = HelpBadge(text: "Explains the thing")
-        XCTAssertNoThrow(try sut.inspect().find(ViewType.Button.self))
-        XCTAssertNoThrow(try sut.inspect().find(text: "Explains the thing"))
+    /// The badge must carry its explanation on exactly ONE affordance.
+    ///
+    /// `.help()` and the hover popover both fire on hover, so a badge carrying
+    /// both renders the same paragraph twice at once: the system tooltip on top
+    /// of the popover it was meant to complement. The popover is the single
+    /// carrier of the explanation, for sighted users and for VoiceOver alike —
+    /// its `Text` is an ordinary accessible element.
+    func testBadgeCarriesTheExplanationOnlyOnce() throws {
+        let sut = try HelpBadge(text: "Explains the thing").inspect()
+        XCTAssertThrowsError(
+            try sut.find(ViewType.Button.self).help(),
+            "a tooltip plus the hover popover shows the same text twice at once",
+        )
+        // And not moved into the hint either, which would duplicate it one
+        // layer down: spoken in full on focus, then read again from the popover.
+        XCTAssertEqual(
+            try sut.find(ViewType.Button.self).accessibilityHint().string(),
+            "Shows an explanation of this setting",
+            "the hint says what the control does; the popover carries the explanation",
+        )
+        XCTAssertEqual(
+            try sut.find(HelpBadge.self).actualView().text, "Explains the thing",
+            "the explanation the popover renders is still the one it was given",
+        )
+    }
+
+    /// Mirror of the badge rule for the row that hosts it. The row carried its
+    /// own `.help`, so hovering the badge raised the row tooltip as well.
+    func testHelpfulToggleRowCarriesNoTooltipOfItsOwn() throws {
+        let row = try HelpfulToggle(title: "T", help: "h", isOn: .constant(false)).inspect()
+        // Anchor first. `XCTAssertThrowsError(row.hStack().help())` alone is
+        // vacuum-safe in the wrong direction: if the row ever stops being an
+        // HStack, `hStack()` throws and the assertion passes without a tooltip
+        // ever having been looked for.
+        XCTAssertEqual(try row.hStack().find(HelpBadge.self).actualView().text, "h")
+        XCTAssertThrowsError(
+            try row.hStack().help(),
+            "the row tooltip duplicates the badge that already explains the setting",
+        )
     }
 
     // MARK: - Behavioural (hosted)
@@ -65,6 +96,20 @@ final class HelpBadgeTests: XCTestCase {
     /// exercises the tap -> popover path and the popover's content builder;
     /// ViewInspector 0.10.3 can't reach native `.popover` content, so it hosts
     /// the view in a real NSWindow (the popover is an AppKit window).
+    ///
+    /// It asserts that a popover appeared, not what it says, and that is a
+    /// real gap rather than an oversight: after the tooltip was dropped the
+    /// popover is the only thing that shows this text to anyone. Two ways to
+    /// close it were tried and neither works here, so do not spend the time
+    /// again. ViewInspector's `popover()` exists but throws
+    /// `notSupported` for a native `.popover` unless the view adopts its
+    /// hosting pattern, which nothing in this suite uses. Walking the popover
+    /// window's `NSView` tree for accessibility strings returns an empty list,
+    /// because a SwiftUI `Text`'s accessibility lives in the `AXUIElement`
+    /// tree and not on the views — the same asymmetry `/ui/tree` exists for,
+    /// and an in-process AX walk is not populated in a bare xctest process.
+    /// What still pins the content is that `HelpBadge.text` is asserted above
+    /// and the popover renders exactly that property.
     func testClickingBadgePresentsPopover() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
@@ -105,9 +150,11 @@ final class HelpBadgeTests: XCTestCase {
         let body = try HelpfulToggle(title: "My Option", help: "the help text", isOn: .constant(false)).inspect()
         XCTAssertNoThrow(try body.find(text: "My Option"))
         XCTAssertNoThrow(try body.find(ViewType.Toggle.self))
-        // The help param must reach the badge (found via its `.help()` tooltip;
-        // popover content is not inspectable), not just render some badge.
-        XCTAssertNoThrow(try body.find(text: "the help text"))
+        // The help param must reach the badge, not just render some badge.
+        XCTAssertEqual(
+            try body.find(HelpBadge.self).actualView().text,
+            "the help text",
+        )
         let names = body.findAll(ViewType.Image.self).compactMap { try? $0.actualImage().name() }
         XCTAssertTrue(names.contains("info.circle"))
     }
@@ -124,6 +171,51 @@ final class HelpBadgeTests: XCTestCase {
             try toggle.find(ViewType.Button.self),
             "the help badge must not live inside the Toggle's label",
         )
+    }
+
+    // MARK: - The rule, swept
+
+    /// No settings row offers the explanation twice.
+    ///
+    /// The fix removed three sites that each paired a `HelpBadge` with a
+    /// `.help()`, and the three were found by looking at a screenshot. This is
+    /// the same question asked of the whole tab at once, so a fourth one is
+    /// caught by a test run instead of by noticing it on screen: any view
+    /// carrying a tooltip must not have a badge anywhere beneath it, because
+    /// both fire on hover and render the same paragraph on top of each other.
+    ///
+    /// A bare `.help()` with no badge is untouched — that is the older pattern
+    /// and it is still fine.
+    ///
+    /// What it does NOT catch, measured by restoring each of the three original
+    /// sites in turn: a tooltip on `HelpBadge` itself. `findAll` matches the
+    /// modifier where it is applied, and one inside the badge's own body is not
+    /// reachable from the tab. That site is `testBadgeCarriesTheExplanationOnlyOnce`.
+    /// Of the other two this sweep catches both, and for the warn-after row it
+    /// is the only cover there is.
+    func testNoSettingsRowOffersTheExplanationTwice() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.perChannelIndicatorEnabled = true
+
+        for (name, view) in try [
+            ("Audio", AudioSettingsView(settings: settings).inspect()),
+            ("Speakers", SpeakersSettingsView(
+                settings: settings,
+                recognitionStatsLog: RecognitionStatsLog(),
+                stageTimingLog: StageTimingLog(),
+                enrollmentDiarizerFactory: nil,
+                namingDialogActive: false,
+                pipelineBusy: false,
+                matcherFactory: { SpeakerMatcher() },
+            ).inspect()),
+        ] {
+            for tooltipped in view.findAll(where: { (try? $0.help()) != nil }) {
+                XCTAssertThrowsError(
+                    try tooltipped.find(HelpBadge.self),
+                    "\(name): a row with a badge must not also carry a tooltip — both fire on hover",
+                )
+            }
+        }
     }
 
     // MARK: - Catalog
@@ -164,14 +256,14 @@ final class HelpBadgeTests: XCTestCase {
 
     /// Each option must carry ITS help string (not merely some badge), so a
     /// swapped/empty SettingsHelp constant is caught; the count checks alone
-    /// would not notice. The catalog strings are found via each badge's
-    /// `.help()` tooltip (ViewInspector can't inspect popover content).
+    /// would not notice.
     func testAudioTabWiresEachOptionsHelpText() throws {
         let settings = AppSettings(defaults: defaults)
         settings.perChannelIndicatorEnabled = true
         let body = try AudioSettingsView(settings: settings).inspect()
-        XCTAssertNoThrow(try body.find(text: SettingsHelp.vad))
-        XCTAssertNoThrow(try body.find(text: SettingsHelp.silentCaptureChannel))
-        XCTAssertNoThrow(try body.find(text: SettingsHelp.asymmetricSilenceWarning))
+        let texts = body.findAll(HelpBadge.self).compactMap { try? $0.actualView().text }
+        XCTAssertTrue(texts.contains(SettingsHelp.vad))
+        XCTAssertTrue(texts.contains(SettingsHelp.silentCaptureChannel))
+        XCTAssertTrue(texts.contains(SettingsHelp.asymmetricSilenceWarning))
     }
 }


### PR DESCRIPTION
## What

Three Settings rows rendered the same help paragraph **twice at the same time** on hover: `.help()` (the AppKit tooltip) and `HelpBadge`'s popover both fire on hover, so the tooltip drew on top of the popover it was meant to complement.

- `HelpBadge` carried a `.help(text)` of its own.
- `HelpfulToggle` put `.help(help)` on the whole row, so hovering the badge raised the row tooltip too.
- The "Warn after" row in Audio had both a badge and its own `.help(...)`.

All three are removed. `TuningHelpIcon` (the older questionmark-icon-plus-tooltip pattern, 2 call sites) becomes a `HelpBadge` and the type is deleted, so every help affordance in Settings now behaves the same way.

## Where the explanation lives, and why not in the accessibility hint

Moving the text to `.accessibilityHint` was tried and rejected. It is wrong twice over:

- A hint is **spoken in full on every focus**, with no way to skim. These strings are two paragraphs.
- Hints are **suppressible** (VoiceOver Verbosity, "Speak hints"). The text would be read out unasked to everyone who leaves them on, and be gone entirely for everyone who turns them off — more losable than what it replaced, not less.

It also reproduces the very duplication this change removes, one layer down: hint on focus, then the same paragraph from the popover. So the hint stays terse and action-describing per HIG, and the popover's `Text` — an ordinary accessible element — carries the explanation for everyone.

## The sweep test is the durable half

The three sites were found by looking at a screenshot. `testNoSettingsRowOffersTheExplanationTwice` asks the same question of two whole tabs, so a fourth is caught by a test run instead of by noticing it on screen.

Its reach is **measured, not assumed** — each original site was restored in turn:

| site | caught by |
|---|---|
| tooltip on the badge itself | `testBadgeCarriesTheExplanationOnlyOnce` (**not** the sweep) |
| tooltip on the toggle row | both |
| tooltip on the warn-after row | **the sweep alone** |

The first row is a real limit and is written into the test: `findAll` matches a modifier where it is applied, and one inside the badge's own body is not reachable from the tab. The third is why the sweep earns its place.

## A dead end, recorded so it is not walked again

No test reaches the popover's own content, and the hosted test's comment now says why, with both routes tried:

- ViewInspector has `popover()`, but it throws `notSupported` for a native `.popover` unless the view adopts its hosting pattern, which nothing in this suite uses.
- Walking the popover window's `NSView` tree for accessibility strings returns an empty list, because a SwiftUI `Text` exposes accessibility through the `AXUIElement` tree and not through the views — the same asymmetry `/ui/tree` exists for.

What still pins the content is that `HelpBadge.text` is asserted and the popover renders exactly that property.

## Verification

Full suite green, `swiftlint analyze --strict` over a full compiler log (430 files, 0 violations), release-mode and App Store parity builds both pass, lint 0 violations.

## Follow-ups, deliberately not in here

- `PermissionRow` is a second hand-rolled badge — same Button, same `@State`, same popover — with **no accessibility modifiers at all**, so its help button is unlabeled to VoiceOver. Not a drop-in swap: it needs an optional footer parameter on `HelpBadge`.
- Five Speakers help strings bypass the `SettingsHelp` catalogue, one as a 110-character literal inline in a view body.
- One Speakers toggle row builds its own layout instead of using `HelpfulToggle`, opting out of the sibling-placement guarantee; swapping it moves the switch to the trailing edge, which is a visual change.
- Hover cost: the four tuning slider rows sit in a column and each popover is a real AppKit window, where previously they were delay-gated system tooltips sharing one. If it reads as restless, open on hover-in only.