### PR TITLE
build(app): bound FluidAudio below 0.15.6 to restore the sanitizer lane

### DIFF
--- a/app/MeetingTranscriber/Package.resolved
+++ b/app/MeetingTranscriber/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "737035cc3ea1e44ab236a23b84fc49f4d1dd6aad5aa3b2022e127c4499311f9e",
+  "originHash" : "09136fc86af69410e218d5b7a6c07e59809ffc1505ad3d800f0651ad425df45a",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b",
-        "version" : "0.15.6"
+        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
+        "version" : "0.15.5"
       }
     },
     {

--- a/app/MeetingTranscriber/Package.swift
+++ b/app/MeetingTranscriber/Package.swift
@@ -9,7 +9,20 @@ let package = Package(
         .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.3"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.19.1"),
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "1.0.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
+        // Upper bound, not a preference: 0.15.6 adds a Rust static library
+        // (NemoTextProcessing) whose `_rust_eh_personality` is a fourth
+        // exception personality routine in the linked image. Apple's compact
+        // unwind format encodes three (`UNWIND_PERSONALITY_MASK` is a two bit
+        // index, 0 means none), so the ThreadSanitizer build stops linking:
+        // C++ and Rust come from FluidAudio itself, Objective-C from our
+        // AVFAudio exception wrapper, and ThreadSanitizer injects the fourth.
+        // The regular build still links because it sits at exactly three.
+        //
+        // Measured: Apple's ld fails the same on Xcode 26.6 and the 27.0 beta,
+        // and `-Wl,-no_compact_unwind` links but then aborts on the first
+        // exception. Lift this bound once FluidAudio offers a way to link
+        // without that archive, or ships it as a dynamic library.
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.13.4" ..< "0.15.6"),
         .package(path: "../../tools/audiotap"),
     ],
     targets: [


### PR DESCRIPTION
The nightly ThreadSanitizer leg has been unable to link since 0.15.6 landed on main. This sets an upper bound on the dependency so the lane is green again, and records why, so the bound can be lifted deliberately rather than forgotten.

## What broke

`0.15.6` adds `NemoTextProcessing.xcframework`, a Rust static library, as an unconditional dependency of the `FluidAudio` target. It contributes `_rust_eh_personality`, a fourth exception personality routine. Apple's compact unwind format encodes three: `UNWIND_PERSONALITY_MASK` in `mach-o/compact_unwind_encoding.h` is a two bit index whose 0 means "no personality".

Counted on this app:

| routine | contributed by |
|---|---|
| `___gxx_personality_v0` | FluidAudio's own `FastClusterWrapper.cpp` |
| `_rust_eh_personality` | FluidAudio's new archive |
| `___objc_personality_v0` | our AVFAudio exception wrapper |
| `___gcc_personality_v0` | ThreadSanitizer, injected into 925 Swift objects |

Regular and AddressSanitizer builds keep working because they sit at exactly three. Only ThreadSanitizer adds the fourth.

## Why a bound and not a revert

Reverting the resolved file alone would not hold, since the next resolution picks 0.15.6 again. An upper bound keeps 0.15.5 updatable and needs no Dependabot ignore rule, because Dependabot honours the manifest constraint.

## What it costs

The fixes in 0.15.6 that we want, notably the Sortformer streaming timestamp drift. The bound is meant to be lifted once FluidAudio offers a way to link without that archive, or ships it as a dynamic library. An upstream report is being prepared.

## Alternatives measured and rejected

- `-Wl,-no_compact_unwind`, the usual advice, links and then terminates at runtime: a C++ `try/catch` that succeeds without the flag aborts with it, because clang emits only compact unwind for the affected functions on arm64.
- `-Xlinker -ld_classic` hits the same cap.
- `ld64.lld` links the same inputs, but only because it demotes almost everything to DWARF. Forced to encode four personalities compactly it fails identically, so it is an accident of the current object mix rather than headroom.
- Apple's linker behaves the same in Xcode 26.6 (`ld-1267`) and the 27.0 beta (`ld-27037.1`).

## Verification

Full suite green, lint clean, release parity passed, and `swift build --build-tests --sanitize=thread` links again.

Closes the need for #657, which cannot merge on top of this.