### PR TITLE
fix(app): detect Webex calls via Cisco's "On a call" assertion

### DIFF
--- a/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
+++ b/app/MeetingTranscriber/Sources/PowerAssertionDetector.swift
@@ -131,7 +131,10 @@ class PowerAssertionDetector: MeetingDetecting {
         AssertionPattern(
             appName: "Webex",
             processNames: ["Webex", "Cisco Webex Meetings", "Meeting Center"],
-            keywords: ["webex"],
+            // Cisco names the call assertion "On a call", not "webex" (measured:
+            // Webex 46.7.0.35472 on macOS 26.5.2). Keyword-only like Teams, so
+            // the #475 concern does not arise; bound to processNames above.
+            keywords: ["webex", "on a call"],
         ),
         AssertionPattern(
             appName: AppMeetingPattern.simulator.appName,

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -298,7 +298,7 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
     /// the desktop client can never be auto-detected, which in turn means no
     /// auto-stop, because a hand-started recording only ends on
     /// `.stopPidExited` / `.stopMaxDurationExceeded`.
-    func testWebexCallWithCiscoAssertionNameIsDetected() {
+    func testWebexCallWithCiscoAssertionNameIsDetected() throws {
         let detector = PowerAssertionDetector(
             patterns: PowerAssertionDetector.patterns(watching: ["Webex"]),
             confirmationCount: 1,
@@ -307,9 +307,42 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
         detector.assertionProvider = {
             PowerAssertionFixture.assertionDict(processName: "Webex", assertName: "On a call")
         }
+        let meeting = try XCTUnwrap(
+            detector.checkOnce(),
+            "Cisco names the call assertion \"On a call\", not \"webex\"",
+        )
+        XCTAssertEqual(meeting.pattern.appName, "Webex")
+        // Auto-stop is the other half of the fix, and liveness takes a
+        // different route: `isMeetingActive` filters by `identifies` before it
+        // re-applies `matches`. Correct today because Webex is `.shared`, so
+        // both paths end in the same static `matches` — pinned here so a later
+        // split of the two routes has to fail out loud.
+        XCTAssertTrue(
+            detector.isMeetingActive(meeting),
+            "the measured assertion must also keep the meeting alive, or auto-stop fires at the end grace",
+        )
+    }
+
+    /// The measured pair, verbatim: one pid held both assertions at the same
+    /// time, and only the second one matches. The unmatched sibling must not
+    /// hide it — and the fixture has to be able to express the shape at all,
+    /// which is what the count pins.
+    func testWebexCallIsDetectedBesideTheUnmatchedSecondAssertion() {
+        let measured = PowerAssertionFixture.typedAssertions([
+            (pid: 870, processName: "Webex", assertName: "io avilable", assertType: PowerAssertionFixture.systemSleep),
+            (pid: 870, processName: "Webex", assertName: "On a call", assertType: PowerAssertionFixture.displaySleep),
+        ])
+        XCTAssertEqual(measured[870]?.count, 2, "one process holds several assertions at once; the fixture must keep both")
+
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Webex"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = { measured }
         XCTAssertEqual(
             detector.checkOnce()?.pattern.appName, "Webex",
-            "Cisco names the call assertion \"On a call\", not \"webex\"",
+            "\"io avilable\" comes first and matches nothing; \"On a call\" must still be found",
         )
     }
 

--- a/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionDetectorPatternsTests.swift
@@ -282,4 +282,92 @@ final class PowerAssertionDetectorPatternsTests: XCTestCase {
         _ = off.checkOnce()
         XCTAssertNil(off.checkOnce(), "browser toggle off → a Chrome WebRTC call must be ignored")
     }
+
+    // MARK: - Webex desktop client — Cisco's assertion name is not "webex"
+
+    /// Measured on macOS 26.5.2 with Webex 46.7.0.35472 during an instant
+    /// meeting: the client holds two assertions, and neither name contains
+    /// "webex".
+    ///
+    ///     pid 870(Webex): PreventUserIdleSystemSleep  named: "io avilable"
+    ///     pid 870(Webex): PreventUserIdleDisplaySleep named: "On a call"
+    ///
+    /// Same failure mode as Zoom in #562 (Apple's "Describe Activity Type"
+    /// placeholder): `processNames` passes the bound gate, then both remaining
+    /// tests fail — no "webex" in the name, and `assertionTypes` is empty. So
+    /// the desktop client can never be auto-detected, which in turn means no
+    /// auto-stop, because a hand-started recording only ends on
+    /// `.stopPidExited` / `.stopMaxDurationExceeded`.
+    func testWebexCallWithCiscoAssertionNameIsDetected() {
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Webex"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            PowerAssertionFixture.assertionDict(processName: "Webex", assertName: "On a call")
+        }
+        XCTAssertEqual(
+            detector.checkOnce()?.pattern.appName, "Webex",
+            "Cisco names the call assertion \"On a call\", not \"webex\"",
+        )
+    }
+
+    /// The "on a call" keyword must stay bound to the Webex client: `matches()`
+    /// checks `processNames.contains` before testing the name, so a foreign
+    /// process holding an identically named assertion cannot fire. Amphetamine
+    /// holds both display-sleep assertion types permanently on the measured
+    /// machine.
+    ///
+    /// That gate is NOT what makes a keyword preferable to the `assertionTypes`
+    /// fallback #475 gave Zoom: it runs ahead of both arms, so it excludes
+    /// foreign processes either way. The keyword earns its keep against
+    /// assertions Webex ITSELF holds outside a call, which is the #475 concern
+    /// and what `testWebexWithUnrelatedAssertionNameIsNotDetected` pins.
+    func testWebexKeywordIsBoundToTheWebexProcess() {
+        for process in ["Amphetamine", "Google Chrome", PowerAssertionFixture.unknownBrowser] {
+            let detector = PowerAssertionDetector(
+                patterns: PowerAssertionDetector.patterns(watching: ["Webex"]),
+                confirmationCount: 1,
+            )
+            detector.windowListProvider = { [] }
+            detector.assertionProvider = {
+                PowerAssertionFixture.assertionDict(processName: process, assertName: "On a call")
+            }
+            XCTAssertNil(
+                detector.checkOnce(),
+                "\(process): the Webex keyword must not fire for a foreign process",
+            )
+        }
+    }
+
+    /// A Webex client holding an unrelated assertion must still not count as a
+    /// meeting — the keyword gate, not the process name, decides. Measured: an
+    /// idle Webex client holds no assertion at all, so this is the guard against
+    /// widening the pattern to plain display-sleep later.
+    func testWebexWithUnrelatedAssertionNameIsNotDetected() {
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Webex"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            PowerAssertionFixture.assertionDict(processName: "Webex", assertName: "Playing audio")
+        }
+        XCTAssertNil(detector.checkOnce(), "an unrelated Webex assertion must not be a meeting")
+    }
+
+    /// The Webex toggle still gates the new keyword: with Webex unchecked, the
+    /// measured assertion must be ignored.
+    func testWebexCallIsIgnoredWhenWebexIsNotWatched() {
+        let detector = PowerAssertionDetector(
+            patterns: PowerAssertionDetector.patterns(watching: ["Zoom"]),
+            confirmationCount: 1,
+        )
+        detector.windowListProvider = { [] }
+        detector.assertionProvider = {
+            PowerAssertionFixture.assertionDict(processName: "Webex", assertName: "On a call")
+        }
+        XCTAssertNil(detector.checkOnce(), "Webex off → a Webex call must not be detected")
+    }
 }

--- a/app/MeetingTranscriber/Tests/PowerAssertionFixture.swift
+++ b/app/MeetingTranscriber/Tests/PowerAssertionFixture.swift
@@ -13,19 +13,36 @@ enum PowerAssertionFixture {
     /// implementation can pass a test that uses it.
     static let unknownBrowser = "Fjordfox"
 
+    /// The two assertion types a meeting client is observed to hold. Only
+    /// patterns that set `assertionTypes` read this field, so `assertions`
+    /// pins the display-sleep one and a test spells both out when it
+    /// reproduces a measured mixture.
+    static let displaySleep = "PreventUserIdleDisplaySleep"
+    static let systemSleep = "PreventUserIdleSystemSleep"
+
     /// Assertions from one or more processes in a single poll. Variadic so a
     /// test can pin which browser a shared-keying implementation would have
     /// picked arbitrarily.
     static func assertions(
         _ entries: (pid: Int32, processName: String, assertName: String)...,
     ) -> [Int32: [[String: Any]]] {
+        typedAssertions(entries.map { (pid: $0.pid, processName: $0.processName, assertName: $0.assertName, assertType: Self.displaySleep) })
+    }
+
+    /// Same, with the assertion type spelled out per entry. Entries sharing a
+    /// pid accumulate rather than overwrite: one process holding several
+    /// assertions at once is the shape a real client produces during a call,
+    /// and it was the one shape this fixture could not express.
+    static func typedAssertions(
+        _ entries: [(pid: Int32, processName: String, assertName: String, assertType: String)],
+    ) -> [Int32: [[String: Any]]] {
         var out: [Int32: [[String: Any]]] = [:]
         for entry in entries {
-            out[entry.pid] = [[
+            out[entry.pid, default: []].append([
                 "Process Name": entry.processName,
                 "AssertName": entry.assertName,
-                "AssertType": "PreventUserIdleDisplaySleep",
-            ]]
+                "AssertType": entry.assertType,
+            ])
         }
         return out
     }


### PR DESCRIPTION
Fixes #652.

## What

The Webex desktop client is never auto-detected. Its `AssertionPattern` is
keyword-only on `"webex"`, but Cisco does not put the product name in the
assertion name. Measured with Webex 46.7.0.35472 on macOS 26.5.2 during an
instant meeting:

```
pid 870(Webex): [0x000402e000019b1b] 00:00:39 PreventUserIdleSystemSleep  named: "io avilable"
pid 870(Webex): [0x000402e200059b1c] 00:00:37 PreventUserIdleDisplaySleep named: "On a call"
```

`matches()` passes the bound `processNames` gate and then fails both remaining
tests — no `"webex"` in the name, and `assertionTypes` is empty — so detection
is impossible by construction. This is the #562 failure mode one app over
(Zoom carried Apple's `"Describe Activity Type"` placeholder).

It also explains a second symptom the reporter saw: with auto-detection dead
every recording is hand-started, and `ManualRecordingMonitorPolicy` only ends on
`.stopPidExited` / `.stopMaxDurationExceeded` — `WatchLoopEndPolicy.endGrace`
applies to auto-detected meetings only. One root cause, two symptoms.

## Why a keyword and not the `assertionTypes` fallback

#475 gave Zoom an `assertionTypes` fallback but deliberately kept Webex
keyword-only:

> Teams and Webex stay keyword-only, because Teams' WebView holds a
> display-sleep "Video Wake Lock" even with no call in progress.

Adding a keyword keeps that property, so the concern does not arise. The
pattern is also *bound*: `matches()` requires `processNames.contains(processName)`
first, so no foreign process can trigger it. On the measured machine
Amphetamine holds both display-sleep assertion types permanently and still
cannot false-positive — pinned by a counter-test.

`"io avilable"` is deliberately **not** used as a keyword: it is a Cisco typo a
future release will plausibly fix, and `PreventUserIdleSystemSleep` is the
weaker of the two signals.

## Tests

Four tests in `PowerAssertionDetectorPatternsTests`:

| test | pins |
|---|---|
| `testWebexCallWithCiscoAssertionNameIsDetected` | the measured assertion is detected |
| `testWebexKeywordIsBoundToTheWebexProcess` | `"On a call"` from Amphetamine / Chrome / an unknown process does **not** fire |
| `testWebexWithUnrelatedAssertionNameIsNotDetected` | a Webex client holding an unrelated assertion is not a meeting |
| `testWebexCallIsIgnoredWhenWebexIsNotWatched` | the "Apps to Watch" toggle still gates it |

Verified in that order, on the reporter's machine (Xcode 26.6, Swift 6.3.3,
macOS 26.5.2, Apple Silicon):

- **red first, deliberately** — with the tests added but the source unpatched:
  `Executed 18 tests, with 1 failure`, and the failure is
  `testWebexCallWithCiscoAssertionNameIsDetected`. The three guard tests pass
  before and after, since they pin behaviour the change must not alter.
- with the change: `Executed 78 tests, with 0 failures` across all
  `PowerAssertionDetector*` suites.
- wider regression (`--filter "Detector|Watching|Assertion|Settings|Pattern|Monitor"`):
  `Executed 484 tests, with 0 failures`.

`./scripts/lint.sh` was not run (SwiftLint/SwiftFormat unavailable in that
environment); the diff was checked by hand against `.swiftlint.yml` and
`.swiftformat` — no line exceeds 160 columns, the test file is 368 lines
(`file_length` 600), the class body 361 (`type_body_length` 400), and trailing
commas follow `--commas always`.

## Not verified

Whether `"On a call"` is localized in a non-English Webex UI. If it is, the
`assertionTypes` fallback becomes the more robust option after all — and a
measurement in #652 shows it would be safe for Webex: an **idle** Webex client
holds no assertion at all, unlike Teams' WebView.

## Follow-up, not in this PR

#652 also describes a detector that would remove this whole class of bug: the
same `IOPMCopyAssertionsByProcess` output already carries `coreaudiod`
assertions attributed to the consuming process via `kIOPMAssertionOnBehalfOfPID`
with `audio-in` / `audio-out` in the resources field. Keying on that is
vendor-string-independent, needs no new API or entitlement, and would cover
#608 (Slack Huddles) too. Happy to prepare it separately if you want it.

One small thing in the same area: `logUnmatchedWatchedAssertions` — the one line
that would have diagnosed this from the outside — is emitted at `logger.info`,
which macOS does not persist, so it is invisible after the fact. Emitting it at
`.default` would make future detection-gap reports self-diagnosing.
