### PR TITLE
fix(app): clear the probe guard before the sink reports the read

### DIFF
--- a/tools/audiotap/Sources/SilentTrackDiagnostics.swift
+++ b/tools/audiotap/Sources/SilentTrackDiagnostics.swift
@@ -110,10 +110,16 @@ final class SilentTrackDiagnostics: @unchecked Sendable {
         // time. Holding self here costs a queue, two closures and a lock until
         // the read returns, which is the same lifetime a wedged read already has.
         queue.async {
-            self.sink(reason, .read(self.probe(processes)))
-            // After the sink, so a caller waiting for the flag to clear cannot
-            // observe it clear before the result was reported.
+            let states = self.probe(processes)
+            // Cleared as soon as the read is back, before the sink hears of it,
+            // so the guard means exactly what `Outcome.skipped` says: a read
+            // still inside coreaudiod, never a line still being written. A
+            // caller the sink wakes can therefore start the next probe straight
+            // away. Reads still never overlap, since the queue is serial; the
+            // flag only ever bounds how many blocks a wedged read can collect
+            // behind it, and a clear the read must return to reach keeps that.
             self.state.withLock { $0.probeInFlight = false }
+            self.sink(reason, .read(states))
         }
         return true
     }

--- a/tools/audiotap/Tests/SilentTrackDiagnosticsTests.swift
+++ b/tools/audiotap/Tests/SilentTrackDiagnosticsTests.swift
@@ -49,23 +49,36 @@ final class SilentTrackDiagnosticsTests: XCTestCase {
     }
 
     func testAProbeCanRunAgainOnceTheFirstReturned() {
+        // The sink is the only word a caller gets that a read has returned, so
+        // the guard must already be open when it fires: whoever the sink wakes
+        // starts the next probe straight away, with no waiting and no retry.
+        // The sink is held open while the test asks, so what is asserted is the
+        // guard's state at the moment the sink fires, not who wins a race
+        // against the block returning. Waking from the sink and then asking
+        // won that race every time even with the clear after the sink, so that
+        // shape pins nothing; this one is refused every time under that order.
         let spy = ProbeSpy()
-        let done = expectation(description: "both probes reported")
-        done.expectedFulfillmentCount = 2
-        let diagnostics = SilentTrackDiagnostics(probe: spy.probe(hold: false)) { _, _ in
-            done.fulfill()
+        let firstReported = DispatchSemaphore(value: 0)
+        let secondRequested = DispatchSemaphore(value: 0)
+        let secondReported = DispatchSemaphore(value: 0)
+        let diagnostics = SilentTrackDiagnostics(probe: spy.probe(hold: false)) { reason, outcome in
+            guard case .read = outcome else { return }
+            if reason == "first" {
+                firstReported.signal()
+                secondRequested.wait()
+            } else {
+                secondReported.signal()
+            }
         }
 
         XCTAssertTrue(diagnostics.probeAsync(processes, reason: "first"))
-        XCTAssertEqual(spy.entered.wait(timeout: .now() + 2), .success)
-        // Wait for the in-flight flag to clear, which happens after the sink.
-        var restarted = false
-        for _ in 0 ..< 100 where !restarted {
-            restarted = diagnostics.probeAsync(processes, reason: "second")
-            if !restarted { usleep(20000) }
-        }
-        XCTAssertTrue(restarted, "the guard must clear when the probe returns")
-        wait(for: [done], timeout: 5)
+        XCTAssertEqual(firstReported.wait(timeout: .now() + 5), .success, "the first read reached the sink")
+        let restarted = diagnostics.probeAsync(processes, reason: "second")
+        secondRequested.signal()
+        XCTAssertTrue(restarted, "the guard must be open by the time the sink reports the read")
+        guard restarted else { return }
+        XCTAssertEqual(secondReported.wait(timeout: .now() + 5), .success, "the second read reached the sink")
+        XCTAssertEqual(spy.calls, 2)
     }
 
     func testTheReasonReachesTheSink() {


### PR DESCRIPTION
Unbreaks `main`. The `Quality & Safety` sanitiser lane aborts on it right now.

## What is failing

`AudioTapLibTests.SilentTrackDiagnosticsTests/testAProbeCanRunAgainOnceTheFirstReturned` exits with signal 6. It is **not** a data race, and there is no ThreadSanitizer report in the log. XCTest raises

```
API violation - multiple calls made to -[XCTestExpectation fulfill]
```

which is an `NSInternalInconsistencyException`, and under one process per test method that is the abort the runner reports.

The test polled `probeAsync` in a `usleep` loop until the in-flight flag cleared, counted every sink outcome against an expectation of two, and each refusal the loop provoked reached the same sink as `.skipped`. On a machine slow enough not to drain the queue between two iterations, that over-fulfilled: a read plus a skip satisfied the wait, the method returned, and the second read's `fulfill` landed afterwards. Hence flaky rather than broken, and green twice before, including a nightly.

## Why the ordering, not just the accounting

The poll loop existed because of the production ordering. `probeAsync` cleared `probeInFlight` **after** calling the sink, with a comment saying a caller waiting for the flag must not see it clear before the result was reported.

No production caller waits for that flag. All three call sites discard the returned `Bool`, and the flag is private. The only thing that ever polled it was this test, which was timing-dependent for it. The production behaviour existed for the test.

So the flag is now cleared as soon as the read returns, before the sink hears of it. That makes the guard mean exactly what `Outcome.skipped` documents, a read still inside coreaudiod rather than a log line still being written, and it lets whoever the sink wakes start the next probe immediately.

Nothing else about the guard changes. The queue is serial, so two reads never overlapped; the flag was only ever admission control, bounding how many blocks a wedged read can collect behind it. The clear still runs only after the read returns, so a read that never comes back still closes admission for good. **The one measurable difference:** the bound on queued blocks goes from one to two, since one more probe can be admitted while the previous sink is still running. Bounded either way, and unchanged in the wedged case the guard exists for.

## The test now pins that ordering, which nothing did before

It holds the sink open while asking for the second probe, so what it asserts is the guard's state at the moment the sink fires, not who wins a race against the block returning.

That shape is the point. The obvious alternative, wait for the sink and then ask, **passed 30 of 30 runs against the old ordering**, because the clear runs microseconds after the sink returns while the test thread is still waking up. Held open, the old ordering is refused every time:

```
error: ... XCTAssertTrue failed - the guard must be open by the time the sink reports the read
```

No loop, no `usleep`, no expectation. The timing dependence is gone rather than reduced.

## Verification

* `swift test --parallel --sanitize=thread` in `tools/audiotap`: 325 tests, exit 0, no ThreadSanitizer reports. That is the lane that fails on `main`.
* `swift test --parallel` green in both packages.
* `./scripts/lint.sh` clean.
* `./scripts/pre-push.sh` passed.
* Mutation: restoring the old ordering fails the new test with the message above, in a separate worktree.