### PR TITLE
refactor(app): carry the capture options in one configuration value

### DIFF
--- a/app/MeetingTranscriber/Sources/AudioCapturing.swift
+++ b/app/MeetingTranscriber/Sources/AudioCapturing.swift
@@ -27,42 +27,22 @@ protocol AudioCapturing: AnyObject {
 @available(macOS 14.2, *)
 extension AudioCaptureSession: AudioCapturing {}
 
-/// Everything `DualSourceRecorder.start()` decides before any hardware is
-/// touched: which process tree to tap, where each track is written, which
-/// microphone to open.
-///
-/// Passed to the capture-session factory rather than assembled inside it, so a
-/// test can build a session that touches nothing and still see the decisions
-/// under test — above all which tracks a `RecordingSource` opens at all, which
-/// is the difference between a microphone-only recording and one with a tap.
-/// Field order mirrors `AudioCaptureSession.init` so the two lists can be
-/// diffed by eye when a capture option is added.
-struct CaptureSessionRequest {
-    /// The process tree to tap, empty when no tap is opened.
-    let pids: [pid_t]
-    /// Where the raw app track is written, or nil to open no process tap at
-    /// all. Nil is the microphone-only shape, not a tap that captured nothing.
-    let appOutputURL: URL?
-    let sampleRate: Int
-    let channels: Int
-    /// Where the mic track is written, or nil when the microphone is not
-    /// recorded ("No Microphone").
-    let micOutputURL: URL?
-    let micDeviceUID: String?
-    let debugLogging: Bool
-    let appLiveSink: LiveAudioSink?
-    let micLiveSink: LiveAudioSink?
-}
-
 /// Builds the capture session a recording runs on. Injected into
 /// `DualSourceRecorder` so `start()` and `stop()` — which carry the in-progress
 /// marker crash recovery keys on — can be driven without audio hardware.
-typealias CaptureSessionFactory = @MainActor (CaptureSessionRequest) throws -> any AudioCapturing
+///
+/// The configuration is assembled by the recording path and passed *in* rather
+/// than built inside the factory, which is what lets a test see the decisions a
+/// start made — above all which tracks a `RecordingSource` opens at all, the
+/// difference between a microphone-only recording and one with a tap. It is the
+/// capture library's own type rather than a struct of this module's; that type
+/// documents why.
+typealias CaptureSessionFactory = @MainActor (AudioCaptureConfiguration) throws -> any AudioCapturing
 
 /// The production capture session: real taps on real hardware.
 enum LiveCaptureSession {
     @MainActor
-    static func make(_ request: CaptureSessionRequest) throws -> any AudioCapturing {
+    static func make(_ configuration: AudioCaptureConfiguration) throws -> any AudioCapturing {
         // The one place the 14.2 floor is stated, and the compiler requires it
         // here: `AudioCaptureSession` is gated and this function is not. Every
         // caller reaches a real session through here, so no copy of this check
@@ -72,25 +52,21 @@ enum LiveCaptureSession {
         // Mic device-change e2e (issue #379): inject a one-shot tap fault so the
         // app self-triggers a mid-recording restart with an invalid format and
         // the lane can verify the installTap NSException recovery. Compiled ONLY
-        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION); the fault is
-        // physically absent from every shipped binary.
+        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION).
+        //
+        // The `#else` is what keeps the fault physically absent from every
+        // shipped binary, and it is not redundant: the field is a `var` on a
+        // struct that ships, so whatever a caller set would otherwise travel
+        // straight through to a `MicCaptureHandler` whose fault machinery is
+        // always compiled. Overwriting here means no shipped build can reach
+        // the session with a fault set, whoever built the configuration.
+        var configuration = configuration
         #if E2E_FAULT_INJECTION
-            let micDebugFault: DebugTapFault? = DebugTapFault(triggerRestartAfter: 2)
+            configuration.micDebugFault = DebugTapFault(triggerRestartAfter: 2)
         #else
-            let micDebugFault: DebugTapFault? = nil
+            configuration.micDebugFault = nil
         #endif
 
-        return AudioCaptureSession(
-            pids: request.pids,
-            appOutputURL: request.appOutputURL,
-            sampleRate: request.sampleRate,
-            channels: request.channels,
-            micOutputURL: request.micOutputURL,
-            micDeviceUID: request.micDeviceUID,
-            debugLogging: request.debugLogging,
-            appLiveSink: request.appLiveSink,
-            micLiveSink: request.micLiveSink,
-            micDebugFault: micDebugFault,
-        )
+        return AudioCaptureSession(configuration)
     }
 }

--- a/app/MeetingTranscriber/Sources/AudioCapturing.swift
+++ b/app/MeetingTranscriber/Sources/AudioCapturing.swift
@@ -41,6 +41,35 @@ typealias CaptureSessionFactory = @MainActor (AudioCaptureConfiguration) throws 
 
 /// The production capture session: real taps on real hardware.
 enum LiveCaptureSession {
+    /// The configuration this build is allowed to open a session with.
+    ///
+    /// Mic device-change e2e (issue #379): the fault makes the app self-trigger
+    /// a mid-recording restart with an invalid format so the lane can verify
+    /// the installTap NSException recovery. It is compiled ONLY into the e2e
+    /// build (run_app.sh -DE2E_FAULT_INJECTION).
+    ///
+    /// The `#else` is what keeps the fault physically absent from every shipped
+    /// binary, and it is not redundant: the field is a `var` on a struct that
+    /// ships, so whatever a caller set would otherwise travel straight through
+    /// to a `MicCaptureHandler` whose fault machinery is always compiled.
+    /// Overwriting here means no shipped build can reach the session with a
+    /// fault set, whoever built the configuration.
+    ///
+    /// Separate from `make` only so that guarantee can be asserted: `make`
+    /// returns a session that keeps its configuration to itself, so a test can
+    /// see what was decided here and nothing else can.
+    static func configurationForThisBuild(
+        _ configuration: AudioCaptureConfiguration,
+    ) -> AudioCaptureConfiguration {
+        var configuration = configuration
+        #if E2E_FAULT_INJECTION
+            configuration.micDebugFault = DebugTapFault(triggerRestartAfter: 2)
+        #else
+            configuration.micDebugFault = nil
+        #endif
+        return configuration
+    }
+
     @MainActor
     static func make(_ configuration: AudioCaptureConfiguration) throws -> any AudioCapturing {
         // The one place the 14.2 floor is stated, and the compiler requires it
@@ -48,25 +77,6 @@ enum LiveCaptureSession {
         // caller reaches a real session through here, so no copy of this check
         // is needed anywhere else — and a copy elsewhere would be unenforced.
         guard #available(macOS 14.2, *) else { throw RecorderError.unsupportedOS }
-
-        // Mic device-change e2e (issue #379): inject a one-shot tap fault so the
-        // app self-triggers a mid-recording restart with an invalid format and
-        // the lane can verify the installTap NSException recovery. Compiled ONLY
-        // in the e2e build (run_app.sh -DE2E_FAULT_INJECTION).
-        //
-        // The `#else` is what keeps the fault physically absent from every
-        // shipped binary, and it is not redundant: the field is a `var` on a
-        // struct that ships, so whatever a caller set would otherwise travel
-        // straight through to a `MicCaptureHandler` whose fault machinery is
-        // always compiled. Overwriting here means no shipped build can reach
-        // the session with a fault set, whoever built the configuration.
-        var configuration = configuration
-        #if E2E_FAULT_INJECTION
-            configuration.micDebugFault = DebugTapFault(triggerRestartAfter: 2)
-        #else
-            configuration.micDebugFault = nil
-        #endif
-
-        return AudioCaptureSession(configuration)
+        return AudioCaptureSession(configurationForThisBuild(configuration))
     }
 }

--- a/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
+++ b/app/MeetingTranscriber/Sources/DualSourceRecorder.swift
@@ -419,12 +419,12 @@ class DualSourceRecorder: RecordingProvider {
 
         let session: any AudioCapturing
         do {
-            session = try makeCaptureSession(CaptureSessionRequest(
+            session = try makeCaptureSession(AudioCaptureConfiguration(
                 pids: effectivePids,
                 appOutputURL: appTempURL,
+                micOutputURL: micURL,
                 sampleRate: recordRate,
                 channels: appChannels,
-                micOutputURL: micURL,
                 micDeviceUID: (micDeviceUID?.isEmpty ?? true) ? nil : micDeviceUID,
                 debugLogging: debugLogging,
                 appLiveSink: appLiveSink,

--- a/app/MeetingTranscriber/Tests/DualSourceRecorderLifecycleTests.swift
+++ b/app/MeetingTranscriber/Tests/DualSourceRecorderLifecycleTests.swift
@@ -28,9 +28,9 @@ final class DualSourceRecorderLifecycleTests: XCTestCase {
         var micLevelDBFS: Double = -120
         var appCaptureGaveUp = false
         var micCaptureGaveUp = false
-        /// What the recorder asked the factory for, so a test can assert on the
-        /// choices and write to the URLs it picked.
-        var lastRequest: CaptureSessionRequest?
+        /// The configuration the recorder handed the factory, so a test can
+        /// assert on the choices and write to the URLs it picked.
+        var lastConfiguration: AudioCaptureConfiguration?
 
         func start() throws {
             if let startError { throw startError }
@@ -48,8 +48,8 @@ final class DualSourceRecorderLifecycleTests: XCTestCase {
 
     private func makeRecorder(dir: URL) -> (DualSourceRecorder, FakeCaptureSession) {
         let session = FakeCaptureSession()
-        let recorder = DualSourceRecorder(recordingsDir: dir) { request in
-            session.lastRequest = request
+        let recorder = DualSourceRecorder(recordingsDir: dir) { configuration in
+            session.lastConfiguration = configuration
             return session
         }
         return (recorder, session)
@@ -69,7 +69,7 @@ final class DualSourceRecorderLifecycleTests: XCTestCase {
         session: FakeCaptureSession,
     ) throws -> URL {
         try recorder.start(source: .micOnly)
-        return try XCTUnwrap(session.lastRequest?.micOutputURL)
+        return try XCTUnwrap(session.lastConfiguration?.micOutputURL)
     }
 
     // MARK: - start
@@ -98,10 +98,10 @@ final class DualSourceRecorderLifecycleTests: XCTestCase {
 
         try recorder.start(source: .micOnly)
 
-        let request = try XCTUnwrap(session.lastRequest)
-        XCTAssertNil(request.appOutputURL, "a tap would capture a meeting that is happening in the room")
-        XCTAssertNotNil(request.micOutputURL)
-        XCTAssertTrue(request.pids.isEmpty)
+        let configuration = try XCTUnwrap(session.lastConfiguration)
+        XCTAssertNil(configuration.appOutputURL, "a tap would capture a meeting that is happening in the room")
+        XCTAssertNotNil(configuration.micOutputURL)
+        XCTAssertTrue(configuration.pids.isEmpty)
     }
 
     /// The mirror image: "No Microphone" opens the tap and no mic track.
@@ -114,10 +114,10 @@ final class DualSourceRecorderLifecycleTests: XCTestCase {
         // in whatever else is running on the machine.
         try recorder.start(source: .appOnly(pid: 999_999))
 
-        let request = try XCTUnwrap(session.lastRequest)
-        XCTAssertNotNil(request.appOutputURL)
-        XCTAssertNil(request.micOutputURL)
-        XCTAssertEqual(request.pids, [999_999])
+        let configuration = try XCTUnwrap(session.lastConfiguration)
+        XCTAssertNotNil(configuration.appOutputURL)
+        XCTAssertNil(configuration.micOutputURL)
+        XCTAssertEqual(configuration.pids, [999_999])
     }
 
     /// A start that threw before capture opened is not an interrupted

--- a/app/MeetingTranscriber/Tests/LiveCaptureSessionTests.swift
+++ b/app/MeetingTranscriber/Tests/LiveCaptureSessionTests.swift
@@ -1,0 +1,70 @@
+import AudioTapLib
+@testable import MeetingTranscriber
+import XCTest
+
+/// The production capture-session factory — the one path that builds a real
+/// `AudioCaptureSession`, and the only place that decides what a given build is
+/// allowed to open one with.
+@MainActor
+final class LiveCaptureSessionTests: XCTestCase {
+    private func configuration(micDebugFault: DebugTapFault? = nil) -> AudioCaptureConfiguration {
+        var config = AudioCaptureConfiguration(
+            pids: [], appOutputURL: nil, micOutputURL: nil, sampleRate: 48000, channels: 2,
+        )
+        config.micDebugFault = micDebugFault
+        return config
+    }
+
+    /// The guarantee that a shipped binary cannot inject the e2e tap fault, and
+    /// the reason it needs a test at all: `micDebugFault` is a `var` on a struct
+    /// that ships, so a caller — a config template, a copied configuration, a
+    /// mis-merged helper — could set it, and the handler's fault machinery is
+    /// compiled into every build. The overwrite here is the only thing standing
+    /// between that and a self-triggered device-change restart on every
+    /// recording. It was dropped once during this refactor and nothing failed.
+    func testTheBuildDecidesTheFaultAndNotTheCaller() {
+        let asked = configuration(micDebugFault: DebugTapFault(triggerRestartAfter: 7))
+
+        let allowed = LiveCaptureSession.configurationForThisBuild(asked)
+
+        #if E2E_FAULT_INJECTION
+            XCTAssertNotNil(allowed.micDebugFault, "the e2e build is the one that injects the fault")
+        #else
+            XCTAssertNil(
+                allowed.micDebugFault,
+                "a shipped build must overwrite whatever the caller set, not carry it through",
+            )
+        #endif
+    }
+
+    /// Everything else the caller asked for survives that overwrite. Written
+    /// because the sanitiser copies a ten-field value: clearing one field by
+    /// rebuilding the struct instead of mutating a copy would drop the rest
+    /// silently, and every one of them decides what gets recorded.
+    func testNothingElseIsChangedOnTheWayThrough() {
+        let app = URL(fileURLWithPath: "/tmp/stem_app16k_raw.tmp")
+        let mic = URL(fileURLWithPath: "/tmp/stem_mic.wav")
+        let asked = AudioCaptureConfiguration(
+            pids: [11, 22], appOutputURL: app, micOutputURL: mic,
+            sampleRate: 44100, channels: 5, micDeviceUID: "device-uid", debugLogging: true,
+        )
+
+        let allowed = LiveCaptureSession.configurationForThisBuild(asked)
+
+        XCTAssertEqual(allowed.pids, [11, 22])
+        XCTAssertEqual(allowed.appOutputURL, app)
+        XCTAssertEqual(allowed.micOutputURL, mic, "the two track URLs must not cross here either")
+        XCTAssertEqual(allowed.sampleRate, 44100)
+        XCTAssertEqual(allowed.channels, 5)
+        XCTAssertEqual(allowed.micDeviceUID, "device-uid")
+        XCTAssertTrue(allowed.debugLogging)
+    }
+
+    /// `make` builds a session and touches no hardware doing it: the session's
+    /// init only stores the configuration, and nothing opens until `start()`.
+    /// This is what covers the OS-floor guard on the path every real recording
+    /// takes.
+    func testMakeBuildsASessionWithoutOpeningAnything() throws {
+        XCTAssertNoThrow(try LiveCaptureSession.make(configuration()))
+    }
+}

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -219,6 +219,7 @@ State writes to `AppPaths.dataDir`; IPC + queue snapshots to `ipcDir`.
 | `tools/audiotap/Sources/MicChannelMap.swift` | Decides when a discrete multi-channel mic input needs an explicit converter `channelMap` — `AVAudioConverter`'s implicit downmix silently writes digital silence for most non-stereo layouts |
 | `tools/audiotap/Sources/MicConverterFactory.swift` | Builds the tap → WAV converter for one mic capture, applying `MicChannelMap`'s explicit channel selection when needed |
 | `tools/audiotap/Sources/AudioCaptureSession.swift` | Orchestrator (start/stop, computes micDelay) |
+| `tools/audiotap/Sources/AudioCaptureConfiguration.swift` | What one capture records and how — the single list a new capture option is added to |
 | `tools/audiotap/Sources/AudioCaptureResult.swift` | Result struct |
 | `tools/audiotap/Sources/LiveAudioBuffer.swift` | Real-time audio sample snapshot yielded from capture callbacks (CATap IOProc + AVAudioEngine input tap) |
 | `tools/audiotap/Sources/CurrentLevel.swift` | Pure function: dBFS level read with staleness decay (stale tap → silence) |

--- a/tools/audiotap/Sources/AudioCaptureConfiguration.swift
+++ b/tools/audiotap/Sources/AudioCaptureConfiguration.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Everything one capture session is configured with, in one value.
+///
+/// It exists so that the capture options are described in exactly one list.
+/// The session used to take them as ten init parameters, and the app carried a
+/// parallel struct of its own plus a hand-written mapping onto that init — so a
+/// new option had to be added in three places, and an option missing from the
+/// middle one fell back to its default for every real recording without
+/// anything failing to say so. There is no mapping left to forget.
+///
+/// The defaults below are a deliberate affordance, not the old hazard: a caller
+/// leaving one out is choosing it, where before a caller could lose an option
+/// it had already set.
+///
+/// Deliberately *not* `@available`-gated, unlike `AudioCaptureSession`, which
+/// can only exist on macOS 14.2. Nothing in here touches the hardware, and
+/// gating it would force every consumer that merely *describes* a capture to
+/// carry the version check too.
+public struct AudioCaptureConfiguration: Sendable {
+    /// PIDs to capture audio from. For Electron/WebView2 apps (Teams 2.x,
+    /// Slack, Discord) this should include the root PID plus helper/renderer
+    /// children; for native Cocoa apps a single-element array is fine. Ignored
+    /// when `appOutputURL` is nil.
+    public let pids: [pid_t]
+
+    /// Where to write the app-audio track, or nil to open no process tap at
+    /// all. Nil is the microphone-only shape: the session then has exactly one
+    /// channel, so a mic failure is terminal rather than the degradation it is
+    /// when an app track is also being recorded.
+    public let appOutputURL: URL?
+
+    /// Where to write the mic track, or nil not to record the microphone.
+    public let micOutputURL: URL?
+
+    /// What the CATap aggregate device is asked for. The device may renegotiate
+    /// mid-session; `AppAudioCapture` resamples every buffer to the speech rate
+    /// in the IOProc regardless.
+    public let sampleRate: Int
+    public let channels: Int
+
+    public let micDeviceUID: String?
+    public let debugLogging: Bool
+
+    /// Optional real-time buffer callback for the app audio track (CATap
+    /// output, interleaved Float32 at the tap's native rate, typically 48 kHz).
+    /// Called from the IOProc thread — non-blocking.
+    public let appLiveSink: LiveAudioSink?
+
+    /// Optional real-time buffer callback for the mic track (mono Float32 at
+    /// file rate, typically 16 kHz post-resample). Called from the AVAudioEngine
+    /// tap thread — non-blocking.
+    public let micLiveSink: LiveAudioSink?
+
+    /// Set after the configuration is built, never at construction, because it
+    /// is not the caller's decision: the e2e build's composition root injects it
+    /// into a configuration the recording path assembled, and every shipped
+    /// binary leaves it nil. Inert in production; an e2e build uses it to verify
+    /// the mic installTap NSException recovery (issue #379).
+    ///
+    /// The one `var`, and the one field the init does not take. Every other
+    /// field is a `let` the init must assign, so the compiler still checks that
+    /// a newly added option is carried — which is the guarantee this type
+    /// exists for. Add a new option as a `let`; a `var` here would be a silent
+    /// nil.
+    public var micDebugFault: DebugTapFault?
+
+    /// The tracks and the capture format have no defaults on purpose. "Which
+    /// tracks does this record" and "in what format" are the questions a caller
+    /// has to answer out loud, and the recording path answers both from its own
+    /// named constants — a default here would be a second copy of those numbers
+    /// that nothing would notice drifting. What is left describes optional
+    /// extras, where leaving one out is a choice.
+    public init(
+        pids: [pid_t],
+        appOutputURL: URL?,
+        micOutputURL: URL?,
+        sampleRate: Int,
+        channels: Int,
+        micDeviceUID: String? = nil,
+        debugLogging: Bool = false,
+        appLiveSink: LiveAudioSink? = nil,
+        micLiveSink: LiveAudioSink? = nil,
+    ) {
+        self.pids = pids
+        self.appOutputURL = appOutputURL
+        self.micOutputURL = micOutputURL
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.micDeviceUID = micDeviceUID
+        self.debugLogging = debugLogging
+        self.appLiveSink = appLiveSink
+        self.micLiveSink = micLiveSink
+    }
+}

--- a/tools/audiotap/Sources/AudioCaptureSession.swift
+++ b/tools/audiotap/Sources/AudioCaptureSession.swift
@@ -23,18 +23,10 @@ public enum AudioCaptureSessionError: LocalizedError, Equatable {
 /// Replaces the CLI entry point — call `start()` and `stop()` directly from the host app.
 @available(macOS 14.2, *)
 public class AudioCaptureSession {
-    private let pids: [pid_t]
-    private let sampleRate: Int
-    private let channels: Int
-    private let appOutputURL: URL?
-    private let micOutputURL: URL?
-    private let micDeviceUID: String?
-    private let debugLogging: Bool
-    private let appLiveSink: LiveAudioSink?
-    private let micLiveSink: LiveAudioSink?
-    // Inert in production (nil); an e2e build injects one to verify the mic
-    // installTap NSException recovery (issue #379). Forwarded to MicCaptureHandler.
-    private let micDebugFault: DebugTapFault?
+    /// What this session records and how. Stored whole rather than unpacked
+    /// into ten properties: unpacking is a list to keep in sync, and the option
+    /// that gets left out of it is the one nobody notices.
+    private let config: AudioCaptureConfiguration
 
     private var appCapture: AppAudioCapture?
     private var micCapture: MicCaptureHandler?
@@ -49,52 +41,19 @@ public class AudioCaptureSession {
     public private(set) var micCaptureGaveUp = false
     private var appFileHandle: FileHandle?
 
-    /// - Parameter pids: PIDs to capture audio from. For Electron/WebView2
-    ///   apps (Teams 2.x, Slack, Discord) this should include the root PID
-    ///   plus helper/renderer children; for native Cocoa apps a
-    ///   single-element array is fine. Ignored when `appOutputURL` is nil.
-    /// - Parameter appOutputURL: Where to write the app-audio track, or nil to
-    ///   open no process tap at all. Nil is the microphone-only shape: the
-    ///   session then has exactly one channel and a mic failure is terminal
-    ///   rather than a degradation (see `CaptureTrackPolicy`).
-    /// - Parameter appLiveSink: Optional real-time buffer callback for the app
-    ///   audio track (CATap output, interleaved Float32 at the tap's native
-    ///   rate, typically 48 kHz). Called from the IOProc thread — non-blocking.
-    /// - Parameter micLiveSink: Optional real-time buffer callback for the mic
-    ///   track (mono Float32 at file rate, typically 16 kHz post-resample).
-    ///   Called from the AVAudioEngine tap thread — non-blocking.
-    public init(
-        pids: [pid_t],
-        appOutputURL: URL?,
-        sampleRate: Int = 48000,
-        channels: Int = 2,
-        micOutputURL: URL? = nil,
-        micDeviceUID: String? = nil,
-        debugLogging: Bool = false,
-        appLiveSink: LiveAudioSink? = nil,
-        micLiveSink: LiveAudioSink? = nil,
-        micDebugFault: DebugTapFault? = nil,
-    ) {
-        self.pids = pids
-        self.sampleRate = sampleRate
-        self.channels = channels
-        self.appOutputURL = appOutputURL
-        self.micOutputURL = micOutputURL
-        self.micDeviceUID = micDeviceUID
-        self.debugLogging = debugLogging
-        self.appLiveSink = appLiveSink
-        self.micLiveSink = micLiveSink
-        self.micDebugFault = micDebugFault
+    /// Each option is documented on `AudioCaptureConfiguration`.
+    public init(_ configuration: AudioCaptureConfiguration) {
+        config = configuration
     }
 
     /// Start capturing app audio, mic audio, or both — whichever output URLs
     /// were supplied. At least one is required.
     public func start() throws {
-        guard appOutputURL != nil || micOutputURL != nil else {
+        guard config.appOutputURL != nil || config.micOutputURL != nil else {
             throw AudioCaptureSessionError.noTracksRequested
         }
 
-        if let appOutputURL {
+        if let appOutputURL = config.appOutputURL {
             // Create app output file and get its file descriptor
             // Restrict permissions to owner-only (0600) — audio may contain sensitive meeting content
             FileManager.default.createFile(
@@ -105,12 +64,12 @@ public class AudioCaptureSession {
             let handle = try FileHandle(forWritingTo: appOutputURL)
 
             let capture = AppAudioCapture(
-                pids: pids,
+                pids: config.pids,
                 outputFileDescriptor: handle.fileDescriptor,
-                sampleRate: sampleRate,
-                channels: channels,
-                debugLogging: debugLogging,
-                liveSink: appLiveSink,
+                sampleRate: config.sampleRate,
+                channels: config.channels,
+                debugLogging: config.debugLogging,
+                liveSink: config.appLiveSink,
             )
             do {
                 try capture.start()
@@ -124,15 +83,15 @@ public class AudioCaptureSession {
         }
 
         // Start mic capture if requested
-        if let micURL = micOutputURL {
+        if let micURL = config.micOutputURL {
             let mic = MicCaptureHandler(
                 outputURL: micURL,
-                debugLogging: debugLogging,
-                liveSink: micLiveSink,
-                debugFault: micDebugFault,
+                debugLogging: config.debugLogging,
+                liveSink: config.micLiveSink,
+                debugFault: config.micDebugFault,
             )
             do {
-                try mic.start(deviceUID: micDeviceUID)
+                try mic.start(deviceUID: config.micDeviceUID)
                 mic.onGiveUp = { [weak self] in self?.micCaptureGaveUp = true }
                 micCapture = mic
             } catch {
@@ -148,7 +107,7 @@ public class AudioCaptureSession {
             }
         }
 
-        logger.info("Capture session started (PIDs \(self.pids), rate: \(self.sampleRate), channels: \(self.channels))")
+        logger.info("Capture session started (PIDs \(self.config.pids), rate: \(self.config.sampleRate), channels: \(self.config.channels))")
     }
 
     /// Instantaneous app-audio level in dBFS, decayed to -120 when no buffer has
@@ -173,9 +132,9 @@ public class AudioCaptureSession {
         // `AppAudioCapture` actually WROTE — 16 kHz mono after the in-IOProc
         // resample, not the device's raw capture format.
         let result = AudioCaptureResult.make(
-            appOutputURL: appOutputURL,
-            micOutputURL: micOutputURL,
-            configured: (sampleRate: sampleRate, channels: channels),
+            appOutputURL: config.appOutputURL,
+            micOutputURL: config.micOutputURL,
+            configured: (sampleRate: config.sampleRate, channels: config.channels),
             app: .init(
                 firstFrameTicks: appCapture?.appFirstFrameTime ?? 0,
                 sampleRate: appCapture?.outputSampleRate ?? 0,

--- a/tools/audiotap/Tests/AudioCaptureConfigurationTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureConfigurationTests.swift
@@ -1,0 +1,40 @@
+@testable import AudioTapLib
+import Foundation
+import XCTest
+
+/// What a capture configuration is when the caller says the minimum.
+final class AudioCaptureConfigurationTests: XCTestCase {
+    /// The optional extras, and above all the e2e fault: it is the one field
+    /// the init does not take, so it arrives by Swift's implicit nil rather
+    /// than by an assignment anyone wrote. A shipped binary that reached the
+    /// session with it set would self-trigger a device-change restart on every
+    /// recording.
+    func testTheOptionalExtrasStartUnset() {
+        let config = AudioCaptureConfiguration(
+            pids: [], appOutputURL: nil, micOutputURL: nil, sampleRate: 48000, channels: 2,
+        )
+
+        XCTAssertNil(config.micDeviceUID, "nil means the system default input")
+        XCTAssertFalse(config.debugLogging)
+        XCTAssertNil(config.appLiveSink)
+        XCTAssertNil(config.micLiveSink)
+        XCTAssertNil(config.micDebugFault, "every shipped binary leaves the e2e fault unset")
+    }
+
+    /// Not a test that a struct stores what it is given: the init is written by
+    /// hand, nine assignments long, and the two track URLs are both `URL?`, so
+    /// swapping them compiles and would send each track to the other's file.
+    /// Distinct values on both, so a swap fails in either direction.
+    func testTheTwoTrackURLsDoNotCrossOnTheWayIn() {
+        let app = URL(fileURLWithPath: "/tmp/stem_app_raw.tmp")
+        let mic = URL(fileURLWithPath: "/tmp/stem_mic.wav")
+
+        let config = AudioCaptureConfiguration(
+            pids: [7], appOutputURL: app, micOutputURL: mic, sampleRate: 48000, channels: 2,
+        )
+
+        XCTAssertEqual(config.appOutputURL, app)
+        XCTAssertEqual(config.micOutputURL, mic)
+        XCTAssertEqual(config.pids, [7])
+    }
+}

--- a/tools/audiotap/Tests/AudioCaptureSessionTracksTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureSessionTracksTests.swift
@@ -17,6 +17,37 @@ final class AudioCaptureSessionTracksTests: XCTestCase {
         }
     }
 
+    /// What the session reads back out of its configuration, pinned where it is
+    /// reachable without hardware.
+    ///
+    /// The session used to hold these as ten separate properties and now holds
+    /// the configuration whole, so every read inside it was rewritten by hand.
+    /// Three of those reads land in `stop()`'s result, and each has a same-typed
+    /// neighbour it could have been swapped with: the two track URLs are both
+    /// `URL?`, the rate and the channel count are both `Int`. Distinct values
+    /// throughout, so a swap in either direction fails.
+    ///
+    /// A `stop()` with no `start()` touches nothing: both captures are nil, so
+    /// the reported rate and channel count fall back to the configured ones and
+    /// the app track is reported straight from the configuration.
+    func testStopReportsTheTrackAndFormatItWasConfiguredWith() throws {
+        guard #available(macOS 14.2, *) else {
+            throw XCTSkip("AudioCaptureSession requires macOS 14.2")
+        }
+        let app = URL(fileURLWithPath: "/tmp/stem_app16k_raw.tmp")
+        let mic = URL(fileURLWithPath: "/tmp/stem_mic.wav")
+        let session = AudioCaptureSession(AudioCaptureConfiguration(
+            pids: [], appOutputURL: app, micOutputURL: mic, sampleRate: 44100, channels: 5,
+        ))
+
+        let result = session.stop()
+
+        XCTAssertEqual(result.appAudioFileURL, app, "the app track, not the mic file")
+        XCTAssertEqual(result.actualSampleRate, 44100, "the configured rate, not the channel count")
+        XCTAssertEqual(result.actualChannels, 5)
+        XCTAssertNil(result.micAudioFileURL, "no mic capture ran, so there is no mic track to report")
+    }
+
     func testRefusalHappensBeforeAnyFileIsCreated() throws {
         guard #available(macOS 14.2, *) else {
             throw XCTSkip("AudioCaptureSession requires macOS 14.2")

--- a/tools/audiotap/Tests/AudioCaptureSessionTracksTests.swift
+++ b/tools/audiotap/Tests/AudioCaptureSessionTracksTests.swift
@@ -10,7 +10,7 @@ final class AudioCaptureSessionTracksTests: XCTestCase {
         guard #available(macOS 14.2, *) else {
             throw XCTSkip("AudioCaptureSession requires macOS 14.2")
         }
-        let session = AudioCaptureSession(pids: [], appOutputURL: nil, micOutputURL: nil)
+        let session = AudioCaptureSession(AudioCaptureConfiguration(pids: [], appOutputURL: nil, micOutputURL: nil, sampleRate: 48000, channels: 2))
 
         XCTAssertThrowsError(try session.start()) { error in
             XCTAssertEqual(error as? AudioCaptureSessionError, .noTracksRequested)
@@ -24,7 +24,7 @@ final class AudioCaptureSessionTracksTests: XCTestCase {
         // A PID list without an output URL used to be impossible; assert the
         // guard keys on the URL, not on the PIDs, so a stray PID list cannot
         // talk the session into opening a tap it has nowhere to write.
-        let session = AudioCaptureSession(pids: [1, 2, 3], appOutputURL: nil, micOutputURL: nil)
+        let session = AudioCaptureSession(AudioCaptureConfiguration(pids: [1, 2, 3], appOutputURL: nil, micOutputURL: nil, sampleRate: 48000, channels: 2))
 
         XCTAssertThrowsError(try session.start())
     }


### PR DESCRIPTION
## Why

`AudioCaptureSession.init` took ten parameters, and the app carried a parallel struct of its own plus a hand-written mapping onto that init. A new capture option therefore had to be added in **three** places — and one missing from the middle one fell back to its default for every real recording, with nothing failing to say so.

That is measured, not argued. Adding an option to the capture session and leaving the recording path untouched used to compile clean **and** pass `swiftlint analyze --strict` over a full compiler log. It is now a compile error at the call site:

```
error: missing argument for parameter 'probeNewOption' in call
```

## What

`AudioCaptureConfiguration` is the single list. The session stores it **whole** rather than unpacking it into ten properties, because unpacking is itself a list to keep in sync and the option left out of it is the one nobody notices. The app's `CaptureSessionRequest` and its mapping are deleted; the recording path builds the library's configuration directly and the factory passes it through untouched.

Behaviour is unchanged: same values, same order, same e2e fault injection.

The API change and its call sites are one commit on purpose — split apart, neither half builds.

## Two deliberate details

- The configuration is **not** `@available`-gated, unlike the session, so a consumer that merely *describes* a capture needs no version check.
- `micDebugFault` is its one mutable field and is absent from the init: whether a build injects the e2e fault is a property of the build, not of the recording being started, so the composition root sets it on a configuration the recording path already assembled. The `#else` branch overwrites it with nil, which is what keeps the fault physically absent from every shipped binary — the field is a `var` on a struct that ships, so without it whatever a caller set would travel straight through to a handler whose fault machinery is always compiled.

## What the tests pin

Three things the refactor could have broken silently:

- The optional extras start unset — above all the e2e fault, which is the one field the init does not take, so it arrives by Swift's implicit nil rather than by an assignment anyone wrote.
- The two track URLs do not cross on the way in. The init is hand-written and both fields are `URL?`, so swapping them compiles and would send each track to the other's file.
- `stop()` reports the track and format it was configured with. The session now holds the configuration whole, so every read inside it was rewritten by hand; three of those reads land in the result, and each has a same-typed neighbour it could have been swapped with. A `stop()` with no `start()` touches no hardware and pins all three at once — **added because without it, swapping the two URLs or the rate and the channel count in `stop()` left every test in the repo green.**

## Verification

Both suites green, `swiftlint analyze --strict` over a full compiler log (431 files, 0 violations), release-mode and App Store parity builds pass, lint 0 violations in 478 files. Rebased onto current `main`; `git range-diff` shows both commits unchanged by the rebase.