### PR TITLE
ci: report the slowest type-checked bodies on every analyze run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,38 @@ jobs:
           # SWIFT_SUPPRESS_WARNINGS=NO: without it xcodebuild fails outright on
           # AudioTapLib's warning gate. Reason at the flag in
           # tools/audiotap/Package.swift.
-          xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' SWIFT_SUPPRESS_WARNINGS=NO build-for-testing 2>&1 | tee /tmp/xcodebuild.log
+          #
+          # OTHER_SWIFT_FLAGS adds the per-body type-check timing print that the
+          # report step below turns into a step summary. `$(inherited)` is
+          # load-bearing: a command-line setting reaches every SPM target, and
+          # without it the override would replace the package's own
+          # -warn-long-function-bodies gate instead of sitting next to it
+          # (verified on Xcode 26.6: both flags on the same compile command).
+          # The compiler prints one line per body, some 33,000 across app and
+          # dependencies, so the file keeps them and the console stream does
+          # not. Clean build time was unchanged within noise.
+          # shellcheck disable=SC2016  # $(inherited) is an Xcode setting reference, not a shell expansion
+          xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' SWIFT_SUPPRESS_WARNINGS=NO \
+            OTHER_SWIFT_FLAGS='$(inherited) -Xfrontend -debug-time-function-bodies' build-for-testing 2>&1 \
+            | tee /tmp/xcodebuild.log | bash "$GITHUB_WORKSPACE/scripts/ci/type-check-timings.sh" strip
           cd "$GITHUB_WORKSPACE"
-          swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging
+          # swiftlint analyze re-runs the compiler with the arguments it finds
+          # in the log, timing flag included, so SourceKit prints the same lines
+          # into swiftlint's output; stripped the same way. Its findings do not
+          # change: output identical after the strip, +14 s on a 212 s run.
+          swiftlint analyze --strict --compiler-log-path /tmp/xcodebuild.log --reporter github-actions-logging 2>&1 \
+            | bash scripts/ci/type-check-timings.sh strip
+      # Non-gating by construction: the 300 ms limit in Package.swift stays the
+      # only enforcement. `continue-on-error` keeps any report problem from
+      # failing the job, including the script's own exit 1 when it found no
+      # timings, which then shows as a tolerated step failure plus a warning
+      # annotation rather than as an empty table. Runs after a failed build
+      # too: when the gate fires, the bodies measured before the error are
+      # exactly the ones to read.
+      - name: Report slowest type-checks
+        if: success() || failure()
+        continue-on-error: true
+        run: bash scripts/ci/type-check-timings.sh report /tmp/xcodebuild.log --root "$GITHUB_WORKSPACE"
       - name: Cancel run on failure
         if: failure()
         uses: ./.github/actions/cancel-on-failure

--- a/scripts/ci/type-check-timings.sh
+++ b/scripts/ci/type-check-timings.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # single-quoted Markdown backticks and an awk `$1` are meant literally
+# Per-body type-check timings from an xcodebuild log: which function bodies come
+# closest to the limit that app/MeetingTranscriber/Package.swift enforces with
+# `-warn-long-function-bodies`.
+#
+# Why this exists: that flag reports a body only once it is already over the
+# limit, and warnings are errors in those targets, so the first signal that a
+# body is close is a red build on a commit that changed nothing near it. Adding
+# `-Xfrontend -debug-time-function-bodies` to the same compile makes the
+# compiler print one line per type-checked body:
+#
+#   151.67ms<TAB>/abs/path/AppState.swift:213:5<TAB>initializer Module.(file).AppState.init(settings:)@/abs/path/AppState.swift:213:5
+#
+# The analyze lane in .github/workflows/ci.yml adds that flag through
+# OTHER_SWIFT_FLAGS and feeds its log here. This report never gates anything:
+# the limit itself stays the only enforcement, and this only makes the margin
+# to it visible before it is gone.
+#
+# Usage:
+#   type-check-timings.sh report <xcodebuild.log> [--root <dir>] [--limit <n>]
+#       Writes a Markdown report to stdout and, when $GITHUB_STEP_SUMMARY is
+#       set, appends it there too. Only bodies in files under <root> count
+#       (default: the repository this script lives in), which drops
+#       dependencies, macro expansion buffers and synthesized declarations
+#       that carry no file. A body measured by several compiler jobs is listed
+#       once with its slowest measurement, since the gate fires on any single
+#       one. Ordered by time, then by location, so two runs with the same
+#       numbers render the same table. The limit is reported per module, read
+#       from that module's own compile commands in the log, and a module with
+#       bodies under <root> but no limit on its commands is named as ungated.
+#       Exit 0 with a table. Exit 1 when the log holds no timings under
+#       <root>: the report then says so in place of the table, so an empty
+#       result cannot read as "nothing is close to the limit". Exit 2 on
+#       usage errors.
+#   type-check-timings.sh strip
+#       stdin to stdout, minus the timing lines. Used on the console stream of
+#       the build, which otherwise gains some 33,000 of them, and on the output
+#       of `swiftlint analyze`, which re-runs the compiler with the arguments
+#       it finds in the log, timing flag included, so SourceKit prints the same
+#       lines again. Always exits 0 on a readable stream.
+#
+# Reproduce the CI report locally (the same build the analyze lane runs):
+#   cd app/MeetingTranscriber
+#   xcodebuild -scheme MeetingTranscriber -destination 'platform=macOS' \
+#     SWIFT_SUPPRESS_WARNINGS=NO \
+#     OTHER_SWIFT_FLAGS='$(inherited) -Xfrontend -debug-time-function-bodies' \
+#     build-for-testing 2>&1 | tee /tmp/xcodebuild.log | ../../scripts/ci/type-check-timings.sh strip
+#   ../../scripts/ci/type-check-timings.sh report /tmp/xcodebuild.log
+
+set -uo pipefail
+
+# One predicate for both modes, so the lines the report parses and the lines
+# `strip` removes can never drift apart: a format change makes the report say
+# it found nothing while the console shows the new lines, both at once.
+timing_line='$1 ~ /^[0-9]+\.[0-9]+ms$/ && NF >= 3'
+
+usage() {
+    echo "usage: $(basename "$0") report <xcodebuild.log> [--root <dir>] [--limit <n>]" >&2
+    echo "       $(basename "$0") strip < build-output" >&2
+    exit 2
+}
+
+mode="${1:-}"
+case "$mode" in
+    strip)
+        [ $# -eq 1 ] || usage
+        exec awk -F '\t' "!($timing_line)"
+        ;;
+    report) ;;
+    *) usage ;;
+esac
+shift
+
+log="${1:-}"
+[ -n "$log" ] || usage
+shift
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+limit=10
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --root)
+            [ $# -ge 2 ] || usage
+            root="$2"
+            shift 2
+            ;;
+        --limit)
+            [ $# -ge 2 ] || usage
+            case "$2" in
+                '' | *[!0-9]*) usage ;;
+            esac
+            limit="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+if [ ! -r "$log" ]; then
+    echo "$(basename "$0"): cannot read log '$log'" >&2
+    exit 2
+fi
+root="${root%/}"
+
+rows="$(mktemp)"
+counts="$(mktemp)"
+gates="$(mktemp)"
+report="$(mktemp)"
+trap 'rm -f -- "$rows" "$counts" "$gates" "$report"' EXIT
+
+# Pass 1: one row per location under root, keeping the slowest measurement,
+# with the module that owns the body (from the Module.(file). prefix of the
+# declaration reference) so the limit can be attributed per module below.
+# Counts go to a second file so the report can name what it skipped.
+awk -F '\t' -v root="$root/" -v counts="$counts" "
+$timing_line {
+    total++
+    if (index(\$2, root) != 1) next
+    under++
+    ms = substr(\$1, 1, length(\$1) - 2) + 0
+    if (!(\$2 in best) || ms > best[\$2]) {
+        best[\$2] = ms
+        decl[\$2] = \$3
+        mod[\$2] = match(\$3, /[A-Za-z_0-9]+\\.\\(file\\)\\./) ? substr(\$3, RSTART, RLENGTH - 8) : \"\"
+    }
+}
+END {
+    for (loc in best) printf \"%.2f\t%s\t%s\t%s\n\", best[loc], loc, decl[loc], mod[loc]
+    printf \"%d %d\n\", total + 0, under + 0 > counts
+}" "$log" > "$rows"
+read -r total under < "$counts"
+
+# Pass 2: the gate per module, read from the compile commands in the same log
+# rather than from Package.swift, so the report describes the flags each
+# target actually ran under. Every package in this repository sets its own
+# -warn-long-function-bodies, so one flag found anywhere in the log says
+# nothing about the module a body belongs to: with the app package's gate
+# gone, the local audiotap package would still supply a "300". xcodebuild
+# prints the command shell-escaped, hence the optional backslash before the
+# equals sign. When one command line carries the flag more than once the
+# compiler applies the last (checked on Xcode 26.6: =100000 followed by =1
+# warns at 1 ms), so the last value on the line is the one taken.
+awk '
+    match($0, /-module-name [^ ]+/) {
+        module = substr($0, RSTART + 13, RLENGTH - 13)
+        value = ""
+        rest = $0
+        while (match(rest, /-warn-long-function-bodies\\?=[0-9]+/)) {
+            value = substr(rest, RSTART, RLENGTH)
+            sub(/.*=/, "", value)
+            rest = substr(rest, RSTART + RLENGTH)
+        }
+        if (value != "") print module "\t" value
+    }' "$log" | LC_ALL=C sort -u > "$gates"
+
+# gate_field <key>: one entry of the per-module gate summary computed below.
+gate_field() {
+    printf '%s\n' "$gate_summary" | awk -F '\t' -v k="$1" '$1 == k { print substr($0, length(k) + 2) }'
+}
+
+{
+    echo "### Type-check timings (analyze build)"
+    echo
+    if [ "$under" -eq 0 ]; then
+        echo "**No type-check timings were found under \`$root\`.**"
+        echo
+        if [ "$total" -eq 0 ]; then
+            echo "The log has no lines of the form \`12.34ms<TAB>/path/File.swift:1:2<TAB>declaration\`, which \`-Xfrontend -debug-time-function-bodies\` prints for every type-checked body. Either the flag no longer reaches the compiler or the compiler changed the format."
+        else
+            echo "The log has $total such lines, none of them for a file under that root. Either the root is wrong or the flag reached only dependency targets."
+        fi
+        echo
+        echo "Nothing is known about the margin to the type-check limit from this run."
+    else
+        if ! grep -qE '^\*\* (TEST )?BUILD SUCCEEDED \*\*' "$log"; then
+            echo "The build did not report success, so these timings cover only the bodies checked before it stopped."
+            echo
+        fi
+        bodies="$(wc -l < "$rows" | tr -d ' ')"
+        slowest_row="$(LC_ALL=C sort -t "$(printf '\t')" -k1,1gr -k2,2 "$rows" | head -n 1)"
+        slowest="$(printf '%s' "$slowest_row" | cut -f 1)"
+        slowest_module="$(printf '%s' "$slowest_row" | cut -f 4)"
+        # The modules with bodies under root, each with the limit its compile
+        # commands carried: one value, several (conflicting), or none.
+        gate_summary="$(awk -F '\t' -v gates="$gates" -v slowest_module="$slowest_module" '
+            FILENAME == gates {
+                if (!($1 in limit)) limit[$1] = $2
+                else if (index("|" limit[$1] "|", "|" $2 "|") == 0) limit[$1] = limit[$1] "|" $2
+                next
+            }
+            $4 != "" && !($4 in seen) { seen[$4] = 1; modules[++n] = $4 }
+            END {
+                for (i = 2; i <= n; i++) {
+                    v = modules[i]
+                    for (j = i - 1; j >= 1 && modules[j] > v; j--) modules[j + 1] = modules[j]
+                    modules[j + 1] = v
+                }
+                for (i = 1; i <= n; i++) {
+                    m = modules[i]
+                    if (!(m in limit)) ungated = ungated (ungated == "" ? "" : ", ") m
+                    else if (index(limit[m], "|")) {
+                        c = limit[m]; gsub(/\|/, " and ", c)
+                        conflicting = conflicting (conflicting == "" ? "" : ", ") m " (" c " ms)"
+                    } else gated = gated (gated == "" ? "" : ", ") m " " limit[m] " ms"
+                }
+                print "gated\t" gated
+                print "ungated\t" ungated
+                print "conflicting\t" conflicting
+                if ((slowest_module in limit) && !index(limit[slowest_module], "|")) print "slowest_limit\t" limit[slowest_module]
+            }' "$gates" "$rows")"
+        gated="$(gate_field gated)"
+        ungated="$(gate_field ungated)"
+        conflicting="$(gate_field conflicting)"
+        slowest_limit="$(gate_field slowest_limit)"
+        shown="$limit"
+        [ "$bodies" -lt "$shown" ] && shown="$bodies"
+        printf 'The %s slowest of %s function bodies in this repository, out of %s timings (the other %s are dependencies, macro expansions and declarations without a source location, all skipped). ' \
+            "$shown" "$bodies" "$total" "$((total - under))"
+        if [ -n "$gated" ]; then
+            printf 'Limit (`-warn-long-function-bodies`, read from each module'"'"'s compile commands): %s. ' "$gated"
+        fi
+        if [ -n "$conflicting" ]; then
+            printf '**Conflicting limits on the compile commands of %s.** ' "$conflicting"
+        fi
+        if [ -n "$ungated" ]; then
+            printf '**No `-warn-long-function-bodies` limit on any compile command of %s**, so those bodies ran without the type-check gate. ' "$ungated"
+        fi
+        if [ -z "$gated$conflicting$ungated" ]; then
+            printf 'No body under the root names its module, so the limit could not be attributed. '
+        fi
+        if [ -n "$slowest_limit" ]; then
+            headroom="$(awk -v g="$slowest_limit" -v s="$slowest" 'BEGIN { printf "%.0f", g - s }')"
+            printf 'The slowest body leaves %s ms of headroom to the limit of its module. ' "$headroom"
+        fi
+        echo "Times are from one run on a shared runner and vary by tens of milliseconds between runs. Non-gating: the limit is the only enforcement."
+        echo
+        echo "| ms | Location | Declaration |"
+        echo "|---:|---|---|"
+        LC_ALL=C sort -t "$(printf '\t')" -k1,1gr -k2,2 "$rows" | head -n "$limit" \
+            | awk -F '\t' -v root="$root/" '
+                {
+                    loc = substr($2, length(root) + 1)
+                    sub(/:[0-9]+$/, "", loc)               # column adds nothing a reader acts on
+                    decl = $3
+                    sub(/@[^@]*$/, "", decl)                # trailing @/path:line:col repeats the location
+                    sub(/[A-Za-z_0-9]+\.\(file\)\./, "", decl)   # Module.(file). prefix
+                    sub(/\.(getter|setter|didSet observer|willSet observer)$/, "", decl)   # repeats the leading kind word
+                    gsub(/\|/, "\\|", decl)                 # keep the Markdown table intact
+                    gsub(/`/, "\047", decl)
+                    printf "| %s | `%s` | `%s` |\n", $1, loc, decl
+                }'
+    fi
+    echo
+} > "$report"
+
+cat "$report"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "$report" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$under" -eq 0 ]; then
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "::warning title=Type-check timings missing::The analyze build produced no per-body type-check timings under $root, so the margin to the type-check limit is unknown for this run. See the step summary."
+    fi
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_type_check_timings.sh
+++ b/scripts/tests/test_type_check_timings.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2064,SC2329
+# SC2016: the expected Markdown carries literal backticks. SC2064: the RETURN
+# traps expand now on purpose, capturing this call's temp path. SC2329: the
+# test functions are invoked by name through run_test.
+# Regression test for scripts/ci/type-check-timings.sh, the non-gating report of
+# the slowest type-checked function bodies in the analyze lane.
+#
+# What it pins, and why each matters:
+#   - A body measured by several compiler jobs appears once, with its slowest
+#     measurement. The 300 ms gate fires on any single measurement, so a table
+#     that averaged or took the first would understate the risk.
+#   - Lines outside the repository root (dependencies), macro expansion buffers
+#     and `<invalid loc>` declarations are skipped: none of them is a place a
+#     reader can act on, and the gate that matters runs on our targets.
+#   - Ordering is by time, then location, so equal times render identically
+#     from one run to the next.
+#   - The limit is attributed per module, from that module's own compile
+#     commands. Every package in this repository sets its own
+#     -warn-long-function-bodies, so a flag found anywhere in the log proves
+#     nothing about the module a body belongs to: a report that took the first
+#     flag it saw would still print "300 ms" after the app package lost its
+#     gate, because the local audiotap package still carries one.
+#   - A log with no timings under the root produces a warning and exit 1, not
+#     an empty table. An empty table reads as "nothing is close to the limit",
+#     which is the one thing the report must never say by accident.
+#   - `strip` removes exactly the timing lines, exits 0, and keeps everything
+#     the console must still show: the gate's own diagnostic, source excerpts,
+#     SwiftLint annotations. It runs inside the Build & Analyze pipeline under
+#     pipefail, where an overbroad filter would hide the very error that
+#     failed the build and a non-zero exit would fail a green one. That step
+#     has no continue-on-error, so this is the one part of the report that
+#     can turn the job red.
+
+set -uo pipefail   # NOT -e: harness keeps running on test failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ci/type-check-timings.sh"
+
+FAILED=0
+
+run_test() {
+    local name="$1"
+    printf '%s ... ' "$name"
+    if "$name"; then printf 'PASS\n'; else printf 'FAIL\n'; FAILED=1; fi
+}
+
+# The analyze lane's log as one tagged list: `T<TAB>line` for a timing line,
+# `K<TAB>line` for everything else. write_fixture drops the tag;
+# strip_survivors keeps the K lines. One list, so the strip test and the
+# report tests cannot disagree about which lines are timings. Tabs inside the
+# lines are real, as the compiler prints them.
+FAKE_ROOT="/w/repo"
+fixture_lines() {
+    local r="$FAKE_ROOT"
+    printf 'K\tBuild settings from command line:\n'
+    # Compile commands as xcodebuild prints them, shell-escaped (hence `\=`).
+    # The local audiotap package comes first on purpose: a report that took
+    # the first gate flag in the log would read the app's limit off it. The
+    # frontend line carries the flag unwrapped, the driver line still inside
+    # -Xfrontend; both shapes occur. FluidAudio is a dependency built without
+    # the gate and must not be reported as ungated: none of its bodies are in
+    # the repository.
+    printf 'K\t    builtin-swiftTaskExecution -- /Applications/Xcode.app/x/swift-frontend -frontend -c -primary-file %s/tools/audiotap/Sources/Tap.swift -module-name AudioTapLib -warn-long-function-bodies\\=300 -debug-time-function-bodies\n' "$r"
+    printf 'K\t    builtin-SwiftDriver -- /Applications/Xcode.app/x/swiftc -module-name MeetingTranscriber -Onone -Xfrontend -warn-long-function-bodies\\=300 -Xfrontend -debug-time-function-bodies\n'
+    printf 'K\t    builtin-SwiftDriver -- /Applications/Xcode.app/x/swiftc -module-name FluidAudio -Onone -Xfrontend -debug-time-function-bodies\n'
+    # The same body seen by two compiler jobs; the slower one must win.
+    printf 'T\t40.00ms\t%s/app/Sources/AppState.swift:213:5\tinitializer MeetingTranscriber.(file).AppState.init(settings:)@%s/app/Sources/AppState.swift:213:5\n' "$r" "$r"
+    printf 'T\t151.67ms\t%s/app/Sources/AppState.swift:213:5\tinitializer MeetingTranscriber.(file).AppState.init(settings:)@%s/app/Sources/AppState.swift:213:5\n' "$r" "$r"
+    # Slower than anything under the root, but a dependency: must not appear.
+    printf 'T\t999.00ms\t/Users/runner/Library/Developer/Xcode/DerivedData/M-abc/SourcePackages/checkouts/FluidAudio/Sources/A.swift:1:1\tglobal function FluidAudio.(file).f()@/Users/runner/Library/Developer/Xcode/DerivedData/M-abc/SourcePackages/checkouts/FluidAudio/Sources/A.swift:1:1\n'
+    # Synthesized conformance without a file, and a macro expansion buffer.
+    printf 'T\t20.61ms\t<invalid loc>\toperator function WhisperKit.(file).TranscriptionSegment.==\n'
+    printf 'T\t3.44ms\t@__swiftmacro_18MeetingTranscriber11AppSettingsC12pollInterval18ObservationTrackedfMp_.swift:7:9\tdidSet observer MeetingTranscriber.(file).AppSettings._pollInterval.didSet observer@@__swiftmacro_18MeetingTranscriber11AppSettingsC12pollInterval18ObservationTrackedfMp_.swift:7:9\n'
+    # Lines under the root that look like measurements and are not. Each must
+    # survive `strip` and stay out of the table. First the gate's own
+    # diagnostic with its source excerpt, in the compiler's current layout:
+    # the one line a reader of a red build needs, and the one an overbroad
+    # filter (anything on "ms") would swallow.
+    printf 'K\t%s/app/Sources/Slow.swift:40:5: error: instance method '\''render()'\'' took 327ms to type-check (limit: 300ms)\n' "$r"
+    printf 'K\t40 |     func render() -> some View {\n'
+    printf 'K\t   |          `- error: instance method '\''render()'\'' took 327ms to type-check (limit: 300ms)\n'
+    # SwiftLint's github-actions-logging reporter, whose output passes through
+    # the same filter after `swiftlint analyze`.
+    printf 'K\t::error file=%s/app/Sources/Slow.swift,line=40,col=5::Function Body Length Violation: Function body should span 50 lines or less (function_body_length)\n' "$r"
+    printf 'K\t::warning file=%s/app/Sources/AppState.swift,line=213,col=5::Cyclomatic Complexity Violation: Function should have complexity 10 or less (cyclomatic_complexity)\n' "$r"
+    # A timing line without its declaration field: the report cannot place it
+    # in the table, so the console keeps it rather than losing it.
+    printf 'K\t12.34ms\t%s/app/Sources/Cut.swift:1:1\n' "$r"
+    # A tie, listed in reverse location order so the sort has to fix it.
+    printf 'T\t50.00ms\t%s/app/Sources/Zeta.swift:1:1\tgetter MeetingTranscriber.(file).Zeta.body.getter@%s/app/Sources/Zeta.swift:1:1\n' "$r" "$r"
+    printf 'T\t50.00ms\t%s/app/Sources/Alpha.swift:9:9\tgetter MeetingTranscriber.(file).Alpha.body.getter@%s/app/Sources/Alpha.swift:9:9\n' "$r" "$r"
+    # The local audiotap package lives in the repository too.
+    printf 'T\t12.00ms\t%s/tools/audiotap/Sources/Tap.swift:5:5\tinstance method AudioTapLib.(file).Tap.start()@%s/tools/audiotap/Sources/Tap.swift:5:5\n' "$r" "$r"
+    printf 'K\t** TEST BUILD SUCCEEDED **\n'
+}
+write_fixture() { fixture_lines | cut -f 2- > "$1"; }
+strip_survivors() { fixture_lines | grep $'^K\t' | cut -f 2-; }
+
+# The table the full fixture must render, top to bottom.
+EXPECTED_ROWS='| 151.67 | `app/Sources/AppState.swift:213` | `initializer AppState.init(settings:)` |
+| 50.00 | `app/Sources/Alpha.swift:9` | `getter Alpha.body` |
+| 50.00 | `app/Sources/Zeta.swift:1` | `getter Zeta.body` |
+| 12.00 | `tools/audiotap/Sources/Tap.swift:5` | `instance method Tap.start()` |'
+
+# run_report <log> [args...] -> sets REPORT_OUT, REPORT_RC (no step summary, not on Actions)
+run_report() {
+    REPORT_OUT=$(env -u GITHUB_STEP_SUMMARY -u GITHUB_ACTIONS bash "$SCRIPT" report "$@")
+    REPORT_RC=$?
+}
+
+# table_rows <report> -> the data rows of the Markdown table, in order
+table_rows() {
+    printf '%s\n' "$1" | grep -E '^\| [0-9]+\.[0-9]+ \|'
+}
+
+# expect_in <haystack> <pattern> <what> -> 0 when grep finds it, else prints why
+expect_in() {
+    if printf '%s\n' "$1" | grep -q -- "$2"; then return 0; fi
+    echo; echo "  $3"; echo "$1"; return 1
+}
+expect_not_in() {
+    if ! printf '%s\n' "$1" | grep -q -- "$2"; then return 0; fi
+    echo; echo "  $3"; echo "$1"; return 1
+}
+
+test_dedupes_filters_and_orders() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    if [ "$REPORT_RC" -ne 0 ]; then
+        echo; echo "  expected exit 0, got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    local rows; rows=$(table_rows "$REPORT_OUT")
+    if [ "$rows" != "$EXPECTED_ROWS" ]; then
+        echo; echo "  table differs from expected:"; echo "$rows"; echo "  expected:"; echo "$EXPECTED_ROWS"; return 1
+    fi
+    # The counts name what was skipped. "8 timings" also pins the recogniser:
+    # the diagnostic, the excerpt and the truncated line under the root would
+    # make it 9 or more.
+    expect_in "$REPORT_OUT" "4 slowest of 4 function bodies in this repository, out of 8 timings (the other 3 are" \
+        "counts sentence missing or wrong" || return 1
+    # Both modules with bodies in the repository are named with their limit,
+    # and the headroom is the slowest body's distance to its own module's.
+    expect_in "$REPORT_OUT" 'Limit (`-warn-long-function-bodies`, read from each module.s compile commands): AudioTapLib 300 ms, MeetingTranscriber 300 ms\.' \
+        "per-module limit sentence missing or wrong" || return 1
+    expect_in "$REPORT_OUT" "The slowest body leaves 148 ms of headroom" "headroom sentence missing or wrong" || return 1
+    expect_not_in "$REPORT_OUT" "FluidAudio" "a dependency module leaked into the gate sentence" || return 1
+    expect_not_in "$REPORT_OUT" "did not report success" "partial-build note shown for a successful build" || return 1
+    return 0
+}
+
+test_limit_truncates() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx"
+    run_report "$fx" --root "$FAKE_ROOT" --limit 2
+    if [ "$REPORT_RC" -ne 0 ]; then
+        echo; echo "  expected exit 0, got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    # The two rows are the top two, not any two.
+    local rows; rows=$(table_rows "$REPORT_OUT")
+    if [ "$rows" != "$(printf '%s\n' "$EXPECTED_ROWS" | head -n 2)" ]; then
+        echo; echo "  expected the two slowest rows, got:"; echo "$rows"; return 1
+    fi
+    expect_in "$REPORT_OUT" "The 2 slowest of 4 function bodies" "shown count not reported as 2" || return 1
+    return 0
+}
+
+test_no_timings_is_loud_not_empty() {
+    local fx summary; fx=$(mktemp); summary=$(mktemp)
+    trap "rm -f -- '$fx' '$summary'" RETURN
+    printf 'Build settings from command line:\n** TEST BUILD SUCCEEDED **\n' > "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    if [ "$REPORT_RC" -ne 1 ]; then
+        echo; echo "  expected exit 1 for a log without timings, got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    expect_in "$REPORT_OUT" "No type-check timings were found" "missing the loud warning" || return 1
+    expect_not_in "$REPORT_OUT" '^| ms |' "an empty table was printed" || return 1
+    # On Actions the same case raises a workflow annotation on the console and
+    # lands in the step summary, where a reader looks for the table.
+    local out
+    out=$(GITHUB_STEP_SUMMARY="$summary" GITHUB_ACTIONS=1 bash "$SCRIPT" report "$fx" --root "$FAKE_ROOT")
+    expect_in "$out" '^::warning title=Type-check timings missing::' "no ::warning annotation under GITHUB_ACTIONS" || return 1
+    if ! grep -q "No type-check timings were found" "$summary"; then
+        echo; echo "  the step summary did not receive the loud warning"; cat "$summary"; return 1
+    fi
+    if grep -q '^::warning' "$summary"; then
+        echo; echo "  the console annotation leaked into the step summary"; cat "$summary"; return 1
+    fi
+    return 0
+}
+
+test_timings_only_outside_root_name_the_count() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx"
+    run_report "$fx" --root /nowhere/else
+    if [ "$REPORT_RC" -ne 1 ]; then
+        echo; echo "  expected exit 1 when nothing is under the root, got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    # "8" counts the timing lines only; the diagnostic and the truncated line
+    # under the fake root do not raise it.
+    expect_in "$REPORT_OUT" "The log has 8 such lines, none of them for a file under that root" \
+        "the outside-root case does not name the count" || return 1
+    expect_not_in "$REPORT_OUT" '^| ms |' "an empty table was printed" || return 1
+    return 0
+}
+
+test_partial_build_and_missing_gate_are_named() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx'" RETURN
+    write_fixture "$fx"
+    # Drop the success marker and every compile command that carries the gate.
+    grep -v 'BUILD SUCCEEDED\|warn-long-function-bodies' "$fx" > "$fx.edited" && mv "$fx.edited" "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    if [ "$REPORT_RC" -ne 0 ]; then
+        echo; echo "  expected exit 0 (timings exist), got $REPORT_RC"; echo "$REPORT_OUT"; return 1
+    fi
+    expect_in "$REPORT_OUT" "The build did not report success" "partial-build note missing" || return 1
+    expect_in "$REPORT_OUT" 'No `-warn-long-function-bodies` limit on any compile command of AudioTapLib, MeetingTranscriber\*\*' \
+        "missing-gate note does not name both modules" || return 1
+    expect_not_in "$REPORT_OUT" "Limit (" "a limit was claimed with no gate in the log" || return 1
+    expect_not_in "$REPORT_OUT" "headroom" "headroom was computed against no limit" || return 1
+    return 0
+}
+
+test_gate_is_read_per_module() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx*'" RETURN
+    local mt='-module-name MeetingTranscriber'
+
+    # Different limits per module, audiotap's first in the log: each value
+    # goes to its module, and the headroom (148) is measured against the
+    # slowest body's own module, not the first flag seen (200 would give 48).
+    write_fixture "$fx"
+    sed -i.bak 's/AudioTapLib -warn-long-function-bodies\\=300/AudioTapLib -warn-long-function-bodies\\=200/' "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    expect_in "$REPORT_OUT" "compile commands): AudioTapLib 200 ms, MeetingTranscriber 300 ms\." "per-module limits not attributed" || return 1
+    expect_in "$REPORT_OUT" "leaves 148 ms of headroom" "headroom not taken from the slowest body's own module" || return 1
+
+    # The app module lost its gate while audiotap kept it: the report must say
+    # which module is ungated instead of announcing audiotap's 300 for all,
+    # and must not give a headroom for a body that has no limit.
+    write_fixture "$fx"
+    grep -v -- "$mt" "$fx" > "$fx.edited" && mv "$fx.edited" "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    expect_in "$REPORT_OUT" 'No `-warn-long-function-bodies` limit on any compile command of MeetingTranscriber\*\*' "ungated app module not named" || return 1
+    expect_in "$REPORT_OUT" "compile commands): AudioTapLib 300 ms\." "audiotap's own limit not kept" || return 1
+    expect_not_in "$REPORT_OUT" "headroom" "headroom given for a body whose module has no limit" || return 1
+    expect_not_in "$REPORT_OUT" "FluidAudio" "a dependency was reported as ungated" || return 1
+
+    # The flag twice on one command line: the compiler applies the last one
+    # (checked on Xcode 26.6), so the report must too.
+    write_fixture "$fx"
+    sed -i.bak "s/\($mt .*\)-warn-long-function-bodies\\\\=300/\1-warn-long-function-bodies\\\\=300 -Xfrontend -warn-long-function-bodies\\\\=500/" "$fx"
+    if ! grep -q 'bodies\\=300 -Xfrontend -warn-long-function-bodies\\=500' "$fx"; then
+        echo; echo "  fixture edit for the duplicate flag did not apply"; return 1
+    fi
+    run_report "$fx" --root "$FAKE_ROOT"
+    expect_in "$REPORT_OUT" "MeetingTranscriber 500 ms\." "last flag on the command line not taken" || return 1
+    expect_in "$REPORT_OUT" "leaves 348 ms of headroom" "headroom not against the effective limit" || return 1
+
+    # Two compile commands of one module with different limits: say so, and
+    # give no headroom against a value the report cannot pick.
+    write_fixture "$fx"
+    local second; second=$(grep -- "$mt" "$fx" | sed 's/bodies\\=300/bodies\\=500/')
+    printf '%s\n' "$second" >> "$fx"
+    run_report "$fx" --root "$FAKE_ROOT"
+    expect_in "$REPORT_OUT" 'Conflicting limits on the compile commands of MeetingTranscriber (300 and 500 ms)\.\*\*' "conflicting limits not named" || return 1
+    expect_in "$REPORT_OUT" "compile commands): AudioTapLib 300 ms\." "audiotap's own limit not kept beside the conflict" || return 1
+    expect_not_in "$REPORT_OUT" "headroom" "headroom given against one of two conflicting limits" || return 1
+    return 0
+}
+
+test_step_summary_receives_the_report() {
+    local fx summary; fx=$(mktemp); summary=$(mktemp)
+    trap "rm -f -- '$fx' '$summary'" RETURN
+    write_fixture "$fx"
+    printf 'earlier content\n' > "$summary"
+    local out
+    out=$(GITHUB_STEP_SUMMARY="$summary" bash "$SCRIPT" report "$fx" --root "$FAKE_ROOT")
+    if [ "$(head -n 1 "$summary")" != "earlier content" ]; then
+        echo; echo "  summary file was overwritten instead of appended"; return 1
+    fi
+    # The whole report, heading and sentences included, not just the rows.
+    if [ "$(tail -n +2 "$summary")" != "$out" ]; then
+        echo; echo "  summary file and stdout differ:"; diff <(tail -n +2 "$summary") <(printf '%s\n' "$out"); return 1
+    fi
+    return 0
+}
+
+test_strip_removes_exactly_the_timing_lines() {
+    local fx; fx=$(mktemp)
+    trap "rm -f -- '$fx' '$fx.stripped' '$fx.keep'" RETURN
+    write_fixture "$fx"
+    bash "$SCRIPT" strip < "$fx" > "$fx.stripped"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo; echo "  strip exited $rc; under pipefail that fails the Build & Analyze step"; return 1
+    fi
+    # Byte-exact against the tagged list: every K line in order, including
+    # the compile commands, the gate diagnostic and its excerpt, the SwiftLint
+    # annotations and the truncated timing line; no T line.
+    strip_survivors > "$fx.keep"
+    if ! cmp -s "$fx.stripped" "$fx.keep"; then
+        echo; echo "  strip output differs from the non-timing lines:"; diff "$fx.keep" "$fx.stripped"; return 1
+    fi
+    return 0
+}
+
+test_usage_errors_exit_2() {
+    local rc out err
+    bash "$SCRIPT" >/dev/null 2>&1; rc=$?
+    [ "$rc" -eq 2 ] || { echo; echo "  no arguments: expected exit 2, got $rc"; return 1; }
+    bash "$SCRIPT" report /nonexistent/log >/dev/null 2>&1; rc=$?
+    [ "$rc" -eq 2 ] || { echo; echo "  unreadable log: expected exit 2, got $rc"; return 1; }
+    bash "$SCRIPT" strip extra </dev/null >/dev/null 2>&1; rc=$?
+    [ "$rc" -eq 2 ] || { echo; echo "  strip with an argument: expected exit 2, got $rc"; return 1; }
+    # Usage goes to stderr, and nothing that could pass for a report to stdout.
+    out=$(bash "$SCRIPT" report /dev/null --limit ten 2>/dev/null); rc=$?
+    err=$(bash "$SCRIPT" report /dev/null --limit ten 2>&1 >/dev/null)
+    [ "$rc" -eq 2 ] || { echo; echo "  non-numeric limit: expected exit 2, got $rc"; return 1; }
+    [ -z "$out" ] || { echo; echo "  usage error wrote to stdout:"; echo "$out"; return 1; }
+    printf '%s' "$err" | grep -q '^usage:' || { echo; echo "  usage text missing from stderr:"; echo "$err"; return 1; }
+    return 0
+}
+
+run_test test_dedupes_filters_and_orders
+run_test test_limit_truncates
+run_test test_no_timings_is_loud_not_empty
+run_test test_timings_only_outside_root_name_the_count
+run_test test_partial_build_and_missing_gate_are_named
+run_test test_gate_is_read_per_module
+run_test test_step_summary_receives_the_report
+run_test test_strip_removes_exactly_the_timing_lines
+run_test test_usage_errors_exit_2
+
+exit "$FAILED"


### PR DESCRIPTION
Today `main` failed CI on an unchanged commit because `MeetingTranscriberApp.body` type-checked at 327 ms against the 300 ms limit in `Package.swift`. The same commit had passed the same job eight hours earlier. Nobody could have seen it coming, because the build reports a body only once it is already over the limit: the margin is invisible until it is gone.

That cost real time. Every projection made while fixing it rested on that single 327 ms observation and a factor estimated from it, and the factor was wrong twice, in different directions, depending on which local compile layout was used as the model. No one has ever measured a passing body on the runner.

This makes the `analyze` job print the ten slowest function bodies on every run.

## How

`OTHER_SWIFT_FLAGS='$(inherited) -Xfrontend -debug-time-function-bodies'` on the `xcodebuild` command the job already runs. No second build, and `Package.swift` is untouched, so a local `swift build` gains nothing.

`$(inherited)` is load-bearing and was verified rather than assumed on a real build: with it, the package's own `-warn-long-function-bodies=300` and the new flag sit on the same compile command, so the gate is intact. Without it the command-line setting would replace the package's flags. Checked that the setting reaches every SPM target, ours and the dependencies.

The compiler prints one line per body, about 33,000 across the app and its dependencies. Those stay in `/tmp/xcodebuild.log`, which the report parses, and are filtered out of the console. `swiftlint analyze` re-runs the compiler with the arguments it finds in that log, timing flag included, so its own output is filtered the same way; its findings are byte-identical after filtering.

## Cost, measured

```
clean build            35 s without, 32 s with   (noise)
log                    1.1 MB -> 13 MB
swiftlint analyze      212 s -> 226 s            (single runs)
```

## What it reports

The ten slowest bodies, deduplicated per location keeping the maximum, since the gate fires on any single measurement. The limit is read from the compile commands in the log rather than hardcoded. From a local run:

```
| 151.67 | app/MeetingTranscriber/Sources/AppState.swift:213 | initializer AppState.init(settings:notifier:updateChecker:) |
| 126.49 | .../Settings/AdvancedSettingsView.swift:33         | getter AdvancedSettingsView.body |
|  97.55 | app/MeetingTranscriber/Sources/AppState.swift:355  | instance method AppState.buildDebugRPCServer(port:token:) |
|  95.18 | app/MeetingTranscriber/Sources/AppState+RPC.swift:103 | instance method rpcStateSnapshot() |
```

That local ranking is already informative and already corrects a claim made while fixing the outage: reconstructing the CI batch with the SwiftPM driver put `AppState.init` at 29 ms and a settings view at the top. Measured through the build that CI actually runs, `AppState.init` leads. Reconstructions of a compile layout are not the layout.

## When it collects nothing

It says so loudly rather than printing an empty table, which would read as "nothing is near the limit". It distinguishes "no timing lines at all" from "lines exist but none under the repository root", emits a warning annotation, and exits 1. The step carries `continue-on-error: true`, so that surfaces as a tolerated step failure and never a red job. It also runs after a failed build and labels the numbers partial, and it says so if the gate flag is missing from the compile commands entirely.

The 300 ms limit stays the only thing that can fail the job. This step is reporting.

## The limit is attributed per module

Read from the compile commands, per `-module-name`, taking the last `-warn-long-function-bodies=` on each command because the last one wins (confirmed on Xcode 26.6 with `=100000` followed by `=1`, which warns at 1 ms). The summary names them, for example `Limit (...): AudioTapLib 300 ms, MeetingTranscriber 300 ms`, headroom is measured against the slowest body's own module, a module with bodies in this repository and no flag is called out as ungated, and commands of one module that disagree are reported as a conflict rather than silently resolved. Without that, `tools/audiotap` carrying its own 300 ms flag would let the report claim a limit after the app package lost one.

## Known gap

A line of the exact shape `12.34ms<TAB>path<TAB>text` would be filtered as a timing even if it were a diagnostic. Nothing the compiler or SwiftLint emits today has that shape, and the tests pin the shapes that do exist. But no test can catch this one: a fixture asserting such a line survives would be the fix, not the guard. It would surface in a real run as a table row whose declaration column reads like an error message.

## Verification

`scripts/tests/test_type_check_timings.sh`, 9 cases: deduplication, filtering to the repository, ordering, limit extraction, the loud-empty path, the outside-root count, the partial-build path, summary append, strip parity, and usage exit codes. All seven pre-existing `scripts/tests/test_*.sh` still pass.

The tests were tightened after review: `strip`'s output is compared byte-exact **and** its exit status asserted, and the fixture carries lines that look like timings but are not, so an overbroad predicate fails. Nine wrong implementations were applied to the script and each was caught: an overbroad predicate, a predicate without the field-count check, `strip` exiting non-zero after correct output, the first gate flag applied to every module, never naming an ungated module, the first flag on a command line winning over the last, conflicting values silently resolved, `--limit 2` taking the bottom two rows, and a summary that appends rows without the heading or the warnings. `shellcheck` clean on both new files, `actionlint` clean on the workflow, `./scripts/lint.sh` 0 violations in 538 files.
