### PR TITLE
fix(app): guide protocol prompts when no meeting start was captured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 **Protocol generation:**
 - `ProtocolGenerating` protocol with two implementations: `ClaudeCLIProtocolGenerator` and `OpenAIProtocolGenerator`.
 - `AppSettings.protocolProvider` enum (`.claudeCLI` / `.openAICompatible` / `.none`) selects the provider. `.none` skips LLM generation and saves the transcript only.
-- `AppSettings.protocolLanguage` string (default `"German"`) is substituted into the prompt as `{LANGUAGE}`. `{MEETING_DATE}` (`YYYY-MM-DD`) and `{MEETING_TIME}` (`HH:mm`) resolve from a captured recording start time, or to `Unknown` for imports and recovery jobs. Only a captured recording start adds the authoritative meeting-metadata preamble, so processing time is never presented as a meeting time.
+- `AppSettings.protocolLanguage` string (default `"German"`) is substituted into the prompt as `{LANGUAGE}`. `{MEETING_DATE}` (`YYYY-MM-DD`) and `{MEETING_TIME}` (`HH:mm`) resolve from a captured recording start time, or to `Unknown` for imports and recovery jobs, whose prompts open with guidance to use a date or time the transcript states for the meeting itself and otherwise keep `Unknown`. Only a captured recording start adds the authoritative meeting-metadata preamble, so processing time is never presented as a meeting time.
 - `ProtocolGenerator.loadPrompt()` loads custom prompt from `AppPaths.customPromptFile` (`~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`), falls back to built-in default.
 - `OpenAIProtocolGenerator` supports any OpenAI-compatible HTTP API (Ollama, LM Studio, llama.cpp, etc.).
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ flowchart TD
 - **Speaker recognition** — Voice embeddings stored across meetings, matched via cosine similarity
 - **VAD preprocessing** — Optional silence trimming via FluidAudio Silero v6 before transcription, with automatic timestamp remapping
 - **AI protocol generation** — Structured Markdown via [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code), OpenAI-compatible APIs (Ollama, LM Studio, etc.), or disabled (save transcript only)
-- **Configurable protocol prompt** — Custom prompt file support (`~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`) with `{LANGUAGE}`, `{MEETING_DATE}` (`YYYY-MM-DD`), and `{MEETING_TIME}` (`HH:mm`) variables; recordings include authoritative metadata, while imports and recovery jobs resolve time placeholders to `Unknown`
+- **Configurable protocol prompt** — Custom prompt file support (`~/Library/Application Support/MeetingTranscriber/protocol_prompt.md`) with `{LANGUAGE}`, `{MEETING_DATE}` (`YYYY-MM-DD`), and `{MEETING_TIME}` (`HH:mm`) variables; recordings include authoritative metadata, while imports and recovery jobs resolve time placeholders to `Unknown` and the prompt tells the model to prefer a date or time the transcript states for the meeting itself, never the processing time
 - **Manual recording** — Record any app via app picker, not just detected meetings
 - **Multi-format input** — Supports WAV, MP3, M4A, MP4, FLAC, plus the phone and messenger voice formats AMR, 3GP/3G2 and OPUS/OGG; MKV and WebM additionally need ffmpeg
 - **Update checker** — Notifies when a new version is available

--- a/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ProtocolGenerator.swift
@@ -111,7 +111,8 @@ enum ProtocolGenerator {
     /// Build the system prompt from an optional authoritative meeting-time context,
     /// loaded prompt with variables replaced, and optional `diarizationNote`.
     /// Imports and recovery jobs have no reliable meeting start and therefore
-    /// receive no authoritative time anchor. Excludes the transcript itself —
+    /// receive no authoritative time anchor, only guidance on how to fill the
+    /// unknown date and time. Excludes the transcript itself —
     /// callers append or attach it as they see fit.
     ///
     /// `promptURL` is forwarded to `loadPrompt` and exists for the same reason:
@@ -149,8 +150,24 @@ enum ProtocolGenerator {
         )
     }
 
+    /// Prepends time context to the system prompt. With a captured start this
+    /// is the authoritative metadata block. Without one it is guidance instead
+    /// of silence, because the template header reproduces the substituted
+    /// `Unknown` literally: the model may adopt a date or time the transcript
+    /// states for this meeting itself, but must not promote a deadline or an
+    /// unrelated mentioned date, and must never fall back to the current date
+    /// or the processing time. The guidance lives here and not in the
+    /// substituted values, so placeholders stay short scalars for custom
+    /// prompts and no English instruction lands inside the reproduced header.
     private static func meetingTimeContext(metadata: MeetingPromptMetadata?) -> String {
-        guard let metadata else { return "" }
+        guard let metadata else {
+            return [
+                "No reliable meeting start time was captured for this recording.",
+                "If the transcript states when this meeting itself took place, use that",
+                "date and time; otherwise leave them as Unknown. Never substitute the",
+                "current date or the processing time.",
+            ].joined(separator: "\n") + "\n\n"
+        }
         return [
             "Meeting metadata:",
             "Date: \(metadata.date)",

--- a/app/MeetingTranscriber/Tests/MeetingPromptMetadataTests.swift
+++ b/app/MeetingTranscriber/Tests/MeetingPromptMetadataTests.swift
@@ -23,7 +23,55 @@ final class MeetingPromptMetadataTests: XCTestCase {
             promptURL: url,
         )
 
-        XCTAssertEqual(prompt, "Date: Unknown; Time: Unknown.")
+        // Guidance about the unknown start is fine; an authority claim is not.
+        // Equality pins that the placeholders stay a short scalar (custom
+        // prompts may embed them in front matter or table cells) and that the
+        // guidance scopes any transcript-stated date to this meeting itself.
+        XCTAssertEqual(
+            prompt,
+            """
+            No reliable meeting start time was captured for this recording.
+            If the transcript states when this meeting itself took place, use that
+            date and time; otherwise leave them as Unknown. Never substitute the
+            current date or the processing time.
+
+            Date: Unknown; Time: Unknown.
+            """,
+        )
         XCTAssertFalse(prompt.localizedCaseInsensitiveContains("authoritative"))
+    }
+
+    func testBuiltInTemplateHeaderResolvesToUnknownWithGuidance() {
+        // The prompt file is never created, so loadPrompt falls back to the
+        // built-in default template, the one whose reproduced header showed
+        // the defect. The other tests inject their own template, which leaves
+        // the shipped header unasserted.
+        let url = makeTempFile(suffix: ".md")
+        let prompt = ProtocolGenerator.buildSystemPrompt(
+            diarized: false,
+            language: "German",
+            meetingStartTime: nil,
+            promptURL: url,
+        )
+
+        XCTAssertTrue(prompt.contains("**Date:** Unknown"))
+        XCTAssertTrue(prompt.contains("**Time:** Unknown"))
+        XCTAssertTrue(prompt.contains("No reliable meeting start time was captured"))
+    }
+
+    func testPromptWithoutMeetingStartNeverMentionsToday() {
+        // Invariant, deliberately looser than string equality: no rewording
+        // of the guidance or the built-in template may quietly reintroduce
+        // "or today", because presenting the processing day as the meeting
+        // day was the defect the captured-start feature fixed.
+        let url = makeTempFile(suffix: ".md")
+        let prompt = ProtocolGenerator.buildSystemPrompt(
+            diarized: false,
+            language: "German",
+            meetingStartTime: nil,
+            promptURL: url,
+        )
+
+        XCTAssertFalse(prompt.localizedCaseInsensitiveContains("today"))
     }
 }

--- a/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ProtocolGeneratorTests.swift
@@ -227,6 +227,10 @@ final class ProtocolGeneratorTests: XCTestCase {
             promptURL: url,
         )
 
+        // Equality also pins that the injected URL is honoured (reading the
+        // shared user file or the built-in default would not produce this
+        // exact string) and that the authoritative metadata block precedes
+        // the loaded prompt verbatim.
         XCTAssertEqual(
             prompt,
             """

--- a/docs/architecture-macos.md
+++ b/docs/architecture-macos.md
@@ -519,7 +519,7 @@ When dual-source recording (app + mic) is available:
 - **`.openAICompatible`** — Any OpenAI-compatible HTTP API (Ollama, LM Studio, llama.cpp, etc.)
 - **`.none`** — Skip LLM generation; save transcript only
 
-`AppSettings.protocolLanguage` (default `"German"`) is substituted into the prompt as `{LANGUAGE}`. Custom prompts can also use `{MEETING_DATE}` (`YYYY-MM-DD`) and `{MEETING_TIME}` (`HH:mm`), derived from the captured recording start time. Imports and recovery jobs resolve those time placeholders to `Unknown` rather than their enqueue or processing time. Only recordings with a captured start receive the authoritative meeting-metadata block, so existing custom prompts receive reliable temporal context without needing to add the placeholders.
+`AppSettings.protocolLanguage` (default `"German"`) is substituted into the prompt as `{LANGUAGE}`. Custom prompts can also use `{MEETING_DATE}` (`YYYY-MM-DD`) and `{MEETING_TIME}` (`HH:mm`), derived from the captured recording start time. Imports and recovery jobs resolve those time placeholders to `Unknown` rather than their enqueue or processing time, and their prompts open with guidance to use a date or time the transcript states for the meeting itself, keeping `Unknown` otherwise. Only recordings with a captured start receive the authoritative meeting-metadata block, so existing custom prompts receive reliable temporal context without needing to add the placeholders.
 
 ### Claude CLI Invocation
 


### PR DESCRIPTION
## What

Follow-up to #643. Since that change, a job with no captured recording start (file imports, crash recovery) substitutes `Unknown` for `{MEETING_DATE}` / `{MEETING_TIME}`, and those placeholders sit inside the built-in template's output structure that the model is told to reproduce verbatim. An imported recording therefore produced a protocol header literally reading `**Date:** Unknown`, with no instruction anywhere on what to do about it.

The placeholders keep resolving to the short scalar `Unknown`. Instead, when no start was captured, the system prompt now opens with guidance in the same preamble slot the authoritative metadata block uses:

> No reliable meeting start time was captured for this recording.
> If the transcript states when this meeting itself took place, use that
> date and time; otherwise leave them as Unknown. Never substitute the
> current date or the processing time.

Design points:

- Scoped to the meeting's own date: a deadline or a past event mentioned in the transcript must not be stamped into the header as the meeting date, and transcripts state clock times constantly without ever stating their own start.
- The common case (transcript states no date) stays deterministic: the header keeps `Unknown`.
- Guidance lives in the preamble, not in the substituted values, so custom prompts that embed the placeholders as short scalars (front matter, table cells) are unaffected and no English instruction lands inside a document whose output language is configurable.

Tests: a regression test now composes the prompt against the built-in default template (both existing tests injected their own) and pins what the header placeholders resolve to plus the guidance; an invariant test asserts the no-start prompt never contains "today", so a rewording cannot quietly reintroduce a current-date fallback. Docs updated at the three sites describing the placeholder resolution, and a dropped rationale comment on the system-prompt equality assertion is restored.

## Unchanged

The authoritative metadata block behaviour from #643 is untouched: a job without a captured start still receives no authoritative time anchor, and nothing reintroduces processing time or the current date as a fallback.