### PR TITLE
docs: attribute the third-party components the app redistributes

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -2,12 +2,83 @@
 
 Meeting Transcriber itself is MIT licensed (see `LICENSE`).
 
-**Scope, stated so nothing here is mistaken for a completeness claim:** this
-file covers third-party **data resources** bundled into the shipped
-application. It does not yet enumerate the source dependencies compiled into
-the app binary (WhisperKit, FluidAudio, AudioTapLib and their own
-dependencies), which are also redistributed and carry their own attribution
-terms. That gap is known and not addressed here.
+**Scope:** this file covers every third-party component redistributed in the
+shipped application, whether statically linked into the app binary or bundled as
+a data resource. The licence text of each ships inside the app at
+`Contents/Resources/licenses/`, and the same files are kept in this repository
+under `licenses/`.
+
+Not covered, because they are not redistributed: dependencies used only to build
+the app (`swift-syntax`, which runs as a compiler macro plugin) and dependencies
+used only to run its tests (ViewInspector, swift-snapshot-testing,
+swift-custom-dump, xctest-dynamic-overlay). `swift-argument-parser` is likewise
+absent, since it is linked only into `tools/mt-cli`, a developer client that is
+not part of the `.app`. `AudioTapLib` is first-party code in this repository
+(`tools/audiotap`), not a third-party component.
+
+## WhisperKit
+
+Speech recognition (the default transcription engine), statically linked into
+the app binary.
+
+- **Project:** <https://github.com/argmaxinc/WhisperKit>
+- **Version:** 1.1.0, pinned in `app/MeetingTranscriber/Package.resolved`
+- **Copyright:** Copyright (c) 2024 argmax, inc.
+- **License:** MIT. MIT requires the copyright notice and permission notice in
+  all copies, and a binary is a copy, so the text ships as
+  `Contents/Resources/licenses/WhisperKit-LICENSE.txt`.
+
+WhisperKit is MIT licensed but incorporates Apache-2.0 code, and discharges that
+obligation through a `NOTICES` file rather than by restating the terms in its
+own licence. Section 4d of Apache-2.0 requires that a NOTICE travelling with a
+work be propagated by anyone who redistributes it, so that file ships unmodified
+as `Contents/Resources/licenses/WhisperKit-NOTICES.txt`. It attributes portions
+derived from swift-transformers (<https://github.com/huggingface/swift-transformers>,
+Copyright 2022 Hugging Face SAS) and carries the full Apache-2.0 text those
+portions are licensed under.
+
+## FluidAudio
+
+Speaker diarization, voice activity detection, speaker embeddings and the
+Parakeet and Nemotron live-caption engines, statically linked into the app
+binary.
+
+- **Project:** <https://github.com/FluidInference/FluidAudio>
+- **Version:** 0.15.5, pinned in `app/MeetingTranscriber/Package.resolved`
+- **Copyright:** the upstream `LICENSE` is the unmodified Apache-2.0 text with
+  the boilerplate `Copyright [yyyy] [name of copyright owner]` line left as
+  written, so it names no holder. The project is published by FluidInference.
+- **License:** Apache License 2.0. Section 4a requires a copy of the License
+  with any redistribution, so the text ships as
+  `Contents/Resources/licenses/FluidAudio-LICENSE.txt`. Upstream carries no
+  NOTICE file, so section 4d imposes nothing further here.
+
+FluidAudio vendors third-party code of its own, which this app therefore
+redistributes as well, so those notices ship too:
+
+- **fastcluster** (<https://github.com/fastcluster/fastcluster>), BSD-2-Clause,
+  © 2011 Daniel Müllner and, from version 1.1.24 on, © Google Inc. Upstream C++
+  source sits in FluidAudio's `Sources/FastClusterWrapper`, a target the
+  `FluidAudio` library depends on directly, so it is compiled into the app
+  binary. BSD-2-Clause requires binary redistributions to reproduce the
+  copyright notice in the materials accompanying the distribution, which is what
+  `Contents/Resources/licenses/FluidAudio-fastcluster-LICENSE.txt` is.
+- **VBx** (<https://github.com/BUTSpeechFIT/VBx>), Apache License 2.0,
+  © 2021-2024 BUT Speech@FIT. FluidAudio's variational Bayes clustering is a
+  Swift implementation based on it, and cites it as such. Shipped as
+  `Contents/Resources/licenses/FluidAudio-VBx-LICENSE.txt`.
+
+### NVIDIA NeMo
+
+FluidAudio's Sortformer diarization is ported from NeMo's implementation, which
+its own source files state. That is the same relationship its VBx entry above
+records, and it is user-reachable through the Sortformer diarization mode.
+
+- **Project:** <https://github.com/NVIDIA/NeMo>
+- **Copyright:** NVIDIA Corporation
+- **License:** Apache License 2.0, shipping as
+  `Contents/Resources/licenses/FluidAudio-NeMo-LICENSE.txt`. NeMo publishes no
+  NOTICE file, so section 4(d) adds nothing here.
 
 ## LocalVQE
 
@@ -20,9 +91,9 @@ app binary, and the model weights, bundled as
   `29ca38495cba9d6393a92a4dd890f28dd81f758d`, file
   `localvqe-v1.4-aec-200K-f32.gguf`
 - **Copyright:** 2024-2026 Richard Sherwood Palethorpe
-- **License:** Apache License 2.0. The full text ships alongside the model as
-  `Contents/Resources/LocalVQE-LICENSE.txt`, and is kept in this repository at
-  `licenses/LocalVQE-LICENSE.txt`.
+- **License:** Apache License 2.0. Bundling the weights is redistribution just
+  as linking the library is, so the full text ships as
+  `Contents/Resources/licenses/LocalVQE-LICENSE.txt`.
 
 LocalVQE is a streaming, CPU-tuned derivative of DeepVQE (Indenbom et al.,
 Interspeech 2023, <https://arxiv.org/abs/2306.03177>).
@@ -30,8 +101,7 @@ Interspeech 2023, <https://arxiv.org/abs/2306.03177>).
 The macOS `.xcframework` this app links is built from that source and published
 separately, because upstream ships no macOS artifact; `app/MeetingTranscriber/Package.swift`
 pins it by checksum. `scripts/fetch-localvqe-model.sh` pins the weights the same
-way, by revision and SHA-256, and `scripts/lib/localvqe-resources.sh` installs
-the model and this licence into the bundle together.
+way, by revision and SHA-256.
 
 The weights are also mirrored, unmodified, at
 <https://github.com/pasrom/localvqe-xcframework/releases/tag/model-v1.4-aec-200K>,
@@ -39,3 +109,25 @@ and the build fetches that copy first so a release does not depend on a single
 external host staying up. The mirror is a convenience for availability and not a
 source of authority: the SHA-256 above is verified whichever host answers, and
 the upstream revision named above remains the provenance.
+
+### ggml
+
+That archive is not LocalVQE alone. It statically links ggml, which supplies the
+tensor library, the CPU and BLAS backends and the GGUF reader, and which is a
+separate project under its own terms rather than part of LocalVQE's grant. It
+reaches this app only through the `CLocalVQE` binary target, so it is invisible
+in `Package.resolved` and easy to miss: verified by listing the objects in the
+linked archive, where ggml accounts for most of them.
+
+- **Project:** <https://github.com/ggml-org/ggml>
+- **Copyright:** 2023-2026 The ggml authors
+- **License:** MIT. The full text ships as
+  `Contents/Resources/licenses/ggml-LICENSE.txt`.
+
+## How these files get into the bundle
+
+`scripts/lib/bundle-licenses.sh` copies everything in `licenses/` into
+`Contents/Resources/licenses/`, and both `scripts/build_release.sh` and
+`scripts/run_app.sh` call it. It loops over the directory rather than naming
+components, so attributing a new dependency means adding its licence file to
+`licenses/` and nothing else.

--- a/licenses/FluidAudio-LICENSE.txt
+++ b/licenses/FluidAudio-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/FluidAudio-NeMo-LICENSE.txt
+++ b/licenses/FluidAudio-NeMo-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/FluidAudio-VBx-LICENSE.txt
+++ b/licenses/FluidAudio-VBx-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but not
+limited to compiled object code, generated documentation, and
+conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2021-2024 BUT Speech@FIT (original VBx project)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/licenses/FluidAudio-fastcluster-LICENSE.txt
+++ b/licenses/FluidAudio-fastcluster-LICENSE.txt
@@ -1,0 +1,11 @@
+Copyright:
+  * Until package version 1.1.23: © 2011 Daniel Müllner <https://danifold.net>
+  * All changes from version 1.1.24 on: © Google Inc. <https://www.google.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/WhisperKit-LICENSE.txt
+++ b/licenses/WhisperKit-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 argmax, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/WhisperKit-NOTICES.txt
+++ b/licenses/WhisperKit-NOTICES.txt
@@ -1,0 +1,210 @@
+This file lists third-party software incorporated into Argmax OSS and the
+license terms under which that software is distributed. Argmax OSS itself is
+released under the MIT License (see LICENSE in the repository root).
+
+================================================================================
+swift-transformers
+================================================================================
+
+Portions of Argmax OSS (under Sources/ArgmaxCore/External) are derived from the
+swift-transformers project:
+
+  https://github.com/huggingface/swift-transformers
+
+Copyright 2022 Hugging Face SAS.
+
+These files have been modified by Argmax, Inc. Modifications are marked in the
+source with "Argmax-modification:" comments, and each derived file retains its
+original copyright notice in the file header.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+The full text of the Apache License, Version 2.0 follows.
+
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/licenses/ggml-LICENSE.txt
+++ b/licenses/ggml-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -118,7 +118,14 @@ if [ -d "$ICONSET_SRC" ]; then
     echo "  App icon: $RESOURCES/AppIcon.icns"
 fi
 
-# LocalVQE acoustic echo cancellation model, plus the licence it ships under.
+# Licences for the third-party code and weights this bundle redistributes.
+# Installed before the model, and unconditionally, so no failure further down
+# can produce a bundle that ships the components without their notices.
+# shellcheck source=lib/bundle-licenses.sh
+source "$SCRIPT_DIR/lib/bundle-licenses.sh"
+install_third_party_licenses "$RESOURCES"
+
+# LocalVQE acoustic echo cancellation model.
 # Bundled rather than downloaded on first use; the reasoning is in the header of
 # app/MeetingTranscriber/Sources/LocalVQEModel.swift. Both variants get it: the
 # model is a plain data file, so nothing here is sandbox-sensitive.

--- a/scripts/lib/bundle-licenses.sh
+++ b/scripts/lib/bundle-licenses.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Installs the third-party licence texts every shipped bundle has to carry.
+#
+# The app statically links third-party source (WhisperKit, FluidAudio) and
+# bundles third-party weights (LocalVQE), so the .app redistributes all of them.
+# Apache-2.0 section 4a wants a copy of the License with any redistribution and
+# 4d wants an existing NOTICE propagated; MIT wants its copyright and permission
+# notice in all copies, and a binary is a copy. Nothing about that is visible at
+# link time, which is exactly why it needs a build step rather than good
+# intentions.
+#
+# The loop copies whatever `licenses/` holds instead of naming components, so a
+# new dependency is attributed by dropping its licence file into that directory:
+# no build script has to learn about it, and there is no per-component list that
+# can silently fall behind the one in Package.swift.
+#
+# This is why the licence copy no longer rides along with the LocalVQE model
+# install. Installing it here strengthens the property that helper's header
+# claims: licences land unconditionally from a directory, not as a side effect of
+# a model download that a caller is allowed to fail past.
+#
+# Source this, don't execute it.
+
+# Copies every licence text in the repo's licenses/ directory into
+# <resources-dir>/licenses/. Fatal on failure under `set -e`: a bundle that
+# redistributes the code without the notices is not one to ship.
+install_third_party_licenses() {
+    local resources_dir="$1"
+    local lib_dir licenses_src dest
+    local -a licence_files
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    licenses_src="$lib_dir/../../licenses"
+    dest="$resources_dir/licenses"
+
+    # Collected rather than globbed straight into cp so an empty directory is a
+    # hard stop. Unmatched, the glob would reach cp as a literal path and the
+    # error would read like a missing file instead of "this bundle attributes
+    # nothing".
+    licence_files=("$licenses_src"/*.txt)
+    if [ ! -e "${licence_files[0]}" ]; then
+        echo "  ERROR: no licence texts in $licenses_src" >&2
+        return 1
+    fi
+
+    # Anything outside the glob would be skipped in silence, and the directory
+    # would still be non-empty so the check above would not catch it. Upstream
+    # projects commonly ship LICENSE.md, so dropping one in unrenamed is the
+    # natural mistake: it has to fail the build rather than bundle nothing.
+    local candidate
+    for candidate in "$licenses_src"/*; do
+        case "$candidate" in
+            *.txt) ;;
+            *)
+                echo "  ERROR: $candidate is not a .txt and would not be bundled" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    mkdir -p "$dest"
+    cp "${licence_files[@]}" "$dest/"
+
+    echo "  Third-party licenses: $dest (${#licence_files[@]} files)"
+}

--- a/scripts/lib/localvqe-resources.sh
+++ b/scripts/lib/localvqe-resources.sh
@@ -3,15 +3,15 @@
 #
 # Two scripts assemble a bundle — build_release.sh for distribution and
 # run_app.sh for the dev app that e2e-app.sh then deploys — and both need the
-# same two files in Contents/Resources. Spelled twice they drift, which the
-# first version of this change proved by dropping the licence copy from the dev
-# path on day one. The failure policy is NOT shared, because it legitimately
-# differs: see the callers.
+# same model in Contents/Resources. Spelled twice they drift, which the first
+# version of this change proved by dropping the licence copy from the dev path
+# on day one. The failure policy is NOT shared, because it legitimately differs:
+# see the callers.
 #
 # Source this, don't execute it.
 
-# Fetches the pinned model and installs it, with its licence, into the given
-# Resources directory. Returns non-zero if ANY step fails, not just the fetch.
+# Fetches the pinned model and installs it into the given Resources directory.
+# Returns non-zero if ANY step fails, not just the fetch.
 #
 # Every step propagates its own failure explicitly rather than leaning on the
 # caller's `set -e`, because one of the callers invokes this as
@@ -20,6 +20,14 @@
 # failing `cp` would fall through to the next statement and the closing `echo`
 # would hand back status 0: the build log would announce an installed model,
 # the warning would never print, and the signed bundle would contain nothing.
+#
+# The LocalVQE licence copy lives in lib/bundle-licenses.sh now, and the
+# guarantee it used to give here got stronger in the move: the licence no
+# longer arrives as a side effect of a model download that run_app.sh is
+# allowed to fail past, but unconditionally, from a directory, before this
+# function is ever reached. A bundle carrying the weights without the licence
+# was previously prevented by the two copies sitting next to each other; it is
+# now impossible by ordering.
 install_localvqe_resources() {
     local resources_dir="$1"
     local lib_dir model_path model_name
@@ -39,10 +47,6 @@ install_localvqe_resources() {
     # belongs here where both callers inherit it.
     rm -f "$resources_dir"/localvqe-*.gguf || return 1
     cp "$model_path" "$resources_dir/$model_name" || return 1
-    # Bundling the weights is redistribution, which is what makes the licence
-    # copy mandatory rather than courteous (Apache-2.0 section 4a). The two are
-    # installed together so no bundle can carry one without the other.
-    cp "$lib_dir/../../licenses/LocalVQE-LICENSE.txt" "$resources_dir/LocalVQE-LICENSE.txt" || return 1
 
     echo "  LocalVQE model: $resources_dir/$model_name"
 }

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -61,6 +61,15 @@ GIT_HASH=$(git -C "$TRANSCRIBER_ROOT" rev-parse --short HEAD 2>/dev/null || echo
 
 cp "$BUILD_BINARY" "$APP_BINARY"
 
+# Licences for the third-party code and weights this bundle redistributes. The
+# dev app is not distributed, but scripts/e2e-app.sh deploys it, so keeping it
+# identical to a release bundle is what makes an e2e run evidence about the
+# thing users get. Fatal here, unlike the model below: a missing licence file in
+# the repo is a repo bug, not an unreachable download.
+# shellcheck source=lib/bundle-licenses.sh
+source "$SCRIPT_DIR/lib/bundle-licenses.sh"
+install_third_party_licenses "$APP_BUNDLE/Contents/Resources"
+
 # LocalVQE echo-cancellation model, the same resources build_release.sh bundles,
 # so the dev app (which scripts/e2e-app.sh deploys) can exercise the feature.
 # Non-fatal here and fatal there: an unreachable download must not stop someone


### PR DESCRIPTION
**Stacked on #655. Merge this after #655.** Its base is `feat/localvqe-model-provisioning`, which introduces `THIRD-PARTY-NOTICES.md`, `licenses/` and `scripts/lib/localvqe-resources.sh`; this PR extends all three. Merging it before #655 would take those files with it.

## What was missing

The shipped `.app` statically links three third-party components and redistributes them. Only one was attributed.

| Component | Licence | Before | After |
|---|---|---|---|
| LocalVQE (library + bundled weights) | Apache-2.0 | attributed (#655) | unchanged, moved into `licenses/` subdir |
| FluidAudio | Apache-2.0 | not attributed | licence ships |
| WhisperKit | MIT, ships a `NOTICES` | not attributed | licence + `NOTICES` ship |

What the licences ask for:

- Apache-2.0 section 4a: a copy of the License travels with any redistribution. That covers FluidAudio.
- Apache-2.0 section 4d: a NOTICE that travels with a work must be propagated by anyone redistributing it. WhisperKit is MIT but incorporates Apache-2.0 code (swift-transformers, Hugging Face) and discharges that through its 210-line `NOTICES` rather than in its own licence, so that file has to travel with our build too.
- MIT: the copyright and permission notice in all copies. A binary is a copy.

## Also found while doing it

FluidAudio vendors third-party code that reaches our binary with it, which the original scoping did not account for:

- **fastcluster**, BSD-2-Clause. Upstream C++ source sits in FluidAudio's `Sources/FastClusterWrapper`, a target the `FluidAudio` library depends on directly. The release build log shows `Compiling FastClusterWrapper FastClusterWrapper.cpp`, so it is in our binary. BSD-2-Clause requires binary redistributions to reproduce that copyright notice in the accompanying materials.
- **VBx**, Apache-2.0. FluidAudio's variational Bayes clustering is a Swift implementation based on the BUT Speech@FIT work and cites it as such.

Both notices now ship as well. This is exactly the case the design below was built for: attributing them was dropping two files into `licenses/`, no script change. If you would rather scope this PR to the three components originally listed, deleting those two files is the whole revert, but the scope paragraph in `THIRD-PARTY-NOTICES.md` would then need to stop claiming completeness.

## How it works

`scripts/lib/bundle-licenses.sh` exposes `install_third_party_licenses <resources-dir>`, which copies everything in `licenses/` into `<resources-dir>/licenses/`. Both `scripts/build_release.sh` and `scripts/run_app.sh` call it.

It loops over the directory rather than naming components. A per-component list is a second place that has to be kept in step with `Package.swift`, and it fails silently: nothing about adding a statically linked dependency announces at build time that it needs attributing. With a loop, attributing a dependency is adding its licence file and nothing else.

The LocalVQE licence copy moves out of `localvqe-resources.sh`, which now only fetches and installs the model. That helper's header argued the model and licence were installed together so no bundle could carry one without the other. The property survives and gets stronger, so the comment now says so accurately: the licences no longer arrive as a side effect of a model download that `run_app.sh` is explicitly allowed to fail past, but unconditionally, from a directory, at a call placed ahead of the model install in both scripts.

The dev bundle gets them too. It is not distributed, but `scripts/e2e-app.sh` deploys it, and an e2e run is only evidence about the shipped artifact insofar as the two bundles are alike. Four small text files is a cheap price for that.

`THIRD-PARTY-NOTICES.md` previously narrowed its scope to bundled data resources and said in as many words that it did not yet enumerate the source dependencies compiled into the binary. That caveat was the gap, so it is replaced by an accurate scope rather than softened, with entries for each component (project, pinned version, copyright holder as the upstream files state it, licence, where the text lands in the bundle) and a plain statement of what is not covered: `swift-syntax` runs as a build-time macro plugin, the test dependencies never reach the app, and `swift-argument-parser` is linked only into `tools/mt-cli`, which is not part of the `.app`.

One nit recorded rather than papered over: FluidAudio's `LICENSE` leaves the Apache boilerplate `Copyright [yyyy] [name of copyright owner]` line as written, so it names no holder. The notices file says that instead of inventing one.

## Verification

All licence texts are byte-identical copies (`cmp`) of the files in the SwiftPM checkouts, at the revisions `Package.resolved` pins (WhisperKit 1.1.0 / `1e2a1637`, FluidAudio 0.15.5 / `19600a48`, both confirmed against the checkout HEADs). No reflow, no summarising; renamed to `.txt` only.

- `./scripts/lint.sh`: exit 0, `Found 0 violations, 0 serious in 490 files`.
- `shellcheck -S warning` on `bundle-licenses.sh`, `localvqe-resources.sh`, `build_release.sh`, `run_app.sh`: exit 0. Also clean at `-S style`.
- `swift test --parallel --skip SpeakerMatcherRealRecordingBacktest`: exit 0, 2849 tests, no failures.
- `./scripts/build_release.sh --no-notarize`: exit 0, and the bundled `Contents/Resources/licenses/` listed and each file `cmp`-checked against the repository copy. All six present and identical.
- `./scripts/build_release.sh --appstore --no-notarize`: exit 0, same assertion, same result. Both variants carry them.
- `codesign --verify --strict --deep`: valid on disk, satisfies its Designated Requirement. All six licences are sealed into `_CodeSignature/CodeResources`, so the new nested directory under `Resources` does not break sealing.