### PR TITLE
feat(app): instrument the app track for runs of exact zeros

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ the naming-confirm lane, or runner configuration.
 
 ## Diagnostics
 
-`AppSettings.audioDebugLogging` (Settings → Diagnostics → "Verbose Audio Logging") enables forensic logging in the audio-capture path:
+`AppSettings.verboseDiagnostics` (Settings → Diagnostics → "Verbose Audio Logging"; renamed from the legacy `audioDebugLogging` key, which is migrated on read) enables forensic logging in the audio-capture path:
 
 - `[debug] Tap target: pid=… exe=… bundle=… audioObjectID=…` at start
 - `[debug] Default output device: name=… uid=… transport=… rate=…` at start and on device change
@@ -349,6 +349,16 @@ the naming-confirm lane, or runner configuration.
 - `[debug] App audio capture stopping: totalBytes=…` at stop
 - `[debug] Mic input device: name=… uid=… hwRate=… hwChannels=…` at mic capture start
 - `[debug] Mic RMS (5s): … dBFS, samples=…` every 5 s during mic capture
+
+**Unconditional** (not behind the toggle), because a silent-track report cannot be triaged by asking the user to have enabled logging beforehand, and because these are bounded rather than per-buffer (issue #672):
+
+- `App audio tap: N PID(s) [names]` at start
+- `System output device: … transport=…` at start
+- `App audio process state (start|zero run started|stop): exe=… pid=… object=… isRunningOutput=… outputDevices=…` — one line per tapped process. `isRunningOutput` separates a dead tap from a process that rendered nothing; it does **not** separate a silent far end from a dead tap, because a stream rendering zeroes still reports true. `outputDevices` says whether the process's output went to the output device or into some other device (a voice-processing aggregate, say) that the tap does not follow.
+- `App audio: track has been at exact zeros for … s while buffers keep arriving` on entering a zero run, and the matching `signal returned after … s` on leaving. Capped at `SilentTrackObserver.maxEdgesPerRecording` edges per recording; the counters keep going past the cap so the stop line stays honest.
+- `App audio at stop: bytes=… lastBufferAge=… lastEnergyAge=… zeroRuns=… longestZeroRun=…`. `lastEnergyAge=never` means the channel carried no non-zero sample at all, which is the signature of a tap that was never allowed to hear the app (issue #524), not of one that died.
+
+The process-state reads run on their own queue (`com.meetingtranscriber.audiotap.diagnostics`), never on the write queue: that is the IOProc's delivery queue and `AppTapSession.destroy()` drains it with a `sync`, so a HAL read wedged there would wedge every teardown behind it (issue #588). One read at a time, so a wedged one costs a single parked thread rather than a pile.
 
 View via Console.app, subsystem `com.meetingtranscriber.audiotap`. Off by default; turn on when investigating silent recordings or unusual routing.
 

--- a/tools/audiotap/Sources/AppAudioCapture+DebugLogging.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+DebugLogging.swift
@@ -33,11 +33,23 @@ extension AppAudioCapture {
         debugTotalBytes += UInt64(byteCount)
     }
 
-    /// Drain the 5-s throttle and emit one RMS-energy log line per tick, but
-    /// only when `debugLogging` is on. The drain itself runs unconditionally
-    /// so the reporter's accumulators stay bounded for long sessions.
-    func maybeReportDebugRMS() {
+    /// Drain the 5-s throttle and act on it.
+    ///
+    /// Two consumers ride the same tick because `tick()` resets the
+    /// accumulators, so only one caller can have it: the RMS log line, which is
+    /// gated on `debugLogging`, and the silent-track observer, which is not
+    /// (issue #672) because a track that went to zeroes has to be triageable
+    /// without the user having turned verbose logging on beforehand. The drain
+    /// itself runs unconditionally so the accumulators stay bounded.
+    ///
+    /// `processes` comes from the session whose IOProc is delivering these
+    /// buffers, not from a field, so a block that outlives its own attempt
+    /// cannot report about a tap it does not belong to. Required rather than
+    /// defaulted: an empty list is a real state (a session built by a test seam
+    /// has none) and a default would let a new call site reach it by accident.
+    func maybeReportDebugRMS(processes: [TappedProcess]) {
         guard let report = debugRMS.tick() else { return }
+        observeSilentTrack(processes: processes)
         guard debugLogging else { return }
         let dBStr = String(format: "%.1f", report.dBFS)
         logger.info(

--- a/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+PIDTranslation.swift
@@ -13,11 +13,12 @@ extension AppAudioCapture {
     ///
     /// Returns pairs (not parallel arrays) so callers can log per-PID
     /// without re-zipping against `pids` — `compactMap` would otherwise
-    /// silently mis-align the two sequences.
-    func translatePIDs() throws -> [(pid: pid_t, audioObjectID: AudioObjectID)] {
-        let translated: [(pid: pid_t, audioObjectID: AudioObjectID)] = pids.compactMap { pid in
+    /// silently mis-align the two sequences. `TappedProcess` is that pair
+    /// named, and it is what the tap session stores (issue #672).
+    func translatePIDs() throws -> [TappedProcess] {
+        let translated: [TappedProcess] = pids.compactMap { pid in
             guard let objectID = Self.translatePID(pid) else { return nil }
-            return (pid: pid, audioObjectID: objectID)
+            return TappedProcess(pid: pid, audioObjectID: objectID)
         }
         guard !translated.isEmpty else {
             throw NSError(

--- a/tools/audiotap/Sources/AppAudioCapture+SilentTrackDiagnostics.swift
+++ b/tools/audiotap/Sources/AppAudioCapture+SilentTrackDiagnostics.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.meetingtranscriber.audiotap", category: "AppAudioCapture")
+
+/// The log call sites for the silent-track instrumentation (issue #672), split
+/// from `AppAudioCapture.swift` to stay under the 600-line lint cap, and kept
+/// together so the wording and the privacy annotations are readable in one
+/// place.
+///
+/// **Why these lines are not gated on verbose logging.** The library's
+/// convention is that per-buffer forensics are gated and that one triage line
+/// per recording is not: the existing `App audio tap: N PID(s)` line is
+/// unconditional precisely so a silent-track report can be triaged without the
+/// user having turned Verbose Audio Logging on beforehand, which they cannot do
+/// retroactively. A run of exact zeros is that same kind of event, and it is
+/// bounded: two lines per process at start and stop, plus at most
+/// `SilentTrackObserver.maxEdgesPerRecording` edges. The 5 s cadence line stays
+/// gated, because 720 lines an hour is not a triage line.
+///
+/// **Privacy.** These carry pids, executable names, booleans, CoreAudio object
+/// ids and status codes. Executable names are already logged unconditionally by
+/// `startCapture` for the same triage reason. Bundle ids and device names are
+/// gated elsewhere in this file's neighbours and stay out of here entirely, and
+/// no path is interpolated anywhere, so the username-in-a-path leak does not
+/// apply.
+@available(macOS 14.2, *)
+extension AppAudioCapture {
+    /// Three call sites drive this, and the reasoning lives here rather than at
+    /// any of them.
+    ///
+    /// **At start**, right after `AudioDeviceStart`: a baseline for everything
+    /// below, because a tap whose processes were already not running output is a
+    /// different story from one whose processes stopped later. Asynchronous, so
+    /// a HAL read that hangs cannot hold up the start path (issue #588).
+    ///
+    /// **On a zero-run edge**, from the 5 s tick.
+    ///
+    /// **At stop**, from `stop()` and specifically *not* from `stopCapture()`.
+    /// The reading is taken from the processes the last adoption remembered, not
+    /// from the live session, which `.stopAndRetry` clears before any restart
+    /// attempt launches and only adoption puts back.
+    /// A device-change restart calls `stopCapture()` too, so a summary there
+    /// would claim "at stop" in the middle of a recording, and it would stay
+    /// silent on the give-up path, whose zero-run history is the one that
+    /// matters most. `stop()` covers both of its branches because the reading is
+    /// taken before the arbiter decides, while the session is still there.
+    /// Asynchronous, which is why the line arrives after "Audio capture stopped"
+    /// and says "(stop)" so the order is not misread. Reading the process
+    /// objects a moment after the tap is gone is still the state at stop: they
+    /// belong to coreaudiod's model of the tapped process, not to our tap.
+    ///
+    /// The counters deliberately span restarts rather than resetting with each
+    /// tap: the question the summary answers is whether *this recording's* app
+    /// track went silent, and a restart is an event inside a recording.
+    ///
+    /// The sink `SilentTrackDiagnostics` reports into, on its own queue.
+    /// `@Sendable` and static because it must not capture a capture instance.
+    static let logSilentTrackProbe: SilentTrackDiagnostics.Sink = { reason, outcome in
+        guard case let .read(states) = outcome else {
+            // Not swallowed: a skip means an earlier read has not come back, and
+            // if that one is wedged every later probe is skipped too. Silence
+            // here would look identical to a probe nobody asked for.
+            logger.info(
+                "App audio process state (\(reason, privacy: .public)): skipped, a read is still outstanding",
+            )
+            return
+        }
+        guard !states.isEmpty else {
+            logger.info("App audio process state (\(reason, privacy: .public)): no tapped processes")
+            return
+        }
+        for state in states {
+            let exe = getExecutableName(pid: state.process.pid)
+            logger.info(
+                "App audio process state (\(reason, privacy: .public)): exe=\(exe, privacy: .public) \(state.summary, privacy: .public)",
+            )
+        }
+    }
+
+    /// Feed one 5 s tick into the observer and log the edges. Runs on the write
+    /// queue; every HAL read it triggers runs on the diagnostics queue.
+    func observeSilentTrack(processes: [TappedProcess]) {
+        guard let event = silentTrackDiagnostics.observe(currentSignalAges) else { return }
+        switch event {
+        case let .enteredZeroRun(afterSignalSeconds):
+            logger.warning(
+                "App audio: track has been at exact zeros for \(Self.seconds(afterSignalSeconds), privacy: .public) s while buffers keep arriving",
+            )
+            // The one moment worth asking the tapped processes what they are
+            // doing: whether their output is still running, and whether it went
+            // to a device this tap does not follow.
+            silentTrackDiagnostics.probeAsync(processes, reason: "zero run started")
+
+        case let .exitedZeroRun(durationSeconds):
+            logger.info(
+                "App audio: signal returned after \(Self.seconds(durationSeconds), privacy: .public) s of exact zeros",
+            )
+        }
+    }
+
+    /// One line saying what the app track did over the whole recording, plus the
+    /// tapped processes' final state. Called from `stop()` on the main queue.
+    ///
+    /// The processes come from the diagnostics object rather than the session,
+    /// which is nil on every give-up and mid-restart stop. `debugTotalBytes` is
+    /// deliberately not reported here: the IOProc may still be writing it on the
+    /// write queue at this point, and the gated stopping line already carries it.
+    func logSilentTrackSummary() {
+        let counters = silentTrackDiagnostics.counters
+        let ages = currentSignalAges
+        let lastBuffer = ages.secondsSinceLastBuffer.map(Self.seconds) ?? "never"
+        let lastEnergy = ages.secondsSinceLastEnergy.map(Self.seconds) ?? "never"
+        logger.info(
+            "App audio at stop: lastBufferAge=\(lastBuffer, privacy: .public) lastEnergyAge=\(lastEnergy, privacy: .public) zeroRuns=\(counters.zeroRuns, privacy: .public) longestZeroRun=\(Self.seconds(counters.longestZeroRun), privacy: .public)",
+        )
+        silentTrackDiagnostics.probeAsync(silentTrackDiagnostics.lastInstalledProcesses, reason: "stop")
+    }
+
+    /// One decimal place: these are durations in seconds, and the full Double
+    /// makes the line harder to read without saying anything more.
+    private static func seconds(_ value: TimeInterval) -> String {
+        String(format: "%.1f", value)
+    }
+}

--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -64,6 +64,9 @@ public class AppAudioCapture: @unchecked Sendable {
 
     /// `internal` (not `private`) so the cross-file `+DebugLogging` extension
     /// can drive the per-buffer RMS accumulator + dBFS report cadence.
+    /// Issue #672; see `AppAudioCapture+SilentTrackDiagnostics`.
+    let silentTrackDiagnostics = SilentTrackDiagnostics(sink: AppAudioCapture.logSilentTrackProbe)
+
     var debugRMS = DebugRMSReporter()
     var debugTotalBytes: UInt64 = 0
     let levelPublisher = LevelPublisher()
@@ -202,6 +205,7 @@ public class AppAudioCapture: @unchecked Sendable {
     /// something" a fact the type system carries rather than a convention.
     func install(_ session: AppTapSession) {
         tapSession = session
+        silentTrackDiagnostics.remember(session.tappedProcesses)
         actualSampleRate = session.resolvedSampleRate
     }
 
@@ -405,7 +409,9 @@ public class AppAudioCapture: @unchecked Sendable {
         // would silently skip the barrier once self is gone, which is exactly the
         // write-after-close bug the barrier exists to prevent, and a strong self
         // would make the session keep its owner alive.
-        let session = AppTapSession(tapID: newTapID) { [writeQueue] in writeQueue.sync {} }
+        let session = AppTapSession(tapID: newTapID, tappedProcesses: translated) { [writeQueue] in
+            writeQueue.sync {}
+        }
         let tapRate = Self.queryTapSampleRate(tapID: newTapID)
         logger.info("Created process tap: \(newTapID) rate=\(tapRate, privacy: .public) Hz")
 
@@ -505,7 +511,7 @@ public class AppAudioCapture: @unchecked Sendable {
 
             self.accumulateDebugRMS(data: data, byteCount: byteCount)
             self.publishCurrentLevel()
-            self.maybeReportDebugRMS()
+            self.maybeReportDebugRMS(processes: session.tappedProcesses)
         }
 
         guard ioProcStatus == noErr, let validProcID = newProcID else {
@@ -539,6 +545,7 @@ public class AppAudioCapture: @unchecked Sendable {
         logger.info(
             "Audio capture started (PIDs \(self.pids), rate: \(session.resolvedSampleRate) Hz)",
         )
+        silentTrackDiagnostics.probeAsync(session.tappedProcesses, reason: "start")
         return session
     }
 
@@ -560,6 +567,8 @@ public class AppAudioCapture: @unchecked Sendable {
     }
 
     public func stop() {
+        // Not in stopCapture, which a restart also calls. See the extension.
+        logSilentTrackSummary()
         // Ask first: an attempt may be stuck inside the same coreaudiod, and every
         // HAL call below would block behind it. Safe to skip in that case because
         // an attempt is only ever launched after the coordinator already ran

--- a/tools/audiotap/Sources/AppTapSession.swift
+++ b/tools/audiotap/Sources/AppTapSession.swift
@@ -43,6 +43,12 @@ struct AppTapSessionHAL {
 @available(macOS 14.2, *)
 final class AppTapSession: @unchecked Sendable {
     let tapID: AudioObjectID
+    /// The processes this tap was built from, kept so a diagnostic can ask them
+    /// what their output is doing (issue #672). Stored rather than re-translated
+    /// because a fresh translation can answer about a different object after a
+    /// PID is reused, and because re-translating is another HAL call. Defaults
+    /// to empty so a session built by a test seam is honest about having none.
+    let tappedProcesses: [TappedProcess]
     /// Filled in as the attempt gets further. A session that never got past the
     /// tap still cleans up correctly, which is the point: every failure path
     /// hands back one object instead of remembering which of three ids it owns.
@@ -61,10 +67,12 @@ final class AppTapSession: @unchecked Sendable {
 
     init(
         tapID: AudioObjectID,
+        tappedProcesses: [TappedProcess] = [],
         hal: AppTapSessionHAL = .real,
         drain: @escaping () -> Void,
     ) {
         self.tapID = tapID
+        self.tappedProcesses = tappedProcesses
         self.hal = hal
         self.drain = drain
     }

--- a/tools/audiotap/Sources/ProcessOutputState.swift
+++ b/tools/audiotap/Sources/ProcessOutputState.swift
@@ -1,0 +1,111 @@
+import CoreAudio
+import Foundation
+
+/// What a tapped process's CoreAudio object says about its output (issue #672).
+///
+/// Two properties, and it is worth being precise about what each buys, because
+/// one of them looks more useful than it is.
+///
+/// `kAudioProcessPropertyIsRunningOutput` is 1 when the process is running IO
+/// with at least one active output stream. It separates a dead tap from a
+/// process that rendered nothing at all. It does **not** separate a muted or
+/// silent far end from a dead tap, because a stream rendering zeroes still
+/// reports true. That limit is why this is instrumentation and not a trigger.
+///
+/// `kAudioProcessPropertyDevices` on the output scope says where the process's
+/// output actually went: straight to the output device, or into some other
+/// device such as a voice-processing aggregate the tap does not follow. That is
+/// the distinction the field case in issue #671 turns on, and it is the reason
+/// this is worth logging at all.
+struct ProcessOutputState: Equatable, Sendable {
+    /// A value that was read, or the status that says why it was not. Each
+    /// property carries its own, because either can fail on its own: a stored
+    /// object id whose process has exited fails both, but a property the OS
+    /// version does not implement fails one. Collapsing them to a value plus a
+    /// nullable status would make "no output devices" and "could not ask"
+    /// indistinguishable, and a reader would draw the first conclusion from the
+    /// second.
+    enum Reading<Value: Equatable & Sendable>: Equatable, Sendable {
+        case value(Value)
+        case failed(OSStatus)
+
+        /// `String(describing:)` already renders an array of ids as
+        /// `[73, 512]` and an empty one as `[]`, which is exactly the
+        /// distinction the failure case has to stay apart from.
+        var rendered: String {
+            switch self {
+            case let .value(value): String(describing: value)
+            case let .failed(status): "?(\(status))"
+            }
+        }
+    }
+
+    let process: TappedProcess
+    let isRunningOutput: Reading<Bool>
+    let outputDevices: Reading<[AudioObjectID]>
+
+    var summary: String {
+        "pid=\(process.pid) object=\(process.audioObjectID) "
+            + "isRunningOutput=\(isRunningOutput.rendered) "
+            + "outputDevices=\(outputDevices.rendered)"
+    }
+}
+
+/// The HAL side of `ProcessOutputState`. Separated so the reads have one home
+/// and the value type stays free of CoreAudio calls.
+///
+/// **Never call this on the write queue.** It is a synchronous HAL round trip
+/// through the same coreaudiod that can stop answering, and `AppTapSession`
+/// drains the write queue with a `sync`, so a read wedged there would wedge
+/// every capture teardown and restart behind it. That is the shape of issue
+/// #588. `SilentTrackDiagnostics` owns the queue this belongs on.
+enum ProcessOutputProbe {
+    static func readAll(_ processes: [TappedProcess]) -> [ProcessOutputState] {
+        processes.map(read)
+    }
+
+    static func read(_ process: TappedProcess) -> ProcessOutputState {
+        ProcessOutputState(
+            process: process,
+            isRunningOutput: readIsRunningOutput(process.audioObjectID),
+            outputDevices: readOutputDevices(process.audioObjectID),
+        )
+    }
+
+    private static func readIsRunningOutput(
+        _ objectID: AudioObjectID,
+    ) -> ProcessOutputState.Reading<Bool> {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyIsRunningOutput,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, &value)
+        guard status == noErr else { return .failed(status) }
+        return .value(value != 0)
+    }
+
+    private static func readOutputDevices(
+        _ objectID: AudioObjectID,
+    ) -> ProcessOutputState.Reading<[AudioObjectID]> {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyDevices,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        var size: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(objectID, &address, 0, nil, &size)
+        guard sizeStatus == noErr else { return .failed(sizeStatus) }
+        let count = Int(size) / MemoryLayout<AudioObjectID>.size
+        guard count > 0 else { return .value([]) }
+
+        var ids = [AudioObjectID](repeating: kAudioObjectUnknown, count: count)
+        let status = AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, &ids)
+        guard status == noErr else { return .failed(status) }
+        // The second call updates `size`, and the list can have shrunk between
+        // the two. Without the trim the tail would be logged as device 0.
+        return .value(Array(ids.prefix(Int(size) / MemoryLayout<AudioObjectID>.size)))
+    }
+}

--- a/tools/audiotap/Sources/SilentTrackDiagnostics.swift
+++ b/tools/audiotap/Sources/SilentTrackDiagnostics.swift
@@ -1,0 +1,120 @@
+import Foundation
+import os
+
+/// Owns the three things the silent-track instrumentation needs that a value
+/// type cannot hold: a queue the HAL reads may safely block on, a guard so a
+/// read that never returns costs one parked thread instead of a growing pile,
+/// and the observer's state, which the write queue updates and the main queue
+/// reads at stop (issue #672).
+///
+/// One object rather than four stored properties on `AppAudioCapture`, which is
+/// close enough to the 600-line lint cap that four would not fit.
+///
+/// **Why a dedicated queue.** The reads cannot go on `writeQueue`: that is the
+/// IOProc's delivery queue, and `AppTapSession.destroy()` drains it with a
+/// `sync`, so a HAL call wedged there would wedge every capture teardown and
+/// restart behind it, which is the shape of issue #588. They cannot go on the
+/// main queue for the same reason one step worse. And they must not go on
+/// `restartQueue`, which is bounded by `RestartArbiter` for work that owns HAL
+/// resources; a diagnostic sharing it could delay a restart that matters.
+final class SilentTrackDiagnostics: @unchecked Sendable {
+    typealias Probe = @Sendable ([TappedProcess]) -> [ProcessOutputState]
+
+    /// What a probe request came to. `skipped` is reported rather than swallowed
+    /// because the reason it happens is a read still inside coreaudiod, which is
+    /// the failure class this whole object is shaped around: without a line, a
+    /// wedged first probe would silence every later one for the whole recording
+    /// and the log would simply be missing, with nothing saying why.
+    enum Outcome: Equatable {
+        case read([ProcessOutputState])
+        case skipped
+    }
+
+    /// Called on the diagnostics queue with the reason the probe was taken and
+    /// what came of it, except for `skipped`, which is reported inline on the
+    /// caller's thread because no work was queued. Injected rather than logging
+    /// here so the wording and the privacy annotations stay next to the other
+    /// capture logging, and so a test can assert without reading the system log.
+    typealias Sink = @Sendable (String, Outcome) -> Void
+
+    private let queue = DispatchQueue(
+        label: "com.meetingtranscriber.audiotap.diagnostics", qos: .utility,
+    )
+    private let probe: Probe
+    private let sink: Sink
+
+    /// The observer and the in-flight flag, behind one lock. Scoped access
+    /// rather than a queue hop because `observe` is called from the IOProc's
+    /// write queue and must not hop anywhere, and `withLock` rather than a bare
+    /// lock because it makes an unbalanced early return structurally impossible.
+    /// Same primitive its neighbours use for a state machine behind a lock.
+    private struct State {
+        var observer = SilentTrackObserver()
+        var probeInFlight = false
+        /// The processes of the most recently installed tap. The stop summary
+        /// cannot read them off the session: `.stopAndRetry` clears it before
+        /// any restart attempt launches, and only adoption puts one back, so on
+        /// every give-up and mid-restart stop the session is nil. That is
+        /// exactly the recording whose process state is worth having.
+        var lastInstalledProcesses: [TappedProcess] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(probe: @escaping Probe = ProcessOutputProbe.readAll, sink: @escaping Sink) {
+        self.probe = probe
+        self.sink = sink
+    }
+
+    /// Feed one tick's signal ages and hand back the edge, if this tick is one.
+    /// Called on the write queue.
+    func observe(_ ages: ChannelSignalAges) -> SilentTrackObserver.Event? {
+        state.withLock { $0.observer.observe(ages) }
+    }
+
+    /// What the stop summary reports. Safe from any thread.
+    var counters: (zeroRuns: Int, longestZeroRun: TimeInterval) {
+        state.withLock { ($0.observer.zeroRuns, $0.observer.longestZeroRun) }
+    }
+
+    /// The processes of the most recently installed tap, which is what the stop
+    /// summary asks about. See `State.lastInstalledProcesses`.
+    var lastInstalledProcesses: [TappedProcess] {
+        state.withLock { $0.lastInstalledProcesses }
+    }
+
+    /// Called from the tap adoption, on the main queue.
+    func remember(_ processes: [TappedProcess]) {
+        state.withLock { $0.lastInstalledProcesses = processes }
+    }
+
+    /// Take a process-state reading off every hot queue, unless one is already
+    /// running. Returns whether this call started one, which is what makes the
+    /// guard assertable.
+    @discardableResult
+    func probeAsync(_ processes: [TappedProcess], reason: String) -> Bool {
+        let started = state.withLock { state -> Bool in
+            guard !state.probeInFlight else { return false }
+            state.probeInFlight = true
+            return true
+        }
+        guard started else {
+            sink(reason, .skipped)
+            return false
+        }
+
+        // Strongly, deliberately. The stop probe is requested from
+        // `AppAudioCapture.stop()`, and `AudioCaptureSession.stop()` releases the
+        // capture object a few statements later, before this queue gets to run
+        // the block: with a weak reference the stop reading was lost almost every
+        // time. Holding self here costs a queue, two closures and a lock until
+        // the read returns, which is the same lifetime a wedged read already has.
+        queue.async {
+            self.sink(reason, .read(self.probe(processes)))
+            // After the sink, so a caller waiting for the flag to clear cannot
+            // observe it clear before the result was reported.
+            self.state.withLock { $0.probeInFlight = false }
+        }
+        return true
+    }
+}

--- a/tools/audiotap/Sources/SilentTrackObserver.swift
+++ b/tools/audiotap/Sources/SilentTrackObserver.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Notices when the app track enters and leaves a run of exact zeros while
+/// buffers keep arriving, so the transition is in the log rather than only the
+/// end state (issue #672).
+///
+/// Nothing in the capture path acted on the samples it recorded. The app layer
+/// eventually notices (`ChannelFaultMonitor` reports `digitalSilence` after a
+/// debounce) but the library, which is where a rebuild would have to happen and
+/// where the tap's own state can be read, saw nothing. A field case ran 1193 of
+/// 1194 seconds at exact zeros with buffers delivered throughout, and the only
+/// evidence anyone had afterwards was the finished file.
+///
+/// This is the sensor, not the actuator. It says when a run began and how long
+/// it lasted, which is what the log needs to tell a dying tap apart from a
+/// meeting app that moved its output somewhere the tap does not follow. Whether
+/// a run should trigger a tap rebuild is a separate question, and it is
+/// deliberately not answered here: two of the three live readings of the field
+/// case mean a rebuild changes nothing, and each rebuild is an exposure to the
+/// wedge class of issue #588, which is terminal for the channel.
+///
+/// Driven from the existing 5 s tick with `ChannelSignalAges`, so it needs no
+/// clock of its own and no timer. That does mean it cannot see a tap whose
+/// IOProc stopped, since the tick is IOProc-driven; that failure is `noBuffers`
+/// and the app layer already reports it.
+struct SilentTrackObserver: Equatable {
+    /// How long the track must have been at exact zeros before the run is worth
+    /// a log line. Not a rebuild threshold: this only writes to the log, so it
+    /// can afford to be shorter than anything that would act.
+    static let zeroRunThreshold: TimeInterval = 10
+    /// Buffers must still be arriving for a zero run to mean anything. Beyond
+    /// this the fault is the transport, not the content.
+    static let maxBufferAge: TimeInterval = 2
+    /// A pathological toggle must not flood the log. The counters keep going
+    /// past this, so the stop summary stays honest.
+    static let maxEdgesPerRecording = 20
+
+    enum Event: Equatable {
+        /// The track carried signal and has now been at exact zeros for
+        /// `afterSignalSeconds`.
+        case enteredZeroRun(afterSignalSeconds: TimeInterval)
+        /// Signal came back after `durationSeconds` of zeros.
+        case exitedZeroRun(durationSeconds: TimeInterval)
+    }
+
+    private(set) var edges = 0
+    private(set) var zeroRuns = 0
+    private(set) var longestZeroRun: TimeInterval = 0
+    /// The longest energy age seen inside the run currently open, and zero when
+    /// none is. At the moment signal returns the age has already reset, so the
+    /// run's length has to have been remembered while it was still running, and
+    /// a run only ever opens above the threshold, so this doubles as the flag.
+    private var currentRunPeak: TimeInterval = 0
+
+    var inZeroRun: Bool {
+        currentRunPeak > 0
+    }
+
+    mutating func observe(_ ages: ChannelSignalAges) -> Event? {
+        // A channel that never carried a single non-zero sample is the signature
+        // of a tap that was never allowed to hear the app (issue #524). Different
+        // failure, different fix, and claiming it here would bury this one.
+        guard let energyAge = ages.secondsSinceLastEnergy else { return nil }
+        // Buffers stopping is `noBuffers`, which the app layer reports. A run
+        // already open stays open: the transport dying is not signal returning.
+        guard let bufferAge = ages.secondsSinceLastBuffer, bufferAge <= Self.maxBufferAge else {
+            return nil
+        }
+
+        guard inZeroRun else {
+            guard energyAge >= Self.zeroRunThreshold else { return nil }
+            zeroRuns += 1
+            currentRunPeak = energyAge
+            longestZeroRun = max(longestZeroRun, currentRunPeak)
+            return emit(.enteredZeroRun(afterSignalSeconds: energyAge))
+        }
+        currentRunPeak = max(currentRunPeak, energyAge)
+        longestZeroRun = max(longestZeroRun, currentRunPeak)
+        guard energyAge < Self.zeroRunThreshold else { return nil }
+        let duration = currentRunPeak
+        currentRunPeak = 0
+        return emit(.exitedZeroRun(durationSeconds: duration))
+    }
+
+    /// Counts the edge and hands it back, or swallows it once the cap is
+    /// reached. The state above is updated either way.
+    private mutating func emit(_ event: Event) -> Event? {
+        guard edges < Self.maxEdgesPerRecording else { return nil }
+        edges += 1
+        return event
+    }
+}

--- a/tools/audiotap/Sources/TappedProcess.swift
+++ b/tools/audiotap/Sources/TappedProcess.swift
@@ -1,0 +1,13 @@
+import CoreAudio
+import Foundation
+
+/// One process the tap was built from, kept so its state can be read again
+/// later. `startCapture` translates PIDs to CoreAudio process objects and used
+/// to drop the ids on the floor; a diagnostic that asks "what is the state of
+/// the objects this tap is attached to" needs the ids the `CATapDescription` was
+/// actually built from, not a fresh translation, which can answer about a
+/// different object after a PID is reused.
+struct TappedProcess: Equatable, Sendable {
+    let pid: pid_t
+    let audioObjectID: AudioObjectID
+}

--- a/tools/audiotap/Tests/AppAudioCaptureDebugLoggingTests.swift
+++ b/tools/audiotap/Tests/AppAudioCaptureDebugLoggingTests.swift
@@ -106,7 +106,7 @@ final class AppAudioCaptureDebugLoggingTests: XCTestCase {
         // side-effects, no crash). The 5-s elapsed-time path is exercised
         // only by the live-recording E2E.
         let capture = makeCapture(debugLogging: true)
-        capture.maybeReportDebugRMS()
+        capture.maybeReportDebugRMS(processes: [])
         XCTAssertEqual(capture.debugRMS.sampleCount, 0)
     }
 
@@ -117,7 +117,7 @@ final class AppAudioCaptureDebugLoggingTests: XCTestCase {
         // documents the contract by exercising the early-return path
         // and ensuring it stays crash-free with `debugLogging=false`.
         let capture = makeCapture(debugLogging: false)
-        capture.maybeReportDebugRMS()
+        capture.maybeReportDebugRMS(processes: [])
         XCTAssertEqual(capture.debugRMS.sampleCount, 0)
     }
 }

--- a/tools/audiotap/Tests/AppTapSessionTests.swift
+++ b/tools/audiotap/Tests/AppTapSessionTests.swift
@@ -120,4 +120,25 @@ final class AppTapSessionTests: XCTestCase {
         XCTAssertEqual(session.resolvedSampleRate, 48000)
         XCTAssertNil(session.procID, "a session only has a registration once one was attached")
     }
+
+    // MARK: - What the tap was built from (issue #672)
+
+    func testTheSessionCarriesTheProcessesItsTapWasBuiltFrom() {
+        // Stored rather than re-translated: a fresh PID translation can answer
+        // about a different audio object after a PID is reused, and the
+        // diagnostic's question is about the objects this tap is attached to.
+        let processes = [
+            TappedProcess(pid: 3497, audioObjectID: 91),
+            TappedProcess(pid: 3498, audioObjectID: 92),
+        ]
+        let session = AppTapSession(tapID: 11, tappedProcesses: processes) {}
+        XCTAssertEqual(session.tappedProcesses, processes)
+    }
+
+    func testASessionBuiltWithoutProcessesSaysSoRatherThanGuessing() {
+        // The default keeps every existing construction site compiling, and a
+        // caller that forgets the processes gets an empty list and a log line
+        // that says "no tapped processes", which is visible rather than silent.
+        XCTAssertTrue(AppTapSession(tapID: 11) {}.tappedProcesses.isEmpty)
+    }
 }

--- a/tools/audiotap/Tests/ProcessOutputStateTests.swift
+++ b/tools/audiotap/Tests/ProcessOutputStateTests.swift
@@ -1,0 +1,68 @@
+@testable import AudioTapLib
+import CoreAudio
+import XCTest
+
+/// What a tapped process's output state renders as in the log (issue #672).
+/// The HAL reads themselves need hardware; the rendering does not, and the
+/// rendering is where a diagnostic becomes readable or useless.
+final class ProcessOutputStateTests: XCTestCase {
+    private let process = TappedProcess(pid: 3497, audioObjectID: 91)
+
+    private func state(
+        running: ProcessOutputState.Reading<Bool>,
+        devices: ProcessOutputState.Reading<[AudioObjectID]>,
+    ) -> ProcessOutputState {
+        ProcessOutputState(process: process, isRunningOutput: running, outputDevices: devices)
+    }
+
+    func testAHealthyReadRendersEveryField() {
+        XCTAssertEqual(
+            state(running: .value(true), devices: .value([73])).summary,
+            "pid=3497 object=91 isRunningOutput=true outputDevices=[73]",
+        )
+    }
+
+    func testSeveralOutputDevicesAreAllListed() {
+        // The distinction the field case turns on: output going to a separate
+        // aggregate rather than straight to the output device.
+        let summary = state(running: .value(true), devices: .value([73, 512])).summary
+        XCTAssertTrue(summary.contains("outputDevices=[73, 512]"))
+    }
+
+    func testNoOutputDeviceIsNotTheSameAsAFailedRead() {
+        // "The process output went nowhere" and "we could not find out" are
+        // different findings, and a log that rendered both as empty would let a
+        // reader draw the first conclusion from the second.
+        let none = state(running: .value(false), devices: .value([]))
+        let failed = state(running: .value(false), devices: .failed(-4))
+        XCTAssertTrue(none.summary.contains("outputDevices=[]"))
+        XCTAssertTrue(failed.summary.contains("outputDevices=?(-4)"))
+        XCTAssertNotEqual(none.summary, failed.summary)
+    }
+
+    func testEachReadingCarriesItsOwnFailure() {
+        // A stored object id whose process has exited fails both reads, and that
+        // is itself the finding: the tap has nothing left to follow. One
+        // property the OS does not implement fails alone, and the other's value
+        // must survive that.
+        XCTAssertEqual(
+            state(running: .failed(-4), devices: .failed(-4)).summary,
+            "pid=3497 object=91 isRunningOutput=?(-4) outputDevices=?(-4)",
+        )
+        XCTAssertEqual(
+            state(running: .value(true), devices: .failed(2003)).summary,
+            "pid=3497 object=91 isRunningOutput=true outputDevices=?(2003)",
+        )
+    }
+
+    func testTheSummaryCarriesNothingPersonal() {
+        // Every field is a number or a boolean. Executable names are added by
+        // the call site, which already logs them unconditionally for the same
+        // triage reason; device names and bundle ids are gated elsewhere and
+        // stay out of here. No path is interpolated, so the username leak that
+        // String(describing:) causes on URLs cannot happen here.
+        let summary = state(running: .value(true), devices: .value([73])).summary
+        XCTAssertFalse(summary.contains("/"))
+        XCTAssertFalse(summary.contains("Users"))
+    }
+}

--- a/tools/audiotap/Tests/SilentTrackDiagnosticsTests.swift
+++ b/tools/audiotap/Tests/SilentTrackDiagnosticsTests.swift
@@ -1,0 +1,167 @@
+@testable import AudioTapLib
+import XCTest
+
+/// `SilentTrackDiagnostics` owns the queue the process-state reads run on, the
+/// guard that keeps a wedged read from piling up, and the observer's state
+/// (issue #672). The reads themselves need hardware; everything around them is
+/// what this pins.
+final class SilentTrackDiagnosticsTests: XCTestCase {
+    private let processes = [TappedProcess(pid: 1, audioObjectID: 11)]
+
+    /// Records probe calls and lets a test hold one open, which is how the
+    /// wedged-read case is reproduced without a wedged HAL.
+    private final class ProbeSpy: @unchecked Sendable {
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        private let lock = NSLock()
+        private var _calls = 0
+        var calls: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+
+        func probe(hold: Bool) -> SilentTrackDiagnostics.Probe {
+            { [self] _ in
+                lock.lock(); _calls += 1; lock.unlock()
+                entered.signal()
+                if hold { release.wait() }
+                return []
+            }
+        }
+    }
+
+    // MARK: - The guard
+
+    func testASecondProbeIsRefusedWhileTheFirstIsStillRunning() {
+        let spy = ProbeSpy()
+        let diagnostics = SilentTrackDiagnostics(probe: spy.probe(hold: true)) { _, _ in }
+
+        XCTAssertTrue(diagnostics.probeAsync(processes, reason: "first"))
+        XCTAssertEqual(spy.entered.wait(timeout: .now() + 2), .success, "the first probe started")
+
+        // A HAL read that never comes back must cost one parked thread, not a
+        // growing queue of them. This is the whole reason the guard exists.
+        XCTAssertFalse(diagnostics.probeAsync(processes, reason: "second"))
+        XCTAssertFalse(diagnostics.probeAsync(processes, reason: "third"))
+
+        spy.release.signal()
+        XCTAssertEqual(spy.calls, 1)
+    }
+
+    func testAProbeCanRunAgainOnceTheFirstReturned() {
+        let spy = ProbeSpy()
+        let done = expectation(description: "both probes reported")
+        done.expectedFulfillmentCount = 2
+        let diagnostics = SilentTrackDiagnostics(probe: spy.probe(hold: false)) { _, _ in
+            done.fulfill()
+        }
+
+        XCTAssertTrue(diagnostics.probeAsync(processes, reason: "first"))
+        XCTAssertEqual(spy.entered.wait(timeout: .now() + 2), .success)
+        // Wait for the in-flight flag to clear, which happens after the sink.
+        var restarted = false
+        for _ in 0 ..< 100 where !restarted {
+            restarted = diagnostics.probeAsync(processes, reason: "second")
+            if !restarted { usleep(20000) }
+        }
+        XCTAssertTrue(restarted, "the guard must clear when the probe returns")
+        wait(for: [done], timeout: 5)
+    }
+
+    func testTheReasonReachesTheSink() {
+        // Asserted inside the sink rather than through a box: the sink is
+        // `@Sendable`, so anything it writes back out would need its own lock
+        // for one string.
+        let reported = expectation(description: "reported")
+        let diagnostics = SilentTrackDiagnostics(probe: { _ in [] }, sink: { reason, _ in
+            XCTAssertEqual(reason, "stop")
+            reported.fulfill()
+        })
+        diagnostics.probeAsync(processes, reason: "stop")
+        wait(for: [reported], timeout: 5)
+    }
+
+    func testARefusedProbeIsReportedRatherThanSwallowed() {
+        // A skip means an earlier read has not come back. If that one is wedged,
+        // every later probe is skipped for the rest of the recording, and a
+        // silent skip would leave a log that is simply missing, with nothing
+        // saying why.
+        let spy = ProbeSpy()
+        let skipped = expectation(description: "skip reported")
+        let diagnostics = SilentTrackDiagnostics(probe: spy.probe(hold: true)) { reason, outcome in
+            guard outcome == .skipped else { return }
+            XCTAssertEqual(reason, "second")
+            skipped.fulfill()
+        }
+        XCTAssertTrue(diagnostics.probeAsync(processes, reason: "first"))
+        XCTAssertEqual(spy.entered.wait(timeout: .now() + 2), .success)
+        XCTAssertFalse(diagnostics.probeAsync(processes, reason: "second"))
+        wait(for: [skipped], timeout: 5)
+        spy.release.signal()
+    }
+
+    func testAProbeStillReportsAfterItsOwnerIsReleased() {
+        // The stop reading is requested from AppAudioCapture.stop(), and
+        // AudioCaptureSession releases the capture object a few statements
+        // later, which releases this one with it. Under a weak capture the
+        // queue found nothing left and the stop reading was lost almost every
+        // time, which is the one reading the whole feature exists to produce.
+        //
+        // The release below wins the race against the queue by a wide margin
+        // (an async dispatch costs microseconds, the next statement does not),
+        // so under the defect this times out rather than flaking green.
+        let reported = expectation(description: "reported after release")
+        var diagnostics: SilentTrackDiagnostics? = SilentTrackDiagnostics(
+            probe: { _ in [] }, sink: { _, _ in reported.fulfill() },
+        )
+        diagnostics?.probeAsync(processes, reason: "stop")
+        diagnostics = nil
+        wait(for: [reported], timeout: 5)
+    }
+
+    // MARK: - What the stop summary reads
+
+    func testTheRememberedProcessesSurviveASessionThatIsAlreadyGone() {
+        // .stopAndRetry clears the tap session before any restart attempt
+        // launches, and only adoption puts one back. So on every give-up and
+        // mid-restart stop the session is nil, which is exactly the recording
+        // whose process state is worth having.
+        let diagnostics = SilentTrackDiagnostics(probe: { _ in [] }, sink: { _, _ in })
+        XCTAssertTrue(diagnostics.lastInstalledProcesses.isEmpty)
+        diagnostics.remember(processes)
+        XCTAssertEqual(diagnostics.lastInstalledProcesses, processes)
+    }
+
+    func testAnEmptyProcessListStillReports() {
+        // A session built by a test seam has no tapped processes. The stop line
+        // must still be written, saying so, rather than vanishing.
+        let reported = expectation(description: "reported")
+        let diagnostics = SilentTrackDiagnostics(probe: ProcessOutputProbe.readAll) { _, outcome in
+            XCTAssertEqual(outcome, .read([]))
+            reported.fulfill()
+        }
+        XCTAssertTrue(diagnostics.probeAsync([], reason: "start"))
+        wait(for: [reported], timeout: 5)
+    }
+
+    // MARK: - The observer behind it
+
+    func testTheEdgeIsHandedBackToTheCaller() {
+        let diagnostics = SilentTrackDiagnostics(probe: { _ in [] }, sink: { _, _ in })
+        XCTAssertNil(diagnostics.observe(ages(energy: 0.5)))
+        XCTAssertEqual(
+            diagnostics.observe(ages(energy: 11.0)),
+            .enteredZeroRun(afterSignalSeconds: 11.0),
+        )
+    }
+
+    func testTheCountersSurviveForTheStopSummary() {
+        let diagnostics = SilentTrackDiagnostics(probe: { _ in [] }, sink: { _, _ in })
+        _ = diagnostics.observe(ages(energy: 30.0))
+        _ = diagnostics.observe(ages(energy: 0.02))
+        _ = diagnostics.observe(ages(energy: 12.0))
+        let counters = diagnostics.counters
+        XCTAssertEqual(counters.zeroRuns, 2)
+        XCTAssertEqual(counters.longestZeroRun, 30.0)
+    }
+}

--- a/tools/audiotap/Tests/SilentTrackObserverTests.swift
+++ b/tools/audiotap/Tests/SilentTrackObserverTests.swift
@@ -1,0 +1,119 @@
+@testable import AudioTapLib
+import XCTest
+
+/// Shared with `SilentTrackDiagnosticsTests`. `buffer` defaults to a fresh one
+/// because almost every case here is about the energy age; the two that are
+/// about the buffer age say so by passing it.
+func ages(energy: Double?, buffer: Double? = 0.01) -> ChannelSignalAges {
+    ChannelSignalAges(secondsSinceLastBuffer: buffer, secondsSinceLastEnergy: energy)
+}
+
+/// `SilentTrackObserver` decides when the app track has entered and left a run
+/// of exact zeros while buffers keep arriving (issue #672). Pure, so the bulk of
+/// the assertions live here rather than against a live tap.
+final class SilentTrackObserverTests: XCTestCase {
+    // MARK: - The signature it exists to find
+
+    func testAChannelThatCarriedAudioAndWentToZerosEntersARun() {
+        var observer = SilentTrackObserver()
+        XCTAssertNil(observer.observe(ages(energy: 0.5)))
+        XCTAssertNil(observer.observe(ages(energy: 9.0)), "not yet past the threshold")
+        XCTAssertEqual(
+            observer.observe(ages(energy: 11.0)),
+            .enteredZeroRun(afterSignalSeconds: 11.0),
+        )
+        XCTAssertTrue(observer.inZeroRun)
+        XCTAssertEqual(observer.zeroRuns, 1)
+    }
+
+    func testTheRunIsReportedOnceWhileItLasts() {
+        var observer = SilentTrackObserver()
+        _ = observer.observe(ages(energy: 11.0))
+        for energy in stride(from: 16.0, through: 120.0, by: 5.0) {
+            XCTAssertNil(
+                observer.observe(ages(energy: energy)),
+                "a run in progress is not an edge",
+            )
+        }
+        XCTAssertEqual(observer.zeroRuns, 1)
+    }
+
+    func testSignalComingBackLeavesTheRunAndReportsItsLength() {
+        var observer = SilentTrackObserver()
+        _ = observer.observe(ages(energy: 11.0))
+        _ = observer.observe(ages(energy: 40.0))
+        XCTAssertEqual(
+            observer.observe(ages(energy: 0.02)),
+            .exitedZeroRun(durationSeconds: 40.0),
+            "the run's length is the last age seen inside it, not the age at the exit",
+        )
+        XCTAssertFalse(observer.inZeroRun)
+        XCTAssertEqual(observer.longestZeroRun, 40.0)
+    }
+
+    func testTheLongestRunSurvivesLaterShorterOnes() {
+        var observer = SilentTrackObserver()
+        _ = observer.observe(ages(energy: 60.0))
+        _ = observer.observe(ages(energy: 0.02))
+        _ = observer.observe(ages(energy: 12.0))
+        _ = observer.observe(ages(energy: 0.02))
+        XCTAssertEqual(observer.longestZeroRun, 60.0)
+        XCTAssertEqual(observer.zeroRuns, 2)
+    }
+
+    // MARK: - The two failures it must not claim
+
+    func testAChannelSilentSinceTheFirstBufferIsNeverAnEdge() {
+        // Zeroes from the very first buffer is the signature of a tap that was
+        // never allowed to hear the app (issue #524). It is a different failure
+        // with a different fix, and reporting it here would bury the one this
+        // observer is for.
+        var observer = SilentTrackObserver()
+        for buffer in stride(from: 0.01, through: 300.0, by: 10.0) {
+            XCTAssertNil(observer.observe(ages(energy: nil)), "\(buffer)")
+        }
+        XCTAssertEqual(observer.zeroRuns, 0)
+        XCTAssertFalse(observer.inZeroRun)
+    }
+
+    func testBuffersStoppingIsNotAZeroRun() {
+        // A tap that stopped delivering is not a tap delivering zeroes. The
+        // capture layer reports that one as noBuffers, and a rebuild triggered
+        // off this observer would be answering the wrong question.
+        var observer = SilentTrackObserver()
+        _ = observer.observe(ages(energy: 0.5))
+        XCTAssertNil(observer.observe(ages(energy: 30.0, buffer: 30.0)))
+        XCTAssertNil(observer.observe(ages(energy: 40.0, buffer: nil)))
+        XCTAssertEqual(observer.zeroRuns, 0)
+    }
+
+    func testARunEndedByBuffersStoppingDoesNotReportAnExit() {
+        var observer = SilentTrackObserver()
+        _ = observer.observe(ages(energy: 11.0))
+        XCTAssertNil(
+            observer.observe(ages(energy: 35.0, buffer: 25.0)),
+            "the transport died; that is not signal coming back",
+        )
+        XCTAssertTrue(observer.inZeroRun, "and the run is still open")
+    }
+
+    // MARK: - Bounds
+
+    func testTheEdgeLogIsCappedButTheCountersKeepGoing() {
+        var observer = SilentTrackObserver()
+        var events = 0
+        // Ten full cycles is twenty edges, exactly the cap.
+        for _ in 0 ..< 10 {
+            if observer.observe(ages(energy: 11.0)) != nil { events += 1 }
+            if observer.observe(ages(energy: 0.02)) != nil { events += 1 }
+        }
+        XCTAssertEqual(events, SilentTrackObserver.maxEdgesPerRecording)
+
+        // An eleventh cycle is silent in the log ...
+        XCTAssertNil(observer.observe(ages(energy: 11.0)))
+        XCTAssertNil(observer.observe(ages(energy: 0.02)))
+        // ... but the stop summary still counts it, which is the point of the
+        // cap: bound the log, not the evidence.
+        XCTAssertEqual(observer.zeroRuns, 11)
+    }
+}


### PR DESCRIPTION
Part of #672 (the instrumentation). The corrected notification text is #681. The watchdog that issue also describes is deliberately **not** here, for the reason the issue itself gives: it is gated on the diagnosis in #671, which is still open.

## Why

A process tap can deliver a full-length file of digital silence while its IOProc keeps firing. Nothing in the capture library noticed. The app layer eventually tells the user (`ChannelFaultMonitor` reports `digitalSilence` after a debounce), but the library is where the tap's own state can be read, and it saw nothing. In the field case the app track ran 1193 of 1194 seconds at exact zeros with buffers delivered throughout, and the only evidence anyone had afterwards was the finished file.

This adds the sensor. What it logs is the evidence needed to tell two stories apart: a tap whose data path died, and a meeting app that moved its output to a path the tap does not follow.

## What is logged

Three moments, one line per tapped process: at tap start, when a zero run begins or ends, and at stop. Plus a per-recording summary.

Two CoreAudio properties, and it is worth being precise about what each buys:

* `kAudioProcessPropertyIsRunningOutput` separates a dead tap from a process that rendered nothing at all. It does **not** separate a muted or silent far end from a dead tap, because a stream rendering zeroes still reports true. That limit is why this is instrumentation and not a trigger, and it is the objection the external report of the same signature raised against this property.
* `kAudioProcessPropertyDevices` on the output scope says whether the process's output went to the output device or into some other device, such as a voice-processing aggregate. That is the distinction the field case turns on.

## Three decisions worth reviewing

**Where the reads run.** Not the write queue: that is the IOProc's delivery queue, and `AppTapSession.destroy()` drains it with a `sync`, so a HAL read wedged there would wedge every capture teardown and restart behind it, which is the shape of issue #588. Not the main queue, for the same reason one step worse. Not `restartQueue`, which is budgeted for work that owns HAL resources. A dedicated queue, with one read in flight at a time, so a read that never returns costs one parked thread rather than a pile. A refused read is reported through the same sink rather than swallowed, because if the outstanding one is wedged then every later probe is refused for the whole recording, and silence would leave a log that is merely missing.

**The dispatched block holds `self` strongly**, which looks like the wrong reflex and is not. Review measured the weak version: the stop reading is asked for by `AppAudioCapture`, whose owner releases it a few statements later, before the utility queue runs the block, so the guard found nothing and **one probe in two thousand reported**. That is the one reading this whole feature exists to produce. Holding `self` costs a queue, two closures and a lock for as long as the read takes, which is the lifetime a wedged read already had. The acceptance test releases the last reference immediately after asking and times out against the weak version.

**Not gated on Verbose Audio Logging.** The library's convention is that per-buffer forensics are gated and that one triage line per recording is not: the existing `App audio tap: N PID(s)` line is unconditional precisely so a silent-track report can be triaged without the user having enabled logging beforehand, which nobody can do retroactively. These are bounded rather than per-buffer: two lines per process at start and stop, plus at most twenty edges. The 5 s cadence line keeps its gate.

**The summary hangs off `stop()`, not `stopCapture()`.** A device-change restart calls `stopCapture()` too, so a summary there would claim "at stop" mid-recording and stay silent on the give-up path, whose zero-run history is the one that matters most. The counters span restarts rather than resetting per tap: the question is whether *this recording's* app track went silent.

Its processes come from what the last adoption remembered, not from the live tap session. Review found the difference matters: `.stopAndRetry` clears the session before any restart attempt launches and only adoption puts one back, so on every give-up and mid-restart stop the session is nil and the line said "no tapped processes" for exactly the recordings worth having it for.

## What is not covered

The three log call sites themselves. The observer's decision and the probe's queueing are both pinned directly, but reaching a zero run through the live path needs the mach clock to advance ten seconds and there is no clock seam on the level publisher. Adding one would have widened production surface to pin log statements, which is the wrong trade for a diagnostic.

## Known, deliberately not in this PR

* **The 5 s throttle is in the wrong object.** `DebugRMSReporter.tick()` fuses a cadence gate with an accumulator drain, and both consumers want only the gate. The visible symptom is that the RMS logging function now takes the tapped processes. Splitting the cadence out as its own type would let the IOProc ask once and call the two consumers as peers; it touches the microphone handler's sibling, so it is its own change.
* **The observer will need corroboration when the actuator lands.** Zeroes on both channels is a quiet meeting, not a dead tap. `AudioCaptureSession` already exposes both channels' ages, so the signal is reachable; adding a parameter no caller uses today would be speculative.
* **The per-edge probe could log only its delta from the start baseline.** A five-process tap with many zero runs produces more unconditional lines than the two-line precedent.

## Verification

* `swift test --parallel` green in both packages.
* `./scripts/lint.sh` clean.
* `./scripts/pre-push.sh` (release-mode parity) passed.
