### PR TITLE
fix(ci): make the e2e lanes configure the app they are testing

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -572,32 +572,32 @@ fi
 # explicit "Start Watching" menu click would — necessary because that
 # menu isn't reachable over SSH. `debugRPCEnabled` brings the RPC up at
 # launch instead of after a Settings toggle.
-defaults write "$DEV_BUNDLE_ID" debugRPCEnabled -bool true
-defaults write "$DEV_BUNDLE_ID" autoWatch -bool true
+write_dev_default "$DEV_BUNDLE_ID" debugRPCEnabled true bool
+write_dev_default "$DEV_BUNDLE_ID" autoWatch true bool
 # The echo dedup ships off, so the lane has to ask for it. Set unconditionally
 # rather than only for --echo-bleed: a stale toggle from an earlier run on the
 # same host would otherwise decide it, and the lane that asserts nothing is
 # removed on a clean pair needs the feature ON to mean anything.
-defaults write "$DEV_BUNDLE_ID" echoDedupEnabled -bool true
+write_dev_default "$DEV_BUNDLE_ID" echoDedupEnabled true bool
 
 if [ "$MIC_ONLY" = true ]; then
     # Record-only so the lane needs no ASR models, and auto-watch OFF so nothing
     # detects a meeting and starts a second recording next to the manual one.
     log "Enabling record-only mode and disabling auto-watch for the mic-only lane"
-    defaults write "$DEV_BUNDLE_ID" recordOnly -bool true
-    defaults write "$DEV_BUNDLE_ID" autoWatch -bool false
+    write_dev_default "$DEV_BUNDLE_ID" recordOnly true bool
+    write_dev_default "$DEV_BUNDLE_ID" autoWatch false bool
     mkdir -p "$RECORDINGS_DIR"
     touch "$RECORD_ONLY_MARKER"
     RECORD_ONLY=true   # reuse the record-only cleanup + marker-bounded sweep
 elif [ "$RECORD_ONLY" = true ]; then
     log "Enabling record-only mode (no transcript/protocol generation)"
-    defaults write "$DEV_BUNDLE_ID" recordOnly -bool true
+    write_dev_default "$DEV_BUNDLE_ID" recordOnly true bool
     mkdir -p "$RECORDINGS_DIR"
     touch "$RECORD_ONLY_MARKER"
 else
     # Reset stale toggle from a previous --record-only run on the same host
     # so a plain `--two-meetings` invocation isn't silently still in record-only.
-    defaults delete "$DEV_BUNDLE_ID" recordOnly 2>/dev/null || true
+    delete_dev_default "$DEV_BUNDLE_ID" recordOnly
 fi
 
 # Optional diarizer-mode override. `MTT_DIARIZER_MODE=sortformer` flips the
@@ -606,41 +606,24 @@ fi
 # actually lights up the naming dialog in production-chain. Always cleared
 # on exit so subsequent runs return to the default `.offline` mode.
 #
-# `defaults write $DEV_BUNDLE_ID` from outside writes to the
-# *standard* preferences domain. The dev .app's bundle has a pre-existing
-# container at `~/Library/Containers/$DEV_BUNDLE_ID/...` —
-# from a prior App Store-variant build or interactive use — and macOS
-# routes the app's UserDefaults reads to that container regardless of
-# whether the current binary is sandboxed. A naïve `defaults write` is
-# silently a no-op there. Write to both: container if it exists (covers
-# this runner) AND standard domain (covers a clean runner where the
-# container hasn't been created yet).
+# Domain handling lives in `write_dev_default` / `delete_dev_default` (see
+# scripts/lib/e2e-helpers.sh for why a bare `defaults write <bundle-id>` reaches
+# a domain the app does not read). These two wrappers only bind the bundle id
+# and keep the call sites below short.
 _CONTAINER_PLIST="$(dev_container_plist)"
+_STANDARD_PLIST="$(dev_standard_plist)"
 _set_dev_default() {
     local key="$1" value="$2" type="${3:-string}"
     # `numSpeakers` is read as `defaults.object(forKey:) as? Int`, so it must be
     # written with `-int`; a string-typed write would fail the `as? Int` cast
     # and silently fall back to the auto-detect sentinel (0).
-    case "$type" in
-        bool)
-            defaults write "$DEV_BUNDLE_ID" "$key" -bool "$value" 2>/dev/null || true
-            [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
-            ;;
-        int)
-            defaults write "$DEV_BUNDLE_ID" "$key" -int "$value" 2>/dev/null || true
-            [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -int "$value" 2>/dev/null || true
-            ;;
-        *)
-            defaults write "$DEV_BUNDLE_ID" "$key" "$value" 2>/dev/null || true
-            [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" "$value" 2>/dev/null || true
-            ;;
-    esac
+    write_dev_default "$DEV_BUNDLE_ID" "$key" "$value" "$type"
 }
 _delete_dev_default() {
     local key="$1"
-    defaults delete "$DEV_BUNDLE_ID" "$key" 2>/dev/null || true
-    [ -f "$_CONTAINER_PLIST" ] && defaults delete "$_CONTAINER_PLIST" "$key" 2>/dev/null || true
+    delete_dev_default "$DEV_BUNDLE_ID" "$key"
 }
+
 if [ -n "${MTT_DIARIZER_MODE:-}" ]; then
     log "Overriding diarizerMode=$MTT_DIARIZER_MODE for this run"
     _set_dev_default diarizerMode "$MTT_DIARIZER_MODE"
@@ -782,8 +765,8 @@ _naming_confirm_cleanup() {
     # Restore each domain to exactly its own snapshot. The shared restore_*_default
     # helpers translate `defaults read`'s 1/0 into the -bool true/false tokens and
     # write -int for numSpeakers (a raw 1/0 into `-bool` errors; see the helpers).
-    restore_bool_default "$DEV_BUNDLE_ID" diarize "$_NC_PRE_DIARIZE_STD"
-    restore_int_default "$DEV_BUNDLE_ID" numSpeakers "$_NC_PRE_NUMSPK_STD"
+    restore_bool_default "$_STANDARD_PLIST" diarize "$_NC_PRE_DIARIZE_STD"
+    restore_int_default "$_STANDARD_PLIST" numSpeakers "$_NC_PRE_NUMSPK_STD"
     if [ -f "$_CONTAINER_PLIST" ]; then
         restore_bool_default "$_CONTAINER_PLIST" diarize "$_NC_PRE_DIARIZE_CTR"
         restore_int_default "$_CONTAINER_PLIST" numSpeakers "$_NC_PRE_NUMSPK_CTR"
@@ -800,8 +783,8 @@ if [ "$NAMING_CONFIRM" = true ] || [ "$NAMING_ESCAPE" = true ]; then
     log "Enabling naming lane (diarize on, expected speakers = 2)"
     # Snapshot BOTH domains (standard + container) BEFORE overriding so cleanup
     # restores each domain to exactly its own pre-lane state.
-    _NC_PRE_DIARIZE_STD="$(snapshot_default "$DEV_BUNDLE_ID" diarize)"
-    _NC_PRE_NUMSPK_STD="$(snapshot_default "$DEV_BUNDLE_ID" numSpeakers)"
+    _NC_PRE_DIARIZE_STD="$(snapshot_default "$_STANDARD_PLIST" diarize)"
+    _NC_PRE_NUMSPK_STD="$(snapshot_default "$_STANDARD_PLIST" numSpeakers)"
     if [ -f "$_CONTAINER_PLIST" ]; then
         _NC_PRE_DIARIZE_CTR="$(snapshot_default "$_CONTAINER_PLIST" diarize)"
         _NC_PRE_NUMSPK_CTR="$(snapshot_default "$_CONTAINER_PLIST" numSpeakers)"
@@ -862,10 +845,22 @@ open "$DEV_BUNDLE_DEPLOY"
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
 # Assigns RPC_TOKEN in caller scope on success so subsequent `rpc` calls
 # carry the bearer token.
-_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+# `rpc` ends in `|| true` so its callers can read a body without tripping
+# `set -e`, which also means it reports success for a refused connection. That
+# made this check "the token file exists", and the token file survives every
+# previous run on the host, so "RPC up" could be logged 70 ms after launch with
+# nothing listening yet. Ask curl directly and let its exit status decide.
+_rpc_ready() {
+    [ -f "$RPC_TOKEN_FILE" ] || return 1
+    RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")"
+    curl --silent --fail --max-time 5 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE/healthz" >/dev/null 2>&1
+}
 poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready \
     || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
 log "RPC up"
+
 
 # Single trap covers the simulator process + record-only side-effects for
 # any exit path (success, fail, signal). Set before the first `&` line so
@@ -883,10 +878,10 @@ on_exit() {
         # The lane turns auto-watch off; nothing else here would turn it back
         # on, and a human using the dev app on this host would find detection
         # silently disabled.
-        defaults write "$DEV_BUNDLE_ID" autoWatch -bool true 2>/dev/null || true
+        write_dev_default "$DEV_BUNDLE_ID" autoWatch true bool
     fi
     if [ "$RECORD_ONLY" = true ]; then
-        defaults delete "$DEV_BUNDLE_ID" recordOnly 2>/dev/null || true
+        delete_dev_default "$DEV_BUNDLE_ID" recordOnly
         # Marker-bounded cleanup: only files created since `touch $MARKER`
         # at launch — never touches pre-existing user data. See feedback
         # memory `no_destructive_fs_on_real_dirs`. Skipped under
@@ -936,6 +931,37 @@ on_exit() {
 trap on_exit EXIT
 trap 'on_exit; exit 130' INT
 trap 'on_exit; exit 143' TERM
+
+# The lane configures the app by writing preferences from the shell, and a write
+# that misses the domain the app resolves is completely silent: the app runs on
+# its own defaults, and the lane fails minutes later with a missing artifact
+# that says nothing about why. `/state.settings` is the running process's own
+# resolved view, so assert it here, where the answer is still cheap and points
+# at the cause. recordOnly is the setting under test because it decides which
+# pipeline runs at all.
+#
+# Placed AFTER the exit trap is armed, not next to the readiness poll where it
+# logically belongs: this assertion can fail, and failing ahead of the trap
+# would leave the app running with this lane's recordOnly and autoWatch
+# unrestored.
+if [ "$RECORD_ONLY" = true ]; then _EXPECTED_RECORD_ONLY=true; else _EXPECTED_RECORD_ONLY=false; fi
+# A 200 from /healthz is not proof the app under test is the one answering, and
+# neither is a non-empty /state: `rpc` has no --fail, so an error body would
+# satisfy a bare emptiness test and then read as a null setting, which would get
+# reported as the wrong preference domain. Require the field itself to be
+# present before believing anything about its value.
+_state_snapshot() {
+    _SNAP="$(rpc /state)"
+    [ -n "$_SNAP" ] && jq -e '.settings.recording | has("recordOnly")' <<<"$_SNAP" >/dev/null 2>&1
+}
+_SNAP=""
+poll_until 20 1 _state_snapshot \
+    || fail "/healthz answered but no /state carrying settings.recording.recordOnly arrived within 20s. Either the app came up without serving a state snapshot, or something other than the dev app is holding 127.0.0.1:9876."
+_RESOLVED_RECORD_ONLY="$(jq -r '.settings.recording.recordOnly' <<<"$_SNAP")"
+[ "$_RESOLVED_RECORD_ONLY" = "$_EXPECTED_RECORD_ONLY" ] \
+    || fail "the app resolved settings.recording.recordOnly=$_RESOLVED_RECORD_ONLY but this lane needs $_EXPECTED_RECORD_ONLY. Most likely the preference write did not reach the domain the app reads (see write_dev_default in scripts/lib/e2e-helpers.sh); the other possibility is that a different MeetingTranscriber instance is answering on 127.0.0.1:9876."
+log "app resolved recordOnly=$_RESOLVED_RECORD_ONLY (as configured)"
+
 
 
 # Trigger one meeting, poll until a new pipeline job reaches a terminal

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -109,6 +109,7 @@ CHROME_PROFILE="$(mktemp -d /tmp/e2e-browser-chrome.XXXXXX)"
 source "$ROOT/scripts/lib/bundle-ids.sh"
 BUNDLE_ID="$DEV_BUNDLE_ID"
 _CONTAINER_PLIST="$(dev_container_plist)"
+_STANDARD_PLIST="$(dev_standard_plist)"
 
 # --- timing budgets -------------------------------------------------------
 
@@ -144,14 +145,13 @@ rpc() {
 # never the user's own Chrome windows.
 quit_chrome() { pkill -f "$CHROME_PROFILE" 2>/dev/null || true; }
 
-# Write a dev default to BOTH the standard domain and the app's container
-# plist (if present) — macOS routes the dev .app's reads to the container when
-# it exists, so a standard-domain-only write is silently a no-op there. Mirrors
-# e2e-app.sh's `_set_dev_default`.
+# Bind the bundle id for the shared both-domain writer. Which domains a dev
+# default has to be written to, and why a bare `defaults write <bundle-id>`
+# reaches one the app does not read, is documented on `write_dev_default` in
+# scripts/lib/e2e-helpers.sh.
 _set_dev_bool() {
     local key="$1" value="$2"
-    defaults write "$BUNDLE_ID" "$key" -bool "$value" 2>/dev/null || true
-    [ -f "$_CONTAINER_PLIST" ] && defaults write "$_CONTAINER_PLIST" "$key" -bool "$value" 2>/dev/null || true
+    write_dev_default "$BUNDLE_ID" "$key" "$value" bool
 }
 
 # Per-domain snapshots of the behaviour toggles this lane flips, so cleanup
@@ -222,9 +222,9 @@ fi
 # --- settings -------------------------------------------------------------
 
 # Snapshot the behaviour toggles per domain before flipping them.
-_PRE_BROWSER_STD="$(snapshot_default "$BUNDLE_ID" watchBrowserMeetings)"
-_PRE_RECORDONLY_STD="$(snapshot_default "$BUNDLE_ID" recordOnly)"
-_PRE_NOMIC_STD="$(snapshot_default "$BUNDLE_ID" noMic)"
+_PRE_BROWSER_STD="$(snapshot_default "$_STANDARD_PLIST" watchBrowserMeetings)"
+_PRE_RECORDONLY_STD="$(snapshot_default "$_STANDARD_PLIST" recordOnly)"
+_PRE_NOMIC_STD="$(snapshot_default "$_STANDARD_PLIST" noMic)"
 if [ -f "$_CONTAINER_PLIST" ]; then
     _PRE_BROWSER_CTR="$(snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
     _PRE_RECORDONLY_CTR="$(snapshot_default "$_CONTAINER_PLIST" recordOnly)"
@@ -232,8 +232,8 @@ if [ -f "$_CONTAINER_PLIST" ]; then
 fi
 
 # debugRPCEnabled + autoWatch are set-and-leave (like e2e-app.sh — harmless on).
-defaults write "$BUNDLE_ID" debugRPCEnabled -bool true
-defaults write "$BUNDLE_ID" autoWatch -bool true
+_set_dev_bool debugRPCEnabled true
+_set_dev_bool autoWatch true
 _set_dev_bool watchBrowserMeetings true   # append the browser category to watchApps
 _set_dev_bool recordOnly true             # sidecar + WAVs, skip transcription/protocol
 _set_dev_bool noMic true                  # app-track only; no mic needed for the proof
@@ -259,9 +259,9 @@ on_exit() {
     [ "$KEEP_CHROME" = false ] && quit_chrome
     [ "$KEEP_APP" = false ] && quit_running_app || true
     # Restore the behaviour toggles per domain (empty snapshot → delete).
-    restore_bool_default "$BUNDLE_ID" watchBrowserMeetings "$_PRE_BROWSER_STD"
-    restore_bool_default "$BUNDLE_ID" recordOnly "$_PRE_RECORDONLY_STD"
-    restore_bool_default "$BUNDLE_ID" noMic "$_PRE_NOMIC_STD"
+    restore_bool_default "$_STANDARD_PLIST" watchBrowserMeetings "$_PRE_BROWSER_STD"
+    restore_bool_default "$_STANDARD_PLIST" recordOnly "$_PRE_RECORDONLY_STD"
+    restore_bool_default "$_STANDARD_PLIST" noMic "$_PRE_NOMIC_STD"
     if [ -f "$_CONTAINER_PLIST" ]; then
         restore_bool_default "$_CONTAINER_PLIST" watchBrowserMeetings "$_PRE_BROWSER_CTR"
         restore_bool_default "$_CONTAINER_PLIST" recordOnly "$_PRE_RECORDONLY_CTR"
@@ -278,9 +278,37 @@ trap 'on_exit; exit 130' INT
 trap 'on_exit; exit 143' TERM
 
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
-_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+# See e2e-app.sh: `rpc` ends in `|| true`, so probing through it reports success
+# even for a refused connection, leaving the token file (which outlives every
+# run on the host) as the only real condition. Ask curl directly instead.
+_rpc_ready() {
+    [ -f "$RPC_TOKEN_FILE" ] || return 1
+    RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")"
+    curl --silent --fail --max-time 5 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE/healthz" >/dev/null 2>&1
+}
 poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
 log "RPC up"
+
+# Same reasoning as in e2e-app.sh: a preference write that misses the domain the
+# app resolves is silent, and this lane's whole proof rests on record-only being
+# on. Assert the app's own resolved view instead of discovering it as a missing
+# sidecar several minutes later.
+# `rpc` has no --fail, so a bare emptiness test would accept an error body and
+# then read the setting as null, which would be reported as the wrong
+# preference domain. Require the field itself before believing its value.
+_state_snapshot() {
+    _SNAP="$(rpc /state)"
+    [ -n "$_SNAP" ] && jq -e '.settings.recording | has("recordOnly")' <<<"$_SNAP" >/dev/null 2>&1
+}
+_SNAP=""
+poll_until 20 1 _state_snapshot \
+    || fail "/healthz answered but no /state carrying settings.recording.recordOnly arrived within 20s. Either the app came up without serving a state snapshot, or something other than the dev app is holding 127.0.0.1:9876."
+_RESOLVED_RECORD_ONLY="$(jq -r '.settings.recording.recordOnly' <<<"$_SNAP")"
+[ "$_RESOLVED_RECORD_ONLY" = "true" ] \
+    || fail "the app resolved settings.recording.recordOnly=$_RESOLVED_RECORD_ONLY, this lane needs true. Most likely the preference write did not reach the domain the app reads (see write_dev_default in scripts/lib/e2e-helpers.sh); the other possibility is that a different MeetingTranscriber instance is answering on 127.0.0.1:9876."
+log "app resolved recordOnly=true (as configured)"
 
 # The lane answers the consent prompt over RPC, which resolves the parked
 # continuation whether or not a notification was ever posted, authorised or
@@ -357,8 +385,8 @@ _watch_state() { rpc /state | jq -r '.watchState // ""'; }
 _dump_detection_diag() {
     log "DIAG: watchState=$(_watch_state)"
     log "DIAG: /state.settings.detection = $(rpc /state | jq -c '.settings.detection // {}' 2>/dev/null)"
-    log "DIAG: effective watchBrowserMeetings std=$(snapshot_default "$BUNDLE_ID" watchBrowserMeetings) ctr=$([ -f "$_CONTAINER_PLIST" ] && snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
-    log "DIAG: effective autoWatch std=$(snapshot_default "$BUNDLE_ID" autoWatch)"
+    log "DIAG: effective watchBrowserMeetings std=$(snapshot_default "$_STANDARD_PLIST" watchBrowserMeetings) ctr=$([ -f "$_CONTAINER_PLIST" ] && snapshot_default "$_CONTAINER_PLIST" watchBrowserMeetings)"
+    log "DIAG: effective autoWatch std=$(snapshot_default "$_STANDARD_PLIST" autoWatch)"
     log "DIAG: pmset WebRTC assertions:"
     pmset -g assertions 2>/dev/null | grep -iE "webrtc|peerconnection|$BROWSER_LABEL" || log "DIAG:   (none)"
 }

--- a/scripts/e2e-cpu-load.sh
+++ b/scripts/e2e-cpu-load.sh
@@ -162,11 +162,19 @@ if ! system_profiler SPAudioDataType 2>/dev/null | grep -A4 "Default Input" | gr
     fail "no default audio input device — install BlackHole 2ch and set it as the default Input"
 fi
 
-SAVED_LIVE_TRANS=$(snapshot_default "$BUNDLE_ID" liveTranscriptionEnabled)
-SAVED_TRANS_ENGINE=$(snapshot_default "$BUNDLE_ID" transcriptionEngine)
-SAVED_DEBUG_RPC=$(snapshot_default "$BUNDLE_ID" debugRPCEnabled)
-SAVED_AUTO_WATCH=$(snapshot_default "$BUNDLE_ID" autoWatch)
-SAVED_RECORD_ONLY=$(snapshot_default "$BUNDLE_ID" recordOnly)
+# Address the standard-domain plist directly, and write through
+# `write_dev_default`. `defaults <bundle-id>` is redirected into the app's
+# container once containermanagerd has registered one, while the dev .app is not
+# sandboxed and
+# resolves the standard domain, so the two disagree and a lane can configure
+# nothing at all without any error. See write_dev_default in
+# scripts/lib/e2e-helpers.sh.
+_STANDARD_PLIST="$(dev_standard_plist "$BUNDLE_ID")"
+SAVED_LIVE_TRANS=$(snapshot_default "$_STANDARD_PLIST" liveTranscriptionEnabled)
+SAVED_TRANS_ENGINE=$(snapshot_default "$_STANDARD_PLIST" transcriptionEngine)
+SAVED_DEBUG_RPC=$(snapshot_default "$_STANDARD_PLIST" debugRPCEnabled)
+SAVED_AUTO_WATCH=$(snapshot_default "$_STANDARD_PLIST" autoWatch)
+SAVED_RECORD_ONLY=$(snapshot_default "$_STANDARD_PLIST" recordOnly)
 
 quit_running_app
 
@@ -227,7 +235,17 @@ if [ "$fg_user" != "$my_user" ]; then
     fail "Aqua foreground user is '$fg_user', not '$my_user' — Fast User Switching is active."
 fi
 
-_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+# See the shared note in e2e-app.sh: `rpc` ends in `|| true`, so probing
+# through it reports success for a refused connection and leaves the token
+# file, which outlives every run on the host, as the only real condition.
+# Ask curl directly and let its exit status decide.
+_rpc_ready() {
+    [ -f "$RPC_TOKEN_FILE" ] || return 1
+    RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")"
+    curl --silent --fail --max-time 5 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE/healthz" >/dev/null 2>&1
+}
 
 launch_app_and_wait() {
     log "Launching $DEV_BUNDLE_DEPLOY"
@@ -245,15 +263,15 @@ RUN_START_MARKER="$(mktemp "${TMPDIR:-/tmp}/e2e-cpu-load-start.XXXXXX")"
 SIM_PID=""
 on_exit() {
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
-    restore_bool_default "$BUNDLE_ID" liveTranscriptionEnabled "$SAVED_LIVE_TRANS"
+    restore_bool_default "$_STANDARD_PLIST" liveTranscriptionEnabled "$SAVED_LIVE_TRANS"
     if [ -n "$SAVED_TRANS_ENGINE" ]; then
-        defaults write "$BUNDLE_ID" transcriptionEngine -string "$SAVED_TRANS_ENGINE"
+        write_dev_default "$BUNDLE_ID" transcriptionEngine "$SAVED_TRANS_ENGINE" string
     else
-        defaults delete "$BUNDLE_ID" transcriptionEngine 2>/dev/null || true
+        delete_dev_default "$BUNDLE_ID" transcriptionEngine
     fi
-    restore_bool_default "$BUNDLE_ID" debugRPCEnabled "$SAVED_DEBUG_RPC"
-    restore_bool_default "$BUNDLE_ID" autoWatch       "$SAVED_AUTO_WATCH"
-    restore_bool_default "$BUNDLE_ID" recordOnly      "$SAVED_RECORD_ONLY"
+    restore_bool_default "$_STANDARD_PLIST" debugRPCEnabled "$SAVED_DEBUG_RPC"
+    restore_bool_default "$_STANDARD_PLIST" autoWatch       "$SAVED_AUTO_WATCH"
+    restore_bool_default "$_STANDARD_PLIST" recordOnly      "$SAVED_RECORD_ONLY"
     if [ "$APP_AFTER" = quit ]; then
         # `|| true`: under set -e a wedged app (quit ladder exhausted) must not
         # abort the trap before the artifact sweep below runs.
@@ -328,11 +346,11 @@ contamination_flag() {
 # (file move instead of batch transcription) so session B starts quiet; the
 # recording path itself is byte-identical to a normal meeting while it runs.
 
-defaults write "$BUNDLE_ID" liveTranscriptionEnabled -bool false
-defaults write "$BUNDLE_ID" recordOnly -bool true
-defaults write "$BUNDLE_ID" transcriptionEngine -string parakeet
-defaults write "$BUNDLE_ID" debugRPCEnabled -bool true
-defaults write "$BUNDLE_ID" autoWatch -bool true
+write_dev_default "$BUNDLE_ID" liveTranscriptionEnabled false bool
+write_dev_default "$BUNDLE_ID" recordOnly true bool
+write_dev_default "$BUNDLE_ID" transcriptionEngine parakeet string
+write_dev_default "$BUNDLE_ID" debugRPCEnabled true bool
+write_dev_default "$BUNDLE_ID" autoWatch true bool
 
 launch_app_and_wait
 
@@ -372,8 +390,8 @@ quit_running_app
 # a user with the feature enabled — and so session A's idle window stayed
 # free of preload memory/CPU.
 
-defaults write "$BUNDLE_ID" liveTranscriptionEnabled -bool true
-defaults write "$BUNDLE_ID" recordOnly -bool false
+write_dev_default "$BUNDLE_ID" liveTranscriptionEnabled true bool
+write_dev_default "$BUNDLE_ID" recordOnly false bool
 
 launch_app_and_wait
 

--- a/scripts/e2e-live-captions.sh
+++ b/scripts/e2e-live-captions.sh
@@ -110,10 +110,18 @@ fi
 # Snapshot toggles we'll mutate so cleanup can restore them. Captures the
 # state from a previous run on the same host (which might have left
 # anything behind).
-SAVED_LIVE_TRANS=$(snapshot_default "$BUNDLE_ID" liveTranscriptionEnabled)
-SAVED_TRANS_ENGINE=$(snapshot_default "$BUNDLE_ID" transcriptionEngine)
-SAVED_DEBUG_RPC=$(snapshot_default "$BUNDLE_ID" debugRPCEnabled)
-SAVED_AUTO_WATCH=$(snapshot_default "$BUNDLE_ID" autoWatch)
+# Address the standard-domain plist directly, and write through
+# `write_dev_default`. `defaults <bundle-id>` is redirected into the app's
+# container once containermanagerd has registered one, while the dev .app is not
+# sandboxed and
+# resolves the standard domain, so the two disagree and a lane can configure
+# nothing at all without any error. See write_dev_default in
+# scripts/lib/e2e-helpers.sh.
+_STANDARD_PLIST="$(dev_standard_plist "$BUNDLE_ID")"
+SAVED_LIVE_TRANS=$(snapshot_default "$_STANDARD_PLIST" liveTranscriptionEnabled)
+SAVED_TRANS_ENGINE=$(snapshot_default "$_STANDARD_PLIST" transcriptionEngine)
+SAVED_DEBUG_RPC=$(snapshot_default "$_STANDARD_PLIST" debugRPCEnabled)
+SAVED_AUTO_WATCH=$(snapshot_default "$_STANDARD_PLIST" autoWatch)
 
 quit_running_app
 
@@ -161,10 +169,10 @@ fi
 # These four defaults are the actual production seams the toggle uses.
 # Crucially we do NOT set any debug env var that bypasses the real chain
 # — the test must catch a regression in the wiring, not in a debug shim.
-defaults write "$BUNDLE_ID" liveTranscriptionEnabled -bool true
-defaults write "$BUNDLE_ID" transcriptionEngine -string parakeet
-defaults write "$BUNDLE_ID" debugRPCEnabled -bool true
-defaults write "$BUNDLE_ID" autoWatch -bool true
+write_dev_default "$BUNDLE_ID" liveTranscriptionEnabled true bool
+write_dev_default "$BUNDLE_ID" transcriptionEngine parakeet string
+write_dev_default "$BUNDLE_ID" debugRPCEnabled true bool
+write_dev_default "$BUNDLE_ID" autoWatch true bool
 
 # --- launch + wait for RPC ------------------------------------------------
 
@@ -180,7 +188,17 @@ open "$DEV_BUNDLE_DEPLOY"
 log "Waiting up to ${RPC_READY_TIMEOUT_S}s for RPC /healthz"
 # Assigns RPC_TOKEN in caller scope on success so subsequent `rpc` calls
 # carry the bearer token.
-_rpc_ready() { [ -f "$RPC_TOKEN_FILE" ] && RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")" && rpc /healthz >/dev/null 2>&1; }
+# See the shared note in e2e-app.sh: `rpc` ends in `|| true`, so probing
+# through it reports success for a refused connection and leaves the token
+# file, which outlives every run on the host, as the only real condition.
+# Ask curl directly and let its exit status decide.
+_rpc_ready() {
+    [ -f "$RPC_TOKEN_FILE" ] || return 1
+    RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")"
+    curl --silent --fail --max-time 5 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE/healthz" >/dev/null 2>&1
+}
 poll_until "$RPC_READY_TIMEOUT_S" 1 _rpc_ready \
     || fail "RPC /healthz did not respond within ${RPC_READY_TIMEOUT_S}s"
 log "RPC up"
@@ -189,14 +207,14 @@ log "RPC up"
 SIM_PID=""
 on_exit() {
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
-    restore_bool_default  "$BUNDLE_ID" liveTranscriptionEnabled "$SAVED_LIVE_TRANS"
+    restore_bool_default  "$_STANDARD_PLIST" liveTranscriptionEnabled "$SAVED_LIVE_TRANS"
     if [ -n "$SAVED_TRANS_ENGINE" ]; then
-        defaults write "$BUNDLE_ID" transcriptionEngine -string "$SAVED_TRANS_ENGINE"
+        write_dev_default "$BUNDLE_ID" transcriptionEngine "$SAVED_TRANS_ENGINE" string
     else
-        defaults delete "$BUNDLE_ID" transcriptionEngine 2>/dev/null || true
+        delete_dev_default "$BUNDLE_ID" transcriptionEngine
     fi
-    restore_bool_default "$BUNDLE_ID" debugRPCEnabled "$SAVED_DEBUG_RPC"
-    restore_bool_default "$BUNDLE_ID" autoWatch       "$SAVED_AUTO_WATCH"
+    restore_bool_default "$_STANDARD_PLIST" debugRPCEnabled "$SAVED_DEBUG_RPC"
+    restore_bool_default "$_STANDARD_PLIST" autoWatch       "$SAVED_AUTO_WATCH"
 }
 trap on_exit EXIT INT TERM
 

--- a/scripts/e2e-silent-recording.sh
+++ b/scripts/e2e-silent-recording.sh
@@ -73,6 +73,10 @@ REC_DIR="$HOME/Library/Application Support/MeetingTranscriber/recordings"
 RUN_START_MARKER="$(mktemp "${TMPDIR:-/tmp}/e2e-silent-rec-start.XXXXXX")"
 
 # Defaults to restore after the test — empty string means "key wasn't set".
+# Empty until the snapshot below runs. `cleanup` is trapped before that point
+# and keys on this being set: an empty snapshot means "delete the key", which
+# is right after this lane wrote it and destructive before it ever read it.
+_STANDARD_PLIST=""
 SAVED_AUTOWATCH=""
 SAVED_THRESHOLD=""
 SAVED_INDICATOR=""
@@ -90,9 +94,14 @@ cleanup() {
     rm -f "${RUN_START_MARKER:-}" 2>/dev/null || true
     # Restore defaults to whatever they were before we ran (or delete the
     # keys if they didn't exist).
-    restore_bool_default  "$BUNDLE_ID" autoWatch                       "$SAVED_AUTOWATCH"
-    restore_float_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds "$SAVED_THRESHOLD"
-    restore_bool_default  "$BUNDLE_ID" perChannelIndicatorEnabled      "$SAVED_INDICATOR"
+    # Only restore what was actually snapshotted. An empty snapshot means
+    # "delete the key", which is right after this lane set it and catastrophic
+    # if the lane exited before the snapshot ran.
+    if [ -n "$_STANDARD_PLIST" ]; then
+        restore_bool_default  "$_STANDARD_PLIST" autoWatch                       "$SAVED_AUTOWATCH"
+        restore_float_default "$_STANDARD_PLIST" asymmetricSilenceWarningSeconds "$SAVED_THRESHOLD"
+        restore_bool_default  "$_STANDARD_PLIST" perChannelIndicatorEnabled      "$SAVED_INDICATOR"
+    fi
     bootout_stale_launchctl
 }
 trap cleanup EXIT
@@ -163,19 +172,38 @@ for path in "$BIN" "$MTCLI" "$SIM"; do
     [ -x "$path" ] || die "required binary missing: $path — run without --no-build first"
 done
 
-# --- 2. Snapshot + override defaults so the test is deterministic -----------
+# --- 2. Snapshot the defaults this lane overrides ---------------------------
 
-SAVED_AUTOWATCH="$(snapshot_default "$BUNDLE_ID" autoWatch)"
-SAVED_THRESHOLD="$(snapshot_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds)"
-SAVED_INDICATOR="$(snapshot_default "$BUNDLE_ID" perChannelIndicatorEnabled)"
+# Address the standard-domain plist directly. `defaults <bundle-id>` is
+# redirected into the app's container once containermanagerd has registered
+# one for the identifier, and the dev .app is not sandboxed, so it resolves
+# the standard domain. Reading and restoring the wrong one silently leaks this
+# lane's 30 s threshold into whatever runs next, or leaves the app on its
+# built-in 90 s while the lane waits 50 s for a flag that cannot flip in time.
+#
+# The snapshot runs BEFORE the quit below for a reason that has nothing to do
+# with preferences and everything to do with the exit trap. `quit_running_app`
+# is bare under `set -e`, so an exhausted quit ladder exits the script straight
+# into `cleanup` with every SAVED_* still empty, and an empty snapshot restores
+# by DELETING the key. Snapshotting first means the trap can never delete a
+# developer's real settings that this lane never read.
+#
+# The writes still run after the quit, which is defensive rather than measured:
+# a live instance owning the same domain did NOT clobber an external write in
+# testing on macOS 26, but nothing is gained by writing underneath a process
+# that is about to be killed anyway.
+_STANDARD_PLIST="$(dev_standard_plist "$BUNDLE_ID")"
+SAVED_AUTOWATCH="$(snapshot_default "$_STANDARD_PLIST" autoWatch)"
+SAVED_THRESHOLD="$(snapshot_default "$_STANDARD_PLIST" asymmetricSilenceWarningSeconds)"
+SAVED_INDICATOR="$(snapshot_default "$_STANDARD_PLIST" perChannelIndicatorEnabled)"
 
-/usr/bin/defaults write "$BUNDLE_ID" autoWatch -bool true
-/usr/bin/defaults write "$BUNDLE_ID" asymmetricSilenceWarningSeconds -float 30
-/usr/bin/defaults write "$BUNDLE_ID" perChannelIndicatorEnabled -bool true
-
-# --- 3. Kill any running instance -------------------------------------------
+# --- 3. Kill any running instance, then override ----------------------------
 
 quit_running_app "$BUNDLE_ID"
+
+write_dev_default "$BUNDLE_ID" autoWatch true bool
+write_dev_default "$BUNDLE_ID" asymmetricSilenceWarningSeconds 30 float
+write_dev_default "$BUNDLE_ID" perChannelIndicatorEnabled true bool
 
 # --- 4. Launch app with RPC enabled -----------------------------------------
 

--- a/scripts/e2e-soak.sh
+++ b/scripts/e2e-soak.sh
@@ -159,7 +159,17 @@ growth_summary() {
         }'
 }
 
-_rpc_ready() { [ -n "$(rpc /healthz)" ]; }
+# See the shared note in e2e-app.sh: `rpc` ends in `|| true`, so probing
+# through it reports success for a refused connection and leaves the token
+# file, which outlives every run on the host, as the only real condition.
+# Ask curl directly and let its exit status decide.
+_rpc_ready() {
+    [ -f "$RPC_TOKEN_FILE" ] || return 1
+    RPC_TOKEN="$(cat "$RPC_TOKEN_FILE")"
+    curl --silent --fail --max-time 5 \
+        --header "Authorization: Bearer $RPC_TOKEN" \
+        "$RPC_BASE/healthz" >/dev/null 2>&1
+}
 
 # --- preflight ------------------------------------------------------------
 
@@ -175,18 +185,26 @@ case "$SAMPLE_EVERY_MIN" in ''|*[!0-9]*) fail "--sample-every must be a positive
 [ $((SOAK_MINUTES / SAMPLE_EVERY_MIN)) -ge 2 ] \
     || fail "--minutes/--sample-every must yield at least 2 samples (got $((SOAK_MINUTES / SAMPLE_EVERY_MIN)))"
 
-SAVED_DEBUG_RPC=$(snapshot_default "$BUNDLE_ID" debugRPCEnabled)
-SAVED_AUTO_WATCH=$(snapshot_default "$BUNDLE_ID" autoWatch)
-SAVED_RECORD_ONLY=$(snapshot_default "$BUNDLE_ID" recordOnly)
+# Address the standard-domain plist directly, and write through
+# `write_dev_default`. `defaults <bundle-id>` is redirected into the app's
+# container once containermanagerd has registered one, while the dev .app is not
+# sandboxed and
+# resolves the standard domain, so the two disagree and a lane can configure
+# nothing at all without any error. See write_dev_default in
+# scripts/lib/e2e-helpers.sh.
+_STANDARD_PLIST="$(dev_standard_plist "$BUNDLE_ID")"
+SAVED_DEBUG_RPC=$(snapshot_default "$_STANDARD_PLIST" debugRPCEnabled)
+SAVED_AUTO_WATCH=$(snapshot_default "$_STANDARD_PLIST" autoWatch)
+SAVED_RECORD_ONLY=$(snapshot_default "$_STANDARD_PLIST" recordOnly)
 
 RUN_START_MARKER="$(mktemp "${TMPDIR:-/tmp}/e2e-soak-start.XXXXXX")"
 SIM_PID=""
 
 on_exit() {
     [ -n "${SIM_PID:-}" ] && kill "$SIM_PID" 2>/dev/null || true
-    restore_bool_default "$BUNDLE_ID" debugRPCEnabled "$SAVED_DEBUG_RPC"
-    restore_bool_default "$BUNDLE_ID" autoWatch       "$SAVED_AUTO_WATCH"
-    restore_bool_default "$BUNDLE_ID" recordOnly      "$SAVED_RECORD_ONLY"
+    restore_bool_default "$_STANDARD_PLIST" debugRPCEnabled "$SAVED_DEBUG_RPC"
+    restore_bool_default "$_STANDARD_PLIST" autoWatch       "$SAVED_AUTO_WATCH"
+    restore_bool_default "$_STANDARD_PLIST" recordOnly      "$SAVED_RECORD_ONLY"
     if [ "$APP_AFTER" = quit ]; then
         quit_running_app || true
         sweep_run_artifacts "$REC_DIR" "$RUN_START_MARKER"
@@ -213,9 +231,9 @@ fi
 # Record-only: the soak is about the resident process over an hour, and running
 # transcription on every loop of the fixture would measure the ASR engine
 # instead. The pipeline assertion at the end re-enables the full path.
-defaults write "$BUNDLE_ID" debugRPCEnabled -bool true
-defaults write "$BUNDLE_ID" autoWatch       -bool true
-defaults write "$BUNDLE_ID" recordOnly      -bool true
+write_dev_default "$BUNDLE_ID" debugRPCEnabled true bool
+write_dev_default "$BUNDLE_ID" autoWatch true bool
+write_dev_default "$BUNDLE_ID" recordOnly true bool
 
 mkdir -p "$REC_DIR"
 quit_running_app || true

--- a/scripts/lib/bundle-ids.sh
+++ b/scripts/lib/bundle-ids.sh
@@ -31,3 +31,13 @@ dev_container_plist() {
     local bundle_id="${1:-$DEV_BUNDLE_ID}"
     printf '%s' "$HOME/Library/Containers/$bundle_id/Data/Library/Preferences/$bundle_id.plist"
 }
+
+# Where a NON-SANDBOXED app resolves its UserDefaults, which the dev .app is.
+# This is the domain that decides what the running app sees, and the one
+# `defaults write <id>` stops reaching as soon as a container exists for the
+# identifier. The redirect keys on a container that containermanagerd has
+# registered, whatever created it, not on the directory merely existing.
+dev_standard_plist() {
+    local bundle_id="${1:-$DEV_BUNDLE_ID}"
+    printf '%s' "$HOME/Library/Preferences/$bundle_id.plist"
+}

--- a/scripts/lib/e2e-helpers.sh
+++ b/scripts/lib/e2e-helpers.sh
@@ -223,22 +223,102 @@ restore_int_default() {
     fi
 }
 
+# Write a dev-bundle default so the RUNNING APP actually sees it.
+#
+# Say once per run that this host redirects `defaults <bundle-id>` into a
+# container, so the next time one appears it carries a timestamp in a log
+# instead of surfacing days later as a lane that configures nothing.
+_CONTAINER_WARNED=""
+_warn_once_about_container() {
+    local bundle="$1"
+    [ -n "$_CONTAINER_WARNED" ] && return 0
+    if [ -d "$HOME/Library/Containers/$bundle" ]; then
+        _CONTAINER_WARNED=1
+        echo "note: $HOME/Library/Containers/$bundle exists, so \`defaults <bundle-id>\` is redirected there." >&2
+        echo "note: lane settings are written to $(dev_standard_plist "$bundle") instead. Remove the container to clear the redirect." >&2
+    fi
+    return 0
+}
+
+# The write that matters is the FIRST one: the standard-domain plist, because a
+# non-sandboxed app resolves its UserDefaults there and the dev .app is not
+# sandboxed. Writing it by absolute path was measured coherent with cfprefsd on
+# macOS 26.6.2 in every configuration tried: cold and warm daemon cache, file
+# absent or present, container present or absent, and a live client that does
+# its own set plus synchronize after an external write. No failure window, so
+# this is not a race the lanes keep winning by luck.
+#
+# `defaults write <bundle-id>` is deliberately NOT used. cfprefsd redirects it
+# into the app's container, and the trigger is a container that
+# containermanagerd has REGISTERED for the identifier, not the directory merely
+# existing: creating the path by hand does not redirect, and `rm -rf` of a
+# registered container stops the redirect without the directory coming back.
+# That removal is the operational cure on a host that has one. What created the
+# container on the runner is NOT established, and it was not this repo:
+# build_release.sh signs even the App Store variant with the release
+# identifier, and that workflow runs on a GitHub-hosted image.
+#
+# The container plist is written only when it already exists, so a lane never
+# creates one. Feeding a domain nothing reads would leave a future sandboxed
+# build under this identifier starting up with a test lane's settings.
+#
+# Measured on the self-hosted runner: with only the redirected write, every
+# setting a lane wrote was invisible to the app, which is how e2e-app and
+# e2e-browser came to fail with no record-only sidecar and no error anywhere.
+#
+# `type` is one of bool / int / float / string (default string).
+write_dev_default() {
+    local bundle="$1" key="$2" value="$3" type="${4:-string}"
+    local -a args
+    case "$type" in
+        bool) args=(-bool "$value") ;;
+        int) args=(-int "$value") ;;
+        float) args=(-float "$value") ;;
+        *) args=("$value") ;;
+    esac
+    /usr/bin/defaults write "$(dev_standard_plist "$bundle")" "$key" "${args[@]}" 2>/dev/null || true
+    _warn_once_about_container "$bundle"
+    local container
+    container="$(dev_container_plist "$bundle")"
+    if [ -f "$container" ]; then
+        /usr/bin/defaults write "$container" "$key" "${args[@]}" 2>/dev/null || true
+    fi
+    return 0
+}
+
+# Delete a dev-bundle default from every domain `write_dev_default` writes.
+# Deleting only some of them leaves the app reading a stale value from the one
+# that was missed, which looks exactly like the delete having had no effect.
+delete_dev_default() {
+    local bundle="$1" key="$2"
+    /usr/bin/defaults delete "$(dev_standard_plist "$bundle")" "$key" 2>/dev/null || true
+    local container
+    container="$(dev_container_plist "$bundle")"
+    if [ -f "$container" ]; then
+        /usr/bin/defaults delete "$container" "$key" 2>/dev/null || true
+    fi
+    return 0
+}
+
 # Read the EFFECTIVE value of a dev-bundle default the way the app resolves it.
-# The dev `.app` has a pre-existing container at
-# `~/Library/Containers/<bundle>/…`, and macOS routes the app's UserDefaults
-# reads there regardless of whether the current binary is sandboxed, so a plain
-# `defaults read <bundle> <key>` (standard domain) can disagree with what the
-# app actually sees. When the container plist exists it wins; else fall back to
-# the standard domain. Empty when unset. Shared so e2e-app.sh / e2e-live-captions.sh
-# / e2e-cpu-load.sh read their blind `defaults write`s back consistently instead
-# of each re-deriving the container redirect. NOTE: mutating a dev default still
-# needs BOTH domains written (see the per-domain snapshot/restore in e2e-app.sh);
-# this reader is for verification/readback only.
+# The dev .app is NOT sandboxed, so it resolves its UserDefaults from the
+# standard domain, and that is what this returns when the file exists. The
+# container copy is only a fallback for a host where the standard plist has not
+# been created yet; a plain `defaults read <bundle> <key>` cannot stand in for
+# either, because cfprefsd redirects it into the container whenever one exists.
+# Empty when unset. Only e2e-app.sh calls this, for a diagnostic log line rather
+# than an assertion; it exists so a reader does not re-derive the container
+# redirect by hand. Mutating a dev default needs `write_dev_default`; this is
+# for verification and readback only.
 read_dev_default_effective() {
     local bundle="$1"
     local container_plist="$2"
     local key="$3"
-    if [ -f "$container_plist" ]; then
+    local standard_plist
+    standard_plist="$(dev_standard_plist "$bundle")"
+    if [ -f "$standard_plist" ]; then
+        /usr/bin/defaults read "$standard_plist" "$key" 2>/dev/null || true
+    elif [ -f "$container_plist" ]; then
         /usr/bin/defaults read "$container_plist" "$key" 2>/dev/null || true
     else
         /usr/bin/defaults read "$bundle" "$key" 2>/dev/null || true


### PR DESCRIPTION
Repairs `main`, whose nightly `e2e-app` run started failing the moment a container appeared for the dev bundle id on the runner:

```
2026-09-01 19:43 UTC  e2e-app -> success        last green run
2026-09-01 20:08 UTC  ~/Library/Containers/app.meetingtranscriber.dev is created
2026-09-01 20:17 UTC  e2e-app -> failure        and every run after it
2026-09-02 04:39 UTC  nightly on main -> failure
                      FAIL: no *_meta.json appeared in
                            ~/Downloads/MeetingTranscriber/recordings within 60s
```

The boundary is sharp because the defect needs the two preference domains to disagree, and until that directory existed they could not.

## What was wrong

Every e2e lane configures the dev app by writing preferences from the shell, and none of those writes reached the running app.

The dev `.app` is not sandboxed, so it resolves UserDefaults from the standard domain at `~/Library/Preferences/<id>.plist`. The lanes wrote `defaults write <bundle-id>`, which cfprefsd redirects into `~/Library/Containers` as soon as a container exists for the identifier, and one is left over on the runner from an App Store-variant build. The second write went to that same container explicitly, so the standard domain was never written at all, despite the comment stating both were covered.

The failure is completely silent. From the shell every write succeeds, and the app simply runs on its own defaults. `e2e-app` and `e2e-browser` therefore never enabled record-only and failed a minute later on a sidecar that was never going to be written, with nothing anywhere pointing at the cause.

While the two domains happened to agree, none of this was visible: with no container, `defaults write <bundle-id>` wrote exactly the file the app reads, so the lanes were not correct, they were accidentally correct. macOS redirects the CLI the moment a container exists for the identifier, and from that minute every lane wrote to a file nothing reads.

What created the container at 20:08 is not established. Its `containermanagerd` metadata is root-owned and unreadable, and the timing only narrows it to that evening's build activity on the runner. It does not change the fix: a lane must not depend on which domain the CLI happens to pick.

`e2e-silent-recording` shows the same defect from the other side. It sets the silence threshold to 30 s, the app kept its built-in 90 s, and the lane waited 50 s for a flag that could not flip in that time. It had been passing only because another lane happened to leave a low value in the standard domain; repairing the restore path takes that accident away. The defect does not fail where it sits, it fails wherever something else stops covering for it.

## What changed

One shared `write_dev_default` that writes the standard plist by absolute path, with a matching deleter so a cleanup cannot leave a stale value behind in a domain it missed. Snapshot and restore address the same file instead of going through the redirect, which also stops a lane leaking its settings into the next run. `read_dev_default_effective` preferred the container for the same wrong reason and now prefers the standard domain, which is what the app resolves.

It deliberately does not write the redirected domain. Nothing reads it, and it is the only thing that would create a container plist, which would leave a future sandboxed build under this identifier starting up with a test lane's `recordOnly=true`, `noMic=true` and friends. The container plist is written only when it already exists, and a one-time note on stderr records that a host redirects, so the next container to appear carries a timestamp instead of surfacing days later as a lane that configures nothing.

That the path write is coherent with cfprefsd is measured rather than assumed: cold and warm daemon cache, file absent or present, container present or absent, and a live client doing its own set plus synchronize after an external write. No failure window, so this is not a race the lanes keep winning by luck.

Operationally, the redirect can also be cleared at the source. `rm -rf ~/Library/Containers/app.meetingtranscriber.dev` on the runner stops it and the directory does not come back. That is worth doing but does not replace the fix, since nothing stops another container from appearing.

The silent-recording lane additionally wrote its overrides before quitting the running instance, which owns the same domain and can write its in-memory copy back over them. That order is reversed.

`e2e-live-captions`, `e2e-soak` and `e2e-cpu-load` carry the same defect and are converted too. None of them gates a pull request, which is exactly why they were worth fixing now: a lane that configures nothing still reports success.

## The second defect, which is why this was diagnosed twice

The lanes' readiness probe called `/healthz` through a wrapper that ends in `|| true`, so callers can read a body without tripping `set -e`. That made a refused connection report success as well, leaving "the token file exists" as the only condition actually tested, and that file outlives every run on the host. So `RPC up` could be logged 70 ms after launch, before anything could be listening. It now asks curl directly and lets its exit status decide.

## Why neither could be caught

Nothing in any lane ever observed the setting the run depended on. So both lanes now read `/state.settings.recording.recordOnly` right after the RPC comes up and compare it against what they configured. That is the running process's own resolved view, so a configuration that did not apply fails within seconds and names the cause instead of surfacing minutes later as a missing file.

## Review

Reviewed adversarially by a second model, briefed with the weakest claims rather than the strongest. It measured the mechanism on a throwaway bundle id with a real sandboxed container rather than reasoning about it, which settled two questions and found three defects worth fixing:

- The readiness fix was incomplete. `e2e-cpu-load` and `e2e-live-captions` kept the false probe verbatim, and `e2e-soak`'s body test was right only by accident, because `/healthz` answers `ok\n`. All four share one probe now.
- Reordering the silent-recording lane opened a path that deletes a developer's real settings: `quit_running_app` is bare under `set -e`, so an exhausted quit ladder exits into the cleanup trap with every snapshot still empty, and an empty snapshot restores by deleting. It snapshots first now, and the trap refuses to restore before the snapshot has run.
- Several comments asserted a provenance and a trigger that the repo and the measurements contradict. The container cannot have come from an App Store-variant build, the redirect keys on a registered container rather than the directory existing, and the claim that a live instance clobbers an external write did not reproduce.

## Verified

Every change here has already run green on the runner as part of #663, which is where it was found:

```
[e2e-app]     app resolved recordOnly=false (as configured)   transcription lane
[e2e-app]     app resolved recordOnly=true  (as configured)   record-only lane
[e2e-app]       found sidecar .../recordings/20260902_071218_meta.json
[e2e-app]     app resolved recordOnly=true  (as configured)   microphone-only lane
[e2e-app]       found sidecar .../recordings/20260902_071340_meta.json
[e2e-app]     Run silent-recording detector E2E: success
[e2e-browser] app resolved recordOnly=true  (as configured)
[e2e-browser] PASS: browser detection -> RPC consent -> non-silent CATap capture
```

Split out of #663 so the repair of `main` does not wait on a feature review. #663 rebases on top of this.


