### PR TITLE
fix(app): keep offline diarization off Metal

### DIFF
--- a/app/MeetingTranscriber/Sources/FluidDiarizer.swift
+++ b/app/MeetingTranscriber/Sources/FluidDiarizer.swift
@@ -1,3 +1,4 @@
+import CoreML
 import FluidAudio
 import Foundation
 import os.log
@@ -283,6 +284,17 @@ struct FluidOfflineProcessor: OfflineDiarizationProcessing {
         return config
     }
 
+    /// Keep FluidAudio's offline inference off Metal. Core ML's `.all`
+    /// routing can send the WeSpeaker embedding model through MPSGraph, whose
+    /// in-process abort cannot be caught or retried by the pipeline. The CPU +
+    /// Neural Engine route retains hardware acceleration without invoking the
+    /// crash-prone GPU path.
+    static func makeModelConfiguration() -> MLModelConfiguration {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = .cpuAndNeuralEngine
+        return configuration
+    }
+
     mutating func prepare(numSpeakers: Int?) async throws {
         guard manager == nil || numSpeakers != currentNumSpeakers else { return }
 
@@ -296,7 +308,7 @@ struct FluidOfflineProcessor: OfflineDiarizationProcessing {
                 "FluidAudio offline tuning (\(flag)): clusterThreshold=\(t.clusterThreshold) warmStartFa=\(t.warmStartFa) warmStartFb=\(t.warmStartFb) minSegmentDurationSeconds=\(t.minSegmentDurationSeconds) excludeOverlap=\(t.excludeOverlap)",
             )
         let newManager = OfflineDiarizerManager(config: config)
-        try await newManager.prepareModels()
+        try await newManager.prepareModels(configuration: Self.makeModelConfiguration())
         manager = newManager
         currentNumSpeakers = numSpeakers
         logger.info("FluidAudio offline models ready")

--- a/app/MeetingTranscriber/Tests/FluidDiarizerTuningTests.swift
+++ b/app/MeetingTranscriber/Tests/FluidDiarizerTuningTests.swift
@@ -1,3 +1,4 @@
+import CoreML
 import FluidAudio
 @testable import MeetingTranscriber
 import XCTest
@@ -103,5 +104,11 @@ final class FluidDiarizerTuningTests: XCTestCase {
         let negative = FluidOfflineProcessor.makeConfig(tuning: .defaults, numSpeakers: -3)
         XCTAssertNil(negative.clustering.minSpeakers)
         XCTAssertNil(negative.clustering.maxSpeakers)
+    }
+
+    func testModelConfigurationAvoidsMetalInference() {
+        let configuration = FluidOfflineProcessor.makeModelConfiguration()
+
+        XCTAssertEqual(configuration.computeUnits, MLComputeUnits.cpuAndNeuralEngine)
     }
 }


### PR DESCRIPTION
## Summary

- route FluidAudio offline diarization through CPU + Neural Engine
- avoid the Metal/MPSGraph path whose in-process abort bypasses Swift error handling
- pin the compute-unit policy with a regression test

## Evidence

A symbolicated crash ended in `OfflineEmbeddingExtractor.runEmbeddingModel` above Metal/MPSGraph/Core ML. The process received SIGABRT, so pipeline retry logic cannot contain it. CPU + Neural Engine retains hardware acceleration without invoking that GPU path.

## Validation

- `git diff --check`
- local Swift tests unavailable: repository requires Swift 6.2; this host has Swift 6.1
- CI is the build/test authority for this change