### PR TITLE
fix(ci): decide each sanitizer leg's verdict and its reason in one place

### DIFF
--- a/.github/workflows/quality-and-safety.yml
+++ b/.github/workflows/quality-and-safety.yml
@@ -512,39 +512,70 @@ jobs:
             exit 0
           fi
           # Which legs this event should have run; mirrors the legs' `if:`.
+          # Whether a leg was expected and why are decided together, in one
+          # arm per event. They used to be decided in two switches over the
+          # same variable, and the two disagreed: the why-chain knew only the
+          # pull_request case, so a push or nightly run, where TSan is asked
+          # unconditionally and the diff step never runs, fell through to the
+          # "not asked" wording and printed the self-contradicting row
+          # "passed (not asked: ...)". One arm per event is what keeps the
+          # verdict and its explanation from drifting apart again.
           expect_asan=false
           expect_tsan=false
           not_run_reason=""
+          tsan_why=""
           case "$EVENT" in
             push|schedule)
               expect_asan=true
               expect_tsan=true
+              tsan_why="asked unconditionally on $EVENT"
               ;;
             workflow_dispatch)
+              tsan_why="workflow_dispatch with run-sanitizer=$DISPATCH_SANITIZER"
               if [ "$DISPATCH_SANITIZER" = "true" ]; then
                 expect_asan=true
                 expect_tsan=true
               else
-                not_run_reason="workflow_dispatch with run-sanitizer=false"
+                not_run_reason="$tsan_why"
               fi
               ;;
             pull_request)
               if [ "$SAME_REPO" = "true" ]; then
                 expect_asan=true
+                # Both branches read tsan-relevant, never the reason text as a
+                # stand-in for it. Reading `-n "$TSAN_REASON"` here would be
+                # the same defect once more: the `changes` job writes the two
+                # outputs from one variable today, so they cannot disagree,
+                # but a future arm that sets the flag without a sentence would
+                # bring "passed (not asked: ...)" straight back.
                 if [ "$LABELLED" = "true" ] || [ "$TSAN_RELEVANT" = "true" ]; then
                   expect_tsan=true
                 fi
+                if [ "$LABELLED" = "true" ] && [ "$TSAN_RELEVANT" = "true" ]; then
+                  tsan_why="run-quality label; $TSAN_REASON"
+                elif [ "$LABELLED" = "true" ]; then
+                  tsan_why="run-quality label"
+                elif [ "$TSAN_RELEVANT" = "true" ]; then
+                  tsan_why="$TSAN_REASON"
+                else
+                  tsan_why="not asked: no run-quality label, no concurrency primitive on the changed source lines, no package manifest or sanitizer workflow change"
+                fi
               else
                 not_run_reason="fork PR: sanitizer legs never run fork code (self-hosted runner, unlocked CI keychain)"
+                tsan_why="$not_run_reason"
               fi
               ;;
+            *)
+              tsan_why="event '$EVENT' not understood"
+              ;;
           esac
-          if [ "$LABELLED" = "true" ]; then
-            tsan_why="run-quality label"
-          elif [ -n "$TSAN_REASON" ]; then
-            tsan_why="$TSAN_REASON"
-          else
-            tsan_why="not asked: no run-quality label, no concurrency primitive on the changed source lines, no package manifest or sanitizer workflow change"
+          # Every arm above leaves a sentence behind. A leg reporting success
+          # with no reason would print an empty "passed ()", which reads like a
+          # bug in the gate rather than an answer, and the arms that cannot run
+          # a leg today are exactly the ones a later change to the fork guard
+          # or the trigger list would make reachable.
+          if [ -z "$tsan_why" ]; then
+            tsan_why="no reason recorded, which is a bug in this job"
           fi
 
           failed=0


### PR DESCRIPTION
The `sanitizer-gate` job from #689 prints a table saying which sanitizer legs ran and why. Its reason chain described only the `pull_request` case, so on a push, a nightly or a dispatch, where the diff step never runs and no label is present, it fell through to its "not asked" wording. The first push run after the gate landed (run 34142836098, `main` at 0f41fcc1) printed:

```
| TSan | passed (not asked: no run-quality label, no concurrency primitive on the changed source lines, no package manifest or sanitizer workflow change) |
```

That contradicts itself. TSan is asked unconditionally on those events, and it had just run and passed. The table exists to say truthfully which legs ran, so a row reading as both passed and never asked is the one defect this job cannot afford: it teaches a reader to discount the wording exactly where #688 needs them to trust it.

## Why this is a fold, not a patch

The first version of this fix put an event switch in front of the chain. That left two switches over `github.event_name` deciding the same thing, one for whether a leg was expected and one for how to explain it. Both reviews said fold them, and they were right: the split had already produced this bug once, and a second instance was sitting latent beside it. The expectation reads `tsan-relevant`; the wording read whether `tsan-reason` was non-empty. Those two outputs agree only because the `changes` job writes them from a single variable. Any future arm that set the flag without a sentence would have brought `passed (not asked: ...)` straight back, this time on a pull request.

So each `case` arm now sets `expect_asan`, `expect_tsan` and the reason together. Both `pull_request` branches read `tsan-relevant` rather than the reason text as a proxy for it. And no arm can leave the reason empty: the fork arm carries the fork sentence, an unrecognised event says so, and a final guard names a missing reason as a bug in this job instead of printing `passed ()`.

## Verification

The gate's script was extracted from this commit and from `origin/main` and both were run over 2048 combinations of event, same-repo, label, dispatch input, `changes` result and both leg results.

| | |
|---|---|
| differences in exit code | **0 of 2048** |
| differences in wording | 464, every one in the direction of being true |

Zero exit-code differences is the load-bearing number: the pass or fail verdict is unchanged on every input, which is the only thing that can make a required check wrongly green or red.

The wording changes are:

- push, schedule and dispatch stop claiming TSan was not asked.
- A fork PR names the fork instead of a label it does not have, or a diff reason that never applied to it.
- A PR carrying the `run-quality` label that also trips the diff arm now names both reasons instead of dropping the diff one.

An earlier draft of the fold set the reason only inside the same-repo branch, so a fork PR would have printed `passed ()`. That is unreachable while `test-tsan` excludes forks, but it is the same class of defect as the one being fixed and would have come alive the day the fork guard moved. The differential run above is what caught it.

`actionlint` clean, YAML parses, `./scripts/lint.sh` 0 violations in 534 files.

Only the gate's summary text changes. No trigger, no `if:`, no job name is touched, so what runs is identical. This PR touches the workflow file, so the manifest arm asks for TSan on it and the change is exercised by its own run. The push path it fixes can only be observed after merge, and that row will be checked then.

Refs #688
