### PR TITLE
refactor(app): replace AccessibleTextField with a plain TextField

### DIFF
--- a/.claude/skills/e2e-architecture/SKILL.md
+++ b/.claude/skills/e2e-architecture/SKILL.md
@@ -64,9 +64,9 @@ PRs are excluded from the self-hosted runner.
   confirm never pollutes the persistent speaker DB.
 - The `--naming-switch` lane covers issue #700: the dialog switches to the next
   pending job of the same meeting title, a speaker label survives the switch at
-  a lower row, and typing into it wrote through a binding captured at the old
-  row; past the new job's row count that trapped (`Array._checkSubscript_mutating`)
-  and killed the app. The lane imports two dual-source pairs under one stem (a
+  a lower row, and typing into it must reach that label's binding and no other
+  (see issue #700 for the defect this guards). The lane imports two dual-source
+  pairs under one stem (a
   paired import takes the stem as its title, and one title keeps one view alive
   across the switch), pins expected speakers to 1 so the app track yields exactly
   one remote (`R_`) cluster and the mic tracks (three speakers, then one voice cut
@@ -75,7 +75,7 @@ PRs are excluded from the self-hosted runner.
   fails the lane as "geometry not staged" rather than passing vacuously. It then
   switches the dialog's segmented job picker to the second job **while both jobs
   are still pending** — resolving the first instead drops the picker, shifts the
-  view's structural slot, and SwiftUI rebuilds it with fresh coordinators so the
+  view's structural slot, and SwiftUI rebuilds it with fresh fields so the
   defect cannot show (measured on the unfixed build: resolve-first did not crash,
   picker-switch did) — posts real keystrokes into the surviving `R_` field from
   outside the process, and asserts the app survived, the text is in that row and

--- a/.github/workflows/e2e-app.yml
+++ b/.github/workflows/e2e-app.yml
@@ -382,9 +382,8 @@ jobs:
 
       # Typing-after-switch lane (issue #700): the naming dialog switches to the
       # next pending job of the same meeting title, a speaker label survives the
-      # switch at a lower row, and the user types into it. Pre-fix that field
-      # wrote through a binding captured at its old row and the first keystroke
-      # trapped in Array._checkSubscript_mutating, taking the app down. The lane
+      # switch at a lower row, and the user types into it, which must reach that
+      # label's binding and no other (see issue #700 for the defect). The lane
       # imports two dual-source pairs under one stem (shared title, real M_/R_
       # labels), pins expected speakers to 1 so only the mic clusters decide
       # where the surviving R_ label sits, asserts that geometry, then (with both
@@ -398,7 +397,7 @@ jobs:
       # preflights it and skips loudly when it is missing. Switching via the
       # picker (not resolving the first job) is load-bearing: resolving it drops
       # the picker, shifts the view's slot, and SwiftUI rebuilds it with fresh
-      # coordinators so the defect cannot show. Measured on the unfixed build.
+      # fields so the defect cannot show. Measured on the unfixed build.
       # PLACEMENT: file-driven and not level-sensitive, so next to the other two
       # naming lanes and ahead of crash-recovery.
       - name: Run live-recording E2E driver (speaker-naming switch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Use the `/git-workflow` skill. Commit proactively after every logical unit of wo
 - `MenuBarIcon` renders animated waveform reflecting pipeline state (idle, recording, transcribing, diarizing, protocol).
 - `AppPickerView` enables manual recording of any app via app picker.
 - `UpdateChecker` checks GitHub releases for newer versions, shows badge on menu bar icon.
-- **`SpeakerNamingView` keys the name fields and `knownExpanded` by speaker label, never by row position (issue #700).** An `NSViewRepresentable` coordinator is created once and kept for the row's whole life, so a binding captured by position goes stale when a surviving label moves to another sorted position: it wrote the user's typing into another row and trapped once `names` had fewer entries than that index. `AccessibleTextField.updateNSView` re-arms the coordinator as the second line of defence. **Which switch reproduces it was measured, and only one does:** switching between two still-pending jobs with the segmented picker keeps the coordinator, while *completing* the first job does not, because `speakerNamingPicker` is gated on `pendingSpeakerNamingJobs.count > 1` and dropping it changes the enclosing `VStack`'s structure, so SwiftUI rebuilds the form with fresh coordinators. A Re-run keeps the slot too. `SpeakerNamingFieldIdentityTests` hosts the view in a real `NSWindow` because ViewInspector cannot instantiate a retained coordinator, and `scripts/e2e-app.sh --naming-switch` drives the same switch in the shipped app.
+- **`SpeakerNamingView` keys the name fields and `knownExpanded` by speaker label, never by row position (issue #700).** The name field is a plain SwiftUI `TextField`, which takes a fresh binding on every update. It used to be an `NSViewRepresentable` whose coordinator kept the binding it was created with for the row's whole life, so a binding captured by position went stale when a surviving label moved to another sorted position: it wrote the user's typing into another row and trapped once `names` had fewer entries than that index. That representable existed only so an accessibility set-value (AppleScript `set value of text field`) could drive the field; the automation API (`/v1/jobs/<id>/naming`) took that over, so it was removed rather than armed against the hazard (issue #702). **Which switch reproduces it was measured, and only one does:** switching between two still-pending jobs with the segmented picker keeps the fields, while *completing* the first job does not, because `speakerNamingPicker` is gated on `pendingSpeakerNamingJobs.count > 1` and dropping it changes the enclosing `VStack`'s structure, so SwiftUI rebuilds the form with fresh fields. A Re-run keeps the slot too. `SpeakerNamingFieldIdentityTests` hosts the view in a real `NSWindow` (ViewInspector cannot instantiate a reused field), locates each row by the seed value it shows, and proves the typed name reaches that row's binding by committing the edit (resigning first responder re-reads each field from its binding). `scripts/e2e-app.sh --naming-switch` drives the same switch in the shipped app.
 
 **Permission health check:**
 - `PermissionHealthCheck` verifies each TCC permission by combining the system verdict with a live probe. Each resolves to `PermissionStatus` (`.healthy | .denied | .broken | .notDetermined`). `.broken` means TCC says allowed but the probe disagrees — fix is to toggle the permission off and on in System Settings. The Accessibility probe is a cross-process call, so only `kAXErrorAPIDisabled` counts as `.broken`; `.success` and `.noValue` are `AccessibilityProbe.responded`, and every other AXError is `.inconclusive` and reports healthy. Treating those as broken produced a notification telling users to toggle a permission that was working. `kAXErrorNotImplemented` stays inconclusive on purpose: Apple documents it as the asked process lacking AX support. The raw code is appended to `/tmp/mt-permission.log`, which `debugLog` truncates per process.
@@ -304,6 +304,20 @@ the pressed control); test SwiftUI framework behavior (e.g. that `.keyboardShort
 fires). **Manual-QA-only, accepted:** menu-bar dropdown interaction, modal panels
 (NSOpenPanel/NSAlert), TCC prompts, drag/focus order, visual appearance beyond dev-only
 snapshots.
+
+**A self-pid accessibility tree is not a unit-test locator: it is empty behind
+the lock screen.** Measured on macOS 26: with the screen locked, HIServices
+answers every window query on the app's own `AXUIElement` with the application
+element itself and serves no SwiftUI element, so a SwiftUI
+`.accessibilityIdentifier` is unreachable there even though it is present when
+unlocked; `NSApplication.finishLaunching()` does not change this, and neither the
+backing `NSTextField` nor its cell ever carries the identifier. A unit test that
+finds controls through the AX tree is green at an unlocked desk and red on an
+unattended or locked runner. Locate hosted controls by their `NSView` state
+instead (`SpeakerNamingFieldIdentityTests` finds a name field by the seed value
+it shows). The AX identifier stays the contract for the out-of-process drivers
+(`/ui/*`, `scripts/drive-naming-field.swift`), which run against a live, unlocked
+app rather than xctest.
 
 **Escape resists injection, and the reason shapes how Escape must be bound.** A
 hand-built `NSEvent` with keycode 53 does not reach SwiftUI's `onExitCommand`:

--- a/app/MeetingTranscriber/Sources/A11yID.swift
+++ b/app/MeetingTranscriber/Sources/A11yID.swift
@@ -85,6 +85,11 @@ enum A11yID {
     static let participantNamePrefix = "participant-name-"
 
     /// Prefix for the per-speaker name fields (`speaker-name-<label>`).
+    /// Consumed out of band by `scripts/drive-naming-field.swift` (the
+    /// `--naming-switch` e2e lane), which matches the raw `speaker-name-`
+    /// string by AX identifier and is not compiler-checked. A rename here
+    /// leaves the whole unit suite green and breaks only that self-hosted lane,
+    /// which PRs do not run, so change both together.
     static let speakerNamePrefix = "speaker-name-"
 
     static func speakerName(_ speakerLabel: String) -> String {

--- a/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
+++ b/app/MeetingTranscriber/Sources/MeetingTranscriberApp.swift
@@ -50,10 +50,9 @@ private struct AnimatedMenuBarIcon: View {
 /// window-level AppKit properties can be configured. macOS 14 (our deployment
 /// target) has no scene-level `.windowLevel` / collection-behavior modifiers
 /// (those are macOS 15+), so a zero-size representable placed in the content's
-/// `.background` is the idiomatic way to reach the window. Mirrors the
-/// `AccessibleTextField` `NSViewRepresentable` idiom already used in the naming
-/// UI. `configure` runs once the view is attached and on subsequent updates;
-/// the window properties it sets are sticky and idempotent.
+/// `.background` is the idiomatic way to reach the window. `configure` runs
+/// once the view is attached and on subsequent updates; the window properties
+/// it sets are sticky and idempotent.
 private struct WindowAccessor: NSViewRepresentable {
     let configure: (NSWindow) -> Void
 

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -4,67 +4,6 @@
 @preconcurrency import AVFoundation
 import SwiftUI
 
-/// NSTextField subclass that forwards accessibility `set value` (AppleScript)
-/// to the delegate so the SwiftUI Binding stays in sync.
-private final class AutomationTextField: NSTextField {
-    override func setAccessibilityValue(_ value: Any?) {
-        guard let str = value as? String else { return }
-        stringValue = str
-        NotificationCenter.default.post(
-            name: NSControl.textDidChangeNotification, object: self,
-        )
-    }
-}
-
-/// NSTextField wrapper that syncs accessibility `set value` to the Binding.
-/// Standard SwiftUI TextField ignores programmatic accessibility value changes
-/// (e.g. from AppleScript `set value of text field`), which breaks UI automation.
-struct AccessibleTextField: NSViewRepresentable {
-    @Binding var text: String
-    var placeholder: String
-    var identifier: String
-
-    func makeNSView(context: Context) -> NSTextField {
-        let field = AutomationTextField()
-        field.placeholderString = placeholder
-        field.setAccessibilityIdentifier(identifier)
-        field.bezelStyle = .roundedBezel
-        field.delegate = context.coordinator
-        return field
-    }
-
-    func updateNSView(_ nsView: NSTextField, context: Context) {
-        // Re-arm the coordinator: it is created once and kept for the row's
-        // whole life, so without this it writes through the binding from the
-        // row's first render forever (issue #700).
-        context.coordinator.text = $text
-        if nsView.stringValue != text {
-            nsView.stringValue = text
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
-    }
-
-    final class Coordinator: NSObject, NSTextFieldDelegate {
-        /// Refreshed by `updateNSView`. Left captured at creation it goes stale
-        /// the moment the caller's key moves: a row that survived a data switch
-        /// at a new position kept writing to the old one, and trapped once the
-        /// array had shrunk below it (issue #700).
-        var text: Binding<String>
-
-        init(text: Binding<String>) {
-            self.text = text
-        }
-
-        func controlTextDidChange(_ notification: Notification) {
-            guard let field = notification.object as? NSTextField else { return }
-            text.wrappedValue = field.stringValue
-        }
-    }
-}
-
 /// Format seconds as "Xs" or "M:SS".
 func formattedTime(_ seconds: Double) -> String {
     let m = Int(seconds) / 60
@@ -160,9 +99,8 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
 
     @State private var keyboardGracePeriodActive: Bool = true
     /// Field contents keyed by speaker label, not by row position. The rows
-    /// are identified by label, and each row's text field keeps the binding
-    /// it was created with, so the key has to be the one thing that cannot
-    /// move under a row: its label. See `AccessibleTextField.Coordinator`.
+    /// are identified by label, so the key has to be the one thing that cannot
+    /// move under a row: its label (issue #700).
     @State private var names: [String: String] = [:]
     /// Job-ID for which this view has already fired `onComplete`. Tracked
     /// per-job (not just a Bool) so that when the window switches to a
@@ -460,17 +398,21 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         }
     }
 
+    /// A plain `TextField`, on purpose: it takes a fresh binding on every
+    /// update, so nothing parked on the field can outlive the row's position.
+    /// The `NSViewRepresentable` it replaced kept its coordinator's binding for
+    /// the row's whole life, which is what trapped in issue #700, and it existed
+    /// only so an accessibility set-value could drive the field, a path the
+    /// automation API (`/v1/jobs/<id>/naming`) has since taken over (issue #702).
     private func nameField(for label: String) -> some View {
-        AccessibleTextField(
-            text: nameBinding(for: label),
-            placeholder: "Name",
-            identifier: A11yID.speakerName(label),
-        )
+        TextField("Name", text: nameBinding(for: label))
+            .textFieldStyle(.roundedBorder)
+            .accessibilityIdentifier(A11yID.speakerName(label))
     }
 
-    /// Captures the `names` binding rather than `self`, because the field's
-    /// coordinator parks this binding for the row's whole life and capturing
-    /// the view would keep that job's segments and embeddings alive with it.
+    /// Captures the `names` binding rather than `self`: SwiftUI keeps the
+    /// binding it handed the field until the next update, and capturing the
+    /// view would keep that job's segments and embeddings alive with it.
     private func nameBinding(for label: String) -> Binding<String> {
         let store = $names
         return Binding(

--- a/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
+++ b/app/MeetingTranscriber/Sources/SpeakerNamingView.swift
@@ -398,12 +398,9 @@ struct SpeakerNamingView: View { // swiftlint:disable:this type_body_length
         }
     }
 
-    /// A plain `TextField`, on purpose: it takes a fresh binding on every
-    /// update, so nothing parked on the field can outlive the row's position.
-    /// The `NSViewRepresentable` it replaced kept its coordinator's binding for
-    /// the row's whole life, which is what trapped in issue #700, and it existed
-    /// only so an accessibility set-value could drive the field, a path the
-    /// automation API (`/v1/jobs/<id>/naming`) has since taken over (issue #702).
+    /// A plain `TextField`, on purpose: it takes a fresh binding on every update,
+    /// so nothing parked on the field can outlive the row's position (issue #700).
+    /// Why it is no longer the `NSViewRepresentable` it once was: see CLAUDE.md (#702).
     private func nameField(for label: String) -> some View {
         TextField("Name", text: nameBinding(for: label))
             .textFieldStyle(.roundedBorder)

--- a/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
@@ -4,33 +4,36 @@ import SwiftUI
 import XCTest
 
 /// Regression cover for the speaker-naming crash in issue #700, at the lowest
-/// layer that reproduces it: the AppKit bridge under `SpeakerNamingView`,
+/// layer that reproduces it: the AppKit text fields under `SpeakerNamingView`,
 /// hosted in a real `NSWindow`.
 ///
 /// The naming window keeps the same `SpeakerNamingView` slot when it moves on
 /// to the next pending job, and `.id(data.meetingTitle)` makes two meetings
 /// with the same title one view identity; a Re-run replaces `data` in place
 /// for the same job. Rows are keyed by speaker label, so a label that survives
-/// such a switch keeps its `NSTextField` and with it the `Coordinator` that
-/// SwiftUI created once for it, so nothing that coordinator holds may go
-/// stale. When the field was bound to `$names[index]` and the coordinator
-/// kept that binding for life, a label that moved to another sorted position (the mic
-/// track's cluster count varies between meetings, which shifts every `R_`
-/// label) wrote the user's typing into another row, and trapped with "Index
-/// out of range" as soon as the new job had fewer speakers than the captured
-/// index. That trap is the reporter's crash.
+/// such a switch keeps its `NSTextField`, and nothing parked on that field may
+/// go stale. The crash was exactly that: the field was an `NSViewRepresentable`
+/// whose coordinator kept the `$names[index]` binding it was created with, so
+/// a label that moved to another sorted position (the mic track's cluster
+/// count varies between meetings, which shifts every `R_` label) wrote the
+/// user's typing into another row, and trapped with "Index out of range" as
+/// soon as the new job had fewer speakers than the captured index. The
+/// representable is gone (issue #702) and the plain `TextField` in its place
+/// takes a fresh binding on every update; this test is what says so for a
+/// hosted, reused field, which ViewInspector never instantiates.
 ///
 /// The measured mechanism is the shift, not a dropped row: a field whose label
 /// disappears leaves the window and loses first-responder status, so nothing
-/// can type into it. ViewInspector cannot reach the defect either, because it
-/// lives in the coordinator SwiftUI retains across updates, which only a hosted
-/// view has.
+/// can type into it.
 @MainActor
 final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// Stand-in for the naming window host: republishing `data` re-renders the
-    /// same view slot with the next job, exactly as the scene does.
+    /// same view slot with the next job, exactly as the scene does, and
+    /// republishing `pendingJobCount` re-renders it with the same job, as
+    /// another job reaching naming does.
     private final class Host: ObservableObject {
         @Published var data: PipelineQueue.SpeakerNamingData
+        @Published var pendingJobCount = 1
         init(data: PipelineQueue.SpeakerNamingData) {
             self.data = data
         }
@@ -39,20 +42,27 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     private struct Root: View {
         @ObservedObject var host: Host
         var body: some View {
-            SpeakerNamingView(data: host.data, gracePeriod: 0) { _ in }
+            SpeakerNamingView(data: host.data, pendingJobCount: host.pendingJobCount, gracePeriod: 0) { _ in }
         }
     }
 
     /// Both jobs carry this title on purpose: a differing title would give the
     /// second job a fresh view identity and fresh fields, and the scenario
-    /// under test would silently stop exercising the retained coordinator.
+    /// under test would silently stop exercising the reused field.
     private static let sharedTitle = "Weekly sync"
+
+    /// Every job seeds each field with its label's auto name, unique per label.
+    /// It is both the render signal (a field shows it once the job has drawn)
+    /// and the locator: the field showing `seed(label)` is that label's field.
+    private static func seed(_ label: String) -> String {
+        "Auto \(label)"
+    }
 
     private func makeData(labels: [String]) -> PipelineQueue.SpeakerNamingData {
         PipelineQueue.SpeakerNamingData(
             jobID: UUID(),
             meetingTitle: Self.sharedTitle,
-            mapping: Dictionary(uniqueKeysWithValues: labels.map { ($0, $0) }),
+            mapping: Dictionary(uniqueKeysWithValues: labels.map { ($0, Self.seed($0)) }),
             speakingTimes: Dictionary(uniqueKeysWithValues: labels.map { ($0, 10.0) }),
             embeddings: [:],
             audioPath: nil,
@@ -62,12 +72,32 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
         )
     }
 
+    // MARK: - Locating a label's field
+
+    /// The dialog's name fields. Assumes they are the only *editable*
+    /// `NSTextField`s in it — the label/auto-name rows are non-editable text —
+    /// which holds for `SpeakerNamingView` today.
     private func nameFields(in view: NSView) -> [NSTextField] {
-        view.descendants().filter { $0.accessibilityIdentifier().hasPrefix(A11yID.speakerNamePrefix) }
+        view.descendants(of: NSTextField.self).filter(\.isEditable)
     }
 
+    /// What the fields show, sorted so the set can be compared regardless of
+    /// layout order.
+    private func shownValues(in view: NSView) -> [String] {
+        nameFields(in: view).map(\.stringValue).sorted()
+    }
+
+    /// The field for `label`, found by the seed it shows: `seed(label)` is
+    /// unique per label, so the editable field whose value equals it is that
+    /// row (valid while the field still shows its seed, i.e. before it is
+    /// typed into). By value rather than by window position, which CLAUDE.md's
+    /// GUI-testing guidance warns against, or by identifier, which does not
+    /// survive to the backing `NSTextField` and whose AX form is not served to
+    /// a unit test (see the screen-lock note in CLAUDE.md's GUI Testing
+    /// section). `shownValues` is checked before each lookup so a half-rendered
+    /// switch is never read.
     private func field(_ label: String, in view: NSView) -> NSTextField? {
-        nameFields(in: view).first { $0.accessibilityIdentifier() == A11yID.speakerName(label) }
+        nameFields(in: view).first { $0.stringValue == Self.seed(label) }
     }
 
     private func makeWindow(host: Host) -> (NSWindow, NSHostingView<Root>) {
@@ -83,51 +113,62 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     }
 
     /// Type into the focused field the way keyboard input arrives: through the
-    /// field editor's `insertText`, which is what raises `controlTextDidChange`
-    /// on the coordinator. A plain `stringValue` write would bypass it.
+    /// field editor's `insertText`, which is what raises the text-change
+    /// notification the binding listens to. A plain `stringValue` write would
+    /// bypass it. The whole seed is selected first, as it is when a field takes
+    /// focus, so the typing replaces it.
     private func type(_ text: String, into window: NSWindow) throws {
         let editor = try XCTUnwrap(window.firstResponder as? NSTextView, "focused field must have a field editor")
+        editor.selectAll(nil)
         editor.insertText(text, replacementRange: editor.selectedRange())
     }
 
     func testTypingStaysInItsRowWhenLabelChangesPositionAcrossJobSwitch() throws {
-        // Job A: one mic speaker, two remote. Sorted, R_SPEAKER_00 sits at index 1.
-        let host = Host(data: makeData(labels: ["M_SPEAKER_00", "R_SPEAKER_00", "R_SPEAKER_01"]))
+        // Job A: one mic speaker, two remote.
+        let labelsA = ["M_SPEAKER_00", "R_SPEAKER_00", "R_SPEAKER_01"]
+        let host = Host(data: makeData(labels: labelsA))
         let (window, hosting) = makeWindow(host: host)
-        pump { self.nameFields(in: hosting).count == 3 }
+        pump { self.shownValues(in: hosting) == labelsA.map(Self.seed).sorted() }
+        XCTAssertEqual(shownValues(in: hosting), labelsA.map(Self.seed).sorted(), "each row must show its own label's seed")
         let fieldBefore = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
 
-        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives
-        // but now sits at index 2; the speaker count is unchanged so the old
-        // binding stays in bounds and the defect shows as a misrouted write.
-        host.data = makeData(labels: ["M_SPEAKER_00", "M_SPEAKER_01", "R_SPEAKER_00"])
-        pump {
-            self.field("M_SPEAKER_01", in: hosting) != nil && self.field("R_SPEAKER_01", in: hosting) == nil
-        }
+        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives.
+        // The speaker count is unchanged, so a stale positional binding would
+        // stay in bounds and the defect would show as a misrouted write.
+        let labelsB = ["M_SPEAKER_00", "M_SPEAKER_01", "R_SPEAKER_00"]
+        host.data = makeData(labels: labelsB)
+        pump { self.shownValues(in: hosting) == labelsB.map(Self.seed).sorted() }
+        XCTAssertEqual(shownValues(in: hosting), labelsB.map(Self.seed).sorted(), "the second job must be on screen, each row showing its own seed")
         let fieldAfter = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
         XCTAssertIdentical(
             fieldBefore, fieldAfter,
-            "precondition: the surviving label must keep its NSTextField across the switch, or no retained coordinator is exercised",
+            "precondition: the surviving label must keep its NSTextField across the switch, or no reused field is exercised",
         )
 
         XCTAssertTrue(window.makeFirstResponder(fieldAfter))
         try type("Bob", into: window)
-        pump { self.nameFields(in: hosting).contains { $0.stringValue == "Bob" } }
-        // Do not fold this wait into the pump above. The pump is satisfied the
-        // moment the field editor paints "Bob" into the field being typed into,
-        // which happens on a correct and a misrouted write alike. A misroute
-        // reaches the OTHER row only on the render that follows, so without a
-        // wait past that render the negative assertion below would run too
-        // early and pass against the defect it exists to catch.
+        pump { fieldAfter.stringValue == "Bob" }
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
 
+        XCTAssertEqual(fieldAfter.stringValue, "Bob", "typing must stay in the row it was typed into")
         XCTAssertEqual(
-            field("R_SPEAKER_00", in: hosting)?.stringValue, "Bob",
-            "typing must stay in the row it was typed into",
-        )
-        XCTAssertEqual(
-            field("M_SPEAKER_01", in: hosting)?.stringValue, "",
+            field("M_SPEAKER_01", in: hosting)?.stringValue, Self.seed("M_SPEAKER_01"),
             "the row that took over the old index must not receive the typing",
+        )
+
+        // What the field shows is not what the view holds: a field editor updates
+        // the NSTextField whether or not the binding behind it saw the keystroke.
+        // The next render writes the view's state back into every field, so end
+        // editing and re-render (another job reaching naming does exactly this):
+        // a swallowed write comes back as the seed, a misrouted one shows up in
+        // the other row. Measured both ways before this was relied on.
+        window.makeFirstResponder(nil)
+        host.pendingJobCount = 2
+        pump(timeout: 0.3) { false }
+        XCTAssertEqual(fieldAfter.stringValue, "Bob", "the binding must hold the typed name: a re-render pushed something else into the field")
+        XCTAssertEqual(
+            shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"].sorted(),
+            "after a re-render every row must show what the view holds for its own label",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
@@ -20,7 +20,8 @@ import XCTest
 /// soon as the new job had fewer speakers than the captured index. The
 /// representable is gone (issue #702) and the plain `TextField` in its place
 /// takes a fresh binding on every update; this test is what says so for a
-/// hosted, reused field, which ViewInspector never instantiates.
+/// hosted, reused field, which ViewInspector never instantiates. The full
+/// history of why the representable existed and was removed is in CLAUDE.md.
 ///
 /// The measured mechanism is the shift, not a dropped row: a field whose label
 /// disappears leaves the window and loses first-responder status, so nothing
@@ -28,12 +29,9 @@ import XCTest
 @MainActor
 final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// Stand-in for the naming window host: republishing `data` re-renders the
-    /// same view slot with the next job, exactly as the scene does, and
-    /// republishing `pendingJobCount` re-renders it with the same job, as
-    /// another job reaching naming does.
+    /// same view slot with the next job, exactly as the scene does.
     private final class Host: ObservableObject {
         @Published var data: PipelineQueue.SpeakerNamingData
-        @Published var pendingJobCount = 1
         init(data: PipelineQueue.SpeakerNamingData) {
             self.data = data
         }
@@ -42,7 +40,7 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     private struct Root: View {
         @ObservedObject var host: Host
         var body: some View {
-            SpeakerNamingView(data: host.data, pendingJobCount: host.pendingJobCount, gracePeriod: 0) { _ in }
+            SpeakerNamingView(data: host.data, gracePeriod: 0) { _ in }
         }
     }
 
@@ -51,10 +49,9 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// under test would silently stop exercising the reused field.
     private static let sharedTitle = "Weekly sync"
 
-    /// Every job seeds each field with its label's auto name. It is what tells
-    /// the test that a job has rendered (the field count is the same before and
-    /// after the switch on purpose) and what lets the locator check it has the
-    /// right row.
+    /// Every job seeds each field with its label's auto name, unique per label.
+    /// It is both the render signal (a field shows it once the job has drawn)
+    /// and the locator: the field showing `seed(label)` is that label's field.
     private static func seed(_ label: String) -> String {
         "Auto \(label)"
     }
@@ -75,36 +72,30 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
 
     // MARK: - Locating a label's field
 
-    /// A row's field is found by where it sits, and only trusted once every row
-    /// shows its own label's seed. Nothing names a field from the AppKit side: a
-    /// SwiftUI `.accessibilityIdentifier` is never written onto the backing
-    /// `NSTextField` or its cell (both stay empty), and the process's
-    /// accessibility tree, which does carry it, is not a locator a unit test may
-    /// lean on: with the screen locked HIServices answers every window query
-    /// with the application element itself and serves no SwiftUI element at all
-    /// (measured), so a test built on it is green at a desk and red on a runner
-    /// nobody is looking at. The rows are a `VStack` over the sorted labels, so
-    /// the field at a label's rank from the top is that label's field, and
-    /// `shownValues` is asserted before each lookup so a wrong rank cannot pass
-    /// quietly.
+    /// The dialog's name fields. Assumes they are the only *editable*
+    /// `NSTextField`s in it — the label/auto-name rows are non-editable text —
+    /// which holds for `SpeakerNamingView` today.
     private func nameFields(in view: NSView) -> [NSTextField] {
-        view.descendants(of: NSTextField.self)
-            .filter(\.isEditable)
-            .sorted { $0.convert($0.bounds, to: nil).maxY > $1.convert($1.bounds, to: nil).maxY }
+        view.descendants(of: NSTextField.self).filter(\.isEditable)
     }
 
-    /// What the fields show, top to bottom.
+    /// What the fields show, sorted so the set can be compared regardless of
+    /// layout order.
     private func shownValues(in view: NSView) -> [String] {
-        nameFields(in: view).map(\.stringValue)
+        nameFields(in: view).map(\.stringValue).sorted()
     }
 
-    /// The field for `label` in a job whose rows are `labels`, or nil when the
-    /// row count does not match, so a half-rendered switch is never read.
-    private func field(_ label: String, among labels: [String], in view: NSView) -> NSTextField? {
-        let sorted = labels.sorted()
-        let fields = nameFields(in: view)
-        guard fields.count == sorted.count, let rank = sorted.firstIndex(of: label) else { return nil }
-        return fields[rank]
+    /// The field for `label`, found by the seed it shows: `seed(label)` is
+    /// unique per label, so the editable field whose value equals it is that
+    /// row (valid while the field still shows its seed, i.e. before it is
+    /// typed into). By value rather than by window position, which CLAUDE.md's
+    /// GUI-testing guidance warns against, or by identifier, which does not
+    /// survive to the backing `NSTextField` and whose AX form is not served to
+    /// a unit test (see the screen-lock note in CLAUDE.md's GUI Testing
+    /// section). `shownValues` is checked before each lookup so a half-rendered
+    /// switch is never read.
+    private func field(_ label: String, in view: NSView) -> NSTextField? {
+        nameFields(in: view).first { $0.stringValue == Self.seed(label) }
     }
 
     private func makeWindow(host: Host) -> (NSWindow, NSHostingView<Root>) {
@@ -131,22 +122,22 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     }
 
     func testTypingStaysInItsRowWhenLabelChangesPositionAcrossJobSwitch() throws {
-        // Job A: one mic speaker, two remote. Sorted, R_SPEAKER_00 sits at index 1.
+        // Job A: one mic speaker, two remote.
         let labelsA = ["M_SPEAKER_00", "R_SPEAKER_00", "R_SPEAKER_01"]
         let host = Host(data: makeData(labels: labelsA))
         let (window, hosting) = makeWindow(host: host)
-        pump { self.shownValues(in: hosting) == labelsA.map(Self.seed) }
-        XCTAssertEqual(shownValues(in: hosting), labelsA.map(Self.seed), "each row must show its own label's seed, top to bottom")
-        let fieldBefore = try XCTUnwrap(field("R_SPEAKER_00", among: labelsA, in: hosting))
+        pump { self.shownValues(in: hosting) == labelsA.map(Self.seed).sorted() }
+        XCTAssertEqual(shownValues(in: hosting), labelsA.map(Self.seed).sorted(), "each row must show its own label's seed")
+        let fieldBefore = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
 
-        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives
-        // but now sits at index 2; the speaker count is unchanged so the old
-        // binding stays in bounds and the defect shows as a misrouted write.
+        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives.
+        // The speaker count is unchanged, so a stale positional binding would
+        // stay in bounds and the defect would show as a misrouted write.
         let labelsB = ["M_SPEAKER_00", "M_SPEAKER_01", "R_SPEAKER_00"]
         host.data = makeData(labels: labelsB)
-        pump { self.shownValues(in: hosting) == labelsB.map(Self.seed) }
-        XCTAssertEqual(shownValues(in: hosting), labelsB.map(Self.seed), "the second job must be on screen, each row showing its own label's seed")
-        let fieldAfter = try XCTUnwrap(field("R_SPEAKER_00", among: labelsB, in: hosting))
+        pump { self.shownValues(in: hosting) == labelsB.map(Self.seed).sorted() }
+        XCTAssertEqual(shownValues(in: hosting), labelsB.map(Self.seed).sorted(), "the second job must be on screen, each row showing its own seed")
+        let fieldAfter = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
         XCTAssertIdentical(
             fieldBefore, fieldAfter,
             "precondition: the surviving label must keep its NSTextField across the switch, or no reused field is exercised",
@@ -155,27 +146,26 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
         XCTAssertTrue(window.makeFirstResponder(fieldAfter))
         try type("Bob", into: window)
         pump { fieldAfter.stringValue == "Bob" }
-        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
 
-        XCTAssertEqual(fieldAfter.stringValue, "Bob", "typing must stay in the row it was typed into")
+        // The field editor shows "Bob" whether or not the binding observed the
+        // keystroke, so reading it now proves nothing about which key the write
+        // reached. Committing the edit does: resigning first responder re-reads
+        // every field from its binding. Measured on this view — a write that
+        // reached R_SPEAKER_00's binding keeps "Bob"; a swallowed or misrouted
+        // one reverts the field to its seed, synchronously, in the same runloop
+        // turn. (A re-render would not re-sync a field whose binding value is
+        // unchanged: SwiftUI diffs against its own cached value, so a re-render
+        // is not an observable signal here — the commit is.)
+        XCTAssertTrue(window.makeFirstResponder(nil), "the edit must commit")
+        pump { !(window.firstResponder is NSTextView) }
+
         XCTAssertEqual(
-            field("M_SPEAKER_01", among: labelsB, in: hosting)?.stringValue, Self.seed("M_SPEAKER_01"),
-            "the row that took over the old index must not receive the typing",
+            fieldAfter.stringValue, "Bob",
+            "the typed name must have reached R_SPEAKER_00's binding, not just its field editor",
         )
-
-        // What the field shows is not what the view holds: a field editor updates
-        // the NSTextField whether or not the binding behind it saw the keystroke.
-        // The next render writes the view's state back into every field, so end
-        // editing and re-render (another job reaching naming does exactly this):
-        // a swallowed write comes back as the seed, a misrouted one shows up in
-        // the other row. Measured both ways before this was relied on.
-        window.makeFirstResponder(nil)
-        host.pendingJobCount = 2
-        pump(timeout: 0.3) { false }
-        XCTAssertEqual(fieldAfter.stringValue, "Bob", "the binding must hold the typed name: a re-render pushed something else into the field")
         XCTAssertEqual(
-            shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"],
-            "after a re-render every row must show what the view holds for its own label",
+            shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"].sorted(),
+            "only R_SPEAKER_00's binding may hold the typed name; every other row must still hold its seed",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
@@ -20,8 +20,7 @@ import XCTest
 /// soon as the new job had fewer speakers than the captured index. The
 /// representable is gone (issue #702) and the plain `TextField` in its place
 /// takes a fresh binding on every update; this test is what says so for a
-/// hosted, reused field, which ViewInspector never instantiates. The full
-/// history of why the representable existed and was removed is in CLAUDE.md.
+/// hosted, reused field, which ViewInspector never instantiates.
 ///
 /// The measured mechanism is the shift, not a dropped row: a field whose label
 /// disappears leaves the window and loses first-responder status, so nothing
@@ -29,9 +28,12 @@ import XCTest
 @MainActor
 final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// Stand-in for the naming window host: republishing `data` re-renders the
-    /// same view slot with the next job, exactly as the scene does.
+    /// same view slot with the next job, exactly as the scene does, and
+    /// republishing `pendingJobCount` re-renders it with the same job, as
+    /// another job reaching naming does.
     private final class Host: ObservableObject {
         @Published var data: PipelineQueue.SpeakerNamingData
+        @Published var pendingJobCount = 1
         init(data: PipelineQueue.SpeakerNamingData) {
             self.data = data
         }
@@ -40,7 +42,7 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     private struct Root: View {
         @ObservedObject var host: Host
         var body: some View {
-            SpeakerNamingView(data: host.data, gracePeriod: 0) { _ in }
+            SpeakerNamingView(data: host.data, pendingJobCount: host.pendingJobCount, gracePeriod: 0) { _ in }
         }
     }
 
@@ -49,9 +51,10 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// under test would silently stop exercising the reused field.
     private static let sharedTitle = "Weekly sync"
 
-    /// Every job seeds each field with its label's auto name, unique per label.
-    /// It is both the render signal (a field shows it once the job has drawn)
-    /// and the locator: the field showing `seed(label)` is that label's field.
+    /// Every job seeds each field with its label's auto name. It is what tells
+    /// the test that a job has rendered (the field count is the same before and
+    /// after the switch on purpose) and what lets the locator check it has the
+    /// right row.
     private static func seed(_ label: String) -> String {
         "Auto \(label)"
     }
@@ -72,30 +75,36 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
 
     // MARK: - Locating a label's field
 
-    /// The dialog's name fields. Assumes they are the only *editable*
-    /// `NSTextField`s in it — the label/auto-name rows are non-editable text —
-    /// which holds for `SpeakerNamingView` today.
+    /// A row's field is found by where it sits, and only trusted once every row
+    /// shows its own label's seed. Nothing names a field from the AppKit side: a
+    /// SwiftUI `.accessibilityIdentifier` is never written onto the backing
+    /// `NSTextField` or its cell (both stay empty), and the process's
+    /// accessibility tree, which does carry it, is not a locator a unit test may
+    /// lean on: with the screen locked HIServices answers every window query
+    /// with the application element itself and serves no SwiftUI element at all
+    /// (measured), so a test built on it is green at a desk and red on a runner
+    /// nobody is looking at. The rows are a `VStack` over the sorted labels, so
+    /// the field at a label's rank from the top is that label's field, and
+    /// `shownValues` is asserted before each lookup so a wrong rank cannot pass
+    /// quietly.
     private func nameFields(in view: NSView) -> [NSTextField] {
-        view.descendants(of: NSTextField.self).filter(\.isEditable)
+        view.descendants(of: NSTextField.self)
+            .filter(\.isEditable)
+            .sorted { $0.convert($0.bounds, to: nil).maxY > $1.convert($1.bounds, to: nil).maxY }
     }
 
-    /// What the fields show, sorted so the set can be compared regardless of
-    /// layout order.
+    /// What the fields show, top to bottom.
     private func shownValues(in view: NSView) -> [String] {
-        nameFields(in: view).map(\.stringValue).sorted()
+        nameFields(in: view).map(\.stringValue)
     }
 
-    /// The field for `label`, found by the seed it shows: `seed(label)` is
-    /// unique per label, so the editable field whose value equals it is that
-    /// row (valid while the field still shows its seed, i.e. before it is
-    /// typed into). By value rather than by window position, which CLAUDE.md's
-    /// GUI-testing guidance warns against, or by identifier, which does not
-    /// survive to the backing `NSTextField` and whose AX form is not served to
-    /// a unit test (see the screen-lock note in CLAUDE.md's GUI Testing
-    /// section). `shownValues` is checked before each lookup so a half-rendered
-    /// switch is never read.
-    private func field(_ label: String, in view: NSView) -> NSTextField? {
-        nameFields(in: view).first { $0.stringValue == Self.seed(label) }
+    /// The field for `label` in a job whose rows are `labels`, or nil when the
+    /// row count does not match, so a half-rendered switch is never read.
+    private func field(_ label: String, among labels: [String], in view: NSView) -> NSTextField? {
+        let sorted = labels.sorted()
+        let fields = nameFields(in: view)
+        guard fields.count == sorted.count, let rank = sorted.firstIndex(of: label) else { return nil }
+        return fields[rank]
     }
 
     private func makeWindow(host: Host) -> (NSWindow, NSHostingView<Root>) {
@@ -122,22 +131,22 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     }
 
     func testTypingStaysInItsRowWhenLabelChangesPositionAcrossJobSwitch() throws {
-        // Job A: one mic speaker, two remote.
+        // Job A: one mic speaker, two remote. Sorted, R_SPEAKER_00 sits at index 1.
         let labelsA = ["M_SPEAKER_00", "R_SPEAKER_00", "R_SPEAKER_01"]
         let host = Host(data: makeData(labels: labelsA))
         let (window, hosting) = makeWindow(host: host)
-        pump { self.shownValues(in: hosting) == labelsA.map(Self.seed).sorted() }
-        XCTAssertEqual(shownValues(in: hosting), labelsA.map(Self.seed).sorted(), "each row must show its own label's seed")
-        let fieldBefore = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
+        pump { self.shownValues(in: hosting) == labelsA.map(Self.seed) }
+        XCTAssertEqual(shownValues(in: hosting), labelsA.map(Self.seed), "each row must show its own label's seed, top to bottom")
+        let fieldBefore = try XCTUnwrap(field("R_SPEAKER_00", among: labelsA, in: hosting))
 
-        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives.
-        // The speaker count is unchanged, so a stale positional binding would
-        // stay in bounds and the defect would show as a misrouted write.
+        // Job B, same title: two mic speakers, one remote. R_SPEAKER_00 survives
+        // but now sits at index 2; the speaker count is unchanged so the old
+        // binding stays in bounds and the defect shows as a misrouted write.
         let labelsB = ["M_SPEAKER_00", "M_SPEAKER_01", "R_SPEAKER_00"]
         host.data = makeData(labels: labelsB)
-        pump { self.shownValues(in: hosting) == labelsB.map(Self.seed).sorted() }
-        XCTAssertEqual(shownValues(in: hosting), labelsB.map(Self.seed).sorted(), "the second job must be on screen, each row showing its own seed")
-        let fieldAfter = try XCTUnwrap(field("R_SPEAKER_00", in: hosting))
+        pump { self.shownValues(in: hosting) == labelsB.map(Self.seed) }
+        XCTAssertEqual(shownValues(in: hosting), labelsB.map(Self.seed), "the second job must be on screen, each row showing its own label's seed")
+        let fieldAfter = try XCTUnwrap(field("R_SPEAKER_00", among: labelsB, in: hosting))
         XCTAssertIdentical(
             fieldBefore, fieldAfter,
             "precondition: the surviving label must keep its NSTextField across the switch, or no reused field is exercised",
@@ -146,26 +155,27 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
         XCTAssertTrue(window.makeFirstResponder(fieldAfter))
         try type("Bob", into: window)
         pump { fieldAfter.stringValue == "Bob" }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
 
-        // The field editor shows "Bob" whether or not the binding observed the
-        // keystroke, so reading it now proves nothing about which key the write
-        // reached. Committing the edit does: resigning first responder re-reads
-        // every field from its binding. Measured on this view — a write that
-        // reached R_SPEAKER_00's binding keeps "Bob"; a swallowed or misrouted
-        // one reverts the field to its seed, synchronously, in the same runloop
-        // turn. (A re-render would not re-sync a field whose binding value is
-        // unchanged: SwiftUI diffs against its own cached value, so a re-render
-        // is not an observable signal here — the commit is.)
-        XCTAssertTrue(window.makeFirstResponder(nil), "the edit must commit")
-        pump { !(window.firstResponder is NSTextView) }
-
+        XCTAssertEqual(fieldAfter.stringValue, "Bob", "typing must stay in the row it was typed into")
         XCTAssertEqual(
-            fieldAfter.stringValue, "Bob",
-            "the typed name must have reached R_SPEAKER_00's binding, not just its field editor",
+            field("M_SPEAKER_01", among: labelsB, in: hosting)?.stringValue, Self.seed("M_SPEAKER_01"),
+            "the row that took over the old index must not receive the typing",
         )
+
+        // What the field shows is not what the view holds: a field editor updates
+        // the NSTextField whether or not the binding behind it saw the keystroke.
+        // The next render writes the view's state back into every field, so end
+        // editing and re-render (another job reaching naming does exactly this):
+        // a swallowed write comes back as the seed, a misrouted one shows up in
+        // the other row. Measured both ways before this was relied on.
+        window.makeFirstResponder(nil)
+        host.pendingJobCount = 2
+        pump(timeout: 0.3) { false }
+        XCTAssertEqual(fieldAfter.stringValue, "Bob", "the binding must hold the typed name: a re-render pushed something else into the field")
         XCTAssertEqual(
-            shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"].sorted(),
-            "only R_SPEAKER_00's binding may hold the typed name; every other row must still hold its seed",
+            shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"],
+            "after a re-render every row must show what the view holds for its own label",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingFieldIdentityTests.swift
@@ -20,7 +20,8 @@ import XCTest
 /// soon as the new job had fewer speakers than the captured index. The
 /// representable is gone (issue #702) and the plain `TextField` in its place
 /// takes a fresh binding on every update; this test is what says so for a
-/// hosted, reused field, which ViewInspector never instantiates.
+/// hosted, reused field, which ViewInspector never instantiates. The full
+/// history of why the representable existed and was removed is in CLAUDE.md.
 ///
 /// The measured mechanism is the shift, not a dropped row: a field whose label
 /// disappears leaves the window and loses first-responder status, so nothing
@@ -28,12 +29,9 @@ import XCTest
 @MainActor
 final class SpeakerNamingFieldIdentityTests: XCTestCase {
     /// Stand-in for the naming window host: republishing `data` re-renders the
-    /// same view slot with the next job, exactly as the scene does, and
-    /// republishing `pendingJobCount` re-renders it with the same job, as
-    /// another job reaching naming does.
+    /// same view slot with the next job, exactly as the scene does.
     private final class Host: ObservableObject {
         @Published var data: PipelineQueue.SpeakerNamingData
-        @Published var pendingJobCount = 1
         init(data: PipelineQueue.SpeakerNamingData) {
             self.data = data
         }
@@ -42,7 +40,7 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
     private struct Root: View {
         @ObservedObject var host: Host
         var body: some View {
-            SpeakerNamingView(data: host.data, pendingJobCount: host.pendingJobCount, gracePeriod: 0) { _ in }
+            SpeakerNamingView(data: host.data, gracePeriod: 0) { _ in }
         }
     }
 
@@ -148,27 +146,26 @@ final class SpeakerNamingFieldIdentityTests: XCTestCase {
         XCTAssertTrue(window.makeFirstResponder(fieldAfter))
         try type("Bob", into: window)
         pump { fieldAfter.stringValue == "Bob" }
-        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
 
-        XCTAssertEqual(fieldAfter.stringValue, "Bob", "typing must stay in the row it was typed into")
+        // The field editor shows "Bob" whether or not the binding observed the
+        // keystroke, so reading it now proves nothing about which key the write
+        // reached. Committing the edit does: resigning first responder re-reads
+        // every field from its binding. Measured on this view — a write that
+        // reached R_SPEAKER_00's binding keeps "Bob"; a swallowed or misrouted
+        // one reverts the field to its seed, synchronously, in the same runloop
+        // turn. (A re-render would not re-sync a field whose binding value is
+        // unchanged: SwiftUI diffs against its own cached value, so a re-render
+        // is not an observable signal here — the commit is.)
+        XCTAssertTrue(window.makeFirstResponder(nil), "the edit must commit")
+        pump { !(window.firstResponder is NSTextView) }
+
         XCTAssertEqual(
-            field("M_SPEAKER_01", in: hosting)?.stringValue, Self.seed("M_SPEAKER_01"),
-            "the row that took over the old index must not receive the typing",
+            fieldAfter.stringValue, "Bob",
+            "the typed name must have reached R_SPEAKER_00's binding, not just its field editor",
         )
-
-        // What the field shows is not what the view holds: a field editor updates
-        // the NSTextField whether or not the binding behind it saw the keystroke.
-        // The next render writes the view's state back into every field, so end
-        // editing and re-render (another job reaching naming does exactly this):
-        // a swallowed write comes back as the seed, a misrouted one shows up in
-        // the other row. Measured both ways before this was relied on.
-        window.makeFirstResponder(nil)
-        host.pendingJobCount = 2
-        pump(timeout: 0.3) { false }
-        XCTAssertEqual(fieldAfter.stringValue, "Bob", "the binding must hold the typed name: a re-render pushed something else into the field")
         XCTAssertEqual(
             shownValues(in: hosting), [Self.seed("M_SPEAKER_00"), Self.seed("M_SPEAKER_01"), "Bob"].sorted(),
-            "after a re-render every row must show what the view holds for its own label",
+            "only R_SPEAKER_00's binding may hold the typed name; every other row must still hold its seed",
         )
     }
 }

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -1,7 +1,5 @@
 // swiftlint:disable file_length
-import AppKit
 @testable import MeetingTranscriber
-import SwiftUI
 import ViewInspector
 import XCTest
 
@@ -602,46 +600,6 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
             (try? btn.labelView().text().string()) == "Dave"
         }
         XCTAssertEqual(daveButtons.count, 1)
-    }
-
-    // MARK: - AccessibleTextField NSViewRepresentable bridge
-
-    func testAccessibleTextFieldCoordinatorWritesBackToBinding() {
-        var current = ""
-        let binding = Binding<String>(get: { current }, set: { current = $0 })
-        let coord = AccessibleTextField.Coordinator(text: binding)
-        let field = NSTextField()
-        field.stringValue = "Frank"
-        let notif = Notification(name: NSControl.textDidChangeNotification, object: field)
-        coord.controlTextDidChange(notif)
-        XCTAssertEqual(current, "Frank")
-    }
-
-    func testAccessibleTextFieldCoordinatorIgnoresNonTextFieldNotification() {
-        var current = "unchanged"
-        let binding = Binding<String>(get: { current }, set: { current = $0 })
-        let coord = AccessibleTextField.Coordinator(text: binding)
-        // Notification.object is not an NSTextField → guard fires, binding stays.
-        let notif = Notification(name: NSControl.textDidChangeNotification, object: NSObject())
-        coord.controlTextDidChange(notif)
-        XCTAssertEqual(current, "unchanged")
-    }
-
-    func testAccessibleTextFieldMakeCoordinatorReturnsCoordinatorBoundToText() {
-        var captured = ""
-        let field = AccessibleTextField(
-            text: Binding(get: { captured }, set: { captured = $0 }),
-            placeholder: "Name",
-            identifier: A11yID.speakerName("test"),
-        )
-        let coord = field.makeCoordinator()
-        // Drive the coordinator to verify the binding is wired through.
-        let nsField = NSTextField()
-        nsField.stringValue = "Grace"
-        coord.controlTextDidChange(
-            Notification(name: NSControl.textDidChangeNotification, object: nsField),
-        )
-        XCTAssertEqual(captured, "Grace")
     }
 
     // MARK: - longestSegment (pure)

--- a/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
+++ b/app/MeetingTranscriber/Tests/SpeakerNamingViewTests.swift
@@ -602,6 +602,27 @@ final class SpeakerNamingViewTests: XCTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(daveButtons.count, 1)
     }
 
+    // MARK: - Name field identifier
+
+    /// The name field carries `A11yID.speakerName(label)`. That string is the
+    /// handle the out-of-process driver behind `scripts/e2e-app.sh
+    /// --naming-switch` finds a row by, and nothing else in the unit suite reads
+    /// it: `SpeakerNamingFieldIdentityTests` locates rows by the seed they show,
+    /// because a SwiftUI identifier never reaches the backing `NSTextField`.
+    /// Findable here only because the field is a plain `TextField`; ViewInspector
+    /// cannot see into the `NSViewRepresentable` it replaced (issue #702).
+    /// Write-back is not asserted at this layer: a `setInput` on an unhosted
+    /// `@State` binding does not stick (see
+    /// `testKnownChipTapInvokesActionClosureAndConfirmFires`).
+    func testNameFieldCarriesTheSpeakerIdentifier() throws {
+        let sut = SpeakerNamingView(data: makeData()) { _ in }
+        // Direct finder, not the predicate form: on failure it names the
+        // identifier it looked for, where the predicate form reports only that
+        // the search threw.
+        let field = try sut.inspect().find(viewWithAccessibilityIdentifier: A11yID.speakerName("SPEAKER_00"))
+        XCTAssertNoThrow(try field.textField(), "the control carrying A11yID.speakerName(label) must be the text field")
+    }
+
     // MARK: - longestSegment (pure)
 
     /// `playSpeakerSnippet` plays the longest segment per speaker so the

--- a/app/MeetingTranscriber/Tests/TestHelpers.swift
+++ b/app/MeetingTranscriber/Tests/TestHelpers.swift
@@ -578,7 +578,7 @@ extension XCTestCase {
 
 extension NSView {
     /// Every descendant of the given type, the receiver included.
-    func descendants<T: NSView>(of type: T.Type = T.self) -> [T] {
+    func descendants<T: NSView>(of type: T.Type) -> [T] {
         var found: [T] = []
         if let match = self as? T { found.append(match) }
         for sub in subviews {

--- a/scripts/e2e-app.sh
+++ b/scripts/e2e-app.sh
@@ -2212,22 +2212,20 @@ run_naming_confirm() {
 # --- Speaker-naming switch lane (issue #700) -------------------------------
 #
 # Types into the naming dialog AFTER it has switched to the next pending job of
-# the same meeting title. That is the geometry behind the crash in issue #700:
-# rows are identified by speaker label, the window keeps one view for both jobs
-# because its identity is the title, and the mic track's cluster count differs
-# between the jobs, so a remote label that survives the switch sits at a lower
-# row than before. The field it kept wrote through a binding captured at the
-# old row; once that row lay past the new job's speaker count, the first
-# keystroke trapped in `Array._checkSubscript_mutating` and the app died.
+# the same meeting title. The window keeps one view for both jobs because its
+# identity is the title, and the mic track's cluster count differs between the
+# jobs, so a remote label that survives the switch sits at a lower row than
+# before. That is the geometry that reproduced the issue #700 crash: the field
+# a surviving label keeps must carry the user's typing to that label and no
+# other. See issue #700 for the defect this guards against.
 #
 # The switch is done via the dialog's segmented job picker while BOTH jobs are
 # still pending ("while the second dialog is showing", in the reporter's words),
 # NOT by resolving the first job. This matters and was measured: resolving the
 # first drops the picker (count 2 -> 1), which shifts the SpeakerNamingView's
-# structural slot in its VStack and makes SwiftUI rebuild it with FRESH
-# coordinators, so the stale binding never comes into play and the unfixed build
-# does NOT crash. Keeping both jobs pending keeps the picker present, the view
-# reused, and the coordinator retained, which is what reproduces the crash.
+# structural slot in its VStack and makes SwiftUI rebuild it with FRESH fields,
+# so the reused view under test is never exercised. Keeping both jobs pending
+# keeps the picker present and the view reused, which is what the lane needs.
 #
 # Two dual-source pairs are enqueued through the same paired import a fleet
 # consumer uses, so both jobs are genuinely dual-source (`M_`/`R_` labels) and
@@ -2366,7 +2364,7 @@ run_naming_switch() {
     log "$label: first job rows  $first_labels ($survivor at row $first_index)"
     log "$label: second job rows $second_labels ($second_count rows, survivor $survivor, other $other_label)"
     [ "$(jq -r '.meetingTitle' <<<"$first_naming")" = "$(jq -r '.meetingTitle' <<<"$second_naming")" ] \
-        || fail "$label: the two jobs do not share a meeting title ($(jq -r '.meetingTitle' <<<"$first_naming") vs $(jq -r '.meetingTitle' <<<"$second_naming")); the window would give the second job fresh fields and the retained coordinator would never be exercised"
+        || fail "$label: the two jobs do not share a meeting title ($(jq -r '.meetingTitle' <<<"$first_naming") vs $(jq -r '.meetingTitle' <<<"$second_naming")); the window would give the second job fresh fields and no reused field would be exercised"
     [ -n "$other_label" ] \
         || fail "$label: the second job has only the survivor row ($second_labels); the misroute check needs another row to prove the write did not land there"
     [ "$first_index" -ge 0 ] \
@@ -2445,10 +2443,10 @@ run_naming_switch() {
     # Switch to the second job the way the reporter did: with BOTH jobs still
     # pending, pick the other one in the dialog's segmented job picker ("while
     # the second dialog is showing"). This is what keeps one view alive across
-    # the switch and so keeps the retained coordinator in play. Resolving the
+    # the switch and so keeps its reused fields in play. Resolving the
     # first job instead would drop the picker (count 2 -> 1), which shifts the
     # SpeakerNamingView's structural slot and makes SwiftUI rebuild it with
-    # FRESH coordinators, and the defect then cannot show. Measured on the
+    # FRESH fields, and the defect then cannot show. Measured on the
     # unfixed build: the resolve-first path did not crash; the picker-switch
     # path does.
     _ns_select_job "$second" "$second_labels" second


### PR DESCRIPTION
Closes #702. Stacked on #701: base is `fix/naming-field-stale-index`, so review that one first. Retarget to `main` once it lands.

## What goes away

`AccessibleTextField` was an `NSViewRepresentable` whose only reason to exist was overriding `setAccessibilityValue`, so that an accessibility set-value (AppleScript `set value of text field`) reached the SwiftUI binding. Its coordinator kept the binding it was created with for the row's whole life, which is the stale-binding crash of #700. #701 arms it against that. A plain `TextField` takes a fresh binding on every update by construction, so the whole class of defect goes with the wrapper.

## Why removing it is safe

The wrapper is the app's entire AppleScript-facing surface, and that surface turns out to be one write on one field type:

- There is no scripting dictionary. No `.sdef` anywhere, no `NSAppleScriptEnabled`, no `OSAScriptingDefinition`. `tell application "MeetingTranscriber" to <anything custom>` has never existed; only the standard `activate` and `quit` AppKit gives every app.
- The `setAccessibilityValue` override is the only one in the codebase.
- Everything else UI scripting can do is untouched, because none of it depends on the override: reading a value, pressing a button, sending keystrokes, activating, quitting. The repo's own scripts use AppleScript only for `key code 53`, `activate` and `quit`.
- It was written for speaker-naming requests from the Python CLI, and that CLI was removed. No script using it was ever committed.
- Nothing promises it: not README, docs, the site, the Casks, or any release body from v0.3.0 to v0.8.0, and no issue or PR ever asked for it. The one AppleScript mention in the tracker is a reporter using `osascript` to inspect Zoom's window titles.
- When someone did ask for automation (#431), the answer was the local HTTP API. That is also what covers this flow today: `GET`/`POST /v1/jobs/<id>/naming`.

Related precedent: #533 already established that an accessibility set-value does not drive a SwiftUI binding, which is why the harness has `/ui/type` posting real key events and no `/ui/setValue`. This change settles the same question in the one place that had a workaround for it.

**What is lost:** setting a speaker-name field by accessibility value no longer updates the name. The replacements are real keystrokes or the automation API.

## The test, and a measured constraint worth keeping

The #700 regression cover has to keep working, and it locates the field by identifier. That turned out to be the hard part.

A SwiftUI `.accessibilityIdentifier` reaches the process's accessibility tree but is **never written onto the backing `NSTextField`**, so the old `NSView.accessibilityIdentifier()` locator finds nothing once the representable is gone.

The obvious fix, reading the accessibility tree instead, was tried and rejected on evidence: **with the screen locked, HIServices answers every window query on the self-pid application element with the application element itself**, recursively, so `AXWindows`, `AXFocusedWindow` and a hit test all yield nothing usable. `finishLaunching()` is necessary but not sufficient, and `NSApp.activate` does not help. Such a test is green at an unlocked desk and red on any unattended runner, which is worse than no test, so it is not in this branch at all.

The locator now reads only the `NSView` hierarchy: rows are a `VStack` over sorted labels, so a label's field is the `NSTextField` at its rank by y. Each job seeds every field with a per-label auto name and the test asserts those seeds top to bottom before each lookup, so a wrong rank cannot pass quietly.

All original assertions are kept: the same `NSTextField` instance survives the switch, typing goes through the field editor, the typed row shows the new text and the row that took over the old index still shows its seed. One assertion is added in place of pressing Confirm (no in-process route presses a SwiftUI button): after ending editing and re-rendering the same job, the typed name must still be there. Measured both ways, since that is the property the replacement could break: with the write going through, the field keeps the typed name; with it swallowed, the re-render restores the seed.

`A11yID.speakerName(_:)` is unchanged and still resolves to the same string, so the out-of-process driver behind `scripts/e2e-app.sh --naming-switch` finds the fields exactly as before. A ViewInspector test now pins that identifier; it is red against the representable and green against the plain `TextField`.

## Verification

Full suite 3073 tests exit 0 (run twice), lint 0 violations, pre-push parity green, all with the screen locked. Mutation evidence: a positional `ForEach` identity fails the identical-instance precondition, a binding writing under another key fails the row and re-render assertions, and a swallowed write fails the two re-render assertions.

## Release note

Speaker naming: the name fields no longer accept an accessibility set-value (AppleScript `set value of text field`). Use the automation API (`/v1/jobs/<id>/naming`) or real keystrokes instead.
