### PR TITLE
fix(app): split the scene body so no declaration nears the type-check limit

### DIFF
--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -100,91 +100,117 @@ struct MeetingTranscriberApp: App {
         }
     }
 
+    // One scene per declaration, not one `body` holding the whole tree. The
+    // analyze build passes `-warn-long-function-bodies=300` with warnings as
+    // errors, so a getter that type-checks slowly is a build failure, and the
+    // whole tree as a single expression shared one budget and crossed it on a
+    // GitHub-hosted runner. Each declaration below is type-checked on its own
+    // budget. Nothing leaves `body`'s evaluation: the properties are read from
+    // the same closures at the same moment, so `@Observable` records the same
+    // reads, and the scene order, window ids and modifiers are unchanged.
     var body: some Scene {
         MenuBarExtra {
-            MenuBarView(
-                status: appState.currentStatus,
-                isWatching: appState.isWatching,
-                pipelineQueue: appState.pipelineQueue,
-                updateChecker: appState.updateChecker,
-                onStartStop: { appState.watching.toggleWatching() },
-                onRecordApp: { bringWindowToFront(id: "record-app") },
-                onRecordMicrophone: { appState.watching.startMicrophoneRecording() },
-                noMic: appState.settings.noMic,
-                manualRecordingPendingOrActive: appState.watching.isManualRecording,
-                onStopManualRecording: appState.isManualRecording ? {
-                    appState.watching.stopManualRecording()
-                } : nil,
-                onOpenLastProtocol: openLastProtocol,
-                onOpenProtocol: { url in NSWorkspace.shared.open(url) },
-                onOpenProtocolsFolder: openProtocolsFolder,
-                onOpenSettings: {
-                    bringWindowToFront(id: "settings")
-                },
-                onNameSpeakers: appState.hasPendingSpeakerNamingJobs ? {
-                    bringWindowToFront(id: "speaker-naming")
-                } : nil,
-                onProcessFiles: processAudioFiles,
-                onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
-                onQuit: quit,
-            )
-        } label: { // swiftlint:disable:this closure_body_length
-            Label {
-                Text(appState.currentStateLabel)
-            } icon: {
-                AnimatedMenuBarIcon(
-                    badge: appState.currentBadge,
-                    permissionOverlay: appState.hasPermissionProblem,
-                    recordOnlyOverlay: appState.settings.recordOnly,
-                    // `recordingSilentActive` paints both halves; folded into the
-                    // hoisted overlay props so MenuBarIcon only needs the two
-                    // per-channel overlay inputs.
-                    micSilentOverlay: appState.micSilentOverlay,
-                    appSilentOverlay: appState.appSilentOverlay,
-                )
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
-                if !appState.isWatching {
-                    appState.watching.toggleWatching(userInitiated: false)
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
-                bringWindowToFront(id: "speaker-naming")
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .showSettings)) { _ in
-                bringWindowToFront(id: "settings")
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .closeSettings)) { _ in
-                closeWindow(id: "settings")
-            }
-            .task {
-                await appState.engines.preloadActiveModel()
-            }
-            .task {
-                appState.updateChecker.startPeriodicChecks(settings: appState.settings)
-            }
-            .task {
-                await appState.permissions.check()
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-                // Re-check permissions when the user returns to the app (e.g. from System
-                // Settings after toggling a permission). Debounced so rapid Cmd-Tab cycles
-                // don't repeatedly churn the mic HAL via the 500 ms probe.
-                Task { @MainActor in
-                    await appState.permissions.check(minimumInterval: 3)
-                }
-            }
-            .onChange(of: appState.shouldShowLiveCaptions, initial: true) { _, visible in
-                let controller = captionsWindow ?? LiveCaptionsWindowController(state: appState.liveCaptions)
-                captionsWindow = controller
-                if visible {
-                    controller.show()
-                } else {
-                    controller.hide()
-                }
-            }
+            menuBarContent
+        } label: {
+            menuBarLabel
         }
 
+        speakerNamingWindow
+        settingsWindow
+        recordAppWindow
+    }
+
+    // MARK: - Menu Bar
+
+    private var menuBarContent: some View {
+        MenuBarView(
+            status: appState.currentStatus,
+            isWatching: appState.isWatching,
+            pipelineQueue: appState.pipelineQueue,
+            updateChecker: appState.updateChecker,
+            onStartStop: { appState.watching.toggleWatching() },
+            onRecordApp: { bringWindowToFront(id: "record-app") },
+            onRecordMicrophone: { appState.watching.startMicrophoneRecording() },
+            noMic: appState.settings.noMic,
+            manualRecordingPendingOrActive: appState.watching.isManualRecording,
+            onStopManualRecording: appState.isManualRecording ? {
+                appState.watching.stopManualRecording()
+            } : nil,
+            onOpenLastProtocol: openLastProtocol,
+            onOpenProtocol: { url in NSWorkspace.shared.open(url) },
+            onOpenProtocolsFolder: openProtocolsFolder,
+            onOpenSettings: {
+                bringWindowToFront(id: "settings")
+            },
+            onNameSpeakers: appState.hasPendingSpeakerNamingJobs ? {
+                bringWindowToFront(id: "speaker-naming")
+            } : nil,
+            onProcessFiles: processAudioFiles,
+            onDismissJob: { id in appState.pipelineQueue.removeJob(id: id) },
+            onQuit: quit,
+        )
+    }
+
+    private var menuBarLabel: some View {
+        Label {
+            Text(appState.currentStateLabel)
+        } icon: {
+            AnimatedMenuBarIcon(
+                badge: appState.currentBadge,
+                permissionOverlay: appState.hasPermissionProblem,
+                recordOnlyOverlay: appState.settings.recordOnly,
+                // `recordingSilentActive` paints both halves; folded into the
+                // hoisted overlay props so MenuBarIcon only needs the two
+                // per-channel overlay inputs.
+                micSilentOverlay: appState.micSilentOverlay,
+                appSilentOverlay: appState.appSilentOverlay,
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .autoWatchStart)) { _ in
+            if !appState.isWatching {
+                appState.watching.toggleWatching(userInitiated: false)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showSpeakerNaming)) { _ in
+            bringWindowToFront(id: "speaker-naming")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showSettings)) { _ in
+            bringWindowToFront(id: "settings")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .closeSettings)) { _ in
+            closeWindow(id: "settings")
+        }
+        .task {
+            await appState.engines.preloadActiveModel()
+        }
+        .task {
+            appState.updateChecker.startPeriodicChecks(settings: appState.settings)
+        }
+        .task {
+            await appState.permissions.check()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // Re-check permissions when the user returns to the app (e.g. from System
+            // Settings after toggling a permission). Debounced so rapid Cmd-Tab cycles
+            // don't repeatedly churn the mic HAL via the 500 ms probe.
+            Task { @MainActor in
+                await appState.permissions.check(minimumInterval: 3)
+            }
+        }
+        .onChange(of: appState.shouldShowLiveCaptions, initial: true) { _, visible in
+            let controller = captionsWindow ?? LiveCaptionsWindowController(state: appState.liveCaptions)
+            captionsWindow = controller
+            if visible {
+                controller.show()
+            } else {
+                controller.hide()
+            }
+        }
+    }
+
+    // MARK: - Windows
+
+    private var speakerNamingWindow: some Scene {
         Window("Name Speakers", id: "speaker-naming") {
             speakerNamingContent
                 // Pin the naming window so it stays visible + on top while the
@@ -208,7 +234,9 @@ struct MeetingTranscriberApp: App {
                 }
         }
         .windowResizability(.contentSize)
+    }
 
+    private var settingsWindow: some Scene {
         Window("Settings", id: "settings") {
             SettingsView(
                 settings: appState.settings,
@@ -231,7 +259,9 @@ struct MeetingTranscriberApp: App {
             )
         }
         .windowResizability(.contentSize)
+    }
 
+    private var recordAppWindow: some Scene {
         Window("Record App", id: "record-app") {
             AppPickerView(
                 appsProvider: SystemRunningAppsProvider(),


### PR DESCRIPTION
`main` is failing CI on unchanged commits, and every open pull request inherits it.

The analyze build passes `-Xfrontend -warn-long-function-bodies=300` alongside `-warnings-as-errors`, so a slow-to-type-check `body` is a build failure. `MeetingTranscriberApp`'s scene body measured 327 ms against that 300 ms limit:

```
MeetingTranscriberApp.swift:103:26: error: getter for property 'body'
took 327ms to type-check (limit: 300ms)
** TEST BUILD FAILED **
```

`685a28c9` passed `analyze` at 11:46 that day; re-running the same job on the same commit at 20:14 reproduced the failure. So this is not any one branch's fault, and the failures now appearing on open pull requests are not theirs either. It also does not present as one failure: the `Cancel run on failure` step takes the run down, so `lint`, `test (homebrew)`, `test (appstore)` and `audiotap-coverage` all report `cancelled` next to it.

## The change

`body` held the whole scene tree as one expression: a `MenuBarExtra` with a long modifier chain on its label, plus three `Window` scenes with large view calls, all sharing one 300 ms budget. Each piece is now its own declaration with its own budget: `menuBarContent`, `menuBarLabel`, and one `some Scene` property per window (`speakerNamingWindow`, `settingsWindow`, `recordAppWindow`). `body` only composes them.

Nothing leaves `body`'s evaluation. The properties are read from the same closures at the same moment, so `@Observable` records the same reads; scene order, window ids, `.windowResizability` and the `WindowAccessor` pin are unchanged. The moved code is identical apart from indentation (`git diff -w --color-moved` shows only the new declaration lines as non-moves).

An earlier revision of this PR hoisted two closure arguments into computed properties instead. That measured 86 ms against 104 ms in the layout below, and most of the difference was cost relocating into the new properties rather than going away. It was replaced by the split.

## Measured

Local, `-Xfrontend -debug-time-function-bodies` on the SwiftPM driver invocation, medians over repeats, idle machine. Two compile layouts, because the number depends on which file in a batch is the first to touch a declaration:

**CI layout.** The analyze log shows this file compiled in a 24-file batch (LiveTranscriptionController+Nemotron.swift through NamingWindowPolicy.swift, this file fifteenth). The local driver at `-j4` produces the identical batch. Median of 5:

```
origin/main        body 104 ms
this PR            body   2 ms
                   menuBarContent 51, menuBarLabel 21,
                   speakerNamingWindow 13, settingsWindow 9, recordAppWindow 1
```

**This file as the only primary.** Median of 7:

```
origin/main        body 99 ms
this PR            body  2 ms; menuBarContent 44, menuBarLabel 20,
                   speakerNamingWindow 12, settingsWindow 9, recordAppWindow 1
```

## Projection to the runner, and how far to trust it

There is one runner datum: 327 ms for `body` on `origin/main`, against 104 ms for the same body in the same layout here, a factor of about three. On that anchor the largest declaration after this PR (`menuBarContent`, 51 ms) lands near 160 ms against the 300 ms limit.

That anchor is one observation. The same commit passed and failed the same job on the same day, and the local figure for `origin/main` has itself ranged from 99 ms to about 150 ms between sessions on one machine, depending on what else was running. So "near 160 ms" is an estimate with a wide band, not a margin anyone has measured on the runner. What can be said from the measurements is the ratio: the largest declaration in this file is now half of what `body` was, in both layouts.

## Measured and left alone

Two figures from the earlier revision of this PR are corrected here.

`AppState.init` was published as 122 ms local. That number came from a local `-j16` build, where `AppState.swift` is the first file in a 12-file batch and pays the first-touch cost of everything it references. In the CI layout it is the thirteenth file of its batch, after the `AppSettings` files, and measures 29 ms (median of 15 driver runs, range 26 to 33). With `AppState.swift` as the only primary it is 85 ms. The CI-layout figure is the one that models the runner; the 122 ms figure does not.

After this PR the module's largest bodies in the CI layout are no longer in this file:

```
AdvancedSettingsView.body        70 to 75 ms
AppState+RPC.swift:103            53 ms
OutputSettingsView.body           48 ms
MeetingTranscriberApp.menuBarContent   51 ms
```

`AdvancedSettingsView.body` is now the closest to the limit, roughly 220 to 235 ms on the same factor-of-three anchor. It has not failed, and it is left alone in this PR. But at the runner variability observed, that body is the next coin flip. Two follow-ups would make this class of failure visible instead of surprising: have the `analyze` job print the ten slowest function bodies on every run (the flag is already on; only the output is discarded), and either split `AdvancedSettingsView.body` the same way or raise the limit with the measured distribution as the justification.

Full suite green (3073 tests), `./scripts/lint.sh` 0 violations in 538 files, `./scripts/pre-push.sh` release build green.
