### PR TITLE
fix(app): make the AppPaths directory constants directory URLs

### DIFF
--- a/app/MeetingTranscriber/Sources/AppPaths.swift
+++ b/app/MeetingTranscriber/Sources/AppPaths.swift
@@ -12,22 +12,22 @@ enum AppPaths {
     static let dataDir: URL = {
         if let appSupport = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            return appSupport.appendingPathComponent("MeetingTranscriber")
+            return appSupport.appendingPathComponent("MeetingTranscriber", isDirectory: true)
         }
         Logger(subsystem: logSubsystem, category: "AppPaths")
             .error("Application Support directory unavailable — falling back to home directory")
         return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".MeetingTranscriber")
+            .appendingPathComponent(".MeetingTranscriber", isDirectory: true)
     }()
 
     /// IPC directory: under `dataDir` for sandbox compatibility.
-    static let ipcDir = dataDir.appendingPathComponent("ipc")
+    static let ipcDir = dataDir.appendingPathComponent("ipc", isDirectory: true)
 
     /// Recordings directory.
-    static let recordingsDir = dataDir.appendingPathComponent("recordings")
+    static let recordingsDir = dataDir.appendingPathComponent("recordings", isDirectory: true)
 
     /// Protocols output directory (legacy, inside Application Support).
-    static let protocolsDir = dataDir.appendingPathComponent("protocols")
+    static let protocolsDir = dataDir.appendingPathComponent("protocols", isDirectory: true)
 
     /// Default protocols output in Downloads: `~/Downloads/MeetingTranscriber/`
     /// In sandbox, `FileManager.urls(for: .downloadsDirectory)` resolves to the container-granted path.
@@ -37,7 +37,7 @@ enum AppPaths {
         else {
             return protocolsDir
         }
-        return downloads.appendingPathComponent("MeetingTranscriber")
+        return downloads.appendingPathComponent("MeetingTranscriber", isDirectory: true)
     }()
 
     /// Speaker voice profiles DB.
@@ -56,7 +56,7 @@ enum AppPaths {
 
     /// Legacy IPC directory (`~/.meeting-transcriber/`) used before sandbox migration.
     private static let legacyIpcDir = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".meeting-transcriber")
+        .appendingPathComponent(".meeting-transcriber", isDirectory: true)
 
     private static let logger = Logger(subsystem: logSubsystem, category: "AppPaths")
 

--- a/app/MeetingTranscriber/Tests/AppPathsTests.swift
+++ b/app/MeetingTranscriber/Tests/AppPathsTests.swift
@@ -63,6 +63,37 @@ final class AppPathsTests: XCTestCase {
         XCTAssertTrue(fm.fileExists(atPath: AppPaths.ipcDir.path))
     }
 
+    /// Every constant that names a directory has to *be* a directory URL, and
+    /// not because it is tidier.
+    ///
+    /// `URL.appendingPathComponent(_:)` without the `isDirectory:` argument asks
+    /// the filesystem whether the component it just appended is a directory, and
+    /// marks the URL (and so its trailing slash) from the answer. These are
+    /// `static let`s, so that question is asked once per process, at whatever
+    /// moment the first access happens, and on a machine where the directory
+    /// does not exist yet the answer is "no". The URL then compares unequal to
+    /// the same directory reached any other way: `deletingLastPathComponent()`
+    /// on a child always yields the slashed form. That is a constant whose value
+    /// depends on disk state and on evaluation order, and it made
+    /// `testLivenessMarkerIsNamedPerBundleInTheDataDirectory` pass on a
+    /// developer machine and fail on a fresh CI runner, in one variant of one
+    /// run, with no code change between the two.
+    ///
+    /// The file constants are left alone: a missing file probes as a file, which
+    /// is what they should be, so they carry no such swing.
+    func testTheDirectoryConstantsAreDirectoryURLs() {
+        let directories: [(String, URL)] = [
+            ("dataDir", AppPaths.dataDir),
+            ("ipcDir", AppPaths.ipcDir),
+            ("recordingsDir", AppPaths.recordingsDir),
+            ("protocolsDir", AppPaths.protocolsDir),
+            ("downloadsProtocolsDir", AppPaths.downloadsProtocolsDir),
+        ]
+        for (name, url) in directories {
+            XCTAssertTrue(url.hasDirectoryPath, "\(name) must not depend on whether it exists yet")
+        }
+    }
+
     /// The liveness marker (issue #703) sits beside the other state in the
     /// data directory and never in the recordings directory, which is scanned
     /// for crash signatures by filename. It is named per bundle identifier


### PR DESCRIPTION
`test (appstore)` went red on an unrelated PR with

```
AppPathsTests.testLivenessMarkerIsNamedPerBundleInTheDataDirectory :
XCTAssertEqual failed: ("file:///Users/runner/Library/Application%20Support/MeetingTranscriber/")
is not equal to ("file:///Users/runner/Library/Application%20Support/MeetingTranscriber")
```

A trailing slash, and nothing in the diff went near `AppPaths`. The same test passed on `main` and in an earlier run of the same branch.

## Why it swings

`URL.appendingPathComponent(_:)` without the `isDirectory:` argument asks the filesystem whether the component it just appended is a directory, and marks the URL, and so its trailing slash, from the answer. `AppPaths.dataDir` and friends are `static let`s, so that question is asked **once per process**, at whatever moment the first access happens. On a fresh runner the directory does not exist yet and the answer is "no".

`livenessMarker.deletingLastPathComponent()` has no such doubt: deleting the last component of a file URL always yields the slashed directory form. So the two sides of that assertion disagree exactly when the data directory did not exist at the moment `dataDir` was first touched, which under `swift test --parallel` is a race between whatever else creates it.

Measured, non-destructively:

```
existing dir : file:///…/MeetingTranscriber/
missing  dir : file:///…/MeetingTranscriberDefinitelyNotThere<uuid>
equal (existing) : true
equal (missing)  : false
```

## The fix

Mark every constant that names a directory with `isDirectory: true`, which is a pure statement of intent and never consults the disk. That removes the probe and with it a constant whose value depended on disk state and evaluation order.

The file constants (`speakersDB`, `customPromptFile`, `livenessMarker`) are deliberately left alone: a missing file probes as a file, which is what they should be, so they carry no such ambiguity.

## Blast radius

One URL equality exists against these constants, `PipelineQueue+Recovery.swift:119` (`recordingsDir == AppPaths.recordingsDir`, the "is this the default directory" gate). Both sides are the same constant in production and a test temp directory never equals it either way, so the gate answers the same before and after. Nothing compares `absoluteString`, and `.path` drops the trailing slash, so path-building is untouched.

## Verification

Full suite green (3,113 app tests), lint clean, release-mode parity including the App Store variant.

Acceptance is this PR's CI job rather than a local red: every one of these directories already exists on a machine that has run the app, `applicationSupportDirectory` does not follow `$HOME`, and the only way to produce the failing state here would be to remove a real user's data directory. The new `testTheDirectoryConstantsAreDirectoryURLs` pins the property that was missing, and it is the assertion that was false on the runner.
