### PR TITLE
feat(app): add transcript output privacy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Open Settings via the menu bar item or ⌘,.
 | **Audio** | Microphone device, voice activity detection (VAD), per-channel silence indicator |
 | **Transcribe** | ASR engine (WhisperKit / Parakeet) and per-engine options (model, language, custom vocabulary), live caption overlay (PoC) |
 | **Speakers** | Diarization, mic speaker name, known voices, recognition stats |
-| **Output** | LLM provider (Claude CLI / OpenAI-compatible / none), protocol language, output folder, custom prompt |
+| **Output** | LLM provider (Claude CLI / OpenAI-compatible / none), transcript-retention options, protocol language, output folder, custom prompt |
 | **Advanced** | Permissions status, diagnostics, version info |
 
 ---
@@ -260,10 +260,17 @@ Files are saved to `~/Library/Application Support/MeetingTranscriber/protocols/`
 
 | File | Content |
 |------|---------|
-| `20260225_1400_meeting.txt` | Raw transcript |
-| `20260225_1400_meeting.md` | Structured protocol |
+| `20260225_1400_meeting.txt` | Raw transcript (when enabled) |
+| `20260225_1400_meeting.md` | Structured protocol (when an LLM provider is configured) |
 
-**Protocol structure:** Summary, Participants, Topics Discussed, Decisions, Tasks (with responsible person, deadline, priority), Open Questions, Full Transcript.
+In **Settings → Output**, both transcript options default to enabled for backward compatibility:
+
+- **Include full transcript in protocol** appends the verbatim transcript to generated Markdown.
+- **Save raw transcript separately** retains the standalone `.txt` file.
+
+Disable both to retain only the generated meeting minutes. The recording follows its own retention policy and is not deleted by either setting. To avoid data loss, a raw transcript is retained if protocol generation is disabled, fails, or the job ends with an error.
+
+**Protocol structure:** Summary, Participants, Topics Discussed, Decisions, Tasks (with responsible person, deadline, priority), Open Questions, and optionally the Full Transcript.
 
 ---
 

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -35,6 +35,8 @@ enum A11yID {
     static let recordOnlyBanner = "recordOnlyBanner"
     static let transcriptionSection = "transcriptionSection"
     static let protocolSection = "protocolSection"
+    static let includeFullTranscriptToggle = "includeFullTranscriptToggle"
+    static let saveRawTranscriptToggle = "saveRawTranscriptToggle"
     static let outputFolderSection = "outputFolderSection"
     static let vadSection = "vadSection"
     static let echoDedupToggle = "echoDedupToggle"

--- a/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+RPC.swift
@@ -92,6 +92,8 @@
                 directory: rpcOutputDirPath(),
                 hasCustomDirectory: customOutputDirBookmark != nil,
                 hasCustomPrompt: FileManager.default.fileExists(atPath: AppPaths.customPromptFile.path),
+                includeFullTranscriptInProtocol: includeFullTranscriptInProtocol,
+                saveRawTranscriptSeparately: saveRawTranscriptSeparately,
             )
         }
 

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -396,8 +396,7 @@ final class AppSettings {
     }
 
     /// Keep the raw transcript as a separate `.txt` artefact after processing.
-    /// A transcript may still be retained while a job is in flight so speaker
-    /// naming and protocol generation can use it; it is removed at completion.
+    /// It remains while needed and is removed only after success with a saved protocol.
     var saveRawTranscriptSeparately: Bool {
         didSet { defaults.set(saveRawTranscriptSeparately, forKey: "saveRawTranscriptSeparately") }
     }

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -388,6 +388,20 @@ final class AppSettings {
         didSet { defaults.set(protocolLanguage, forKey: "protocolLanguage") }
     }
 
+    /// Append the verbatim transcript to generated Markdown meeting minutes.
+    /// Defaults to `true` to preserve the output format used before this option
+    /// was introduced.
+    var includeFullTranscriptInProtocol: Bool {
+        didSet { defaults.set(includeFullTranscriptInProtocol, forKey: "includeFullTranscriptInProtocol") }
+    }
+
+    /// Keep the raw transcript as a separate `.txt` artefact after processing.
+    /// A transcript may still be retained while a job is in flight so speaker
+    /// naming and protocol generation can use it; it is removed at completion.
+    var saveRawTranscriptSeparately: Bool {
+        didSet { defaults.set(saveRawTranscriptSeparately, forKey: "saveRawTranscriptSeparately") }
+    }
+
     static let protocolLanguages = [
         "German", "English", "French", "Spanish", "Italian",
         "Dutch", "Portuguese", "Japanese", "Chinese", "Korean",
@@ -526,6 +540,8 @@ final class AppSettings {
             claudeBin = defaults.object(forKey: "claudeBin") as? String ?? "claude"
         #endif
         protocolLanguage = defaults.string(forKey: "protocolLanguage") ?? "German"
+        includeFullTranscriptInProtocol = defaults.object(forKey: "includeFullTranscriptInProtocol") as? Bool ?? true
+        saveRawTranscriptSeparately = defaults.object(forKey: "saveRawTranscriptSeparately") as? Bool ?? true
 
         openAIEndpoint = defaults.object(forKey: "openAIEndpoint") as? String
             ?? Self.defaultOpenAIEndpoint

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -113,6 +113,12 @@ final class PipelineController {
             micLabel: settings.micName,
             includeFullTranscriptInProtocol: settings.includeFullTranscriptInProtocol,
             saveRawTranscriptSeparately: settings.saveRawTranscriptSeparately,
+            transcriptOutputOptionsProvider: { [settings] in
+                TranscriptOutputOptions(
+                    includeFullTranscriptInProtocol: settings.includeFullTranscriptInProtocol,
+                    saveRawTranscriptSeparately: settings.saveRawTranscriptSeparately,
+                )
+            },
             speakerMatcherFactory: { SpeakerMatcher() },
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -111,6 +111,8 @@ final class PipelineController {
             echoDedupEnabled: settings.echoDedupEnabled,
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
+            includeFullTranscriptInProtocol: settings.includeFullTranscriptInProtocol,
+            saveRawTranscriptSeparately: settings.saveRawTranscriptSeparately,
             speakerMatcherFactory: { SpeakerMatcher() },
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -82,11 +82,13 @@ struct PipelineJob: Identifiable, Codable {
     var transcriptPath: URL?
     var protocolPath: URL?
     var namingSlug: String?
-    /// Output policy captured when this job enters the queue. Optional so
-    /// snapshots saved before transcript-output options existed still decode.
-    /// Nil falls back to the queue's legacy-compatible defaults.
+    // Output policy captured when this job enters the queue. Optional so
+    // snapshots saved before transcript-output options existed still decode.
+    // Nil falls back to the queue's legacy-compatible defaults.
+    // swiftlint:disable:next discouraged_optional_boolean
     var includeFullTranscriptInProtocol: Bool?
-    /// See `includeFullTranscriptInProtocol`.
+    // See `includeFullTranscriptInProtocol`.
+    // swiftlint:disable:next discouraged_optional_boolean
     var saveRawTranscriptSeparately: Bool?
     /// Diarizer mode that produced the *current* `speakerNamingDataByJob`
     /// entry. Set by `PipelineQueue` after diarisation completes (in the
@@ -119,7 +121,9 @@ struct PipelineJob: Identifiable, Codable {
         participants: [String] = [],
         meetingStartTime: Date? = nil,
         autoSkipNaming: Bool = false,
+        // swiftlint:disable:next discouraged_optional_boolean
         includeFullTranscriptInProtocol: Bool? = nil,
+        // swiftlint:disable:next discouraged_optional_boolean
         saveRawTranscriptSeparately: Bool? = nil,
     ) {
         self.id = UUID()

--- a/app/MeetingTranscriber/Sources/PipelineJob.swift
+++ b/app/MeetingTranscriber/Sources/PipelineJob.swift
@@ -82,6 +82,12 @@ struct PipelineJob: Identifiable, Codable {
     var transcriptPath: URL?
     var protocolPath: URL?
     var namingSlug: String?
+    /// Output policy captured when this job enters the queue. Optional so
+    /// snapshots saved before transcript-output options existed still decode.
+    /// Nil falls back to the queue's legacy-compatible defaults.
+    var includeFullTranscriptInProtocol: Bool?
+    /// See `includeFullTranscriptInProtocol`.
+    var saveRawTranscriptSeparately: Bool?
     /// Diarizer mode that produced the *current* `speakerNamingDataByJob`
     /// entry. Set by `PipelineQueue` after diarisation completes (in the
     /// initial pipeline run and after `lateDiarization`). Used by the
@@ -113,6 +119,8 @@ struct PipelineJob: Identifiable, Codable {
         participants: [String] = [],
         meetingStartTime: Date? = nil,
         autoSkipNaming: Bool = false,
+        includeFullTranscriptInProtocol: Bool? = nil,
+        saveRawTranscriptSeparately: Bool? = nil,
     ) {
         self.id = UUID()
         self.meetingTitle = meetingTitle
@@ -131,6 +139,8 @@ struct PipelineJob: Identifiable, Codable {
         self.transcriptPath = nil
         self.protocolPath = nil
         self.namingSlug = nil
+        self.includeFullTranscriptInProtocol = includeFullTranscriptInProtocol
+        self.saveRawTranscriptSeparately = saveRawTranscriptSeparately
         self.usedDiarizerMode = nil
         self.autoSkipNaming = autoSkipNaming
     }

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Recovery.swift
@@ -72,15 +72,19 @@ extension PipelineQueue {
 
         // Rebuild the session's naming cache from disk for
         // .speakerNamingPending jobs.
-        for job in jobs where job.state == .speakerNamingPending {
+        let missingNamingDataJobIDs = jobs.compactMap { job -> UUID? in
+            guard job.state == .speakerNamingPending else { return nil }
             if let slug = job.namingSlug, naming.restore(jobID: job.id, slug: slug) {
-                continue
+                return nil
             }
-            // Naming data lost — transition to done
             logger.warning("Naming data not found for job \(job.id), marking as done")
-            if let idx = jobs.firstIndex(where: { $0.id == job.id }) {
-                jobs[idx].state = .done
-            }
+            return job.id
+        }
+        // Naming data lost — use the normal transition so terminal handling,
+        // artifact retention, callbacks, and the durable job record stay in
+        // sync with every other completion path.
+        for jobID in missingNamingDataJobIDs {
+            updateJobState(id: jobID, to: .done)
         }
 
         saveSnapshot()
@@ -158,7 +162,7 @@ extension PipelineQueue {
 
         for group in candidates {
             guard let mixURL = group.mix else { continue }
-            let job = PipelineJob(
+            var job = PipelineJob(
                 meetingTitle: "Recovered Recording (\(group.stem))",
                 appName: "Unknown",
                 mixPath: mixURL,
@@ -166,6 +170,7 @@ extension PipelineQueue {
                 micPath: group.mic,
                 micDelay: 0,
             )
+            stampTranscriptOutputOptions(on: &job)
             jobs.append(job)
             eventLog.append(jobID: job.id, event: "recovered", from: nil, to: .waiting)
         }

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -130,10 +130,14 @@ extension PipelineQueue {
     /// Best effort on purpose: a job that cannot write here will report the real
     /// problem when stage 3 tries again and does not swallow it.
     private func saveTranscriptDraft(_ transcript: String, ctx: JobContext, outputDir: URL) {
-        _ = try? ProtocolGenerator.saveTranscript(
+        guard let path = try? ProtocolGenerator.saveTranscript(
             transcript, basename: ctx.slug,
             dir: outputDir.appendingPathComponent("protocols"),
-        )
+        ) else { return }
+        if let idx = jobs.firstIndex(where: { $0.id == ctx.jobID }) {
+            jobs[idx].transcriptPath = path
+            jobs[idx].namingSlug = ctx.slug
+        }
     }
 
     /// Thin orchestrator: take the next waiting job and run it through the
@@ -659,7 +663,10 @@ extension PipelineQueue {
         finalTranscript: String, transcription: TranscriptionOutput,
         ctx: JobContext, workDir: URL, outputDir: URL,
     ) async throws {
-        // --- Save Transcript & Audio (always) ---
+        // --- Save Transcript & Audio ---
+        // Keep the transcript until the terminal state, even when the user
+        // opted out of a separate raw file: late speaker naming still needs to
+        // rewrite it before generating the final protocol.
         let protocolsDir = outputDir.appendingPathComponent("protocols")
         let txtPath = try ProtocolGenerator.saveTranscript(finalTranscript, basename: ctx.slug, dir: protocolsDir)
         logger.info("[\(ctx.shortID, privacy: .public)] transcript_saved file=\(txtPath.lastPathComponent, privacy: .private)")
@@ -762,9 +769,11 @@ extension PipelineQueue {
                 diarized: diarized,
                 meetingStartTime: meetingStartTime,
             )
-            let fullMD = protocolMD + "\n\n---\n\n## Full Transcript\n\n" + transcript
+            let markdown = includeFullTranscriptInProtocol
+                ? protocolMD + "\n\n---\n\n## Full Transcript\n\n" + transcript
+                : protocolMD
             let mdPath = try ProtocolGenerator.saveProtocol(
-                fullMD, basename: basename, dir: protocolsDir,
+                markdown, basename: basename, dir: protocolsDir,
             )
             logger.info("[\(shortID, privacy: .public)] protocol_saved file=\(mdPath.lastPathComponent, privacy: .private)")
             if let idx = jobs.firstIndex(where: { $0.id == jobID }) {

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -769,7 +769,7 @@ extension PipelineQueue {
                 diarized: diarized,
                 meetingStartTime: meetingStartTime,
             )
-            let markdown = includeFullTranscriptInProtocol
+            let markdown = transcriptOutputOptions(forJobID: jobID).includeFullTranscriptInProtocol
                 ? protocolMD + "\n\n---\n\n## Full Transcript\n\n" + transcript
                 : protocolMD
             let mdPath = try ProtocolGenerator.saveProtocol(

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -26,7 +26,7 @@ struct DiarizationRun {
 
 @MainActor
 @Observable
-// swiftlint:disable:next attributes
+// swiftlint:disable:next attributes type_body_length
 class PipelineQueue {
     /// Internal setter (not `private(set)`) because the stage and recovery
     /// extension methods in sibling files (PipelineQueue+Stages.swift,

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -535,7 +535,8 @@ class PipelineQueue {
         guard oldState != newState || error != nil else { return }
         jobs[index].state = newState
         if let error { jobs[index].error = error }
-        if (newState == .done || newState == .error), !transcriptOutputOptions(forJobID: id).saveRawTranscriptSeparately {
+        if newState == .done || newState == .error,
+           !transcriptOutputOptions(forJobID: id).saveRawTranscriptSeparately {
             removeRawTranscriptArtifacts(for: index)
         }
         recordStageTransition(from: oldState, to: newState, jobID: id)

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -59,6 +59,12 @@ class PipelineQueue {
     let echoDedupEnabled: Bool
     let numSpeakers: Int
     let micLabel: String
+    /// Captured when the queue is built so a running job has stable output
+    /// semantics even if the user changes Settings mid-processing.
+    let includeFullTranscriptInProtocol: Bool
+    /// See `includeFullTranscriptInProtocol`. When false, the temporary raw
+    /// transcript is removed as soon as the job reaches a terminal state.
+    let saveRawTranscriptSeparately: Bool
     let speakerMatcherFactory: () -> SpeakerMatcher
     let vadConfig: VADConfig?
     /// nil disables JSONL logging. AppState injects a real instance for production;
@@ -234,6 +240,8 @@ class PipelineQueue {
         echoDedupEnabled = true
         self.numSpeakers = 0
         self.micLabel = "Me"
+        self.includeFullTranscriptInProtocol = true
+        self.saveRawTranscriptSeparately = true
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
@@ -310,6 +318,8 @@ class PipelineQueue {
         echoDedupEnabled: Bool = true,
         numSpeakers: Int = 0,
         micLabel: String = "Me",
+        includeFullTranscriptInProtocol: Bool = true,
+        saveRawTranscriptSeparately: Bool = true,
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
@@ -341,6 +351,8 @@ class PipelineQueue {
         // of micLabel for both the tagging and the re-split, so sanitizing here
         // keeps them consistent.)
         self.micLabel = micLabel == DiarizationProcess.remoteSpeakerLabel ? "Me" : micLabel
+        self.includeFullTranscriptInProtocol = includeFullTranscriptInProtocol
+        self.saveRawTranscriptSeparately = saveRawTranscriptSeparately
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig
@@ -483,6 +495,9 @@ class PipelineQueue {
         guard oldState != newState || error != nil else { return }
         jobs[index].state = newState
         if let error { jobs[index].error = error }
+        if (newState == .done || newState == .error), !saveRawTranscriptSeparately {
+            removeRawTranscript(for: index)
+        }
         recordStageTransition(from: oldState, to: newState, jobID: id)
         eventLog.append(jobID: id, event: "state_change", from: oldState, to: newState)
         saveSnapshot()
@@ -505,6 +520,27 @@ class PipelineQueue {
     /// it from the in-memory list. No-op when no store is wired.
     private func recordTerminalJob(_ job: PipelineJob) {
         terminalJobStore?.record(JobStatusDTO(job: job))
+    }
+
+    /// Delete the in-flight transcript once no pipeline stage needs it. The
+    /// speaker-naming flow deliberately reaches `.done` only after it has read
+    /// and rewritten the transcript, so this also covers late confirmation.
+    private func removeRawTranscript(for index: Int) {
+        guard let transcriptPath = jobs[index].transcriptPath else { return }
+        do {
+            try FileManager.default.removeItem(at: transcriptPath)
+            logger.info("Transcript removed according to output setting")
+            jobs[index].transcriptPath = nil
+        } catch CocoaError.fileNoSuchFile {
+            // A failed or interrupted write may leave only the path; the desired
+            // final state is still no raw transcript.
+            jobs[index].transcriptPath = nil
+        } catch {
+            logger.warning(
+                "Failed to remove transcript according to output setting: \(error.localizedDescription, privacy: .public)",
+            )
+            jobs[index].warnings.append("Raw transcript could not be removed")
+        }
     }
 
     func addWarning(id: UUID, _ message: String) {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -4,6 +4,14 @@ import os.log
 
 private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PipelineQueue")
 
+/// Output policy captured when a job enters the queue. Capturing it per job
+/// means a Settings change applies to the next recording without changing the
+/// privacy semantics of a recording that is already being processed.
+struct TranscriptOutputOptions {
+    let includeFullTranscriptInProtocol: Bool
+    let saveRawTranscriptSeparately: Bool
+}
+
 /// Raw diarization output for one run of the diarize loop. `combined` is the
 /// result fed into speaker naming (the prefixed dual-track merge, the app-only
 /// or mic-only single-track fallback, or the single-source result); `app`/`mic`
@@ -59,12 +67,12 @@ class PipelineQueue {
     let echoDedupEnabled: Bool
     let numSpeakers: Int
     let micLabel: String
-    /// Captured when the queue is built so a running job has stable output
-    /// semantics even if the user changes Settings mid-processing.
-    let includeFullTranscriptInProtocol: Bool
-    /// See `includeFullTranscriptInProtocol`. When false, the temporary raw
-    /// transcript is removed as soon as the job reaches a terminal state.
-    let saveRawTranscriptSeparately: Bool
+    /// Compatibility policy for snapshots created before a job carried its own
+    /// output options.
+    private let fallbackTranscriptOutputOptions: TranscriptOutputOptions
+    /// Reads the current Settings only when a job is enqueued; the values are
+    /// then copied onto the job and remain stable for its whole lifecycle.
+    private let transcriptOutputOptionsProvider: () -> TranscriptOutputOptions
     let speakerMatcherFactory: () -> SpeakerMatcher
     let vadConfig: VADConfig?
     /// nil disables JSONL logging. AppState injects a real instance for production;
@@ -240,8 +248,12 @@ class PipelineQueue {
         echoDedupEnabled = true
         self.numSpeakers = 0
         self.micLabel = "Me"
-        self.includeFullTranscriptInProtocol = true
-        self.saveRawTranscriptSeparately = true
+        let outputOptions = TranscriptOutputOptions(
+            includeFullTranscriptInProtocol: true,
+            saveRawTranscriptSeparately: true,
+        )
+        fallbackTranscriptOutputOptions = outputOptions
+        transcriptOutputOptionsProvider = { outputOptions }
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
@@ -320,6 +332,7 @@ class PipelineQueue {
         micLabel: String = "Me",
         includeFullTranscriptInProtocol: Bool = true,
         saveRawTranscriptSeparately: Bool = true,
+        transcriptOutputOptionsProvider: (() -> TranscriptOutputOptions)? = nil,
         speakerMatcherFactory: @escaping () -> SpeakerMatcher = PipelineQueue.throwawayMatcherFactory(),
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
@@ -351,8 +364,12 @@ class PipelineQueue {
         // of micLabel for both the tagging and the re-split, so sanitizing here
         // keeps them consistent.)
         self.micLabel = micLabel == DiarizationProcess.remoteSpeakerLabel ? "Me" : micLabel
-        self.includeFullTranscriptInProtocol = includeFullTranscriptInProtocol
-        self.saveRawTranscriptSeparately = saveRawTranscriptSeparately
+        let outputOptions = TranscriptOutputOptions(
+            includeFullTranscriptInProtocol: includeFullTranscriptInProtocol,
+            saveRawTranscriptSeparately: saveRawTranscriptSeparately,
+        )
+        fallbackTranscriptOutputOptions = outputOptions
+        self.transcriptOutputOptionsProvider = transcriptOutputOptionsProvider ?? { outputOptions }
         self.speakerMatcherFactory = speakerMatcherFactory
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig
@@ -387,12 +404,35 @@ class PipelineQueue {
         jobs.filter { $0.state == .done }
     }
 
-    func enqueue(_ job: PipelineJob) {
+    func enqueue(_ inputJob: PipelineJob) {
+        var job = inputJob
+        let outputOptions = transcriptOutputOptionsProvider()
+        if job.includeFullTranscriptInProtocol == nil {
+            job.includeFullTranscriptInProtocol = outputOptions.includeFullTranscriptInProtocol
+        }
+        if job.saveRawTranscriptSeparately == nil {
+            job.saveRawTranscriptSeparately = outputOptions.saveRawTranscriptSeparately
+        }
         jobs.append(job)
         eventLog.append(jobID: job.id, event: "enqueued", from: nil, to: job.state)
         saveSnapshot()
         logger.info("Enqueued job: \(job.meetingTitle, privacy: .private) (\(job.id))")
         triggerProcessing()
+    }
+
+    /// Resolves the output policy for an existing job. The fallback keeps
+    /// snapshots from versions before per-job settings compatible.
+    /// Internal because pipeline stages in sibling files use it.
+    func transcriptOutputOptions(forJobID jobID: UUID) -> TranscriptOutputOptions {
+        guard let job = jobs.first(where: { $0.id == jobID }) else {
+            return fallbackTranscriptOutputOptions
+        }
+        return TranscriptOutputOptions(
+            includeFullTranscriptInProtocol: job.includeFullTranscriptInProtocol
+                ?? fallbackTranscriptOutputOptions.includeFullTranscriptInProtocol,
+            saveRawTranscriptSeparately: job.saveRawTranscriptSeparately
+                ?? fallbackTranscriptOutputOptions.saveRawTranscriptSeparately,
+        )
     }
 
     /// Test-only: insert a fully-formed job at any state, bypassing
@@ -495,8 +535,8 @@ class PipelineQueue {
         guard oldState != newState || error != nil else { return }
         jobs[index].state = newState
         if let error { jobs[index].error = error }
-        if (newState == .done || newState == .error), !saveRawTranscriptSeparately {
-            removeRawTranscript(for: index)
+        if (newState == .done || newState == .error), !transcriptOutputOptions(forJobID: id).saveRawTranscriptSeparately {
+            removeRawTranscriptArtifacts(for: index)
         }
         recordStageTransition(from: oldState, to: newState, jobID: id)
         eventLog.append(jobID: id, event: "state_change", from: oldState, to: newState)
@@ -522,25 +562,29 @@ class PipelineQueue {
         terminalJobStore?.record(JobStatusDTO(job: job))
     }
 
-    /// Delete the in-flight transcript once no pipeline stage needs it. The
+    /// Delete transcript-bearing output once no pipeline stage needs it. The
     /// speaker-naming flow deliberately reaches `.done` only after it has read
-    /// and rewritten the transcript, so this also covers late confirmation.
-    private func removeRawTranscript(for index: Int) {
-        guard let transcriptPath = jobs[index].transcriptPath else { return }
-        do {
-            try FileManager.default.removeItem(at: transcriptPath)
-            logger.info("Transcript removed according to output setting")
-            jobs[index].transcriptPath = nil
-        } catch CocoaError.fileNoSuchFile {
-            // A failed or interrupted write may leave only the path; the desired
-            // final state is still no raw transcript.
-            jobs[index].transcriptPath = nil
-        } catch {
-            logger.warning(
-                "Failed to remove transcript according to output setting: \(error.localizedDescription, privacy: .public)",
-            )
-            jobs[index].warnings.append("Raw transcript could not be removed")
+    /// and rewritten these files, so this also covers late confirmation.
+    private func removeRawTranscriptArtifacts(for index: Int) {
+        let transcriptPath = jobs[index].transcriptPath
+        let slug = jobs[index].namingSlug
+        if let transcriptPath {
+            do {
+                try FileManager.default.removeItem(at: transcriptPath)
+                logger.info("Transcript removed according to output setting")
+                jobs[index].transcriptPath = nil
+            } catch CocoaError.fileNoSuchFile {
+                // A failed or interrupted write may leave only the path; the
+                // desired final state is still no raw transcript.
+                jobs[index].transcriptPath = nil
+            } catch {
+                logger.warning(
+                    "Failed to remove transcript according to output setting: \(error.localizedDescription, privacy: .public)",
+                )
+                jobs[index].warnings.append("Raw transcript could not be removed")
+            }
         }
+        naming.removeTranscriptSegments(slug: slug)
     }
 
     func addWarning(id: UUID, _ message: String) {

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -406,13 +406,7 @@ class PipelineQueue {
 
     func enqueue(_ inputJob: PipelineJob) {
         var job = inputJob
-        let outputOptions = transcriptOutputOptionsProvider()
-        if job.includeFullTranscriptInProtocol == nil {
-            job.includeFullTranscriptInProtocol = outputOptions.includeFullTranscriptInProtocol
-        }
-        if job.saveRawTranscriptSeparately == nil {
-            job.saveRawTranscriptSeparately = outputOptions.saveRawTranscriptSeparately
-        }
+        stampTranscriptOutputOptions(on: &job)
         jobs.append(job)
         eventLog.append(jobID: job.id, event: "enqueued", from: nil, to: job.state)
         saveSnapshot()
@@ -433,6 +427,19 @@ class PipelineQueue {
             saveRawTranscriptSeparately: job.saveRawTranscriptSeparately
                 ?? fallbackTranscriptOutputOptions.saveRawTranscriptSeparately,
         )
+    }
+
+    /// Copy the current settings onto a newly admitted job. Recovery uses the
+    /// same admission rule as regular enqueueing so a later settings change
+    /// cannot change output handling for an already recovered recording.
+    func stampTranscriptOutputOptions(on job: inout PipelineJob) {
+        let outputOptions = transcriptOutputOptionsProvider()
+        if job.includeFullTranscriptInProtocol == nil {
+            job.includeFullTranscriptInProtocol = outputOptions.includeFullTranscriptInProtocol
+        }
+        if job.saveRawTranscriptSeparately == nil {
+            job.saveRawTranscriptSeparately = outputOptions.saveRawTranscriptSeparately
+        }
     }
 
     /// Test-only: insert a fully-formed job at any state, bypassing
@@ -535,9 +542,15 @@ class PipelineQueue {
         guard oldState != newState || error != nil else { return }
         jobs[index].state = newState
         if let error { jobs[index].error = error }
-        if newState == .done || newState == .error,
-           !transcriptOutputOptions(forJobID: id).saveRawTranscriptSeparately {
-            removeRawTranscriptArtifacts(for: index)
+        if newState == .done {
+            removeRawTranscriptArtifactsIfSafe(for: index)
+        } else if newState == .error,
+                  !transcriptOutputOptions(forJobID: id).saveRawTranscriptSeparately,
+                  jobs[index].transcriptPath != nil {
+            let warning = "Raw transcript retained because the job did not complete"
+            if !jobs[index].warnings.contains(warning) {
+                jobs[index].warnings.append(warning)
+            }
         }
         recordStageTransition(from: oldState, to: newState, jobID: id)
         eventLog.append(jobID: id, event: "state_change", from: oldState, to: newState)
@@ -563,12 +576,30 @@ class PipelineQueue {
         terminalJobStore?.record(JobStatusDTO(job: job))
     }
 
-    /// Delete transcript-bearing output once no pipeline stage needs it. The
-    /// speaker-naming flow deliberately reaches `.done` only after it has read
-    /// and rewritten these files, so this also covers late confirmation.
-    private func removeRawTranscriptArtifacts(for index: Int) {
+    /// Deletes raw transcript artifacts only after a successfully completed job
+    /// has saved a protocol. A failed or disabled protocol generator leaves the
+    /// transcript intact so users can recover the meeting content instead of
+    /// losing it with no generated minutes to show for it.
+    private func removeRawTranscriptArtifactsIfSafe(for index: Int) {
+        guard !transcriptOutputOptions(forJobID: jobs[index].id).saveRawTranscriptSeparately else { return }
+        guard jobs[index].protocolPath != nil else {
+            if jobs[index].transcriptPath != nil {
+                let warning = "Raw transcript retained because no protocol was saved"
+                if !jobs[index].warnings.contains(warning) {
+                    jobs[index].warnings.append(warning)
+                }
+            }
+            return
+        }
+
         let transcriptPath = jobs[index].transcriptPath
         let slug = jobs[index].namingSlug
+        let isAccessingOutputDir = outputDir?.startAccessingSecurityScopedResource() ?? false
+        defer {
+            if isAccessingOutputDir {
+                outputDir?.stopAccessingSecurityScopedResource()
+            }
+        }
         if let transcriptPath {
             do {
                 try FileManager.default.removeItem(at: transcriptPath)
@@ -585,7 +616,17 @@ class PipelineQueue {
                 jobs[index].warnings.append("Raw transcript could not be removed")
             }
         }
-        naming.removeTranscriptSegments(slug: slug)
+        do {
+            try naming.removeTranscriptSegments(slug: slug)
+        } catch {
+            logger.warning(
+                "Failed to remove transcript segments according to output setting: \(error.localizedDescription, privacy: .public)",
+            )
+            let warning = "Raw transcript segments could not be removed"
+            if !jobs[index].warnings.contains(warning) {
+                jobs[index].warnings.append(warning)
+            }
+        }
     }
 
     func addWarning(id: UUID, _ message: String) {

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -60,7 +60,7 @@ enum ProtocolGenerator {
     - [Question 1]
     - [Question 2]
 
-    Do NOT include the full transcript in the output – it will be appended automatically.
+    Do NOT include the full transcript in the output.
 
     ---
     Transcript:

--- a/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
+++ b/app/MeetingTranscriber/Sources/RPCStateSnapshot.swift
@@ -385,8 +385,15 @@
                 /// A custom protocol-prompt file exists on disk. The content is
                 /// intentionally not exposed (potentially large / user-authored).
                 let hasCustomPrompt: Bool
+                /// Whether the generated Markdown includes the verbatim transcript.
+                let includeFullTranscriptInProtocol: Bool
+                /// Whether the completed job keeps a separate raw transcript file.
+                let saveRawTranscriptSeparately: Bool
 
-                static let empty = Self(directory: nil, hasCustomDirectory: false, hasCustomPrompt: false)
+                static let empty = Self(
+                    directory: nil, hasCustomDirectory: false, hasCustomPrompt: false,
+                    includeFullTranscriptInProtocol: false, saveRawTranscriptSeparately: false,
+                )
             }
 
             struct Diagnostics: Codable {

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -79,7 +79,9 @@ struct OutputSettingsView: View {
 
             Section("Protocol Generation") {
                 Toggle("Include full transcript in protocol", isOn: $settings.includeFullTranscriptInProtocol)
+                    .accessibilityIdentifier(A11yID.includeFullTranscriptToggle)
                 Toggle("Save raw transcript separately", isOn: $settings.saveRawTranscriptSeparately)
+                    .accessibilityIdentifier(A11yID.saveRawTranscriptToggle)
 
                 Picker("LLM Provider", selection: $settings.protocolProvider) {
                     ForEach(ProtocolProvider.allCases, id: \.self) { provider in
@@ -128,7 +130,7 @@ struct OutputSettingsView: View {
             openAIConfigView
 
         case .none:
-            Text("No LLM summarization will be generated.")
+            Text("No LLM summarization will be generated. Raw transcripts are retained if no protocol is saved.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -78,6 +78,9 @@ struct OutputSettingsView: View {
             .accessibilityIdentifier(A11yID.outputFolderSection)
 
             Section("Protocol Generation") {
+                Toggle("Include full transcript in protocol", isOn: $settings.includeFullTranscriptInProtocol)
+                Toggle("Save raw transcript separately", isOn: $settings.saveRawTranscriptSeparately)
+
                 Picker("LLM Provider", selection: $settings.protocolProvider) {
                     ForEach(ProtocolProvider.allCases, id: \.self) { provider in
                         Text(provider.label).tag(provider)
@@ -125,7 +128,7 @@ struct OutputSettingsView: View {
             openAIConfigView
 
         case .none:
-            Text("Only the raw transcript will be saved — no LLM summarization.")
+            Text("No LLM summarization will be generated.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -391,6 +391,13 @@ final class SpeakerNamingSession {
         namingStore.cleanupSidecarFiles(slug: slug)
     }
 
+    /// Removes only the transcript-bearing segment sidecar. The queue uses this
+    /// when the user opts out of permanent raw transcript output; audio remains
+    /// governed by the normal recording-retention policy.
+    func removeTranscriptSegments(slug: String?) {
+        namingStore.deleteTranscriptSegments(slug: slug)
+    }
+
     /// Rebuild the RAM naming cache for a restored `.speakerNamingPending` job
     /// from its on-disk sidecar. Returns false when the sidecar is missing (the
     /// queue then marks the job `.done`). Called from `loadSnapshot`.

--- a/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingSession.swift
@@ -394,8 +394,8 @@ final class SpeakerNamingSession {
     /// Removes only the transcript-bearing segment sidecar. The queue uses this
     /// when the user opts out of permanent raw transcript output; audio remains
     /// governed by the normal recording-retention policy.
-    func removeTranscriptSegments(slug: String?) {
-        namingStore.deleteTranscriptSegments(slug: slug)
+    func removeTranscriptSegments(slug: String?) throws {
+        try namingStore.deleteTranscriptSegments(slug: slug)
     }
 
     /// Rebuild the RAM naming cache for a restored `.speakerNamingPending` job

--- a/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
@@ -84,9 +84,11 @@ struct SpeakerNamingStore {
     /// Delete only the cached transcript segments. These contain verbatim
     /// speech, unlike the audio/naming sidecars, and must not outlive a job
     /// when separate raw-transcript output is disabled.
-    func deleteTranscriptSegments(slug: String?) {
+    func deleteTranscriptSegments(slug: String?) throws {
         guard let slug, let recordingsDir else { return }
-        try? FileManager.default.removeItem(at: recordingsDir.appendingPathComponent("\(slug)_segments.json"))
+        let path = recordingsDir.appendingPathComponent("\(slug)_segments.json")
+        guard FileManager.default.fileExists(atPath: path.path) else { return }
+        try FileManager.default.removeItem(at: path)
     }
 
     /// Delete the 16 kHz audio and segment sidecar files for a slug.

--- a/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingStore.swift
@@ -81,6 +81,14 @@ struct SpeakerNamingStore {
         try? FileManager.default.removeItem(at: recordingsDir.appendingPathComponent("\(slug)_naming.json"))
     }
 
+    /// Delete only the cached transcript segments. These contain verbatim
+    /// speech, unlike the audio/naming sidecars, and must not outlive a job
+    /// when separate raw-transcript output is disabled.
+    func deleteTranscriptSegments(slug: String?) {
+        guard let slug, let recordingsDir else { return }
+        try? FileManager.default.removeItem(at: recordingsDir.appendingPathComponent("\(slug)_segments.json"))
+    }
+
     /// Delete the 16 kHz audio and segment sidecar files for a slug.
     func cleanupSidecarFiles(slug: String?) {
         guard let slug, let recordingsDir else { return }

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import MeetingTranscriber
 import XCTest
 
+// swiftlint:disable:next type_body_length
 final class AppSettingsTests: XCTestCase {
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var settings: AppSettings!

--- a/app/MeetingTranscriber/Tests/AppSettingsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsTests.swift
@@ -348,6 +348,22 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(fresh.protocolProvider, .openAICompatible)
     }
 
+    func testTranscriptOutputOptionsDefaultToEnabled() {
+        XCTAssertTrue(settings.includeFullTranscriptInProtocol)
+        XCTAssertTrue(settings.saveRawTranscriptSeparately)
+    }
+
+    func testTranscriptOutputOptionsPersist() {
+        settings.includeFullTranscriptInProtocol = false
+        settings.saveRawTranscriptSeparately = false
+        XCTAssertEqual(defaults.object(forKey: "includeFullTranscriptInProtocol") as? Bool, false)
+        XCTAssertEqual(defaults.object(forKey: "saveRawTranscriptSeparately") as? Bool, false)
+
+        let fresh = AppSettings(defaults: defaults)
+        XCTAssertFalse(fresh.includeFullTranscriptInProtocol)
+        XCTAssertFalse(fresh.saveRawTranscriptSeparately)
+    }
+
     func testOpenAIEndpointDefault() {
         XCTAssertEqual(settings.openAIEndpoint, "http://localhost:11434/v1")
     }

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -100,6 +100,27 @@ final class PipelineQueueTests: XCTestCase {
         XCTAssertEqual(rec?.error, "Empty transcript")
     }
 
+    func testErrorAfterProtocolWriteRetainsRawTranscript() throws {
+        let transcriptPath = tmpDir.appendingPathComponent("meeting.txt")
+        let protocolPath = tmpDir.appendingPathComponent("meeting.md")
+        try Data("verbatim meeting content".utf8).write(to: transcriptPath)
+        try Data("# Minutes".utf8).write(to: protocolPath)
+        var job = makeJob()
+        job.state = .generatingProtocol
+        job.transcriptPath = transcriptPath
+        job.protocolPath = protocolPath
+        job.saveRawTranscriptSeparately = false
+        queue.insertJobForTesting(job)
+
+        queue.updateJobState(id: job.id, to: .error, error: "Post-write failure")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: transcriptPath.path))
+        XCTAssertEqual(queue.jobs.first?.transcriptPath, transcriptPath)
+        XCTAssertTrue(
+            queue.jobs.first?.warnings.contains("Raw transcript retained because the job did not complete") ?? false,
+        )
+    }
+
     func testNoTerminalRecordForNonTerminalState() {
         let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
         let q = PipelineQueue(logDir: tmpDir, terminalJobStore: store)
@@ -795,6 +816,34 @@ final class PipelineQueueTests: XCTestCase {
             freshQueue.jobs[0].mixPath?.standardizedFileURL,
             mixFile.standardizedFileURL,
         )
+    }
+
+    func testRecoveredJobCapturesCurrentTranscriptOutputOptions() async throws {
+        let recDir = tmpDir.appendingPathComponent("recordings")
+        try FileManager.default.createDirectory(at: recDir, withIntermediateDirectories: true)
+        let mixFile = recDir.appendingPathComponent("20260311_100000_mix.wav")
+        try Data(repeating: 0xFF, count: 100).write(to: mixFile)
+        let engine = MockEngine()
+        let freshQueue = PipelineQueue(
+            engine: engine,
+            diarizationFactory: { MockDiarization() },
+            protocolGeneratorFactory: { MockProtocolGen() },
+            outputDir: tmpDir,
+            logDir: tmpDir,
+            // swiftlint:disable:next trailing_closure
+            transcriptOutputOptionsProvider: {
+                TranscriptOutputOptions(
+                    includeFullTranscriptInProtocol: false,
+                    saveRawTranscriptSeparately: false,
+                )
+            },
+        )
+
+        await freshQueue.recoverOrphanedRecordings(recordingsDir: recDir)
+
+        let recovered = try XCTUnwrap(freshQueue.jobs.first)
+        XCTAssertFalse(try XCTUnwrap(recovered.includeFullTranscriptInProtocol))
+        XCTAssertFalse(try XCTUnwrap(recovered.saveRawTranscriptSeparately))
     }
 
     func testRecoverSkipsTrackedFiles() async throws {
@@ -3926,6 +3975,68 @@ final class PipelineQueueTests: XCTestCase {
         // so it remains in the list as .done
         let finalJob = freshQueue.jobs.first
         XCTAssertEqual(finalJob?.state, .done)
+    }
+
+    func testLoadSnapshotMissingNamingUsesTerminalTransitionAndRetainsRawTranscript() throws {
+        let transcriptPath = tmpDir.appendingPathComponent("missing-naming.txt")
+        try Data("recoverable transcript".utf8).write(to: transcriptPath)
+        var job = PipelineJob(
+            meetingTitle: "Missing Naming Data",
+            appName: "App",
+            mixPath: nil,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+            saveRawTranscriptSeparately: false,
+        )
+        job.state = .speakerNamingPending
+        job.namingSlug = "missing_naming_data"
+        job.transcriptPath = transcriptPath
+        try JSONEncoder().encode([job])
+            .write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let store = TerminalJobStore(path: tmpDir.appendingPathComponent("terminal_jobs.json"))
+        let freshQueue = PipelineQueue(logDir: tmpDir, terminalJobStore: store)
+        freshQueue.loadSnapshot()
+
+        XCTAssertEqual(freshQueue.jobs.first?.state, .done)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: transcriptPath.path))
+        XCTAssertTrue(
+            freshQueue.jobs.first?.warnings.contains("Raw transcript retained because no protocol was saved") ?? false,
+        )
+        XCTAssertEqual(store.lookup(jobID: job.id)?.state, .done)
+    }
+
+    func testLoadSnapshotWithoutOutputOptionFieldsUsesLegacyDefaults() throws {
+        let mixPath = tmpDir.appendingPathComponent("legacy-options.wav")
+        try Data("fake audio".utf8).write(to: mixPath)
+        let job = PipelineJob(
+            meetingTitle: "Legacy Options",
+            appName: "App",
+            mixPath: mixPath,
+            appPath: nil,
+            micPath: nil,
+            micDelay: 0,
+        )
+        let encoded = try JSONEncoder().encode([job])
+        guard var jobs = try JSONSerialization.jsonObject(with: encoded) as? [[String: Any]] else {
+            XCTFail("expected encoded jobs to be JSON objects")
+            return
+        }
+        jobs[0].removeValue(forKey: "includeFullTranscriptInProtocol")
+        jobs[0].removeValue(forKey: "saveRawTranscriptSeparately")
+        let legacyData = try JSONSerialization.data(withJSONObject: jobs)
+        try legacyData.write(to: tmpDir.appendingPathComponent(PipelineSnapshot.snapshotFilename))
+
+        let freshQueue = PipelineQueue(logDir: tmpDir)
+        freshQueue.loadSnapshot()
+
+        let restored = try XCTUnwrap(freshQueue.jobs.first)
+        XCTAssertNil(restored.includeFullTranscriptInProtocol)
+        XCTAssertNil(restored.saveRawTranscriptSeparately)
+        let options = freshQueue.transcriptOutputOptions(forJobID: restored.id)
+        XCTAssertTrue(options.includeFullTranscriptInProtocol)
+        XCTAssertTrue(options.saveRawTranscriptSeparately)
     }
 
     // MARK: - Stale Pending Cleanup

--- a/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCSettingsStateTests.swift
@@ -131,6 +131,8 @@
             // Fresh suite → no custom bookmark → effective dir is the default.
             XCTAssertFalse(s.output.hasCustomDirectory)
             XCTAssertEqual(s.output.directory, AppPaths.downloadsProtocolsDir.path)
+            XCTAssertTrue(s.output.includeFullTranscriptInProtocol)
+            XCTAssertTrue(s.output.saveRawTranscriptSeparately)
         }
 
         func test_snapshot_output_resolvesCustomBookmark() throws {
@@ -240,6 +242,7 @@
                 "protocolGeneration.openAIEndpoint", "protocolGeneration.openAIModel",
                 "protocolGeneration.claudeBin",
                 "output.directory", "output.hasCustomDirectory", "output.hasCustomPrompt",
+                "output.includeFullTranscriptInProtocol", "output.saveRawTranscriptSeparately",
                 "diagnostics.verboseDiagnostics", "diagnostics.debugRPCEnabled",
                 "updates.checkForUpdates", "updates.includePreReleases",
             ]

--- a/app/MeetingTranscriber/Tests/SettingsInteractionTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsInteractionTests.swift
@@ -70,6 +70,34 @@ final class SettingsInteractionTests: XCTestCase {
         XCTAssertEqual(settings.protocolProvider, .openAICompatible)
     }
 
+    // MARK: - Transcript output toggles
+
+    func testIncludeFullTranscriptToggleWritesBackToSettings() throws {
+        let settings = makeSettings()
+        settings.includeFullTranscriptInProtocol = true
+        let view = OutputSettingsView(settings: settings)
+
+        let toggle = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.includeFullTranscriptToggle)
+            .find(ViewType.Toggle.self)
+        try toggle.tap()
+
+        XCTAssertFalse(settings.includeFullTranscriptInProtocol)
+    }
+
+    func testSaveRawTranscriptToggleWritesBackToSettings() throws {
+        let settings = makeSettings()
+        settings.saveRawTranscriptSeparately = true
+        let view = OutputSettingsView(settings: settings)
+
+        let toggle = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.saveRawTranscriptToggle)
+            .find(ViewType.Toggle.self)
+        try toggle.tap()
+
+        XCTAssertFalse(settings.saveRawTranscriptSeparately)
+    }
+
     // MARK: - Stepper write-back
 
     func testPollIntervalStepperIncrementsSetting() throws {

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -438,7 +438,7 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.protocolProvider = .none
         let body = try makeOutput(settings: settings).inspect()
-        XCTAssertNoThrow(try body.find(text: "Only the raw transcript will be saved — no LLM summarization."))
+        XCTAssertNoThrow(try body.find(text: "No LLM summarization will be generated."))
     }
 
     func testNoneProviderHidesEndpointField() throws {

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -438,7 +438,9 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         let settings = makeSettings()
         settings.protocolProvider = .none
         let body = try makeOutput(settings: settings).inspect()
-        XCTAssertNoThrow(try body.find(text: "No LLM summarization will be generated."))
+        XCTAssertNoThrow(
+            try body.find(text: "No LLM summarization will be generated. Raw transcripts are retained if no protocol is saved."),
+        )
     }
 
     func testNoneProviderHidesEndpointField() throws {

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -96,6 +96,16 @@ final class WorkflowIntegrationTests: XCTestCase {
         )
     }
 
+    private func assertNoRawTranscriptArtifacts(_ h: Harness) {
+        XCTAssertNil(h.queue.jobs.first?.transcriptPath)
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        let protocolFiles = (try? FileManager.default.contentsOfDirectory(atPath: protocolsDir.path)) ?? []
+        let recordingFiles = (try? FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)) ?? []
+        XCTAssertFalse(protocolFiles.contains { $0.hasSuffix(".txt") })
+        XCTAssertFalse(recordingFiles.contains { $0.hasSuffix("_segments.json") })
+    }
+
     // swiftlint:disable:next function_default_parameter_at_end
     private func makeDualSourceJob(title: String = "Dual Meeting", audioPath: URL) throws -> PipelineJob {
         let appPath = tmpDir.appendingPathComponent("app_\(UUID().uuidString).wav")
@@ -273,6 +283,32 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertEqual(h.diarization.runCount, 1)
         XCTAssertTrue(h.protocolGen.generateCalled)
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
+    }
+
+    func testWorkflowConfirmedNamingCleansRawOutputWhenDisabled() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true, saveRawTranscriptSeparately: false)
+        h.queue.speakerNamingHandler = { _ in
+            .confirmed(["SPEAKER_00": "Alice", "SPEAKER_01": "Speaker C"])
+        }
+
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        assertNoRawTranscriptArtifacts(h)
+    }
+
+    func testWorkflowSkippedNamingCleansRawOutputWhenDisabled() async throws {
+        let (h, _) = try makeHarness(diarizeEnabled: true, saveRawTranscriptSeparately: false)
+        h.queue.speakerNamingHandler = { _ in .skipped }
+
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+        await awaitJobTerminalState(h.queue)
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        assertNoRawTranscriptArtifacts(h)
     }
 
     // MARK: - Happy Path: Dual-Source
@@ -481,6 +517,18 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
         XCTAssertNil(h.queue.jobs.first?.protocolPath)
         XCTAssertFalse(h.queue.jobs.first?.warnings.isEmpty ?? true)
+    }
+
+    func testWorkflowProtocolFailureCleansRawOutputWhenDisabled() async throws {
+        let (h, _) = try makeHarness(saveRawTranscriptSeparately: false)
+        h.protocolGen.shouldThrow = true
+
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertFalse(h.queue.jobs.first?.warnings.isEmpty ?? true)
+        assertNoRawTranscriptArtifacts(h)
     }
 
     // MARK: - Diarization Scenarios

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -232,7 +232,7 @@ final class WorkflowIntegrationTests: XCTestCase {
             includeFullTranscriptInProtocol: true,
             saveRawTranscriptSeparately: true,
         )
-        let (h, _) = try makeHarness(transcriptOutputOptionsProvider: { currentOptions })
+        let (h, _) = try makeHarness { currentOptions }
         currentOptions = TranscriptOutputOptions(
             includeFullTranscriptInProtocol: false,
             saveRawTranscriptSeparately: false,

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -34,6 +34,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         echoDedupEnabled: Bool = true,
         includeFullTranscriptInProtocol: Bool = true,
         saveRawTranscriptSeparately: Bool = true,
+        protocolGeneratorEnabled: Bool = true,
         transcriptOutputOptionsProvider: (() -> TranscriptOutputOptions)? = nil,
     ) throws -> (Harness, TransitionCollector) {
         let engine = MockEngine()
@@ -59,7 +60,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         let queue = PipelineQueue(
             engine: engine,
             diarizationFactory: { diarization },
-            protocolGeneratorFactory: { protocolGen },
+            protocolGeneratorFactory: { protocolGeneratorEnabled ? protocolGen : nil },
             outputDir: tmpDir,
             logDir: tmpDir,
             stagingDir: stagingDir ?? AppPaths.recordingsDir,
@@ -201,6 +202,21 @@ final class WorkflowIntegrationTests: XCTestCase {
         )
     }
 
+    func testWorkflowRawTranscriptCleanupPreservesRecording() async throws {
+        let stagingDir = tmpDir.appendingPathComponent("staging")
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        let stagedAudioPath = try createTestAudioFile(in: stagingDir)
+        let (h, _) = try makeHarness(stagingDir: stagingDir, saveRawTranscriptSeparately: false)
+
+        h.queue.enqueue(makeJob(audioPath: stagedAudioPath))
+        await h.queue.processNext()
+
+        assertNoRawTranscriptArtifacts(h)
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        let recordingFiles = try FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)
+        XCTAssertTrue(recordingFiles.contains { $0.hasSuffix(".wav") })
+    }
+
     func testWorkflowMinutesOnlyRetainsNoTranscriptArtifacts() async throws {
         let (h, _) = try makeHarness(
             includeFullTranscriptInProtocol: false,
@@ -233,18 +249,17 @@ final class WorkflowIntegrationTests: XCTestCase {
             saveRawTranscriptSeparately: true,
         )
         let (h, _) = try makeHarness { currentOptions }
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
         currentOptions = TranscriptOutputOptions(
             includeFullTranscriptInProtocol: false,
             saveRawTranscriptSeparately: false,
         )
-
-        h.queue.enqueue(makeJob(audioPath: h.audioPath))
         await h.queue.processNext()
 
         let protocolPath = try XCTUnwrap(h.queue.jobs.first?.protocolPath)
         let markdown = try String(contentsOf: protocolPath, encoding: .utf8)
-        XCTAssertFalse(markdown.contains("## Full Transcript"))
-        XCTAssertNil(h.queue.jobs.first?.transcriptPath)
+        XCTAssertTrue(markdown.contains("## Full Transcript"))
+        XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
     }
 
     // MARK: - Happy Path: Single-Source, Diarization + Speaker Naming
@@ -519,7 +534,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         XCTAssertFalse(h.queue.jobs.first?.warnings.isEmpty ?? true)
     }
 
-    func testWorkflowProtocolFailureCleansRawOutputWhenDisabled() async throws {
+    func testWorkflowProtocolFailureRetainsRawOutputWhenDisabled() async throws {
         let (h, _) = try makeHarness(saveRawTranscriptSeparately: false)
         h.protocolGen.shouldThrow = true
 
@@ -527,8 +542,23 @@ final class WorkflowIntegrationTests: XCTestCase {
         await h.queue.processNext()
 
         XCTAssertEqual(h.queue.jobs.first?.state, .done)
-        XCTAssertFalse(h.queue.jobs.first?.warnings.isEmpty ?? true)
-        assertNoRawTranscriptArtifacts(h)
+        XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
+        XCTAssertTrue(h.queue.jobs.first?.warnings.contains("Raw transcript retained because no protocol was saved") ?? false)
+    }
+
+    func testWorkflowWithoutProtocolGeneratorRetainsRawOutputWhenDisabled() async throws {
+        let (h, _) = try makeHarness(
+            saveRawTranscriptSeparately: false,
+            protocolGeneratorEnabled: false,
+        )
+
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        XCTAssertEqual(h.queue.jobs.first?.state, .done)
+        XCTAssertNil(h.queue.jobs.first?.protocolPath)
+        XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
+        XCTAssertTrue(h.queue.jobs.first?.warnings.contains("Raw transcript retained because no protocol was saved") ?? false)
     }
 
     // MARK: - Diarization Scenarios

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -34,6 +34,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         echoDedupEnabled: Bool = true,
         includeFullTranscriptInProtocol: Bool = true,
         saveRawTranscriptSeparately: Bool = true,
+        transcriptOutputOptionsProvider: (() -> TranscriptOutputOptions)? = nil,
     ) throws -> (Harness, TransitionCollector) {
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -67,6 +68,7 @@ final class WorkflowIntegrationTests: XCTestCase {
             micLabel: "Me",
             includeFullTranscriptInProtocol: includeFullTranscriptInProtocol,
             saveRawTranscriptSeparately: saveRawTranscriptSeparately,
+            transcriptOutputOptionsProvider: transcriptOutputOptionsProvider,
         )
 
         queue.onJobStateChange = { [collector] _, old, new in
@@ -182,6 +184,57 @@ final class WorkflowIntegrationTests: XCTestCase {
             try FileManager.default.contentsOfDirectory(atPath: protocolsDir.path)
                 .contains { $0.hasSuffix(".txt") },
         )
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)
+                .contains { $0.hasSuffix("_segments.json") },
+        )
+    }
+
+    func testWorkflowMinutesOnlyRetainsNoTranscriptArtifacts() async throws {
+        let (h, _) = try makeHarness(
+            includeFullTranscriptInProtocol: false,
+            saveRawTranscriptSeparately: false,
+        )
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        let protocolPath = try XCTUnwrap(h.queue.jobs.first?.protocolPath)
+        let markdown = try String(contentsOf: protocolPath, encoding: .utf8)
+        XCTAssertFalse(markdown.contains("## Full Transcript"))
+        XCTAssertFalse(markdown.contains("Hello world"))
+        XCTAssertNil(h.queue.jobs.first?.transcriptPath)
+
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: protocolsDir.path)
+                .contains { $0.hasSuffix(".txt") },
+        )
+        let recordingsDir = tmpDir.appendingPathComponent("recordings")
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: recordingsDir.path)
+                .contains { $0.hasSuffix("_segments.json") },
+        )
+    }
+
+    func testWorkflowCapturesCurrentOutputOptionsWhenJobIsEnqueued() async throws {
+        var currentOptions = TranscriptOutputOptions(
+            includeFullTranscriptInProtocol: true,
+            saveRawTranscriptSeparately: true,
+        )
+        let (h, _) = try makeHarness(transcriptOutputOptionsProvider: { currentOptions })
+        currentOptions = TranscriptOutputOptions(
+            includeFullTranscriptInProtocol: false,
+            saveRawTranscriptSeparately: false,
+        )
+
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        let protocolPath = try XCTUnwrap(h.queue.jobs.first?.protocolPath)
+        let markdown = try String(contentsOf: protocolPath, encoding: .utf8)
+        XCTAssertFalse(markdown.contains("## Full Transcript"))
+        XCTAssertNil(h.queue.jobs.first?.transcriptPath)
     }
 
     // MARK: - Happy Path: Single-Source, Diarization + Speaker Naming

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -32,6 +32,8 @@ final class WorkflowIntegrationTests: XCTestCase {
         diarizeEnabled: Bool = false,
         stagingDir: URL? = nil,
         echoDedupEnabled: Bool = true,
+        includeFullTranscriptInProtocol: Bool = true,
+        saveRawTranscriptSeparately: Bool = true,
     ) throws -> (Harness, TransitionCollector) {
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -63,6 +65,8 @@ final class WorkflowIntegrationTests: XCTestCase {
             diarizeEnabled: diarizeEnabled,
             echoDedupEnabled: echoDedupEnabled,
             micLabel: "Me",
+            includeFullTranscriptInProtocol: includeFullTranscriptInProtocol,
+            saveRawTranscriptSeparately: saveRawTranscriptSeparately,
         )
 
         queue.onJobStateChange = { [collector] _, old, new in
@@ -150,6 +154,34 @@ final class WorkflowIntegrationTests: XCTestCase {
         if let path = h.queue.jobs.first?.protocolPath {
             XCTAssertTrue(FileManager.default.fileExists(atPath: path.path))
         }
+    }
+
+    func testWorkflowCanExcludeFullTranscriptFromProtocol() async throws {
+        let (h, _) = try makeHarness(includeFullTranscriptInProtocol: false)
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        let protocolPath = try XCTUnwrap(h.queue.jobs.first?.protocolPath)
+        let markdown = try String(contentsOf: protocolPath, encoding: .utf8)
+        XCTAssertFalse(markdown.contains("## Full Transcript"))
+        XCTAssertFalse(markdown.contains("Hello world"))
+        XCTAssertNotNil(h.queue.jobs.first?.transcriptPath)
+    }
+
+    func testWorkflowCanRemoveSeparateRawTranscriptAfterCompletion() async throws {
+        let (h, _) = try makeHarness(saveRawTranscriptSeparately: false)
+        h.queue.enqueue(makeJob(audioPath: h.audioPath))
+        await h.queue.processNext()
+
+        let protocolPath = try XCTUnwrap(h.queue.jobs.first?.protocolPath)
+        let markdown = try String(contentsOf: protocolPath, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("## Full Transcript"))
+        XCTAssertNil(h.queue.jobs.first?.transcriptPath)
+        let protocolsDir = tmpDir.appendingPathComponent("protocols")
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: protocolsDir.path)
+                .contains { $0.hasSuffix(".txt") },
+        )
     }
 
     // MARK: - Happy Path: Single-Source, Diarization + Speaker Naming

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -519,6 +519,15 @@ When dual-source recording (app + mic) is available:
 - **`.openAICompatible`** — Any OpenAI-compatible HTTP API (Ollama, LM Studio, llama.cpp, etc.)
 - **`.none`** — Skip LLM generation; save transcript only
 
+`AppSettings.includeFullTranscriptInProtocol` and
+`AppSettings.saveRawTranscriptSeparately` default to `true` to preserve the
+legacy output. Their values are captured when a job enters the queue, so a
+later settings change affects only subsequent recordings. The raw `.txt` and
+verbatim segment sidecar are deleted only after a job completes successfully
+with a saved protocol. If protocol generation is disabled, fails, or the job
+ends in an error, the raw transcript is retained with a warning; recordings are
+governed by their separate retention policy.
+
 `AppSettings.protocolLanguage` (default `"German"`) is substituted into the prompt as `{LANGUAGE}`. Custom prompts can also use `{MEETING_DATE}` (`YYYY-MM-DD`) and `{MEETING_TIME}` (`HH:mm`), derived from the captured recording start time. Imports and recovery jobs resolve those time placeholders to `Unknown` rather than their enqueue or processing time. Only recordings with a captured start receive the authoritative meeting-metadata block, so existing custom prompts receive reliable temporal context without needing to add the placeholders.
 
 ### Claude CLI Invocation
@@ -546,7 +555,7 @@ When dual-source recording (app + mic) is available:
 ---
 
 ## Full Transcript
-[appended automatically]
+[appended when enabled]
 ```
 
 ---


### PR DESCRIPTION
## Privacy rationale

The transcript is required internally for diarization and protocol generation,
but users may not want to retain the raw conversation after a meeting. The new
output options allow users to omit the automatic full-transcript appendix and
the separately stored raw transcript while retaining the generated meeting
minutes.

The options control local output retention and automatic attachment. The
transcript is still provided to the selected protocol generator; when that
provider is external, its privacy terms apply.

## Retention behaviour

- Both options default to enabled, preserving existing behaviour.
- Raw text artifacts (`.txt` and transcript-bearing segment sidecars) are
  removed only after a protocol was saved successfully.
- Recordings follow their existing retention policy and are never deleted by
  these options.
- When protocol generation is disabled, fails, or a job is interrupted, the
  draft transcript is retained to avoid data loss and can be removed manually.

## Validation

- SwiftFormat and SwiftLint: passed
- Swift tests: settings, workflow, recovery, snapshot, and full suite passed
- Homebrew and App Store release builds: passed