### PR TITLE
ci: surface a merge commit to the contributor, not just the maintainer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What changed and why
+
+<!-- One or two lines. Link the issue if there is one. -->
+
+## Checklist
+
+- [ ] Rebased on `main`, no merge commits, since a merge commit pulls commits that are
+      already on `main` into this branch and the review reads it commit by commit:
+      `git fetch https://github.com/pasrom/meeting-transcriber main && git rebase FETCH_HEAD`
+      (the URL spelled out because in a fork clone `origin` is your fork)
+- [ ] `./scripts/lint.sh` is clean
+- [ ] Tests pass: `cd app/MeetingTranscriber && swift test`
+- [ ] Conventional Commits, one logical change per commit
+
+The **Update branch** button merges by default; pick **Update with rebase** from its
+dropdown instead. Would rather not rewrite history? Leave *Allow edits by maintainers*
+checked and a maintainer folds the commits before merging, as
+[CONTRIBUTING.md](https://github.com/pasrom/meeting-transcriber/blob/main/CONTRIBUTING.md)
+offers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,46 @@ jobs:
           predicate-quantifier: every
           filters: .github/filters.yml
 
+  # Advisory by design: this job is NOT among the required checks and must never
+  # be the thing that stops a merge. `main` is not at stake either way, and
+  # scripts/ci/check-merge-commits.sh carries the reason. What it protects is the
+  # review of the open PR, which a merge commit makes unreadable commit by commit.
+  #
+  # Two deliberate deviations from the house pattern in the jobs below:
+  #   - No `Cancel run on failure` step. A check that blocks nothing must not take
+  #     the macOS jobs down with it: the contributor still needs to see whether
+  #     their actual change builds and passes.
+  #   - Not gated on `changes`. A merge commit is worth reporting whichever files
+  #     the PR touches, and this costs seconds on a free runner.
+  merge-commit-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Three non-default inputs, each load-bearing. `ref`: the default
+          # checkout for a pull_request event is refs/pull/N/merge, a merge commit
+          # GitHub builds itself; measured on this repo, that ref carries a
+          # `Merge <head> into <base>` commit, so the default would report every
+          # PR. `fetch-depth: 0`: the depth-1 default carries neither the base
+          # branch nor a merge base, so the commit range cannot resolve at all.
+          # `filter: blob:none`: this walks commit topology only, so fetching
+          # every historical file revision is dead weight.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          filter: blob:none
+      # The base branch comes from the event rather than a hardcoded `main`, so
+      # widening the `pull_request` trigger later cannot leave this silently
+      # measuring against the wrong base. Passed via env rather than interpolated
+      # into the command line.
+      - name: Check for merge commits
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: bash scripts/ci/check-merge-commits.sh "origin/$BASE_REF"
+
   lint:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/scripts/ci/check-merge-commits.sh
+++ b/scripts/ci/check-merge-commits.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Reports merge commits on the current branch. Advisory: see .github/workflows/ci.yml.
+#
+# Usage: check-merge-commits.sh <base-ref>      e.g. origin/main, or main locally
+#
+# Exit codes are distinct on purpose:
+#   0  no merge commits between <base-ref> and HEAD
+#   1  merge commits found (a contributor-fixable branch state)
+#   2  the check could not run (unresolvable base ref, git failure)
+#
+# What this is NOT for: `main` cannot acquire a merge commit in the first place.
+# The repo allows rebase-merge only, and a rebase drops merge commits rather
+# than replaying them (verified: a branch with `Merge branch 'main'` rebased
+# onto main keeps the real commit and loses the merge). GitHub's rebase-merge is
+# that same rebase, server-side. What a merge commit costs is the review of the
+# open PR: it pulls commits that are already on the base branch into the
+# branch's commit list, so reading the PR commit by commit stops showing what
+# the contributor actually changed.
+
+set -uo pipefail
+
+base="${1:-}"
+if [ -z "$base" ]; then
+    echo "usage: $(basename "$0") <base-ref>" >&2
+    exit 2
+fi
+
+# Precondition, kept separate from the check itself: an unresolvable base ref is
+# a CI problem (shallow clone, missing fetch, renamed branch), not something the
+# contributor did. Without this it surfaces as a raw `fatal: bad revision`,
+# which reads like a verdict on the branch.
+if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+    echo "Merge-commit check could not run: CI could not resolve the base ref '${base}'." >&2
+    echo "This is a CI problem, not a problem with this branch. The checkout step" >&2
+    echo "needs enough history for '${base}' to exist." >&2
+    exit 2
+fi
+
+if ! merges=$(git rev-list --merges "${base}..HEAD"); then
+    echo "Merge-commit check could not run: git rev-list failed for '${base}..HEAD'." >&2
+    exit 2
+fi
+
+if [ -z "$merges" ]; then
+    echo "No merge commits between ${base} and HEAD."
+    exit 0
+fi
+
+branch="${base##*/}"
+repo_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-pasrom/meeting-transcriber}"
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::error title=Merge commit on branch::This branch merges ${branch} instead of rebasing onto it. Advisory check: it does not block the merge."
+fi
+
+echo "Merge commits between ${base} and HEAD:"
+# Commit subjects are contributor-controlled text. The runner reads any line
+# starting with `::` as a workflow command, so an attacker-chosen subject could
+# forge or suppress one. Fence the untrusted block with the documented
+# stop-commands mechanism rather than trusting the subjects to be inert.
+fence=""
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    fence="merge-commit-list-$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+    echo "::stop-commands::${fence}"
+fi
+git log --merges --format='  %h %s' "${base}..HEAD"
+if [ -n "$fence" ]; then
+    echo "::${fence}::"
+fi
+
+cat <<EOF
+
+This does not endanger ${branch}: the repo allows rebase-merge only, and a
+rebase drops merge commits, so the merge would never land there. It costs the
+review of this PR. Its commit list now carries commits that are already on
+${branch}, so reading the branch commit by commit no longer shows your change,
+and CONTRIBUTING.md asks for a rebase for exactly that reason.
+
+Rebase onto ${branch}. Spelling the URL out works in a fork clone too, where
+'origin' is your fork rather than this repo:
+
+  git fetch ${repo_url} ${branch}
+  git rebase FETCH_HEAD
+  git push --force-with-lease
+
+The "Update branch" button on the PR page is the likeliest way a branch picks
+one up: it creates a merge commit by default. Use "Update with rebase" from its
+dropdown instead.
+
+Would rather not rewrite history? Leave "Allow edits by maintainers" checked and
+a maintainer folds the commits before merging, as CONTRIBUTING.md offers.
+
+This check is advisory and does not block the merge.
+EOF
+
+exit 1

--- a/scripts/tests/test_check_merge_commits.sh
+++ b/scripts/tests/test_check_merge_commits.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Regression test for scripts/ci/check-merge-commits.sh.
+#
+# Why this exists: the check is a shell snippet whose whole job is to fail. A
+# guard that has never been shown to fire is not evidence of anything, and the
+# first version of this check lived inline in ci.yml, where the only way to
+# exercise it was to hand-extract it from the workflow YAML.
+#
+# The four states that matter are cheap to build and easy to get wrong:
+#   - a branch that merged the base in           -> must report, exit 1
+#   - a clean branch                             -> must stay silent, exit 0
+#   - a branch merely behind the base            -> must stay silent, exit 0
+#   - a merge that is on the base already        -> must not blame the branch
+#   - a base ref CI failed to fetch              -> must read as a CI fault, exit 2
+#
+# Each case builds a throwaway repo in a temp dir; the whole file runs in ~1s.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECK_SH="$REPO_ROOT/scripts/ci/check-merge-commits.sh"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$name"; then printf 'PASS\n'; else printf 'FAIL\n'; FAILED=1; fi
+}
+
+# Pinned identity and no signing/hooks, so a contributor's global git config
+# cannot change what these fixtures look like.
+g() {
+    git -c user.email=test@example.invalid -c user.name=Test \
+        -c commit.gpgsign=false -c core.hooksPath=/dev/null "$@"
+}
+
+commit_file() {   # commit_file <name> <message>
+    echo "$1" > "$1"
+    g add "$1"
+    g commit -qm "$2"
+}
+
+# new_repo: fresh repo on branch 'main' with one commit; leaves $PWD inside it.
+new_repo() {
+    local dir
+    dir=$(mktemp -d)
+    cd "$dir" || return 1
+    g init -q -b main .
+    commit_file base.txt "base commit"
+}
+
+# run_check <base-ref> -> sets CHECK_OUT, CHECK_RC
+run_check() {
+    CHECK_OUT=$(bash "$CHECK_SH" "$@" 2>&1)
+    CHECK_RC=$?
+}
+
+fail() {   # fail <message>
+    echo
+    echo "  $1"
+    echo "--- check output ---"
+    echo "$CHECK_OUT"
+    echo "--------------------"
+    return 1
+}
+
+test_merge_commit_is_reported() {
+    local tmp; tmp=$(pwd)
+    ( new_repo || exit 1
+      g switch -qc feat
+      commit_file work.txt "feat: the real change"
+      g switch -q main
+      commit_file other.txt "fix: something on main"
+      g switch -q feat
+      g merge -q --no-edit main               # the mistake this check exists for
+      run_check main
+      [ "$CHECK_RC" -eq 1 ] || fail "expected exit 1 for a merged-in base, got $CHECK_RC" || exit 1
+      echo "$CHECK_OUT" | grep -q "Merge branch 'main' into feat" \
+          || fail "the offending commit is not named in the output" || exit 1
+      # The fix has to be the one that works in a fork clone, where `origin` is
+      # the contributor's fork and rebasing onto it is a no-op.
+      echo "$CHECK_OUT" | grep -q "git rebase FETCH_HEAD" \
+          || fail "no fork-safe rebase command in the output" || exit 1
+      echo "$CHECK_OUT" | grep -q "Allow edits by maintainers" \
+          || fail "CONTRIBUTING.md's escape hatch is missing from the output" || exit 1
+      echo "$CHECK_OUT" | grep -q "advisory" \
+          || fail "output does not say the check is advisory" || exit 1
+    ) || return 1
+    cd "$tmp" || return 1
+}
+
+test_clean_branch_passes() {
+    local tmp; tmp=$(pwd)
+    ( new_repo || exit 1
+      g switch -qc feat
+      commit_file work.txt "feat: the real change"
+      run_check main
+      [ "$CHECK_RC" -eq 0 ] || fail "expected exit 0 for a linear branch, got $CHECK_RC" || exit 1
+    ) || return 1
+    cd "$tmp" || return 1
+}
+
+# A branch that is simply behind the base has no commits of its own in
+# base..HEAD. It must not be reported: nothing about it is wrong.
+test_branch_behind_base_passes() {
+    local tmp; tmp=$(pwd)
+    ( new_repo || exit 1
+      g switch -qc feat
+      g switch -q main
+      commit_file ahead.txt "fix: base moved on"
+      g switch -q feat
+      run_check main
+      [ "$CHECK_RC" -eq 0 ] || fail "expected exit 0 for a branch behind base, got $CHECK_RC" || exit 1
+    ) || return 1
+    cd "$tmp" || return 1
+}
+
+# Merges already reachable from the base are the base's history, not this
+# branch's doing. Pins the range direction (base..HEAD, never --all).
+test_merge_on_base_does_not_blame_branch() {
+    local tmp; tmp=$(pwd)
+    ( new_repo || exit 1
+      g switch -qc side
+      commit_file side.txt "chore: side commit"
+      g switch -q main
+      commit_file main2.txt "fix: main commit"
+      g merge -q --no-edit side               # a merge commit that lives on main
+      g switch -qc feat
+      commit_file work.txt "feat: the real change"
+      run_check main
+      [ "$CHECK_RC" -eq 0 ] || fail "a merge on the base was blamed on the branch (exit $CHECK_RC)" || exit 1
+    ) || return 1
+    cd "$tmp" || return 1
+}
+
+test_unresolvable_base_ref_is_a_ci_error() {
+    local tmp; tmp=$(pwd)
+    ( new_repo || exit 1
+      run_check origin/does-not-exist
+      [ "$CHECK_RC" -eq 2 ] || fail "expected exit 2 for an unresolvable base ref, got $CHECK_RC" || exit 1
+      echo "$CHECK_OUT" | grep -q "CI could not resolve the base ref" \
+          || fail "missing the distinct 'could not resolve' message" || exit 1
+      # Must not read as a verdict on the branch: no rebase instructions here.
+      if echo "$CHECK_OUT" | grep -q "git rebase"; then
+          fail "a CI fault told the contributor to rebase" || exit 1
+      fi
+    ) || return 1
+    cd "$tmp" || return 1
+}
+
+run_test test_merge_commit_is_reported
+run_test test_clean_branch_passes
+run_test test_branch_behind_base_passes
+run_test test_merge_on_base_does_not_blame_branch
+run_test test_unresolvable_base_ref_is_a_ci_error
+
+exit "$FAILED"


### PR DESCRIPTION
## What changed and why

Two open PRs each merged `main` into the branch instead of rebasing. CONTRIBUTING.md asks for a rebase, but nothing says so at the moment a contributor goes wrong, and nobody notices until a maintainer reads the commit list.

- `.github/PULL_REQUEST_TEMPLATE.md`, new: the rule, the fix, and the trap that most often causes it. The **Update branch** button merges by default; **Update with rebase** lives in its dropdown.
- `merge-commit-check` in `ci.yml`, which runs `scripts/ci/check-merge-commits.sh`, with `scripts/tests/test_check_merge_commits.sh` beside it.

## What this deliberately does not do

It does not protect `main`, and it is not a gate. `main` cannot acquire a merge commit in the first place: rebase-merge is the only merge this repo allows, and a rebase **drops** merge commits rather than replaying them. Reproduced in a throwaway repo:

```
=== branch after merging main in ===
*   1332e25 Merge branch 'main' into feat
|\
| * db202d2 fix: something on main
* | 5b8bea6 feat: the real change
|/
* 5dde85e base commit
merge commits in main..HEAD: 1

=== after a plain 'git rebase main' ===
* 8eaf95a feat: the real change
* db202d2 fix: something on main
* 5dde85e base commit
merge commits in main..HEAD: 0
```

GitHub's rebase-merge is that same rebase, server-side, which is why `main` has zero merge commits today. So the check is **advisory**: it is not among the required checks and does not block a merge. What a merge commit actually costs is the review of the open PR, whose commit list fills with commits that are already on the base branch, so reading the branch commit by commit stops showing what the contributor changed.

Two consequences of that, in the job:

- **No `Cancel run on failure` step**, the one place this job departs from the house pattern. A check that blocks nothing must not take the macOS jobs down with it: a contributor with a merge commit still needs to see whether the change they came to make passes.
- The failure message carries CONTRIBUTING.md's existing escape hatch (leave *Allow edits by maintainers* checked and a maintainer folds the commits) rather than only telling people to rewrite history.

## Details

- The base ref comes from the event (`github.event.pull_request.base.ref`), not a hardcoded `origin/main`, so widening the `pull_request` trigger later cannot leave the check silently measuring against the wrong base.
- The printed fix spells out the repo URL, because in a fork clone `origin` is the fork: `git rebase origin/main` there rebases onto the fork's own stale `main` and reports success having done nothing.
- Commit subjects are contributor-controlled and the runner reads a line beginning with `::` as a workflow command, so the listing is fenced with the documented `::stop-commands::` mechanism.
- An unresolvable base ref exits with its own code and message. As a raw `fatal: bad revision` it read like a verdict on the branch, when it is a CI fault.
- Checkout inputs: `ref: head.sha` (the default `refs/pull/N/merge` is a merge commit GitHub builds itself, which would report every PR), `fetch-depth: 0` (the depth-1 default has neither the base branch nor a merge base), `filter: blob:none` (this walks commit topology only).

## Verification

`scripts/tests/test_check_merge_commits.sh` covers the five states, in ~1s:

```
test_merge_commit_is_reported ... PASS
test_clean_branch_passes ... PASS
test_branch_behind_base_passes ... PASS
test_merge_on_base_does_not_blame_branch ... PASS
test_unresolvable_base_ref_is_a_ci_error ... PASS
```

Those tests are themselves shown to fail. Making the check always `exit 0` reddens `test_merge_commit_is_reported`; replacing the base-ref message with a raw `fatal: bad revision` reddens `test_unresolvable_base_ref_is_a_ci_error` on the exact wording the message exists to avoid.

End to end in this repo, running the committed script against a branch built to the shape of the two open PRs (branch off an older `main`, one commit, then `git merge origin/main`):

```
Merge commits between origin/main and HEAD:
  dd662c37 Merge remote-tracking branch 'origin/main' into tmp/merge-check-proof

This does not endanger main: the repo allows rebase-merge only, and a
rebase drops merge commits, so the merge would never land there. It costs the
review of this PR. ...

  git fetch https://github.com/pasrom/meeting-transcriber main
  git rebase FETCH_HEAD
  git push --force-with-lease

The "Update branch" button on the PR page is the likeliest way a branch picks
one up: it creates a merge commit by default. Use "Update with rebase" from its
dropdown instead.

Would rather not rewrite history? Leave "Allow edits by maintainers" checked and
a maintainer folds the commits before merging, as CONTRIBUTING.md offers.

This check is advisory and does not block the merge.
EXIT CODE: 1
```

Applying the fix it prescribes to that same branch, so only the history shape changes:

```
No merge commits between origin/main and HEAD.
EXIT CODE: 0
```

## Checklist

- [x] Rebased on `main`, no merge commits
- [x] `./scripts/lint.sh` is clean
- [x] No Swift is touched, so the app suite is unaffected by this change; CI runs it regardless
- [x] Conventional Commits, one logical change per commit
