### PR TITLE
ci: fail the label check when a PR title is not conventional

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -6,10 +6,18 @@ name: Auto-label PRs
 # with 403 "Resource not accessible by integration". pull_request_target runs
 # in the base-repo context with a token that honors the declared permissions.
 #
+# The job also GATES the title: a title matching no conventional-commit type
+# fails the check instead of passing silently. Before that, an unconventional
+# title simply produced no label and the job still reported success, so nothing
+# ever surfaced it (observed on PR #642, whose title was fixed only because a
+# human noticed it at merge time).
+#
 # SAFETY: this is only safe because the job never checks out or executes the
 # PR's code. It reads the PR title from the event payload as data (via
 # context.payload, not a `${{ }}` interpolation) and applies a label from a
-# fixed allowlist. Do NOT add an `actions/checkout` of the PR head followed by
+# fixed allowlist. The failure message embeds the title through
+# `core.setFailed`, which escapes workflow-command characters, so it stays
+# data there too. Do NOT add an `actions/checkout` of the PR head followed by
 # build/run steps here, and do NOT interpolate PR-controlled fields (title,
 # body, branch name) via `${{ }}` into a script/run block — either would expose
 # the writable token to untrusted fork input.
@@ -23,7 +31,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Label PR from conventional commit title
+      - name: Check conventional commit title and label PR
         uses: actions/github-script@v9
         with:
           script: |
@@ -36,11 +44,24 @@ jobs:
             else if (/^(ci|build|chore)[\s(:|!]/.test(title)) labels.push('chore');
             else if (/^(refactor|perf|test)[\s(:|!]/.test(title)) labels.push('chore');
 
-            if (labels.length > 0) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels
-              });
+            // No label means no recognised type, which is the same condition
+            // the repo's commit convention rejects. Fail with the expected
+            // shape spelled out: an outside contributor cannot be expected to
+            // infer it from a red check alone. Re-editing the title re-runs
+            // this workflow, so the fix is immediate.
+            if (labels.length === 0) {
+              core.setFailed(
+                `PR title does not follow Conventional Commits: "${title}"\n` +
+                'Expected "<type>(<scope>): <description>", where type is one of ' +
+                'feat, fix, docs, refactor, test, perf, chore, build, ci.\n' +
+                'Example: feat(app): add transcript output privacy options',
+              );
+              return;
             }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels
+            });

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,24 +43,47 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const labels = [];
 
-            if (/^feat[\s(:|!]/.test(title)) labels.push('enhancement');
-            else if (/^fix[\s(:|!]/.test(title)) labels.push('bug');
-            else if (/^docs[\s(:|!]/.test(title)) labels.push('documentation');
-            else if (/^(ci|build|chore)[\s(:|!]/.test(title)) labels.push('chore');
-            else if (/^(refactor|perf|test)[\s(:|!]/.test(title)) labels.push('chore');
+            // One pattern decides both questions: whether the title is
+            // acceptable, and which label it earns. The previous per-type
+            // regexes only anchored the type word, so `[\s(:|!]` let
+            // "fix the flaky test" through as a bug and "feat:" through with
+            // no description, while the failure message promised
+            // "<type>(<scope>): <description>". Gate and message now state the
+            // same contract.
+            const CONVENTIONAL_TITLE =
+              /^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-z0-9-]+\))?!?: .+/;
 
-            // No label means no recognised type, which is the same condition
-            // the repo's commit convention rejects. Fail with the expected
-            // shape spelled out: an outside contributor cannot be expected to
-            // infer it from a red check alone. Re-editing the title re-runs
-            // this workflow, so the fix is immediate.
-            if (labels.length === 0) {
+            // GitHub's own Revert button writes `Revert "<original subject>"`,
+            // which no conventional type matches. Rejecting it would fail the
+            // one title a maintainer cannot edit before the PR exists.
+            const REVERT_BUTTON_TITLE = /^Revert ".+"$/;
+
+            const LABEL_BY_TYPE = {
+              feat: 'enhancement',
+              fix: 'bug',
+              docs: 'documentation',
+            };
+
+            let type = null;
+            if (REVERT_BUTTON_TITLE.test(title)) {
+              type = 'revert';
+            } else {
+              const match = CONVENTIONAL_TITLE.exec(title);
+              if (match) type = match[1];
+            }
+
+            // No type means the title states none, which is the same condition
+            // the commit convention rejects. Fail with the expected shape
+            // spelled out: an outside contributor cannot infer it from a red
+            // check alone. Re-editing the title re-runs this workflow, so the
+            // fix is immediate.
+            if (type === null) {
               core.setFailed(
                 `PR title does not follow Conventional Commits: "${title}"\n` +
                 'Expected "<type>(<scope>): <description>", where type is one of ' +
-                'feat, fix, docs, refactor, test, perf, chore, build, ci.\n' +
+                'feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert. ' +
+                'The scope is optional and an exclamation mark may mark a breaking change.\n' +
                 'Example: feat(app): add transcript output privacy options',
               );
               return;
@@ -70,5 +93,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels
+              labels: [LABEL_BY_TYPE[type] ?? 'chore'],
             });

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -34,6 +34,10 @@ on:
 
 jobs:
   label:
+    # The check context is this job's id unless it carries a name, and a
+    # contributor reading "label - failing" concludes the labeling is broken
+    # rather than that their title is. Name it after what it verifies.
+    name: conventional-title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -23,7 +23,14 @@ name: Auto-label PRs
 # the writable token to untrusted fork input.
 on:
   pull_request_target:
-    types: [opened, edited]
+    # `synchronize` and `reopened` matter now that the job can fail. A check
+    # run attaches to the PR head at event time, so without them a push leaves
+    # the new head with no verdict at all: not red, not green, absent. Branch
+    # protection has `strict: true`, so nearly every PR is updated from main
+    # right before merging, which is exactly such a push. The gate would then
+    # be missing at the one moment it is supposed to bind. `ready_for_review`
+    # covers a draft opened before its title was settled.
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 jobs:
   label:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ the stable-tag ruleset gate → see the `distribution` skill (`.claude/skills/di
 
 Use the `/git-workflow` skill. Commit proactively after every logical unit of work — don't wait for user permission.
 
-- **Conventional Commits:** `<type>(<scope>): <description>` — types: feat, fix, docs, refactor, test, perf, chore, build
+- **Conventional Commits:** `<type>(<scope>): <description>` — types: feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert. CI enforces this on the PR title too (`conventional-title` check); the type list there and here must stay in step.
 - **Scopes:** app, test, build, ci, docs
 - **Atomic commits:** one logical change per commit. If you need "and" in the message, split it.
 - **Stage explicitly:** `git add <file1> <file2>` — never `git add -A` or `git add .`


### PR DESCRIPTION
## What

The auto-label job mapped a conventional-commit type in the PR title to a label and applied it only when something matched. A title matching nothing produced no label and the job still reported `success`, so an unconventional title passed every gate unnoticed. The job now fails in that case and names the expected shape.

Four commits, each one change.

## Why

Observed on #642: its title was `improve privacy options for output`, the labeling run reported success, and the title was corrected to `feat(app): …` only because someone happened to look before merging. Nothing in CI would have caught it.

## The three things a blind-spot review turned up

**The verdict used to vanish on every push.** A check run attaches to the PR head at event time, and the job fired only on `opened` and `edited`. A push therefore left the new head with no verdict at all: not red, not green, absent. Branch protection sets `strict: true`, so nearly every PR is updated from main immediately before merging, and that update is a push, which means the gate would have been missing at exactly the moment it is meant to bind. `synchronize`, `reopened` and `ready_for_review` are now in the trigger list.

**The gate accepted far less than its message demanded.** The per-type regexes only anchored the type word, and the character class `[\s(:|!]` accepted a bare word plus a space. `fix the flaky test` passed as a bug, `build the DMG locally` as a chore, and `feat:` passed with no description, while the failure message promised `<type>(<scope>): <description>`. One pattern now answers both questions, so acceptance and message cannot drift apart again.

**The complete list had to include what this repo actually uses.** `style` is a live type here (several `style(app):` commits on main) and previously failed. `revert` was uncovered in both forms, including GitHub's own Revert button, which writes `Revert "<original subject>"` and is the one title a maintainer cannot choose before the PR exists. `CLAUDE.md` listed eight types and treated `ci` as a scope only, while history uses `ci:` as a type heavily; that file now carries the same list and says the two must stay in step.

## Contributor experience

The check is named `conventional-title` rather than `label`, so a red mark reads as a statement about the title instead of broken labeling infrastructure. The message carries the pattern, the full type list, the optional scope and breaking-change marker, and a worked example:

```
PR title does not follow Conventional Commits: "improve privacy options for output"
Expected "<type>(<scope>): <description>", where type is one of feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert. The scope is optional and an exclamation mark may mark a breaking change.
Example: feat(app): add transcript output privacy options
```

Editing the title re-runs the workflow, so a correction turns the check green immediately.

## Safety

The `pull_request_target` properties are unchanged and deliberately so: no checkout of PR code, the title read as data from `context.payload` rather than interpolated through `\${{ }}`, and the failure message emitted through `core.setFailed`, whose `escapeData` escapes `%`, `\r` and `\n`; workflow commands are line-anchored, so a hostile title cannot forge one. The header comment states all of this so the next editor does not undo it.

## Verified

The test extracts the script from the workflow YAML and runs that, rather than a copy: all 25 cases classify as intended, including every type this repo uses, a breaking-change marker, a Dependabot `build(deps):` title, both revert forms, the real #642 title, and near-misses such as `fixup:`, `feature:`, `feat:` and `Fix …` with a capital F.

Calibrated against the last 40 merged PR titles: four would fail, all free-form subjects predating the convention.

## One decision left for you

This is still not a required status check, so it shows red and blocks nothing. That is now a safe thing to change if you want it to gate merges, because the missing `synchronize` trigger that would have deadlocked PRs is fixed here. The required context string would be `conventional-title`.

Note that this PR cannot exercise its own change: `pull_request_target` runs the workflow from the base branch, so the check you see here ran main's version. Confirm after merging by editing a PR title to something unconventional and back.

## Why this is hand-rolled rather than an off-the-shelf action

`amannn/action-semantic-pull-request` does title validation properly and is the usual answer. It was not chosen here, deliberately:

- This job runs under `pull_request_target` with `pull-requests: write`, so any action in it holds a writable token on every fork PR. That is a different risk class from an action in a build job, and the only third-party action this repository puts near a privileged path (`ncipollo/release-action`) is SHA-pinned for the same reason. Keeping the step on first-party `actions/github-script` avoids the question entirely.
- The standard action validates only. This job also assigns the label that `release.yml` turns into changelog categories, so it would be action plus script, with the writable token still in the job.

The cleaner shape, if this grows: split into two jobs, validation in one with `permissions: {}` where a third-party action holds nothing, labeling in this one. Worth doing if the rules get more elaborate than a single pattern; overkill for thirty lines.
