### PR TITLE
feat(app): boost transcription with custom vocabulary and terminology rules

### DIFF
--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -48,6 +48,9 @@ enum A11yID {
     /// only entry: a plain, non-secret text field whose write-back is readable in
     /// `/state`, which is what makes it a usable text-entry probe.
     static let micNameField = "micNameField"
+    static let customVocabularyPathField = "customVocabularyPathField"
+    static let whisperKitVocabularyPromptToggle = "whisperKitVocabularyPromptToggle"
+    static let terminologyRulesEditor = "terminologyRulesEditor"
 
     /// Settings sidebar row for one tab (`settings-tab-<rawValue>`). The detail
     /// pane renders only the selected tab, so a control in another tab is absent

--- a/app/MeetingTranscriber/Sources/AppSettings+Computed.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+Computed.swift
@@ -4,6 +4,29 @@ import Foundation
 /// `AppSettings.swift` purely to keep that file under the `file_length` limit;
 /// there is no behavioural difference from declaring these inline.
 extension AppSettings {
+    /// WhisperKit language as an optional value. Empty string means the engine
+    /// should auto-detect the language.
+    var whisperLanguageOrNil: String? {
+        whisperLanguage.isEmpty ? nil : whisperLanguage
+    }
+
+    /// Parakeet language hint as an optional value. Empty string means the
+    /// engine should auto-detect the language.
+    var parakeetLanguageOrNil: String? {
+        parakeetLanguage.isEmpty ? nil : parakeetLanguage
+    }
+
+    /// The active transcription engine's EXPLICITLY configured language
+    /// (ISO 639-1), or nil for auto-detect. Drives the live-caption streaming
+    /// backend (`LiveCaptionsGate`): `de` → Nemotron German streaming, `en` →
+    /// Parakeet EOU streaming, else → engine-driven re-transcribe.
+    var activeEngineLanguageOrNil: String? {
+        switch transcriptionEngine {
+        case .whisperKit: whisperLanguageOrNil
+        case .parakeet: parakeetLanguageOrNil
+        }
+    }
+
     /// The meeting apps the user opted to watch. Drives auto-detection: the
     /// `WatchingController` default detector keeps only the assertion patterns
     /// whose app is listed here (`PowerAssertionDetector.patterns(watching:)`),

--- a/app/MeetingTranscriber/Sources/AppSettings+Vocabulary.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings+Vocabulary.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+enum CustomVocabularyValidation: Equatable {
+    case notConfigured
+    case empty
+    case unavailable
+    case tooLarge
+    case tooManyTerms
+    case termTooLong
+    case ready(termCount: Int)
+
+    var message: String {
+        switch self {
+        case .notConfigured: "No vocabulary file selected."
+        case .empty: "Vocabulary file contains no terms."
+        case .unavailable: "Vocabulary file cannot be read."
+        case .tooLarge: "Vocabulary file is too large."
+        case .tooManyTerms: "Vocabulary file contains too many terms."
+        case .termTooLong: "Vocabulary file contains a term that is too long."
+        case let .ready(termCount): "Vocabulary file can be read: \(termCount) unique term\(termCount == 1 ? "" : "s")."
+        }
+    }
+}
+
+/// Security-scoped vocabulary-file handling. The plain path remains for UI
+/// display and migration from earlier releases; reads must use the resolved URL
+/// so the App Store build retains access after a relaunch.
+extension AppSettings {
+    var customVocabularyFile: URL? {
+        var isStale = false
+        guard let url = resolveCustomVocabularyFile(isStale: &isStale) else { return nil }
+        if isStale,
+           let refreshed = VocabularyFileAccess.withAccess(to: url, makeCustomVocabularyBookmark) {
+            updateCustomVocabularySelection(path: url.path, bookmark: refreshed)
+        }
+        return url
+    }
+
+    func setCustomVocabularyFile(_ url: URL) {
+        let bookmark = VocabularyFileAccess.withAccess(to: url) { scopedURL in
+            makeCustomVocabularyBookmark(for: scopedURL)
+        }
+        updateCustomVocabularySelection(path: url.path, bookmark: bookmark)
+        refreshCustomVocabularyValidation()
+    }
+
+    /// Handles manual path edits from the Settings text field. A bookmark is
+    /// tied to its original URL, so retaining it after a different path was
+    /// typed would silently read the wrong terminology file.
+    func setCustomVocabularyPath(_ path: String) {
+        guard path != customVocabularyPath else { return }
+        updateCustomVocabularySelection(path: path, bookmark: nil)
+        refreshCustomVocabularyValidation()
+    }
+
+    func clearCustomVocabularyFile() {
+        updateCustomVocabularySelection(path: "", bookmark: nil)
+        customVocabularyValidation = .notConfigured
+    }
+
+    func repairStaleCustomVocabularyBookmark() {
+        var isStale = false
+        guard let url = resolveCustomVocabularyFile(isStale: &isStale), isStale,
+              let refreshed = VocabularyFileAccess.withAccess(to: url, makeCustomVocabularyBookmark)
+        else { return }
+        updateCustomVocabularySelection(path: url.path, bookmark: refreshed)
+        refreshCustomVocabularyValidation()
+    }
+
+    func refreshCustomVocabularyValidation() {
+        guard let url = customVocabularyFile else {
+            customVocabularyValidation = customVocabularyPath.isEmpty ? .notConfigured : .unavailable
+            return
+        }
+        customVocabularyValidation = VocabularyFileAccess.withAccess(to: url) { url in
+            guard let revision = WhisperVocabularyPrompt.fileRevision(at: url.path) else { return .unavailable }
+            guard revision.fileSize <= UInt64(WhisperVocabularyPrompt.maximumFileBytes) else { return .tooLarge }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return .unavailable }
+            let terms = WhisperVocabularyPrompt.terms(from: contents)
+            guard !terms.isEmpty else { return .empty }
+            guard terms.count <= WhisperVocabularyPrompt.maximumTermCount else { return .tooManyTerms }
+            guard terms.allSatisfy({ $0.utf8.count <= WhisperVocabularyPrompt.maximumTermBytes }) else {
+                return .termTooLong
+            }
+            return .ready(termCount: terms.count)
+        }
+    }
+
+    private func resolveCustomVocabularyFile(isStale: inout Bool) -> URL? {
+        if let bookmark = customVocabularyBookmark,
+           let url = try? URL(
+               resolvingBookmarkData: bookmark,
+               options: .withSecurityScope,
+               relativeTo: nil,
+               bookmarkDataIsStale: &isStale,
+           ) {
+            return url
+        }
+        guard !customVocabularyPath.isEmpty else { return nil }
+        return URL(fileURLWithPath: customVocabularyPath)
+    }
+
+    private func makeCustomVocabularyBookmark(for url: URL) -> Data? {
+        try? url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -261,6 +261,11 @@ final class AppSettings {
         didSet { defaults.set(customVocabularyBookmark, forKey: "customVocabularyBookmark") }
     }
 
+    /// Experimental opt-in: WhisperKit's prompt can reduce transcript completeness.
+    var whisperKitVocabularyPromptEnabled: Bool {
+        didSet { defaults.set(whisperKitVocabularyPromptEnabled, forKey: "whisperKitVocabularyPromptEnabled") }
+    }
+
     func updateCustomVocabularySelection(path: String, bookmark: Data?) {
         customVocabularyPath = path
         customVocabularyBookmark = bookmark
@@ -486,6 +491,7 @@ final class AppSettings {
         parakeetLanguage = defaults.object(forKey: "parakeetLanguage") as? String ?? ""
         customVocabularyPath = defaults.string(forKey: "customVocabularyPath") ?? ""
         customVocabularyBookmark = defaults.data(forKey: "customVocabularyBookmark")
+        whisperKitVocabularyPromptEnabled = defaults.object(forKey: "whisperKitVocabularyPromptEnabled") as? Bool ?? false
         customVocabularyValidation = .notConfigured
         diarize = defaults.object(forKey: "diarize") as? Bool ?? true
         vadEnabled = defaults.object(forKey: "vadEnabled") as? Bool ?? false

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -271,6 +271,15 @@ final class AppSettings {
         customVocabularyBookmark = bookmark
     }
 
+    var terminologyRulesText: String {
+        didSet {
+            defaults.set(terminologyRulesText, forKey: "terminologyRulesText")
+            terminologyRulesValidation = TerminologyNormalizer(rulesText: terminologyRulesText).diagnostics
+        }
+    }
+
+    var terminologyRulesValidation: TerminologyNormalizer.Diagnostics
+
     /// Ephemeral UI status; recalculated when the selected vocabulary changes.
     var customVocabularyValidation: CustomVocabularyValidation
 
@@ -492,6 +501,9 @@ final class AppSettings {
         customVocabularyPath = defaults.string(forKey: "customVocabularyPath") ?? ""
         customVocabularyBookmark = defaults.data(forKey: "customVocabularyBookmark")
         whisperKitVocabularyPromptEnabled = defaults.object(forKey: "whisperKitVocabularyPromptEnabled") as? Bool ?? false
+        let savedTerminologyRules = defaults.string(forKey: "terminologyRulesText") ?? ""
+        terminologyRulesText = savedTerminologyRules
+        terminologyRulesValidation = TerminologyNormalizer(rulesText: savedTerminologyRules).diagnostics
         customVocabularyValidation = .notConfigured
         diarize = defaults.object(forKey: "diarize") as? Bool ?? true
         vadEnabled = defaults.object(forKey: "vadEnabled") as? Bool ?? false

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -243,11 +243,6 @@ final class AppSettings {
         didSet { defaults.set(whisperLanguage, forKey: "whisperLanguage") }
     }
 
-    /// Language as Optional for WhisperKit. Empty string → nil (auto-detect).
-    var whisperLanguageOrNil: String? {
-        whisperLanguage.isEmpty ? nil : whisperLanguage
-    }
-
     /// Parakeet language hint (ISO 639-1 code). Empty string = auto-detect.
     /// FluidAudio's v3 TDT decoder uses this for script-aware token filtering;
     /// auto-detect can drift Cyrillic ↔ Latin on multi-script audio.
@@ -258,26 +253,21 @@ final class AppSettings {
         didSet { defaults.set(parakeetLanguage, forKey: "parakeetLanguage") }
     }
 
-    /// Language as Optional for Parakeet. Empty string → nil (auto-detect).
-    var parakeetLanguageOrNil: String? {
-        parakeetLanguage.isEmpty ? nil : parakeetLanguage
-    }
-
-    /// The active transcription engine's EXPLICITLY configured language
-    /// (ISO 639-1), or nil for auto-detect. Drives the live-caption streaming
-    /// backend (`LiveCaptionsGate`): `de` → Nemotron German streaming, `en` →
-    /// Parakeet EOU streaming, else → engine-driven re-transcribe.
-    var activeEngineLanguageOrNil: String? {
-        switch transcriptionEngine {
-        case .whisperKit: whisperLanguageOrNil
-        case .parakeet: parakeetLanguageOrNil
-        }
-    }
-
-    /// Path to a custom vocabulary file for Parakeet CTC boosting (one term per line).
-    var customVocabularyPath: String {
+    private(set) var customVocabularyPath: String {
         didSet { defaults.set(customVocabularyPath, forKey: "customVocabularyPath") }
     }
+
+    private(set) var customVocabularyBookmark: Data? {
+        didSet { defaults.set(customVocabularyBookmark, forKey: "customVocabularyBookmark") }
+    }
+
+    func updateCustomVocabularySelection(path: String, bookmark: Data?) {
+        customVocabularyPath = path
+        customVocabularyBookmark = bookmark
+    }
+
+    /// Ephemeral UI status; recalculated when the selected vocabulary changes.
+    var customVocabularyValidation: CustomVocabularyValidation
 
     var diarize: Bool {
         didSet { defaults.set(diarize, forKey: "diarize") }
@@ -495,6 +485,8 @@ final class AppSettings {
         whisperLanguage = defaults.object(forKey: "whisperLanguage") as? String ?? "de"
         parakeetLanguage = defaults.object(forKey: "parakeetLanguage") as? String ?? ""
         customVocabularyPath = defaults.string(forKey: "customVocabularyPath") ?? ""
+        customVocabularyBookmark = defaults.data(forKey: "customVocabularyBookmark")
+        customVocabularyValidation = .notConfigured
         diarize = defaults.object(forKey: "diarize") as? Bool ?? true
         vadEnabled = defaults.object(forKey: "vadEnabled") as? Bool ?? false
         vadThreshold = defaults.object(forKey: "vadThreshold") as? Float ?? 0.5
@@ -543,6 +535,7 @@ final class AppSettings {
         #endif
         checkForUpdates = defaults.object(forKey: "checkForUpdates") as? Bool ?? true
         includePreReleases = defaults.object(forKey: "includePreReleases") as? Bool ?? false
+        refreshCustomVocabularyValidation()
     }
 
     /// Bag of values used during init to read all 5 tuning knobs in one go.

--- a/app/MeetingTranscriber/Sources/AppState.swift
+++ b/app/MeetingTranscriber/Sources/AppState.swift
@@ -200,6 +200,7 @@ final class AppState {
         // during view updates, and repairing there would write observed state
         // mid-`body`.
         settings.repairStaleCustomOutputDirBookmark()
+        settings.repairStaleCustomVocabularyBookmark()
         return settings
     }
 

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -97,6 +97,15 @@ final class EngineController {
             whisperKit.applyModelVariant(settings.whisperKitModel)
             let next = settings.whisperLanguageOrNil
             if whisperKit.language != next { whisperKit.language = next }
+            let nextVocab = settings.customVocabularyPath
+            if whisperKit.customVocabularyPath != nextVocab { whisperKit.customVocabularyPath = nextVocab }
+            let nextBookmark = settings.customVocabularyBookmark
+            if whisperKit.customVocabularyBookmark != nextBookmark { whisperKit.customVocabularyBookmark = nextBookmark }
+            let nextVocabularyPromptEnabled = settings.whisperKitVocabularyPromptEnabled
+            if whisperKit.vocabularyPromptEnabled != nextVocabularyPromptEnabled {
+                whisperKit.vocabularyPromptEnabled = nextVocabularyPromptEnabled
+            }
+
         case .parakeet:
             let nextVocab = settings.customVocabularyPath
             if parakeetEngine.customVocabularyPath != nextVocab { parakeetEngine.customVocabularyPath = nextVocab }
@@ -116,6 +125,8 @@ final class EngineController {
             _ = settings.whisperKitModel
             _ = settings.whisperLanguage
             _ = settings.customVocabularyPath
+            _ = settings.customVocabularyBookmark
+            _ = settings.whisperKitVocabularyPromptEnabled
             _ = settings.parakeetLanguage
         } onChange: { [weak self] in
             Task { @MainActor in

--- a/app/MeetingTranscriber/Sources/EngineController.swift
+++ b/app/MeetingTranscriber/Sources/EngineController.swift
@@ -97,10 +97,11 @@ final class EngineController {
             whisperKit.applyModelVariant(settings.whisperKitModel)
             let next = settings.whisperLanguageOrNil
             if whisperKit.language != next { whisperKit.language = next }
-
         case .parakeet:
             let nextVocab = settings.customVocabularyPath
             if parakeetEngine.customVocabularyPath != nextVocab { parakeetEngine.customVocabularyPath = nextVocab }
+            let nextBookmark = settings.customVocabularyBookmark
+            if parakeetEngine.customVocabularyBookmark != nextBookmark { parakeetEngine.customVocabularyBookmark = nextBookmark }
             let nextLang = settings.parakeetLanguageOrNil
             if parakeetEngine.language != nextLang { parakeetEngine.language = nextLang }
         }

--- a/app/MeetingTranscriber/Sources/ParakeetEngine.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetEngine.swift
@@ -16,8 +16,21 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
     private(set) var downloadProgress: Double = 0
     private(set) var transcriptionProgress: Double = 0
 
-    /// Path to a custom vocabulary file for CTC boosting. Set from AppSettings before loadModel().
-    var customVocabularyPath: String = ""
+    /// Path to a custom vocabulary file for CTC boosting. A change while the
+    /// model is loaded is applied to the next transcription without restart.
+    var customVocabularyPath: String = "" {
+        didSet {
+            guard customVocabularyPath != oldValue else { return }
+            invalidateVocabularyConfiguration()
+        }
+    }
+
+    var customVocabularyBookmark: Data? {
+        didSet {
+            guard customVocabularyBookmark != oldValue else { return }
+            invalidateVocabularyConfiguration()
+        }
+    }
 
     /// Optional ISO 639-1 language hint. Empty/nil = auto-detect (FluidAudio's
     /// v3 TDT decoder picks the script freely, which can drift Cyrillic ↔ Latin
@@ -45,8 +58,27 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     private var vocabularyBooster: VocabularyBooster?
 
-    /// Tracks the last successfully configured vocabulary path to avoid redundant CTC model downloads.
-    private var currentVocabularyPath: String = ""
+    // The CTC bridge is replaceable only in debug/test builds, where loading
+    // production CTC models would make lifecycle tests impractical.
+    #if DEBUG
+        private var vocabularyPreparationOverride: (([String]) async throws -> Void)?
+        private var fileTranscriptionOverride: ((URL) async throws -> ASRResult)?
+        private var sampleTranscriptionOverride: (([Float]) async throws -> ASRResult)?
+    #endif
+
+    /// The exact vocabulary revision currently being prepared or already
+    /// handled. Unlike a path-only marker it changes when a user edits a file.
+    private var vocabularyPreparationState: ParakeetVocabularyPreparationState?
+    private var vocabularyRefreshGate = ParakeetVocabularyRefreshGate()
+
+    private func invalidateVocabularyConfiguration() {
+        _ = vocabularyRefreshGate.invalidate()
+        vocabularyPreparationState = nil
+        // Do not rescore a new recording with terms from the file that was just
+        // replaced. `ensureVocabularyConfiguration()` prepares the new booster
+        // before the next decode begins.
+        vocabularyBooster = nil
+    }
 
     func loadModel() async {
         await modelLoad.run { [self] in
@@ -64,11 +96,6 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
                 try await manager.loadModels(models)
                 asrManager = manager
                 modelState = .loaded
-
-                // Configure custom vocabulary boosting if a vocabulary file is set
-                if !customVocabularyPath.isEmpty {
-                    try await configureVocabulary(from: customVocabularyPath)
-                }
             } catch {
                 logger.error("Parakeet model load failed: \(error.localizedDescription, privacy: .public)")
                 modelState = .unloaded
@@ -79,6 +106,9 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     private func ensureModel() async throws {
         if asrManager != nil { return }
+        #if DEBUG
+            if fileTranscriptionOverride != nil, sampleTranscriptionOverride != nil { return }
+        #endif
         logger.info("Parakeet: model not loaded, loading…")
         await loadModel()
         guard asrManager != nil else {
@@ -90,13 +120,10 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment] {
         try await ensureModel()
-        guard let manager = asrManager else {
-            throw TranscriptionError.modelNotLoaded
-        }
+        await ensureVocabularyConfiguration()
 
         transcriptionProgress = 0
-        var decoderState = await TdtDecoderState.make(decoderLayers: manager.decoderLayerCount)
-        var result = try await manager.transcribe(audioPath, decoderState: &decoderState, language: fluidLanguageHint)
+        var result = try await decodeFile(audioPath)
         transcriptionProgress = 1.0
 
         // Apply CTC vocabulary rescoring if configured
@@ -123,14 +150,34 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
     /// can be stateless across VAD segments.
     func transcribeSamples(_ samples: [Float]) async throws -> String {
         try await ensureModel()
-        guard let manager = asrManager else {
-            throw TranscriptionError.modelNotLoaded
-        }
+        let result = try await decodeSamples(samples)
+        return result.text.trimmingCharacters(in: .whitespaces)
+    }
+
+    private func decodeFile(_ audioPath: URL) async throws -> ASRResult {
+        #if DEBUG
+            if let fileTranscriptionOverride {
+                return try await fileTranscriptionOverride(audioPath)
+            }
+        #endif
+        guard let manager = asrManager else { throw TranscriptionError.modelNotLoaded }
         var decoderState = await TdtDecoderState.make(decoderLayers: manager.decoderLayerCount)
-        let result = try await manager.transcribe(
+        return try await manager.transcribe(
+            audioPath, decoderState: &decoderState, language: fluidLanguageHint,
+        )
+    }
+
+    private func decodeSamples(_ samples: [Float]) async throws -> ASRResult {
+        #if DEBUG
+            if let sampleTranscriptionOverride {
+                return try await sampleTranscriptionOverride(samples)
+            }
+        #endif
+        guard let manager = asrManager else { throw TranscriptionError.modelNotLoaded }
+        var decoderState = await TdtDecoderState.make(decoderLayers: manager.decoderLayerCount)
+        return try await manager.transcribe(
             samples, decoderState: &decoderState, language: fluidLanguageHint,
         )
-        return result.text.trimmingCharacters(in: .whitespaces)
     }
 
     /// Run CTC keyword spotting on the audio and rescore the TDT transcript.
@@ -176,46 +223,199 @@ final class ParakeetEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     // MARK: - Custom Vocabulary
 
-    /// Configure custom vocabulary for CTC boosting (Parakeet only).
-    ///
-    /// Loads a vocabulary file and downloads CTC models for keyword spotting.
-    /// After configuration, `transcribeSegments` will automatically apply CTC-based
-    /// vocabulary rescoring to improve recognition of domain-specific terms.
-    ///
-    /// Skips silently if path is empty. Logs a warning if loading fails.
-    func configureVocabulary(from path: String) async throws {
-        guard !path.isEmpty else {
-            vocabularyBooster = nil
-            currentVocabularyPath = ""
+    #if DEBUG
+        func installVocabularyPreparationForTesting(
+            _ prepare: @escaping ([String]) async throws -> Void,
+        ) {
+            vocabularyPreparationOverride = prepare
+        }
+
+        /// Installs the final ASR decode boundary for focused lifecycle tests. It
+        /// is excluded from release builds; production always uses `AsrManager`.
+        func installTranscriptionForTesting(
+            file: @escaping (URL) async throws -> ASRResult,
+            samples: @escaping ([Float]) async throws -> ASRResult,
+        ) {
+            fileTranscriptionOverride = file
+            sampleTranscriptionOverride = samples
+        }
+    #endif
+
+    /// Ensures the exact current file revision is ready before a decode. This
+    /// makes an edit to an existing file take effect on the next transcription,
+    /// and avoids an unstructured background task racing the decode.
+    func ensureVocabularyConfiguration() async {
+        let configuration = vocabularyConfiguration(for: customVocabularyPath, bookmark: customVocabularyBookmark)
+        guard vocabularyPreparationState?.configuration != configuration else { return }
+        await configureVocabulary(
+            configuration,
+            attempt: vocabularyRefreshGate.current,
+            requiresCurrentSelection: true,
+        )
+    }
+
+    private func vocabularyConfiguration(for path: String, bookmark: Data?) -> ParakeetVocabularyConfiguration {
+        guard let vocabularyURL = VocabularyFileAccess.resolve(path: path, bookmark: bookmark) else {
+            return ParakeetVocabularyConfiguration(path: path, bookmark: bookmark, revision: nil)
+        }
+        let revision = VocabularyFileAccess.withAccess(to: vocabularyURL) { url in
+            WhisperVocabularyPrompt.fileRevision(at: url.path)
+        }
+        return ParakeetVocabularyConfiguration(path: path, bookmark: bookmark, revision: revision)
+    }
+
+    private func configureVocabulary(
+        _ configuration: ParakeetVocabularyConfiguration,
+        attempt: Int,
+        requiresCurrentSelection: Bool,
+    ) async {
+        guard canAdoptVocabulary(
+            configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+        ) else { return }
+        // A new revision must never rescore with the prior revision while CTC
+        // models are written or loaded. Mark it in-flight so concurrent decodes
+        // do not duplicate the same preparation work.
+        vocabularyBooster = nil
+        vocabularyPreparationState = .preparing(configuration)
+
+        guard !configuration.path.isEmpty else {
+            adoptNoVocabulary(configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection)
             return
         }
-        guard path != currentVocabularyPath else { return }
 
-        let vocab: CustomVocabularyContext
-        let ctcModels: CtcModels
+        guard let terms = vocabularyTerms(for: configuration), !terms.isEmpty else {
+            adoptNoVocabulary(configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection)
+            logger.warning("Parakeet: vocabulary file is unavailable or contains no usable terms")
+            return
+        }
+
+        if await prepareVocabularyUsingOverrideIfPresent(
+            terms,
+            configuration: configuration,
+            attempt: attempt,
+            requiresCurrentSelection: requiresCurrentSelection,
+        ) { return }
+
+        // FluidAudio loads from a path. Give it the bounded, deduplicated list
+        // shared with WhisperKit rather than the original raw file, so both
+        // engines honour the validation limits users see in Settings.
         do {
-            (vocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(
-                from: path,
+            let preparedVocabularyURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("parakeet-vocabulary-\(UUID().uuidString).txt")
+            defer { try? FileManager.default.removeItem(at: preparedVocabularyURL) }
+            try terms.joined(separator: "\n").write(
+                to: preparedVocabularyURL,
+                atomically: true,
+                encoding: .utf8,
+            )
+            let (vocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(
+                from: preparedVocabularyURL.path,
                 ctcVariant: .ctc110m,
             )
+            guard canAdoptVocabulary(
+                configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+            ) else { return }
+
+            let spotter = CtcKeywordSpotter(models: ctcModels, blankId: ctcModels.vocabulary.count)
+            let rescorer = try await VocabularyRescorer.create(
+                spotter: spotter,
+                vocabulary: vocab,
+                config: .default,
+                ctcModelDirectory: CtcModels.defaultCacheDirectory(for: ctcModels.variant),
+            )
+            guard canAdoptVocabulary(
+                configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+            ) else { return }
+            vocabularyBooster = VocabularyBooster(context: vocab, spotter: spotter, rescorer: rescorer)
+            vocabularyPreparationState = .ready(configuration)
+            logger.info("Parakeet: custom vocabulary loaded: \(vocab.terms.count) terms")
         } catch {
-            logger.warning("Parakeet: failed to load vocabulary from \(path): \(error.localizedDescription, privacy: .public)")
-            return
+            adoptVocabularyFailure(
+                configuration,
+                attempt: attempt,
+                requiresCurrentSelection: requiresCurrentSelection,
+                error: error,
+            )
         }
+    }
 
-        let blankId = ctcModels.vocabulary.count
-        let spotter = CtcKeywordSpotter(models: ctcModels, blankId: blankId)
+    private func prepareVocabularyUsingOverrideIfPresent(
+        _ terms: [String],
+        configuration: ParakeetVocabularyConfiguration,
+        attempt: Int,
+        requiresCurrentSelection: Bool,
+    ) async -> Bool {
+        #if DEBUG
+            guard let vocabularyPreparationOverride else { return false }
+            do {
+                try await vocabularyPreparationOverride(terms)
+            } catch {
+                adoptVocabularyFailure(
+                    configuration,
+                    attempt: attempt,
+                    requiresCurrentSelection: requiresCurrentSelection,
+                    error: error,
+                )
+                return true
+            }
+            guard canAdoptVocabulary(
+                configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+            ) else { return true }
+            vocabularyBooster = nil
+            vocabularyPreparationState = .ready(configuration)
+            return true
+        #else
+            false
+        #endif
+    }
 
-        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
-        let rescorer = try await VocabularyRescorer.create(
-            spotter: spotter,
-            vocabulary: vocab,
-            config: .default,
-            ctcModelDirectory: ctcModelDir,
-        )
+    // swiftlint:disable:next discouraged_optional_collection
+    private func vocabularyTerms(for configuration: ParakeetVocabularyConfiguration) -> [String]? {
+        guard let vocabularyURL = VocabularyFileAccess.resolve(
+            path: configuration.path, bookmark: configuration.bookmark,
+        ) else { return nil }
+        // swiftlint:disable:next discouraged_optional_collection
+        return VocabularyFileAccess.withAccess(to: vocabularyURL) { url -> [String]? in
+            guard let revision = WhisperVocabularyPrompt.fileRevision(at: url.path) else { return nil }
+            return WhisperVocabularyPrompt.terms(fromFileAt: url.path, revision: revision)
+        }
+    }
 
-        vocabularyBooster = VocabularyBooster(context: vocab, spotter: spotter, rescorer: rescorer)
-        currentVocabularyPath = path
-        logger.info("Parakeet: custom vocabulary loaded: \(vocab.terms.count) terms")
+    private func adoptNoVocabulary(
+        _ configuration: ParakeetVocabularyConfiguration,
+        attempt: Int,
+        requiresCurrentSelection: Bool,
+    ) {
+        guard canAdoptVocabulary(
+            configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+        ) else { return }
+        vocabularyBooster = nil
+        vocabularyPreparationState = .unavailable(configuration)
+    }
+
+    private func adoptVocabularyFailure(
+        _ configuration: ParakeetVocabularyConfiguration,
+        attempt: Int,
+        requiresCurrentSelection: Bool,
+        error: any Error,
+    ) {
+        guard canAdoptVocabulary(
+            configuration, attempt: attempt, requiresCurrentSelection: requiresCurrentSelection,
+        ) else { return }
+        vocabularyBooster = nil
+        vocabularyPreparationState = .failed(configuration)
+        logger.warning("Parakeet: vocabulary preparation failed for \(configuration.path): \(error.localizedDescription, privacy: .public)")
+    }
+
+    private func canAdoptVocabulary(
+        _ configuration: ParakeetVocabularyConfiguration,
+        attempt: Int,
+        requiresCurrentSelection: Bool,
+    ) -> Bool {
+        guard requiresCurrentSelection else { return true }
+        return vocabularyRefreshGate.isCurrent(attempt)
+            && configuration == vocabularyConfiguration(
+                for: customVocabularyPath, bookmark: customVocabularyBookmark,
+            )
     }
 }

--- a/app/MeetingTranscriber/Sources/ParakeetVocabularyConfiguration.swift
+++ b/app/MeetingTranscriber/Sources/ParakeetVocabularyConfiguration.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Immutable identity of a Parakeet vocabulary configuration. The file revision
+/// matters as much as the path: users commonly edit an existing terminology
+/// file between meetings.
+struct ParakeetVocabularyConfiguration: Equatable, Sendable {
+    let path: String
+    let bookmark: Data?
+    let revision: WhisperVocabularyPrompt.FileRevision?
+}
+
+/// Lifecycle of one exact CTC vocabulary configuration. A failed preparation
+/// is still terminal for that file revision: retrying it for every recording
+/// window only adds repeated I/O and log noise. A new path, bookmark, or file
+/// revision produces a different configuration and is eligible again.
+enum ParakeetVocabularyPreparationState: Equatable, Sendable {
+    case preparing(ParakeetVocabularyConfiguration)
+    case ready(ParakeetVocabularyConfiguration)
+    case unavailable(ParakeetVocabularyConfiguration)
+    case failed(ParakeetVocabularyConfiguration)
+
+    var configuration: ParakeetVocabularyConfiguration {
+        switch self {
+        case let .preparing(configuration),
+             let .ready(configuration),
+             let .unavailable(configuration),
+             let .failed(configuration):
+            configuration
+        }
+    }
+}
+
+/// Invalidates in-flight vocabulary preparation when Settings changes. A
+/// configuration task may resume after a model download, so callers must check
+/// its captured generation before adopting the prepared CTC booster.
+struct ParakeetVocabularyRefreshGate: Sendable {
+    private var generation = 0
+
+    mutating func invalidate() -> Int {
+        generation &+= 1
+        return generation
+    }
+
+    func isCurrent(_ attempt: Int) -> Bool {
+        attempt == generation
+    }
+
+    var current: Int {
+        generation
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -114,6 +114,9 @@ final class PipelineController {
             speakerMatcherFactory: { SpeakerMatcher() },
             vadConfig: settings.vadEnabled ? VADConfig(threshold: settings.vadThreshold) : nil,
             recognitionStatsLog: RecognitionStatsLog(),
+            terminologyNormalizer: { [weak settings] in
+                TerminologyNormalizer(rulesText: settings?.terminologyRulesText ?? "")
+            },
             stageTimingLog: StageTimingLog(),
             terminalJobStore: terminalJobStore,
         )

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -35,6 +35,10 @@ extension PipelineQueue {
         /// Segments cached for diarization reuse (avoids double transcription).
         let cachedSegments: [TimestampedSegment]? // swiftlint:disable:this discouraged_optional_collection
         let isDualSource: Bool
+        /// The exact rules snapshot used for the initial transcription. The
+        /// defensive re-transcription fallback must not pick up Settings edits
+        /// made while this job is being processed.
+        let terminologyNormalizer: TerminologyNormalizer
     }
 
     /// Typed errors thrown by the pipeline stages.
@@ -290,6 +294,10 @@ extension PipelineQueue {
         startElapsedTimer()
         logger.info("[\(ctx.shortID, privacy: .public)] transcription_start title=\(ctx.title, privacy: .private)")
 
+        // Snapshot terminology once per job. A user edit while either track is
+        // decoding must affect the next job, not leave this dual-source result
+        // with differently normalized app and microphone segments.
+        let normalizer = terminologyNormalizer()
         let transcript: String
         // Segments cached for potential diarization reuse (avoids double transcription)
         var cachedSegments: [TimestampedSegment]? // swiftlint:disable:this discouraged_optional_collection
@@ -299,8 +307,9 @@ extension PipelineQueue {
                 ctx, engine: engine, workDir: workDir,
                 appAudioPath: appAudioPath, micAudioPath: micAudioPath,
             )
-            cachedSegments = segments
-            transcript = segments.transcriptText
+            let normalizedSegments = normalize(segments, with: normalizer)
+            cachedSegments = normalizedSegments
+            transcript = normalizedSegments.transcriptText
         } else {
             // Single-source: resample mix to 16kHz
             guard let mixPath = ctx.mixPath else {
@@ -320,7 +329,8 @@ extension PipelineQueue {
             }
 
             // Use transcribeSegments to cache results for diarization
-            var segments = try await engine.transcribeSegments(audioPath: transcriptionPath)
+            let rawSegments = try await engine.transcribeSegments(audioPath: transcriptionPath)
+            var segments = normalize(rawSegments, with: normalizer)
 
             // Remap timestamps back to original timeline if VAD was used
             if let map = vadMap {
@@ -342,7 +352,27 @@ extension PipelineQueue {
             "[\(ctx.shortID, privacy: .public)] transcription_complete segments=\(segCount, privacy: .public) duration=\(totalSecs, privacy: .public)s",
         )
 
-        return TranscriptionOutput(transcript: transcript, cachedSegments: cachedSegments, isDualSource: isDualSource)
+        return TranscriptionOutput(
+            transcript: transcript,
+            cachedSegments: cachedSegments,
+            isDualSource: isDualSource,
+            terminologyNormalizer: normalizer,
+        )
+    }
+
+    private func normalize(
+        _ segments: [TimestampedSegment],
+        with normalizer: TerminologyNormalizer,
+    ) -> [TimestampedSegment] {
+        guard !normalizer.isEmpty else { return segments }
+        return segments.map { segment in
+            TimestampedSegment(
+                start: segment.start,
+                end: segment.end,
+                text: normalizer.normalize(segment.text),
+                speaker: segment.speaker,
+            )
+        }
     }
 
     /// Stage 2 — optional speaker diarization. Returns the transcript with
@@ -570,7 +600,8 @@ extension PipelineQueue {
         } else if transcription.isDualSource {
             return nil
         } else {
-            cachedSegments = try await engine.transcribeSegments(audioPath: mix16k)
+            let rawSegments = try await engine.transcribeSegments(audioPath: mix16k)
+            cachedSegments = normalize(rawSegments, with: transcription.terminologyNormalizer)
         }
         return renderLabeledTranscript(
             run: run, cachedSegments: cachedSegments,

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -64,6 +64,10 @@ class PipelineQueue {
     /// nil disables JSONL logging. AppState injects a real instance for production;
     /// tests leave it nil unless they explicitly want to assert on the log.
     let recognitionStatsLog: RecognitionStatsLog?
+    /// Explicit canonical spelling rules, applied after the ASR engine returns
+    /// text. Kept separate from decoder vocabulary because decoder hints are
+    /// probabilistic while representation rules are deterministic.
+    let terminologyNormalizer: () -> TerminologyNormalizer
 
     /// nil disables per-stage timing capture. AppState injects a real instance;
     /// tests leave it nil unless asserting on the log.
@@ -234,6 +238,7 @@ class PipelineQueue {
         self.snapshotWriter = snapshotWriter
         self.vadConfig = nil
         self.recognitionStatsLog = nil
+        terminologyNormalizer = { TerminologyNormalizer() }
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.terminalJobStore = terminalJobStore
@@ -309,6 +314,7 @@ class PipelineQueue {
         snapshotWriter: @escaping @Sendable ([PipelineJob], URL) throws -> Void = PipelineSnapshot.save,
         vadConfig: VADConfig? = nil,
         recognitionStatsLog: RecognitionStatsLog? = nil,
+        terminologyNormalizer: @escaping () -> TerminologyNormalizer = { TerminologyNormalizer() },
         stageTimingLog: StageTimingLog? = nil,
         completedJobLifetime: TimeInterval = 60,
         terminalJobStore: TerminalJobStore? = nil,
@@ -339,6 +345,7 @@ class PipelineQueue {
         self.snapshotWriter = snapshotWriter
         self.vadConfig = vadConfig
         self.recognitionStatsLog = recognitionStatsLog
+        self.terminologyNormalizer = terminologyNormalizer
         self.stageTimingLog = stageTimingLog
         self.completedJobLifetime = completedJobLifetime
         self.terminalJobStore = terminalJobStore

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -78,6 +78,35 @@ struct TranscriptionSettingsView: View {
                     .onChange(of: settings.customVocabularyPath) { _, _ in
                         settings.refreshCustomVocabularyValidation()
                     }
+                if settings.transcriptionEngine == .whisperKit {
+                    Toggle("Use custom vocabulary prompt (experimental)", isOn: $settings.whisperKitVocabularyPromptEnabled)
+                        .accessibilityIdentifier(A11yID.whisperKitVocabularyPromptToggle)
+                        .help(Self.whisperKitVocabularyPromptHelpText)
+                    Text("Experimental: dense audio can omit whole sentences. See help for measured results; prefer Parakeet for vocabulary boosting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("When enabled, WhisperKit uses a 32-token hint; earlier terms have priority.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Canonical terminology")
+                    TextEditor(text: $settings.terminologyRulesText)
+                        .font(.body.monospaced())
+                        .frame(minHeight: 72)
+                        .accessibilityIdentifier(A11yID.terminologyRulesEditor)
+                    Text(
+                        "Applied to saved transcripts after ASR. One rule per line: "
+                            + "Canonical spelling => spoken variant | another variant. "
+                            + "Rules only replace whole words or phrases.",
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    Text(settings.terminologyRulesValidation.message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 engineStatusView
             }
             .accessibilityIdentifier(A11yID.transcriptionSection)
@@ -155,6 +184,11 @@ struct TranscriptionSettingsView: View {
                 + "WhisperKit; language-specific live backends do not use it."
         }
     }
+
+    static let whisperKitVocabularyPromptHelpText = "Experimental. WhisperKit treats the vocabulary as a decoder hint, "
+        + "not a correction. In a dense four-speaker English evaluation, a 25-content-token prompt "
+        + "from this 32-token budget raised word error rate from 29% to 77% and deletions from 73 to 241. "
+        + "It can omit whole sentences. Results vary by audio; prefer Parakeet for vocabulary boosting."
 
     /// Whether any Nemotron multilingual model variant is already on disk.
     private var nemotronModelDownloaded: Bool {

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -89,6 +89,7 @@ struct TranscriptionSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Canonical terminology")
                     TextEditor(text: $settings.terminologyRulesText)

--- a/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/TranscriptionSettingsView.swift
@@ -51,22 +51,33 @@ struct TranscriptionSettingsView: View {
                             Text(lang.label).tag(lang.code)
                         }
                     }
-
-                    HStack {
-                        TextField("Custom vocabulary file", text: $settings.customVocabularyPath)
-                            .textFieldStyle(.roundedBorder)
-                        Button("Choose\u{2026}") {
-                            let panel = NSOpenPanel()
-                            panel.allowedContentTypes = [.plainText]
-                            panel.allowsMultipleSelection = false
-                            if panel.runModal() == .OK, let url = panel.url {
-                                settings.customVocabularyPath = url.path
-                            }
-                        }
-                    }
-                    .help("Text file with one term per line (e.g. company names, product names)")
                 }
 
+                HStack {
+                    TextField("Custom vocabulary file", text: Binding(
+                        get: { settings.customVocabularyPath },
+                        set: { settings.setCustomVocabularyPath($0) },
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier(A11yID.customVocabularyPathField)
+                    Button("Choose\u{2026}") {
+                        let panel = NSOpenPanel()
+                        panel.allowedContentTypes = [.plainText]
+                        panel.allowsMultipleSelection = false
+                        if panel.runModal() == .OK, let url = panel.url {
+                            settings.setCustomVocabularyFile(url)
+                        }
+                    }
+                }
+                .help(Self.vocabularyHelpText(for: settings.transcriptionEngine))
+
+                Text(settings.customVocabularyValidation.message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .onAppear { settings.refreshCustomVocabularyValidation() }
+                    .onChange(of: settings.customVocabularyPath) { _, _ in
+                        settings.refreshCustomVocabularyValidation()
+                    }
                 engineStatusView
             }
             .accessibilityIdentifier(A11yID.transcriptionSection)
@@ -126,6 +137,23 @@ struct TranscriptionSettingsView: View {
     private var needsCaptionModelConsent: Bool {
         guard let language = settings.activeEngineLanguageOrNil, language != "en" else { return false }
         return !nemotronModelDownloaded
+    }
+
+    /// Engine-specific terminology behaviour is deliberately explained next to
+    /// the shared file picker: the two engines consume the same file but provide
+    /// different levels of influence over recognition.
+    static func vocabularyHelpText(for engine: TranscriptionEngineSetting) -> String {
+        switch engine {
+        case .parakeet:
+            "Text file with one term per line. Parakeet uses CTC rescoring for saved transcription. "
+                + "Live captions do not use CTC vocabulary rescoring."
+
+        case .whisperKit:
+            "Text file with one term per line. Enable the experimental custom vocabulary prompt to pass a "
+                + "soft 32-token decoder hint to WhisperKit; it is not a guaranteed correction. "
+                + "It applies to live captions only when they use "
+                + "WhisperKit; language-specific live backends do not use it."
+        }
     }
 
     /// Whether any Nemotron multilingual model variant is already on disk.

--- a/app/MeetingTranscriber/Sources/TerminologyNormalizer.swift
+++ b/app/MeetingTranscriber/Sources/TerminologyNormalizer.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Opt-in canonical spelling rules applied after ASR. Each non-empty line uses
+/// `Canonical => spoken variant | another variant`. Matching is deliberately
+/// whole-word/phrase and case-insensitive. Rules are bounded before compiling
+/// regular expressions because this runs on the main-actor pipeline path.
+struct TerminologyNormalizer: Sendable {
+    static let maximumRulesTextBytes = 64 * 1024
+    static let maximumRuleCount = 200
+    static let maximumTermBytes = 512
+
+    struct Diagnostics: Equatable, Sendable {
+        let activeRuleCount: Int
+        let ignoredLineCount: Int
+        let isTooLarge: Bool
+
+        var message: String {
+            if isTooLarge {
+                return "Terminology rules are too large to apply."
+            }
+            var result = "\(activeRuleCount) active terminology rule\(activeRuleCount == 1 ? "" : "s")."
+            if ignoredLineCount > 0 {
+                result += " \(ignoredLineCount) invalid line\(ignoredLineCount == 1 ? " was" : "s were") ignored."
+            }
+            return result
+        }
+    }
+
+    private let rules: [Rule]
+    let diagnostics: Diagnostics
+
+    var isEmpty: Bool {
+        rules.isEmpty
+    }
+
+    init(rulesText: String = "") {
+        let result = Self.parse(rulesText)
+        rules = result.rules
+        diagnostics = result.diagnostics
+    }
+
+    func normalize(_ text: String) -> String {
+        var candidates: [Replacement] = []
+        let sourceRange = NSRange(text.startIndex..., in: text)
+        for (ruleIndex, rule) in rules.enumerated() {
+            rule.expression.enumerateMatches(in: text, range: sourceRange) { match, _, _ in
+                guard let match else { return }
+                candidates.append(
+                    Replacement(range: match.range, canonical: rule.canonical, ruleIndex: ruleIndex),
+                )
+            }
+        }
+
+        let sorted = candidates.sorted { lhs, rhs in
+            (lhs.range.location, -lhs.range.length, lhs.ruleIndex)
+                < (rhs.range.location, -rhs.range.length, rhs.ruleIndex)
+        }
+        var selected: [Replacement] = []
+        var nextAvailableLocation = 0
+        for candidate in sorted where candidate.range.location >= nextAvailableLocation {
+            selected.append(candidate)
+            nextAvailableLocation = candidate.range.upperBound
+        }
+
+        return selected.reversed().reduce(text) { current, replacement in
+            guard let range = Range(replacement.range, in: current) else { return current }
+            return current.replacingCharacters(in: range, with: replacement.canonical)
+        }
+    }
+
+    private struct Rule: @unchecked Sendable {
+        let canonical: String
+        let expression: NSRegularExpression
+    }
+
+    private struct Replacement {
+        let range: NSRange
+        let canonical: String
+        let ruleIndex: Int
+    }
+
+    private struct ParseResult {
+        let rules: [Rule]
+        let diagnostics: Diagnostics
+    }
+
+    private static func orderedAlternatives(canonical: String, variants: [String]) -> [String] {
+        ([canonical] + variants)
+            .enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.count != rhs.element.count {
+                    return lhs.element.count > rhs.element.count
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    private static func parse(_ text: String) -> ParseResult {
+        guard text.utf8.count <= maximumRulesTextBytes else {
+            return ParseResult(
+                rules: [],
+                diagnostics: Diagnostics(activeRuleCount: 0, ignoredLineCount: 0, isTooLarge: true),
+            )
+        }
+
+        var ignoredLineCount = 0
+        var rules: [Rule] = []
+        for line in text.components(separatedBy: .newlines) {
+            guard !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            guard rules.count < maximumRuleCount else {
+                ignoredLineCount += 1
+                continue
+            }
+            let pieces = line.components(separatedBy: "=>")
+            guard pieces.count == 2 else {
+                ignoredLineCount += 1
+                continue
+            }
+            let canonical = pieces[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !canonical.isEmpty, canonical.utf8.count <= maximumTermBytes else {
+                ignoredLineCount += 1
+                continue
+            }
+
+            var seen = Set<String>()
+            let variants = pieces[1]
+                .components(separatedBy: "|")
+                .map { variant in variant.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { variant in
+                    !variant.isEmpty
+                        && variant.utf8.count <= maximumTermBytes
+                        && seen.insert(variant.folding(
+                            options: [.caseInsensitive], locale: Locale(identifier: "en_US_POSIX"),
+                        )).inserted
+                }
+            guard !variants.isEmpty else {
+                ignoredLineCount += 1
+                continue
+            }
+
+            // Regex alternation is leftmost-first. Try the longest complete
+            // phrase first so both directions work when one term prefixes the
+            // other: `Kubernetes => Kubernetes Cluster` contracts the latter,
+            // while `Kubernetes Cluster => Cluster` still expands the latter.
+            // Keep the configured order for equal-length terms so the pattern
+            // is deterministic; the replacement is always the canonical form.
+            let alternatives = orderedAlternatives(canonical: canonical, variants: variants)
+                .map(NSRegularExpression.escapedPattern(for:))
+                .joined(separator: "|")
+            let pattern = "(?<![\\p{L}\\p{N}])(?:\(alternatives))(?![\\p{L}\\p{N}])"
+            guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+                ignoredLineCount += 1
+                continue
+            }
+            rules.append(Rule(canonical: canonical, expression: expression))
+        }
+        return ParseResult(
+            rules: rules,
+            diagnostics: Diagnostics(
+                activeRuleCount: rules.count,
+                ignoredLineCount: ignoredLineCount,
+                isTooLarge: false,
+            ),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Sources/VocabularyFileAccess.swift
+++ b/app/MeetingTranscriber/Sources/VocabularyFileAccess.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Resolves persisted sandbox access for terminology files and brackets each
+/// read with the matching security scope. Plain paths remain supported for
+/// existing non-sandbox installations that predate bookmarks.
+enum VocabularyFileAccess {
+    static func resolve(path: String, bookmark: Data?) -> URL? {
+        if let bookmark {
+            var stale = false
+            guard let url = try? URL(
+                resolvingBookmarkData: bookmark,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &stale,
+            ) else { return nil }
+            // A bookmark-backed setting must never fall through to its display
+            // path: that path has no sandbox grant. AppSettings refreshes a
+            // resolvable stale bookmark while it owns the persisted data.
+            return url
+        }
+        guard !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+
+    static func withAccess<Result>(to url: URL, _ body: (URL) -> Result) -> Result {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessing { url.stopAccessingSecurityScopedResource() }
+        }
+        return body(url)
+    }
+}

--- a/app/MeetingTranscriber/Sources/WhisperDecodingClient.swift
+++ b/app/MeetingTranscriber/Sources/WhisperDecodingClient.swift
@@ -1,0 +1,41 @@
+import WhisperKit
+
+// swiftlint:disable discouraged_optional_collection
+
+/// The narrow decode boundary used by `WhisperKitEngine`. Production forwards
+/// to WhisperKit; tests capture the exact options that each public engine flow
+/// hands to this boundary without loading a CoreML model.
+@MainActor
+protocol WhisperDecodingClient: AnyObject {
+    var tokenizer: (any WhisperTokenizer)? { get }
+
+    func transcribeFile(
+        audioPaths: [String],
+        decodeOptions: DecodingOptions,
+        callback: @escaping TranscriptionCallback,
+    ) async -> [[TranscriptionResult]?]
+
+    func transcribeSamples(
+        _ samples: [Float],
+        decodeOptions: DecodingOptions,
+    ) async throws -> [TranscriptionResult]
+}
+
+extension WhisperKit: WhisperDecodingClient {
+    func transcribeFile(
+        audioPaths: [String],
+        decodeOptions: DecodingOptions,
+        callback: @escaping TranscriptionCallback,
+    ) async -> [[TranscriptionResult]?] {
+        await transcribe(audioPaths: audioPaths, decodeOptions: decodeOptions, callback: callback)
+    }
+
+    func transcribeSamples(
+        _ samples: [Float],
+        decodeOptions: DecodingOptions,
+    ) async throws -> [TranscriptionResult] {
+        try await transcribe(audioArray: samples, decodeOptions: decodeOptions)
+    }
+}
+
+// swiftlint:enable discouraged_optional_collection

--- a/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
+++ b/app/MeetingTranscriber/Sources/WhisperKitEngine.swift
@@ -95,14 +95,57 @@ extension TimestampedSegment {
 @MainActor
 @Observable
 final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
-    var modelVariant = "openai_whisper-large-v3-v20240930_turbo"
+    var modelVariant = "openai_whisper-large-v3-v20240930_turbo" {
+        didSet {
+            guard modelVariant != oldValue else { return }
+            vocabularyPromptCache.invalidate()
+        }
+    }
+
     var language: String?
+    /// Path to the shared one-term-per-line vocabulary file. Whisper uses the
+    /// terms as a soft decoder hint; unlike Parakeet CTC rescoring, it cannot
+    /// guarantee a replacement in the resulting transcript.
+    var customVocabularyPath: String = "" {
+        didSet {
+            guard customVocabularyPath != oldValue else { return }
+            vocabularyPromptCache.invalidate()
+        }
+    }
+
+    var customVocabularyBookmark: Data? {
+        didSet {
+            guard customVocabularyBookmark != oldValue else { return }
+            vocabularyPromptCache.invalidate()
+        }
+    }
+
+    /// An explicit opt-in for WhisperKit's experimental decoder prompt. It is
+    /// off by default because a static glossary can reduce transcription
+    /// completeness; Parakeet's CTC boosting does not carry that trade-off.
+    var vocabularyPromptEnabled = false {
+        didSet {
+            if !vocabularyPromptEnabled {
+                vocabularyPromptTokenCount = 0
+            }
+        }
+    }
+
     private(set) var modelState: EngineModelState = .unloaded
     private(set) var downloadProgress: Double = 0
     /// Transcription progress (0.0–1.0) based on WhisperKit's 30s window processing.
     private(set) var transcriptionProgress: Double = 0
     private var pipe: WhisperKit?
+    /// Test-only override of the production decoding boundary. It never reaches
+    /// app wiring; production always resolves this to `pipe`.
+    private var decodingClientOverride: (any WhisperDecodingClient)?
+    /// Test-only loader override used to count content reads on cache hits.
+    private var vocabularyTermsLoaderOverride: ((String, WhisperVocabularyPrompt.FileRevision) -> WhisperVocabularyPrompt.VocabularyTermsLoadResult)?
     private let modelLoad = SingleFlight()
+    private var vocabularyPromptCache = WhisperVocabularyPrompt.TokenCache()
+    /// Debug/quality diagnostic for the effective prompt budget of the most
+    /// recent decode. Zero means the decode ran without a vocabulary hint.
+    private(set) var vocabularyPromptTokenCount = 0
 
     func loadModel() async {
         await modelLoad.run { [self] in
@@ -177,7 +220,10 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
 
     /// Ensure model is loaded, loading it if necessary.
     private func ensureModel() async throws {
-        if pipe != nil { return }
+        // Production state is defined by the loaded WhisperKit instance. The
+        // test decoder is only a narrow decode-boundary substitute and must not
+        // make automation report a real model as loaded.
+        if pipe != nil || decodingClientOverride != nil { return }
         logger.info("WhisperKit: model not loaded, loading \(self.modelVariant, privacy: .public)...")
         await loadModel()
         guard pipe != nil else {
@@ -185,6 +231,25 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
             throw TranscriptionError.modelNotLoaded
         }
         logger.info("WhisperKit: model loaded successfully")
+    }
+
+    private var decodingClient: (any WhisperDecodingClient)? {
+        decodingClientOverride ?? pipe
+    }
+
+    /// Installs a capturing decoder for focused engine tests. Keeping this seam
+    /// at the last boundary before WhisperKit lets tests observe real engine
+    /// flow options without downloading or loading a speech model.
+    func installDecodingClientForTesting(_ client: any WhisperDecodingClient) {
+        decodingClientOverride = client
+    }
+
+    /// Installs a vocabulary-content loader for focused cache tests. Metadata
+    /// revision checks remain in the engine, so tests cannot bypass them.
+    func installVocabularyTermsLoaderForTesting(
+        _ loader: @escaping (String, WhisperVocabularyPrompt.FileRevision) -> WhisperVocabularyPrompt.VocabularyTermsLoadResult,
+    ) {
+        vocabularyTermsLoaderOverride = loader
     }
 
     /// Transcribe a WAV file. Returns lines in `[MM:SS] text` format matching Python output.
@@ -196,7 +261,7 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
     /// Transcribe a WAV file and return structured segments.
     func transcribeSegments(audioPath: URL) async throws -> [TimestampedSegment] {
         try await ensureModel()
-        guard let pipe else {
+        guard let decodingClient else {
             throw TranscriptionError.modelNotLoaded
         }
 
@@ -205,9 +270,14 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
         // Estimate total 30s windows from audio duration
         let totalWindows = max(1, Self.estimateWindowCount(audioPath: audioPath))
 
-        let options = Self.decodingOptions(language: language)
+        // Snapshot all settings-derived decoding options before the asynchronous
+        // decode starts. A later settings change only affects a subsequent run.
+        let options = Self.decodingOptions(
+            language: language,
+            promptTokens: vocabularyPromptTokens(for: decodingClient),
+        )
 
-        let results = await pipe.transcribe(
+        let results = await decodingClient.transcribeFile(
             audioPaths: [audioPath.path],
             decodeOptions: options,
         ) { [weak self] progress in
@@ -250,10 +320,15 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
     /// Hallucination-filter logic matches `transcribeSegments`.
     func transcribeSamples(_ samples: [Float]) async throws -> String {
         try await ensureModel()
-        guard let pipe else { throw TranscriptionError.modelNotLoaded }
-        let options = Self.decodingOptions(language: language)
-        let results = try await pipe.transcribe(
-            audioArray: samples,
+        guard let decodingClient else { throw TranscriptionError.modelNotLoaded }
+        // The explicit experimental prompt choice applies to both saved and
+        // live WhisperKit transcription while retaining an immutable snapshot.
+        let options = Self.decodingOptions(
+            language: language,
+            promptTokens: vocabularyPromptTokens(for: decodingClient),
+        )
+        let results = try await decodingClient.transcribeSamples(
+            samples,
             decodeOptions: options,
         )
         var lastText = ""
@@ -268,16 +343,85 @@ final class WhisperKitEngine: TranscribingEngine, StreamingTranscribingEngine {
         return pieces.joined(separator: " ")
     }
 
-    /// Build the WhisperKit `DecodingOptions` for a transcription run.
-    /// `language` is `nil` for "Auto-detect" and a BCP-47 code otherwise.
-    static func decodingOptions(language: String?) -> DecodingOptions {
+    // Build the WhisperKit `DecodingOptions` for a transcription run.
+    // `language` is `nil` for "Auto-detect" and a BCP-47 code otherwise.
+    static func decodingOptions(language: String?, promptTokens: [Int]? = nil) -> DecodingOptions { // swiftlint:disable:this discouraged_optional_collection
         // WhisperKit defaults `detectLanguage` to `!usePrefillPrompt` (= false),
         // so without this it skips detection and falls back to English (#339).
         DecodingOptions(
             language: language,
             detectLanguage: language == nil,
             wordTimestamps: false,
+            promptTokens: promptTokens,
         )
+    }
+
+    // Returns tokens for the active vocabulary file, cached per path, content
+    // revision, and Whisper model variant. An absent or unreadable file produces
+    // `nil`, which leaves `DecodingOptions` in its exact no-prompt configuration
+    // instead of retaining stale cached terms.
+    private func vocabularyPromptTokens(for decodingClient: any WhisperDecodingClient) -> [Int]? { // swiftlint:disable:this discouraged_optional_collection
+        guard vocabularyPromptEnabled else {
+            vocabularyPromptTokenCount = 0
+            return nil
+        }
+        guard let vocabularyURL = VocabularyFileAccess.resolve(
+            path: customVocabularyPath, bookmark: customVocabularyBookmark,
+        ) else {
+            vocabularyPromptTokenCount = 0
+            return nil
+        }
+        let tokens = VocabularyFileAccess.withAccess(to: vocabularyURL) { url in
+            vocabularyPromptTokens(for: decodingClient, at: url.path)
+        }
+        vocabularyPromptTokenCount = tokens?.count ?? 0
+        return tokens
+    }
+
+    private func vocabularyPromptTokens(
+        for decodingClient: any WhisperDecodingClient,
+        at vocabularyPath: String,
+    ) -> [Int]? { // swiftlint:disable:this discouraged_optional_collection
+        guard let revision = WhisperVocabularyPrompt.fileRevision(at: vocabularyPath) else {
+            vocabularyPromptCache.invalidate()
+            return nil
+        }
+
+        let key = WhisperVocabularyPrompt.CacheKey(
+            vocabularyPath: vocabularyPath,
+            modelVariant: modelVariant,
+            vocabularyRevision: revision,
+        )
+        if let value = vocabularyPromptCache.value(for: key) {
+            switch value {
+            case let .prompt(tokens): return tokens.isEmpty ? nil : tokens
+            case .noPrompt: return nil
+            }
+        }
+        guard revision.fileSize <= UInt64(WhisperVocabularyPrompt.maximumFileBytes) else {
+            vocabularyPromptCache.storeNoPrompt(for: key)
+            return nil
+        }
+
+        let loadResult: WhisperVocabularyPrompt.VocabularyTermsLoadResult = if let vocabularyTermsLoaderOverride {
+            vocabularyTermsLoaderOverride(vocabularyPath, revision)
+        } else {
+            WhisperVocabularyPrompt.loadTerms(fromFileAt: vocabularyPath, revision: revision)
+        }
+        guard case let .loaded(terms) = loadResult,
+              let tokenizer = decodingClient.tokenizer
+        else {
+            vocabularyPromptCache.storeNoPrompt(for: key)
+            return nil
+        }
+
+        let tokens = WhisperVocabularyPrompt.tokens(
+            for: terms,
+            tokenize: tokenizer.encode(text:),
+            specialTokenBegin: tokenizer.specialTokens.specialTokenBegin,
+        )
+        vocabularyPromptCache.store(tokens, for: key)
+        return tokens.isEmpty ? nil : tokens
     }
 
     /// Estimate number of 30-second windows WhisperKit will process for the given audio file.

--- a/app/MeetingTranscriber/Sources/WhisperVocabularyPrompt.swift
+++ b/app/MeetingTranscriber/Sources/WhisperVocabularyPrompt.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+// swiftlint:disable discouraged_optional_collection
+
+/// Converts the shared one-term-per-line vocabulary file into a bounded Whisper
+/// decoder prompt. The individual terms stay in file order, so earlier entries
+/// retain priority when the prompt budget is exhausted.
+enum WhisperVocabularyPrompt {
+    /// WhisperKit 1.1.0 shares its 224-token decoder context between the
+    /// prefill prompt and generated tokens. Keep the vocabulary hint small so
+    /// dense 30-second windows retain enough room to reach their timestamps.
+    static let defaultTokenBudget = 32
+    /// Bounds synchronous file loading and parsing on the main actor.
+    static let maximumFileBytes = 256 * 1024
+    static let maximumTermCount = 256
+    static let maximumTermBytes = 512
+
+    /// The values that identify cached tokens for a loaded Whisper model.
+    struct CacheKey: Equatable {
+        let vocabularyPath: String
+        let modelVariant: String
+        let vocabularyRevision: FileRevision
+    }
+
+    /// Compact metadata checked on every decode before consulting cached tokens.
+    /// File identity distinguishes replacements; timestamp and size distinguish
+    /// ordinary edits without reading the file contents again.
+    struct FileRevision: Equatable {
+        let fileID: UInt64?
+        let modificationTime: Date
+        let fileSize: UInt64
+    }
+
+    enum VocabularyTermsLoadResult {
+        case loaded([String])
+        case unavailable
+    }
+
+    /// A single-entry cache for tokens prepared by the currently loaded model.
+    /// A non-matching key is a cache miss, so a path or model switch can never
+    /// reuse tokens produced by an earlier configuration.
+    struct TokenCache {
+        enum Value: Equatable {
+            case prompt([Int])
+            case noPrompt
+        }
+
+        private var entry: (key: CacheKey, value: Value)?
+
+        init() {}
+
+        mutating func invalidate() {
+            entry = nil
+        }
+
+        func value(for key: CacheKey) -> Value? {
+            guard let entry, entry.key == key else { return nil }
+            return entry.value
+        }
+
+        mutating func store(_ tokens: [Int], for key: CacheKey) {
+            entry = (key, .prompt(tokens))
+        }
+
+        mutating func storeNoPrompt(for key: CacheKey) {
+            entry = (key, .noPrompt)
+        }
+    }
+
+    /// Parses the established custom-vocabulary format: one term per line.
+    /// Blank lines and later duplicate entries are ignored without changing the
+    /// priority of the first matching term.
+    static func terms(from contents: String) -> [String] {
+        var seen = Set<String>()
+        return contents
+            .components(separatedBy: .newlines)
+            .map { term in term.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { term in
+                let key = term.folding(options: [.caseInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+                return !term.isEmpty && seen.insert(key).inserted
+            }
+    }
+
+    /// Reads a vocabulary file, returning `nil` when the path is absent or
+    /// unreadable. Callers treat `nil` as no prompt, preserving baseline decode
+    /// behaviour rather than retaining an earlier vocabulary.
+    static func terms(fromFileAt path: String) -> [String]? {
+        guard let revision = fileRevision(at: path) else { return nil }
+        return terms(fromFileAt: path, revision: revision)
+    }
+
+    /// Reads compact metadata only. This is deliberately separate from content
+    /// loading so cache hits do no string decoding or parsing.
+    static func fileRevision(at path: String) -> FileRevision? {
+        guard !path.isEmpty,
+              let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let modificationTime = attributes[.modificationDate] as? Date,
+              let fileSize = attributes[.size] as? UInt64
+        else { return nil }
+
+        let fileID = attributes[.systemFileNumber] as? UInt64
+        return FileRevision(
+            fileID: fileID,
+            modificationTime: modificationTime,
+            fileSize: fileSize,
+        )
+    }
+
+    /// Loads and parses file contents only after a metadata revision changes.
+    /// Oversized files and files with too many terms are deliberately rejected
+    /// rather than blocking the main actor or expanding a decoder prompt list.
+    static func terms(fromFileAt path: String, revision: FileRevision) -> [String]? {
+        switch loadTerms(fromFileAt: path, revision: revision) {
+        case let .loaded(terms): terms
+        case .unavailable: nil
+        }
+    }
+
+    static func loadTerms(fromFileAt path: String, revision: FileRevision) -> VocabularyTermsLoadResult {
+        guard revision.fileSize <= UInt64(maximumFileBytes),
+              let contents = try? String(contentsOfFile: path, encoding: .utf8)
+        else { return .unavailable }
+
+        let parsedTerms = terms(from: contents)
+        guard parsedTerms.count <= maximumTermCount,
+              parsedTerms.allSatisfy({ $0.utf8.count <= maximumTermBytes })
+        else { return .unavailable }
+        return .loaded(parsedTerms)
+    }
+
+    /// Encodes complete vocabulary terms until the supplied prompt-token budget
+    /// is used. Each term is encoded with leading whitespace, as WhisperKit's
+    /// tokenizer expects ordinary prompt text. WhisperKit's encoder wraps text
+    /// in control tokens, so those are removed before budget accounting; a term
+    /// is never truncated to fit.
+    static func tokens(
+        for terms: [String],
+        tokenize: (String) -> [Int],
+        specialTokenBegin: Int,
+        tokenBudget: Int = defaultTokenBudget,
+    ) -> [Int] {
+        guard tokenBudget > 0 else { return [] }
+
+        var promptTokens: [Int] = []
+        for term in terms.prefix(maximumTermCount) {
+            if promptTokens.count == tokenBudget { break }
+
+            let termTokens = tokenize(" " + term).filter { $0 < specialTokenBegin }
+            guard !termTokens.isEmpty,
+                  promptTokens.count + termTokens.count <= tokenBudget
+            else {
+                continue
+            }
+            promptTokens.append(contentsOf: termTokens)
+        }
+        return promptTokens
+    }
+}
+
+// swiftlint:enable discouraged_optional_collection

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -151,6 +151,13 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(settings.customVocabularyValidation, .termTooLong)
     }
 
+    func testTerminologyRulesPersist() {
+        settings.terminologyRulesText = "Aster => Astor"
+
+        XCTAssertEqual(defaults.string(forKey: "terminologyRulesText"), "Aster => Astor")
+        XCTAssertEqual(AppSettings(defaults: defaults).terminologyRulesText, "Aster => Astor")
+    }
+
     func testManualVocabularyPathEditClearsPreviousBookmark() throws {
         let file = FileManager.default.temporaryDirectory
             .appendingPathComponent("vocabulary-bookmark-\(UUID().uuidString).txt")

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -39,7 +39,7 @@ final class CustomVocabularyTests: XCTestCase {
     // MARK: - Persistence
 
     func testCustomVocabularyPathPersists() {
-        settings.customVocabularyPath = "/tmp/vocab.txt"
+        settings.setCustomVocabularyPath("/tmp/vocab.txt")
         XCTAssertEqual(settings.customVocabularyPath, "/tmp/vocab.txt")
 
         // Verify it persists to the injected store.
@@ -47,9 +47,119 @@ final class CustomVocabularyTests: XCTestCase {
     }
 
     func testCustomVocabularyPathClear() {
-        settings.customVocabularyPath = "/tmp/vocab.txt"
-        settings.customVocabularyPath = ""
+        settings.setCustomVocabularyPath("/tmp/vocab.txt")
+        settings.clearCustomVocabularyFile()
         XCTAssertEqual(settings.customVocabularyPath, "")
+    }
+
+    func testSelectedVocabularyFilePersistsBookmarkAndResolvesAfterReload() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-bookmark-\(UUID().uuidString).txt")
+        try "Northstar\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        settings.setCustomVocabularyFile(file)
+
+        let bookmark = try XCTUnwrap(settings.customVocabularyBookmark)
+        XCTAssertEqual(settings.customVocabularyPath, file.path)
+        XCTAssertEqual(defaults.data(forKey: "customVocabularyBookmark"), bookmark)
+
+        let reloaded = AppSettings(defaults: defaults)
+        XCTAssertEqual(
+            reloaded.customVocabularyFile?.resolvingSymlinksInPath().path,
+            file.resolvingSymlinksInPath().path,
+        )
+    }
+
+    func testClearingVocabularyFileClearsPathAndBookmark() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-bookmark-\(UUID().uuidString).txt")
+        try "Northstar\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+        settings.setCustomVocabularyFile(file)
+
+        settings.clearCustomVocabularyFile()
+
+        XCTAssertEqual(settings.customVocabularyPath, "")
+        XCTAssertNil(settings.customVocabularyBookmark)
+    }
+
+    func testVocabularyValidationReportsUsableTermCount() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-validation-\(UUID().uuidString).txt")
+        try "Northstar\nNorthstar\nAster\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        settings.setCustomVocabularyFile(file)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .ready(termCount: 2))
+    }
+
+    func testVocabularyValidationRejectsAnEmptyFile() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-empty-\(UUID().uuidString).txt")
+        try "\n  \n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        settings.setCustomVocabularyFile(file)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .empty)
+    }
+
+    func testVocabularyValidationAccepts256TermsAndRejects257() throws {
+        let acceptedTerms = (0 ..< 256).map { "Term\($0)" }
+        let acceptedFile = try makeVocabularyFile(contents: acceptedTerms.joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(at: acceptedFile) }
+
+        settings.setCustomVocabularyFile(acceptedFile)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .ready(termCount: 256))
+
+        let rejectedTerms = (0 ... 256).map { "Term\($0)" }
+        let rejectedFile = try makeVocabularyFile(contents: rejectedTerms.joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(at: rejectedFile) }
+
+        settings.setCustomVocabularyFile(rejectedFile)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .tooManyTerms)
+    }
+
+    func testVocabularyValidationAccepts512ByteTermAndRejects513ByteTerm() throws {
+        let acceptedTerm = String(repeating: "x", count: 512)
+        let acceptedFile = try makeVocabularyFile(contents: acceptedTerm)
+        defer { try? FileManager.default.removeItem(at: acceptedFile) }
+
+        settings.setCustomVocabularyFile(acceptedFile)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .ready(termCount: 1))
+
+        let rejectedTerm = String(repeating: "x", count: 513)
+        let rejectedFile = try makeVocabularyFile(contents: rejectedTerm)
+        defer { try? FileManager.default.removeItem(at: rejectedFile) }
+
+        settings.setCustomVocabularyFile(rejectedFile)
+
+        XCTAssertEqual(settings.customVocabularyValidation, .termTooLong)
+    }
+
+    func testManualVocabularyPathEditClearsPreviousBookmark() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-bookmark-\(UUID().uuidString).txt")
+        try "Northstar\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+        settings.setCustomVocabularyFile(file)
+
+        settings.setCustomVocabularyPath("/tmp/manual-vocabulary.txt")
+
+        XCTAssertEqual(settings.customVocabularyPath, "/tmp/manual-vocabulary.txt")
+        XCTAssertNil(settings.customVocabularyBookmark)
+    }
+
+    private func makeVocabularyFile(contents: String) throws -> URL {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-validation-\(UUID().uuidString).txt")
+        try contents.write(to: file, atomically: true, encoding: .utf8)
+        return file
     }
 
     // MARK: - ParakeetEngine vocabulary configuration

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -36,6 +36,15 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(settings.customVocabularyPath, "")
     }
 
+    func testWhisperKitVocabularyPromptDefaultsOffAndPersists() {
+        XCTAssertFalse(settings.whisperKitVocabularyPromptEnabled)
+
+        settings.whisperKitVocabularyPromptEnabled = true
+
+        XCTAssertTrue(defaults.bool(forKey: "whisperKitVocabularyPromptEnabled"))
+        XCTAssertTrue(AppSettings(defaults: defaults).whisperKitVocabularyPromptEnabled)
+    }
+
     // MARK: - Persistence
 
     func testCustomVocabularyPathPersists() {
@@ -176,5 +185,4 @@ final class CustomVocabularyTests: XCTestCase {
         engine.customVocabularyPath = "/tmp/test_vocab.txt"
         XCTAssertEqual(engine.customVocabularyPath, "/tmp/test_vocab.txt")
     }
-
 }

--- a/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/CustomVocabularyTests.swift
@@ -177,17 +177,4 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(engine.customVocabularyPath, "/tmp/test_vocab.txt")
     }
 
-    @MainActor
-    func testConfigureVocabularySkipsEmptyPath() async throws {
-        let engine = ParakeetEngine()
-        // Should not throw for empty path
-        try await engine.configureVocabulary(from: "")
-    }
-
-    @MainActor
-    func testConfigureVocabularyLogsWarningForMissingFile() async throws {
-        let engine = ParakeetEngine()
-        // Should not throw for missing file — just logs a warning
-        try await engine.configureVocabulary(from: "/nonexistent/vocab.txt")
-    }
 }

--- a/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
+++ b/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
@@ -53,6 +53,20 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
     }
 
+    func test_initialSync_propagatesCustomVocabularyPathToWhisperKit() {
+        settings.transcriptionEngine = .whisperKit
+        settings.setCustomVocabularyPath("/tmp/init-vocab.txt")
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.whisperKit.customVocabularyPath, "/tmp/init-vocab.txt")
+    }
+
+    func test_initialSync_propagatesWhisperKitVocabularyPromptChoice() {
+        settings.transcriptionEngine = .whisperKit
+        settings.whisperKitVocabularyPromptEnabled = true
+
+        XCTAssertTrue(EngineController(settings: settings).whisperKit.vocabularyPromptEnabled)
+    }
+
     func test_initialSync_propagatesWhisperKitModelToEngine() {
         settings.transcriptionEngine = .whisperKit
         settings.whisperKitModel = "openai_whisper-small"
@@ -99,6 +113,28 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
 
         await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/runtime-vocab.txt")
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/runtime-vocab.txt")
+    }
+
+    func test_runtimeChange_customVocabularyPath_propagatesToWhisperKit() async {
+        settings.transcriptionEngine = .whisperKit
+        let engines = EngineController(settings: settings)
+        XCTAssertEqual(engines.whisperKit.customVocabularyPath, "")
+
+        settings.setCustomVocabularyPath("/tmp/runtime-vocab.txt")
+
+        await waitFor(engines.whisperKit.customVocabularyPath == "/tmp/runtime-vocab.txt")
+        XCTAssertEqual(engines.whisperKit.customVocabularyPath, "/tmp/runtime-vocab.txt")
+    }
+
+    func test_runtimeChange_whisperKitVocabularyPromptChoice_propagatesToEngine() async {
+        settings.transcriptionEngine = .whisperKit
+        let engines = EngineController(settings: settings)
+        XCTAssertFalse(engines.whisperKit.vocabularyPromptEnabled)
+
+        settings.whisperKitVocabularyPromptEnabled = true
+
+        await waitFor(engines.whisperKit.vocabularyPromptEnabled)
+        XCTAssertTrue(engines.whisperKit.vocabularyPromptEnabled)
     }
 
     // MARK: - Re-arming

--- a/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
+++ b/app/MeetingTranscriber/Tests/EngineSettingsRuntimeSyncTests.swift
@@ -48,7 +48,7 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
 
     func test_initialSync_propagatesCustomVocabularyPathToParakeet() {
         settings.transcriptionEngine = .parakeet
-        settings.customVocabularyPath = "/tmp/init-vocab.txt"
+        settings.setCustomVocabularyPath("/tmp/init-vocab.txt")
         let engines = EngineController(settings: settings)
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/init-vocab.txt")
     }
@@ -95,7 +95,7 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         let engines = EngineController(settings: settings)
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "")
 
-        settings.customVocabularyPath = "/tmp/runtime-vocab.txt"
+        settings.setCustomVocabularyPath("/tmp/runtime-vocab.txt")
 
         await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/runtime-vocab.txt")
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/runtime-vocab.txt")
@@ -110,15 +110,15 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
         settings.transcriptionEngine = .parakeet
         let engines = EngineController(settings: settings)
 
-        settings.customVocabularyPath = "/tmp/v1.txt"
+        settings.setCustomVocabularyPath("/tmp/v1.txt")
         await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v1.txt")
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v1.txt")
 
-        settings.customVocabularyPath = "/tmp/v2.txt"
+        settings.setCustomVocabularyPath("/tmp/v2.txt")
         await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v2.txt")
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v2.txt")
 
-        settings.customVocabularyPath = "/tmp/v3.txt"
+        settings.setCustomVocabularyPath("/tmp/v3.txt")
         await waitFor(engines.parakeetEngine.customVocabularyPath == "/tmp/v3.txt")
         XCTAssertEqual(engines.parakeetEngine.customVocabularyPath, "/tmp/v3.txt")
     }
@@ -131,7 +131,7 @@ final class EngineSettingsRuntimeSyncTests: XCTestCase {
     func test_engineSwitch_syncsNewlyActiveEngine() async {
         settings.transcriptionEngine = .whisperKit
         settings.whisperLanguage = "de"
-        settings.customVocabularyPath = "/tmp/parakeet-vocab.txt"
+        settings.setCustomVocabularyPath("/tmp/parakeet-vocab.txt")
         let engines = EngineController(settings: settings)
 
         XCTAssertEqual(engines.whisperKit.language, "de")

--- a/app/MeetingTranscriber/Tests/ParakeetVocabularyConfigurationTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetVocabularyConfigurationTests.swift
@@ -1,0 +1,28 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class ParakeetVocabularyConfigurationTests: XCTestCase {
+    func testConfigurationKeyChangesWhenVocabularyContentsChange() {
+        let first = ParakeetVocabularyConfiguration(
+            path: "/tmp/terms.txt",
+            bookmark: nil,
+            revision: .init(fileID: 42, modificationTime: .distantPast, fileSize: 12),
+        )
+        let edited = ParakeetVocabularyConfiguration(
+            path: "/tmp/terms.txt",
+            bookmark: nil,
+            revision: .init(fileID: 42, modificationTime: .distantFuture, fileSize: 16),
+        )
+
+        XCTAssertNotEqual(first, edited)
+    }
+
+    func testRefreshGenerationRejectsAnOlderConfigurationAttempt() {
+        var gate = ParakeetVocabularyRefreshGate()
+        let firstAttempt = gate.invalidate()
+        let currentAttempt = gate.invalidate()
+
+        XCTAssertFalse(gate.isCurrent(firstAttempt))
+        XCTAssertTrue(gate.isCurrent(currentAttempt))
+    }
+}

--- a/app/MeetingTranscriber/Tests/ParakeetVocabularyPreparationTests.swift
+++ b/app/MeetingTranscriber/Tests/ParakeetVocabularyPreparationTests.swift
@@ -1,0 +1,153 @@
+import FluidAudio
+@testable import MeetingTranscriber
+import XCTest
+
+@MainActor
+final class ParakeetVocabularyPreparationTests: XCTestCase {
+    func testVocabularyPreparationReceivesValidatedDeduplicatedTerms() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\nnorthstar\nAster\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var preparedTerms: [String] = []
+        engine.installVocabularyPreparationForTesting { terms in
+            preparedTerms = terms
+        }
+
+        await engine.ensureVocabularyConfiguration()
+
+        XCTAssertEqual(preparedTerms, ["Northstar", "Aster"])
+    }
+
+    func testVocabularyPreparationFailureIsContainedAndNotRetriedForTheSameConfiguration() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var attempts = 0
+        engine.installVocabularyPreparationForTesting { _ in
+            attempts += 1
+            throw PreparationError.failed
+        }
+
+        await engine.ensureVocabularyConfiguration()
+        await engine.ensureVocabularyConfiguration()
+
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testVocabularyPreparationRetriesAfterTheFileRevisionChanges() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var attempts = 0
+        engine.installVocabularyPreparationForTesting { _ in
+            attempts += 1
+            throw PreparationError.failed
+        }
+
+        await engine.ensureVocabularyConfiguration()
+        try "Aster\n".write(to: vocabularyFile, atomically: true, encoding: .utf8)
+        await engine.ensureVocabularyConfiguration()
+
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testFailedBatchVocabularyPreparationFallsBackToTheTranscript() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var preparationAttempts = 0
+        engine.installVocabularyPreparationForTesting { _ in
+            preparationAttempts += 1
+            throw PreparationError.failed
+        }
+        engine.installTranscriptionForTesting(
+            file: { _ in Self.transcriptionResult(text: "Fallback transcript") },
+            samples: { _ in Self.transcriptionResult(text: "Live transcript") },
+        )
+
+        let segments = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/input.wav"))
+
+        XCTAssertEqual(segments.map(\.text), ["Fallback transcript"])
+        XCTAssertEqual(preparationAttempts, 1)
+    }
+
+    func testLiveTranscriptionDoesNotPrepareVocabulary() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var preparationAttempts = 0
+        engine.installVocabularyPreparationForTesting { _ in
+            preparationAttempts += 1
+            throw PreparationError.failed
+        }
+        engine.installTranscriptionForTesting(
+            file: { _ in Self.transcriptionResult(text: "Batch transcript") },
+            samples: { _ in Self.transcriptionResult(text: "Live transcript") },
+        )
+
+        let transcript = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(transcript, "Live transcript")
+        XCTAssertEqual(preparationAttempts, 0)
+    }
+
+    func testModelLoadDoesNotPrepareVocabulary() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var preparationAttempts = 0
+        engine.installVocabularyPreparationForTesting { _ in
+            preparationAttempts += 1
+        }
+
+        await engine.loadModel()
+
+        XCTAssertEqual(preparationAttempts, 0)
+    }
+
+    func testVocabularyPreparationRefreshesAfterTheFileChanges() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = ParakeetEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        var preparedTermLists: [[String]] = []
+        engine.installVocabularyPreparationForTesting { terms in
+            preparedTermLists.append(terms)
+        }
+
+        await engine.ensureVocabularyConfiguration()
+        await engine.ensureVocabularyConfiguration()
+        try "Aster\nVega\n".write(to: vocabularyFile, atomically: true, encoding: .utf8)
+        await engine.ensureVocabularyConfiguration()
+
+        XCTAssertEqual(preparedTermLists, [["Northstar"], ["Aster", "Vega"]])
+    }
+
+    private func makeVocabularyFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("parakeet-vocabulary-\(UUID().uuidString).txt")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func transcriptionResult(text: String) -> ASRResult {
+        ASRResult(text: text, confidence: 1, duration: 1, processingTime: 0.01)
+    }
+
+    private enum PreparationError: Error, Equatable {
+        case failed
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineQueueTests.swift
@@ -1015,6 +1015,7 @@ final class PipelineQueueTests: XCTestCase {
 
     private func makeMockProcessingQueue(
         engine: MockEngine? = nil,
+        terminologyNormalizer: @escaping () -> TerminologyNormalizer = { TerminologyNormalizer() },
         diarizationFactory: @escaping () -> any DiarizationProvider = { MockDiarization() },
         diarizationFactoryWithMode: ((DiarizerMode) -> any DiarizationProvider)? = nil,
         diarizeEnabled: Bool = false,
@@ -1031,6 +1032,7 @@ final class PipelineQueueTests: XCTestCase {
             diarizeEnabled: diarizeEnabled,
             numSpeakers: numSpeakers,
             micLabel: "Me",
+            terminologyNormalizer: terminologyNormalizer,
         )
         return (q, engine)
     }
@@ -1053,6 +1055,27 @@ final class PipelineQueueTests: XCTestCase {
         await pQueue.processNext()
 
         XCTAssertTrue(engine.transcribeCallCount > 0)
+    }
+
+    func testProcessNextAppliesTerminologyRulesToSavedTranscript() async throws {
+        let engine = MockEngine()
+        engine.segmentsToReturn = [
+            TimestampedSegment(start: 0, end: 5, text: "Astor reviewed northstar."),
+        ]
+        let (queue, _) = makeMockProcessingQueue(engine: engine) {
+            TerminologyNormalizer(rulesText: "Aster => Astor\nNorthstar => northstar")
+        }
+        let audioPath = try createTestAudioFile(in: tmpDir)
+        queue.enqueue(PipelineJob(
+            meetingTitle: "Terminology Test", appName: "File",
+            mixPath: audioPath, appPath: nil, micPath: nil, micDelay: 0,
+        ))
+
+        await queue.processNext()
+
+        let transcriptURL = try XCTUnwrap(queue.jobs.first?.transcriptPath)
+        let transcript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(transcript.contains("Aster reviewed Northstar."), transcript)
     }
 
     // MARK: - Concurrent runs of the same job (issue #558)

--- a/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
+++ b/app/MeetingTranscriber/Tests/Quality/WhisperKitQualityTests.swift
@@ -40,6 +40,79 @@ final class WhisperKitQualityTests: XCTestCase {
         try await runFixture(named: "four_speakers_en_ami", language: "en")
     }
 
+    /// Reports the experimental prompt's real-model trade-off without gating it.
+    /// The default unprompted path remains protected by the ordinary fixture
+    /// baselines above. This opt-in path instead records WER, added deletions,
+    /// and end-of-audio coverage so its user-facing warning can be kept honest.
+    func test_whisperKit_enabledVocabularyPrompt_reportsDenseFixtureTradeoff() async throws {
+        try skipUnlessQualityRun()
+        let truth = try GroundTruth.load(named: "four_speakers_en_ami")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: truth.audioURL.path))
+
+        let vocabularyFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quality-vocabulary-\(UUID().uuidString).txt")
+        let vocabulary = [
+            "fashionable", "lightweight", "plastic", "moulded", "produced", "territory", "individual",
+            "liaise", "fantastic", "PowerPoint", "presentation", "website", "electronics", "design",
+            "metal", "cheaper", "remote", "controls", "Telewest", "silver", "smarter",
+        ].joined(separator: "\n")
+        try vocabulary.write(
+            to: vocabularyFile, atomically: true, encoding: .utf8,
+        )
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let engine = WhisperKitEngine()
+        engine.modelVariant = modelVariant
+        engine.language = "en"
+        await engine.loadModel()
+        XCTAssertEqual(engine.modelState, .loaded, "WhisperKit model failed to load")
+
+        let baselineSegments = try await engine.transcribeSegments(audioPath: truth.audioURL)
+        let baseline = WERCalculator.werBreakdown(
+            reference: truth.text,
+            hypothesis: baselineSegments.map(\.text).joined(separator: " "),
+        )
+
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        let hintedSegments = try await engine.transcribeSegments(audioPath: truth.audioURL)
+        let hinted = WERCalculator.werBreakdown(
+            reference: truth.text,
+            hypothesis: hintedSegments.map(\.text).joined(separator: " "),
+        )
+
+        XCTAssertGreaterThan(
+            engine.vocabularyPromptTokenCount,
+            0,
+            "The enabled prompt must reach the real WhisperKit decoder as content tokens",
+        )
+        XCTAssertLessThanOrEqual(
+            engine.vocabularyPromptTokenCount,
+            WhisperVocabularyPrompt.defaultTokenBudget,
+            "Tokenizer wrapper tokens must not consume the vocabulary prompt budget",
+        )
+
+        let baselineTailCoverage = tailCoverage(of: baselineSegments, duration: truth.duration)
+        let hintedTailCoverage = tailCoverage(of: hintedSegments, duration: truth.duration)
+        print(
+            """
+            WhisperKit experimental vocabulary prompt measurement (non-gating)
+              fixture: \(truth.fixture), model: \(modelVariant)
+              content tokens: \(engine.vocabularyPromptTokenCount)/\(WhisperVocabularyPrompt.defaultTokenBudget)
+              baseline: WER \(baseline.wer), deletions \(baseline.deletions), tail coverage \(baselineTailCoverage)
+              prompted: WER \(hinted.wer), deletions \(hinted.deletions), tail coverage \(hintedTailCoverage)
+              delta: WER \(hinted.wer - baseline.wer), deletions \(hinted.deletions - baseline.deletions),
+                tail coverage \(hintedTailCoverage - baselineTailCoverage)
+            """,
+        )
+    }
+
+    private func tailCoverage(of segments: [TimestampedSegment], duration: TimeInterval) -> Double {
+        guard duration > 0 else { return 0 }
+        let lastEnd = segments.map(\.end).max() ?? 0
+        return min(max(lastEnd / duration, 0), 1)
+    }
+
     // Soft threshold of 0.5 catches catastrophic breakage (corrupted model,
     // audio not loaded, biasing prompt destroying decoding) but stays well
     // above the production baseline (~0.23-0.29 with explicit `language=de`).

--- a/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
+++ b/app/MeetingTranscriber/Tests/RPCEngineStateTests.swift
@@ -116,7 +116,7 @@
                 state.rpcStateSnapshot().engines.parakeet.customVocabularyPath, "",
             )
 
-            settings.customVocabularyPath = "/tmp/runtime.txt"
+            settings.setCustomVocabularyPath("/tmp/runtime.txt")
             await waitFor(
                 state.rpcStateSnapshot().engines.parakeet.customVocabularyPath
                     == "/tmp/runtime.txt",

--- a/app/MeetingTranscriber/Tests/SettingsViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SettingsViewTests.swift
@@ -232,11 +232,11 @@ final class SettingsViewTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertNoThrow(try body.find(text: "Custom vocabulary file"))
     }
 
-    func testParakeetVocabularyHiddenForWhisperKit() throws {
+    func testWhisperKitShowsCustomVocabularyField() throws {
         let settings = makeSettings()
         settings.transcriptionEngine = .whisperKit
         let body = try makeTranscription(settings: settings).inspect()
-        XCTAssertThrowsError(try body.find(text: "Custom vocabulary file"))
+        XCTAssertNoThrow(try body.find(text: "Custom vocabulary file"))
     }
 
     func testWhisperKitModelPickerHiddenForParakeet() throws {

--- a/app/MeetingTranscriber/Tests/TerminologyNormalizerTests.swift
+++ b/app/MeetingTranscriber/Tests/TerminologyNormalizerTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import MeetingTranscriber
+import XCTest
+
+final class TerminologyNormalizerTests: XCTestCase {
+    func testRulesReplaceOnlyWholeWordsAndPreserveCanonicalCasing() {
+        let normalizer = TerminologyNormalizer(rulesText: "Aster => Astor | Asterx")
+
+        XCTAssertEqual(
+            normalizer.normalize("Astor met Asterx; Astoria bleibt unverändert."),
+            "Aster met Aster; Astoria bleibt unverändert.",
+        )
+    }
+
+    func testRulesSupportMultiWordVariantsCaseInsensitively() {
+        let normalizer = TerminologyNormalizer(rulesText: "Northstar Suite => north star suite")
+
+        XCTAssertEqual(normalizer.normalize("Die NORTH STAR SUITE startet."), "Die Northstar Suite startet.")
+    }
+
+    func testMalformedAndEmptyRulesDoNotModifyText() {
+        let normalizer = TerminologyNormalizer(rulesText: "missing delimiter\n=> empty\nTarget =>")
+
+        XCTAssertTrue(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.normalize("Astor"), "Astor")
+    }
+
+    func testRulesDoNotCascadeIntoLaterRules() {
+        let normalizer = TerminologyNormalizer(rulesText: "Beta => Alpha\nGamma => Beta")
+
+        XCTAssertEqual(normalizer.normalize("Alpha"), "Beta")
+    }
+
+    func testExpansionRuleLeavesAnAlreadyCanonicalPhraseUntouched() {
+        let normalizer = TerminologyNormalizer(rulesText: "Kubernetes Cluster => Cluster")
+        let canonical = "Der Kubernetes Cluster laeuft stabil."
+
+        XCTAssertEqual(normalizer.normalize(canonical), canonical)
+        XCTAssertEqual(normalizer.normalize(normalizer.normalize(canonical)), canonical)
+        XCTAssertEqual(
+            normalizer.normalize("Der Cluster laeuft stabil."),
+            "Der Kubernetes Cluster laeuft stabil.",
+        )
+    }
+
+    func testPrefixExpansionVariantContractsBeforeItsCanonicalPrefix() {
+        let normalizer = TerminologyNormalizer(rulesText: "Kubernetes => Kubernetes Cluster")
+
+        XCTAssertEqual(
+            normalizer.normalize("Der Kubernetes Cluster laeuft stabil."),
+            "Der Kubernetes laeuft stabil.",
+        )
+    }
+
+    func testCasingOnlyRuleCanonicalizesCasing() {
+        let normalizer = TerminologyNormalizer(rulesText: "Northstar => northstar")
+
+        XCTAssertFalse(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.normalize("northstar plant."), "Northstar plant.")
+    }
+
+    func testDiagnosticsReportActiveAndMalformedRules() {
+        let normalizer = TerminologyNormalizer(
+            rulesText: "Northstar => north star\nnot a rule\nA => B => C",
+        )
+
+        XCTAssertEqual(normalizer.diagnostics.activeRuleCount, 1)
+        XCTAssertEqual(normalizer.diagnostics.ignoredLineCount, 2)
+    }
+
+    func testRulesAboveTheByteLimitAreRejectedWithoutCompilingRegexes() {
+        let normalizer = TerminologyNormalizer(
+            rulesText: String(repeating: "x", count: TerminologyNormalizer.maximumRulesTextBytes + 1),
+        )
+
+        XCTAssertTrue(normalizer.isEmpty)
+        XCTAssertTrue(normalizer.diagnostics.isTooLarge)
+    }
+
+    func testRuleLimitAccepts200Rules() {
+        let validRules = (0 ..< 200)
+            .map { "Canonical\($0) => variant\($0)" }
+        let normalizer = TerminologyNormalizer(rulesText: validRules.joined(separator: "\n"))
+
+        XCTAssertEqual(normalizer.diagnostics.activeRuleCount, 200)
+        XCTAssertEqual(normalizer.diagnostics.ignoredLineCount, 0)
+    }
+
+    func testRuleLimitReportsThe201stRuleAsIgnored() {
+        let validRules = (0 ..< 200)
+            .map { "Canonical\($0) => variant\($0)" }
+        let normalizer = TerminologyNormalizer(rulesText: (validRules + ["Extra => extra"]).joined(separator: "\n"))
+
+        XCTAssertEqual(normalizer.diagnostics.activeRuleCount, 200)
+        XCTAssertEqual(normalizer.diagnostics.ignoredLineCount, 1)
+    }
+
+    func testCanonicalTermWith512BytesIsAccepted() {
+        let canonical = String(repeating: "x", count: 512)
+        let normalizer = TerminologyNormalizer(rulesText: "\(canonical) => alias")
+
+        XCTAssertFalse(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.diagnostics.activeRuleCount, 1)
+        XCTAssertEqual(normalizer.normalize("alias"), canonical)
+    }
+
+    func testCanonicalTermWith513BytesIsIgnored() {
+        let canonical = String(repeating: "x", count: 513)
+        let normalizer = TerminologyNormalizer(rulesText: "\(canonical) => alias")
+
+        XCTAssertTrue(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.diagnostics.ignoredLineCount, 1)
+    }
+
+    func testVariantTermWith512BytesIsAccepted() {
+        let variant = String(repeating: "x", count: 512)
+        let normalizer = TerminologyNormalizer(rulesText: "Canonical => \(variant)")
+
+        XCTAssertFalse(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.diagnostics.activeRuleCount, 1)
+        XCTAssertEqual(normalizer.normalize(variant), "Canonical")
+    }
+
+    func testVariantTermWith513BytesIsIgnored() {
+        let variant = String(repeating: "x", count: 513)
+        let normalizer = TerminologyNormalizer(rulesText: "Canonical => \(variant)")
+
+        XCTAssertTrue(normalizer.isEmpty)
+        XCTAssertEqual(normalizer.diagnostics.ignoredLineCount, 1)
+    }
+}

--- a/app/MeetingTranscriber/Tests/TranscriptionSettingsVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/TranscriptionSettingsVocabularyTests.swift
@@ -34,6 +34,14 @@ final class TranscriptionSettingsVocabularyTests: XCTestCase {
         XCTAssertNil(settings.customVocabularyBookmark)
     }
 
+    func testTerminologyEditorHasStableAccessibilityIdentifier() throws {
+        XCTAssertNoThrow(
+            try makeView(settings: AppSettings(defaults: defaults))
+                .inspect()
+                .find(viewWithAccessibilityIdentifier: A11yID.terminologyRulesEditor),
+        )
+    }
+
     func testVocabularyControlsRemainAvailableForBothEngines() throws {
         for engine in [TranscriptionEngineSetting.parakeet, .whisperKit] {
             let settings = AppSettings(defaults: defaults)

--- a/app/MeetingTranscriber/Tests/TranscriptionSettingsVocabularyTests.swift
+++ b/app/MeetingTranscriber/Tests/TranscriptionSettingsVocabularyTests.swift
@@ -1,0 +1,136 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+@MainActor
+final class TranscriptionSettingsVocabularyTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var defaults: UserDefaults!
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "TranscriptionSettingsVocabularyTests-\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+
+    func testVocabularyPathFieldWritesBackThroughTheBookmarkSafeSetter() throws {
+        let settings = AppSettings(defaults: defaults)
+        let field = try makeView(settings: settings).inspect().find(ViewType.TextField.self) { field in
+            try field.accessibilityIdentifier() == A11yID.customVocabularyPathField
+        }
+
+        try field.setInput("/tmp/meeting-terms.txt")
+
+        XCTAssertEqual(settings.customVocabularyPath, "/tmp/meeting-terms.txt")
+        XCTAssertNil(settings.customVocabularyBookmark)
+    }
+
+    func testVocabularyControlsRemainAvailableForBothEngines() throws {
+        for engine in [TranscriptionEngineSetting.parakeet, .whisperKit] {
+            let settings = AppSettings(defaults: defaults)
+            settings.transcriptionEngine = engine
+            XCTAssertNoThrow(
+                try makeView(settings: settings)
+                    .inspect()
+                    .find(viewWithAccessibilityIdentifier: A11yID.customVocabularyPathField),
+                "missing vocabulary field for \(engine)",
+            )
+        }
+    }
+
+    func testWhisperKitVocabularyControlAttachesTheBoundedPriorityHelp() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .whisperKit
+
+        let vocabularyControl = try makeView(settings: settings)
+            .inspect()
+            .form()
+            .section(0)
+            .hStack(3)
+
+        XCTAssertEqual(
+            try vocabularyControl.help().string(),
+            TranscriptionSettingsView.vocabularyHelpText(for: .whisperKit),
+        )
+    }
+
+    func testWhisperKitShowsItsVocabularyHintCapacity() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .whisperKit
+
+        XCTAssertNoThrow(
+            try makeView(settings: settings)
+                .inspect()
+                .find(text: "When enabled, WhisperKit uses a 32-token hint; earlier terms have priority."),
+        )
+    }
+
+    func testWhisperKitExperimentalVocabularyPromptWritesBackToSettings() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .whisperKit
+        let toggle = try makeView(settings: settings)
+            .inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.whisperKitVocabularyPromptToggle)
+            .find(ViewType.Toggle.self)
+
+        try toggle.tap()
+
+        XCTAssertTrue(settings.whisperKitVocabularyPromptEnabled)
+    }
+
+    func testWhisperKitExperimentalVocabularyPromptExplainsTheQualityTradeoff() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .whisperKit
+
+        XCTAssertNoThrow(
+            try makeView(settings: settings)
+                .inspect()
+                .find(text: "Experimental: dense audio can omit whole sentences. See help for measured results; prefer Parakeet for vocabulary boosting."),
+        )
+    }
+
+    func testWhisperKitExperimentalVocabularyPromptAttachesTheQualityTooltip() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .whisperKit
+        let toggle = try makeView(settings: settings)
+            .inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.whisperKitVocabularyPromptToggle)
+            .find(ViewType.Toggle.self)
+
+        XCTAssertEqual(
+            try toggle.help().string(),
+            "Experimental. WhisperKit treats the vocabulary as a decoder hint, "
+                + "not a correction. In a dense four-speaker English evaluation, a 25-content-token prompt "
+                + "from this 32-token budget raised word error rate from 29% to 77% and deletions from 73 to 241. "
+                + "It can omit whole sentences. Results vary by audio; prefer Parakeet for vocabulary boosting.",
+        )
+    }
+
+    func testParakeetHidesWhisperKitExperimentalVocabularyPrompt() throws {
+        let settings = AppSettings(defaults: defaults)
+        settings.transcriptionEngine = .parakeet
+
+        XCTAssertThrowsError(
+            try makeView(settings: settings)
+                .inspect()
+                .find(viewWithAccessibilityIdentifier: A11yID.whisperKitVocabularyPromptToggle),
+        )
+    }
+
+    private func makeView(settings: AppSettings) -> TranscriptionSettingsView {
+        TranscriptionSettingsView(
+            settings: settings,
+            whisperKitEngine: WhisperKitEngine(),
+            parakeetEngine: ParakeetEngine(),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitEngineTests.swift
@@ -29,6 +29,20 @@ final class WhisperKitEngineTests: XCTestCase {
         )
     }
 
+    func testNoVocabularyPromptPreservesExistingDecodingOptions() {
+        let options = WhisperKitEngine.decodingOptions(language: nil)
+
+        XCTAssertNil(options.promptTokens)
+        XCTAssertTrue(options.detectLanguage)
+    }
+
+    func testVocabularyPromptKeepsAutoLanguageDetectionEnabled() {
+        let options = WhisperKitEngine.decodingOptions(language: nil, promptTokens: [11, 12])
+
+        XCTAssertEqual(options.promptTokens, [11, 12])
+        XCTAssertTrue(options.detectLanguage)
+    }
+
     func testDefaultModel() {
         let engine = WhisperKitEngine()
         XCTAssertEqual(engine.modelVariant, "openai_whisper-large-v3-v20240930_turbo")

--- a/app/MeetingTranscriber/Tests/WhisperKitVocabularyFlowTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperKitVocabularyFlowTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+@testable import MeetingTranscriber
+import WhisperKit
+import XCTest
+
+// swiftlint:disable discouraged_optional_collection
+
+@MainActor
+final class WhisperKitVocabularyFlowTests: XCTestCase {
+    func testDisabledVocabularyPromptSkipsFileAccessForBothWhisperKitFlows() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let loader = VocabularyTermsLoaderSpy()
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.installVocabularyTermsLoaderForTesting { _, _ in
+            loader.loadCount += 1
+            return .loaded(["Northstar"])
+        }
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/empty.wav"))
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(loader.loadCount, 0)
+        XCTAssertEqual(client.filePrompts, [.noPrompt])
+        XCTAssertEqual(client.samplePrompts, [.noPrompt])
+    }
+
+    func testEnabledVocabularyPromptTokensReachBothWhisperKitFlows() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/empty.wav"))
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(client.filePrompts, [.tokens([101, 102])])
+        XCTAssertEqual(client.samplePrompts, [.tokens([101, 102])])
+    }
+
+    func testSamePathEditAndDeletionDoNotReuseStaleVocabularyTokens() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/empty.wav"))
+        try "Mikael\n".write(to: vocabularyFile, atomically: true, encoding: .utf8)
+        _ = try await engine.transcribeSamples([0])
+        try FileManager.default.removeItem(at: vocabularyFile)
+        _ = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/empty.wav"))
+
+        XCTAssertEqual(client.filePrompts, [.tokens([101, 102]), .noPrompt])
+        XCTAssertEqual(client.samplePrompts, [.tokens([103])])
+    }
+
+    func testMissingVocabularyFilePassesNoPromptToBothWhisperKitFlows() async throws {
+        let missingFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-vocabulary-\(UUID().uuidString).txt")
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = missingFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSegments(audioPath: URL(fileURLWithPath: "/tmp/empty.wav"))
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(client.filePrompts, [.noPrompt])
+        XCTAssertEqual(client.samplePrompts, [.noPrompt])
+    }
+
+    func testSecurityScopedBookmarkSuppliesVocabularyAfterPathChanges() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = "/missing/legacy-path.txt"
+        engine.customVocabularyBookmark = try vocabularyFile.bookmarkData(options: .withSecurityScope)
+        engine.vocabularyPromptEnabled = true
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(client.samplePrompts, [.tokens([101, 102])])
+    }
+
+    func testUnchangedVocabularyRevisionUsesCachedTokensWithoutReloadingFile() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let loader = VocabularyTermsLoaderSpy()
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installVocabularyTermsLoaderForTesting { _, _ in
+            loader.loadCount += 1
+            return .loaded(["Northstar"])
+        }
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSamples([0])
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(loader.loadCount, 1)
+        XCTAssertEqual(client.samplePrompts, [.tokens([101, 102]), .tokens([101, 102])])
+    }
+
+    func testOversizedVocabularyFilePassesNoPromptAndDoesNotCallLoader() async throws {
+        let oversizedContents = String(
+            repeating: "x",
+            count: WhisperVocabularyPrompt.maximumFileBytes + 1,
+        )
+        let vocabularyFile = try makeVocabularyFile(contents: oversizedContents)
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let loader = VocabularyTermsLoaderSpy()
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installVocabularyTermsLoaderForTesting { _, _ in
+            loader.loadCount += 1
+            return .loaded(["Northstar"])
+        }
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(loader.loadCount, 0)
+        XCTAssertEqual(client.samplePrompts, [.noPrompt])
+    }
+
+    func testUnavailableRevisionIsCachedWithoutReloadingTerms() async throws {
+        let vocabularyFile = try makeVocabularyFile(contents: "Northstar\n")
+        defer { try? FileManager.default.removeItem(at: vocabularyFile) }
+
+        let loader = VocabularyTermsLoaderSpy()
+        let client = CapturingWhisperDecodingClient()
+        let engine = WhisperKitEngine()
+        engine.customVocabularyPath = vocabularyFile.path
+        engine.vocabularyPromptEnabled = true
+        engine.installVocabularyTermsLoaderForTesting { _, _ in
+            loader.loadCount += 1
+            return .unavailable
+        }
+        engine.installDecodingClientForTesting(client)
+
+        _ = try await engine.transcribeSamples([0])
+        _ = try await engine.transcribeSamples([0])
+
+        XCTAssertEqual(loader.loadCount, 1)
+        XCTAssertEqual(client.samplePrompts, [.noPrompt, .noPrompt])
+    }
+
+    private func makeVocabularyFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-\(UUID().uuidString).txt")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}
+
+@MainActor
+private final class CapturingWhisperDecodingClient: WhisperDecodingClient {
+    let tokenizer: (any WhisperTokenizer)? = VocabularyTestTokenizer()
+    private(set) var filePrompts: [PromptObservation] = []
+    private(set) var samplePrompts: [PromptObservation] = []
+
+    func transcribeFile(
+        audioPaths _: [String],
+        decodeOptions: DecodingOptions,
+        callback _: TranscriptionCallback,
+    ) -> [[TranscriptionResult]?] {
+        filePrompts.append(PromptObservation(decodeOptions.promptTokens))
+        return [[]]
+    }
+
+    func transcribeSamples(
+        _: [Float],
+        decodeOptions: DecodingOptions,
+    ) -> [TranscriptionResult] {
+        samplePrompts.append(PromptObservation(decodeOptions.promptTokens))
+        return []
+    }
+}
+
+private enum PromptObservation: Equatable {
+    case noPrompt
+    case tokens([Int])
+
+    init(_ tokens: [Int]?) {
+        self = tokens.map(Self.tokens) ?? .noPrompt
+    }
+}
+
+@MainActor
+private final class VocabularyTermsLoaderSpy {
+    var loadCount = 0
+}
+
+private final class VocabularyTestTokenizer: WhisperTokenizer {
+    let specialTokens = SpecialTokens(
+        endToken: 500,
+        englishToken: 501,
+        noSpeechToken: 502,
+        noTimestampsToken: 503,
+        specialTokenBegin: 500,
+        startOfPreviousToken: 504,
+        startOfTranscriptToken: 505,
+        timeTokenBegin: 506,
+        transcribeToken: 507,
+        translateToken: 508,
+        whitespaceToken: 509,
+    )
+    let allLanguageTokens: Set<Int> = []
+
+    func encode(text: String) -> [Int] {
+        switch text {
+        case " Northstar": [101, 102]
+        case " Mikael": [103]
+        default: []
+        }
+    }
+
+    func decode(tokens _: [Int]) -> String {
+        ""
+    }
+
+    func convertTokenToId(_: String) -> Int? {
+        nil
+    }
+
+    func convertIdToToken(_: Int) -> String? {
+        nil
+    }
+
+    func splitToWordTokens(tokenIds _: [Int]) -> (words: [String], wordTokens: [[Int]]) {
+        ([], [])
+    }
+}
+
+// swiftlint:enable discouraged_optional_collection

--- a/app/MeetingTranscriber/Tests/WhisperVocabularyPromptTests.swift
+++ b/app/MeetingTranscriber/Tests/WhisperVocabularyPromptTests.swift
@@ -1,0 +1,178 @@
+@testable import MeetingTranscriber
+import XCTest
+
+final class WhisperVocabularyPromptTests: XCTestCase {
+    func testDefaultPromptBudgetLeavesMostOfWhisperKitsDecoderContextForSpeech() {
+        // WhisperKit 1.1.0 uses a 224-token context for prompt + generation.
+        // The four control/start tokens and this prompt still leave at least
+        // 80% of the context available for generated speech tokens.
+        XCTAssertLessThanOrEqual(WhisperVocabularyPrompt.defaultTokenBudget, 40)
+        XCTAssertGreaterThanOrEqual(224 - 4 - WhisperVocabularyPrompt.defaultTokenBudget, 180)
+    }
+
+    func testTerms_preservesFirstOccurrenceAndFileOrder() {
+        let terms = WhisperVocabularyPrompt.terms(
+            from: "  Northstar  \n\nMikael\nNorthstar\n  Mikael  \nAster\n",
+        )
+
+        XCTAssertEqual(terms, ["Northstar", "Mikael", "Aster"])
+    }
+
+    func testTermsTreatsCasingVariantsAsOneVocabularyEntry() {
+        XCTAssertEqual(
+            WhisperVocabularyPrompt.terms(from: "Northstar\nnorthstar\nNORTHSTAR\n"),
+            ["Northstar"],
+        )
+    }
+
+    func testPromptTokens_acceptsOnlyCompleteTermsWithinBudget() {
+        let tokens = WhisperVocabularyPrompt.tokens(
+            for: ["Northstar", "Mikael", "Aster"],
+            tokenize: { term in
+                switch term {
+                case " Northstar": [11, 12]
+                case " Mikael": [13, 14, 15]
+                case " Aster": [16]
+                default: []
+                }
+            },
+            specialTokenBegin: 500,
+            tokenBudget: 4,
+        )
+
+        XCTAssertEqual(tokens, [11, 12, 16])
+    }
+
+    func testPromptTokens_filtersTokenizerWrapperTokensBeforeBudgeting() {
+        let tokens = WhisperVocabularyPrompt.tokens(
+            for: ["Northstar", "Mikael"],
+            tokenize: { term in
+                switch term {
+                case " Northstar": [21, 700, 22]
+                case " Mikael": [31, 32]
+                default: []
+                }
+            },
+            specialTokenBegin: 500,
+            tokenBudget: 8,
+        )
+
+        XCTAssertEqual(tokens, [21, 22, 31, 32])
+    }
+
+    func testPromptTokens_stopsTokenizingOnceBudgetIsFull() {
+        var tokenizedTerms: [String] = []
+        let tokens = WhisperVocabularyPrompt.tokens(
+            for: ["Northstar", "Mikael", "Aster"],
+            tokenize: { term in
+                tokenizedTerms.append(term)
+                return switch term {
+                case " Northstar": [31, 32]
+                case " Mikael": [33]
+                case " Aster": [34]
+                default: []
+                }
+            },
+            specialTokenBegin: 500,
+            tokenBudget: 2,
+        )
+
+        XCTAssertEqual(tokens, [31, 32])
+        XCTAssertEqual(tokenizedTerms, [" Northstar"])
+    }
+
+    func testPromptTokens_canFillTheDefaultBudgetWithCompleteTerms() {
+        let terms = (0 ..< WhisperVocabularyPrompt.defaultTokenBudget).map { "Term\($0)" }
+        let tokens = WhisperVocabularyPrompt.tokens(
+            for: terms,
+            tokenize: { _ in [7] },
+            specialTokenBegin: 500,
+        )
+
+        XCTAssertEqual(tokens.count, WhisperVocabularyPrompt.defaultTokenBudget)
+    }
+
+    func testTermsFromFile_returnsNilForEmptyOrUnreadablePath() {
+        XCTAssertNil(WhisperVocabularyPrompt.terms(fromFileAt: ""))
+        XCTAssertNil(
+            WhisperVocabularyPrompt.terms(
+                fromFileAt: "/tmp/not-present-vocabulary-\(UUID().uuidString).txt",
+            ),
+        )
+    }
+
+    func testTermsFromFile_acceptsExactly256UniqueTerms() throws {
+        let contents = (0 ..< 256).map { "Term\($0)" }.joined(separator: "\n")
+        let file = try makeVocabularyFile(contents: contents)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        XCTAssertEqual(WhisperVocabularyPrompt.terms(fromFileAt: file.path)?.count, 256)
+    }
+
+    func testTermsFromFile_rejects257UniqueTerms() throws {
+        let contents = (0 ... 256).map { "Term\($0)" }.joined(separator: "\n")
+        let file = try makeVocabularyFile(contents: contents)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        XCTAssertNil(WhisperVocabularyPrompt.terms(fromFileAt: file.path))
+    }
+
+    func testTermsFromFile_acceptsA512ByteTerm() throws {
+        let term = String(repeating: "x", count: 512)
+        let file = try makeVocabularyFile(contents: term)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        XCTAssertEqual(WhisperVocabularyPrompt.terms(fromFileAt: file.path), [term])
+    }
+
+    func testTermsFromFile_rejectsA513ByteTerm() throws {
+        let term = String(repeating: "x", count: 513)
+        let file = try makeVocabularyFile(contents: term)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        XCTAssertNil(WhisperVocabularyPrompt.terms(fromFileAt: file.path))
+    }
+
+    func testCacheKey_changesWhenVocabularyPathOrModelChanges() {
+        let baseline = WhisperVocabularyPrompt.CacheKey(
+            vocabularyPath: "/tmp/first.txt",
+            modelVariant: "openai_whisper-small",
+            vocabularyRevision: .init(fileID: 1, modificationTime: .distantPast, fileSize: 10),
+        )
+        let changedPath = WhisperVocabularyPrompt.CacheKey(
+            vocabularyPath: "/tmp/second.txt",
+            modelVariant: "openai_whisper-small",
+            vocabularyRevision: .init(fileID: 1, modificationTime: .distantPast, fileSize: 10),
+        )
+        let changedModel = WhisperVocabularyPrompt.CacheKey(
+            vocabularyPath: "/tmp/first.txt",
+            modelVariant: "openai_whisper-base",
+            vocabularyRevision: .init(fileID: 1, modificationTime: .distantPast, fileSize: 10),
+        )
+        let changedContents = WhisperVocabularyPrompt.CacheKey(
+            vocabularyPath: "/tmp/first.txt",
+            modelVariant: "openai_whisper-small",
+            vocabularyRevision: .init(fileID: 1, modificationTime: .distantFuture, fileSize: 10),
+        )
+
+        XCTAssertNotEqual(baseline, changedPath)
+        XCTAssertNotEqual(baseline, changedModel)
+        XCTAssertNotEqual(baseline, changedContents)
+
+        var cache = WhisperVocabularyPrompt.TokenCache()
+        cache.store([31, 32], for: baseline)
+        XCTAssertEqual(cache.value(for: baseline), .prompt([31, 32]))
+        XCTAssertNil(cache.value(for: changedPath))
+        XCTAssertNil(cache.value(for: changedModel))
+        XCTAssertNil(cache.value(for: changedContents))
+        cache.invalidate()
+        XCTAssertNil(cache.value(for: baseline))
+    }
+
+    private func makeVocabularyFile(contents: String) throws -> URL {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocabulary-prompt-\(UUID().uuidString).txt")
+        try contents.write(to: file, atomically: true, encoding: .utf8)
+        return file
+    }
+}

--- a/scripts/generate_quality_fixtures.sh
+++ b/scripts/generate_quality_fixtures.sh
@@ -12,6 +12,7 @@
 # Requires: macOS `say` (voices Anna, Flo, Sandy), `sox`, `python3`.
 
 set -euo pipefail
+export LC_ALL=C
 
 command -v sox >/dev/null 2>&1 || { echo "ERROR: sox is required (brew install sox)"; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is required"; exit 1; }


### PR DESCRIPTION
Fixes #575

## Problem

Custom vocabulary was configured globally but ignored when WhisperKit was the active transcription engine.

## Primary change

- Pass configured custom vocabulary to WhisperKit as decoding prompt context.

## Supporting improvements

- Persist user-selected vocabulary files with security-scoped bookmarks, so a sandboxed app can access them again after restart.
- Validate vocabulary input and enforce file-size, term-count, and term-length limits before it reaches the recognizer.
- Cache both available and unavailable vocabulary revisions, avoiding repeated file reads during live transcription.
- Add optional canonical terminology rules for spelling variants. These are applied after ASR to saved transcripts and are deliberately separate from the WhisperKit decoding prompt.
- Apply terminology changes to subsequent pipeline jobs without requiring an app restart.
- Use boundary-aware, non-cascading replacements so rules do not alter parts of unrelated words or unexpectedly rewrite each other.

## Testing

- Unit tests for vocabulary parsing, validation, file access, prompt construction, cache invalidation, and terminology normalization.
- Pipeline tests covering post-ASR terminology normalization.
- `swift test --parallel --quiet --skip MenuBarIconSnapshotTests`
- `./scripts/lint.sh`
- `swift build -c release`
- `swift build --build-tests -Xswiftc -DAPPSTORE`

## Notes for reviewers

- The vocabulary quality-regression test is opt-in via `RUN_QUALITY_TESTS=1`, as it needs a real WhisperKit model run.
- Snapshot tests remain excluded because of the existing platform-dependent snapshot mismatch.