### PR TITLE
fix(build): choose the signing identity that TCC grants are recorded against

### DIFF
--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -532,10 +532,13 @@ else
         cp -R "$DEV_BUNDLE_BUILD" "$DEV_BUNDLE_DEPLOY"
     fi
 
-    # Re-sign with our stable identity. run_app.sh signs with whatever
-    # `find-identity -v | head -1` returns (often ad-hoc on CI hosts), so
-    # without re-signing TCC would see a different cert SHA on every
-    # rebuild and lose the grant. CI path uses the imported Developer ID;
+    # Re-sign with our stable identity. run_app.sh signs with what
+    # choose_signing_identity picks from the build host's keychain: the
+    # certificate the bundle already carried, else a Developer ID, else the
+    # first identity listed, and nothing at all on an empty keychain. That
+    # choice follows the host's keychain while this lane's grants follow one
+    # certificate, so the deployed copy is put on that certificate here
+    # whatever the build chose. CI path uses the imported Developer ID;
     # local-dev path falls back to the self-signed cert from
     # setup-self-hosted-runner.sh. resign_deployed_bundle carries the dev
     # entitlements through that re-sign, and skips it entirely when the build

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -94,8 +94,7 @@ prepare_signing() {
     # profiles list the Developer ID Application certificate, so prefer that
     # over whatever `security find-identity` happens to return first.
     local devid
-    devid="$(security find-identity -v -p codesigning 2>/dev/null \
-        | grep "Developer ID Application" | head -1 | awk '{print $2}')" || true
+    devid="$(codesigning_identities | identity_fields | first_developer_id)"
     if [ -n "$devid" ]; then
         SIGNING_IDENTITY="$devid"
     else
@@ -235,30 +234,28 @@ bundle_signing_cert_sha1() {
 #      the deployed copy with dev_signing_identity anyway, so this choice
 #      decides nothing there.
 #
-# Only lines of the form `N) <sha1> "<name>"` count as identities. An empty
-# keychain answers `0 valid identities found`, and `head -1 | awk '{print $2}'`
-# over that used to hand the word `valid` to codesign as the identity.
+# The identities are read through codesigning_identities, identity_fields and
+# first_developer_id below, so this and prepare_signing answer "which one is
+# the Developer ID" the same way.
 #
 # shellcheck disable=SC2034  # CHOSEN_IDENTITY* are read by callers
 choose_signing_identity() {
-    local bundle="$1" previous identities devid
+    local bundle="$1" previous listing fields devid carried
     CHOSEN_IDENTITY=""
     CHOSEN_IDENTITY_REASON=""
     CHOSEN_IDENTITY_LISTING=""
 
     previous="$(bundle_signing_cert_sha1 "$bundle")"
-    # `|| true`: a keychain that cannot be read is a normal answer (empty), not
-    # a failure, the trap documented at profile_for. The awk keeps only real
-    # identity lines, so the trailer cannot be mistaken for one; `length` rather
-    # than a `{40}` interval because the system awk does not promise the latter.
-    identities="$(security find-identity -v -p codesigning 2>/dev/null \
-        | awk '$1 ~ /^[0-9]+\)$/ && length($2) == 40 && $2 ~ /^[0-9A-Fa-f]+$/ { sub(/^[ \t]+/, ""); print }' \
-        || true)"
-    devid="$(printf '%s\n' "$identities" | grep 'Developer ID Application' | head -1 | awk '{print $2}' || true)"
+    listing="$(codesigning_identities)"
+    fields="$(printf '%s\n' "$listing" | identity_fields)"
+    devid="$(printf '%s\n' "$fields" | first_developer_id)"
+    # The carried certificate's record: empty when the bundle is unsigned or
+    # the certificate has left the keychain, and either way there is nothing
+    # to keep.
+    carried="$(printf '%s\n' "$fields" | awk -v h="$previous" 'h != "" && $1 == h')"
 
-    if [ -n "$previous" ] && printf '%s\n' "$identities" | grep -q "$previous"; then
-        if [ -z "$devid" ] \
-            || printf '%s\n' "$identities" | grep "$previous" | grep -q 'Developer ID Application'; then
+    if [ -n "$carried" ]; then
+        if [ -z "$devid" ] || [ -n "$(printf '%s\n' "$carried" | first_developer_id)" ]; then
             CHOSEN_IDENTITY="$previous"
             CHOSEN_IDENTITY_REASON="kept the certificate this bundle already carried"
         fi
@@ -268,16 +265,63 @@ choose_signing_identity() {
         CHOSEN_IDENTITY_REASON="chose the Developer ID Application certificate"
     fi
     if [ -z "$CHOSEN_IDENTITY" ]; then
-        CHOSEN_IDENTITY="$(printf '%s\n' "$identities" | head -1 | awk '{print $2}' || true)"
+        CHOSEN_IDENTITY="$(printf '%s\n' "$fields" | awk 'NF { print $1; exit }')"
         if [ -n "$CHOSEN_IDENTITY" ]; then
             CHOSEN_IDENTITY_REASON="no Developer ID Application certificate exists, took the first identity"
             echo "  NOTE: TCC grants made against a different certificate will not apply to this build."
         fi
     fi
     if [ -n "$CHOSEN_IDENTITY" ]; then
-        CHOSEN_IDENTITY_LISTING="$(printf '%s\n' "$identities" | grep "$CHOSEN_IDENTITY" || true)"
+        CHOSEN_IDENTITY_LISTING="$(printf '%s\n' "$listing" | awk -v h="$CHOSEN_IDENTITY" 'toupper($2) == h')"
     fi
     return 0
+}
+
+# codesigning_identities → what `security find-identity -v -p codesigning`
+# lists, one record per line, leading whitespace removed.
+#
+# Only records of the form `N) <sha1> "<name>"` count. An empty keychain
+# answers `0 valid identities found`, and `head -1 | awk '{print $2}'` over
+# that used to hand the word `valid` to codesign as the identity. The name is
+# required along with the hash, not merely described: the rules classify an
+# identity by its name and the log prints it, so a record without one could
+# only ever reach the last-resort rule with nothing to say for itself. The
+# real tool never prints such a record, so the check costs nothing there and
+# keeps the shape stated here true in one place.
+#
+# `length` rather than a `{40}` interval because the system awk does not
+# promise the latter. `|| true`: a keychain that cannot be read is a normal
+# answer (empty), not a failure, the trap documented at profile_for.
+codesigning_identities() {
+    security find-identity -v -p codesigning 2>/dev/null \
+        | awk '$1 ~ /^[0-9]+\)$/ && length($2) == 40 && $2 ~ /^[0-9A-Fa-f]+$/ &&
+               $3 ~ /^"/ && $NF ~ /"$/ { sub(/^[ \t]+/, ""); print }' \
+        || true
+}
+
+# identity_fields: those records on stdin → `<SHA1> <name>` per line, the hash
+# upper-cased, the name without its quotes (everything between the first and
+# the last, so a name with spaces, parentheses or a quote inside survives).
+# The hash is then a whole field and the name starts at a fixed column, so a
+# rule compares the one exactly and anchors on the other, instead of grepping
+# the line, where a name that merely CONTAINS a phrase, or a hash that happens
+# to occur inside a name, would match as well.
+identity_fields() {
+    awk 'NF { name = $0; sub(/^[^"]*"/, "", name); sub(/"[^"]*$/, "", name)
+              print toupper($2) " " name }'
+}
+
+# first_developer_id: identity_fields records on stdin → SHA-1 of the first
+# whose name IS a Developer ID Application certificate's, i.e. begins with
+# `Developer ID Application: `, the form Apple issues (`Developer ID
+# Application: <holder> (<team>)`). Anchored on purpose, where identity_sha1
+# below is deliberately a substring: that one resolves a name the way codesign
+# does, this one decides which certificate the grants belong to, and a
+# self-signed certificate is named by whoever makes it (see
+# setup-self-hosted-runner.sh), so `Archive of Developer ID Application: ...`
+# listed first must not win. Column 42: forty hex digits and one space.
+first_developer_id() {
+    awk 'substr($0, 42) ~ /^Developer ID Application: / { print $1; exit }'
 }
 
 # identity_sha1 <identity> [keychain]

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -184,6 +184,102 @@ bundle_signing_cert_sha1() {
     printf '%s' "$hash"
 }
 
+# choose_signing_identity <app-bundle>
+#
+# Which certificate to sign a dev bundle with so TCC keeps the grants it has
+# already made against that bundle. Sets three globals:
+#   CHOSEN_IDENTITY          SHA-1 of the certificate to sign with; empty when
+#                            the keychain holds no codesigning identity. What
+#                            that means for the bundle is each caller's call
+#   CHOSEN_IDENTITY_REASON   the rule that chose it, one phrase for the log
+#   CHOSEN_IDENTITY_LISTING  its `security find-identity` line(s), leading
+#                            whitespace removed, so the log can name the
+#                            certificate instead of only hashing it
+#
+# Globals rather than stdout, as with prepare_signing: three values, and one
+# keychain query behind all of them.
+#
+# Call it BEFORE the bundle is touched. The certificate of the previous build
+# lives in the main executable's embedded signature, and copying a freshly
+# linked binary over that executable leaves an ad-hoc signature with no
+# certificate in it. Measured: the intact bundle yields the hash, the same
+# bundle after the copy yields nothing. Called after the copy this function is
+# not wrong, only blind: it can never take rule 1 and falls through to rules 2
+# and 3, which costs the renewal case described at rule 1 and, on a keychain
+# without a Developer ID, moves a bundle whose certificate was fine to
+# whatever happens to be listed first.
+#
+# TCC binds a grant to the signing certificate's leaf SHA-1, so the choice made
+# here decides whether the dev app keeps its microphone and screen-recording
+# grants or silently loses all of them: the rebuilt app then records nothing,
+# with no error anywhere and no prompt, because from TCC's point of view it is
+# a different application. `head -1` over the keychain made that depend on
+# listing order, and the order changed under us the day an Apple Development
+# certificate was added. Hence, in order:
+#
+#   1. Keep the certificate the bundle already carries, while it is still in
+#      the keychain AND it is either a Developer ID one or there is no
+#      Developer ID to move to. Two valid Developer ID Application
+#      certificates (the overlap around a renewal) would otherwise put us back
+#      to "whichever is listed first", and switching between them voids the
+#      grants just as thoroughly as switching issuer would. The second half of
+#      the condition matters: a bundle signed with Apple Development before
+#      this rule existed would be pinned to the wrong certificate forever by
+#      "keep what is there" alone, with the only escape being to delete the
+#      bundle by hand. With it, such a bundle moves to Developer ID by itself.
+#   2. Otherwise the Developer ID Application certificate, the one the grants
+#      on a maintainer's machine were made against.
+#   3. Otherwise the first identity listed, with a note that grants made
+#      against a different certificate will not apply. A self-hosted runner
+#      holding only its self-signed certificate lands here; its lanes re-sign
+#      the deployed copy with dev_signing_identity anyway, so this choice
+#      decides nothing there.
+#
+# Only lines of the form `N) <sha1> "<name>"` count as identities. An empty
+# keychain answers `0 valid identities found`, and `head -1 | awk '{print $2}'`
+# over that used to hand the word `valid` to codesign as the identity.
+#
+# shellcheck disable=SC2034  # CHOSEN_IDENTITY* are read by callers
+choose_signing_identity() {
+    local bundle="$1" previous identities devid
+    CHOSEN_IDENTITY=""
+    CHOSEN_IDENTITY_REASON=""
+    CHOSEN_IDENTITY_LISTING=""
+
+    previous="$(bundle_signing_cert_sha1 "$bundle")"
+    # `|| true`: a keychain that cannot be read is a normal answer (empty), not
+    # a failure, the trap documented at profile_for. The awk keeps only real
+    # identity lines, so the trailer cannot be mistaken for one; `length` rather
+    # than a `{40}` interval because the system awk does not promise the latter.
+    identities="$(security find-identity -v -p codesigning 2>/dev/null \
+        | awk '$1 ~ /^[0-9]+\)$/ && length($2) == 40 && $2 ~ /^[0-9A-Fa-f]+$/ { sub(/^[ \t]+/, ""); print }' \
+        || true)"
+    devid="$(printf '%s\n' "$identities" | grep 'Developer ID Application' | head -1 | awk '{print $2}' || true)"
+
+    if [ -n "$previous" ] && printf '%s\n' "$identities" | grep -q "$previous"; then
+        if [ -z "$devid" ] \
+            || printf '%s\n' "$identities" | grep "$previous" | grep -q 'Developer ID Application'; then
+            CHOSEN_IDENTITY="$previous"
+            CHOSEN_IDENTITY_REASON="kept the certificate this bundle already carried"
+        fi
+    fi
+    if [ -z "$CHOSEN_IDENTITY" ] && [ -n "$devid" ]; then
+        CHOSEN_IDENTITY="$devid"
+        CHOSEN_IDENTITY_REASON="chose the Developer ID Application certificate"
+    fi
+    if [ -z "$CHOSEN_IDENTITY" ]; then
+        CHOSEN_IDENTITY="$(printf '%s\n' "$identities" | head -1 | awk '{print $2}' || true)"
+        if [ -n "$CHOSEN_IDENTITY" ]; then
+            CHOSEN_IDENTITY_REASON="no Developer ID Application certificate exists, took the first identity"
+            echo "  NOTE: TCC grants made against a different certificate will not apply to this build."
+        fi
+    fi
+    if [ -n "$CHOSEN_IDENTITY" ]; then
+        CHOSEN_IDENTITY_LISTING="$(printf '%s\n' "$identities" | grep "$CHOSEN_IDENTITY" || true)"
+    fi
+    return 0
+}
+
 # identity_sha1 <identity> [keychain]
 #
 # The same hash for an identity held as either a 40-hex SHA-1 (what the lanes

--- a/scripts/lib/signing.sh
+++ b/scripts/lib/signing.sh
@@ -411,10 +411,17 @@ dev_signing_identity() {
 # key is what makes e2e-browser.sh's pairing check fail while pointing at
 # prepare_signing, which did its job correctly.
 #
-# Validity is part of the question, not a detail: test_rpc.sh copies a fresh
-# binary into an already-signed bundle, so the certificate still matches while the
-# signature no longer does. Keeping that signature would launch a bundle macOS
-# refuses to run.
+# Validity is part of the question, not a detail. The certificate is read from
+# the executable's own signature and says who signed it, not that the bundle
+# still matches what was signed: anything changed under the seal afterwards, a
+# resource or the plist, leaves the certificate readable and the signature
+# invalid, and keeping it would launch a bundle macOS refuses to run.
+# (test_rpc.sh's copy of a fresh binary into the signed bundle is NOT that
+# case: the copy replaces the very executable the certificate is read from,
+# so bundle_signing_cert_sha1 answers nothing and the hash comparison alone
+# sends it to the re-sign. Measured: after the copy `codesign -d` reports an
+# ad-hoc signature and extracts no certificate, and `--verify` fails with
+# "code has no resources but signature indicates they must be present".)
 #
 # The keychain is a parameter rather than pass-through codesign flags, so no
 # caller has to expand a possibly-empty array under `set -u`.

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -44,19 +44,16 @@ if [ -n "${MTT_FAULT_INJECTION:-}" ]; then
 fi
 swift build "${SWIFT_BUILD_FLAGS[@]}"
 
-# Which certificate the previous build signed this bundle with, read BEFORE the
-# bundle is touched. It lives in the main executable's embedded signature, and
-# the `cp "$BUILD_BINARY"` below replaces that executable with a freshly linked,
-# ad-hoc signed one, after which there is no certificate left to read. Measured:
-# intact bundle yields the hash, the same bundle after the copy yields nothing,
-# so a read placed after the copy is dead code that silently always falls
-# through. Used by the identity choice further down.
+# Which certificate to sign with, decided BEFORE the bundle is touched. Half of
+# the answer is the certificate the previous build signed this bundle with,
+# which lives in the main executable's embedded signature; the
+# `cp "$BUILD_BINARY"` below replaces that executable with a freshly linked,
+# ad-hoc signed one, after which there is no certificate left to read (measured,
+# see choose_signing_identity). Reported further down, next to the codesign it
+# feeds.
 # shellcheck source=lib/signing.sh
 source "$SCRIPT_DIR/lib/signing.sh"
-PREV_SIGNING_CERT=""
-if [ -d "$APP_BUNDLE" ]; then
-    PREV_SIGNING_CERT="$(bundle_signing_cert_sha1 "$APP_BUNDLE" 2>/dev/null || true)"
-fi
+choose_signing_identity "$APP_BUNDLE"
 
 # Assemble .app bundle
 mkdir -p "$APP_MACOS"
@@ -104,60 +101,20 @@ fi
 # gated on one behaves differently here than in a release build, notably the
 # time-sensitive consent prompt (issue #543).
 #
-# Prefer Developer ID, do not take whatever the keychain lists first. TCC binds
-# a grant to the signing certificate's leaf SHA-1, so the identity chosen here
-# decides whether the dev app keeps its microphone and screen-recording grants
-# or silently loses all of them. `head -1` made that depend on keychain
-# ordering, and it changed under us the day an Apple Development certificate
-# was added: the rebuilt app then records nothing, with no error anywhere and
-# no prompt, because from TCC's point of view it is a different application.
-# The same preference is applied in lib/signing.sh for the profile case.
-#
-# Ahead of even that: if the deployed bundle is already signed with a
-# certificate that is still in the keychain, keep it. Two valid Developer ID
-# Application certificates (the overlap around a renewal) would otherwise put
-# us back to "whichever is listed first", and switching between them voids the
-# grants just as thoroughly as switching issuer would.
-_IDENTITIES="$(security find-identity -v -p codesigning 2>/dev/null || true)"
-_DEVID="$(grep "Developer ID Application" <<<"$_IDENTITIES" | head -1 | awk '{print $2}')" || true
-
-SIGN_HASH=""
-SIGN_REASON=""
-# Keep the certificate the previous build used, but only while it is still in
-# the keychain AND it is either a Developer ID one or there is no Developer ID
-# to move to. The second half matters: a bundle left over from before this fix
-# is signed with Apple Development, and "keep what is there" alone would pin it
-# to the wrong certificate forever, with the only escape being to delete the
-# bundle by hand. With the check, such a bundle moves to Developer ID by itself
-# and the renewal case still keeps the certificate actually in use.
-if [ -n "$PREV_SIGNING_CERT" ] && grep -q "$PREV_SIGNING_CERT" <<<"$_IDENTITIES"; then
-    if [ -z "$_DEVID" ] || [ "$PREV_SIGNING_CERT" = "$_DEVID" ] \
-        || grep "$PREV_SIGNING_CERT" <<<"$_IDENTITIES" | grep -q "Developer ID Application"; then
-        SIGN_HASH="$PREV_SIGNING_CERT"
-        SIGN_REASON="kept the certificate this bundle already carried"
-    fi
-fi
-if [ -z "$SIGN_HASH" ] && [ -n "$_DEVID" ]; then
-    SIGN_HASH="$_DEVID"
-    SIGN_REASON="chose the Developer ID Application certificate"
-fi
-if [ -z "$SIGN_HASH" ]; then
-    SIGN_HASH=$(head -1 <<<"$_IDENTITIES" | awk '{print $2}') || true
-    if [ -n "$SIGN_HASH" ]; then
-        SIGN_REASON="no Developer ID Application certificate exists, took the first identity"
-        echo "  NOTE: TCC grants made against a different certificate will not apply to this build."
-    fi
-fi
-# Say which rule chose and which certificate it is. Without this the build log
-# shows only a hash, and the whole reason this block exists is that the wrong
-# certificate is invisible until the app silently records nothing.
-if [ -n "$SIGN_HASH" ]; then
-    echo "  Signing identity: $SIGN_REASON"
-    grep "$SIGN_HASH" <<<"$_IDENTITIES" | sed 's/^ */    /'
+# Which certificate, and why, is choose_signing_identity's call: the one this
+# bundle already carries, else the Developer ID, else the first the keychain
+# lists, with a note that grants made against another certificate will not
+# apply. TCC binds a grant to the certificate's leaf SHA-1, so say which rule
+# chose and which certificate it is. Without this the build log shows only a
+# hash, and the whole reason that choice exists is that the wrong certificate
+# is invisible until the app silently records nothing.
+if [ -n "$CHOSEN_IDENTITY" ]; then
+    echo "  Signing identity: $CHOSEN_IDENTITY_REASON"
+    printf '%s\n' "$CHOSEN_IDENTITY_LISTING" | sed 's/^/    /'
 fi
 # $DEV_ENTITLEMENTS is that same path, named once in the library so this build
 # and any later re-sign of the deployed bundle cannot drift apart (issue #609).
-prepare_signing "$APP_BUNDLE" "$DEV_ENTITLEMENTS" "$DEV_BUNDLE_ID" "$SIGN_HASH"
+prepare_signing "$APP_BUNDLE" "$DEV_ENTITLEMENTS" "$DEV_BUNDLE_ID" "$CHOSEN_IDENTITY"
 if [ -n "$SIGNING_IDENTITY" ]; then
     # Failure is fatal and its stderr is kept. This used to be `2>/dev/null && echo`,
     # which hid both: a bad entitlements path left the bundle completely UNSIGNED

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -122,6 +122,16 @@ if [ -n "$SIGNING_IDENTITY" ]; then
     codesign --force --sign "$SIGNING_IDENTITY" --entitlements "$SIGNING_ENTITLEMENTS" "$APP_BUNDLE" \
         || { echo "codesign failed for $APP_BUNDLE (identity $SIGNING_IDENTITY, entitlements $SIGNING_ENTITLEMENTS)" >&2; exit 1; }
     echo "  Signed with: $SIGNING_IDENTITY (+ entitlements)"
+else
+    # Not fatal: a contributor without any certificate can still run the app.
+    # But not silent either. This used to die inside codesign by accident (the
+    # keychain's `0 valid identities found` trailer handed the word `valid`
+    # over as the identity), and an honest empty answer would otherwise pass
+    # without a word, leaving a bundle that loses every TCC grant at the next
+    # rebuild.
+    echo "  WARNING: no codesigning identity in the keychain; this bundle is not signed"
+    echo "  with a certificate. TCC binds its grants to that certificate, so without one"
+    echo "  no grant made to this build survives the next rebuild."
 fi
 verify_signing "$APP_BUNDLE"
 

--- a/scripts/test_rpc.sh
+++ b/scripts/test_rpc.sh
@@ -39,14 +39,23 @@ ok "app built"
 ok "mt-cli built"
 
 # --- Assemble + sign bundle. ---
-cp "$SPM_DIR/.build/release/MeetingTranscriber" "$APP_BINARY"
-SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}')
-# Through the shared helper: signing bare would strip the entitlements the
-# bundle was built with, and this lane launches the bundle it signs (issue #609).
+# Which certificate keeps this bundle's TCC grants (Screen Recording, which
+# /screenshot below stands or falls with), decided BEFORE the cp: the copy
+# replaces the executable whose signature carries half of the answer. Taking
+# whatever the keychain listed first used to pick an Apple Development
+# certificate on a machine that also holds the Developer ID the grants were
+# made against, and the run died at /screenshot with "no window".
 # shellcheck source=lib/signing.sh
 source "$REPO_ROOT/scripts/lib/signing.sh"
-resign_deployed_bundle "$APP_BUNDLE" "$SIGN_HASH" \
-    || fail "codesign failed for $APP_BUNDLE (identity $SIGN_HASH)"
+choose_signing_identity "$APP_BUNDLE"
+[ -n "$CHOSEN_IDENTITY" ] || fail "no codesigning identity in the keychain"
+ok "signing identity: $CHOSEN_IDENTITY_REASON"
+printf '%s\n' "$CHOSEN_IDENTITY_LISTING" | sed 's/^/      /'
+cp "$SPM_DIR/.build/release/MeetingTranscriber" "$APP_BINARY"
+# Through the shared helper: signing bare would strip the entitlements the
+# bundle was built with, and this lane launches the bundle it signs (issue #609).
+resign_deployed_bundle "$APP_BUNDLE" "$CHOSEN_IDENTITY" \
+    || fail "codesign failed for $APP_BUNDLE (identity $CHOSEN_IDENTITY)"
 ok "signed"
 
 # --- Launch with env var. ---

--- a/scripts/tests/test_signing_identity_choice.sh
+++ b/scripts/tests/test_signing_identity_choice.sh
@@ -559,6 +559,64 @@ test_prepare_signing_resolves_the_same_developer_id() {
     return "$rc"
 }
 
+# test_rpc.sh, the caller that had none of the rule: it too asks before the
+# cp that puts the fresh binary over the previous executable. The script runs
+# up to its launch, where the `open` stand-in stops it with 42; any other
+# status means it failed somewhere on the way, its own "no codesigning
+# identity" check included.
+test_test_rpc_decides_before_it_replaces_the_executable() {
+    local workdir carried status signed rc=0
+    workdir="$(mktemp -d)"
+    if ! _stage_dev_bundle_scripts "$workdir" >/dev/null || ! carried="$(_make_leaf_cert "$workdir")"; then
+        echo "  fixture failed: could not stage the scripts or create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    fi
+    _write_security_stub "$workdir" \
+        "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
+        "$carried \"Developer ID Application: Someone (TEAM)\""
+
+    _run_dev_bundle_script "$workdir" test_rpc.sh
+    status=$?
+    signed="$(_signed_with "$workdir")"
+
+    if [ "$status" -ne 42 ]; then
+        echo "  test_rpc.sh exited $status before reaching its launch; its last lines:" >&2
+        tail -5 "$workdir/run.log" | sed 's/^/    /' >&2
+        rc=1
+    fi
+    if [ "$signed" != "$carried" ]; then
+        echo "  signed with '${signed:-<nothing>}' instead of the carried $carried:" >&2
+        echo "  the identity was chosen after the copy replaced the executable, so the" >&2
+        echo "  certificate it carried was no longer there to be kept" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# The defect was a caller asking the keychain for itself. Only the library
+# may, so that the choice has one definition: a dev-bundle script that runs
+# `security find-identity` has, whatever it does with the answer, stopped
+# asking choose_signing_identity. Two scripts are exempt because they are
+# not dev-bundle scripts: build_release.sh signs the release bundle, which
+# nobody grants TCC to and rebuilds every day, and setup-self-hosted-runner.sh
+# creates the runner's keychain and only checks what it holds. A grep can
+# catch the query, on one line or spread over several, but not what a script
+# does with the answer nor where the call sits; the two cases above pin the
+# decision itself.
+test_no_dev_bundle_script_queries_the_keychain_itself() {
+    local offenders
+    # Non-comment lines only, so documenting the rule cannot fail the job.
+    offenders="$(grep -nE '^[^#]*security find-identity' "$REPO_ROOT"/scripts/*.sh 2>/dev/null \
+        | grep -vE '/(build_release|setup-self-hosted-runner)\.sh:' || true)"
+    if [ -n "$offenders" ]; then
+        echo "  these scripts read the keychain themselves instead of asking" >&2
+        echo "  choose_signing_identity, which is how TCC lost the grants:" >&2
+        printf '  %s\n' "$offenders" >&2
+        return 1
+    fi
+}
+
 echo "Testing choose_signing_identity in scripts/lib/signing.sh"
 echo
 run_test "a Developer ID the bundle already carries is kept over a newer one" \
@@ -585,6 +643,10 @@ run_test "a record without a name is not an identity" \
     test_a_record_without_a_name_is_not_an_identity
 run_test "prepare_signing resolves the same Developer ID" \
     test_prepare_signing_resolves_the_same_developer_id
+run_test "test_rpc.sh decides before it replaces the executable" \
+    test_test_rpc_decides_before_it_replaces_the_executable
+run_test "no dev-bundle script queries the keychain itself" \
+    test_no_dev_bundle_script_queries_the_keychain_itself
 echo
 
 if [ "$FAILED" -eq 0 ]; then

--- a/scripts/tests/test_signing_identity_choice.sh
+++ b/scripts/tests/test_signing_identity_choice.sh
@@ -19,6 +19,8 @@
 # the build, the keychain and codesign stubbed out, because the one thing the
 # function cannot check for itself is that a caller asks it BEFORE the copy
 # that destroys the answer.
+#
+# shellcheck disable=SC2329  # every test function is dispatched by name via run_test
 
 set -uo pipefail   # NOT -e: harness keeps running on test failure
 
@@ -79,6 +81,8 @@ _make_bundle() {
 # Anything but find-identity is refused, as no test expects it.
 #
 # Each identity is given as `<sha1> "<name>"`; the stub numbers them.
+#
+# shellcheck disable=SC2016  # the single-quoted strings ARE the stub's source; its $ must not expand here
 _write_security_stub() {
     local workdir="$1" line
     shift
@@ -425,12 +429,12 @@ test_an_empty_keychain_yields_no_identity_and_does_not_abort() {
 # copy, the script would sign with the Developer ID listed first and the
 # grants would go with the certificate it left.
 test_run_app_decides_before_it_replaces_the_executable() {
-    local workdir root carried status signed rc=0
+    local workdir carried status signed rc=0
     workdir="$(mktemp -d)"
-    root="$(_stage_dev_bundle_scripts "$workdir")" && carried="$(_make_leaf_cert "$workdir")" || {
+    if ! _stage_dev_bundle_scripts "$workdir" >/dev/null || ! carried="$(_make_leaf_cert "$workdir")"; then
         echo "  fixture failed: could not stage the scripts or create a test certificate" >&2
         rm -rf "$workdir"; return 1
-    }
+    fi
     _write_security_stub "$workdir" \
         "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
         "$carried \"Developer ID Application: Someone (TEAM)\""
@@ -450,7 +454,108 @@ test_run_app_decides_before_it_replaces_the_executable() {
         echo "  certificate it carried was no longer there to be kept" >&2
         rc=1
     fi
-    [ -d "$root" ] && rm -rf "$workdir"
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# A name that merely CONTAINS the phrase is not a Developer ID. A self-signed
+# certificate is named by whoever makes it (setup-self-hosted-runner.sh names
+# the runner's), so `Archive of Developer ID Application: ...` listed first
+# must lose to the real one listed second. Matched anywhere in the line, it won.
+test_a_name_that_only_contains_developer_id_application_does_not_win() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _write_security_stub "$workdir" \
+        "$SELF_SIGNED \"Archive of Developer ID Application: Someone (TEAM)\"" \
+        "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$DEVID_A" || rc=1
+    _expect "$report" reason "chose the Developer ID Application certificate" || rc=1
+    _expect "$report" listing "2) $DEVID_A \"Developer ID Application: Someone (TEAM)\"" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# The same phrase-in-a-name on the carried side: a bundle carrying such a
+# certificate is not already on a Developer ID, so with a real one in the
+# keychain it moves there rather than being kept.
+test_a_carried_certificate_only_named_after_developer_id_is_not_kept() {
+    local workdir bundle carried report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    carried="$(_make_carried_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$carried \"Archive of Developer ID Application: Someone (TEAM)\"" \
+        "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$DEVID_A" || rc=1
+    _expect "$report" reason "chose the Developer ID Application certificate" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# A record with a hash but no name is not an identity. The real tool never
+# prints one; the rules classify by name, so accepting it could only hand the
+# last-resort rule something it cannot describe.
+test_a_record_without_a_name_is_not_an_identity() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _write_security_stub "$workdir" "$DEVID_A"
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "" || rc=1
+    _expect "$report" reason "" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# prepare_signing resolves the certificate a profile covers through the same
+# lookup, so the two places that ask "which one is the Developer ID" cannot
+# answer differently. Real plutil on a real entitlements file; only the
+# keychain is a transcript.
+test_prepare_signing_resolves_the_same_developer_id() {
+    local workdir bundle identity rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    mkdir -p "$workdir/profiles"
+    printf 'stand-in for a provisioning profile' > "$workdir/profiles/com.example.test.provisionprofile"
+    cp "$REPO_ROOT/app/MeetingTranscriber/Entitlements/Homebrew.entitlements" "$workdir/base.entitlements"
+    _write_security_stub "$workdir" \
+        "$SELF_SIGNED \"Archive of Developer ID Application: Someone (TEAM)\"" \
+        "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
+
+    identity="$(PATH="$workdir/bin:$PATH" \
+        PROFILE_DIR="$workdir/profiles" \
+        SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
+        bash -c 'set -euo pipefail
+                 # shellcheck source=../lib/signing.sh
+                 source "$SIGNING_LIB"
+                 prepare_signing "$1" "$2" com.example.test "" >/dev/null
+                 printf "%s" "$SIGNING_IDENTITY"' bash "$bundle" "$workdir/base.entitlements" 2>&1)"
+
+    if [ "$identity" != "$DEVID_A" ]; then
+        echo "  prepare_signing resolved '${identity:-<empty>}' instead of $DEVID_A" >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
     return "$rc"
 }
 
@@ -472,6 +577,14 @@ run_test "an empty keychain yields no identity and does not abort the caller" \
     test_an_empty_keychain_yields_no_identity_and_does_not_abort
 run_test "run_app.sh decides before it replaces the executable" \
     test_run_app_decides_before_it_replaces_the_executable
+run_test "a name that merely contains 'Developer ID Application' does not win" \
+    test_a_name_that_only_contains_developer_id_application_does_not_win
+run_test "a carried certificate only named after Developer ID is not kept" \
+    test_a_carried_certificate_only_named_after_developer_id_is_not_kept
+run_test "a record without a name is not an identity" \
+    test_a_record_without_a_name_is_not_an_identity
+run_test "prepare_signing resolves the same Developer ID" \
+    test_prepare_signing_resolves_the_same_developer_id
 echo
 
 if [ "$FAILED" -eq 0 ]; then

--- a/scripts/tests/test_signing_identity_choice.sh
+++ b/scripts/tests/test_signing_identity_choice.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# Regression test for choose_signing_identity in scripts/lib/signing.sh: which
+# certificate a dev bundle is signed with, so TCC keeps the grants it has made.
+#
+# Bug history:
+#   scripts/test_rpc.sh picked its identity with
+#   `security find-identity -v -p codesigning | head -1 | awk '{print $2}'`.
+#   On a machine holding both an Apple Development and a Developer ID
+#   certificate, `head -1` is the Apple Development one, while the Screen
+#   Recording grant was made against the Developer ID. To TCC the freshly
+#   signed bundle was a different app, /screenshot found no window, and the
+#   smoketest died with "RPC returned HTTP 503: no window". run_app.sh already
+#   had the right rule, inline; it now lives in the library so both share it.
+#
+# Every case runs against a `security` transcript and a stubbed or genuinely
+# unsigned bundle, never against this machine's keychain: which certificates a
+# contributor happens to hold must not decide whether these pass. The scripts
+# that call the function are run as well, from a copy of the repository with
+# the build, the keychain and codesign stubbed out, because the one thing the
+# function cannot check for itself is that a caller asks it BEFORE the copy
+# that destroys the answer.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$2"; then
+        printf 'PASS\n'
+    else
+        printf 'FAIL\n'
+        FAILED=1
+    fi
+}
+
+# Hashes that only ever appear in transcripts. Any 40 hex digits will do: the
+# library compares them as strings and never asks the keychain about them.
+DEVID_A="AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111"
+DEVID_B="BBBB2222BBBB2222BBBB2222BBBB2222BBBB2222"
+APPLE_DEV="CCCC3333CCCC3333CCCC3333CCCC3333CCCC3333"
+SELF_SIGNED="DDDD4444DDDD4444DDDD4444DDDD4444DDDD4444"
+# What the `security` stand-in adds when it is asked the wrong question; see
+# _write_security_stub.
+REVOKED="EEEE5555EEEE5555EEEE5555EEEE5555EEEE5555"
+NOT_FOR_CODE="FFFF6666FFFF6666FFFF6666FFFF6666FFFF6666"
+NOTE="  NOTE: TCC grants made against a different certificate will not apply to this build."
+
+# A genuinely unsigned throwaway .app in $1; echoes its path. Its executable is
+# a shell script: real codesign answers "code object is not signed at all" and
+# hands out no certificate, which makes this the honest "no previous signature"
+# fixture, so those cases need no codesign stub. A copy of /bin/echo would not
+# do: the copy keeps Apple's signature, and real codesign reads Apple's
+# certificate out of it (measured), so such a bundle "carries" a certificate
+# that merely never appears in any transcript, and the rule that a carried
+# certificate must still be in the keychain is then exercised by accident
+# rather than by the case written for it.
+_make_bundle() {
+    local bundle="$1/Some.app"
+    mkdir -p "$bundle/Contents/MacOS"
+    printf '#!/bin/sh\nexit 0\n' > "$bundle/Contents/MacOS/Some"
+    chmod +x "$bundle/Contents/MacOS/Some"
+    printf '%s' "$bundle"
+}
+
+# A `security` stand-in whose find-identity answer depends on its arguments
+# the way the real tool's does. Asked the right question, `-v -p codesigning`,
+# it lists the given identities in the given order, then the trailer the real
+# tool prints; order is part of the fixture, the bug was "whichever is listed
+# first". Asked without `-p codesigning` it adds, first, an identity the
+# default policy admits although it cannot sign code. Asked without -v it
+# answers in the real tool's two-section form: every matching identity, a
+# revoked Developer ID first and marked as such, then the valid ones once
+# more. Either way a lookup that drops a flag reads a different keychain than
+# the one the case describes and fails it, instead of passing them all.
+# Anything but find-identity is refused, as no test expects it.
+#
+# Each identity is given as `<sha1> "<name>"`; the stub numbers them.
+_write_security_stub() {
+    local workdir="$1" line
+    shift
+    mkdir -p "$workdir/bin"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf '[ "${1:-}" = find-identity ] || { echo "security stub: unexpected: $*" >&2; exit 2; }\n'
+        printf 'shift\nvalid=false\npolicy=basic\n'
+        printf 'while [ $# -gt 0 ]; do\n'
+        printf '    case "$1" in -v) valid=true ;; -p) policy="$2"; shift ;; esac\n'
+        printf '    shift\ndone\n'
+        printf 'matching=()\n'
+        printf '[ "$policy" = codesigning ] || matching+=(%q)\n' \
+            "$NOT_FOR_CODE \"Email Encryption: Someone\""
+        for line in "$@"; do printf 'matching+=(%q)\n' "$line"; done
+        printf 'list() { local n=0 line; for line in "$@"; do n=$((n + 1)); printf "  %%d) %%s\\n" "$n" "$line"; done; }\n'
+        printf 'if [ "$valid" = true ]; then\n'
+        printf '    list "${matching[@]}"\n'
+        printf '    printf "     %%d valid identities found\\n" "${#matching[@]}"\n'
+        printf 'else\n'
+        printf '    printf "\\nPolicy: %%s\\n  Matching identities\\n" "$policy"\n'
+        printf '    list %q "${matching[@]}"\n' \
+            "$REVOKED \"Developer ID Application: Revoked (TEAM)\" (CSSMERR_TP_CERT_REVOKED)"
+        printf '    printf "     %%d identities found\\n\\n  Valid identities only\\n" $(( ${#matching[@]} + 1 ))\n'
+        printf '    list "${matching[@]}"\n'
+        printf '    printf "     %%d valid identities found\\n" "${#matching[@]}"\n'
+        printf 'fi\n'
+    } > "$workdir/bin/security"
+    chmod +x "$workdir/bin/security"
+}
+
+# A real certificate nobody can be assumed to hold, as DER in $1/leaf.der;
+# echoes its SHA-1. Non-zero when it cannot be made, because an empty hash
+# would silently turn "carries X" into "unsigned" and let a case pass without
+# ever exercising the rule it pins.
+_make_leaf_cert() {
+    local workdir="$1" hash
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -keyout "$workdir/key.pem" -outform DER -out "$workdir/leaf.der" \
+        -days 1 -subj "/CN=Identity Choice Test" 2>/dev/null || return 1
+    hash="$(openssl x509 -inform DER -in "$workdir/leaf.der" -noout -fingerprint -sha1 2>/dev/null \
+        | sed 's/^.*=//' | tr -d ':' | tr '[:lower:]' '[:upper:]')"
+    [ -n "$hash" ] || return 1
+    printf '%s' "$hash"
+}
+
+# Makes the bundle "carry" that certificate: a codesign stand-in hands the
+# library the leaf on --extract-certificates, so bundle_signing_cert_sha1
+# computes a real hash, and the transcript is then written around that hash.
+# Echoes the hash; non-zero as _make_leaf_cert.
+_make_carried_cert() {
+    local workdir="$1" hash
+    hash="$(_make_leaf_cert "$workdir")" || return 1
+    mkdir -p "$workdir/bin"
+    cat > "$workdir/bin/codesign" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+    *--extract-certificates*) cp "$workdir/leaf.der" ./codesign0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$workdir/bin/codesign"
+    printf '%s' "$hash"
+}
+
+# Runs the function the way a caller does: a separate bash PROCESS under
+# `set -euo pipefail` (a subshell would inherit run_test's errexit suppression,
+# see test_signing_resign.sh), stubs first on PATH, the library sourced. Prints
+# a `field=value` report: the three globals plus the function's own stdout,
+# because the note it prints is part of the contract.
+_choose() {
+    local workdir="$1" bundle="$2"
+    PATH="$workdir/bin:$PATH" \
+    SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
+        bash -c 'set -euo pipefail
+                 # shellcheck source=../lib/signing.sh
+                 source "$SIGNING_LIB"
+                 choose_signing_identity "$1" > "$2/stdout.log"
+                 printf "identity=%s\nreason=%s\nlisting=%s\n" \
+                     "$CHOSEN_IDENTITY" "$CHOSEN_IDENTITY_REASON" "$CHOSEN_IDENTITY_LISTING"
+                 printf "stdout=%s\n" "$(cat "$2/stdout.log")"' bash "$bundle" "$workdir"
+}
+
+# _expect <report> <field> <want>: one field of _choose's report.
+_expect() {
+    local report="$1" field="$2" want="$3" got
+    got="$(printf '%s\n' "$report" | sed -n "s/^$field=//p")"
+    if [ "$got" != "$want" ]; then
+        echo "  $field: expected '${want:-<empty>}', got '${got:-<empty>}'" >&2
+        return 1
+    fi
+}
+
+# Stages, in $1/repo, the slice of the repository the dev-bundle scripts need
+# to run up to and including their signing step, and echoes that root. Around
+# it, stand-ins for everything that is not the decision under test: `swift`
+# builds nothing, `pgrep` finds no running app, the model fetch answers with
+# a dummy file, and `open` exits 42 so a script that reaches its launch stops
+# there with a status no earlier failure produces. The previous build's
+# executable and the freshly built binary carry markers, and the codesign
+# stand-in hands out the leaf certificate only while the previous executable
+# is still in place. That is what real codesign does (measured: the intact
+# bundle yields the certificate, the same bundle with a fresh binary copied in
+# reports an ad-hoc signature and yields none), so a script that decides after
+# its copy sees no carried certificate here exactly as it would in production.
+# Every codesign call is logged to $1/codesign.log.
+_stage_dev_bundle_scripts() {
+    local workdir="$1" root="$1/repo" spm bundle
+    spm="$root/app/MeetingTranscriber"
+    bundle="$spm/.build/MeetingTranscriber-Dev.app"
+    mkdir -p "$root/scripts/lib" "$root/licenses" "$root/model" "$root/tools/mt-cli" \
+        "$spm/Sources" "$spm/Entitlements" "$spm/.build/release" "$bundle/Contents/MacOS" \
+        "$workdir/bin" || return 1
+    cp "$REPO_ROOT/scripts/run_app.sh" "$REPO_ROOT/scripts/test_rpc.sh" "$root/scripts/" || return 1
+    cp "$REPO_ROOT"/scripts/lib/*.sh "$root/scripts/lib/" || return 1
+    cp "$REPO_ROOT/app/MeetingTranscriber/Sources/Info.plist" "$spm/Sources/" || return 1
+    cp "$REPO_ROOT/app/MeetingTranscriber/Entitlements/Homebrew.entitlements" "$spm/Entitlements/" || return 1
+    printf '0.0.0\n' > "$root/VERSION"
+    printf 'stand-in licence\n' > "$root/licenses/Test-LICENSE.txt"
+    printf 'stand-in model\n' > "$root/model/localvqe-test.gguf"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$root/model/localvqe-test.gguf" \
+        > "$root/scripts/fetch-localvqe-model.sh"
+    printf 'previous build\n' > "$bundle/Contents/MacOS/MeetingTranscriber"
+    printf 'fresh build\n' > "$spm/.build/release/MeetingTranscriber"
+    chmod +x "$root/scripts/fetch-localvqe-model.sh" "$bundle/Contents/MacOS/MeetingTranscriber" \
+        "$spm/.build/release/MeetingTranscriber" || return 1
+
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$workdir/bin/swift"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$workdir/bin/pgrep"
+    printf '#!/usr/bin/env bash\nexit 42\n' > "$workdir/bin/open"
+    cat > "$workdir/bin/codesign" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$workdir/codesign.log"
+case "\$*" in
+    *--extract-certificates*)
+        if [ -f "$workdir/leaf.der" ] \\
+            && grep -q 'previous build' "$bundle/Contents/MacOS/MeetingTranscriber" 2>/dev/null; then
+            cp "$workdir/leaf.der" ./codesign0
+        fi ;;
+    *--verify*) exit 1 ;;
+    *"--entitlements :-"*) printf '<key>stand-in</key>' ;;
+esac
+exit 0
+STUB
+    chmod +x "$workdir/bin/"* || return 1
+    printf '%s' "$root"
+}
+
+# Runs one of the staged scripts with the stand-ins first on PATH; its output
+# goes to $1/run.log, its status is returned.
+_run_dev_bundle_script() {
+    local workdir="$1" script="$2"
+    shift 2
+    PATH="$workdir/bin:$PATH" bash "$workdir/repo/scripts/$script" "$@" > "$workdir/run.log" 2>&1
+}
+
+# The identity a staged script signed with, from the codesign log.
+_signed_with() {
+    sed -n 's/.*--sign \([^ ]*\).*/\1/p' "$1/codesign.log" 2>/dev/null | tail -1
+}
+
+# Each test has one exit point, so the temp dir is removed exactly once: a
+# RETURN trap would outlive the function that set it and fire inside run_test.
+
+# The renewal overlap: two valid Developer ID certificates, and the one the
+# bundle carries is NOT the one listed first. Switching between them voids the
+# grants just as thoroughly as switching issuer would.
+test_keeps_a_developer_id_the_bundle_already_carries() {
+    local workdir bundle carried report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    carried="$(_make_carried_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
+        "$carried \"Developer ID Application: Someone (TEAM)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$carried" || rc=1
+    _expect "$report" reason "kept the certificate this bundle already carried" || rc=1
+    _expect "$report" listing "2) $carried \"Developer ID Application: Someone (TEAM)\"" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# The case that broke test_rpc.sh: the bundle was last signed with an Apple
+# Development certificate (what `head -1` handed out), a Developer ID exists,
+# and the TCC grants belong to the Developer ID. "Keep what is there" alone
+# would pin the bundle to the wrong certificate forever, with the only escape
+# being to delete the bundle by hand.
+test_moves_an_apple_development_bundle_to_developer_id() {
+    local workdir bundle carried report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    carried="$(_make_carried_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$carried \"Apple Development: Someone (ABCDE12345)\"" \
+        "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$DEVID_A" || rc=1
+    _expect "$report" reason "chose the Developer ID Application certificate" || rc=1
+    _expect "$report" listing "2) $DEVID_A \"Developer ID Application: Someone (TEAM)\"" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# Nothing to keep (a first build): the Developer ID, not whatever the keychain
+# lists first.
+test_prefers_developer_id_over_the_first_listed_identity() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _write_security_stub "$workdir" \
+        "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\"" \
+        "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$DEVID_A" || rc=1
+    _expect "$report" reason "chose the Developer ID Application certificate" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# No Developer ID at all (a contributor with an Apple Development certificate,
+# a self-hosted runner with its self-signed one): the first identity, and the
+# log says what that costs.
+test_takes_the_first_identity_when_no_developer_id_exists() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _write_security_stub "$workdir" \
+        "$SELF_SIGNED \"MeetingTranscriberDevSelfHosted\"" \
+        "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$SELF_SIGNED" || rc=1
+    _expect "$report" reason "no Developer ID Application certificate exists, took the first identity" || rc=1
+    _expect "$report" listing "1) $SELF_SIGNED \"MeetingTranscriberDevSelfHosted\"" || rc=1
+    _expect "$report" stdout "$NOTE" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# Same keychain, but the bundle already carries one of its certificates: kept,
+# although it is not a Developer ID one, because there is none to move to and
+# moving would void the grants for nothing.
+test_keeps_a_non_developer_id_certificate_when_there_is_none_to_move_to() {
+    local workdir bundle carried report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    carried="$(_make_carried_cert "$workdir")" || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$APPLE_DEV \"Apple Development: Other (ABCDE12345)\"" \
+        "$carried \"Apple Development: Someone (ABCDE12345)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$carried" || rc=1
+    _expect "$report" reason "kept the certificate this bundle already carried" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# The bundle carries a certificate that has since left the keychain (expired
+# and removed, or the bundle was built on another machine). It cannot sign
+# anything any more, so keeping it is not an option even though there is no
+# Developer ID to move to: the last resort applies, note included. The
+# keychain deliberately holds no Developer ID, because with one present rule 2
+# would give the same answer whether or not the vanished certificate had been
+# considered.
+test_does_not_keep_a_carried_certificate_that_left_the_keychain() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _make_carried_cert "$workdir" >/dev/null || {
+        echo "  fixture failed: could not create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\""
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "$APPLE_DEV" || rc=1
+    _expect "$report" reason "no Developer ID Application certificate exists, took the first identity" || rc=1
+    _expect "$report" stdout "$NOTE" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# An empty keychain answers `0 valid identities found`, and `head -1 | awk`
+# over that used to hand the word `valid` to codesign as the identity. The
+# right answer is no identity, and a normal exit under the callers' `set -e`.
+test_an_empty_keychain_yields_no_identity_and_does_not_abort() {
+    local workdir bundle report status rc=0
+    workdir="$(mktemp -d)"
+    bundle="$(_make_bundle "$workdir")"
+    _write_security_stub "$workdir"
+
+    report="$(_choose "$workdir" "$bundle")"
+    status=$?
+
+    [ "$status" -eq 0 ] || { echo "  choose_signing_identity exited $status" >&2; rc=1; }
+    _expect "$report" identity "" || rc=1
+    _expect "$report" reason "" || rc=1
+    _expect "$report" stdout "" || rc=1
+    rm -rf "$workdir"
+    return "$rc"
+}
+
+# run_app.sh asks BEFORE it copies the fresh binary over the previous build's
+# executable, which is where the carried certificate lives. The renewal overlap
+# again, through the script itself: the carried Developer ID is kept only if
+# the question was asked while it could still be answered; asked after the
+# copy, the script would sign with the Developer ID listed first and the
+# grants would go with the certificate it left.
+test_run_app_decides_before_it_replaces_the_executable() {
+    local workdir root carried status signed rc=0
+    workdir="$(mktemp -d)"
+    root="$(_stage_dev_bundle_scripts "$workdir")" && carried="$(_make_leaf_cert "$workdir")" || {
+        echo "  fixture failed: could not stage the scripts or create a test certificate" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir" \
+        "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
+        "$carried \"Developer ID Application: Someone (TEAM)\""
+
+    _run_dev_bundle_script "$workdir" run_app.sh --build-only
+    status=$?
+    signed="$(_signed_with "$workdir")"
+
+    if [ "$status" -ne 0 ]; then
+        echo "  run_app.sh exited $status; its last lines:" >&2
+        tail -5 "$workdir/run.log" | sed 's/^/    /' >&2
+        rc=1
+    fi
+    if [ "$signed" != "$carried" ]; then
+        echo "  signed with '${signed:-<nothing>}' instead of the carried $carried:" >&2
+        echo "  the identity was chosen after the copy replaced the executable, so the" >&2
+        echo "  certificate it carried was no longer there to be kept" >&2
+        rc=1
+    fi
+    [ -d "$root" ] && rm -rf "$workdir"
+    return "$rc"
+}
+
+echo "Testing choose_signing_identity in scripts/lib/signing.sh"
+echo
+run_test "a Developer ID the bundle already carries is kept over a newer one" \
+    test_keeps_a_developer_id_the_bundle_already_carries
+run_test "an Apple Development bundle moves to the Developer ID" \
+    test_moves_an_apple_development_bundle_to_developer_id
+run_test "with nothing to keep, Developer ID beats the first listed identity" \
+    test_prefers_developer_id_over_the_first_listed_identity
+run_test "without any Developer ID the first identity is taken, with a note" \
+    test_takes_the_first_identity_when_no_developer_id_exists
+run_test "a carried certificate is kept when there is no Developer ID to move to" \
+    test_keeps_a_non_developer_id_certificate_when_there_is_none_to_move_to
+run_test "a carried certificate that left the keychain is not kept" \
+    test_does_not_keep_a_carried_certificate_that_left_the_keychain
+run_test "an empty keychain yields no identity and does not abort the caller" \
+    test_an_empty_keychain_yields_no_identity_and_does_not_abort
+run_test "run_app.sh decides before it replaces the executable" \
+    test_run_app_decides_before_it_replaces_the_executable
+echo
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "Some tests FAILED."
+fi
+exit "$FAILED"

--- a/scripts/tests/test_signing_identity_choice.sh
+++ b/scripts/tests/test_signing_identity_choice.sh
@@ -594,6 +594,42 @@ test_test_rpc_decides_before_it_replaces_the_executable() {
     return "$rc"
 }
 
+# An empty keychain: run_app.sh builds on, since a contributor without any
+# certificate can still run the app, but it says so. It used to die inside
+# codesign by accident (the trailer's word `valid` taken as the identity);
+# with the chooser's honest empty answer it would otherwise pass in silence,
+# the bundle unsigned and every TCC grant gone at the next rebuild.
+test_run_app_says_so_when_it_leaves_the_bundle_unsigned() {
+    local workdir status signed rc=0
+    workdir="$(mktemp -d)"
+    _stage_dev_bundle_scripts "$workdir" >/dev/null || {
+        echo "  fixture failed: could not stage the scripts" >&2
+        rm -rf "$workdir"; return 1
+    }
+    _write_security_stub "$workdir"
+
+    _run_dev_bundle_script "$workdir" run_app.sh --build-only
+    status=$?
+    signed="$(_signed_with "$workdir")"
+
+    if [ "$status" -ne 0 ]; then
+        echo "  run_app.sh exited $status on an empty keychain; its last lines:" >&2
+        tail -5 "$workdir/run.log" | sed 's/^/    /' >&2
+        rc=1
+    fi
+    if [ -n "$signed" ]; then
+        echo "  signed with '$signed' although the keychain holds no identity" >&2
+        rc=1
+    fi
+    if ! grep -q 'WARNING: no codesigning identity' "$workdir/run.log"; then
+        echo "  left the bundle unsigned without saying so; the build log ends:" >&2
+        tail -5 "$workdir/run.log" | sed 's/^/    /' >&2
+        rc=1
+    fi
+    rm -rf "$workdir"
+    return "$rc"
+}
+
 # The defect was a caller asking the keychain for itself. Only the library
 # may, so that the choice has one definition: a dev-bundle script that runs
 # `security find-identity` has, whatever it does with the answer, stopped
@@ -645,6 +681,8 @@ run_test "prepare_signing resolves the same Developer ID" \
     test_prepare_signing_resolves_the_same_developer_id
 run_test "test_rpc.sh decides before it replaces the executable" \
     test_test_rpc_decides_before_it_replaces_the_executable
+run_test "run_app.sh says so when it leaves the bundle unsigned" \
+    test_run_app_says_so_when_it_leaves_the_bundle_unsigned
 run_test "no dev-bundle script queries the keychain itself" \
     test_no_dev_bundle_script_queries_the_keychain_itself
 echo

--- a/scripts/tests/test_signing_identity_choice.sh
+++ b/scripts/tests/test_signing_identity_choice.sh
@@ -26,6 +26,13 @@ set -uo pipefail   # NOT -e: harness keeps running on test failure
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
+# One set of stand-ins for the whole run; see _write_stubs for why.
+STUB_ROOT="$(mktemp -d)"
+trap 'rm -rf "$STUB_ROOT"' EXIT
+STUB_SECURITY="$STUB_ROOT/security"
+STUB_CODESIGN="$STUB_ROOT/codesign"
+STUB_HARNESS="$STUB_ROOT/harness"
+
 FAILED=0
 
 run_test() {
@@ -46,7 +53,7 @@ DEVID_B="BBBB2222BBBB2222BBBB2222BBBB2222BBBB2222"
 APPLE_DEV="CCCC3333CCCC3333CCCC3333CCCC3333CCCC3333"
 SELF_SIGNED="DDDD4444DDDD4444DDDD4444DDDD4444DDDD4444"
 # What the `security` stand-in adds when it is asked the wrong question; see
-# _write_security_stub.
+# _write_stubs.
 REVOKED="EEEE5555EEEE5555EEEE5555EEEE5555EEEE5555"
 NOT_FOR_CODE="FFFF6666FFFF6666FFFF6666FFFF6666FFFF6666"
 NOTE="  NOTE: TCC grants made against a different certificate will not apply to this build."
@@ -54,12 +61,12 @@ NOTE="  NOTE: TCC grants made against a different certificate will not apply to 
 # A genuinely unsigned throwaway .app in $1; echoes its path. Its executable is
 # a shell script: real codesign answers "code object is not signed at all" and
 # hands out no certificate, which makes this the honest "no previous signature"
-# fixture, so those cases need no codesign stub. A copy of /bin/echo would not
-# do: the copy keeps Apple's signature, and real codesign reads Apple's
-# certificate out of it (measured), so such a bundle "carries" a certificate
-# that merely never appears in any transcript, and the rule that a carried
-# certificate must still be in the keychain is then exercised by accident
-# rather than by the case written for it.
+# fixture, so those cases run real codesign and need no stand-in. A copy of
+# /bin/echo would not do: the copy keeps Apple's signature, and real codesign
+# reads Apple's certificate out of it (measured), so such a bundle "carries" a
+# certificate that merely never appears in any transcript, and the rule that a
+# carried certificate must still be in the keychain is then exercised by
+# accident rather than by the case written for it.
 _make_bundle() {
     local bundle="$1/Some.app"
     mkdir -p "$bundle/Contents/MacOS"
@@ -68,56 +75,107 @@ _make_bundle() {
     printf '%s' "$bundle"
 }
 
-# A `security` stand-in whose find-identity answer depends on its arguments
-# the way the real tool's does. Asked the right question, `-v -p codesigning`,
-# it lists the given identities in the given order, then the trailer the real
-# tool prints; order is part of the fixture, the bug was "whichever is listed
+# The stand-ins, written ONCE per run. macOS assesses an executable the first
+# time it is launched, and for a freshly written script that costs about 0.4 s
+# (measured: first run 0.40 s, second 0.015 s), so stand-ins written per case
+# made this suite take ten seconds for two seconds of work. Each case
+# parameterises them instead: the keychain transcript in $SECURITY_IDENTITIES,
+# the leaf certificate in $STUB_LEAF_DER, the executable that certificate is
+# bound to in $STUB_EXECUTABLE, the call log in $CODESIGN_CALLS. Three
+# directories, so a case can put `security` on PATH without `codesign`: the
+# unsigned-bundle cases run real codesign on purpose.
+#
+# `security` answers find-identity the way the real tool does, given its
+# arguments. Asked the right question, `-v -p codesigning`, it lists the
+# transcript's identities in their order, then the trailer the real tool
+# prints; order is part of every fixture, the bug was "whichever is listed
 # first". Asked without `-p codesigning` it adds, first, an identity the
 # default policy admits although it cannot sign code. Asked without -v it
 # answers in the real tool's two-section form: every matching identity, a
-# revoked Developer ID first and marked as such, then the valid ones once
-# more. Either way a lookup that drops a flag reads a different keychain than
-# the one the case describes and fails it, instead of passing them all.
-# Anything but find-identity is refused, as no test expects it.
+# revoked Developer ID first and marked as such, then the valid ones once more.
+# Either way a lookup that drops a flag reads a different keychain than the one
+# the case describes and fails it, instead of passing them all. Anything but
+# find-identity is refused, as no test expects it.
 #
-# Each identity is given as `<sha1> "<name>"`; the stub numbers them.
+# `codesign` hands out the leaf certificate on --extract-certificates, so
+# bundle_signing_cert_sha1 computes a real hash for a certificate nobody can be
+# assumed to hold. When $STUB_EXECUTABLE is set it does so only while that file
+# is still the previous build's: that is what real codesign does (measured: the
+# intact bundle yields the certificate, the same bundle with a fresh binary
+# copied in reports an ad-hoc signature and yields none), so a script that
+# decides after its copy sees no carried certificate here exactly as it would
+# in production. It fails --verify, reports an entitlement on
+# `--entitlements :-`, and logs every call when asked to.
 #
-# shellcheck disable=SC2016  # the single-quoted strings ARE the stub's source; its $ must not expand here
-_write_security_stub() {
-    local workdir="$1" line
+# The harness stand-ins: `swift` builds nothing, `pgrep` finds no running app,
+# `open` exits 42 so a script that reaches its launch stops there with a
+# status no earlier failure produces, and the model fetch names a dummy file.
+_write_stubs() {
+    mkdir -p "$STUB_SECURITY" "$STUB_CODESIGN" "$STUB_HARNESS" "$STUB_ROOT/model"
+    cat > "$STUB_SECURITY/security" <<STUB
+#!/usr/bin/env bash
+[ "\${1:-}" = find-identity ] || { echo "security stub: unexpected: \$*" >&2; exit 2; }
+shift
+valid=false
+policy=basic
+while [ \$# -gt 0 ]; do
+    case "\$1" in -v) valid=true ;; -p) policy="\$2"; shift ;; esac
     shift
-    mkdir -p "$workdir/bin"
-    {
-        printf '#!/usr/bin/env bash\n'
-        printf '[ "${1:-}" = find-identity ] || { echo "security stub: unexpected: $*" >&2; exit 2; }\n'
-        printf 'shift\nvalid=false\npolicy=basic\n'
-        printf 'while [ $# -gt 0 ]; do\n'
-        printf '    case "$1" in -v) valid=true ;; -p) policy="$2"; shift ;; esac\n'
-        printf '    shift\ndone\n'
-        printf 'matching=()\n'
-        printf '[ "$policy" = codesigning ] || matching+=(%q)\n' \
-            "$NOT_FOR_CODE \"Email Encryption: Someone\""
-        for line in "$@"; do printf 'matching+=(%q)\n' "$line"; done
-        printf 'list() { local n=0 line; for line in "$@"; do n=$((n + 1)); printf "  %%d) %%s\\n" "$n" "$line"; done; }\n'
-        printf 'if [ "$valid" = true ]; then\n'
-        printf '    list "${matching[@]}"\n'
-        printf '    printf "     %%d valid identities found\\n" "${#matching[@]}"\n'
-        printf 'else\n'
-        printf '    printf "\\nPolicy: %%s\\n  Matching identities\\n" "$policy"\n'
-        printf '    list %q "${matching[@]}"\n' \
-            "$REVOKED \"Developer ID Application: Revoked (TEAM)\" (CSSMERR_TP_CERT_REVOKED)"
-        printf '    printf "     %%d identities found\\n\\n  Valid identities only\\n" $(( ${#matching[@]} + 1 ))\n'
-        printf '    list "${matching[@]}"\n'
-        printf '    printf "     %%d valid identities found\\n" "${#matching[@]}"\n'
-        printf 'fi\n'
-    } > "$workdir/bin/security"
-    chmod +x "$workdir/bin/security"
+done
+matching=()
+[ "\$policy" = codesigning ] || matching+=('$NOT_FOR_CODE "Email Encryption: Someone"')
+while IFS= read -r line; do [ -n "\$line" ] && matching+=("\$line"); done < "\${SECURITY_IDENTITIES:?}"
+list() { local n=0 line; for line in "\$@"; do n=\$((n + 1)); printf '  %d) %s\n' "\$n" "\$line"; done; }
+if [ "\$valid" = true ]; then
+    list "\${matching[@]}"
+    printf '     %d valid identities found\n' "\${#matching[@]}"
+else
+    printf '\nPolicy: %s\n  Matching identities\n' "\$policy"
+    list '$REVOKED "Developer ID Application: Revoked (TEAM)" (CSSMERR_TP_CERT_REVOKED)' "\${matching[@]}"
+    printf '     %d identities found\n\n  Valid identities only\n' \$(( \${#matching[@]} + 1 ))
+    list "\${matching[@]}"
+    printf '     %d valid identities found\n' "\${#matching[@]}"
+fi
+STUB
+    cat > "$STUB_CODESIGN/codesign" <<'STUB'
+#!/usr/bin/env bash
+[ -n "${CODESIGN_CALLS:-}" ] && printf '%s\n' "$*" >> "$CODESIGN_CALLS"
+case "$*" in
+    *--extract-certificates*)
+        if [ -f "${STUB_LEAF_DER:-}" ] \
+            && { [ -z "${STUB_EXECUTABLE:-}" ] || grep -q 'previous build' "$STUB_EXECUTABLE" 2>/dev/null; }; then
+            cp "$STUB_LEAF_DER" ./codesign0
+        fi ;;
+    *--verify*) exit 1 ;;
+    *"--entitlements :-"*) printf '<key>stand-in</key>' ;;
+esac
+exit 0
+STUB
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_HARNESS/swift"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB_HARNESS/pgrep"
+    printf '#!/usr/bin/env bash\nexit 42\n' > "$STUB_HARNESS/open"
+    printf 'stand-in model\n' > "$STUB_ROOT/model/localvqe-test.gguf"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$STUB_ROOT/model/localvqe-test.gguf" \
+        > "$STUB_HARNESS/fetch-localvqe-model.sh"
+    chmod +x "$STUB_SECURITY/security" "$STUB_CODESIGN/codesign" "$STUB_HARNESS"/*
+}
+
+# The keychain a case runs against: one identity per argument, each given as
+# `<sha1> "<name>"`, in that order; none for an empty keychain.
+_keychain_lists() {
+    local workdir="$1"
+    shift
+    : > "$workdir/identities.txt"
+    [ $# -eq 0 ] || printf '%s\n' "$@" > "$workdir/identities.txt"
 }
 
 # A real certificate nobody can be assumed to hold, as DER in $1/leaf.der;
-# echoes its SHA-1. Non-zero when it cannot be made, because an empty hash
-# would silently turn "carries X" into "unsigned" and let a case pass without
-# ever exercising the rule it pins.
+# echoes its SHA-1. Its presence is what makes a case's bundle "carry" it:
+# _choose and _run_dev_bundle_script put the codesign stand-in on PATH when the
+# file exists, and the transcript is then written around the hash. Non-zero
+# when it cannot be made, because an empty hash would silently turn
+# "carries X" into "unsigned" and let a case pass without ever exercising the
+# rule it pins.
 _make_leaf_cert() {
     local workdir="$1" hash
     openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
@@ -129,33 +187,17 @@ _make_leaf_cert() {
     printf '%s' "$hash"
 }
 
-# Makes the bundle "carry" that certificate: a codesign stand-in hands the
-# library the leaf on --extract-certificates, so bundle_signing_cert_sha1
-# computes a real hash, and the transcript is then written around that hash.
-# Echoes the hash; non-zero as _make_leaf_cert.
-_make_carried_cert() {
-    local workdir="$1" hash
-    hash="$(_make_leaf_cert "$workdir")" || return 1
-    mkdir -p "$workdir/bin"
-    cat > "$workdir/bin/codesign" <<STUB
-#!/usr/bin/env bash
-case "\$*" in
-    *--extract-certificates*) cp "$workdir/leaf.der" ./codesign0 ;;
-esac
-exit 0
-STUB
-    chmod +x "$workdir/bin/codesign"
-    printf '%s' "$hash"
-}
-
 # Runs the function the way a caller does: a separate bash PROCESS under
 # `set -euo pipefail` (a subshell would inherit run_test's errexit suppression,
-# see test_signing_resign.sh), stubs first on PATH, the library sourced. Prints
-# a `field=value` report: the three globals plus the function's own stdout,
-# because the note it prints is part of the contract.
+# see test_signing_resign.sh), stand-ins first on PATH, the library sourced.
+# Prints a `field=value` report: the three globals plus the function's own
+# stdout, because the note it prints is part of the contract.
 _choose() {
-    local workdir="$1" bundle="$2"
-    PATH="$workdir/bin:$PATH" \
+    local workdir="$1" bundle="$2" path="$STUB_SECURITY:$PATH"
+    [ -f "$workdir/leaf.der" ] && path="$STUB_CODESIGN:$path"
+    PATH="$path" \
+    SECURITY_IDENTITIES="$workdir/identities.txt" \
+    STUB_LEAF_DER="$workdir/leaf.der" \
     SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
         bash -c 'set -euo pipefail
                  # shellcheck source=../lib/signing.sh
@@ -177,66 +219,39 @@ _expect() {
 }
 
 # Stages, in $1/repo, the slice of the repository the dev-bundle scripts need
-# to run up to and including their signing step, and echoes that root. Around
-# it, stand-ins for everything that is not the decision under test: `swift`
-# builds nothing, `pgrep` finds no running app, the model fetch answers with
-# a dummy file, and `open` exits 42 so a script that reaches its launch stops
-# there with a status no earlier failure produces. The previous build's
-# executable and the freshly built binary carry markers, and the codesign
-# stand-in hands out the leaf certificate only while the previous executable
-# is still in place. That is what real codesign does (measured: the intact
-# bundle yields the certificate, the same bundle with a fresh binary copied in
-# reports an ad-hoc signature and yields none), so a script that decides after
-# its copy sees no carried certificate here exactly as it would in production.
-# Every codesign call is logged to $1/codesign.log.
+# to run up to and including their signing step. The previous build's
+# executable and the freshly built binary carry the markers the codesign
+# stand-in reads. Echoes nothing; non-zero when the fixture cannot be built.
 _stage_dev_bundle_scripts() {
     local workdir="$1" root="$1/repo" spm bundle
     spm="$root/app/MeetingTranscriber"
     bundle="$spm/.build/MeetingTranscriber-Dev.app"
-    mkdir -p "$root/scripts/lib" "$root/licenses" "$root/model" "$root/tools/mt-cli" \
-        "$spm/Sources" "$spm/Entitlements" "$spm/.build/release" "$bundle/Contents/MacOS" \
-        "$workdir/bin" || return 1
+    mkdir -p "$root/scripts/lib" "$root/licenses" "$root/tools/mt-cli" \
+        "$spm/Sources" "$spm/Entitlements" "$spm/.build/release" "$bundle/Contents/MacOS" || return 1
     cp "$REPO_ROOT/scripts/run_app.sh" "$REPO_ROOT/scripts/test_rpc.sh" "$root/scripts/" || return 1
     cp "$REPO_ROOT"/scripts/lib/*.sh "$root/scripts/lib/" || return 1
     cp "$REPO_ROOT/app/MeetingTranscriber/Sources/Info.plist" "$spm/Sources/" || return 1
     cp "$REPO_ROOT/app/MeetingTranscriber/Entitlements/Homebrew.entitlements" "$spm/Entitlements/" || return 1
+    ln -s "$STUB_HARNESS/fetch-localvqe-model.sh" "$root/scripts/fetch-localvqe-model.sh" || return 1
     printf '0.0.0\n' > "$root/VERSION"
     printf 'stand-in licence\n' > "$root/licenses/Test-LICENSE.txt"
-    printf 'stand-in model\n' > "$root/model/localvqe-test.gguf"
-    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$root/model/localvqe-test.gguf" \
-        > "$root/scripts/fetch-localvqe-model.sh"
     printf 'previous build\n' > "$bundle/Contents/MacOS/MeetingTranscriber"
     printf 'fresh build\n' > "$spm/.build/release/MeetingTranscriber"
-    chmod +x "$root/scripts/fetch-localvqe-model.sh" "$bundle/Contents/MacOS/MeetingTranscriber" \
-        "$spm/.build/release/MeetingTranscriber" || return 1
-
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$workdir/bin/swift"
-    printf '#!/usr/bin/env bash\nexit 1\n' > "$workdir/bin/pgrep"
-    printf '#!/usr/bin/env bash\nexit 42\n' > "$workdir/bin/open"
-    cat > "$workdir/bin/codesign" <<STUB
-#!/usr/bin/env bash
-printf '%s\n' "\$*" >> "$workdir/codesign.log"
-case "\$*" in
-    *--extract-certificates*)
-        if [ -f "$workdir/leaf.der" ] \\
-            && grep -q 'previous build' "$bundle/Contents/MacOS/MeetingTranscriber" 2>/dev/null; then
-            cp "$workdir/leaf.der" ./codesign0
-        fi ;;
-    *--verify*) exit 1 ;;
-    *"--entitlements :-"*) printf '<key>stand-in</key>' ;;
-esac
-exit 0
-STUB
-    chmod +x "$workdir/bin/"* || return 1
-    printf '%s' "$root"
+    chmod +x "$bundle/Contents/MacOS/MeetingTranscriber" "$spm/.build/release/MeetingTranscriber"
 }
 
 # Runs one of the staged scripts with the stand-ins first on PATH; its output
-# goes to $1/run.log, its status is returned.
+# goes to $1/run.log, every codesign call to $1/codesign.log, and its status
+# is returned.
 _run_dev_bundle_script() {
-    local workdir="$1" script="$2"
+    local workdir="$1" script="$2" root="$1/repo"
     shift 2
-    PATH="$workdir/bin:$PATH" bash "$workdir/repo/scripts/$script" "$@" > "$workdir/run.log" 2>&1
+    PATH="$STUB_HARNESS:$STUB_CODESIGN:$STUB_SECURITY:$PATH" \
+    SECURITY_IDENTITIES="$workdir/identities.txt" \
+    STUB_LEAF_DER="$workdir/leaf.der" \
+    STUB_EXECUTABLE="$root/app/MeetingTranscriber/.build/MeetingTranscriber-Dev.app/Contents/MacOS/MeetingTranscriber" \
+    CODESIGN_CALLS="$workdir/codesign.log" \
+        bash "$root/scripts/$script" "$@" > "$workdir/run.log" 2>&1
 }
 
 # The identity a staged script signed with, from the codesign log.
@@ -254,11 +269,11 @@ test_keeps_a_developer_id_the_bundle_already_carries() {
     local workdir bundle carried report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    carried="$(_make_carried_cert "$workdir")" || {
+    carried="$(_make_leaf_cert "$workdir")" || {
         echo "  fixture failed: could not create a test certificate" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
         "$carried \"Developer ID Application: Someone (TEAM)\""
 
@@ -283,11 +298,11 @@ test_moves_an_apple_development_bundle_to_developer_id() {
     local workdir bundle carried report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    carried="$(_make_carried_cert "$workdir")" || {
+    carried="$(_make_leaf_cert "$workdir")" || {
         echo "  fixture failed: could not create a test certificate" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$carried \"Apple Development: Someone (ABCDE12345)\"" \
         "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
 
@@ -309,7 +324,7 @@ test_prefers_developer_id_over_the_first_listed_identity() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\"" \
         "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
 
@@ -331,7 +346,7 @@ test_takes_the_first_identity_when_no_developer_id_exists() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$SELF_SIGNED \"MeetingTranscriberDevSelfHosted\"" \
         "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\""
 
@@ -354,11 +369,11 @@ test_keeps_a_non_developer_id_certificate_when_there_is_none_to_move_to() {
     local workdir bundle carried report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    carried="$(_make_carried_cert "$workdir")" || {
+    carried="$(_make_leaf_cert "$workdir")" || {
         echo "  fixture failed: could not create a test certificate" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$APPLE_DEV \"Apple Development: Other (ABCDE12345)\"" \
         "$carried \"Apple Development: Someone (ABCDE12345)\""
 
@@ -384,11 +399,11 @@ test_does_not_keep_a_carried_certificate_that_left_the_keychain() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _make_carried_cert "$workdir" >/dev/null || {
+    _make_leaf_cert "$workdir" >/dev/null || {
         echo "  fixture failed: could not create a test certificate" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$APPLE_DEV \"Apple Development: Someone (ABCDE12345)\""
 
     report="$(_choose "$workdir" "$bundle")"
@@ -409,7 +424,7 @@ test_an_empty_keychain_yields_no_identity_and_does_not_abort() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _write_security_stub "$workdir"
+    _keychain_lists "$workdir"
 
     report="$(_choose "$workdir" "$bundle")"
     status=$?
@@ -435,7 +450,7 @@ test_run_app_decides_before_it_replaces_the_executable() {
         echo "  fixture failed: could not stage the scripts or create a test certificate" >&2
         rm -rf "$workdir"; return 1
     fi
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
         "$carried \"Developer ID Application: Someone (TEAM)\""
 
@@ -466,7 +481,7 @@ test_a_name_that_only_contains_developer_id_application_does_not_win() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$SELF_SIGNED \"Archive of Developer ID Application: Someone (TEAM)\"" \
         "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
 
@@ -489,11 +504,11 @@ test_a_carried_certificate_only_named_after_developer_id_is_not_kept() {
     local workdir bundle carried report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    carried="$(_make_carried_cert "$workdir")" || {
+    carried="$(_make_leaf_cert "$workdir")" || {
         echo "  fixture failed: could not create a test certificate" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$carried \"Archive of Developer ID Application: Someone (TEAM)\"" \
         "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
 
@@ -514,7 +529,7 @@ test_a_record_without_a_name_is_not_an_identity() {
     local workdir bundle report status rc=0
     workdir="$(mktemp -d)"
     bundle="$(_make_bundle "$workdir")"
-    _write_security_stub "$workdir" "$DEVID_A"
+    _keychain_lists "$workdir" "$DEVID_A"
 
     report="$(_choose "$workdir" "$bundle")"
     status=$?
@@ -538,11 +553,12 @@ test_prepare_signing_resolves_the_same_developer_id() {
     mkdir -p "$workdir/profiles"
     printf 'stand-in for a provisioning profile' > "$workdir/profiles/com.example.test.provisionprofile"
     cp "$REPO_ROOT/app/MeetingTranscriber/Entitlements/Homebrew.entitlements" "$workdir/base.entitlements"
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$SELF_SIGNED \"Archive of Developer ID Application: Someone (TEAM)\"" \
         "$DEVID_A \"Developer ID Application: Someone (TEAM)\""
 
-    identity="$(PATH="$workdir/bin:$PATH" \
+    identity="$(PATH="$STUB_SECURITY:$PATH" \
+        SECURITY_IDENTITIES="$workdir/identities.txt" \
         PROFILE_DIR="$workdir/profiles" \
         SIGNING_LIB="$REPO_ROOT/scripts/lib/signing.sh" \
         bash -c 'set -euo pipefail
@@ -571,7 +587,7 @@ test_test_rpc_decides_before_it_replaces_the_executable() {
         echo "  fixture failed: could not stage the scripts or create a test certificate" >&2
         rm -rf "$workdir"; return 1
     fi
-    _write_security_stub "$workdir" \
+    _keychain_lists "$workdir" \
         "$DEVID_B \"Developer ID Application: Someone (TEAM)\"" \
         "$carried \"Developer ID Application: Someone (TEAM)\""
 
@@ -606,7 +622,7 @@ test_run_app_says_so_when_it_leaves_the_bundle_unsigned() {
         echo "  fixture failed: could not stage the scripts" >&2
         rm -rf "$workdir"; return 1
     }
-    _write_security_stub "$workdir"
+    _keychain_lists "$workdir"
 
     _run_dev_bundle_script "$workdir" run_app.sh --build-only
     status=$?
@@ -653,6 +669,7 @@ test_no_dev_bundle_script_queries_the_keychain_itself() {
     fi
 }
 
+_write_stubs
 echo "Testing choose_signing_identity in scripts/lib/signing.sh"
 echo
 run_test "a Developer ID the bundle already carries is kept over a newer one" \

--- a/scripts/tests/test_signing_resign.sh
+++ b/scripts/tests/test_signing_resign.sh
@@ -200,9 +200,13 @@ test_resign_keeps_a_signature_by_the_same_certificate() {
     return "$rc"
 }
 
-# scripts/test_rpc.sh copies a fresh binary into an already-signed bundle, so the
-# certificate still matches while the signature no longer does. Keeping it would
-# launch a bundle macOS refuses to run, so validity is part of the skip question.
+# A bundle can still name the requested certificate while its signature no longer
+# holds: the certificate sits in the executable's own signature, and the seal over
+# the resources and the plist breaks when anything under it changes after signing.
+# Keeping such a signature would launch a bundle macOS refuses to run, so validity
+# is part of the skip question. (test_rpc.sh's fresh-binary copy is not this case:
+# it replaces the executable the certificate is read from, and the hash comparison
+# already sends that to the re-sign; see resign_deployed_bundle.)
 test_resign_replaces_a_stale_signature_by_the_same_certificate() {
     local workdir bundle status hash rc=0
     workdir="$(mktemp -d)"


### PR DESCRIPTION
`scripts/test_rpc.sh` cannot run on a machine that holds both an Apple Development and a Developer ID certificate, which is every maintainer machine. It picked its signing identity with

```bash
SIGN_HASH=$(security find-identity -v -p codesigning | head -1 | awk '{print $2}')
```

and `head -1` is an Apple Development certificate here. TCC grants are recorded against the Developer ID, so the freshly signed dev bundle looks like a different app, Screen Recording is denied, `/screenshot` finds no window, and the script dies:

```
==> Action + screenshot loop
    ok  idle -> 503
Error: RPC returned HTTP 503: no window
```

Reproduced on `main` and on an unrelated contributor branch, so it is not branch-specific.

## The cause is duplication, not that one line

`run_app.sh` already solved this, carefully: keep the certificate the bundle carries while it is still in the keychain and is a Developer ID one or there is nothing better to move to; otherwise the Developer ID; otherwise the first identity, saying out loud that TCC grants will not apply. `test_rpc.sh` had its own one-line version. Only one of the two was ever fixed, and that is why this reappeared.

So the choice moves into `scripts/lib/signing.sh`, which both scripts already source, and both call it.

## What review turned up on the way

Three defects in the extraction itself, found by two review passes and fixed here:

- **The Developer ID test was an unanchored substring over the whole listing line.** A self-signed certificate named `Archive of Developer ID Application: ...`, listed first, would win, and self-signed names are locally chosen by `setup-self-hosted-runner.sh`. Identities are now parsed into `<sha1> <name>` records and the rule matches the name against `^Developer ID Application: `. The same whole-line grep was in `prepare_signing`; it uses the shared lookup now too.
- **Both scripts chose the literal word `valid` on an empty keychain**, because `find-identity` prints `0 valid identities found` and `head -1 | awk '{print $2}'` reads `valid` out of it. That was latent in `run_app.sh` as well.
- **`run_app.sh` went quiet where it used to fail.** On an empty keychain it died at codesign; the extraction would have let it deploy an unsigned bundle silently. It now warns explicitly and stays non-fatal.

## Ordering matters, and is now pinned

`choose_signing_identity` has to run **before** `test_rpc.sh` copies the fresh binary into the bundle: that copy destroys the signature the decision reads (measured: afterwards `Signature=adhoc`, zero certificates, `--verify` fails). Moving the call back below the copy used to leave every test green, so the tests now pin the ordering behaviourally, by running both scripts from a staged copy with `security` and `codesign` stubbed and asserting which hash is signed with.

## Verification

`scripts/tests/test_signing_identity_choice.sh` covers the rules, the guard, and the caller invariant. Eleven mutations, each with its own failure:

```
drop -v from the query          listing expected '2) ...' got '3) ...'
drop -p codesigning             identity expected DDDD.. got FFFF.. "Email Encryption"
keep a vanished certificate     reason got 'kept the certificate this bundle already carried'
substring Developer ID rule     got 'DDDD.. "Archive of Developer ID Application..."'
accept a nameless record        identity expected '<empty>', got 'AAAA..'
prepare_signing's old grep      resolved 'DDDD..' instead of AAAA..
call moved below the cp (x2)    signed with 'BBBB..' instead of the carried <hash>
one-line and two-stage query    guard names the file and line
else branch removed             left the bundle unsigned without saying so
```

The fixture used to copy `/bin/echo`, which carries Apple's software signing certificate, so a bundle the comment called unsigned was not: under a genuinely unsigned fixture the keychain-presence rule survived mutation. Fixed, and the missing case added.

Measured end to end on a machine with two Apple Development certificates and one Developer ID, which is the failing configuration:

```
bundle carrying Apple Development, Developer ID present
  -> "signing identity: chose the Developer ID Application certificate"
  -> Authority=Developer ID Application: Roman Passler (6TT96JB58N)
  -> ==> All checks passed
```

Before this change the same machine stopped at `503: no window`.

## Not affected

The self-hosted lanes are authoritative about their own signature: they build via `run_app.sh --build-only` and then re-sign the deployed bundle explicitly with `dev_signing_identity` or `$DEVELOPER_ID`, so the in-tree choice never reaches what they run. `build_release.sh` and `e2e-browser.sh` source the library but never call the chooser. Verified by reading; running it would need the runner itself.

All seven `scripts/tests/test_*.sh` pass, `shellcheck -x` is clean on every touched script, `./scripts/lint.sh` reports 0 violations in 538 files.
