### PR TITLE
feat(app): vendor LocalVQE and add the EchoCancelling seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,10 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - Only the opening `PipelineQueue.echoBleedAnalysisSeconds` of a recording are analysed, so the warning names the span it looked at instead of claiming the whole recording. Bleed starting later is not seen; that is a known limit, not an oversight.
 - E2E cover: `scripts/e2e-app.sh --echo-bleed` (see the `e2e-architecture` skill).
 
+**Echo cancellation seam (not wired up yet):** `EchoCancelling` / `LocalVQECanceller` sit over the vendored LocalVQE static library (`CLocalVQE`, a checksum-pinned `binaryTarget(url:)` against our own vendor release, since upstream ships no macOS artifact). Nothing in the pipeline calls it; the `.gguf` model is deliberately not bundled, so model-dependent tests skip unless `MEETINGTRANSCRIBER_LOCALVQE_MODEL` points at one. **It does not compose with `AudioMixer.suppressEcho`**, the RMS gate that already runs inside `AudioMixer.mix`: that one mutes the microphone while the app track is loud and so removes the local speaker along with the echo, this one removes the echo acoustically and leaves the speaker. A consumer has to pick, not chain them.
+- **`--localvqe-selftest` and the entry point.** `@main` is `AppLauncher`, not `MeetingTranscriberApp`, so a probe launch can divert before `AppState` (and its live-caption prewarm) is constructed. The flag is `#if !APPSTORE` like the debug RPC server, but unlike it has no second runtime gate: it is argv-only, prints and exits. `scripts/localvqe-bundle-check.sh` drives it to prove the static archive resolves its compute backends from `Contents/MacOS` of a signed bundle, which a SwiftPM test build cannot show. That script is **not** wired into any gate yet, so it is run by hand.
+
+
 **VAD preprocessing:**
 - `FluidVAD` wraps FluidAudio Silero v6 for voice activity detection. When enabled (`AppSettings.vadEnabled`), silence is trimmed before transcription and timestamps are remapped back to the original timeline via `VadSegmentMap`.
 - `PipelineQueue` holds a cached `FluidVAD` instance (reused across jobs). Pass `vadConfig: nil` to disable.

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -13,12 +13,30 @@ let package = Package(
         .package(path: "../../tools/audiotap"),
     ],
     targets: [
+        // LocalVQE echo-cancellation library (C API over a static xcframework).
+        // SwiftPM downloads the artifact from a pinned release asset and
+        // verifies it against the checksum before linking; no binary lives in
+        // this repository. The artifact is genuinely static — the linked app
+        // gains no new dynamic-library dependencies (otool -L shows system
+        // libraries only).
+        // Hosted on a release of our own vendor repository because upstream
+        // publishes no macOS artifact at all. Checksum-pinned, so a swapped
+        // asset fails the build rather than shipping silently; the exposure
+        // that remains is availability, since the asset disappearing breaks
+        // `swift build` for everyone including CI. Mirror it before relying on
+        // this for a release.
+        .binaryTarget(
+            name: "CLocalVQE",
+            url: "https://github.com/pasrom/localvqe-xcframework/releases/download/1.0.2/LocalVQE.xcframework.zip",
+            checksum: "c0b0f41245611cca194ed279096d4729f87aba1f59cf92972383bff0f8e903c1"
+        ),
         .executableTarget(
             name: "MeetingTranscriber",
             dependencies: [
                 .product(name: "WhisperKit", package: "WhisperKit"),
                 .product(name: "FluidAudio", package: "FluidAudio"),
                 .product(name: "AudioTapLib", package: "audiotap"),
+                "CLocalVQE",
             ],
             path: "Sources",
             // Assets.xcassets is compiled by `actool` in scripts/build_release.sh,
@@ -42,6 +60,14 @@ let package = Package(
                     "-Xfrontend", "-warn-long-expression-type-checking=300",
                 ]),
                 .enableUpcomingFeature("ExistentialAny"),
+            ],
+            linkerSettings: [
+                // CLocalVQE is C++ inside and uses Accelerate for its FFT.
+                // A static archive carries no autolink hints, so the consumer
+                // has to name both dependencies explicitly (proven necessary
+                // in the vendoring link spike).
+                .linkedLibrary("c++"),
+                .linkedFramework("Accelerate"),
             ]
         ),
         .testTarget(

--- a/app/MeetingTranscriber/Sources/AppLauncher.swift
+++ b/app/MeetingTranscriber/Sources/AppLauncher.swift
@@ -1,0 +1,24 @@
+// Process entry point. SwiftUI's App.main() is a protocol requirement, so a
+// conforming type cannot intercept its own launch without recursing into
+// itself; this separate @main enum makes the one pre-launch decision — divert
+// into the LocalVQE selftest probe (scripts/localvqe-bundle-check.sh) or
+// start the GUI — before any app state is constructed.
+import SwiftUI
+
+@main
+enum AppLauncher {
+    // Invoked by the @main synthesis, which the analyzer cannot see.
+    // swiftlint:disable:next unused_declaration
+    static func main() {
+        // The selftest exists for the Homebrew build's bundle check and is
+        // compiled out of the App Store variant entirely, like the debug RPC
+        // server. Where present it is reachable only via this explicit argv
+        // flag; it constructs no app state and exits before the GUI starts.
+        #if !APPSTORE
+            if let mode = LocalVQESelftest.parse(arguments: CommandLine.arguments) {
+                exit(LocalVQESelftest.run(mode))
+            }
+        #endif
+        MeetingTranscriberApp.main()
+    }
+}

--- a/app/MeetingTranscriber/Sources/AudioMixer.swift
+++ b/app/MeetingTranscriber/Sources/AudioMixer.swift
@@ -361,7 +361,12 @@ enum AudioMixer {
 
     /// RMS in dBFS for a Float32 PCM sample buffer.
     /// Returns `-Float.infinity` for an empty buffer (true silence).
-    static func rmsDecibels(samples: [Float]) -> Float {
+    ///
+    /// Takes any `Collection` rather than `[Float]` so a caller measuring part
+    /// of a track can pass the slice directly. The `[Float]` form only accepted
+    /// whole arrays, which forced every windowed measurement to copy its slice
+    /// first, on buffers that reach hundreds of megabytes for a long meeting.
+    static func rmsDecibels(samples: some Collection<Float>) -> Float {
         guard !samples.isEmpty else { return -.infinity }
         let sumSq = samples.reduce(Float(0)) { $0 + $1 * $1 }
         let rms = (sumSq / Float(samples.count)).squareRoot()

--- a/app/MeetingTranscriber/Sources/EchoCancelling.swift
+++ b/app/MeetingTranscriber/Sources/EchoCancelling.swift
@@ -1,0 +1,75 @@
+// Seam for acoustic echo cancellation: removing the far-end (loudspeaker)
+// signal's bleed from the microphone track before transcription. This file is
+// the abstraction only — nothing in the pipeline consumes it yet; the concrete
+// implementation is LocalVQECanceller.
+//
+// Relationship to the echo suppression that already ships, stated here because
+// the binary now contains two of them at different depths and a reader will
+// otherwise have to reconstruct it:
+//
+//   - `AudioMixer.suppressEcho` is an RMS gate applied inside `AudioMixer.mix`.
+//     It mutes microphone windows while the app track is loud, so it removes
+//     the local speaker along with the echo whenever both talk at once.
+//   - This seam removes the echo acoustically and leaves the local speaker.
+//
+// They are not meant to compose. When a consumer lands it has to say which one
+// runs, not let microphone audio pass through both.
+import Foundation
+
+/// Errors surfaced by an `EchoCancelling` implementation.
+enum EchoCancellationError: Error {
+    /// The echo-cancellation model could not be loaded. The payload is the
+    /// underlying library's own error message, passed through verbatim.
+    case modelLoadFailed(String)
+    /// A processing call failed mid-stream. `code` is the library's return
+    /// code, `message` its error string at the time of failure.
+    case processingFailed(code: Int32, message: String)
+}
+
+/// Removes far-end echo from a microphone recording.
+///
+/// Contract: both tracks are mono Float32 PCM at 16 kHz sharing one timeline
+/// (sample `i` of `mic` and `reference` are simultaneous). The result has
+/// exactly `mic.count` samples. No time alignment is performed — the seam
+/// passes both tracks through as given; whether the underlying canceller
+/// tolerates inter-track delay is its own property, not this contract's.
+/// A `reference` shorter than `mic` is treated as silence past its end; a
+/// longer one is ignored past `mic.count`.
+protocol EchoCancelling: Sendable {
+    // Referenced only through the concrete type until the pipeline consumer
+    // lands in a follow-up; the analyzer cannot see that intent.
+    // swiftlint:disable:next unused_declaration
+    func cancelEcho(mic: [Float], reference: [Float]) async throws -> [Float]
+}
+
+/// Did the echo actually drop? Pure arithmetic over two levels, kept beside the
+/// seam rather than inside the diagnostic probe so the probe and the tests read
+/// one threshold instead of two copies of the number 6.
+///
+/// Measurement and decision are separate on purpose: `measure` needs audio,
+/// the decision does not, so a test can pin the rule without synthesising a
+/// signal to do it.
+struct EchoReductionVerdict {
+    /// Floor far below the reduction a healthy model reaches on a synthetic
+    /// probe tone: passing proves the plumbing works, not that the model is
+    /// good.
+    static let minReductionDb: Float = 6
+
+    let beforeDbfs: Float
+    let afterDbfs: Float
+
+    var reductionDb: Float {
+        beforeDbfs - afterDbfs
+    }
+
+    var passes: Bool {
+        reductionDb > Self.minReductionDb
+    }
+
+    static func measure(mic: ArraySlice<Float>, output: ArraySlice<Float>) -> Self {
+        Self(
+            beforeDbfs: AudioMixer.rmsDecibels(samples: mic),
+            afterDbfs: AudioMixer.rmsDecibels(samples: output),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/EchoFrameChunking.swift
+++ b/app/MeetingTranscriber/Sources/EchoFrameChunking.swift
@@ -1,0 +1,56 @@
+// Pure hop arithmetic for streaming a signal through a fixed-hop frame API
+// (LocalVQE processes 256-sample hops): how many hops a signal needs, where
+// each starts, how much of the trailing partial hop is real signal, and the
+// zero-padded window copy both tracks use. Extracted as a value type so the
+// chunking logic is testable without the C library or a model.
+
+/// Slices `totalSamples` into consecutive `hopLength`-sized windows. The last
+/// window may be partial: it is fed to the frame API zero-padded, and only its
+/// `validSamples` of output are kept.
+struct EchoFrameChunking {
+    struct Hop: Equatable {
+        /// Sample offset of this hop's window in the source signal.
+        let start: Int
+        /// Samples of real signal in this window — equal to the hop length
+        /// except for a trailing partial hop.
+        let validSamples: Int
+    }
+
+    let totalSamples: Int
+    let hopLength: Int
+
+    /// Number of hops needed to cover the whole signal (ceiling division).
+    var hopCount: Int {
+        guard totalSamples > 0, hopLength > 0 else { return 0 }
+        return (totalSamples + hopLength - 1) / hopLength
+    }
+
+    /// The window at `index` (0 ..< `hopCount`).
+    func hop(_ index: Int) -> Hop {
+        let start = index * hopLength
+        return Hop(start: start, validSamples: min(hopLength, totalSamples - start))
+    }
+
+    /// Copies `buffer.count` samples of `signal` starting at `start` into
+    /// `buffer`, zero-filling everything past the signal's end. Used for the
+    /// trailing partial hop and for a reference track shorter than the mic
+    /// track, where reading past the end must produce silence.
+    ///
+    /// Deliberately static and taking a bare `start`: the reference track is
+    /// read at the MIC chunking's offsets, so the signal and the chunking that
+    /// produced the offset are routinely different lengths. Taking a `Hop` would
+    /// suggest an invariant this call does not have.
+    ///
+    /// Copies in bulk rather than element by element: the scalar loop paid a
+    /// bounds check per sample on every hop, including the full ones that need
+    /// no padding at all.
+    static func fillHop(from signal: [Float], start: Int, into buffer: inout [Float]) {
+        let available = max(0, min(buffer.count, signal.count - start))
+        if available > 0 {
+            buffer.replaceSubrange(0 ..< available, with: signal[start ..< start + available])
+        }
+        if available < buffer.count {
+            buffer.replaceSubrange(available ..< buffer.count, with: repeatElement(0, count: buffer.count - available))
+        }
+    }
+}

--- a/app/MeetingTranscriber/Sources/LocalVQECanceller.swift
+++ b/app/MeetingTranscriber/Sources/LocalVQECanceller.swift
@@ -1,0 +1,63 @@
+// EchoCancelling implementation over the vendored LocalVQE static library
+// (CLocalVQE binary target). Owns the C context lifecycle per call
+// (localvqe_new / localvqe_free), drives the streaming frame API hop by hop
+// so a long recording stays cancellable, and surfaces the library's own
+// error messages. The .gguf model is not bundled — callers provide a path.
+import CLocalVQE
+import Foundation
+
+struct LocalVQECanceller: EchoCancelling {
+    /// Filesystem path to a LocalVQE AEC .gguf model.
+    let modelPath: String
+
+    /// Hops processed between cooperative `Task.yield()` calls. 64 hops are
+    /// ~1 s of audio (~a few ms of compute), so a long recording cannot pin
+    /// a cooperative-pool thread for its whole duration.
+    private static let yieldStride = 64
+
+    func cancelEcho(mic: [Float], reference: [Float]) async throws -> [Float] {
+        guard !mic.isEmpty else { return [] }
+
+        let ctx = localvqe_new(modelPath)
+        guard ctx != 0 else {
+            throw EchoCancellationError.modelLoadFailed(Self.lastError(ctx: 0))
+        }
+        defer { localvqe_free(ctx) }
+
+        let hopLength = Int(localvqe_hop_length(ctx))
+        let chunking = EchoFrameChunking(totalSamples: mic.count, hopLength: hopLength)
+        var output = [Float]()
+        output.reserveCapacity(mic.count)
+        // Scratch windows reused across hops; fillHop overwrites them fully.
+        var micHop = [Float](repeating: 0, count: hopLength)
+        var refHop = [Float](repeating: 0, count: hopLength)
+        var outHop = [Float](repeating: 0, count: hopLength)
+
+        for index in 0 ..< chunking.hopCount {
+            try Task.checkCancellation()
+            if index > 0, index.isMultiple(of: Self.yieldStride) {
+                await Task.yield()
+            }
+            let hop = chunking.hop(index)
+            EchoFrameChunking.fillHop(from: mic, start: hop.start, into: &micHop)
+            EchoFrameChunking.fillHop(from: reference, start: hop.start, into: &refHop)
+            let code = localvqe_process_frame_f32(ctx, micHop, refHop, Int32(hopLength), &outHop)
+            guard code == 0 else {
+                throw EchoCancellationError.processingFailed(
+                    code: code, message: Self.lastError(ctx: ctx),
+                )
+            }
+            output.append(contentsOf: outHop[0 ..< hop.validSamples])
+        }
+        return output
+    }
+
+    /// The library's own error string, guarded. The C header carries no
+    /// nullability annotations, so this imports as implicitly unwrapped and an
+    /// unguarded read would crash in the one place a second failure is least
+    /// welcome. Shared with the selftest probe rather than spelled twice.
+    static func lastError(ctx: localvqe_ctx_t) -> String {
+        guard let message = localvqe_last_error(ctx) else { return "" }
+        return String(cString: message)
+    }
+}

--- a/app/MeetingTranscriber/Sources/LocalVQESelftest.swift
+++ b/app/MeetingTranscriber/Sources/LocalVQESelftest.swift
@@ -1,0 +1,137 @@
+// Hidden command-line probe (--localvqe-selftest [model.gguf]) that exercises
+// the statically linked LocalVQE library from whatever location the executable
+// was launched at. It answers the one question the SwiftPM link spike could
+// not: does the library still resolve its compute backend when the binary
+// lives in Contents/MacOS of a signed .app bundle? Driven by
+// scripts/localvqe-bundle-check.sh; a normal GUI launch never enters it.
+// Compiled out of the App Store variant (no bundle check exists for it, and
+// the sandboxed build should carry no diagnostic entry points).
+#if !APPSTORE
+    import CLocalVQE
+    import Foundation
+
+    enum LocalVQESelftest {
+        static let flag = "--localvqe-selftest"
+
+        enum Mode: Equatable {
+            /// Prove linking, backend registration, and error plumbing — no model.
+            case linkOnly
+            /// Additionally run synthetic audio through the full streaming seam.
+            case model(path: String)
+        }
+
+        /// Returns the requested selftest mode, or nil for a normal GUI launch.
+        /// The argument after the flag is a model path unless it is another flag.
+        static func parse(arguments: [String]) -> Mode? {
+            guard let index = arguments.firstIndex(of: flag) else { return nil }
+            if let next = arguments.dropFirst(index + 1).first, !next.hasPrefix("--") {
+                return .model(path: next)
+            }
+            return .linkOnly
+        }
+
+        /// The synthetic far-end probe tone: a 440 Hz carrier with a slow
+        /// amplitude wobble, capped at half scale so the half-level mic copy
+        /// stays well inside the C API's [-1, 1] contract. Deliberately not
+        /// EchoTestAudio (a test-target helper tuned for the echo-bleed
+        /// detector's envelope correlation): the probe is a Sources-side link
+        /// check and stays self-contained.
+        static func probeFarEnd(seconds: Int) -> [Float] {
+            let sampleRate = AudioConstants.targetSampleRate
+            return (0 ..< seconds * sampleRate).map { sampleIndex in
+                let t = Double(sampleIndex) / Double(sampleRate)
+                let wobble = 0.6 + 0.4 * sin(2 * .pi * 1.3 * t)
+                return Float(0.5 * wobble * sin(2 * .pi * 440 * t))
+            }
+        }
+
+        /// Runs the probe and returns the process exit code. Prints its verdict to
+        /// stdout; the library reports registered backends on stderr.
+        static func run(_ mode: Mode) -> Int32 {
+            print("localvqe-selftest: executable=\(CommandLine.arguments.first ?? "?")")
+            // Prints every registered backend + device to stderr, no model needed —
+            // the cheapest visible signal of backend registration.
+            localvqe_list_devices()
+
+            // The model-load path must fail cleanly (not crash, not succeed) for a
+            // nonexistent file, and the error string must come through.
+            let bogusPath = "/nonexistent/localvqe-selftest.gguf"
+            let bogusCtx = localvqe_new(bogusPath)
+            guard bogusCtx == 0 else {
+                localvqe_free(bogusCtx)
+                print("localvqe-selftest: FAIL — nonexistent model path yielded a context")
+                return 1
+            }
+            let message = LocalVQECanceller.lastError(ctx: 0)
+            print("localvqe-selftest: bogus model load failed as expected (\(message))")
+
+            switch mode {
+            case .linkOnly:
+                print("LOCALVQE_SELFTEST_OK link-only")
+                return 0
+
+            case let .model(path):
+                return runModelProbe(modelPath: path)
+            }
+        }
+
+        /// Streams synthetic echo-only audio through LocalVQECanceller — the same
+        /// seam the app will use — and checks shape, finiteness, and that the
+        /// echo actually drops. All audio is generated; nothing is recorded.
+        private static func runModelProbe(modelPath: String) -> Int32 {
+            let sampleRate = AudioConstants.targetSampleRate
+            let farEnd = probeFarEnd(seconds: 4)
+            // Half-level echo, with a deliberate partial trailing hop.
+            let mic = farEnd.dropLast(100).map { $0 * 0.5 }
+
+            // Bridge the async seam back to this pre-run-loop synchronous entry
+            // point. The semaphore orders the box write before the read.
+            final class ResultBox: @unchecked Sendable {
+                // Seeded, not optional: every path through the task body
+                // assigns before signalling, so an "absent result" case would be
+                // unreachable code with a permanent coverage hole behind it.
+                var result: Result<[Float], any Error> = .failure(
+                    EchoCancellationError.processingFailed(code: -1, message: "probe task delivered no result"),
+                )
+            }
+            let box = ResultBox()
+            let semaphore = DispatchSemaphore(value: 0)
+            Task.detached {
+                do {
+                    box.result = try await .success(
+                        LocalVQECanceller(modelPath: modelPath)
+                            .cancelEcho(mic: mic, reference: farEnd),
+                    )
+                } catch {
+                    box.result = .failure(error)
+                }
+                semaphore.signal()
+            }
+            semaphore.wait()
+
+            switch box.result {
+            case let .success(output):
+                guard output.count == mic.count, output.allSatisfy(\.isFinite) else {
+                    print("localvqe-selftest: FAIL — bad output shape (\(output.count) for \(mic.count) in)")
+                    return 1
+                }
+                // Skip the first second: the canceller converges from zero state.
+                let verdict = EchoReductionVerdict.measure(mic: mic[sampleRate...], output: output[sampleRate...])
+                print(String(
+                    format: "localvqe-selftest: echo-only %.1f dBFS -> %.1f dBFS (%.1f dB reduction)",
+                    verdict.beforeDbfs, verdict.afterDbfs, verdict.reductionDb,
+                ))
+                guard verdict.passes else {
+                    print("localvqe-selftest: FAIL — echo-only input barely attenuated")
+                    return 1
+                }
+                print("LOCALVQE_SELFTEST_OK model")
+                return 0
+
+            case let .failure(error):
+                print("localvqe-selftest: FAIL — \(error)")
+                return 1
+            }
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -70,7 +70,8 @@ private struct WindowAccessor: NSViewRepresentable {
     }
 }
 
-@main
+// Not @main — AppLauncher owns the entry point so a selftest launch can
+// divert before this scene (and AppState with it) is ever constructed.
 struct MeetingTranscriberApp: App {
     @State private var appState = AppState(notifier: NotificationManager.shared)
     @State private var captionsWindow: LiveCaptionsWindowController?

--- a/app/MeetingTranscriber/Tests/EchoFrameChunkingTests.swift
+++ b/app/MeetingTranscriber/Tests/EchoFrameChunkingTests.swift
@@ -1,0 +1,81 @@
+// Pure-logic tests for EchoFrameChunking: the hop arithmetic that slices a
+// signal into fixed-size frames for the LocalVQE streaming API, including the
+// zero-padded trailing partial hop. No model, no C library — runs everywhere.
+@testable import MeetingTranscriber
+import XCTest
+
+final class EchoFrameChunkingTests: XCTestCase {
+    // MARK: - Hop count
+
+    func testEmptySignalHasNoHops() {
+        let chunking = EchoFrameChunking(totalSamples: 0, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 0)
+    }
+
+    func testExactMultipleSplitsIntoFullHops() {
+        let chunking = EchoFrameChunking(totalSamples: 1024, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 4)
+        for index in 0 ..< 4 {
+            XCTAssertEqual(chunking.hop(index).start, index * 256)
+            XCTAssertEqual(chunking.hop(index).validSamples, 256)
+        }
+    }
+
+    func testRemainderAddsOnePartialTrailingHop() {
+        let chunking = EchoFrameChunking(totalSamples: 1000, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 4)
+        XCTAssertEqual(chunking.hop(3).start, 768)
+        XCTAssertEqual(chunking.hop(3).validSamples, 1000 - 768)
+    }
+
+    func testSignalShorterThanOneHopIsASinglePartialHop() {
+        let chunking = EchoFrameChunking(totalSamples: 100, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 1)
+        XCTAssertEqual(chunking.hop(0).start, 0)
+        XCTAssertEqual(chunking.hop(0).validSamples, 100)
+    }
+
+    func testSingleSampleIsAPartialHop() {
+        let chunking = EchoFrameChunking(totalSamples: 1, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 1)
+        XCTAssertEqual(chunking.hop(0).validSamples, 1)
+    }
+
+    func testOneSampleOverAMultipleYieldsPartialTrailingHop() {
+        let chunking = EchoFrameChunking(totalSamples: 257, hopLength: 256)
+        XCTAssertEqual(chunking.hopCount, 2)
+        XCTAssertEqual(chunking.hop(1).start, 256)
+        XCTAssertEqual(chunking.hop(1).validSamples, 1)
+    }
+
+    // MARK: - Hop buffer filling
+
+    func testFillHopCopiesFullWindow() {
+        let signal: [Float] = (0 ..< 8).map(Float.init)
+        var buffer = [Float](repeating: -1, count: 4)
+        EchoFrameChunking.fillHop(from: signal, start: 4, into: &buffer)
+        XCTAssertEqual(buffer, [4, 5, 6, 7])
+    }
+
+    func testFillHopZeroPadsPastEndOfSignal() {
+        let signal: [Float] = [1, 2, 3]
+        var buffer = [Float](repeating: -1, count: 4)
+        EchoFrameChunking.fillHop(from: signal, start: 2, into: &buffer)
+        XCTAssertEqual(buffer, [3, 0, 0, 0])
+    }
+
+    func testFillHopEntirelyPastEndIsAllZeros() {
+        // The reference track may be shorter than the mic track; hops beyond
+        // its end must read as silence, not stale buffer contents.
+        let signal: [Float] = [1, 2]
+        var buffer = [Float](repeating: -1, count: 4)
+        EchoFrameChunking.fillHop(from: signal, start: 8, into: &buffer)
+        XCTAssertEqual(buffer, [0, 0, 0, 0])
+    }
+
+    func testFillHopFromEmptySignalIsAllZeros() {
+        var buffer = [Float](repeating: -1, count: 4)
+        EchoFrameChunking.fillHop(from: [], start: 0, into: &buffer)
+        XCTAssertEqual(buffer, [0, 0, 0, 0])
+    }
+}

--- a/app/MeetingTranscriber/Tests/LocalVQECancellerTests.swift
+++ b/app/MeetingTranscriber/Tests/LocalVQECancellerTests.swift
@@ -1,0 +1,92 @@
+// Tests for LocalVQECanceller, the EchoCancelling seam over the vendored
+// LocalVQE C API. The always-on tests exercise the linked static library
+// (context creation failure + error reporting) without any model file. Tests
+// that need a real .gguf model skip unless MEETINGTRANSCRIBER_LOCALVQE_MODEL
+// points at one — the model is not bundled with the repository.
+@testable import MeetingTranscriber
+import XCTest
+
+final class LocalVQECancellerTests: XCTestCase {
+    // MARK: - Always-on (no model required)
+
+    func testEmptyInputReturnsEmptyWithoutLoadingTheModel() async throws {
+        // A nonexistent model path proves the short-circuit: reaching
+        // localvqe_new would throw modelLoadFailed instead.
+        let canceller = LocalVQECanceller(modelPath: "/nonexistent/model.gguf")
+        let out = try await canceller.cancelEcho(mic: [], reference: [])
+        XCTAssertEqual(out, [])
+    }
+
+    func testMissingModelThrowsModelLoadFailedWithLibraryMessage() async {
+        let canceller = LocalVQECanceller(modelPath: "/nonexistent/model.gguf")
+        do {
+            _ = try await canceller.cancelEcho(mic: [0.1, 0.2], reference: [0.1, 0.2])
+            XCTFail("expected modelLoadFailed")
+        } catch let EchoCancellationError.modelLoadFailed(message) {
+            // The message comes from localvqe_last_error — pin only that the
+            // plumbing carries something through, not the exact wording.
+            XCTAssertFalse(message.isEmpty)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Model-gated (skip when no .gguf is available)
+
+    func testOutputMatchesInputLengthIncludingPartialTrailingHop() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 2, seed: 7)
+        // Deliberately not a multiple of the 256-sample hop.
+        let mic = Array(farEnd.prefix(farEnd.count - 100))
+        let out = try await LocalVQECanceller(modelPath: model)
+            .cancelEcho(mic: mic, reference: farEnd)
+        XCTAssertEqual(out.count, mic.count)
+        XCTAssertTrue(out.allSatisfy(\.isFinite))
+    }
+
+    func testPureEchoIsAttenuated() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 4, seed: 11)
+        // Mic hears only the loudspeaker at reduced level — the canonical
+        // far-end-only case every AEC must attenuate.
+        let mic = EchoTestAudio.bleed(farEnd, delayMs: 0, gain: 0.5)
+        let out = try await LocalVQECanceller(modelPath: model)
+            .cancelEcho(mic: mic, reference: farEnd)
+        // Ignore the first second: the canceller converges from zero state.
+        let settled = EchoTestAudio.rate
+        let beforeDb = AudioMixer.rmsDecibels(samples: Array(mic[settled...]))
+        let afterDb = AudioMixer.rmsDecibels(samples: Array(out[settled...]))
+        // Measured ~50 dB on this signal with the 200K AEC model; the 6 dB
+        // floor is a plumbing gate with wide headroom, not a quality bar.
+        XCTAssertGreaterThan(
+            beforeDb - afterDb, EchoReductionVerdict.minReductionDb,
+            "echo-only input should drop by more than the probe floor",
+        )
+    }
+
+    func testCancellationStopsTheFrameLoop() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 2, seed: 3)
+        let mic = EchoTestAudio.bleed(farEnd, delayMs: 0, gain: 0.5)
+        let task = Task {
+            try await LocalVQECanceller(modelPath: model)
+                .cancelEcho(mic: mic, reference: farEnd)
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+    }
+
+    func testShortReferenceIsZeroPaddedNotCrashing() async throws {
+        let model = try requireLocalVQEModel()
+        let mic = EchoTestAudio.speechLike(seconds: 1, seed: 5)
+        let reference = Array(mic.prefix(1000))
+        let out = try await LocalVQECanceller(modelPath: model)
+            .cancelEcho(mic: mic, reference: reference)
+        XCTAssertEqual(out.count, mic.count)
+    }
+}

--- a/app/MeetingTranscriber/Tests/LocalVQESelftestTests.swift
+++ b/app/MeetingTranscriber/Tests/LocalVQESelftestTests.swift
@@ -1,0 +1,94 @@
+// Pure-logic tests for the LocalVQE selftest argument parsing — the decision
+// AppLauncher uses to divert a launch into the bundle probe instead of the
+// GUI. The probe itself runs only via scripts/localvqe-bundle-check.sh.
+#if !APPSTORE
+    @testable import MeetingTranscriber
+    import XCTest
+
+    final class LocalVQESelftestTests: XCTestCase {
+        func testAbsentFlagMeansNormalLaunch() {
+            XCTAssertNil(LocalVQESelftest.parse(arguments: ["/path/to/app"]))
+            XCTAssertNil(LocalVQESelftest.parse(arguments: ["/path/to/app", "--auto-watch"]))
+        }
+
+        func testBareFlagRunsLinkOnlyProbe() {
+            let mode = LocalVQESelftest.parse(arguments: ["/path/to/app", "--localvqe-selftest"])
+            XCTAssertEqual(mode, .linkOnly)
+        }
+
+        func testFlagWithPathRunsModelProbe() {
+            let mode = LocalVQESelftest.parse(
+                arguments: ["/path/to/app", "--localvqe-selftest", "/tmp/model.gguf"],
+            )
+            XCTAssertEqual(mode, .model(path: "/tmp/model.gguf"))
+        }
+
+        func testFollowingFlagIsNotMistakenForAModelPath() {
+            let mode = LocalVQESelftest.parse(
+                arguments: ["/path/to/app", "--localvqe-selftest", "--auto-watch"],
+            )
+            XCTAssertEqual(mode, .linkOnly)
+        }
+
+        // MARK: - In-process probe runs (no model required)
+
+        func testLinkOnlyProbeRunsTheLinkedLibraryAndSucceeds() {
+            // The same code path the bundle check drives, minus the bundle:
+            // backend listing plus the clean bogus-model failure.
+            XCTAssertEqual(LocalVQESelftest.run(.linkOnly), 0)
+        }
+
+        func testModelProbeFailsCleanlyWhenTheModelCannotLoad() {
+            // Exercises runModelProbe's async bridge and its failure branch.
+            XCTAssertEqual(LocalVQESelftest.run(.model(path: "/nonexistent/model.gguf")), 1)
+        }
+
+        func testModelProbeSucceedsWithARealModel() throws {
+            let model = try requireLocalVQEModel()
+            XCTAssertEqual(LocalVQESelftest.run(.model(path: model)), 0)
+        }
+
+        // MARK: - Probe tone
+
+        func testProbeToneMatchesLengthAndStaysWithinHalfScale() {
+            let tone = LocalVQESelftest.probeFarEnd(seconds: 2)
+            XCTAssertEqual(tone.count, 2 * AudioConstants.targetSampleRate)
+            // The C API wants [-1, 1]; the tone deliberately keeps 6 dB of
+            // headroom so the half-level mic copy stays well inside too.
+            XCTAssertLessThanOrEqual(tone.map(abs).max() ?? 1, 0.5)
+            // And it must not be silence, or the verdict divides noise floors.
+            XCTAssertGreaterThan(AudioMixer.rmsDecibels(samples: tone), -40)
+        }
+
+        // MARK: - Reduction verdict
+
+        // No test asserting `minReductionDb == 6`: that only fails when someone
+        // deliberately edits the constant, and the two boundary cases below pin
+        // the rule behaviourally, which is the assertion with meaning.
+
+        func testVerdictFailsWhenTheEchoDoesNotDrop() {
+            // The regression this type exists to prevent: an output identical
+            // to the mic input must never pass the probe.
+            let verdict = EchoReductionVerdict(beforeDbfs: -20, afterDbfs: -20)
+            XCTAssertEqual(verdict.reductionDb, 0, accuracy: 0.01)
+            XCTAssertFalse(verdict.passes)
+        }
+
+        func testVerdictAroundTheThreshold() {
+            let floor = EchoReductionVerdict.minReductionDb
+            XCTAssertFalse(EchoReductionVerdict(beforeDbfs: -20, afterDbfs: -20 - floor + 1).passes)
+            XCTAssertTrue(EchoReductionVerdict(beforeDbfs: -20, afterDbfs: -20 - floor - 1).passes)
+        }
+
+        // Measurement is tested separately from the decision, because only this
+        // one needs audio: it pins that `measure` reads the two levels off the
+        // slices it is given rather than off the whole track.
+        func testMeasureReadsTheLevelsOffTheGivenSlices() {
+            let mic = LocalVQESelftest.probeFarEnd(seconds: 1)
+            let quiet = mic.map { $0 * 0.001 }
+            let verdict = EchoReductionVerdict.measure(mic: mic[...], output: quiet[...])
+            XCTAssertEqual(verdict.reductionDb, 60, accuracy: 0.1)
+            XCTAssertTrue(verdict.passes)
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -105,6 +105,18 @@ func shouldSkipForE2EGate(env: [String: String]) -> Bool {
 }
 
 extension XCTestCase {
+    /// Path to a LocalVQE AEC .gguf model for the echo-cancellation seam
+    /// tests. The model is deliberately not bundled with the repository, so
+    /// model-dependent tests skip cleanly when the opt-in env var is unset
+    /// or dangling.
+    func requireLocalVQEModel() throws -> String {
+        guard let path = ProcessInfo.processInfo.environment["MEETINGTRANSCRIBER_LOCALVQE_MODEL"],
+              FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Set MEETINGTRANSCRIBER_LOCALVQE_MODEL to a LocalVQE .gguf to run")
+        }
+        return path
+    }
+
     func skipIfCIWithoutE2EOptIn(_ reason: String) throws {
         try XCTSkipIf(
             shouldSkipForE2EGate(env: ProcessInfo.processInfo.environment),

--- a/scripts/localvqe-bundle-check.sh
+++ b/scripts/localvqe-bundle-check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Verify the vendored LocalVQE static library works from inside the signed
+# .app bundle that build_release.sh produces — not only from a SwiftPM build
+# directory. The library resolves its compute backends relative to the
+# executable's own path (visible in its "self-resolved from ..." log line), so
+# Contents/MacOS placement is the case that needs proving, and this script is
+# that check.
+#
+# Usage:
+#   ./scripts/localvqe-bundle-check.sh [--no-build]
+#
+#   --no-build   Reuse an existing .build/release/MeetingTranscriber.app
+#                  instead of rebuilding.
+#
+# Environment:
+#   MEETINGTRANSCRIBER_LOCALVQE_MODEL
+#       Optional path to a LocalVQE AEC .gguf. When set, a full streaming
+#       pass over synthetic audio runs through the model from inside the
+#       bundle. Without it only the link-level probe runs — the model is
+#       deliberately not bundled with the app.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_BUNDLE="$PROJECT_ROOT/.build/release/MeetingTranscriber.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/MeetingTranscriber"
+
+SKIP_BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-build) SKIP_BUILD=true ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$SKIP_BUILD" = false ] || [ ! -x "$APP_BINARY" ]; then
+    "$SCRIPT_DIR/build_release.sh" --no-notarize
+fi
+
+echo ""
+echo "=== localvqe-bundle-check ==="
+codesign --verify --deep --strict "$APP_BUNDLE"
+echo "Bundle signature verified: $APP_BUNDLE"
+
+# Tier 1 — link-level probe, no model: backend registration + clean failure
+# of a bogus model load, executed from Contents/MacOS.
+echo ""
+echo "--- link-only probe ---"
+LINK_OUT="$("$APP_BINARY" --localvqe-selftest 2>&1)" || {
+    echo "$LINK_OUT"
+    echo "FAIL: link-only selftest exited non-zero" >&2
+    exit 1
+}
+echo "$LINK_OUT"
+grep -q "LOCALVQE_SELFTEST_OK link-only" <<< "$LINK_OUT" || {
+    echo "FAIL: link-only success marker missing" >&2
+    exit 1
+}
+
+# Tier 2 — full streaming pass through a real model, when one is available.
+if [ -n "${MEETINGTRANSCRIBER_LOCALVQE_MODEL:-}" ]; then
+    echo ""
+    echo "--- model probe ($MEETINGTRANSCRIBER_LOCALVQE_MODEL) ---"
+    MODEL_OUT="$("$APP_BINARY" --localvqe-selftest "$MEETINGTRANSCRIBER_LOCALVQE_MODEL" 2>&1)" || {
+        echo "$MODEL_OUT"
+        echo "FAIL: model selftest exited non-zero" >&2
+        exit 1
+    }
+    echo "$MODEL_OUT"
+    grep -q "LOCALVQE_SELFTEST_OK model" <<< "$MODEL_OUT" || {
+        echo "FAIL: model success marker missing" >&2
+        exit 1
+    }
+else
+    echo ""
+    echo "MEETINGTRANSCRIBER_LOCALVQE_MODEL not set — skipped the model pass."
+fi
+
+echo ""
+echo "localvqe-bundle-check: OK"


### PR DESCRIPTION
## What this is

The integration seam for LocalVQE echo cancellation: vendoring plus wrapper only. Nothing consumes it yet, deliberately. No pipeline wiring, no settings surface, no bundled model; those are later steps. This PR exists to settle whether the vendored library works from inside the shipped app bundle at all.

- **`CLocalVQE` binary target.** SwiftPM downloads the static xcframework from a pinned release asset ([localvqe-xcframework 1.0.2](https://github.com/pasrom/localvqe-xcframework/releases/tag/1.0.2)) and verifies its SHA-256 before linking; no binary enters repo history. The archive is genuinely static: the linked app gains no new dynamic-library dependencies (`otool -L` shows system libraries only). The asset is publicly fetchable, and the committed checksum was re-verified against a fresh unauthenticated download.
- **`EchoCancelling` + `LocalVQECanceller`.** Context lifecycle (`localvqe_new`/`localvqe_free` with `defer`), the streaming frame loop (`localvqe_process_frame_f32`, 256-sample hops read from `localvqe_hop_length` at runtime), a zero-padded trailing partial hop trimmed back out of the output, `Task.checkCancellation()` between hops plus a periodic yield so a long recording cannot pin a cooperative thread, and error passthrough from `localvqe_last_error`. No time alignment is performed in either direction; the seam passes both tracks through as given.
- **`EchoFrameChunking`.** The hop and partial-hop arithmetic as a pure value type, tested without the C library.
- **`--localvqe-selftest` + `scripts/localvqe-bundle-check.sh`.** The signed-bundle probe, below.

## The result the PR exists for: the signed-bundle check

The library resolves its compute backends relative to the executable's own path. The link spike proved that from a SwiftPM build directory; inside a `.app` bundle the executable sits at `Contents/MacOS/`, which was untested and the most likely thing to break.

**Observed: it works, identically to the build-dir case.** `scripts/localvqe-bundle-check.sh` built the bundle via `build_release.sh --no-notarize` (signed, Apple Development identity), verified the signature (`codesign --verify --deep --strict`), and ran the probe from inside the bundle. Link-level probe, no model:

```
localvqe: loading embedded backends from '.../MeetingTranscriber.app/Contents/MacOS'
  (self-resolved from '.../MeetingTranscriber.app/Contents/MacOS/MeetingTranscriber')
Registered backends (2):
  BLAS (1 device)
    [0] BLAS — Accelerate (ACCEL)
  CPU (1 device)
    [0] CPU — Apple M3 Max (CPU)
localvqe: cannot open '/nonexistent/localvqe-selftest.gguf'
localvqe-selftest: bogus model load failed as expected (null context)
LOCALVQE_SELFTEST_OK link-only
```

Full streaming pass through `LocalVQECanceller` with a local AEC .gguf supplied via `MEETINGTRANSCRIBER_LOCALVQE_MODEL` (the model is a local artifact, not part of this PR):

```
localvqe: backend=CPU device[0]=CPU (Apple M3 Max) threads=4
localvqe: DAF front-end active (203K cascade)
Graph model: 159 tensors, n_fft=512, dmax=16
localvqe-selftest: echo-only -18.8 dBFS -> -75.8 dBFS (57.0 dB reduction)
LOCALVQE_SELFTEST_OK model
```

The probe enforces the reduction rather than only printing it: below a 6 dB floor it exits non-zero. The same bundle was additionally re-signed with hardened runtime (`--options runtime`, the notarized shipping shape) and the model probe re-run with identical results. The probe signal is a synthetic 440 Hz amplitude-wobbled tone with the mic track a half-level copy of the far end; the dB figure is a link-level health signal, not a quality benchmark.

The check stays cheap: the model pass only runs when a model path is supplied, and `--skip-build` reuses an existing bundle.

## A diagnostic entry point now exists in the shipped binary, and how it is bounded

To make the probe runnable from inside the real bundle, `@main` moved from `MeetingTranscriberApp` to a small `AppLauncher` enum (SwiftUI's `App.main()` is a protocol requirement, so the App type cannot intercept its own launch without recursing into itself). Bounds:

- **App Store variant: compiled out entirely** (`#if !APPSTORE`, the same policy as the debug RPC server). The sandboxed build contains no selftest code; `AppLauncher` falls straight through to `MeetingTranscriberApp.main()`.
- **Homebrew variant: reachable only by the explicit `--localvqe-selftest` argv flag.** No environment variable, URL handler, or notification reaches it. It constructs no app state (the diversion happens before `AppState` exists), reads nothing user-related, writes nothing, and exits.

## Tests

- Hop and partial-hop arithmetic plus selftest argument parsing: pure, run everywhere.
- Two canceller tests exercise the linked library with **no model** (bogus-path load failure surfaces the library's error string; empty input short-circuits), so every `swift test` run proves the binary target links and the C ABI is callable.
- Model-dependent tests (output length across a partial trailing hop, finiteness, echo attenuation, cancellation mid-stream, short-reference zero-padding) skip cleanly unless `MEETINGTRANSCRIBER_LOCALVQE_MODEL` points at a `.gguf`. Verified in both modes: 20 executed / 0 skipped with a model, 20 executed / 4 skipped without.
- All audio in tests and the selftest is synthesized (the shared `EchoTestAudio` generator on the test side); no recordings are used. Attenuation on the speech-like signal measured about 50 dB with the 200K AEC model, so the tests' 6 dB assertion keeps wide headroom.

## Deliberately out of scope

- No `.gguf` model bundled or downloaded.
- No wiring into `PipelineQueue`, `AppSettings`, or the UI.
- No alignment or offset logic; whether the library tolerates inter-track delay is a property to establish later, not to assume here.

## Local gates (all on the final revision)

- `./scripts/lint.sh`: 0 violations, 0 serious in 487 files.
- `cd app/MeetingTranscriber && swift test --parallel`: exit 0, all 2834 tests, zero failures.
- `./scripts/pre-push.sh`: passed. `./scripts/pre-push.sh --with-appstore --with-tests`: passed, so the `#if !APPSTORE` gating compiles in release mode for both variants.
- `xcodebuild build-for-testing` + `swiftlint analyze --strict` (the CI analyze recipe): 0 violations.
- `MEETINGTRANSCRIBER_LOCALVQE_MODEL=<local .gguf> ./scripts/localvqe-bundle-check.sh`: OK (output quoted above).

One library behavior worth knowing for later steps: after a failed `localvqe_new`, the global `localvqe_last_error(0)` returns only a generic "null context"; the specific reason ("cannot open ...") goes to stderr. The wrapper passes the library's message through verbatim, so consumers should not expect a detailed load-failure reason from the thrown error alone.
