### PR TITLE
build(ci): bump pinned SwiftFormat to 0.63.0

### DIFF
--- a/scripts/tool-versions.sh
+++ b/scripts/tool-versions.sh
@@ -15,8 +15,8 @@
 # Bumping is a deliberate act: land the new version, its checksum, and whatever
 # the new release wants changed in the same commit.
 
-SWIFTFORMAT_VERSION="0.62.1"
-SWIFTFORMAT_SHA256="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
+SWIFTFORMAT_VERSION="0.63.0"
+SWIFTFORMAT_SHA256="28c7802e11fa5ae113d903066439c6bb1be20a8ac1ad9709c42616a7e273fb0f"
 SWIFTFORMAT_REPO="nicklockwood/SwiftFormat"
 SWIFTFORMAT_ASSET="swiftformat.zip"
 


### PR DESCRIPTION
Closes #664.

## Result

Nothing to reformat. `0 of 502 files require formatting` on this tree, so the version and the checksum are the entire change.

## What the release changes, and why none of it lands here

0.63.0 adds `ifExpressions`, `preferLazyMap` and `redundantExtendedLifetime`, and moves several defaults, notably `--single-line-ternary` to `convert`, `--wrapstringinterpolation` to `preserve`, and `redundantOptionalBinding` to the `if let property` shorthand.

The issue asks for a judgement about new default rules, so I compared the two binaries' own rule listings rather than reading the changelog and hoping. **0.63.0 enables no rule by default that 0.62.1 did not.** Six names drop out of the default set, and all six are deprecated aliases now listed separately: `redundantProperty`, `sortedImports`, `sortedSwitchCases`, `specifiers`, `throwingTests`, `wrapConditionalBodies`. `.swiftformat` references none of them, so there is nothing to migrate.

## How it was measured

In a worktree **outside** the repository, deliberately. SwiftFormat merges configuration from parent directories, so a worktree nested under the main checkout also reads that checkout's `.swiftformat`, and on a stale branch that is a different file. My first run did exactly that and the result would have been unsound.

The 0.62.1 archive used for the comparison hashes to the checksum already pinned in `scripts/tool-versions.sh`, which confirms the download path matches what CI installs.

## Checksum

```
curl -fsSL -o /tmp/t.zip https://github.com/nicklockwood/SwiftFormat/releases/download/0.63.0/swiftformat.zip && shasum -a 256 /tmp/t.zip
28c7802e11fa5ae113d903066439c6bb1be20a8ac1ad9709c42616a7e273fb0f
```