### PR TITLE
build(app): fix the xcframework header collision that FluidAudio 0.15.6 exposes

### DIFF
--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -25,10 +25,20 @@ let package = Package(
         // that remains is availability, since the asset disappearing breaks
         // `swift build` for everyone including CI. Mirror it before relying on
         // this for a release.
+        //
+        // Its headers sit in `Headers/CLocalVQE/`, not at the root of
+        // `Headers/`, and a rebuild must keep it that way. For a static-library
+        // slice xcodebuild stages every artifact's `Headers/*` into one shared
+        // `include/` directory, so two xcframeworks with a root-level
+        // `module.modulemap` write the same path and the build dies with
+        // "Multiple commands produce". FluidAudio started shipping a binary
+        // target in 0.15.6 and hit exactly that. `swift build` never noticed,
+        // because it passes each artifact's Headers directory as its own `-I`,
+        // which is why this can only fail in Xcode and in the analyze lane.
         .binaryTarget(
             name: "CLocalVQE",
-            url: "https://github.com/pasrom/localvqe-xcframework/releases/download/1.0.2/LocalVQE.xcframework.zip",
-            checksum: "c0b0f41245611cca194ed279096d4729f87aba1f59cf92972383bff0f8e903c1"
+            url: "https://github.com/pasrom/localvqe-xcframework/releases/download/1.0.3/LocalVQE.xcframework.zip",
+            checksum: "15a7503e7d764012ee955ba04cef78a0b24f8d51856fc85b96d9be49d38624ba"
         ),
         .executableTarget(
             name: "MeetingTranscriber",


### PR DESCRIPTION
Repoints the `CLocalVQE` binary target at LocalVQE.xcframework **1.0.3**, whose headers sit in `Headers/CLocalVQE/` instead of at the root of `Headers/`.

## What breaks without this

FluidAudio 0.15.6 (#657) ships its first binary target, `NemoTextProcessing.xcframework`. Both it and our LocalVQE artifact kept a `module.modulemap` directly in `Headers/`. For a static-library slice, xcodebuild's `ProcessXCFramework` stages every artifact's `Headers/*` into one shared `BUILT_PRODUCTS_DIR/include/`, so the two write the same destination path:

```
error: Multiple commands produce '.../Build/Products/Debug/include/module.modulemap'
  note: ProcessXCFramework .../fluidaudio/NemoTextProcessing/NemoTextProcessing.xcframework
  note: ProcessXCFramework .../meetingtranscriber/CLocalVQE/LocalVQE.xcframework
```

`swift build` is unaffected, because it passes each artifact's own Headers directory as a separate `-I`. That asymmetry is why the SwiftPM jobs stayed green and only `analyze` failed, and why anyone opening the package in Xcode after the bump hits it too.

## Verified both ways

A fix for a failure nobody has reproduced is a guess, so both arms were run locally against FluidAudio 0.15.6:

| LocalVQE headers | `xcodebuild build-for-testing` | `swift test` |
|---|---|---|
| flat (1.0.2, shipping today) | Multiple commands produce, **FAILED** | passes |
| nested (1.0.3) | **SUCCEEDED** | passes |

The published 1.0.3 asset was then re-downloaded from the release and checked against the pinned checksum, rather than trusting the local build.

## Compatibility

None for consumers. The static library, the module name `CLocalVQE` and the C API are unchanged; the modulemap's `header "localvqe_api.h"` is modulemap-relative and both files stay siblings. Two files import the module and nothing includes the header directly, so the one spelling that could have changed has no call site.

## Sequencing

This must land **before** #657. Merging the FluidAudio bump first leaves `main` red.

No version pin is added: `Package.resolved` is committed, so CI is already reproducible, and a pin would block a dependency the project tracks while buying nothing.

## Not fixed here

The collision is over identical staged file names, not specifically `module.modulemap`. A third dependency shipping a flat static xcframework would collide with FluidAudio's, and only upstream can fix that pair. Worth reporting to FluidAudio and text-processing-rs so they nest theirs too, but it does not block this: a collision needs two flat artifacts and ours is no longer one.
