### PR TITLE
feat(app): remove the far end from the microphone track before transcription

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,16 @@ jobs:
         with:
           cache-key-suffix: ${{ matrix.variant }}
           swift-flags: ${{ matrix.swift-flags }}
+      # Without this the echo-cancellation tests skip, which is how this
+      # feature reached a review with single-digit patch coverage on the two
+      # files that do the work. The gap is worse than the number: the library
+      # checks a model against a SHA-256 list compiled into it, so a model the
+      # linked library rejects fails only at load time — compiling stays green,
+      # the tests skip, and both builds merely copy the file. `appstore.yml`
+      # already downloads the same model through `build_release.sh`, so this
+      # adds no network dependency that CI did not have.
+      - name: Fetch the echo-cancellation model
+        run: echo "MEETINGTRANSCRIBER_LOCALVQE_MODEL=$(./scripts/fetch-localvqe-model.sh)" >> "$GITHUB_ENV"
       # 18 min step-timeout on the actual tests: typical hot-cache run is
       # 5–7 min, so this is ~3× margin while still failing fast as
       # `timed_out` (not `cancelled`) when a single test hangs.

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -39,6 +39,7 @@ enum A11yID {
     static let saveRawTranscriptToggle = "saveRawTranscriptToggle"
     static let outputFolderSection = "outputFolderSection"
     static let vadSection = "vadSection"
+    static let echoCancellationToggle = "echoCancellationToggle"
     static let echoDedupToggle = "echoDedupToggle"
     static let diarizationSection = "diarizationSection"
     static let liveTranscriptionSection = "liveTranscriptionSection"

--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -1,3 +1,11 @@
+// swiftlint:disable file_length
+//
+// A settings registry grows by one documented property per feature, so the
+// 600-line cap measures how many features the app has rather than whether this
+// file does too much. Suppressed rather than split because the honest split is
+// to move the three enums below into their own file, and two open pull requests
+// are editing this one; that move is worth doing on a quiet tree, not folded
+// into a feature branch.
 import SwiftUI
 
 // SwiftFormat strips redundant raw values matching their case name, which then
@@ -296,6 +304,14 @@ final class AppSettings {
         didSet { defaults.set(vadThreshold, forKey: "vadThreshold") }
     }
 
+    /// Remove the far end from the microphone audio before transcription
+    /// (`EchoRemedy.cancellation`). Off by default: it has been measured on an
+    /// archive with synthetic loudspeaker echo, never in the field, and it wins
+    /// over the transcript dedup wherever both are on.
+    var echoCancellationEnabled: Bool {
+        didSet { defaults.set(echoCancellationEnabled, forKey: "echoCancellationEnabled") }
+    }
+
     /// Leave the far end out of the transcript when the microphone only picked
     /// it up from the loudspeaker.
     ///
@@ -522,6 +538,7 @@ final class AppSettings {
         diarize = defaults.object(forKey: "diarize") as? Bool ?? true
         vadEnabled = defaults.object(forKey: "vadEnabled") as? Bool ?? false
         vadThreshold = defaults.object(forKey: "vadThreshold") as? Float ?? 0.5
+        echoCancellationEnabled = defaults.object(forKey: "echoCancellationEnabled") as? Bool ?? false
         echoDedupEnabled = defaults.object(forKey: "echoDedupEnabled") as? Bool ?? false
         diarizerMode = (defaults.string(forKey: "diarizerMode")
             .flatMap(DiarizerMode.init(rawValue:))) ?? .offline

--- a/app/MeetingTranscriber/Sources/EchoCancellationSelfCheck.swift
+++ b/app/MeetingTranscriber/Sources/EchoCancellationSelfCheck.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Whether a cancellation run actually removed anything, decided from the
+/// canceller's own per-window measurements.
+///
+/// This exists because "it removed nothing" is a real outcome of this model and
+/// an invisible one. On a minority of recordings it removes essentially nothing
+/// once local speech is present, for the whole file rather than just the
+/// overlapping parts, while removing tens of decibels from the same echo
+/// presented on its own. Nothing about such a run looks wrong from the outside:
+/// it completes, it writes a full-length track, and every gate stays green.
+///
+/// The separation below was measured on recordings that cannot be shared, so
+/// the reasoning is written out here rather than pointed at: what a reader
+/// needs is why these two constants have these shapes, not a citation they
+/// cannot check.
+///
+/// Pure, and separate from the canceller, so the threshold can be chosen from
+/// data without touching the code that produces the audio. That split is the
+/// same one `EchoReductionVerdict` makes for the bundle probe.
+enum EchoCancellationSelfCheck {
+    /// What the run achieved. Three cases and not a `Bool?`, for the same
+    /// reason `EchoVerdict` is not one: *not enough evidence* is not *no*, and
+    /// a caller that collapses them either warns about a recording nobody
+    /// measured or stays quiet about one that failed.
+    enum Effect: Equatable {
+        /// The reduction cleared the threshold. The echo is gone.
+        case removed
+        /// The run completed and took essentially nothing off. The measured
+        /// silent failure.
+        case ineffective
+        /// The run made the recording worse where there was no echo to remove.
+        /// Its own case, because "removed almost nothing" is wrong twice over
+        /// for such a run: it may have removed plenty, and what disqualified it
+        /// was damage, not inaction.
+        case damagedControl
+        /// Too little far-end audio to say either way.
+        case indeterminate
+    }
+
+    /// Windows quieter than this on the reference carry no echo to remove, so
+    /// a canceller doing nothing in them is the correct outcome. They are not
+    /// discarded, though: how much a run attenuates them is the control that
+    /// separates removing the echo from turning the whole track down. The exact
+    /// value is not delicate; moving it twenty decibels either way moved the
+    /// separation by less than one, because what it excludes is windows with no
+    /// far end at all rather than merely quiet ones.
+    static let referenceFloorDBFS: Float = -45
+
+    /// How much more a run has to attenuate the windows carrying echo than the
+    /// windows carrying none.
+    ///
+    /// A difference, not a level, and that is the correction that matters here.
+    /// A level answers "did the track get quieter where the far end was
+    /// playing", which a run that simply halves the microphone answers just as
+    /// well as one that cancels: it reports about six decibels everywhere and
+    /// leaves the echo exactly as audible relative to the local voice. The
+    /// difference answers "did it get quieter *there specifically*", which is
+    /// the only thing that distinguishes cancellation from attenuation.
+    ///
+    /// Placed inside the gap the two populations left, at the least favourable
+    /// echo level tested, with an order of magnitude of room on the failure
+    /// side and better than a factor of two on the healthy side. Healthy runs
+    /// leave the quiet windows within a fraction of a decibel of untouched,
+    /// which is what gives the difference its room.
+    ///
+    /// Serving as both the level floor and the difference floor is deliberate
+    /// but not free: it holds because the control group barely moves on a
+    /// healthy run, so the two quantities are nearly equal there and were
+    /// measured to separate at the same place. A model that denoised the
+    /// microphone broadly would break that, and it would break it the safe
+    /// way, by refusing to confirm runs that worked.
+    static let minMedianReductionDb: Float = 3
+
+    /// How far the control group may move in the wrong direction.
+    ///
+    /// A difference rewards anything that pushes the two groups apart, and
+    /// *amplifying* the windows that carry no echo does exactly that: a run
+    /// barely clearing the level test with a control group boosted twenty
+    /// decibels reads as a large difference and would otherwise be confirmed.
+    /// That run is not cancelling anything; it is making the recording worse
+    /// in the stretches where the local speaker is alone.
+    ///
+    /// One-sided, and measured that way. Healthy runs attenuate the control a
+    /// little, occasionally by ten decibels or so, which the difference already
+    /// handles by shrinking. None of them amplified it at all: across both
+    /// echo levels tested the smallest control median was a small positive
+    /// number. So the floor sits just below zero, where no healthy run has
+    /// ever been.
+    static let minQuietBaselineDb: Float = -1
+
+    /// Fewer scored windows than this, on either side, is not enough to judge.
+    /// A verdict from a handful of windows is a coin toss reported as a fact.
+    static let minScoredWindows = 10
+
+    /// What a run achieved, from its own per-window measurements.
+    ///
+    /// `indeterminate` covers two cases and both are real: too little far-end
+    /// audio to judge, and a far end that never stops, which leaves no quiet
+    /// windows to compare against. The second is exactly the situation where
+    /// broad attenuation is indistinguishable from cancellation, so it is
+    /// withheld rather than waved through.
+    static func effect(of report: EchoCancellationReport) -> Effect {
+        // Both populations first, so a run nobody could measure is never
+        // reported as one that was measured and failed. The two send the user
+        // to different places: one is a fault worth chasing, the other is
+        // usually a far end that never paused long enough to compare against.
+        guard let active = median(report.windows.filter { $0.referenceDBFS >= referenceFloorDBFS }),
+              let quiet = median(report.windows.filter { $0.referenceDBFS < referenceFloorDBFS })
+        else { return .indeterminate }
+
+        guard quiet >= minQuietBaselineDb else { return .damagedControl }
+        guard active >= minMedianReductionDb else { return .ineffective }
+        return active - quiet >= minMedianReductionDb ? .removed : .ineffective
+    }
+
+    /// Median reduction over these windows, or nil when there are too few of
+    /// them to mean anything.
+    private static func median(_ windows: [EchoCancellationWindow]) -> Float? {
+        guard windows.count >= minScoredWindows else { return nil }
+        let sorted = windows.map(\.reductionDb).sorted()
+        return sorted[sorted.count / 2]
+    }
+}

--- a/app/MeetingTranscriber/Sources/EchoCancelling.swift
+++ b/app/MeetingTranscriber/Sources/EchoCancelling.swift
@@ -26,20 +26,56 @@ enum EchoCancellationError: Error {
     case processingFailed(code: Int32, message: String)
 }
 
-/// Removes far-end echo from a microphone recording.
+/// One second of the recording, as the canceller saw it. Measurement only: it
+/// carries the reference level beside the reduction and draws no conclusion
+/// from either, because which windows count towards "did this work" is a
+/// policy that wants to be chosen from data without touching the canceller.
+struct EchoCancellationWindow: Equatable {
+    /// Level of the far-end reference in this window. The only gate a shipped
+    /// check can apply, since nothing here knows who was speaking.
+    let referenceDBFS: Float
+    /// How much quieter the microphone track came out, in this window.
+    let reductionDb: Float
+}
+
+/// What one cancellation run did, per window and in order.
+struct EchoCancellationReport: Equatable {
+    let windows: [EchoCancellationWindow]
+}
+
+/// Removes far-end echo from a microphone recording, file to file.
 ///
-/// Contract: both tracks are mono Float32 PCM at 16 kHz sharing one timeline
-/// (sample `i` of `mic` and `reference` are simultaneous). The result has
-/// exactly `mic.count` samples. No time alignment is performed — the seam
-/// passes both tracks through as given; whether the underlying canceller
-/// tolerates inter-track delay is its own property, not this contract's.
-/// A `reference` shorter than `mic` is treated as silence past its end; a
-/// longer one is ignored past `mic.count`.
+/// Contract: both files are mono 16 kHz PCM. The output has exactly as many
+/// samples as the microphone input. A reference shorter than the microphone is
+/// treated as silence past its end; a longer one is ignored past the
+/// microphone's length. Nothing is written to `outputURL` unless the whole run
+/// succeeds, so a caller can adopt the file's existence as "this is a cancelled
+/// track".
+///
+/// **The two files do not share sample 0, and the caller has to say by how
+/// much.** The recorder starts its two captures independently, and the delta is
+/// what `micDelay` carries everywhere else in the pipeline. An echo canceller
+/// fed a reference that does not line up is not a weaker canceller: it is being
+/// shown the wrong audio, so it removes nothing it should and may take out
+/// something it should not. The seam therefore aligns, rather than declaring
+/// alignment someone else's problem, because there is no caller for whom the
+/// answer is zero by construction.
+///
+/// **Why files and not arrays.** At 16 kHz Float32 a track costs 64 kB per
+/// second, so a 90 minute meeting is ~345 MB and an array-shaped call would
+/// hold microphone, reference and output at once: roughly 1 GB on top of what
+/// the pipeline already carries. The project paid that lesson one file over,
+/// where `warnIfEchoBleed` reads through a bounded loader for the same reason.
+/// Here the ceiling is a property of the seam rather than of the caller's
+/// discipline.
 protocol EchoCancelling: Sendable {
-    // Referenced only through the concrete type until the pipeline consumer
-    // lands in a follow-up; the analyzer cannot see that intent.
-    // swiftlint:disable:next unused_declaration
-    func cancelEcho(mic: [Float], reference: [Float]) async throws -> [Float]
+    /// - Parameter referenceLead: how far the reference has to be advanced to
+    ///   line up with the microphone, in seconds. Positive when the microphone
+    ///   started late, which is the sign convention `micDelay` already uses:
+    ///   microphone sample *j* belongs with reference sample *j + lead*.
+    func cancelEcho(
+        micURL: URL, referenceURL: URL, outputURL: URL, referenceLead: TimeInterval,
+    ) async throws -> EchoCancellationReport
 }
 
 /// Did the echo actually drop? Pure arithmetic over two levels, kept beside the

--- a/app/MeetingTranscriber/Sources/EchoRemedy.swift
+++ b/app/MeetingTranscriber/Sources/EchoRemedy.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Which remedy a dual-source recording gets for the loudspeaker coming back
+/// through the microphone.
+///
+/// The two cannot compose, and `EchoCancelling`'s header says so as a
+/// requirement on whoever lands the first consumer: cancellation removes the
+/// far end from the microphone *audio*, the dedup drops microphone *transcript*
+/// lines that duplicate the far end. Run together the dedup would be judging
+/// audio the echo has already been taken out of, where its own measure (how
+/// closely a microphone segment tracks the app track) no longer means what it
+/// was calibrated to mean.
+///
+/// A named decision rather than an `if` at the call site, so the precedence is
+/// written down once and a test can pin it. It is deliberately not a `Bool`
+/// pair for the same reason `EchoVerdict` is not: three states, and collapsing
+/// them loses the one that matters.
+enum EchoRemedy: Equatable {
+    /// Neither remedy is on. The transcript keeps both copies, which is what
+    /// shipped before either existed. Not spelled `none`: as a `case` that
+    /// name reads as `Optional.none` at every call site.
+    case neither
+
+    /// Acoustic cancellation on the microphone track before anything reads it.
+    case cancellation
+
+    /// Leave loudspeaker copies out of the merged transcript after the fact.
+    case transcriptDedup
+
+    /// What the settings ask for. Cancellation wins when both are on: it acts
+    /// earlier and on the audio itself, so everything downstream of it
+    /// (transcription, per-track diarization, the speaker embeddings taken from
+    /// that diarization) sees a microphone track with the far end already gone.
+    /// The dedup only ever reached the transcript, and could not keep a bled-in
+    /// voice out of a stored speaker centroid.
+    static func intended(cancellationEnabled: Bool, dedupEnabled: Bool) -> Self {
+        if cancellationEnabled { return .cancellation }
+        return dedupEnabled ? .transcriptDedup : .neither
+    }
+
+    /// What the recording actually got, which is not always what was asked for.
+    ///
+    /// The dedup stands down under cancellation for one reason: the far end is
+    /// no longer in the audio its measure was calibrated on. When cancellation
+    /// does not happen — no model, a throw, or a run that could not be shown to
+    /// have removed anything — that reason is gone with it, the microphone
+    /// track is exactly as it was recorded, and the fallback is valid again.
+    ///
+    /// Deciding this from the settings alone meant a user with both switches on
+    /// and a missing model got neither remedy, on every affected recording,
+    /// with one warning line as the only sign.
+    static func applied(cancellationSucceeded: Bool, dedupEnabled: Bool) -> Self {
+        if cancellationSucceeded { return .cancellation }
+        return dedupEnabled ? .transcriptDedup : .neither
+    }
+}

--- a/app/MeetingTranscriber/Sources/LocalVQECanceller+File.swift
+++ b/app/MeetingTranscriber/Sources/LocalVQECanceller+File.swift
@@ -1,0 +1,231 @@
+// The file-to-file half of LocalVQECanceller: the shape the pipeline calls.
+// Split from LocalVQECanceller.swift so the C bridging stays in one place and
+// the streaming file I/O in another; the hop loop itself is shared through
+// `processHops`.
+import AVFoundation
+import CLocalVQE
+import Foundation
+
+extension LocalVQECanceller {
+    /// Frames read, processed and written per block. A multiple of the hop
+    /// length so no hop straddles a block, and about a second of audio, which
+    /// keeps the resident cost of a two-hour recording in the tens of kilobytes
+    /// rather than the hundreds of megabytes an array-shaped call would need.
+    private static let blockHops = 64
+
+    /// One report window. Fixed at a second of audio rather than derived from
+    /// the block size, so the report keeps the same resolution if the block
+    /// size is ever tuned for throughput.
+    static let reportWindowSamples = AudioConstants.targetSampleRate
+
+    func cancelEcho(
+        micURL: URL, referenceURL: URL, outputURL: URL, referenceLead: TimeInterval,
+    ) async throws -> EchoCancellationReport {
+        let mic = try AVAudioFile(forReading: micURL)
+        let reference = try AVAudioFile(forReading: referenceURL)
+        let format = mic.processingFormat
+
+        // Line the reference up with the microphone before a single hop runs.
+        // A positive lead means the microphone started late, so its sample 0
+        // belongs with reference sample `lead`; seek past that much. A negative
+        // one means the reference started late, and the missing head is silence
+        // the microphone heard nothing of, so it is padded rather than sought.
+        let leadFrames = Int((referenceLead * Double(AudioConstants.targetSampleRate)).rounded())
+        var referencePadding = max(0, -leadFrames)
+        if leadFrames > 0 {
+            reference.framePosition = min(AVAudioFramePosition(leadFrames), reference.length)
+        }
+
+        let ctx = localvqe_new(modelPath)
+        guard ctx != 0 else {
+            throw EchoCancellationError.modelLoadFailed(Self.lastError(ctx: 0))
+        }
+        defer { localvqe_free(ctx) }
+
+        let hopLength = Int(localvqe_hop_length(ctx))
+        // Written beside the destination and moved into place at the end. A
+        // caller adopts the output as "the cancelled track", so a run that
+        // throws half way must leave nothing that could be adopted.
+        let staging = outputURL.deletingLastPathComponent()
+            .appendingPathComponent("\(outputURL.lastPathComponent).partial")
+        try? FileManager.default.removeItem(at: staging)
+        let output = try AVAudioFile(forWriting: staging, settings: Self.outputSettings)
+
+        var windows: [EchoCancellationWindow] = []
+        var accumulator = WindowAccumulator(samplesPerWindow: Self.reportWindowSamples)
+        var processor = HopProcessor(ctx: ctx, hopLength: hopLength)
+
+        do {
+            let blockFrames = AVAudioFrameCount(hopLength * Self.blockHops)
+            var produced = [Float]()
+            produced.reserveCapacity(Int(blockFrames))
+            while mic.framePosition < mic.length {
+                try Task.checkCancellation()
+                await Task.yield()
+                let micBlock = try Self.read(mic, frames: blockFrames, format: format)
+                // Only ever read what this block will use. Reading a whole
+                // block and trimming it to fit the padding threw the trimmed
+                // frames away with the file already advanced past them, so
+                // every later block came out that much early: the head was
+                // padded and the rest of the recording was misaligned by
+                // exactly the amount the padding was meant to correct.
+                let pad = min(referencePadding, micBlock.count)
+                referencePadding -= pad
+                var refBlock = [Float](repeating: 0, count: pad)
+                if micBlock.count > pad {
+                    // Past the reference's end this reads nothing, and the hop
+                    // processor zero-fills, which is how the contract's "a
+                    // shorter reference is silence" is actually kept.
+                    refBlock += try Self.read(
+                        reference, frames: AVAudioFrameCount(micBlock.count - pad), format: format,
+                    )
+                }
+                produced.removeAll(keepingCapacity: true)
+                try processor.process(mic: micBlock, reference: refBlock) { hop in
+                    produced.append(contentsOf: hop)
+                }
+                try Self.write(produced[...], to: output, format: format)
+                accumulator.add(
+                    mic: micBlock, reference: refBlock, output: produced, into: &windows,
+                )
+            }
+            accumulator.flush(into: &windows)
+        } catch {
+            try? FileManager.default.removeItem(at: staging)
+            throw error
+        }
+
+        try? FileManager.default.removeItem(at: outputURL)
+        try FileManager.default.moveItem(at: staging, to: outputURL)
+        return EchoCancellationReport(windows: windows)
+    }
+
+    /// 16-bit PCM, matching what `AudioMixer.saveWAV` writes for every other
+    /// intermediate in the pipeline. A cancelled track that differed in format
+    /// from the one it replaces would make every downstream reader's behaviour
+    /// depend on whether cancellation ran.
+    private static var outputSettings: [String: Any] {
+        [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: AudioConstants.targetSampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+        ]
+    }
+
+    /// The three `bufferCreationFailed` guards below are unreachable as these
+    /// two are called, and stay in rather than becoming force-unwraps.
+    /// `AVAudioPCMBuffer` returns nil for a zero capacity or a format it
+    /// cannot represent; both callers rule the first out before they ask, and
+    /// the format is the one the file handed back. They are the boundary of
+    /// what this file can promise, not dead code, and a crash is a worse way
+    /// to find out the assumption stopped holding.
+    private static func read(
+        _ file: AVAudioFile, frames: AVAudioFrameCount, format: AVAudioFormat,
+    ) throws -> [Float] {
+        let remaining = file.length - file.framePosition
+        guard remaining > 0 else { return [] }
+        let wanted = AVAudioFrameCount(min(Int64(frames), remaining))
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: wanted) else {
+            throw AudioMixerError.bufferCreationFailed
+        }
+        try file.read(into: buffer, frameCount: wanted)
+        guard let channel = buffer.floatChannelData?[0] else { return [] }
+        return Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+    }
+
+    private static func write(
+        _ samples: ArraySlice<Float>, to file: AVAudioFile, format: AVAudioFormat,
+    ) throws {
+        guard !samples.isEmpty else { return }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count),
+        ) else {
+            throw AudioMixerError.bufferCreationFailed
+        }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        guard let destination = buffer.floatChannelData?[0] else {
+            throw AudioMixerError.bufferCreationFailed
+        }
+        for (offset, sample) in samples.enumerated() {
+            destination[offset] = sample
+        }
+        try file.write(from: buffer)
+    }
+}
+
+/// Rolls per-hop energies up into the report's one-second windows.
+///
+/// A separate value rather than three running variables in the loop: the roll
+/// over a window boundary is the part that is easy to get wrong, and as a type
+/// it can be tested without a model, a file, or the C library.
+struct WindowAccumulator {
+    let samplesPerWindow: Int
+    private var micEnergy = 0.0
+    private var refEnergy = 0.0
+    private var outEnergy = 0.0
+    private var windowSamples = 0
+
+    init(samplesPerWindow: Int) {
+        self.samplesPerWindow = samplesPerWindow
+    }
+
+    /// Folds one block of audio in, emitting a window every time the boundary
+    /// is crossed. A block is about a second and a window is exactly one, so a
+    /// block can complete a window and start the next; the loop rather than a
+    /// single check is what keeps the two sizes independent, so the block can
+    /// be tuned for throughput without changing the report's resolution.
+    mutating func add(
+        mic: [Float], reference: [Float], output: [Float],
+        into windows: inout [EchoCancellationWindow],
+    ) {
+        var offset = 0
+        while offset < output.count {
+            let take = min(samplesPerWindow - windowSamples, output.count - offset)
+            let range = offset ..< (offset + take)
+            micEnergy += Self.energy(mic[range.clamped(to: mic.indices)])
+            refEnergy += Self.energy(reference[range.clamped(to: reference.indices)])
+            outEnergy += Self.energy(output[range])
+            windowSamples += take
+            offset += take
+            if windowSamples >= samplesPerWindow {
+                windows.append(current())
+                reset()
+            }
+        }
+    }
+
+    /// Emits the trailing partial window, if any. A recording is almost never
+    /// a whole number of seconds, and dropping the remainder would silently
+    /// lose the end of a short one.
+    mutating func flush(into windows: inout [EchoCancellationWindow]) {
+        guard windowSamples > 0 else { return }
+        windows.append(current())
+        reset()
+    }
+
+    private func current() -> EchoCancellationWindow {
+        let n = Double(max(windowSamples, 1))
+        let refRMS = (refEnergy / n).squareRoot()
+        let micRMS = (micEnergy / n).squareRoot()
+        let outRMS = (outEnergy / n).squareRoot()
+        return EchoCancellationWindow(
+            referenceDBFS: Float(refRMS > 0 ? 20 * log10(refRMS) : -120),
+            // Same arithmetic as `EchoReductionVerdict.reductionDb`, on running
+            // sums rather than on buffers the streaming path never holds whole.
+            reductionDb: Float(20 * log10(max(micRMS, 1e-12) / max(outRMS, 1e-12))),
+        )
+    }
+
+    private mutating func reset() {
+        micEnergy = 0
+        refEnergy = 0
+        outEnergy = 0
+        windowSamples = 0
+    }
+
+    private static func energy(_ samples: some Collection<Float>) -> Double {
+        samples.reduce(0.0) { $0 + Double($1) * Double($1) }
+    }
+}

--- a/app/MeetingTranscriber/Sources/LocalVQECanceller.swift
+++ b/app/MeetingTranscriber/Sources/LocalVQECanceller.swift
@@ -16,6 +16,10 @@ struct LocalVQECanceller: EchoCancelling {
     /// a cooperative-pool thread for its whole duration.
     private static let yieldStride = 64
 
+    /// Array form. Kept for the callers whose input is seconds long by
+    /// construction (the bundle selftest and the unit tests); the pipeline
+    /// calls the file form, which is what the seam promises and what bounds
+    /// memory on a real recording.
     func cancelEcho(mic: [Float], reference: [Float]) async throws -> [Float] {
         guard !mic.isEmpty else { return [] }
 
@@ -26,33 +30,80 @@ struct LocalVQECanceller: EchoCancelling {
         defer { localvqe_free(ctx) }
 
         let hopLength = Int(localvqe_hop_length(ctx))
-        let chunking = EchoFrameChunking(totalSamples: mic.count, hopLength: hopLength)
+        var processor = HopProcessor(ctx: ctx, hopLength: hopLength)
         var output = [Float]()
         output.reserveCapacity(mic.count)
-        // Scratch windows reused across hops; fillHop overwrites them fully.
-        var micHop = [Float](repeating: 0, count: hopLength)
-        var refHop = [Float](repeating: 0, count: hopLength)
-        var outHop = [Float](repeating: 0, count: hopLength)
 
-        for index in 0 ..< chunking.hopCount {
+        var start = 0
+        let blockSamples = hopLength * Self.yieldStride
+        while start < mic.count {
             try Task.checkCancellation()
-            if index > 0, index.isMultiple(of: Self.yieldStride) {
-                await Task.yield()
+            if start > 0 { await Task.yield() }
+            let end = min(start + blockSamples, mic.count)
+            try processor.process(
+                mic: Array(mic[start ..< end]),
+                reference: Array(reference[min(start, reference.count) ..< min(end, reference.count)]),
+            ) { produced in
+                output.append(contentsOf: produced)
             }
+            start = end
+        }
+        return output
+    }
+}
+
+/// One canceller session: the C context plus the scratch buffers a hop is
+/// filled into. Together rather than as eight parameters on a free function,
+/// because they have exactly one lifetime between them and separating them
+/// invited a caller to bring its own buffers to someone else's context.
+///
+/// Not an owner: `LocalVQECanceller` creates and frees the context around it,
+/// so this stays a plain struct that can be handed around inside one call.
+struct HopProcessor {
+    let ctx: localvqe_ctx_t
+    let hopLength: Int
+    private var micHop: [Float]
+    private var refHop: [Float]
+    private var outHop: [Float]
+
+    init(ctx: localvqe_ctx_t, hopLength: Int) {
+        self.ctx = ctx
+        self.hopLength = hopLength
+        micHop = [Float](repeating: 0, count: hopLength)
+        refHop = [Float](repeating: 0, count: hopLength)
+        outHop = [Float](repeating: 0, count: hopLength)
+    }
+
+    /// Drives one contiguous block through the streaming frame API, hop by hop,
+    /// and hands each hop's output to `emit`.
+    ///
+    /// Shared by the array and file forms rather than written twice: the
+    /// streaming context carries state across hops, so two copies of this loop
+    /// would be two chances to reset it on a boundary and produce audio that
+    /// differs depending on which entry point the caller took. A block is a
+    /// slice of one recording, never a fresh start.
+    mutating func process(
+        mic: [Float], reference: [Float], emit: (ArraySlice<Float>) throws -> Void,
+    ) throws {
+        let chunking = EchoFrameChunking(totalSamples: mic.count, hopLength: hopLength)
+        for index in 0 ..< chunking.hopCount {
             let hop = chunking.hop(index)
             EchoFrameChunking.fillHop(from: mic, start: hop.start, into: &micHop)
+            // Zero-filled past the reference's end, which is how the seam's
+            // "a shorter reference is silence" contract is actually kept.
             EchoFrameChunking.fillHop(from: reference, start: hop.start, into: &refHop)
             let code = localvqe_process_frame_f32(ctx, micHop, refHop, Int32(hopLength), &outHop)
             guard code == 0 else {
                 throw EchoCancellationError.processingFailed(
-                    code: code, message: Self.lastError(ctx: ctx),
+                    code: code, message: LocalVQECanceller.lastError(ctx: ctx),
                 )
             }
-            output.append(contentsOf: outHop[0 ..< hop.validSamples])
+            try emit(outHop[0 ..< hop.validSamples])
         }
-        return output
     }
+}
 
+extension LocalVQECanceller {
     /// The library's own error string, guarded. The C header carries no
     /// nullability annotations, so this imports as implicitly unwrapped and an
     /// unguarded read would crash in the one place a second failure is least

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -109,6 +109,7 @@ final class PipelineController {
             outputDir: settings.effectiveOutputDir,
             diarizeEnabled: settings.diarize,
             echoDedupEnabled: settings.echoDedupEnabled,
+            echoCancellationEnabled: { [settings] in settings.echoCancellationEnabled },
             numSpeakers: settings.numSpeakers,
             micLabel: settings.micName,
             includeFullTranscriptInProtocol: settings.includeFullTranscriptInProtocol,

--- a/app/MeetingTranscriber/Sources/PipelineQueue+EchoBleed.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+EchoBleed.swift
@@ -21,10 +21,22 @@ private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "Pipelin
 struct EchoBleedAnalysis {
     let verdict: EchoVerdict
     let windowScores: [EchoBleedDetector.WindowScore]
+    /// Share of scored windows that carried bleed, and how many were scored.
+    /// Only meaningful on an `.affected` analysis, which is the only one the
+    /// announcement says anything about.
+    let affectedPercent: Int
+    let windowsScored: Int
 
-    init(verdict: EchoVerdict, windowScores: [EchoBleedDetector.WindowScore] = []) {
+    init(
+        verdict: EchoVerdict,
+        windowScores: [EchoBleedDetector.WindowScore] = [],
+        affectedPercent: Int = 0,
+        windowsScored: Int = 0,
+    ) {
         self.verdict = verdict
         self.windowScores = windowScores
+        self.affectedPercent = affectedPercent
+        self.windowsScored = windowsScored
     }
 }
 
@@ -49,8 +61,7 @@ extension PipelineQueue {
     /// caller that need not re-read the job, plus the per-window scores the
     /// segment classification aligns with; those exist only here, since the
     /// recorded DTO deliberately drops the series.
-    @discardableResult
-    func warnIfEchoBleed(jobID: UUID, appURL: URL, micURL: URL, micDelay: TimeInterval) async -> EchoBleedAnalysis {
+    func measureEchoBleed(jobID: UUID, appURL: URL, micURL: URL, micDelay: TimeInterval) async -> EchoBleedAnalysis {
         // Clamped exactly as `AudioMixer.mix` clamps it, and for the same
         // reason: a device switch mid-recording can reset the first-frame
         // timestamp on one source only (issue #99), and an absurd delay here
@@ -93,24 +104,44 @@ extension PipelineQueue {
         let detail = Self.windowDetail(result.windowScores)
         logger.info("echo_bleed windows=\(detail, privacy: .public)")
         guard result.isAffected else { return EchoBleedAnalysis(verdict: .clean, windowScores: result.windowScores) }
+        return EchoBleedAnalysis(
+            verdict: .affected, windowScores: result.windowScores,
+            // Carried rather than recomputed later: the announcement says what
+            // was measured, and the two numbers it says it by have to be the
+            // ones the verdict came from.
+            affectedPercent: Int((result.affectedWindowShare * 100).rounded()),
+            windowsScored: scored,
+        )
+    }
 
+    /// Tells the user what the measurement found, once the remedy has had its
+    /// turn. Split from the measurement because the sentence in the middle
+    /// depends on what actually happened afterwards: promising that the far end
+    /// was removed, before the run that removes it, would be a claim the app
+    /// cannot keep when the model is missing or the canceller throws.
+    func announceEchoBleed(_ analysis: EchoBleedAnalysis, jobID: UUID, echoRemoved: Bool) {
+        guard analysis.verdict == .affected else { return }
         // Says what was measured, not more: the share is over the windows that
         // were scored inside the analysed span, which for a long meeting is a
         // fraction of it.
-        let analysedSeconds = Double(scored) * EchoBleedDetector.windowSeconds
+        let analysedSeconds = Double(analysis.windowsScored) * EchoBleedDetector.windowSeconds
         let minutes = Int((analysedSeconds / 60).rounded())
         // "1 minutes" is reachable: the minimum firing configuration is three
         // ten-second windows, and the E2E fixture produces four.
         let span = minutes == 1 ? "minute" : "minutes"
-        let head = "Speaker output was picked up by the microphone in \(percent)% of the \(minutes) \(span) analysed."
-        let tail = "Remote speech may appear twice in the transcript. Using headphones avoids it."
+        let head = "Speaker output was picked up by the microphone in \(analysis.affectedPercent)% of the \(minutes) \(span) analysed."
+        let tail = echoRemoved
+            ? "It was removed from the microphone track before transcription. Headphones still give the cleaner recording."
+            : "Remote speech may appear twice in the transcript. Using headphones avoids it."
         // Third sentence because the consequence is otherwise invisible: naming
         // speakers on this recording will look like it worked and teach the app
         // nothing. Saying so here is honest — the quarantine follows from this
         // same verdict, so it is a statement of fact rather than a prediction.
+        // Unchanged by cancellation on purpose: the quarantine is a safety
+        // measure, and lifting it on a repair that has never been watched in
+        // the field is exactly the trade this project keeps refusing.
         let db = "Voices from this recording are not added to the speaker database."
         addWarning(id: jobID, "\(head) \(tail) \(db)")
-        return EchoBleedAnalysis(verdict: .affected, windowScores: result.windowScores)
     }
 
     /// Per microphone segment: is it the loudspeaker coming back?
@@ -127,19 +158,26 @@ extension PipelineQueue {
     /// detached task through the actor to keep them alive would cost more than
     /// it saves.
     func classifyMicEcho(
+        remedy: EchoRemedy,
         analysis: EchoBleedAnalysis,
-        appURL: URL,
-        micURL: URL,
-        micDelay: TimeInterval,
+        // One argument, the way the neighbouring dual-track diarization call
+        // already spells the same three: they are never meaningful apart, and
+        // apart they were the fifth, sixth and seventh things a reader had to
+        // keep in order at the call site.
+        tracks: (app: URL, mic: URL, micDelay: TimeInterval),
         micSegments: [TimestampedSegment],
     ) async -> [EchoSegmentVerdict] {
-        guard echoDedupEnabled, analysis.verdict == .affected, !micSegments.isEmpty else { return [] }
-        let delay = AudioMixer.clampMicDelay(micDelay)
+        // The remedy, not the setting: with cancellation on there is nothing
+        // here to find, because the far end is already out of the audio these
+        // segments were transcribed from, and this measure was calibrated on
+        // audio that still had it.
+        guard remedy == .transcriptDedup, analysis.verdict == .affected, !micSegments.isEmpty else { return [] }
+        let delay = AudioMixer.clampMicDelay(tracks.micDelay)
         let windowScores = analysis.windowScores
         return await Task.detached(priority: .utility) { () -> [EchoSegmentVerdict] in
             let analysed = Self.echoBleedAnalysisSeconds
-            guard let (app, appRate) = Self.loadBounded(appURL, maxSeconds: analysed),
-                  let (mic, micRate) = Self.loadBounded(micURL, maxSeconds: analysed),
+            guard let (app, appRate) = Self.loadBounded(tracks.app, maxSeconds: analysed),
+                  let (mic, micRate) = Self.loadBounded(tracks.mic, maxSeconds: analysed),
                   appRate == micRate
             else {
                 logger.warning("echo_dedup skipped: tracks unreadable or at different rates")

--- a/app/MeetingTranscriber/Sources/PipelineQueue+EchoCancellation.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+EchoCancellation.swift
@@ -1,0 +1,179 @@
+// The cancellation half of the echo work: takes the far end out of the
+// microphone track before anything reads it. Sits beside
+// PipelineQueue+EchoBleed.swift, which measures, and is the other branch of
+// the same decision (`EchoRemedy`).
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppPaths.logSubsystem, category: "PipelineQueue+EchoCancellation")
+
+extension PipelineQueue {
+    /// Rewrites the 16 kHz microphone track with the far end removed, in place.
+    ///
+    /// In place, and that is the design rather than an economy. Everything
+    /// downstream reads `mic_16k.wav` from the work directory by convention:
+    /// transcription, the per-track diarization, and through it the speaker
+    /// embeddings. Replacing the file is what makes all three see a cleaned
+    /// track without a second path threaded through the pipeline, and without
+    /// a future reader having to remember which of two microphone files it is
+    /// supposed to open.
+    ///
+    /// Returns whether the echo can honestly be said to be gone, which is not
+    /// the same as whether the run completed: the model sometimes removes
+    /// nothing while reporting success, so the answer is the self-check's, not
+    /// the file system's. A false here is not an error the job should fail on
+    /// — the track is left as recorded, which is what shipped before this
+    /// existed — but the user is told, because a feature that is on and
+    /// silently doing nothing is the failure mode this direction keeps
+    /// running into.
+    func cancelEchoOnMicTrack(
+        jobID: UUID, appURL: URL, micURL: URL, micDelay: TimeInterval,
+    ) async throws -> Bool {
+        guard let canceller = echoCancellerFactory() else {
+            logger.warning("echo_cancel skipped: no model available")
+            addWarning(
+                id: jobID,
+                "Echo cancellation is on but its model is missing, so the microphone track was left as recorded.",
+            )
+            return false
+        }
+        let staged = micURL.deletingLastPathComponent()
+            .appendingPathComponent("mic_16k_cancelled.wav")
+        let report: EchoCancellationReport
+        do {
+            report = try await canceller.cancelEcho(
+                micURL: micURL, referenceURL: appURL, outputURL: staged,
+                // Clamped exactly as the detector and the mix clamp it, and for
+                // the same reason: a device switch mid-recording can reset one
+                // source's first-frame timestamp, and an absurd lead would seek
+                // the reference past the end of itself.
+                referenceLead: AudioMixer.clampMicDelay(micDelay),
+            )
+        } catch is CancellationError {
+            try? FileManager.default.removeItem(at: staged)
+            // Rethrown, not turned into "declined". The job is already gone
+            // from the queue by the time this arrives, so swallowing it let the
+            // run continue into two transcription passes and write artifacts
+            // for a recording the user had cancelled.
+            throw CancellationError()
+        } catch {
+            try? FileManager.default.removeItem(at: staged)
+            logger.error(
+                "echo_cancel failed error=\(error.localizedDescription, privacy: .public)",
+            )
+            addWarning(
+                id: jobID,
+                "Echo cancellation failed, so the microphone track was left as recorded.",
+            )
+            return false
+        }
+
+        // Judged before it is adopted, which is the whole reason the seam hands
+        // the report back before the swap. Adopting first and asking after left
+        // the model's output in place on exactly the runs that could not be
+        // shown to have improved it.
+        let effect = EchoCancellationSelfCheck.effect(of: report)
+        logger.info(
+            "echo_cancel windows=\(report.windows.count, privacy: .public) effect=\(String(describing: effect), privacy: .public)",
+        )
+        guard effect == .removed else {
+            try? FileManager.default.removeItem(at: staged)
+            addWarning(id: jobID, Self.unconfirmedWarning(for: effect))
+            return false
+        }
+        return adopt(staged: staged, as: micURL, jobID: jobID)
+    }
+
+    /// Puts the cancelled track where every later stage will look for it, by
+    /// renames whose failure states are defined.
+    ///
+    /// Not `replaceItemAt`. That reads as the safe primitive and its success
+    /// path is exactly right, but its documentation says nothing about where
+    /// the original is when it throws, and the recovery here was written as
+    /// though it did: delete the staged file and report that the recording was
+    /// left as recorded. Two reviewers disagreed about whether that can lose
+    /// the original, which is the answer by itself. Every step below is a
+    /// rename inside one directory, so each either happened or did not, and
+    /// the step that undoes it is written out.
+    private func adopt(staged: URL, as micURL: URL, jobID: UUID) -> Bool {
+        let manager = FileManager.default
+        let backup = micURL.appendingPathExtension("original")
+        try? manager.removeItem(at: backup)
+        do {
+            try manager.moveItem(at: micURL, to: backup)
+        } catch {
+            // Nothing has moved, so the recording is where it always was.
+            try? manager.removeItem(at: staged)
+            return reportAdoptFailure(error, jobID: jobID)
+        }
+        do {
+            try manager.moveItem(at: staged, to: micURL)
+        } catch {
+            try? manager.moveItem(at: backup, to: micURL)
+            try? manager.removeItem(at: staged)
+            return reportAdoptFailure(error, jobID: jobID)
+        }
+        try? manager.removeItem(at: backup)
+        return true
+    }
+
+    /// Close to unreachable: both files sit in this run's own work directory.
+    /// Reported rather than thrown because the original track is still there
+    /// and still usable, and losing a meeting over a rename would be a worse
+    /// outcome than an echo left in.
+    private func reportAdoptFailure(_ error: any Error, jobID: UUID) -> Bool {
+        logger.error(
+            "echo_cancel adopt failed error=\(error.localizedDescription, privacy: .public)",
+        )
+        addWarning(
+            id: jobID,
+            "Echo cancellation finished but its result could not be used, so the microphone track was left as recorded.",
+        )
+        return false
+    }
+
+    /// What to tell the user about a run whose output is not being used.
+    ///
+    /// All of them say "left as recorded" because all of them now do that. The
+    /// distinction they keep is what happened, because the three ask for
+    /// different things: a run that did nothing is a fault worth reporting
+    /// upstream, a run nobody could judge is usually a far end that never
+    /// paused long enough to measure against, and a run that damaged the
+    /// quiet stretches is the one case where the model actively made the
+    /// recording worse.
+    private static func unconfirmedWarning(for effect: EchoCancellationSelfCheck.Effect) -> String {
+        switch effect {
+        case .ineffective:
+            "Echo cancellation ran but removed almost nothing, so the microphone track was left as recorded."
+
+        case .damagedControl:
+            "Echo cancellation altered parts of the recording where there was no echo, so the microphone track was left as recorded."
+
+        case .indeterminate:
+            "Echo cancellation could not be confirmed on this recording, so the microphone track was left as recorded."
+
+        case .removed:
+            ""
+        }
+    }
+
+    /// The production canceller: whatever `LocalVQEModel` resolves out of the
+    /// bundle or the override variable, or nil when neither is there.
+    ///
+    /// The three pieces of ambient state are default arguments rather than
+    /// reads in the body, the same way `LocalVQEModel.resolve` already takes
+    /// its `fileExists`. Read inline they made the one decision here — a
+    /// resolution that came up empty means no canceller, and reporting that is
+    /// how the user learns the feature is not running — reachable only by
+    /// arranging the machine the test happened to run on.
+    static func bundledEchoCanceller(
+        override: String? = ProcessInfo.processInfo.environment[LocalVQEModel.overrideEnvironmentKey],
+        bundledPath: String? = LocalVQEModel.bundledModelPath(in: .main),
+        fileExists: (String) -> Bool = FileManager.default.fileExists(atPath:),
+    ) -> (any EchoCancelling)? {
+        guard let path = LocalVQEModel.resolve(
+            override: override, bundledPath: bundledPath, fileExists: fileExists,
+        ).path else { return nil }
+        return LocalVQECanceller(modelPath: path)
+    }
+}

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -204,6 +204,12 @@ extension PipelineQueue {
             )
         } catch is CancellationError {
             stopElapsedTimer()
+            // Cleared here too, not only in the branch below. The set is what
+            // tells a later generic error apart from a cancellation, so an ID
+            // left in it outlives the job it described for the rest of the
+            // session. Nothing threw this out of a stage until the echo
+            // cancellation did, which is what made the leak reachable.
+            cancelledJobIDs.remove(ctx.jobID)
             logger.info("Job \(ctx.jobID) cancelled")
             // Job already removed by cancelJob()
         } catch {
@@ -240,13 +246,37 @@ extension PipelineQueue {
         try await appResample
         try await micResample
 
-        // Both tracks now exist at 16 kHz. Check here, before transcription,
-        // whether they carry the same speech: that means the loudspeaker output
-        // is coming back through the microphone, and every affected utterance
-        // would otherwise land in the transcript twice.
-        let echoAnalysis = await warnIfEchoBleed(
+        // Both tracks now exist at 16 kHz. Measure here, before transcription
+        // and before any remedy touches the audio, whether they carry the same
+        // speech: that means the loudspeaker output is coming back through the
+        // microphone. Measuring first is not an ordering detail — a cancelled
+        // track no longer correlates with the app track, so a detector run
+        // after the remedy would report every repaired recording as clean and
+        // take the quarantine off the audio that needed it.
+        let echoAnalysis = await measureEchoBleed(
             jobID: ctx.jobID, appURL: app16k, micURL: mic16k, micDelay: ctx.micDelay,
         )
+        let intended = EchoRemedy.intended(
+            cancellationEnabled: echoCancellationEnabled, dedupEnabled: echoDedupEnabled,
+        )
+        // Both remedies are tied to a verdict the user was told about rather
+        // than applied wherever two tracks happen to correlate. For the
+        // canceller that also keeps it off the large majority of recordings
+        // that have no echo at all, where it could only cost time and take
+        // something away.
+        var echoRemoved = false
+        if intended == .cancellation, echoAnalysis.verdict == .affected {
+            echoRemoved = try await cancelEchoOnMicTrack(
+                jobID: ctx.jobID, appURL: app16k, micURL: mic16k, micDelay: ctx.micDelay,
+            )
+        }
+        // From the outcome, not the setting: a cancellation that did not happen
+        // leaves the microphone track exactly as recorded, and the dedup's
+        // reason for standing down goes with it.
+        let remedy = EchoRemedy.applied(
+            cancellationSucceeded: echoRemoved, dedupEnabled: echoDedupEnabled,
+        )
+        announceEchoBleed(echoAnalysis, jobID: ctx.jobID, echoRemoved: echoRemoved)
 
         let appSegments = try await engine.transcribeSegments(audioPath: app16k)
         let micSegments = try await engine.transcribeSegments(audioPath: mic16k)
@@ -255,8 +285,9 @@ extension PipelineQueue {
         // the loudspeaker coming back, so the merge can leave them out of the
         // transcript instead of writing the far end twice.
         let micEchoVerdicts = await classifyMicEcho(
-            analysis: echoAnalysis, appURL: app16k, micURL: mic16k,
-            micDelay: ctx.micDelay, micSegments: micSegments,
+            remedy: remedy, analysis: echoAnalysis,
+            tracks: (app: app16k, mic: mic16k, micDelay: ctx.micDelay),
+            micSegments: micSegments,
         )
 
         let segments = DiarizationProcess.mergeDualSourceSegments(

--- a/app/MeetingTranscriber/Sources/PipelineQueue.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue.swift
@@ -65,6 +65,32 @@ class PipelineQueue {
     let diarizeEnabled: Bool
     /// Leave loudspeaker copies out of the transcript (`AppSettings.echoDedupEnabled`).
     let echoDedupEnabled: Bool
+
+    /// Take the far end out of the microphone audio (`AppSettings.echoCancellationEnabled`).
+    /// Wins over `echoDedupEnabled`; `EchoRemedy` holds that precedence.
+    ///
+    /// Read through a closure rather than copied at construction. The queue is
+    /// built once when watching starts, so a copied value meant turning the
+    /// feature on mid-session did nothing at all until watching was restarted:
+    /// the switch said yes and the next recording was processed by a queue
+    /// still holding no. Its neighbours here are still copies, which is the
+    /// same latent problem; widening that is not this change's to make, and
+    /// `transcriptOutputOptionsProvider` below shows the shape it would take.
+    private let isEchoCancellationEnabled: () -> Bool
+
+    var echoCancellationEnabled: Bool {
+        isEchoCancellationEnabled()
+    }
+
+    /// Produces the canceller for a run, or nil when no model can be resolved.
+    ///
+    /// Stored non-optional with the production resolution as its default, so
+    /// there is one thing to call rather than a factory and a fallback path
+    /// that only one of them is ever tested. Returning an optional is what
+    /// makes "no model available" injectable at all: with a factory that
+    /// always produced a canceller, the branch that reports a missing model
+    /// could only be reached by removing the file from the machine.
+    let echoCancellerFactory: () -> (any EchoCancelling)?
     let numSpeakers: Int
     let micLabel: String
     /// Compatibility policy for snapshots created before a job carried its own
@@ -234,6 +260,8 @@ class PipelineQueue {
         completedJobLifetime: TimeInterval = 60,
         terminalJobStore: TerminalJobStore? = nil,
         inFlightRuns: InFlightRunRegistry? = nil,
+        echoCancellationEnabled: @escaping () -> Bool = { false },
+        echoCancellerFactory: (() -> (any EchoCancelling)?)? = nil,
     ) {
         self.logDir = logDir ?? AppPaths.ipcDir
         self.processedLedger = ProcessedRecordingsLedger(logDir: self.logDir)
@@ -246,6 +274,8 @@ class PipelineQueue {
         stagingDir = AppPaths.recordingsDir
         self.diarizeEnabled = false
         echoDedupEnabled = true
+        isEchoCancellationEnabled = echoCancellationEnabled
+        self.echoCancellerFactory = echoCancellerFactory ?? { Self.bundledEchoCanceller() }
         self.numSpeakers = 0
         self.micLabel = "Me"
         let outputOptions = TranscriptOutputOptions(
@@ -328,6 +358,8 @@ class PipelineQueue {
         stagingDir: URL = AppPaths.recordingsDir,
         diarizeEnabled: Bool = false,
         echoDedupEnabled: Bool = true,
+        echoCancellationEnabled: @escaping () -> Bool = { false },
+        echoCancellerFactory: (() -> (any EchoCancelling)?)? = nil,
         numSpeakers: Int = 0,
         micLabel: String = "Me",
         includeFullTranscriptInProtocol: Bool = true,
@@ -354,6 +386,8 @@ class PipelineQueue {
         self.stagingDir = stagingDir
         self.diarizeEnabled = diarizeEnabled
         self.echoDedupEnabled = echoDedupEnabled
+        isEchoCancellationEnabled = echoCancellationEnabled
+        self.echoCancellerFactory = echoCancellerFactory ?? { Self.bundledEchoCanceller() }
         self.numSpeakers = numSpeakers
         // "Remote" is the reserved routing tag for the app/remote track
         // (DiarizationProcess.remoteSpeakerLabel). If the user names the mic

--- a/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/AudioSettingsView.swift
@@ -76,11 +76,24 @@ private struct EchoSection: View {
     var body: some View {
         Section("Echo") {
             HelpfulToggle(
+                title: "Remove echoed remote speech before transcribing",
+                help: SettingsHelp.echoCancellation,
+                isOn: $settings.echoCancellationEnabled,
+            )
+            .accessibilityIdentifier(A11yID.echoCancellationToggle)
+
+            HelpfulToggle(
                 title: "Remove echoed remote speech from the transcript",
                 help: SettingsHelp.echoDedup,
                 isOn: $settings.echoDedupEnabled,
             )
             .accessibilityIdentifier(A11yID.echoDedupToggle)
+            // Disabled rather than hidden while cancellation is on. The two
+            // remedies do not compose, so this one would not run; a switch
+            // that is on and does nothing is worse than one that is visibly
+            // unavailable, and hiding it would leave a stored setting nobody
+            // can see or change.
+            .disabled(settings.echoCancellationEnabled)
         }
         .recordOnlyDisabled(settings.recordOnly)
     }

--- a/app/MeetingTranscriber/Sources/Settings/SettingsHelp.swift
+++ b/app/MeetingTranscriber/Sources/Settings/SettingsHelp.swift
@@ -6,6 +6,19 @@ import Foundation
 /// (no inline string literals inflating SwiftUI expression type-checking), and
 /// so the help copy is auditable in one place.
 enum SettingsHelp {
+    static let echoCancellation =
+        """
+        Removes the remote voices from the microphone audio with an on-device \
+        model before it is transcribed. Because it works on the audio rather \
+        than on the text, the cleaned track is also what speaker detection \
+        sees.
+
+        The saved recording is not changed: what is kept on disk stays the \
+        audio your devices captured. Only runs on recordings already reported \
+        as affected, and replaces the transcript option below wherever both \
+        are on.
+        """
+
     static let echoDedup =
         """
         When a meeting is held on loudspeakers, the microphone picks the remote \

--- a/app/MeetingTranscriber/Tests/EchoCancellationSelfCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/EchoCancellationSelfCheckTests.swift
@@ -1,0 +1,123 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Did the cancellation actually do anything?
+///
+/// The question exists because the answer is sometimes no, silently: on a
+/// minority of recordings the model removes nothing at all while removing tens
+/// of decibels from the same echo presented on its own. Compiling, the tests,
+/// and both builds stay green through that, and the user gets a recording with
+/// the echo still in it and no reason to suspect anything.
+final class EchoCancellationSelfCheckTests: XCTestCase {
+    private func window(reference: Float, reduction: Float) -> EchoCancellationWindow {
+        EchoCancellationWindow(referenceDBFS: reference, reductionDb: reduction)
+    }
+
+    private func report(
+        _ windows: [(Float, Float)],
+    ) -> EchoCancellationReport {
+        EchoCancellationReport(windows: windows.map { window(reference: $0.0, reduction: $0.1) })
+    }
+
+    /// A healthy run: it empties the windows carrying echo and leaves the rest
+    /// where they were.
+    func testAHealthyRunTookEffect() {
+        var windows = (0 ..< 30).map { _ in (Float(-20), Float(28)) }
+        windows += (0 ..< 20).map { _ in (Float(-80), Float(0.3)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .removed)
+    }
+
+    /// The measured failure shape: the run completes, writes a full-length
+    /// track, and takes about a tenth of a decibel off it.
+    func testARunThatRemovedNothingDidNotTakeEffect() {
+        var windows = (0 ..< 30).map { _ in (Float(-20), Float(0.2)) }
+        windows += (0 ..< 20).map { _ in (Float(-80), Float(0.1)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .ineffective)
+    }
+
+    /// The reason this is a difference and not a level. A run that simply
+    /// halves the microphone reports six decibels of "reduction" in every
+    /// window carrying echo, and leaves that echo exactly as audible next to
+    /// the local voice as it was. Against a level it passes; against the
+    /// windows that carried no echo it does not.
+    func testUniformAttenuationIsNotRemoval() {
+        var windows = (0 ..< 30).map { _ in (Float(-20), Float(6)) }
+        windows += (0 ..< 20).map { _ in (Float(-80), Float(6)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .ineffective)
+    }
+
+    /// A difference rewards anything that pushes the two groups apart, and
+    /// amplifying the control group does exactly that. This run barely clears
+    /// the level test and boosts the windows where the local speaker is alone
+    /// by twenty decibels; the difference alone would call that a success.
+    func testAmplifyingTheControlGroupIsNotRemoval() {
+        var windows = (0 ..< 15).map { _ in (Float(-20), Float(3.5)) }
+        windows += (0 ..< 15).map { _ in (Float(-80), Float(-20)) }
+        XCTAssertEqual(
+            EchoCancellationSelfCheck.effect(of: report(windows)), .damagedControl,
+            "not .ineffective: it may have removed plenty, and damage is why it was refused",
+        )
+    }
+
+    /// Healthy runs do attenuate the control a little, occasionally by a lot,
+    /// and that must not be confused with amplifying it. The difference is
+    /// what shrinks; the run is still judged on it.
+    func testAttenuatingTheControlGroupIsJudgedOnTheDifference() {
+        var windows = (0 ..< 15).map { _ in (Float(-20), Float(30)) }
+        windows += (0 ..< 15).map { _ in (Float(-80), Float(10)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .removed)
+    }
+
+    /// A far end that never stops leaves nothing to compare against, and that
+    /// is precisely the case where broad attenuation and cancellation look the
+    /// same. Withheld rather than waved through.
+    func testAReferenceThatNeverStopsYieldsNoVerdict() {
+        let windows = (0 ..< 40).map { _ in (Float(-20), Float(28)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .indeterminate)
+    }
+
+    /// The same missing control, with a low reduction this time. It has to
+    /// stay indeterminate rather than becoming a measured failure: the two
+    /// send the user to different places, and nobody measured this one.
+    func testAMissingControlIsNeverReportedAsAMeasuredFailure() {
+        let windows = (0 ..< 40).map { _ in (Float(-20), Float(0.2)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .indeterminate)
+    }
+
+    /// Windows where the far end is not playing carry no echo to remove, so a
+    /// canceller correctly doing nothing in them must not be counted against
+    /// it. They are the control, not part of the measurement.
+    func testQuietReferenceWindowsAreTheControlNotTheMeasurement() {
+        var windows = (0 ..< 40).map { _ in (Float(-80), Float(0)) }
+        windows += (0 ..< 15).map { _ in (Float(-20), Float(28)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .removed)
+    }
+
+    /// Too little far-end audio to judge is its own answer. A verdict from
+    /// three windows would be a coin toss reported as a fact.
+    func testTooFewScoredWindowsAreIndeterminate() {
+        var windows = (0 ..< 5).map { _ in (Float(-20), Float(0.1)) }
+        windows += (0 ..< 20).map { _ in (Float(-80), Float(0.1)) }
+        XCTAssertEqual(EchoCancellationSelfCheck.effect(of: report(windows)), .indeterminate)
+    }
+
+    func testAnEmptyReportIsIndeterminate() {
+        XCTAssertEqual(
+            EchoCancellationSelfCheck.effect(of: EchoCancellationReport(windows: [])),
+            .indeterminate,
+        )
+    }
+
+    /// The threshold has to leave room on both sides. Above zero, or a run
+    /// that removed nothing would pass; below the floor a healthy model clears
+    /// on the synthetic probe the bundle check uses, or a working run could
+    /// fail. Sourced from a constant that ships in the repository rather than
+    /// from a corpus a reader cannot open.
+    func testTheThresholdLeavesRoomOnBothSides() {
+        XCTAssertGreaterThan(EchoCancellationSelfCheck.minMedianReductionDb, 0)
+        XCTAssertLessThan(
+            EchoCancellationSelfCheck.minMedianReductionDb,
+            EchoReductionVerdict.minReductionDb,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/EchoCancellationSettingTests.swift
+++ b/app/MeetingTranscriber/Tests/EchoCancellationSettingTests.swift
@@ -1,0 +1,87 @@
+@testable import MeetingTranscriber
+import ViewInspector
+import XCTest
+
+/// The switch behind echo cancellation, and the one interaction it has with
+/// the transcript dedup sitting under it.
+@MainActor
+final class EchoCancellationSettingTests: XCTestCase {
+    private func freshSettings() -> AppSettings {
+        let defaults = UserDefaults(suiteName: "echo-cancel-\(UUID().uuidString)")!
+        // swiftlint:disable:previous force_unwrapping
+        return AppSettings(defaults: defaults)
+    }
+
+    /// Off by default, and it stays off until it has been watched working on
+    /// real recordings rather than on an archive with synthetic loudspeaker
+    /// echo. The measurement behind it says the trade is favourable; it does
+    /// not say the model never fails, and it is known to remove nothing at all
+    /// on a minority of recordings without reporting it.
+    func testCancellationIsOffByDefault() {
+        XCTAssertFalse(freshSettings().echoCancellationEnabled)
+    }
+
+    func testTogglePersists() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "echo-cancel-persist-\(UUID().uuidString)"))
+        let settings = AppSettings(defaults: defaults)
+        settings.echoCancellationEnabled = true
+        XCTAssertTrue(
+            AppSettings(defaults: defaults).echoCancellationEnabled,
+            "the choice has to survive a relaunch",
+        )
+    }
+
+    func testToggleWritesBackToSettings() throws {
+        let settings = freshSettings()
+        let before = settings.echoCancellationEnabled
+        let view = AudioSettingsView(settings: settings)
+        let toggle = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: A11yID.echoCancellationToggle)
+        try toggle.find(ViewType.Toggle.self).tap()
+        XCTAssertEqual(settings.echoCancellationEnabled, !before)
+    }
+
+    /// The two remedies do not compose, and cancellation wins. The dedup row
+    /// therefore has to look unavailable rather than look like a choice: an
+    /// enabled switch that is on and does nothing is the failure this project
+    /// has already shipped once.
+    func testTheDedupRowIsDisabledWhileCancellationIsOn() throws {
+        let settings = freshSettings()
+        settings.echoCancellationEnabled = true
+        let view = AudioSettingsView(settings: settings)
+        let dedup = try view.inspect().find(viewWithAccessibilityIdentifier: A11yID.echoDedupToggle)
+        XCTAssertTrue(dedup.isDisabled())
+    }
+
+    func testTheDedupRowIsAvailableWhenCancellationIsOff() throws {
+        let settings = freshSettings()
+        settings.echoCancellationEnabled = false
+        let view = AudioSettingsView(settings: settings)
+        let dedup = try view.inspect().find(viewWithAccessibilityIdentifier: A11yID.echoDedupToggle)
+        XCTAssertFalse(dedup.isDisabled())
+    }
+
+    /// The queue is built once, when watching starts. Copied at construction,
+    /// the setting could only take effect after stopping and restarting
+    /// watching: the switch said yes and the next recording was processed by a
+    /// queue still holding no, which is the shape of "the feature is on and
+    /// does nothing" this project keeps having to undo.
+    func testTheSettingReachesAQueueThatWasBuiltBeforeItChanged() {
+        let settings = freshSettings()
+        settings.echoCancellationEnabled = false
+        // Bound to a local first: as a trailing argument the formatter
+        // detaches it from the call.
+        let live: () -> Bool = { settings.echoCancellationEnabled }
+        let queue = PipelineQueue(
+            logDir: FileManager.default.temporaryDirectory, echoCancellationEnabled: live,
+        )
+        XCTAssertFalse(queue.echoCancellationEnabled)
+
+        settings.echoCancellationEnabled = true
+
+        XCTAssertTrue(
+            queue.echoCancellationEnabled,
+            "turning it on must not wait for watching to be restarted",
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/EchoRemedyTests.swift
+++ b/app/MeetingTranscriber/Tests/EchoRemedyTests.swift
@@ -1,0 +1,68 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// Which of the two echo remedies runs for one recording.
+///
+/// The seam's own header states they must not compose: the canceller takes the
+/// far end out of the microphone audio, the dedup drops microphone transcript
+/// lines that duplicate the far end. Run together, the dedup judges audio the
+/// echo has already been removed from. Pinned here rather than left to an `if`
+/// in the transcribe stage, because "which one runs" is the requirement the
+/// first consumer had to answer.
+final class EchoRemedyTests: XCTestCase {
+    func testCancellationWinsWhenBothAreEnabled() {
+        XCTAssertEqual(
+            EchoRemedy.intended(cancellationEnabled: true, dedupEnabled: true),
+            .cancellation,
+            "the dedup must not judge audio the canceller already cleaned",
+        )
+    }
+
+    func testDedupRunsOnlyWhenCancellationIsOff() {
+        XCTAssertEqual(
+            EchoRemedy.intended(cancellationEnabled: false, dedupEnabled: true),
+            .transcriptDedup,
+        )
+    }
+
+    func testCancellationRunsWithoutTheDedup() {
+        XCTAssertEqual(
+            EchoRemedy.intended(cancellationEnabled: true, dedupEnabled: false),
+            .cancellation,
+        )
+    }
+
+    func testNeitherRemedyIsTheDefault() {
+        XCTAssertEqual(
+            EchoRemedy.intended(cancellationEnabled: false, dedupEnabled: false),
+            .neither,
+        )
+    }
+
+    // MARK: - What the recording actually got
+
+    /// The fallback the settings-only decision took away. Both switches on and
+    /// a cancellation that did not happen meant neither remedy ran, on every
+    /// affected recording, with one warning line as the only sign.
+    func testAFailedCancellationHandsBackToTheDedup() {
+        XCTAssertEqual(
+            EchoRemedy.applied(cancellationSucceeded: false, dedupEnabled: true),
+            .transcriptDedup,
+            "the track is exactly as recorded, so the dedup's measure is valid again",
+        )
+    }
+
+    func testASucceededCancellationStillKeepsTheDedupOut() {
+        XCTAssertEqual(
+            EchoRemedy.applied(cancellationSucceeded: true, dedupEnabled: true),
+            .cancellation,
+        )
+    }
+
+    func testNoFallbackWhenTheDedupIsOffToo() {
+        XCTAssertEqual(
+            EchoRemedy.applied(cancellationSucceeded: false, dedupEnabled: false),
+            .neither,
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
+++ b/app/MeetingTranscriber/Tests/HelpBadgeTests.swift
@@ -225,18 +225,21 @@ final class HelpBadgeTests: XCTestCase {
         XCTAssertFalse(SettingsHelp.silentCaptureChannel.isEmpty)
         XCTAssertFalse(SettingsHelp.asymmetricSilenceWarning.isEmpty)
         XCTAssertFalse(SettingsHelp.echoDedup.isEmpty)
+        XCTAssertFalse(SettingsHelp.echoCancellation.isEmpty)
     }
 
     // MARK: - Adoption in AudioSettingsView (issue #505)
 
-    /// VAD toggle + echo-dedup toggle + Detect Silent Capture Channel toggle +
-    /// Warn-after row each carry a clickable info badge. All four rows are
-    /// visible with defaults (perChannelIndicatorEnabled defaults to true →
-    /// warn-after row shown).
+    /// VAD toggle + echo-cancellation toggle + echo-dedup toggle + Detect
+    /// Silent Capture Channel toggle + Warn-after row each carry a clickable
+    /// info badge. All five rows are visible with defaults
+    /// (perChannelIndicatorEnabled defaults to true → warn-after row shown;
+    /// the dedup row is disabled while cancellation is on, and cancellation
+    /// defaults to off, so both echo rows are enabled here).
     func testAudioTabShowsHelpBadgesForNamedOptions() throws {
         let settings = AppSettings(defaults: defaults)
         settings.perChannelIndicatorEnabled = true
-        XCTAssertEqual(try infoBadgeCount(in: AudioSettingsView(settings: settings)), 4)
+        XCTAssertEqual(try infoBadgeCount(in: AudioSettingsView(settings: settings)), 5)
     }
 
     /// The warn-after row stays whatever the per-channel toggle says.

--- a/app/MeetingTranscriber/Tests/HopProcessorTests.swift
+++ b/app/MeetingTranscriber/Tests/HopProcessorTests.swift
@@ -1,0 +1,36 @@
+// The hop loop's error plumbing. Model-gated like the rest of the canceller
+// tests: a real context is the only way to make the library reject anything.
+import CLocalVQE
+@testable import MeetingTranscriber
+import XCTest
+
+final class HopProcessorTests: XCTestCase {
+    /// A refusal from the library has to arrive as a thrown error carrying its
+    /// code, not as a silent short read. This is the only failure the streaming
+    /// loop can hit once a model has loaded, and without it a mid-recording
+    /// refusal would leave a truncated track that looks like a finished one.
+    ///
+    /// Provoked with a frame length the library does not expect, which it
+    /// rejects with a nonzero code. The buffers stay at the real hop length, so
+    /// the library is asked to read less than it is given rather than more.
+    func testALibraryRefusalBecomesAThrownProcessingError() throws {
+        let model = try requireLocalVQEModel()
+        let ctx = localvqe_new(model)
+        try XCTSkipIf(ctx == 0, "model did not load")
+        defer { localvqe_free(ctx) }
+
+        let hopLength = Int(localvqe_hop_length(ctx))
+        var processor = HopProcessor(ctx: ctx, hopLength: hopLength / 2)
+        let block = [Float](repeating: 0.1, count: hopLength * 4)
+
+        XCTAssertThrowsError(
+            try processor.process(mic: block, reference: block) { _ in },
+        ) { error in
+            guard case let EchoCancellationError.processingFailed(code, _) = error else {
+                XCTFail("expected processingFailed, got \(error)")
+                return
+            }
+            XCTAssertNotEqual(code, 0, "a refusal has to carry the library's own code")
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/LocalVQECancellerFileTests.swift
+++ b/app/MeetingTranscriber/Tests/LocalVQECancellerFileTests.swift
@@ -1,0 +1,266 @@
+// Tests for the file-to-file half of the EchoCancelling seam. The array form
+// is the engine; this is the shape the pipeline actually calls, and the reason
+// it exists is memory: at 16 kHz Float32 a 90 minute track is ~345 MB, and the
+// array call holds microphone, reference and output at once.
+//
+// Model-gated like LocalVQECancellerTests: set
+// MEETINGTRANSCRIBER_LOCALVQE_MODEL to a .gguf, or these skip.
+@testable import MeetingTranscriber
+import XCTest
+
+final class LocalVQECancellerFileTests: XCTestCase {
+    private var workDir = FileManager.default.temporaryDirectory
+
+    override func setUpWithError() throws {
+        workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("aecfile_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: workDir)
+    }
+
+    /// Median reduction over the windows that carried a reference signal.
+    ///
+    /// The floor mirrors the one the self-check uses in production and is
+    /// repeated rather than imported: this file tests the seam, and pinning it
+    /// to a constant that belongs to a policy would tie the two together for
+    /// no reason beyond convenience.
+    private func activeMedianReduction(_ report: EchoCancellationReport) -> Float {
+        let active = report.windows
+            .filter { $0.referenceDBFS >= -45 }
+            .map(\.reductionDb)
+            .sorted()
+        guard !active.isEmpty else { return 0 }
+        return active[active.count / 2]
+    }
+
+    private func write(_ samples: [Float], _ name: String) throws -> URL {
+        let url = workDir.appendingPathComponent(name)
+        try AudioMixer.saveWAV(
+            samples: samples, sampleRate: AudioConstants.targetSampleRate, url: url,
+        )
+        return url
+    }
+
+    /// The characterization that gives the file path its right to exist: it has
+    /// to be the same canceller, not a second one that drifts. Fails against an
+    /// identity stub, and against a chunked implementation that resets the
+    /// streaming context on a block boundary.
+    func testFileToFileMatchesTheArrayFormSampleForSample() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 4, seed: 11)
+        let micURL = try write(farEnd.map { $0 * 0.5 }, "mic.wav")
+        let refURL = try write(farEnd, "ref.wav")
+        let canceller = LocalVQECanceller(modelPath: model)
+
+        // The array form is fed what the FILES contain, not the Float32 arrays
+        // they were written from. The intermediates are 16-bit PCM, and the
+        // canceller is a neural model: a quantisation step at the input does
+        // not stay a quantisation step at the output. Comparing against the
+        // unquantised arrays measured that difference and called it drift.
+        let expected = try await canceller.cancelEcho(
+            mic: AudioMixer.loadAudioFileAsFloat32(url: micURL),
+            reference: AudioMixer.loadAudioFileAsFloat32(url: refURL),
+        )
+        let output = workDir.appendingPathComponent("out.wav")
+        _ = try await canceller.cancelEcho(
+            micURL: micURL, referenceURL: refURL, outputURL: output, referenceLead: 0,
+        )
+        let got = try AudioMixer.loadAudioFileAsFloat32(url: output)
+
+        XCTAssertEqual(got.count, expected.count)
+        let worst = zip(got, expected).map { abs($0 - $1) }.max() ?? 0
+        XCTAssertLessThan(
+            worst, 2.0 / 32767.0,
+            "same canceller on the same input, one output quantisation step apart",
+        )
+    }
+
+    /// The seam's contract: a reference shorter than the microphone is silence
+    /// past its end. A recording where the app track stopped early must still
+    /// produce a full-length microphone track, or the transcript loses its tail.
+    func testShortReferenceIsTreatedAsSilenceAndOutputKeepsMicLength() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 3, seed: 3)
+        let mic = EchoTestAudio.speechLike(seconds: 3, seed: 4)
+        let output = workDir.appendingPathComponent("out.wav")
+
+        _ = try await LocalVQECanceller(modelPath: model).cancelEcho(
+            micURL: write(mic, "mic.wav"),
+            referenceURL: write(Array(farEnd.prefix(farEnd.count / 3)), "ref.wav"),
+            outputURL: output, referenceLead: 0,
+        )
+
+        let got = try AudioMixer.loadAudioFileAsFloat32(url: output)
+        XCTAssertEqual(got.count, mic.count)
+    }
+
+    /// The report is measurement, not a verdict: one entry per window, carrying
+    /// the reference level beside the reduction. Which windows count is the
+    /// self-check's business, and keeping the threshold out of here is what
+    /// lets it be chosen from data without touching the canceller.
+    func testTheReportCarriesOneWindowPerSecondWithTheReferenceLevel() async throws {
+        let model = try requireLocalVQEModel()
+        let farEnd = EchoTestAudio.speechLike(seconds: 5, seed: 5)
+        let output = workDir.appendingPathComponent("out.wav")
+
+        let report = try await LocalVQECanceller(modelPath: model).cancelEcho(
+            micURL: write(farEnd.map { $0 * 0.5 }, "mic.wav"),
+            referenceURL: write(farEnd, "ref.wav"),
+            outputURL: output, referenceLead: 0,
+        )
+
+        XCTAssertEqual(report.windows.count, 5)
+        // Echo only, so the canceller has everything to remove and nothing to
+        // keep. A floor far below what a healthy model reaches, to pin the
+        // plumbing rather than the model's quality.
+        let median = report.windows.map(\.reductionDb).sorted()[report.windows.count / 2]
+        XCTAssertGreaterThan(median, 6.0)
+        XCTAssertGreaterThan(report.windows[0].referenceDBFS, -60)
+    }
+
+    /// A cancelled run must not leave the partial file behind. It sits beside
+    /// the destination, and a later run that found it there would be working
+    /// next to a stranger's leftovers.
+    func testACancelledRunLeavesNoPartialFile() async throws {
+        let model = try requireLocalVQEModel()
+        let output = workDir.appendingPathComponent("out.wav")
+        let mic = try write(EchoTestAudio.speechLike(seconds: 3, seed: 21), "mic.wav")
+        let ref = try write(EchoTestAudio.speechLike(seconds: 3, seed: 22), "ref.wav")
+
+        let task = Task {
+            try await LocalVQECanceller(modelPath: model).cancelEcho(
+                micURL: mic, referenceURL: ref, outputURL: output, referenceLead: 0,
+            )
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: output.path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: output.path + ".partial"),
+            "the staging file has to go with the run that made it",
+        )
+    }
+
+    /// The two capture files do not share sample 0. The recorder starts them
+    /// independently and reports the delta as `micDelay`, and a Bluetooth
+    /// device spinning up makes it large. Fed a reference that does not line
+    /// up, the canceller is not weaker, it is looking at the wrong audio.
+    ///
+    /// Asserted on the reduction the report carries, not through the check
+    /// that later judges it: what the seam owes is that lining the reference
+    /// up changes what comes out, and a test that borrowed a downstream
+    /// policy for the assertion would fail whenever that policy moved.
+    func testTheReferenceLeadIsWhatMakesTheCancellationWork() async throws {
+        let model = try requireLocalVQEModel()
+        // Two seconds, which is half the fixture's speak/pause period, so the
+        // unaligned reference is loud exactly where the echo is not. A smaller
+        // offset proves less than it looks: the model's own front-end searches
+        // for the echo path, and with a periodic fixture a shift that keeps
+        // most of the activity overlapping is one it can still work through.
+        let leadSeconds = 2.0
+        let leadSamples = Int(leadSeconds * Double(AudioConstants.targetSampleRate))
+        // With pauses, because the self-check is a difference and a far end
+        // that never stops leaves nothing to compare against. A real call has
+        // gaps; the fixture generator does not, so they are cut in here.
+        var farEnd = EchoTestAudio.speechLike(seconds: 30, seed: 41)
+        let rate = AudioConstants.targetSampleRate
+        for block in 0 ..< 15 where block.isMultiple(of: 2) {
+            for index in (block * 2 * rate) ..< min((block * 2 + 2) * rate, farEnd.count) {
+                farEnd[index] = 0
+            }
+        }
+        // The microphone file starts late, so its first sample belongs with
+        // the reference two seconds in. Exactly what a positive micDelay is.
+        let mic = Array(EchoTestAudio.bleed(farEnd, delayMs: 15, gain: 0.5).dropFirst(leadSamples))
+        let micURL = try write(mic, "mic.wav")
+        let refURL = try write(farEnd, "ref.wav")
+        let canceller = LocalVQECanceller(modelPath: model)
+
+        let aligned = try await canceller.cancelEcho(
+            micURL: micURL, referenceURL: refURL,
+            outputURL: workDir.appendingPathComponent("aligned.wav"),
+            referenceLead: leadSeconds,
+        )
+        let unaligned = try await canceller.cancelEcho(
+            micURL: micURL, referenceURL: refURL,
+            outputURL: workDir.appendingPathComponent("unaligned.wav"),
+            referenceLead: 0,
+        )
+
+        XCTAssertGreaterThan(
+            activeMedianReduction(aligned), 15,
+            "with the reference lined up the echo has to go",
+        )
+        XCTAssertLessThan(
+            activeMedianReduction(unaligned), 3,
+            "without it the canceller is looking at the wrong audio",
+        )
+    }
+
+    /// The other sign, which `micDelay` produces just as readily: the
+    /// reference starts late, so its head is the silence the microphone heard
+    /// nothing of and has to be padded rather than sought.
+    ///
+    /// Worth its own test because the padding is where the arithmetic can go
+    /// wrong without looking wrong: a first block that pads correctly and then
+    /// consumes a full block from the file leaves every later block early by
+    /// exactly the amount the padding was meant to correct, and the head of
+    /// the recording sounds right while the rest is misaligned.
+    func testANegativeLeadPadsTheReferenceWithoutLosingWhatFollows() async throws {
+        let model = try requireLocalVQEModel()
+        let lagSeconds = 2.0
+        let lagSamples = Int(lagSeconds * Double(AudioConstants.targetSampleRate))
+        var farEnd = EchoTestAudio.speechLike(seconds: 30, seed: 43)
+        let rate = AudioConstants.targetSampleRate
+        for block in 0 ..< 15 where block.isMultiple(of: 2) {
+            for index in (block * 2 * rate) ..< min((block * 2 + 2) * rate, farEnd.count) {
+                farEnd[index] = 0
+            }
+        }
+        // The reference file is missing its head, so the microphone's sample 0
+        // belongs with reference sample -lag. A negative lead.
+        let micURL = try write(EchoTestAudio.bleed(farEnd, delayMs: 15, gain: 0.5), "mic.wav")
+        let refURL = try write(Array(farEnd.dropFirst(lagSamples)), "ref.wav")
+        let canceller = LocalVQECanceller(modelPath: model)
+
+        let aligned = try await canceller.cancelEcho(
+            micURL: micURL, referenceURL: refURL,
+            outputURL: workDir.appendingPathComponent("aligned.wav"),
+            referenceLead: -lagSeconds,
+        )
+        let unaligned = try await canceller.cancelEcho(
+            micURL: micURL, referenceURL: refURL,
+            outputURL: workDir.appendingPathComponent("unaligned.wav"),
+            referenceLead: 0,
+        )
+
+        XCTAssertGreaterThan(activeMedianReduction(aligned), 15)
+        XCTAssertLessThan(activeMedianReduction(unaligned), 3)
+    }
+
+    func testAnAbsentModelFailsBeforeWritingAnOutputFile() async throws {
+        let output = workDir.appendingPathComponent("out.wav")
+        do {
+            _ = try await LocalVQECanceller(modelPath: "/nonexistent/model.gguf").cancelEcho(
+                micURL: write(EchoTestAudio.speechLike(seconds: 1, seed: 1), "mic.wav"),
+                referenceURL: write(EchoTestAudio.speechLike(seconds: 1, seed: 2), "ref.wav"),
+                outputURL: output, referenceLead: 0,
+            )
+            XCTFail("expected modelLoadFailed")
+        } catch EchoCancellationError.modelLoadFailed {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: output.path),
+                "a half-written output would be adopted by the caller as a cancelled track",
+            )
+        }
+    }
+}

--- a/app/MeetingTranscriber/Tests/PipelineEchoCancellationTests.swift
+++ b/app/MeetingTranscriber/Tests/PipelineEchoCancellationTests.swift
@@ -1,0 +1,287 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The cancellation stage: what it does to the microphone track, and what it
+/// tells the user when it cannot.
+///
+/// Driven with a stub canceller rather than the real model. The model is a
+/// separate ~3 MB download that no CI job has, and what is under test here is
+/// the stage's decisions — replace or keep, warn or stay quiet — not the
+/// quality of the audio, which `LocalVQECancellerFileTests` covers.
+@MainActor
+final class PipelineEchoCancellationTests: XCTestCase {
+    private struct StubCanceller: EchoCancelling {
+        let report: EchoCancellationReport
+        let failure: (any Error)?
+        /// Written by the stub so a test can tell "produced silence" from
+        /// "never ran", which an assertion on the file's contents alone cannot.
+        let marker: Float
+        let writesOutput: Bool
+
+        init(
+            medianReduction: Float,
+            failure: (any Error)? = nil,
+            marker: Float = 0.25,
+            quietWindows: Int = 20,
+            writesOutput: Bool = true,
+        ) {
+            self.writesOutput = writesOutput
+            // Both populations, because the self-check is a difference: the
+            // windows carrying echo AND the ones carrying none, which a healthy
+            // run leaves alone. A stub that emitted only the first would be
+            // asking a question the check refuses to answer.
+            report = EchoCancellationReport(
+                windows: (0 ..< 30).map { _ in
+                    EchoCancellationWindow(referenceDBFS: -20, reductionDb: medianReduction)
+                } + (0 ..< quietWindows).map { _ in
+                    EchoCancellationWindow(referenceDBFS: -80, reductionDb: 0.2)
+                },
+            )
+            self.failure = failure
+            self.marker = marker
+        }
+
+        func cancelEcho(
+            micURL: URL, referenceURL _: URL, outputURL: URL, referenceLead _: TimeInterval,
+        ) throws -> EchoCancellationReport {
+            if let failure { throw failure }
+            guard writesOutput else { return report }
+            let samples = try AudioMixer.loadAudioFileAsFloat32(url: micURL)
+            try AudioMixer.saveWAV(
+                samples: samples.map { _ in marker },
+                sampleRate: AudioConstants.targetSampleRate,
+                url: outputURL,
+            )
+            return report
+        }
+    }
+
+    private var dir = FileManager.default.temporaryDirectory
+
+    @MainActor
+    override func setUp() async throws {
+        dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("echocancel_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        // Guarded rather than `try?`: with no `try` in the body the formatter
+        // strips `throws`, and the override then clashes with XCTest's
+        // throwing signature.
+        if FileManager.default.fileExists(atPath: dir.path) {
+            try FileManager.default.removeItem(at: dir)
+        }
+    }
+
+    private func makeTracks() throws -> (app: URL, mic: URL) {
+        let app = dir.appendingPathComponent("app_16k.wav")
+        let mic = dir.appendingPathComponent("mic_16k.wav")
+        try AudioMixer.saveWAV(
+            samples: EchoTestAudio.speechLike(seconds: 2, seed: 1),
+            sampleRate: AudioConstants.targetSampleRate, url: app,
+        )
+        try AudioMixer.saveWAV(
+            samples: EchoTestAudio.speechLike(seconds: 2, seed: 2),
+            sampleRate: AudioConstants.targetSampleRate, url: mic,
+        )
+        return (app, mic)
+    }
+
+    private func makeQueue(_ canceller: StubCanceller?) -> (PipelineQueue, UUID) {
+        // A factory that returns nil is "no model could be resolved", which is a
+        // different branch from a canceller that fails once it runs. Bound to a
+        // local first: as a trailing argument the formatter detaches it from
+        // the call.
+        let factory: () -> (any EchoCancelling)? = { canceller }
+        let queue = PipelineQueue(
+            logDir: dir.appendingPathComponent("logs"),
+            echoCancellationEnabled: { true },
+            echoCancellerFactory: factory,
+        )
+        let job = PipelineJob(
+            meetingTitle: "meeting", appName: "File",
+            mixPath: nil, appPath: nil, micPath: nil, micDelay: 0,
+        )
+        queue.insertJobForTesting(job)
+        return (queue, job.id)
+    }
+
+    /// The point of doing it in place: every later stage opens `mic_16k.wav`
+    /// by convention, so the replacement is what makes transcription, the
+    /// per-track diarization and the speaker embeddings taken from it all see
+    /// a cleaned track without a second path threaded through the pipeline.
+    func testASuccessfulRunReplacesTheMicrophoneTrack() async throws {
+        let tracks = try makeTracks()
+        let (queue, jobID) = makeQueue(StubCanceller(medianReduction: 30))
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertTrue(removed)
+        let samples = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        XCTAssertEqual(samples.first ?? 0, 0.25, accuracy: 0.001, "the file at the old path is the new audio")
+        XCTAssertTrue(queue.jobs.first?.warnings.isEmpty ?? false, "a run that worked says nothing")
+    }
+
+    /// The measured silent failure: the run completes, writes a full-length
+    /// track, and takes a tenth of a decibel off it. Nothing about that is
+    /// visible from the outside, which is why it has to be said.
+    func testARunThatRemovedNothingIsReportedAndNotAdopted() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(StubCanceller(medianReduction: 0.2))
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertFalse(removed, "the echo is still there, so nothing may claim it is gone")
+        XCTAssertEqual(
+            try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before,
+            "a run that cannot be shown to have improved the track must not replace it",
+        )
+        let warnings = queue.jobs.first?.warnings ?? []
+        XCTAssertEqual(warnings.count, 1)
+        XCTAssertTrue(warnings[0].contains("removed almost nothing"))
+    }
+
+    /// A run nobody could judge is not a run that failed, and the two send the
+    /// user somewhere different. Reached here by a far end that never pauses,
+    /// which leaves no control group to compare against.
+    func testAnUnjudgeableRunSaysSoAndIsNotAdopted() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(StubCanceller(medianReduction: 30, quietWindows: 0))
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertFalse(removed)
+        XCTAssertEqual(try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before)
+        XCTAssertTrue(
+            (queue.jobs.first?.warnings ?? []).contains { $0.contains("could not be confirmed") },
+        )
+    }
+
+    /// The adoption itself can fail, and the recovery must not be the thing
+    /// that loses the recording. Written as a remove followed by a move, a
+    /// remove that succeeded before a move that failed left no microphone
+    /// track at all, while the warning said it had been left as recorded.
+    func testAFailedAdoptionStillLeavesTheOriginalTrack() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(StubCanceller(medianReduction: 30, writesOutput: false))
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertFalse(removed)
+        XCTAssertEqual(
+            try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before,
+            "the recording has to survive its own recovery path",
+        )
+        XCTAssertTrue(
+            (queue.jobs.first?.warnings ?? []).contains { $0.contains("could not be used") },
+        )
+    }
+
+    /// A canceller that throws must leave the recording exactly as it was. The
+    /// job keeps going: an echo left in is worse audio, a lost microphone track
+    /// is a lost meeting.
+    func testAFailedRunKeepsTheOriginalTrackAndSaysSo() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(StubCanceller(
+            medianReduction: 30,
+            failure: EchoCancellationError.processingFailed(code: 7, message: "boom"),
+        ))
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertFalse(removed)
+        XCTAssertEqual(try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before)
+        XCTAssertTrue((queue.jobs.first?.warnings ?? []).contains { $0.contains("failed") })
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent("mic_16k_cancelled.wav").path),
+            "the staged file must not be left behind for the next run to trip over",
+        )
+    }
+
+    /// The setting is on and no model could be resolved. Silence would be the
+    /// worst answer: the user has asked for the feature and would get a
+    /// recording with the echo still in it and no reason to suspect anything.
+    func testNoResolvableModelIsReportedRatherThanSilentlySkipped() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(nil)
+
+        let removed = try await queue.cancelEchoOnMicTrack(
+            jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+        )
+
+        XCTAssertFalse(removed)
+        XCTAssertEqual(try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before)
+        XCTAssertTrue((queue.jobs.first?.warnings ?? []).contains { $0.contains("model is missing") })
+    }
+
+    /// The production resolution, with its ambient state handed in. Two lines
+    /// of decision, and the one that matters is the empty case: a resolution
+    /// that came up empty has to become no canceller, which is what makes the
+    /// stage report a missing model instead of running with a bad path.
+    func testTheProductionResolutionTurnsAMissingModelIntoNoCanceller() {
+        XCTAssertNil(PipelineQueue.bundledEchoCanceller(
+            override: nil, bundledPath: nil,
+        ) { _ in true })
+        XCTAssertNil(
+            PipelineQueue.bundledEchoCanceller(
+                override: "/nope/model.gguf", bundledPath: nil,
+            ) { _ in false },
+            "an override that points at nothing is not a reason to fall back to the bundle",
+        )
+    }
+
+    func testTheProductionResolutionUsesTheResolvedPath() throws {
+        let canceller = try XCTUnwrap(PipelineQueue.bundledEchoCanceller(
+            override: nil, bundledPath: "/models/localvqe.gguf",
+        ) { _ in true } as? LocalVQECanceller)
+        XCTAssertEqual(canceller.modelPath, "/models/localvqe.gguf")
+    }
+
+    /// Cancellation has to propagate, not become "the feature declined".
+    /// Swallowed, the run continued into two transcription passes and stage
+    /// three for a job the user had already removed from the queue, so the
+    /// warnings and state updates went nowhere while the artifacts were still
+    /// written.
+    func testACancelledRunPropagatesAndLeavesTheTrackAlone() async throws {
+        let tracks = try makeTracks()
+        let before = try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic)
+        let (queue, jobID) = makeQueue(StubCanceller(
+            medianReduction: 30, failure: CancellationError(),
+        ))
+
+        do {
+            _ = try await queue.cancelEchoOnMicTrack(
+                jobID: jobID, appURL: tracks.app, micURL: tracks.mic, micDelay: 0,
+            )
+            XCTFail("expected the cancellation to propagate")
+        } catch is CancellationError {
+            // expected
+        }
+
+        XCTAssertEqual(try AudioMixer.loadAudioFileAsFloat32(url: tracks.mic), before)
+        XCTAssertTrue(
+            (queue.jobs.first?.warnings ?? []).isEmpty,
+            "the user stopped this job; it is not a fault to report",
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent("mic_16k_cancelled.wav").path),
+        )
+    }
+}

--- a/app/MeetingTranscriber/Tests/WindowAccumulatorTests.swift
+++ b/app/MeetingTranscriber/Tests/WindowAccumulatorTests.swift
@@ -1,0 +1,124 @@
+@testable import MeetingTranscriber
+import XCTest
+
+/// The report's window arithmetic, without a model or a file.
+///
+/// This is why the roll-up is a value type rather than three running variables
+/// in the streaming loop: the boundary crossing is the part that is easy to get
+/// wrong, and every assertion below would otherwise need the C library and a
+/// 3 MB model that no CI job has.
+final class WindowAccumulatorTests: XCTestCase {
+    private let rate = AudioConstants.targetSampleRate
+
+    private func constant(_ value: Float, _ count: Int) -> [Float] {
+        [Float](repeating: value, count: count)
+    }
+
+    /// Feeds `total` samples through in blocks of `blockSize`.
+    private func run(
+        blockSize: Int, total: Int,
+        mic: Float, reference: Float, output: Float,
+    ) -> [EchoCancellationWindow] {
+        var accumulator = WindowAccumulator(samplesPerWindow: rate)
+        var windows: [EchoCancellationWindow] = []
+        var done = 0
+        while done < total {
+            let take = min(blockSize, total - done)
+            accumulator.add(
+                mic: constant(mic, take), reference: constant(reference, take),
+                output: constant(output, take), into: &windows,
+            )
+            done += take
+        }
+        accumulator.flush(into: &windows)
+        return windows
+    }
+
+    func testOneWindowPerSecondOfAudio() {
+        let windows = run(blockSize: rate, total: 5 * rate, mic: 0.5, reference: 0.5, output: 0.5)
+        XCTAssertEqual(windows.count, 5)
+    }
+
+    /// The invariant the doc comment claims and the reason the window is a
+    /// second rather than "whatever a block happens to be": the block size is a
+    /// throughput knob, and turning it must not change what the report says.
+    /// Blocks here are deliberately not divisors of a window, so every one of
+    /// them crosses a boundary somewhere.
+    func testTheBlockSizeDoesNotChangeTheWindows() {
+        let reference = run(blockSize: rate, total: 4 * rate, mic: 0.5, reference: 0.25, output: 0.05)
+        for blockSize in [256, 16384, 3 * rate / 7, 2 * rate] {
+            let got = run(blockSize: blockSize, total: 4 * rate, mic: 0.5, reference: 0.25, output: 0.05)
+            XCTAssertEqual(got.count, reference.count, "block size \(blockSize) changed the window count")
+            // Compared with a tolerance rather than for equality: the same
+            // additions in a different grouping is a different rounding, and
+            // asserting bit equality would pin the grouping instead of the
+            // invariant.
+            for (index, pair) in zip(got, reference).enumerated() {
+                XCTAssertEqual(
+                    pair.0.reductionDb, pair.1.reductionDb, accuracy: 0.001,
+                    "block size \(blockSize), window \(index)",
+                )
+                XCTAssertEqual(
+                    pair.0.referenceDBFS, pair.1.referenceDBFS, accuracy: 0.001,
+                    "block size \(blockSize), window \(index)",
+                )
+            }
+        }
+    }
+
+    /// A recording is almost never a whole number of seconds. Dropping the
+    /// remainder would silently lose the end of a short one, which is exactly
+    /// where a run has the fewest windows to be judged on.
+    func testTheTrailingPartialWindowIsKept() {
+        let windows = run(
+            blockSize: rate, total: 2 * rate + rate / 4,
+            mic: 0.5, reference: 0.5, output: 0.5,
+        )
+        XCTAssertEqual(windows.count, 3)
+    }
+
+    func testNothingIsEmittedForAnEmptyRun() {
+        var accumulator = WindowAccumulator(samplesPerWindow: rate)
+        var windows: [EchoCancellationWindow] = []
+        accumulator.flush(into: &windows)
+        XCTAssertTrue(windows.isEmpty)
+    }
+
+    /// Half the amplitude out is 6 dB of reduction, and the reference level is
+    /// its own dBFS. Pinned on a constant signal so the expected value is
+    /// arithmetic rather than a recorded output.
+    func testTheLevelsAreTheOnesTheSelfCheckReads() throws {
+        let windows = run(blockSize: rate, total: rate, mic: 0.5, reference: 0.25, output: 0.25)
+        let window = try XCTUnwrap(windows.first)
+        XCTAssertEqual(window.reductionDb, 6.0206, accuracy: 0.01)
+        XCTAssertEqual(window.referenceDBFS, -12.0412, accuracy: 0.01)
+    }
+
+    /// Silence must produce a floor, not a negative infinity that poisons every
+    /// comparison downstream. The self-check sorts these and takes a median.
+    func testSilenceProducesAFiniteFloorRatherThanInfinity() throws {
+        let windows = run(blockSize: rate, total: rate, mic: 0, reference: 0, output: 0)
+        let window = try XCTUnwrap(windows.first)
+        XCTAssertTrue(window.referenceDBFS.isFinite)
+        XCTAssertTrue(window.reductionDb.isFinite)
+        // Well under any floor a reader of these windows would set. Written as
+        // a number rather than borrowed from the self-check: this file tests
+        // the arithmetic, and a policy's constant moving is not a reason for an
+        // arithmetic test to fail.
+        XCTAssertLessThan(window.referenceDBFS, -100)
+    }
+
+    /// The output is the shorter array on a partial trailing hop, and the mic
+    /// and reference are read only as far as it goes. A mismatch here used to
+    /// be the kind of thing that crashes on the last block of a recording.
+    func testAShorterOutputDoesNotReadPastTheOtherArrays() {
+        var accumulator = WindowAccumulator(samplesPerWindow: rate)
+        var windows: [EchoCancellationWindow] = []
+        accumulator.add(
+            mic: constant(0.5, 100), reference: constant(0.5, 100),
+            output: constant(0.5, 40), into: &windows,
+        )
+        accumulator.flush(into: &windows)
+        XCTAssertEqual(windows.count, 1)
+    }
+}

--- a/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
+++ b/app/MeetingTranscriber/Tests/WorkflowIntegrationTests.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable file_length
 @testable import MeetingTranscriber
+import os
 import XCTest
 
 @MainActor
@@ -36,6 +37,8 @@ final class WorkflowIntegrationTests: XCTestCase {
         saveRawTranscriptSeparately: Bool = true,
         protocolGeneratorEnabled: Bool = true,
         transcriptOutputOptionsProvider: (() -> TranscriptOutputOptions)? = nil,
+        echoCancellationEnabled: Bool = false,
+        echoCancellerFactory: (() -> (any EchoCancelling)?)? = nil,
     ) throws -> (Harness, TransitionCollector) {
         let engine = MockEngine()
         engine.segmentsToReturn = [
@@ -66,6 +69,8 @@ final class WorkflowIntegrationTests: XCTestCase {
             stagingDir: stagingDir ?? AppPaths.recordingsDir,
             diarizeEnabled: diarizeEnabled,
             echoDedupEnabled: echoDedupEnabled,
+            echoCancellationEnabled: { echoCancellationEnabled },
+            echoCancellerFactory: echoCancellerFactory,
             micLabel: "Me",
             includeFullTranscriptInProtocol: includeFullTranscriptInProtocol,
             saveRawTranscriptSeparately: saveRawTranscriptSeparately,
@@ -905,7 +910,7 @@ final class WorkflowIntegrationTests: XCTestCase {
         try writeTrack(speechLike(seconds: 40, seed: 31), to: appURL)
 
         let id = UUID()
-        let analysis = await h.queue.warnIfEchoBleed(
+        let analysis = await h.queue.measureEchoBleed(
             jobID: id,
             appURL: appURL,
             micURL: dir.appendingPathComponent("never-written.wav"),
@@ -937,7 +942,7 @@ final class WorkflowIntegrationTests: XCTestCase {
             meetingTitle: "meeting", appName: "File",
             mixPath: nil, appPath: appURL, micPath: micURL, micDelay: 0,
         ))
-        let analysis = await h.queue.warnIfEchoBleed(
+        let analysis = await h.queue.measureEchoBleed(
             jobID: id, appURL: appURL, micURL: micURL, micDelay: 0,
         )
         XCTAssertEqual(analysis.verdict, .notMeasured)
@@ -1025,6 +1030,99 @@ final class WorkflowIntegrationTests: XCTestCase {
                 TimestampedSegment(start: 29, end: 58, text: "local sentence"),
             ],
         ]
+    }
+
+    /// Counts calls so a test can tell "the canceller ran" from "the audio
+    /// happened to come out the same", which no assertion on the transcript
+    /// can distinguish when the engine is a mock that ignores its input.
+    private final class CountingCanceller: EchoCancelling, @unchecked Sendable {
+        let calls = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let medianReduction: Float
+
+        init(medianReduction: Float) {
+            self.medianReduction = medianReduction
+        }
+
+        func cancelEcho(
+            micURL: URL, referenceURL _: URL, outputURL: URL, referenceLead _: TimeInterval,
+        ) throws -> EchoCancellationReport {
+            calls.withLock { $0 += 1 }
+            let samples = try AudioMixer.loadAudioFileAsFloat32(url: micURL)
+            try AudioMixer.saveWAV(
+                samples: [Float](repeating: 0, count: samples.count),
+                sampleRate: AudioConstants.targetSampleRate, url: outputURL,
+            )
+            // Both populations: the self-check is a difference between the
+            // windows carrying echo and the ones carrying none.
+            return EchoCancellationReport(windows: (0 ..< 30).map { _ in
+                EchoCancellationWindow(referenceDBFS: -20, reductionDb: medianReduction)
+            } + (0 ..< 20).map { _ in
+                EchoCancellationWindow(referenceDBFS: -80, reductionDb: 0.2)
+            })
+        }
+    }
+
+    /// The whole chain in one run, which the unit tests only cover in pieces:
+    /// the recording is measured, the remedy is resolved to cancellation, the
+    /// microphone track is replaced, the transcript dedup does not run on top
+    /// of it, and the warning says what actually happened.
+    ///
+    /// The transcript is deliberately not asserted on. The engine is a mock
+    /// that returns segments by path suffix and never reads the audio, so it
+    /// cannot notice that the far end is gone; asserting on its output would
+    /// be asserting on the mock. What is checkable here is the decision, and
+    /// the decision is the thing that had no end-to-end cover.
+    @MainActor
+    func testCancellationRunsAndTheDedupStandsDown() async throws {
+        let canceller = CountingCanceller(medianReduction: 30)
+        let (h, _) = try makeHarness(
+            echoDedupEnabled: true,
+            echoCancellationEnabled: true,
+        ) { canceller }
+        configureDedupTracks(h.engine)
+        let pair = try writeDedupPair(tmpDir.appendingPathComponent("cancel-e2e"), bleed: true)
+
+        await runDualSource(h, app: pair.app, mic: pair.mic)
+
+        XCTAssertEqual(canceller.calls.withLock { $0 }, 1, "the canceller has to have run")
+        let job = try XCTUnwrap(h.queue.jobs.first)
+        XCTAssertEqual(job.echo?.detected, true, "measured before the repair, not after it")
+        // The discriminating assertion, not a tautology: this is the same
+        // fixture and the same mock segments that make the dedup suppress
+        // exactly one line two tests up. Under cancellation nothing may be
+        // taken out of the transcript, because the far end was taken out of
+        // the audio instead and the dedup's measure no longer means what it
+        // was calibrated to mean.
+        XCTAssertEqual(job.echo?.suppressedSegments ?? 0, 0)
+        let transcript = try String(
+            contentsOf: XCTUnwrap(job.transcriptPath), encoding: .utf8,
+        )
+        XCTAssertEqual(
+            micLines(transcript).count, 2,
+            "no microphone line may be dropped, got:\n\(transcript)",
+        )
+        XCTAssertTrue(
+            job.warnings.contains { $0.contains("removed from the microphone track") },
+            "the warning must not still be recommending headphones for a fixed recording, got: \(job.warnings)",
+        )
+    }
+
+    /// The same run on a recording nobody called affected. The canceller costs
+    /// time and can only take something away, so it must not fire on the large
+    /// majority of recordings that have no echo at all.
+    @MainActor
+    func testCancellationStaysOffACleanRecording() async throws {
+        let canceller = CountingCanceller(medianReduction: 30)
+        let (h, _) = try makeHarness(
+            echoCancellationEnabled: true,
+        ) { canceller }
+        configureDedupTracks(h.engine)
+        let pair = try writeDedupPair(tmpDir.appendingPathComponent("cancel-clean"), bleed: false)
+
+        await runDualSource(h, app: pair.app, mic: pair.mic)
+
+        XCTAssertEqual(canceller.calls.withLock { $0 }, 0)
+        XCTAssertEqual(h.queue.jobs.first?.echo?.detected, false)
     }
 
     /// The same acceptance criterion with diarization on, which is the default.
@@ -1144,10 +1242,13 @@ final class WorkflowIntegrationTests: XCTestCase {
         try writeTrack(speechLike(seconds: 40, seed: 81), to: appURL)
 
         let verdicts = await h.queue.classifyMicEcho(
+            remedy: .transcriptDedup,
             analysis: EchoBleedAnalysis(verdict: .affected),
-            appURL: appURL,
-            micURL: dir.appendingPathComponent("never-written.wav"),
-            micDelay: 0,
+            tracks: (
+                app: appURL,
+                mic: dir.appendingPathComponent("never-written.wav"),
+                micDelay: 0,
+            ),
             micSegments: [TimestampedSegment(start: 0, end: 10, text: "x")],
         )
         XCTAssertTrue(verdicts.isEmpty)
@@ -1170,14 +1271,16 @@ final class WorkflowIntegrationTests: XCTestCase {
 
         for verdict in [EchoVerdict.clean, .notMeasured] {
             let out = await h.queue.classifyMicEcho(
+                remedy: .transcriptDedup,
                 analysis: EchoBleedAnalysis(verdict: verdict),
-                appURL: appURL, micURL: micURL, micDelay: 0, micSegments: segments,
+                tracks: (app: appURL, mic: micURL, micDelay: 0), micSegments: segments,
             )
             XCTAssertTrue(out.isEmpty, "\(verdict) must not classify anything, even on audio that would light up")
         }
         let noSegments = await h.queue.classifyMicEcho(
+            remedy: .transcriptDedup,
             analysis: EchoBleedAnalysis(verdict: .affected),
-            appURL: appURL, micURL: micURL, micDelay: 0, micSegments: [],
+            tracks: (app: appURL, mic: micURL, micDelay: 0), micSegments: [],
         )
         XCTAssertTrue(noSegments.isEmpty)
     }


### PR DESCRIPTION
Wires the echo canceller into the pipeline. It has been on main since it was vendored, with its model shipping in the bundle, and until now nothing has ever called it. **Off by default.**

## What it does

On a dual-source recording the detector already reports whether the loudspeaker output is coming back through the microphone. On a recording it calls affected, and only there, the far end is removed from the microphone track before anything reads it.

Removing it from the audio rather than from the text is the point. The transcript dedup that shipped earlier could only drop lines; it could not keep a bled-in voice out of the per-track diarization, and through that out of a stored speaker centroid.

## Five things worth reviewing

**The seam became file to file, and aligned.** At 16 kHz Float32 a 90 minute meeting is around 345 MB per track, and the array-shaped call held microphone, reference and output at once. It also declared that sample `i` of both files is simultaneous, which no caller can satisfy: the recorder starts its two captures independently and every neighbour already uses the delta — the detector centres its lag search on it, the mixer prepends silence by it, the merge shifts segment times by it. Fed a reference that does not line up, a canceller is not weaker, it is looking at the wrong audio.

**The microphone track is rewritten in place.** Every later stage opens `mic_16k.wav` by convention, so replacing the file is what makes transcription, diarization and the speaker embeddings all see the cleaned track without a second path threaded through the pipeline. The adoption is three renames inside one directory, each of which either happened or did not, with the step that undoes it written out: `replaceItemAt` documents nothing about where the original is when it throws, and a recovery path whose whole job is to still have the recording must not rest on that.

**Measure first, then repair.** The detector runs on the raw tracks. A cancelled track no longer correlates with the app track, so a detector run afterwards would report every repaired recording as clean and take the embedding quarantine off exactly the audio that needed it.

**The run checks itself, by a difference.** This model sometimes removes essentially nothing while reporting success, for a whole file, and nothing about such a run is visible from outside. The check compares the windows where the reference carried signal against the windows where it did not. Those are the control, not noise to discard: a healthy run leaves them within a fraction of a decibel of untouched, so requiring the echo windows to drop that much further is what separates cancellation from attenuation. A level cannot: a run that simply halves the microphone reports about six decibels wherever the far end plays and leaves the echo exactly as audible as it was. A one-sided floor on the control catches the other direction, a run that pushes the two groups apart by amplifying the quiet ones.

**Only a confirmed run is adopted.** A missing model, a throw, a run that removed nothing, a run that damaged the control, and a run nobody could judge all leave the track as recorded and say which of those happened. The remedy is then resolved from the outcome, so the transcript dedup takes over rather than standing down for a cancellation that did not occur.

## What does not change

The embedding quarantine stays on an affected recording even when cancellation succeeded. Lifting a safety measure on a repair nobody has watched in the field is not something this PR is prepared to argue for.

**The saved recording is not cleaned**, and the setting text says so. What is cleaned is the 16 kHz track transcription and diarization consume; the persisted audio stays what the devices captured, and the mix beside it still comes from the raw originals through the older RMS gate. Whether that should change is a bigger question than this feature, since it decides what the saved artifact of a meeting is.

## Settings

One new switch in Audio, off by default, read live so it takes effect without restarting watching. The transcript-dedup row below it is disabled while it is on: the two do not compose, cancellation wins, and a switch that is on and does nothing is a failure this project has shipped before.

`AppSettings` crosses the file-length cap with the new property and is suppressed rather than split. The honest split is to move its three enums out, and other open PRs are editing that file.

## Testing

`swift test --parallel` with the model present, `scripts/lint.sh`, `swiftlint analyze --strict`, and `scripts/pre-push.sh` release parity, all green locally, plus the four E2E lanes on the self-hosted runner. Every commit was verified to build on its own.

Six mutations were checked, each turning exactly one test red: resetting the streaming context on a block boundary; the previous reference read, which lost what followed the padding; the two-step adoption, which left no microphone track at all; removing the restore after a failed adoption; the previous self-check rule, which confirmed both a uniformly attenuated run and one with no control group; and removing the disabled state from the dedup row.

## Not in this PR

The E2E lane that exercises cancellation itself, and the removal of the transcript dedup this replaces. Both want this landed first.