### PR TITLE
feat(app): probe a capture that has delivered no first buffer

### DIFF
--- a/tools/audiotap/Sources/AppAudioCapture.swift
+++ b/tools/audiotap/Sources/AppAudioCapture.swift
@@ -69,7 +69,11 @@ public class AppAudioCapture: @unchecked Sendable {
     /// `internal` (not `private`) so the cross-file `+DebugLogging` extension
     /// can drive the per-buffer RMS accumulator + dBFS report cadence.
     /// Issue #672; see `AppAudioCapture+SilentTrackDiagnostics`.
-    let silentTrackDiagnostics = SilentTrackDiagnostics(sink: AppAudioCapture.logSilentTrackProbe)
+    /// Injected rather than constructed inline so a test can watch what the
+    /// capture lifecycle asks of it. Production passes nothing and gets the
+    /// logging sink; the seam is the same one `probe` and `sink` already are one
+    /// level down.
+    let silentTrackDiagnostics: SilentTrackDiagnostics
 
     var debugRMS = DebugRMSReporter()
     var debugTotalBytes: UInt64 = 0
@@ -181,6 +185,9 @@ public class AppAudioCapture: @unchecked Sendable {
         debugLogging: Bool = false,
         liveSink: LiveAudioSink? = nil,
         attemptBody: (() throws -> AppTapSession?)?,
+        silentTrackDiagnostics: SilentTrackDiagnostics = SilentTrackDiagnostics(
+            sink: AppAudioCapture.logSilentTrackProbe,
+        ),
     ) {
         self.pids = pids
         self.outputFileDescriptor = outputFileDescriptor
@@ -189,6 +196,7 @@ public class AppAudioCapture: @unchecked Sendable {
         self.debugLogging = debugLogging
         self.liveSink = liveSink
         self.attemptBody = attemptBody
+        self.silentTrackDiagnostics = silentTrackDiagnostics
         resampler = StreamingMonoResampler(targetRate: Int(speechSampleRate))
     }
 
@@ -384,6 +392,12 @@ public class AppAudioCapture: @unchecked Sendable {
             // Log format on first callback
             if !self.didLogFormat {
                 self.didLogFormat = true
+                // This capture is delivering, so nothing it was armed with has
+                // anything left to report. Safe from the write queue:
+                // cancelling a `DispatchWorkItem` is documented as safe from
+                // any thread, and it takes only the diagnostics object's own
+                // lock, never the HAL.
+                self.silentTrackDiagnostics.cancelNoBufferProbes()
                 // Only record the very first frame time — not after device restarts.
                 // MicCaptureHandler uses the same guard. Without this, a device change
                 // mid-recording overwrites the timestamp, corrupting the micDelay
@@ -461,11 +475,24 @@ public class AppAudioCapture: @unchecked Sendable {
         silentTrackDiagnostics.probeAsync(
             session.tappedProcesses, aggregateID: session.aggregateID, reason: "start",
         )
+        // The reading this one cannot take. The start probe above lands before
+        // `AudioCaptureSession.start()` opens the microphone, and that open is
+        // what flips a Bluetooth headset out of A2DP, so it reads the state
+        // before the trigger. These are taken while the recording is running and
+        // are disarmed by the first buffer, so a healthy capture emits none of
+        // them (issue #693).
+        silentTrackDiagnostics.scheduleNoBufferProbes(
+            session.tappedProcesses, aggregateID: session.aggregateID,
+        )
         return session
     }
 
     func stopCapture() {
         isRunning = false
+        // Before the teardown below, so no deadline can read an aggregate that
+        // `destroy()` is about to remove. A restart calls this too, and
+        // `startCapture()` re-arms.
+        silentTrackDiagnostics.cancelNoBufferProbes()
 
         if debugLogging {
             logger.info(

--- a/tools/audiotap/Sources/NoFirstBufferProbeSchedule.swift
+++ b/tools/audiotap/Sources/NoFirstBufferProbeSchedule.swift
@@ -18,10 +18,22 @@ import Foundation
 ///
 /// So the one reading that separates a dormant aggregate from a dead one has to
 /// be taken while the recording is still running, which is what this schedules.
-/// The pair it produces is the discriminator: a tapped process rendering to the
-/// tapped device while nothing arrives is the fault, because
+/// The pair it produces is the discriminator: a tapped process reporting
+/// `isRunningOutput` while nothing arrives is the fault, because
 /// `kAudioAggregateDeviceTapAutoStartKey` promises the aggregate starts when a
 /// tapped process runs IO. No process rendering is the benign case.
+///
+/// **The device the process renders to is not part of that test**, and reading
+/// it as part of it was measured wrong. A `stereoMixdownOfProcesses` tap follows
+/// the process, not the device: with the tapped aggregate on the default output
+/// and the target rendering to an entirely different device, the capture came
+/// back byte-identical to the control, at the same levels, and the aggregate
+/// reported running throughout. `outputDevices` said the other device the whole
+/// time. So a user who picks a different output inside the meeting app, which
+/// Teams, Zoom and Webex all offer, is captured exactly as anyone else is, and a
+/// verdict gated on that list would call their genuine fault undecided.
+/// `outputDevices` stays on the line because it says where the audio went, which
+/// is what issue #671 turns on. It just does not gate this.
 ///
 /// A healthy recording emits nothing: every offset is cancelled by the first
 /// buffer, which arrives inside the first of them by two orders of magnitude.

--- a/tools/audiotap/Sources/NoFirstBufferProbeSchedule.swift
+++ b/tools/audiotap/Sources/NoFirstBufferProbeSchedule.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// When an app-audio capture that has delivered nothing is probed, and what the
+/// resulting diagnostic line says.
+///
+/// **Why a fourth probe point.** The three that shipped with issue #693 cannot
+/// answer the question they were built for, and each for its own reason:
+///
+/// - `start` is taken right after `AudioDeviceStart` and therefore *before*
+///   `AudioCaptureSession.start()` opens the microphone. That open is what
+///   flips a Bluetooth headset out of A2DP, so the start probe reads the state
+///   before the trigger and cannot see the fault at all.
+/// - `zero run started` needs buffers to be arriving and carrying only zeroes.
+///   In this fault none arrive, so it never fires.
+/// - `stop` is enqueued asynchronously and then raced by a synchronous
+///   teardown, and it reads `isRunning` last of all its fields. A healthy
+///   recording reads `running=false` there, which is what the field reported.
+///
+/// So the one reading that separates a dormant aggregate from a dead one has to
+/// be taken while the recording is still running, which is what this schedules.
+/// The pair it produces is the discriminator: a tapped process rendering to the
+/// tapped device while nothing arrives is the fault, because
+/// `kAudioAggregateDeviceTapAutoStartKey` promises the aggregate starts when a
+/// tapped process runs IO. No process rendering is the benign case.
+///
+/// A healthy recording emits nothing: every offset is cancelled by the first
+/// buffer, which arrives inside the first of them by two orders of magnitude.
+struct NoFirstBufferProbeSchedule: Equatable, Sendable {
+    /// Seconds after the device was started, ascending.
+    let offsets: [TimeInterval]
+
+    /// Measured, not chosen. A healthy tap's first buffer arrives 30 to 60 ms
+    /// after the device starts and the slowest first callback in the field logs
+    /// was 0.78 s, so five seconds is two orders of magnitude of headroom and
+    /// still short enough to sit inside the opening of a call. Thirty clears the
+    /// benign case: an aggregate waiting under
+    /// `kAudioAggregateDeviceTapAutoStartKey` for a target that is playing
+    /// nothing was measured sitting dormant for the best part of a minute and
+    /// then delivering normally. A hundred and twenty is there because a meeting
+    /// can genuinely open in silence, and because a second reading tells a
+    /// process that started rendering late apart from one that never did.
+    static let production = Self(offsets: [5, 30, 120])
+
+    /// The reason string the probe is logged under. It carries the elapsed time
+    /// because that is what separates a late start, one line then delivery, from
+    /// a capture that never came back.
+    func reason(after seconds: TimeInterval) -> String {
+        let rendered = seconds == seconds.rounded()
+            ? String(Int(seconds))
+            : String(seconds)
+        return "no buffers after \(rendered) s"
+    }
+}

--- a/tools/audiotap/Sources/SilentTrackDiagnostics.swift
+++ b/tools/audiotap/Sources/SilentTrackDiagnostics.swift
@@ -87,9 +87,79 @@ final class SilentTrackDiagnostics: @unchecked Sendable {
 
     private let state = OSAllocatedUnfairLock(initialState: State())
 
-    init(probe: @escaping Probe = SilentTrackDiagnostics.readAll, sink: @escaping Sink) {
+    /// The deadlines armed for the capture attempt currently installed, held so
+    /// the first buffer and teardown can disarm them. Kept out of `State` and
+    /// behind its own lock because `DispatchWorkItem` is not `Sendable` and
+    /// `State` has to stay so; this class is already `@unchecked Sendable`, and
+    /// cancelling a work item is documented as safe from any thread.
+    private let armedLock = NSLock()
+    private var armedNoBufferProbes: [DispatchWorkItem] = []
+
+    /// How a deadline is armed. Nil means the diagnostics queue's own
+    /// `asyncAfter`, which is what production uses; a test injects one so it
+    /// decides when each deadline is reached. Proving a probe did *not* fire by
+    /// sleeping past a real five-second deadline is a coin toss on a loaded
+    /// machine, not an assertion.
+    typealias DelayedWork = @Sendable (TimeInterval, DispatchWorkItem) -> Void
+
+    private let delayedWork: DelayedWork?
+
+    init(
+        probe: @escaping Probe = SilentTrackDiagnostics.readAll,
+        sink: @escaping Sink,
+        delayedWork: DelayedWork? = nil,
+    ) {
         self.probe = probe
         self.sink = sink
+        self.delayedWork = delayedWork
+    }
+
+    /// Arm one probe per offset, replacing anything a previous attempt armed.
+    ///
+    /// Called from `startCapture()`, so a device-change restart re-arms rather
+    /// than stacking: without the replacement the old attempt's deadlines would
+    /// keep firing against an aggregate that no longer exists, and every rebuild
+    /// would add another set.
+    ///
+    /// The processes and the aggregate are captured by value for the same
+    /// reason the IOProc block captures its session: a deadline that outlives
+    /// its own attempt must report the aggregate it was armed for, not whatever
+    /// the newest attempt installed.
+    func scheduleNoBufferProbes(
+        _ processes: [TappedProcess],
+        aggregateID: AudioObjectID,
+        schedule: NoFirstBufferProbeSchedule = .production,
+    ) {
+        cancelNoBufferProbes()
+        let items = schedule.offsets.map { offset in
+            let reason = schedule.reason(after: offset)
+            return (offset, DispatchWorkItem { [weak self] in
+                _ = self?.probeAsync(processes, aggregateID: aggregateID, reason: reason)
+            })
+        }
+        armedLock.lock()
+        armedNoBufferProbes = items.map(\.1)
+        armedLock.unlock()
+        for (offset, item) in items {
+            if let delayedWork {
+                delayedWork(offset, item)
+            } else {
+                queue.asyncAfter(deadline: .now() + offset, execute: item)
+            }
+        }
+    }
+
+    /// Disarm every pending probe. Called when the first buffer arrives, which
+    /// is why a healthy recording emits none of these lines, and again on
+    /// teardown so a destroyed aggregate is never read.
+    func cancelNoBufferProbes() {
+        armedLock.lock()
+        let pending = armedNoBufferProbes
+        armedNoBufferProbes = []
+        armedLock.unlock()
+        for item in pending {
+            item.cancel()
+        }
     }
 
     /// Feed one tick's signal ages and hand back the edge, if this tick is one.

--- a/tools/audiotap/Tests/NoFirstBufferProbeScheduleTests.swift
+++ b/tools/audiotap/Tests/NoFirstBufferProbeScheduleTests.swift
@@ -1,0 +1,48 @@
+@testable import AudioTapLib
+import XCTest
+
+/// When an app-audio capture that has delivered nothing gets probed, and what
+/// the resulting line says.
+///
+/// Worth a value type of its own because the three probe points that shipped
+/// with issue #693 cannot answer the question they were built for: `start`
+/// lands before the microphone open that triggers the fault, `zero run started`
+/// needs buffers to be arriving and so never fires here, and `stop` races the
+/// teardown. This is the fourth, and the only one taken while the recording is
+/// still running.
+final class NoFirstBufferProbeScheduleTests: XCTestCase {
+    func testTheProductionOffsetsStraddleTheKnownRecoveryTimes() {
+        // The first has to clear a healthy start by a wide margin: a tap's first
+        // buffer arrives about 30 to 60 ms after the device starts, and the
+        // slowest first callback in the field logs was 0.78 s. The second has to
+        // clear the benign case, an aggregate waiting under
+        // `kAudioAggregateDeviceTapAutoStartKey` for a target that is playing
+        // nothing, which was measured recovering by itself after the best part
+        // of a minute. The third exists because a meeting can start in silence.
+        XCTAssertEqual(NoFirstBufferProbeSchedule.production.offsets, [5, 30, 120])
+    }
+
+    func testTheOffsetsAreOrderedAndDistinct() {
+        // They are rendered into the reason string, so two equal offsets would
+        // produce two lines a reader cannot tell apart.
+        let offsets = NoFirstBufferProbeSchedule.production.offsets
+        XCTAssertEqual(offsets, offsets.sorted())
+        XCTAssertEqual(Set(offsets).count, offsets.count)
+    }
+
+    func testTheReasonNamesTheElapsedTimeAndTheAbsenceOfBuffers() {
+        // The reason is the only thing separating these lines from the three
+        // that already exist, and the elapsed time is what makes a late start
+        // ("no buffers after 5 s" alone, then delivery) distinguishable from one
+        // that never came.
+        XCTAssertEqual(NoFirstBufferProbeSchedule.production.reason(after: 5), "no buffers after 5 s")
+        XCTAssertEqual(NoFirstBufferProbeSchedule.production.reason(after: 120), "no buffers after 120 s")
+    }
+
+    func testTheReasonDoesNotRenderAFractionForAWholeNumberOfSeconds() {
+        // The offsets are whole seconds and the line is read by people, so
+        // "5.0 s" would be noise. A schedule with a fractional offset, which
+        // only a test uses, still has to render readably.
+        XCTAssertEqual(NoFirstBufferProbeSchedule(offsets: [0.25]).reason(after: 0.25), "no buffers after 0.25 s")
+    }
+}

--- a/tools/audiotap/Tests/NoFirstBufferProbeSchedulingTests.swift
+++ b/tools/audiotap/Tests/NoFirstBufferProbeSchedulingTests.swift
@@ -1,0 +1,133 @@
+@testable import AudioTapLib
+import CoreAudio
+import Foundation
+import os
+import XCTest
+
+/// The scheduling half of the no-first-buffer probe: that one probe is armed
+/// per offset, that the first buffer disarms all of them, and that a restart
+/// replaces the previous arming rather than stacking on it.
+///
+/// The delay is injected rather than waited out. A test that sleeps past a real
+/// five-second deadline to prove a probe fired would also have to sleep past it
+/// to prove one did not, and the second half of that is a coin toss on a loaded
+/// machine, not an assertion.
+/// Captures what was armed instead of arming it, so the test decides when
+/// each deadline is reached.
+final class ProbeClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var armed: [(TimeInterval, DispatchWorkItem)] = []
+
+    var delays: [TimeInterval] {
+        lock.lock(); defer { lock.unlock() }
+        return armed.map(\.0)
+    }
+
+    var items: [DispatchWorkItem] {
+        lock.lock(); defer { lock.unlock() }
+        return armed.map(\.1)
+    }
+
+    func arm(_ delay: TimeInterval, _ item: DispatchWorkItem) {
+        lock.lock(); defer { lock.unlock() }
+        armed.append((delay, item))
+    }
+
+    /// Runs every armed item, cancelled ones included: `DispatchWorkItem`
+    /// skips its body when cancelled, which is the behaviour under test.
+    func fireAll() {
+        lock.lock()
+        let items = armed.map(\.1)
+        lock.unlock()
+        for item in items {
+            item.perform()
+        }
+    }
+}
+
+final class ProbeReasons: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [String] = []
+    func append(_ reason: String) {
+        lock.lock(); seen.append(reason); lock.unlock()
+    }
+
+    var all: [String] {
+        lock.lock(); defer { lock.unlock() }; return seen
+    }
+}
+
+final class NoFirstBufferProbeSchedulingTests: XCTestCase {
+    private func makeDiagnostics(clock: ProbeClock, reasons: ProbeReasons) -> SilentTrackDiagnostics {
+        SilentTrackDiagnostics(
+            probe: { _, aggregateID in
+                .init(processes: [], device: AggregateRunState(
+                    aggregateID: aggregateID,
+                    isRunning: .value(false),
+                    defaultOutputDeviceID: .value(7),
+                    defaultOutputRate: .value(48000),
+                ))
+            },
+            sink: { reason, _ in reasons.append(reason) },
+            delayedWork: { clock.arm($0, $1) },
+        )
+    }
+
+    func testOneProbeIsArmedPerOffset() {
+        let clock = ProbeClock()
+        let diagnostics = makeDiagnostics(clock: clock, reasons: ProbeReasons())
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 42, schedule: .production)
+        XCTAssertEqual(clock.delays, NoFirstBufferProbeSchedule.production.offsets)
+    }
+
+    func testEachArmedProbeReportsItsOwnOffset() {
+        let clock = ProbeClock()
+        let reasons = ProbeReasons()
+        let diagnostics = makeDiagnostics(clock: clock, reasons: reasons)
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 42, schedule: .init(offsets: [5, 30]))
+        clock.fireAll()
+        expectEventually(reasons, ["no buffers after 5 s", "no buffers after 30 s"])
+    }
+
+    func testTheFirstBufferDisarmsEveryPendingProbe() {
+        // The whole reason a healthy recording emits nothing. Without this the
+        // line fires on every recording whose far end is quiet for five seconds.
+        let clock = ProbeClock()
+        let reasons = ProbeReasons()
+        let diagnostics = makeDiagnostics(clock: clock, reasons: reasons)
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 42, schedule: .init(offsets: [5, 30]))
+        diagnostics.cancelNoBufferProbes()
+        // Asserted on the work items, not on an empty sink. The sink hops to the
+        // diagnostics queue, so "no reasons yet" is also what a queue that has
+        // simply not run yet looks like, and the sink form of this assertion
+        // passed with the cancellation deleted.
+        XCTAssertTrue(clock.items.allSatisfy(\.isCancelled))
+        clock.fireAll()
+        XCTAssertEqual(reasons.all, [], "and nothing is reported once they do run")
+    }
+
+    func testArmingAgainDisarmsThePreviousSchedule() {
+        // A device-change restart runs `startCapture()` again. Without this the
+        // old attempt's deadlines keep firing against an aggregate that no
+        // longer exists, and each rebuild would add three more.
+        let clock = ProbeClock()
+        let reasons = ProbeReasons()
+        let diagnostics = makeDiagnostics(clock: clock, reasons: reasons)
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 42, schedule: .init(offsets: [5]))
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 99, schedule: .init(offsets: [30]))
+        clock.fireAll()
+        expectEventually(reasons, ["no buffers after 30 s"])
+    }
+
+    /// The probe itself hops to the diagnostics queue, so the sink lands after
+    /// `perform()` returns.
+    private func expectEventually(
+        _ reasons: ProbeReasons, _ expected: [String], file: StaticString = #filePath, line: UInt = #line,
+    ) {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, reasons.all.count < expected.count {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertEqual(reasons.all.sorted(), expected.sorted(), file: file, line: line)
+    }
+}

--- a/tools/audiotap/Tests/NoFirstBufferProbeWiringTests.swift
+++ b/tools/audiotap/Tests/NoFirstBufferProbeWiringTests.swift
@@ -1,0 +1,48 @@
+@testable import AudioTapLib
+import CoreAudio
+import Foundation
+import os
+import XCTest
+
+/// That the capture lifecycle actually asks `SilentTrackDiagnostics` for the
+/// scheduling. Without this the call sites in `AppAudioCapture` can be deleted
+/// and every test in `NoFirstBufferProbeSchedulingTests` stays green.
+///
+/// `Clock` and `Reasons` are shared with that file.
+@available(macOS 14.2, *)
+final class NoFirstBufferProbeWiringTests: XCTestCase {
+    func testStoppingACaptureDisarmsItsPendingProbes() {
+        // The teardown call site, and the one with teeth: `stopCapture()` runs
+        // `destroy()` a few statements later, so a deadline that survived it
+        // would read an aggregate CoreAudio has removed and render a failed-read
+        // marker into a field log as if it were a finding.
+        let clock = ProbeClock()
+        let reasons = ProbeReasons()
+        let diagnostics = SilentTrackDiagnostics(
+            probe: { _, _ in .init(processes: [], device: nil) },
+            sink: { reason, _ in reasons.append(reason) },
+            delayedWork: { clock.arm($0, $1) },
+        )
+        let capture = AppAudioCapture(
+            pids: [1],
+            outputFileDescriptor: -1,
+            attemptBody: { nil },
+            silentTrackDiagnostics: diagnostics,
+        )
+
+        diagnostics.scheduleNoBufferProbes([], aggregateID: 42, schedule: .init(offsets: [5]))
+        XCTAssertEqual(clock.delays, [5], "precondition: one deadline is armed")
+
+        capture.stopCapture()
+
+        // On the items, for the reason given in the scheduling tests: an empty sink
+        // is indistinguishable from a queue that has not run yet, and the sink
+        // form of this assertion was green with the call site deleted.
+        XCTAssertTrue(
+            clock.items.allSatisfy(\.isCancelled),
+            "stopCapture must disarm what startCapture armed",
+        )
+        clock.fireAll()
+        XCTAssertEqual(reasons.all, [])
+    }
+}


### PR DESCRIPTION
Step one of the work on #693, and deliberately only the sensor. It changes no capture behaviour.

## The three existing probe points cannot answer the question

The `App audio device (<reason>)` line shipped in 0.8.1 to separate a dormant aggregate from a dead one. A reporter's data plus a code read says none of its three points can do it.

**`start`** is taken right after `AudioDeviceStart`, and `AudioCaptureSession.start()` brings the app tap up *before* it opens the microphone. Our own microphone open is what flips a Bluetooth headset out of A2DP, so the start probe reads the state before the trigger it is meant to catch.

**`zero run started`** needs buffers to be arriving and carrying only zeroes. In this fault none arrive at all, so it never fires. Three independent guards close it: the tick lives inside the IOProc block, and the observer returns early while either signal age is nil.

**`stop`** is enqueued asynchronously and then raced by a synchronous teardown, and it reads `isRunning` last of its four fields, after every tapped process. It is expected to *lose* that race. Two field recordings that produced full transcripts both read `running=false` there. The reading is noise in both directions: a slow `AudioDeviceStop` would let a healthy recording read `true`.

## What this adds

A fourth point, taken while the recording is still running, at 5, 30 and 120 s, disarmed by the first buffer.

The pair it produces is the discriminator, and `running` is not the load-bearing half of it: a tapped process reporting `isRunningOutput` while nothing arrives is the fault, because `kAudioAggregateDeviceTapAutoStartKey` promises the aggregate starts once a tapped process runs IO. No process rendering is the benign case, which recovers by itself. A field log confirms the process half reads what it needs to: one of six tapped Teams processes rendering.

**The device the process renders to is deliberately not part of that test.** The first draft gated the verdict on the tapped device appearing in `outputDevices`, and that was measured wrong. With the tapped aggregate on the default output and the target rendering to a different device entirely, the capture came back byte-identical to the control at the same levels (935 callbacks, 3829760 bytes either way) and the aggregate reported running throughout, while `outputDevices` named the other device. A `stereoMixdownOfProcesses` tap follows the process, not the device.

That is not a corner: Teams, Zoom and Webex all carry their own output picker. A user who points it somewhere other than the system output is captured exactly as anyone else is, and a verdict gated on the device list would have called their genuine fault undecided. `outputDevices` stays on the line because it says where the audio went, which is what #671 turns on; it just does not gate this.

The offsets are measured rather than chosen: five seconds is two orders of magnitude past a healthy first buffer, thirty clears a dormancy that was measured recovering after the best part of a minute, and a hundred and twenty exists because a meeting can open in silence.

**A healthy recording emits nothing.** At most three lines per attempt on a recording that is already lost.

## Queue discipline

The reads keep running on the dedicated diagnostics queue behind the existing single-in-flight guard, never on the write queue that `AppTapSession.destroy()` drains with a `sync` (#588). Cancelling from the IOProc's first-callback branch is safe: `DispatchWorkItem.cancel` is documented as safe from any thread and takes only the diagnostics object's own lock.

Disarmed at the top of `stopCapture()`, before the teardown below it removes the aggregate a pending deadline would otherwise read. That also covers the give-up path, where the stop line can currently read a destroyed id.

## Verification

Nine tests. The delay is injected so the tests decide when a deadline is reached.

Both negatives are asserted on the work item rather than on an empty sink, and that is not a style choice: the sink hops to the diagnostics queue, so an empty list is also what a queue that has not run yet looks like. Written the obvious way first, both assertions were **green with the cancellation deleted**. In the current form, deleting the `stopCapture` call site turns the wiring test red.

Arming at start is not covered by a test. `startCapture()` does real HAL work and the `attemptBody` seam replaces it wholesale, so there is no hardware-free way to reach it; saying so beats a test that pretends.

Full suites green (3,147 app, 342 audiotap), lint clean, release-mode parity including the App Store variant.

## What comes next, not in here

The chosen repair is to open the microphone before creating the tap, which removes a trigger the app causes itself (measured: 9 of 30 runs fail with the current order, 0 of 30 with the microphone first). That flips the sign of the recorder's microphone delay for every recording and exposes a timeline disagreement between the mix and the transcript, so it needs its own change. This sensor lands first on purpose: without it the first field series after the reordering would run blind.
