### PR TITLE
fix(app): stop reporting a working Accessibility grant as broken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - `UpdateChecker` checks GitHub releases for newer versions, shows badge on menu bar icon.
 
 **Permission health check:**
-- `PermissionHealthCheck` verifies each TCC permission by combining the system verdict with a live probe. Each resolves to `PermissionStatus` (`.healthy | .denied | .broken | .notDetermined`). `.broken` means TCC says allowed but the probe disagrees — fix is to toggle the permission off and on in System Settings.
+- `PermissionHealthCheck` verifies each TCC permission by combining the system verdict with a live probe. Each resolves to `PermissionStatus` (`.healthy | .denied | .broken | .notDetermined`). `.broken` means TCC says allowed but the probe disagrees — fix is to toggle the permission off and on in System Settings. The Accessibility probe is a cross-process call, so only `kAXErrorAPIDisabled` counts as `.broken`; `.success` and `.noValue` are `AccessibilityProbe.responded`, and every other AXError is `.inconclusive` and reports healthy. Treating those as broken produced a notification telling users to toggle a permission that was working. `kAXErrorNotImplemented` stays inconclusive on purpose: Apple documents it as the asked process lacking AX support. The raw code is appended to `/tmp/mt-permission.log`, which `debugLog` truncates per process.
 - `WatchLoop` runs the check on startup; `AppState` re-runs on app activation.
 - When unhealthy: `MenuBarIcon` composites a red "!" badge over the current icon (non-template, stays red in dark mode). `BadgeKind.compute()` returns `.error` when idle with a problem. A deduped notification is posted via `NotificationManager`.
 

--- a/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
+++ b/app/MeetingTranscriber/Sources/PermissionHealthCheck.swift
@@ -427,22 +427,83 @@ enum PermissionHealthCheck {
 
     // MARK: - Accessibility (pure, testable)
 
+    /// What the AX probe actually learned. Three cases and not a `Bool`, because
+    /// the probe reaches ACROSS PROCESSES and its failures are therefore not all
+    /// about us: only one of them is evidence about our own grant.
+    enum AccessibilityProbe: Equatable {
+        /// The API answered. Says our grant works.
+        case responded
+        /// The AX API is disabled for us (`kAXErrorAPIDisabled`). The only
+        /// outcome that is evidence our own grant is not working.
+        case apiDisabled
+        /// The call failed for a reason that has not been shown to be about our
+        /// permission. Carries the raw code for the log, so the next occurrence
+        /// can be attributed instead of guessed.
+        case inconclusive(AXError)
+
+        /// Compact, PII-free token for the diagnostic log. The raw `AXError`
+        /// value is spelled out because the name alone ("inconclusive") is what
+        /// the old `Bool` already told us; the number is the part that says
+        /// which failure it was.
+        var logToken: String {
+            switch self {
+            case .responded: "responded"
+            case .apiDisabled: "apiDisabled"
+            case let .inconclusive(err): "inconclusive(AXError \(err.rawValue))"
+            }
+        }
+    }
+
     /// Pure decision function for Accessibility permission state.
     ///
     /// - `trusted`: whether `AXIsProcessTrusted()` returns true.
-    /// - `probeSucceeds`: whether a concrete AX API call (e.g. reading the focused app of
-    ///   `AXUIElementCreateSystemWide`) returns `.success`.
+    /// - `probe`: what a concrete AX API call learned.
+    ///
+    /// **An inconclusive probe reports `.healthy`, not `.broken`.** This used to
+    /// be a `Bool` where every non-success collapsed to "broken", and the
+    /// reported consequence was a false alarm telling users to toggle a
+    /// permission that was fine: one process, no user action, and the verdict
+    /// flipping healthy -> broken -> healthy inside 70 seconds. A revoked grant
+    /// does not repair itself in a minute.
+    ///
+    /// `.broken` exists for exactly one situation, TCC saying yes while the API
+    /// says no, and `AXIsProcessTrusted()` is already the system's own answer
+    /// about our grant. So the probe only has to catch that contradiction, which
+    /// is `.apiDisabled`.
     static func checkAccessibility(
         trusted: Bool,
-        probeSucceeds: Bool,
+        probe: AccessibilityProbe,
     ) -> PermissionStatus {
         if !trusted { return .denied }
-        return probeSucceeds ? .healthy : .broken
+        switch probe {
+        case .responded, .inconclusive: return .healthy
+        case .apiDisabled: return .broken
+        }
+    }
+
+    /// What one `AXError` says about *our* Accessibility access. Kept apart from
+    /// the call that produces it because this mapping is the decision the fix
+    /// turns on, and welding it to an I/O call would leave it untestable.
+    ///
+    /// `.notImplemented` takes the default branch deliberately: Apple documents
+    /// it as "can be returned if a PROCESS does not support the accessibility
+    /// API" — the process being asked, not us.
+    static func classify(_ err: AXError) -> AccessibilityProbe {
+        switch err {
+        // .noValue: nothing focused right now, but the API answered.
+        case .success, .noValue: .responded
+        case .apiDisabled: .apiDisabled
+        default: .inconclusive(err)
+        }
     }
 
     /// Probes the Accessibility API with a lightweight system-wide call.
-    /// Returns true if the call succeeds (and we either get a valid attribute or `noValue`).
-    static func probeAccessibility() -> Bool {
+    ///
+    /// `kAXFocusedApplicationAttribute` on the system-wide element is a question
+    /// put to whichever app currently has focus, so its failure modes belong to
+    /// that app as much as to us — which is what `AccessibilityProbe` separates.
+    /// Everything except the call itself lives in `classify`.
+    static func probeAccessibility() -> AccessibilityProbe {
         let systemWide = AXUIElementCreateSystemWide()
         var value: CFTypeRef?
         let err = AXUIElementCopyAttributeValue(
@@ -450,9 +511,7 @@ enum PermissionHealthCheck {
             kAXFocusedApplicationAttribute as CFString,
             &value,
         )
-        // .success: got the focused app. .noValue: no focused app right now, but the API worked.
-        // Any other error (e.g. .cannotComplete, .apiDisabled) indicates AX isn't actually granted.
-        return err == .success || err == .noValue
+        return classify(err)
     }
 
     static func checkAccessibilityLive() -> PermissionStatus {
@@ -462,8 +521,11 @@ enum PermissionHealthCheck {
             return .denied
         }
         let probe = probeAccessibility()
-        let r = checkAccessibility(trusted: trusted, probeSucceeds: probe)
-        debugLog("checkAccessibilityLive: trusted=true probe=\(probe) → \(r)")
+        let r = checkAccessibility(trusted: trusted, probe: probe)
+        // The raw AXError is logged, not just the verdict. Without it the false
+        // alarm above could only be diagnosed by noticing the timing, because a
+        // `Bool` had already thrown away the one fact that explains it.
+        debugLog("checkAccessibilityLive: trusted=true probe=\(probe.logToken) → \(r)")
         return r
     }
 

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckAccessibilityTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckAccessibilityTests.swift
@@ -1,0 +1,124 @@
+import ApplicationServices
+@testable import MeetingTranscriber
+import XCTest
+
+/// Accessibility permission verdicts, split out of `PermissionHealthCheckTests`
+/// so neither class outgrows the 400-line body limit. The probe's three-way
+/// outcome carries most of the reasoning in this area, so it earns its own file.
+final class PermissionHealthCheckAccessibilityTests: XCTestCase {
+    func testAccessibilityHealthy() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probe: .responded)
+        XCTAssertEqual(result, .healthy)
+    }
+
+    func testAccessibilityDenied() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probe: .apiDisabled)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testAccessibilityDeniedEvenIfProbeSucceeds() {
+        // Defensive: if the system says no, we never report healthy.
+        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probe: .responded)
+        XCTAssertEqual(result, .denied)
+    }
+
+    func testAccessibilityBroken() {
+        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probe: .apiDisabled)
+        XCTAssertEqual(result, .broken)
+    }
+
+    /// The regression this split exists for. `.cannotComplete` is what a
+    /// frontmost app that does not answer AX produces, and it used to collapse
+    /// into the same "broken" as a genuinely closed API — which is how a healthy
+    /// grant got a notification telling the user to toggle it off and on.
+    func testAccessibilityInconclusiveProbeIsNotReportedAsBroken() {
+        let result = PermissionHealthCheck.checkAccessibility(
+            trusted: true, probe: .inconclusive(.cannotComplete),
+        )
+        XCTAssertEqual(
+            result, .healthy,
+            "An unresponsive frontmost app says nothing about our own grant",
+        )
+    }
+
+    /// Every non-`apiDisabled` error takes the inconclusive path, so the fix
+    /// does not depend on guessing which code a busy app happens to return.
+    func testAccessibilityOtherAXErrorsAreAlsoInconclusive() {
+        for error in [AXError.failure, .invalidUIElement, .illegalArgument, .attributeUnsupported] {
+            XCTAssertEqual(
+                PermissionHealthCheck.checkAccessibility(trusted: true, probe: .inconclusive(error)),
+                .healthy,
+                "AXError \(error.rawValue) describes the element asked, not our permission",
+            )
+        }
+    }
+
+    // MARK: - AXError classification
+
+    /// `.notImplemented` sits next to `.apiDisabled` in the AX header and means
+    /// something entirely different: the *asked* process has incomplete AX
+    /// support. Classifying it as a permission failure would re-create the false
+    /// alarm for every such app, so the classifier must keep them apart. This
+    /// asserts the mapping itself, not its consequence two calls downstream.
+    func testClassifyMapsOnlyApiDisabledToTheBrokenSignal() {
+        XCTAssertEqual(PermissionHealthCheck.classify(.apiDisabled), .apiDisabled)
+    }
+
+    func testClassifyKeepsNotImplementedOutOfTheBrokenSignal() {
+        XCTAssertEqual(
+            PermissionHealthCheck.classify(.notImplemented),
+            .inconclusive(.notImplemented),
+            "notImplemented describes the process being asked, not our grant",
+        )
+    }
+
+    func testClassifyTreatsAnsweredCallsAsResponded() {
+        // `.noValue` is not a failure: nothing has focus right now, but the API
+        // answered, which is the only thing the probe asked.
+        XCTAssertEqual(PermissionHealthCheck.classify(.success), .responded)
+        XCTAssertEqual(PermissionHealthCheck.classify(.noValue), .responded)
+    }
+
+    func testClassifyTreatsCannotCompleteAsInconclusive() {
+        XCTAssertEqual(
+            PermissionHealthCheck.classify(.cannotComplete),
+            .inconclusive(.cannotComplete),
+        )
+    }
+
+    /// Every remaining error describes the element that was asked. Enumerated
+    /// rather than sampled, so a future regrouping of any one of them has to
+    /// come here and say so.
+    func testClassifyTreatsEveryOtherErrorAsInconclusive() {
+        let others: [AXError] = [
+            .failure, .illegalArgument, .invalidUIElement, .invalidUIElementObserver,
+            .cannotComplete, .attributeUnsupported, .actionUnsupported,
+            .notificationUnsupported, .notImplemented, .notificationAlreadyRegistered,
+            .notificationNotRegistered, .parameterizedAttributeUnsupported,
+            .notEnoughPrecision,
+        ]
+        for error in others {
+            XCTAssertEqual(
+                PermissionHealthCheck.classify(error), .inconclusive(error),
+                "AXError \(error.rawValue) is about the element asked, not our permission",
+            )
+        }
+    }
+
+    /// The end-to-end shape of the fix: a classified error carried through to a
+    /// permission verdict.
+    func testInconclusiveClassificationReachesAHealthyVerdict() {
+        let probe = PermissionHealthCheck.classify(.cannotComplete)
+        XCTAssertEqual(PermissionHealthCheck.checkAccessibility(trusted: true, probe: probe), .healthy)
+    }
+
+    /// The verdict alone could not explain the false alarm; the raw code can.
+    func testAccessibilityProbeLogTokenCarriesTheRawErrorCode() {
+        XCTAssertEqual(
+            PermissionHealthCheck.AccessibilityProbe.inconclusive(.cannotComplete).logToken,
+            "inconclusive(AXError \(AXError.cannotComplete.rawValue))",
+        )
+        XCTAssertEqual(PermissionHealthCheck.AccessibilityProbe.responded.logToken, "responded")
+        XCTAssertEqual(PermissionHealthCheck.AccessibilityProbe.apiDisabled.logToken, "apiDisabled")
+    }
+}

--- a/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
+++ b/app/MeetingTranscriber/Tests/PermissionHealthCheckTests.swift
@@ -117,29 +117,6 @@ final class PermissionHealthCheckTests: XCTestCase {
         )
     }
 
-    // MARK: - Accessibility
-
-    func testAccessibilityHealthy() {
-        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probeSucceeds: true)
-        XCTAssertEqual(result, .healthy)
-    }
-
-    func testAccessibilityDenied() {
-        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probeSucceeds: false)
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testAccessibilityDeniedEvenIfProbeSucceeds() {
-        // Defensive: if the system says no, we never report healthy.
-        let result = PermissionHealthCheck.checkAccessibility(trusted: false, probeSucceeds: true)
-        XCTAssertEqual(result, .denied)
-    }
-
-    func testAccessibilityBroken() {
-        let result = PermissionHealthCheck.checkAccessibility(trusted: true, probeSucceeds: false)
-        XCTAssertEqual(result, .broken)
-    }
-
     // MARK: - Overall Health
 
     func testOverallHealthy() {


### PR DESCRIPTION
## The bug

The permission check tells users "Accessibility looks enabled but isn't working —
toggle it off and on in System Settings" while nothing is wrong with the grant.
`/tmp/mt-permission.log`, all in one process, with no user action in between:

```
17:37:50  trusted=true probe=true  -> healthy
17:39:29  trusted=true probe=false -> broken     (notification sent)
17:40:39  trusted=true probe=true  -> healthy
17:47:13  trusted=true probe=false -> broken     (notification sent)
```

A revoked grant does not repair itself in seventy seconds.

## Why it happens

`probeAccessibility()` asks the system-wide AX element for the **frontmost app's**
focused application. That is a cross-process call, so its failure modes belong to
whichever app happens to have focus — but the result was a `Bool` where every
non-success collapsed into "our permission is broken". The check was measuring
how responsive some other application is and announcing the answer as if it were
about us.

## The fix

`AXIsProcessTrusted()` is already the system's own answer about our grant, and
`.broken` exists for exactly one situation: TCC says yes while the API says no.
So the probe only has to catch that contradiction. `kAXErrorAPIDisabled` is
documented as "the accessibility API is disabled" and is the one error that
qualifies; everything else becomes `AccessibilityProbe.inconclusive` and reports
healthy.

`kAXErrorNotImplemented` is deliberately kept out of that bucket even though it
reads like a sibling — Apple documents it as returned when *the process being
asked* does not support the accessibility API, so classifying it as a permission
failure would re-create the same false alarm for every frontmost app with
incomplete AX support. `testClassifyKeepsNotImplementedOutOfTheBrokenSignal` pins that
distinction against `classify` itself, and fails if the two are regrouped.

The raw `AXError` now reaches the diagnostic log. The `Bool` had thrown away the
one fact that explained the failure, which is why this could only be diagnosed by
noticing the timing rather than by reading the code.

**Rejected:** hysteresis over consecutive failures. With the errors classified,
the only remaining route to `.broken` is a non-transient condition, so a counter
would just delay a correct verdict while keeping the incorrect one reachable.

## Notes

The accessibility cases move into their own test file: the four added here push
`PermissionHealthCheckTests` past the 400-line `type_body_length` limit, and the
lint config allows one XCTestCase per file.

## Verification

- `swift test --parallel --skip ModelPreloadTests` — 3077 tests, 0 failures
- SwiftFormat clean, SwiftLint `--strict` exit 0
- `swift build -c release` clean under warnings-as-errors
