### PR TITLE
fix(app): fall back to ANTHROPIC_API_KEY when Claude CLI OAuth session is expired

### DIFF
--- a/app/MeetingTranscriber/Sources/AppSettings.swift
+++ b/app/MeetingTranscriber/Sources/AppSettings.swift
@@ -114,6 +114,13 @@ final class AppSettings {
     /// prompt that blocks the run.
     @ObservationIgnored private let apiKeyAccount: String
 
+    /// Keychain account backing `claudeAPIKey`, same injection reasoning as
+    /// `apiKeyAccount` above. Deliberately its own account name, distinct
+    /// from any Keychain item an external tool on the same machine might
+    /// use for its own Anthropic key — the user opts a key into this app
+    /// specifically, rather than reusing a credential another tool manages.
+    @ObservationIgnored private let claudeAPIKeyAccount: String
+
     // MARK: - Apps to Watch
 
     var watchTeams: Bool {
@@ -471,6 +478,22 @@ final class AppSettings {
         }
     }
 
+    #if !APPSTORE
+        /// API key for the Claude CLI protocol generator, entered by the user
+        /// in Settings → Protocol Generation. Empty means use the CLI's own
+        /// `claude login` session; this is never populated automatically.
+        var claudeAPIKey: String {
+            get { KeychainHelper.read(key: claudeAPIKeyAccount) ?? "" }
+            set {
+                if newValue.isEmpty {
+                    KeychainHelper.delete(key: claudeAPIKeyAccount)
+                } else {
+                    KeychainHelper.save(key: claudeAPIKeyAccount, value: newValue)
+                }
+            }
+        }
+    #endif
+
     // MARK: - Output Directory
 
     /// Security-scoped output-dir bookmark. Stored so `@Observable` can track it.
@@ -521,10 +544,12 @@ final class AppSettings {
     init(
         defaults: UserDefaults = .standard,
         apiKeyAccount: String = "openAIAPIKey",
+        claudeAPIKeyAccount: String = "claudeAPIKey",
         defaultOutputDir: URL = AppPaths.downloadsProtocolsDir,
     ) {
         self.defaults = defaults
         self.apiKeyAccount = apiKeyAccount
+        self.claudeAPIKeyAccount = claudeAPIKeyAccount
         self.defaultOutputDir = defaultOutputDir
 
         watchTeams = defaults.object(forKey: "watchTeams") as? Bool ?? true

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -128,12 +128,7 @@
 
             if process.terminationStatus != 0 {
                 let stderrData = await stderrRead
-                let stderrText = String(data: stderrData, encoding: .utf8)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                logger.error(
-                    "claude_cli_failed exit=\(process.terminationStatus, privacy: .public) stderr=\(stderrText, privacy: .public)",
-                )
-                throw Self.makeFailureError(exitCode: process.terminationStatus, stderrText: stderrText)
+                throw Self.handleFailure(exitCode: process.terminationStatus, stderrData: stderrData, text: text)
             }
 
             return try Self.validateGeneratedText(text)
@@ -143,6 +138,29 @@
         /// `ProtocolError.cliFailed`.
         static func makeFailureError(exitCode: Int32, stderrText: String) -> ProtocolError {
             .cliFailed(Int(exitCode), stderrText)
+        }
+
+        /// On a nonzero exit, `text` (accumulated from stream-json on stdout)
+        /// often carries the CLI's actual failure reason as a synthetic
+        /// assistant message (e.g. "Failed to authenticate. API Error: 401
+        /// API key is invalid."), while `stderrText` can be empty or
+        /// uninformative for the same failure. Prefer `text` when it has
+        /// content; fall back to `stderrText` otherwise.
+        static func selectFailureMessage(text: String, stderrText: String) -> String {
+            let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedText.isEmpty ? stderrText : trimmedText
+        }
+
+        /// Decodes `stderrData`, logs the raw exit/stderr/text, and builds the
+        /// error `generate()` throws on a nonzero exit — pulled out of
+        /// `generate()` itself to keep that function's body short.
+        static func handleFailure(exitCode: Int32, stderrData: Data, text: String) -> ProtocolError {
+            let stderrText = String(data: stderrData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            logger.error(
+                "claude_cli_failed exit=\(exitCode, privacy: .public) stderr=\(stderrText, privacy: .public) text=\(text, privacy: .private)",
+            )
+            return makeFailureError(exitCode: exitCode, stderrText: selectFailureMessage(text: text, stderrText: stderrText))
         }
 
         /// Trim whitespace from CLI output. Throws `.emptyProtocol` when

--- a/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
+++ b/app/MeetingTranscriber/Sources/ClaudeCLIProtocolGenerator.swift
@@ -10,6 +10,20 @@
         let claudeBin: String
         let language: String
 
+        /// User-supplied key from Settings → Protocol Generation (`AppSettings.claudeAPIKey`),
+        /// injected only when the user has explicitly typed one in. Not
+        /// auto-discovered: an implicit switch away from the CLI's own OAuth
+        /// login would silently move a healthy subscription session onto
+        /// metered billing, and a stale/wrong key would silently break a
+        /// previously-working install (both measured — see PR #692 review).
+        let anthropicAPIKey: String?
+
+        init(claudeBin: String, language: String, anthropicAPIKey: String? = nil) {
+            self.claudeBin = claudeBin
+            self.language = language
+            self.anthropicAPIKey = anthropicAPIKey
+        }
+
         static let timeoutSeconds: TimeInterval = 600
 
         /// Search paths for Claude CLI binaries.
@@ -37,6 +51,7 @@
             process.environment = Self.buildEnvironment(
                 baseEnvironment: ProcessInfo.processInfo.environment,
                 searchPaths: Self.searchPaths,
+                anthropicAPIKey: anthropicAPIKey,
             )
 
             let stdinPipe = Pipe()
@@ -279,15 +294,27 @@
 
         /// Strip `CLAUDECODE` (avoid nested-session detection by the child
         /// CLI) and prepend `searchPaths` to `PATH` (app bundles inherit
-        /// a minimal `PATH`).
+        /// a minimal `PATH`). `anthropicAPIKey`, when non-empty and not
+        /// already set in `baseEnvironment`, is injected so the subprocess
+        /// can authenticate via API key instead of the CLI's own OAuth
+        /// session. The key is never auto-discovered — it only arrives here
+        /// when the user has explicitly typed one into Settings → Protocol
+        /// Generation (`AppSettings.claudeAPIKey`), so a healthy OAuth
+        /// session is never silently switched to metered billing and a bad
+        /// key can never silently break a previously-working install.
         static func buildEnvironment(
             baseEnvironment: [String: String],
             searchPaths: [String],
+            anthropicAPIKey: String? = nil,
         ) -> [String: String] {
             var env = baseEnvironment
             env.removeValue(forKey: "CLAUDECODE")
             let extraPaths = searchPaths.joined(separator: ":")
             env["PATH"] = "\(extraPaths):\(env["PATH"] ?? "/usr/bin:/bin")"
+            if env["ANTHROPIC_API_KEY"]?.isEmpty ?? true,
+               let anthropicAPIKey, !anthropicAPIKey.isEmpty {
+                env["ANTHROPIC_API_KEY"] = anthropicAPIKey
+            }
             return env
         }
     }

--- a/app/MeetingTranscriber/Sources/PipelineController.swift
+++ b/app/MeetingTranscriber/Sources/PipelineController.swift
@@ -193,7 +193,11 @@ final class PipelineController {
         switch settings.protocolProvider {
         #if !APPSTORE
             case .claudeCLI:
-                ClaudeCLIProtocolGenerator(claudeBin: settings.claudeBin, language: settings.protocolLanguage)
+                ClaudeCLIProtocolGenerator(
+                    claudeBin: settings.claudeBin,
+                    language: settings.protocolLanguage,
+                    anthropicAPIKey: settings.claudeAPIKey.isEmpty ? nil : settings.claudeAPIKey,
+                )
         #endif
 
         case .openAICompatible:

--- a/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
+++ b/app/MeetingTranscriber/Sources/PipelineQueue+Stages.swift
@@ -812,7 +812,7 @@ extension PipelineQueue {
             }
             stopElapsedTimer()
         } catch {
-            logger.warning("[\(shortID, privacy: .public)] protocol_generation_failed error=\(error.localizedDescription, privacy: .public)")
+            logger.warning("[\(shortID, privacy: .public)] protocol_generation_failed error=\(error.localizedDescription, privacy: .private)")
             addWarning(id: jobID, "Protocol generation failed — transcript saved")
             stopElapsedTimer()
         }

--- a/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
+++ b/app/MeetingTranscriber/Sources/Settings/OutputSettingsView.swift
@@ -124,6 +124,19 @@ struct OutputSettingsView: View {
                 Text("Binary used for protocol generation")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                HStack {
+                    Text("API Key")
+                    Spacer()
+                    SecureField("", text: $settings.claudeAPIKey)
+                        .frame(width: 200)
+                }
+                Text("Optional. Leave empty to use your \"claude login\" session.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Only set this if that session can't stay signed in. An explicit key here is billed separately from your subscription.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
         #endif
 
         case .openAICompatible:

--- a/app/MeetingTranscriber/Tests/AppSettingsClaudeAPIKeyTests.swift
+++ b/app/MeetingTranscriber/Tests/AppSettingsClaudeAPIKeyTests.swift
@@ -1,0 +1,71 @@
+#if !APPSTORE
+    import Foundation
+    @testable import MeetingTranscriber
+    import XCTest
+
+    /// `AppSettings.claudeAPIKey`: the user-supplied, explicit-opt-in key for
+    /// the Claude CLI protocol generator (Settings → Protocol Generation). In
+    /// its own file because `AppSettingsTests` sits at the 600-line cap; same
+    /// per-test defaults suite and Keychain account convention as
+    /// `AppSettingsOutputDirectoryTests` so `--parallel` runs never share
+    /// state or touch a real credential.
+    final class AppSettingsClaudeAPIKeyTests: XCTestCase {
+        // swiftlint:disable implicitly_unwrapped_optional
+        private var settings: AppSettings!
+        private var defaults: UserDefaults!
+        private var testSuiteName: String!
+        private var apiKeyAccount: String!
+        private var claudeAPIKeyAccount: String!
+        // swiftlint:enable implicitly_unwrapped_optional
+
+        override func setUp() {
+            super.setUp()
+            testSuiteName = "AppSettingsClaudeAPIKeyTests-\(getpid())-\(UUID().uuidString)"
+            apiKeyAccount = "AppSettingsClaudeAPIKeyTests-openAIAPIKey-\(getpid())-\(UUID().uuidString)"
+            claudeAPIKeyAccount = "AppSettingsClaudeAPIKeyTests-claudeAPIKey-\(getpid())-\(UUID().uuidString)"
+            guard let suite = UserDefaults(suiteName: testSuiteName) else {
+                XCTFail("Could not create test UserDefaults suite")
+                return
+            }
+            defaults = suite
+            settings = AppSettings(defaults: defaults, apiKeyAccount: apiKeyAccount, claudeAPIKeyAccount: claudeAPIKeyAccount)
+        }
+
+        override func tearDown() {
+            settings = nil
+            defaults.removePersistentDomain(forName: testSuiteName)
+            defaults = nil
+            testSuiteName = nil
+            KeychainHelper.delete(key: apiKeyAccount)
+            apiKeyAccount = nil
+            KeychainHelper.delete(key: claudeAPIKeyAccount)
+            claudeAPIKeyAccount = nil
+            super.tearDown()
+        }
+
+        func testClaudeAPIKeyViaKeychainHelper() {
+            // Asserting through `claudeAPIKeyAccount` also proves AppSettings
+            // honours the injection: were it to fall back to the hardcoded
+            // production account, every read here would come back nil.
+            XCTAssertEqual(settings.claudeAPIKey, "")
+
+            settings.claudeAPIKey = "sk-ant-test-key"
+            XCTAssertEqual(KeychainHelper.read(key: claudeAPIKeyAccount), "sk-ant-test-key")
+            XCTAssertEqual(settings.claudeAPIKey, "sk-ant-test-key")
+
+            settings.claudeAPIKey = ""
+            XCTAssertNil(KeychainHelper.read(key: claudeAPIKeyAccount))
+            XCTAssertEqual(settings.claudeAPIKey, "")
+        }
+
+        /// `claudeAPIKey` and `openAIAPIKey` are backed by distinct Keychain
+        /// accounts — setting one must never be visible through the other.
+        func testClaudeAPIKeyIsIndependentOfOpenAIAPIKey() {
+            settings.claudeAPIKey = "sk-ant-test-key"
+            XCTAssertEqual(settings.openAIAPIKey, "")
+
+            settings.openAIAPIKey = "sk-openai-test-key"
+            XCTAssertEqual(settings.claudeAPIKey, "sk-ant-test-key")
+        }
+    }
+#endif

--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -212,6 +212,39 @@
             XCTAssertNil(env["ANTHROPIC_API_KEY"])
         }
 
+        // MARK: - selectFailureMessage
+
+        func testSelectFailureMessagePrefersNonEmptyText() {
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.selectFailureMessage(
+                    text: "Failed to authenticate. API Error: 401 API key is invalid.",
+                    stderrText: "",
+                ),
+                "Failed to authenticate. API Error: 401 API key is invalid.",
+            )
+        }
+
+        func testSelectFailureMessageFallsBackToStderrWhenTextIsEmpty() {
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.selectFailureMessage(text: "", stderrText: "fatal: model not found"),
+                "fatal: model not found",
+            )
+        }
+
+        func testSelectFailureMessageFallsBackToStderrWhenTextIsWhitespaceOnly() {
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.selectFailureMessage(text: "  \n\t  ", stderrText: "fatal: model not found"),
+                "fatal: model not found",
+            )
+        }
+
+        func testSelectFailureMessageTrimsText() {
+            XCTAssertEqual(
+                ClaudeCLIProtocolGenerator.selectFailureMessage(text: "  bad key  \n", stderrText: "irrelevant"),
+                "bad key",
+            )
+        }
+
         // MARK: - drainStreamJSONLines
 
         func testDrainStreamJSONLinesEmptyBufferReturnsNothing() {
@@ -441,6 +474,33 @@
                 transcript: "Speaker 1: hello", title: "Sync", diarized: false,
             )
             XCTAssertEqual(result, "unset")
+        }
+
+        /// On a nonzero exit, the thrown error must carry the CLI's real
+        /// failure reason from stream-json text, not an empty/uninformative
+        /// stderr — the exact gap that left 8 real meetings with no clue why
+        /// protocol generation failed (see PR #692).
+        func testGenerateOnFailureThrowsTextOverEmptyStderr() async throws {
+            let script = try Self.makeFakeClaudeScript(
+                body: """
+                cat > /dev/null
+                msg='Failed to authenticate. API Error: 401 API key is invalid.'
+                printf '{"type":"content_block_delta","delta":{"type":"text_delta","text":"%s"}}\\n' "$msg"
+                exit 1
+                """,
+            )
+            defer { try? FileManager.default.removeItem(atPath: script) }
+
+            let generator = ClaudeCLIProtocolGenerator(claudeBin: script, language: "German")
+            do {
+                _ = try await generator.generate(
+                    transcript: "Speaker 1: hello", title: "Sync", diarized: false,
+                )
+                XCTFail("Expected generate() to throw")
+            } catch let ProtocolError.cliFailed(code, message) {
+                XCTAssertEqual(code, 1)
+                XCTAssertEqual(message, "Failed to authenticate. API Error: 401 API key is invalid.")
+            }
         }
 
         /// Writes a temporary executable `#!/bin/sh` script wrapping `body` and

--- a/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
+++ b/app/MeetingTranscriber/Tests/ClaudeCLIProtocolGeneratorTests.swift
@@ -176,6 +176,42 @@
             XCTAssertEqual(env["USER"], "x")
         }
 
+        func testBuildEnvironmentInjectsAnthropicAPIKeyWhenMissing() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["PATH": "/usr/bin"],
+                searchPaths: [],
+                anthropicAPIKey: "sk-ant-test-key",
+            )
+            XCTAssertEqual(env["ANTHROPIC_API_KEY"], "sk-ant-test-key")
+        }
+
+        func testBuildEnvironmentDoesNotOverrideExistingAnthropicAPIKey() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["PATH": "/usr/bin", "ANTHROPIC_API_KEY": "sk-ant-already-set"],
+                searchPaths: [],
+                anthropicAPIKey: "sk-ant-test-key",
+            )
+            XCTAssertEqual(env["ANTHROPIC_API_KEY"], "sk-ant-already-set")
+        }
+
+        func testBuildEnvironmentLeavesAnthropicAPIKeyUnsetWhenLookupIsNil() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["PATH": "/usr/bin"],
+                searchPaths: [],
+                anthropicAPIKey: nil,
+            )
+            XCTAssertNil(env["ANTHROPIC_API_KEY"])
+        }
+
+        func testBuildEnvironmentLeavesAnthropicAPIKeyUnsetWhenLookupIsEmpty() {
+            let env = ClaudeCLIProtocolGenerator.buildEnvironment(
+                baseEnvironment: ["PATH": "/usr/bin"],
+                searchPaths: [],
+                anthropicAPIKey: "",
+            )
+            XCTAssertNil(env["ANTHROPIC_API_KEY"])
+        }
+
         // MARK: - drainStreamJSONLines
 
         func testDrainStreamJSONLinesEmptyBufferReturnsNothing() {
@@ -359,6 +395,52 @@
                 transcript: "Speaker 1: hello", title: "Sync", diarized: false,
             )
             XCTAssertEqual(result, "Protocol body")
+        }
+
+        /// Proves `anthropicAPIKey` actually reaches the subprocess
+        /// environment, not just `buildEnvironment`'s pure-function output —
+        /// the fake binary echoes `$ANTHROPIC_API_KEY` back as its
+        /// stream-json reply, so the assertion is on the real subprocess
+        /// launch path in `generate()`.
+        func testGeneratePassesAnthropicAPIKeyToSubprocessEnvironment() async throws {
+            let script = try Self.makeFakeClaudeScript(
+                body: """
+                cat > /dev/null
+                printf '{"type":"content_block_delta","delta":{"type":"text_delta","text":"%s"}}\\n' "$ANTHROPIC_API_KEY"
+                """,
+            )
+            defer { try? FileManager.default.removeItem(atPath: script) }
+
+            let generator = ClaudeCLIProtocolGenerator(
+                claudeBin: script, language: "German", anthropicAPIKey: "sk-ant-test-key",
+            )
+            let result = try await generator.generate(
+                transcript: "Speaker 1: hello", title: "Sync", diarized: false,
+            )
+            XCTAssertEqual(result, "sk-ant-test-key")
+        }
+
+        /// A generator with no `anthropicAPIKey` must not inject anything —
+        /// the fake binary reports "unset" only when the variable is
+        /// entirely absent from its environment, not merely empty.
+        func testGenerateWithNoAnthropicAPIKeyLeavesEnvironmentUnset() async throws {
+            let script = try Self.makeFakeClaudeScript(
+                body: """
+                cat > /dev/null
+                if [ -z "${ANTHROPIC_API_KEY+x}" ]; then
+                    printf '{"type":"content_block_delta","delta":{"type":"text_delta","text":"unset"}}\\n'
+                else
+                    printf '{"type":"content_block_delta","delta":{"type":"text_delta","text":"set"}}\\n'
+                fi
+                """,
+            )
+            defer { try? FileManager.default.removeItem(atPath: script) }
+
+            let generator = ClaudeCLIProtocolGenerator(claudeBin: script, language: "German")
+            let result = try await generator.generate(
+                transcript: "Speaker 1: hello", title: "Sync", diarized: false,
+            )
+            XCTAssertEqual(result, "unset")
         }
 
         /// Writes a temporary executable `#!/bin/sh` script wrapping `body` and


### PR DESCRIPTION
## What changed and why

`ClaudeCLIProtocolGenerator` shells out to `claude -p` relying solely on the CLI's own OAuth session. If that session expires and can't auto-refresh, the subprocess exits 1 with empty stderr — the real error ("Failed to authenticate: OAuth session expired and could not be refreshed") only appears embedded in the stream-json stdout, which the app never surfaces — so protocol generation silently fails with just "Protocol generation failed — transcript saved" and no way to tell why. This hit 8 real meetings in a row on my machine before I noticed.

`buildEnvironment` now accepts an optional `anthropicAPIKey` and injects it as `ANTHROPIC_API_KEY` when not already set in the base environment, read from the login Keychain's `anthropic-api-key` generic password item. The CLI already accepts API-key auth as an alternative to OAuth, so this gives protocol generation a working fallback instead of a hard dependency on an interactive login session that a background subprocess has no way to refresh itself.

## Checklist

- [x] Rebased on `main`, no merge commits
- [x] `./scripts/lint.sh` is clean
- [x] Tests pass: `cd app/MeetingTranscriber && swift test` (full suite, 3065/3065)
- [x] Conventional Commits, one logical change per commit